### PR TITLE
[Fleet] Add agentless bulk upgrade endpoint (`_upgrade` + dry-run)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -26452,7 +26452,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.
+        Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Policies already at the installed version are a genuine no-op: they still report `success: true` (calls stay idempotent) but nothing is re-persisted or redeployed. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.
       operationId: post-fleet-agentless-policies-upgrade
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -70120,11 +70120,13 @@ components:
           properties:
             message:
               description: Error message when the dry-run failed for this policy.
+              maxLength: 4096
               type: string
           required:
             - message
         currentVersion:
           description: The current installed package version of the policy.
+          maxLength: 256
           type: string
         errors:
           description: Migration errors encountered while computing the upgrade.
@@ -70134,23 +70136,28 @@ components:
             properties:
               message:
                 description: Human-readable migration error.
+                maxLength: 4096
                 type: string
             required:
               - message
+          maxItems: 1000
           type: array
         hasErrors:
           description: Whether the dry-run migration produced any errors.
           type: boolean
         id:
           description: The ID of the agentless policy.
+          maxLength: 256
           type: string
         name:
           description: The name of the agentless policy.
+          maxLength: 256
           type: string
         proposedPolicy:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy'
         proposedVersion:
           description: The package version the policy would be upgraded to.
+          maxLength: 256
           type: string
         statusCode:
           description: HTTP-like status code when the dry-run failed for this policy.
@@ -71497,14 +71504,17 @@ components:
           properties:
             message:
               description: Error message when the upgrade failed for this policy.
+              maxLength: 4096
               type: string
           required:
             - message
         id:
           description: The ID of the agentless policy.
+          maxLength: 256
           type: string
         name:
           description: The name of the agentless policy.
+          maxLength: 256
           type: string
         statusCode:
           description: HTTP-like status code when the upgrade failed for this policy.

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -26443,6 +26443,277 @@ paths:
       x-metaTags:
         - content: Kibana, Elastic Cloud Serverless
           name: product_name
+  /api/fleet/agentless_policies/_upgrade:
+    post:
+      description: |-
+        **Spaces method and path for this operation:**
+
+        <div><span class="operation-verb post">post</span>&nbsp;<span class="operation-path">/s/{space_id}/api/fleet/agentless_policies/_upgrade</span></div>
+
+        Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
+
+        Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.
+      operationId: post-fleet-agentless-policies-upgrade
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              upgradeAgentlessPoliciesRequestExample:
+                description: Bulk upgrade agentless policies to their installed package version
+                value:
+                  policyIds:
+                    - d52a7812-5736-4fdc-aed8-72152afa1ffa
+                    - aws-policy-12345
+            schema:
+              $ref: '#/components/schemas/Kibana_HTTP_APIs_bulk_upgrade_agentless_policies_request'
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                upgradeAgentlessPoliciesPartialFailureResponseExample:
+                  description: Example response where one policy upgraded and another id was missing or not an agentless policy (the batch still returns 200)
+                  value:
+                    - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      success: true
+                    - body:
+                        message: Agentless policy aws-policy-12345 not found
+                      id: aws-policy-12345
+                      statusCode: 404
+                      success: false
+                upgradeAgentlessPoliciesResponseExample:
+                  description: Example response where every policy was upgraded
+                  value:
+                    - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      success: true
+                    - id: aws-policy-12345
+                      name: cspm-aws-policy
+                      success: true
+              schema:
+                items:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_bulk_upgrade_agentless_policy_result'
+                maxItems: 10000
+                type: array
+          description: 'Indicates a successful response. Each item reports the per-policy upgrade outcome; inspect every item''s `success` flag. A missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch.'
+        '400':
+          content:
+            application/json:
+              examples:
+                genericErrorResponseExample:
+                  description: Example of a generic error response
+                  value:
+                    error: Bad Request
+                    message: An error message describing what went wrong
+                    statusCode: 400
+              schema:
+                additionalProperties: false
+                description: Generic Error
+                type: object
+                properties:
+                  attributes:
+                    nullable: true
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+                  message:
+                    type: string
+                  statusCode:
+                    type: number
+                required:
+                  - message
+                  - attributes
+          description: Bad Request
+      summary: Bulk upgrade agentless policies
+      tags:
+        - Fleet agentless policies
+      x-state: Experimental
+      x-metaTags:
+        - content: Kibana, Elastic Cloud Serverless
+          name: product_name
+  /api/fleet/agentless_policies/_upgrade/dryrun:
+    post:
+      description: |-
+        **Spaces method and path for this operation:**
+
+        <div><span class="operation-verb post">post</span>&nbsp;<span class="operation-path">/s/{space_id}/api/fleet/agentless_policies/_upgrade/dryrun</span></div>
+
+        Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
+
+        Preview upgrading multiple agentless policies without applying any change. Targets the installed package version by default; pass `pkgVersion` to preview a specific (for example, not-yet-installed) version. Each result returns the current/proposed version and any migration errors, plus — only on a clean dry-run (`hasErrors: false`) — the migrated `proposedPolicy`. `proposedPolicy` is for the edit-and-upgrade flow (edit it, then save via the update (PUT) endpoint); to apply an upgrade as-is, use `_upgrade`.
+      operationId: post-fleet-agentless-policies-upgrade-dryrun
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              upgradeAgentlessPoliciesDryRunRequestExample:
+                description: Preview the upgrade of agentless policies to their installed package version
+                value:
+                  policyIds:
+                    - d52a7812-5736-4fdc-aed8-72152afa1ffa
+              upgradeAgentlessPoliciesDryRunTargetVersionRequestExample:
+                description: Preview the upgrade against an explicit target package version (for example, before installing the new version). Defaults to the installed package version when omitted.
+                value:
+                  pkgVersion: 1.6.0
+                  policyIds:
+                    - d52a7812-5736-4fdc-aed8-72152afa1ffa
+            schema:
+              $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_request'
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                upgradeAgentlessPoliciesDryRunMigrationErrorsExample:
+                  description: Example dry-run response where migrating the config to the new version produced errors. `hasErrors` is true and `errors` explains why; do not feed the (partial) proposed config into the update endpoint without resolving them.
+                  value:
+                    - currentVersion: 1.5.0
+                      errors:
+                        - message: Variable "organization_id" is required
+                      hasErrors: true
+                      id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      proposedVersion: 1.6.0
+                upgradeAgentlessPoliciesDryRunMixedResponseExample:
+                  description: 'Example dry-run response for a mixed batch: one policy previews cleanly while two ids are missing or not agentless. Missing / non-agentless ids are surfaced as per-item failures (`hasErrors: true` + `statusCode`) without failing the batch, and results stay in request order.'
+                  value:
+                    - currentVersion: 0.5.0
+                      hasErrors: false
+                      id: 2e426392-f856-4ab2-bc31-92d4dbb8d134
+                      name: agentless_hello_world-16
+                      proposedPolicy:
+                        cloud_connector: null
+                        created_at: '2026-07-01T15:59:08.299Z'
+                        created_by: admin
+                        description: ''
+                        id: 2e426392-f856-4ab2-bc31-92d4dbb8d134
+                        inputs:
+                          agentless_hello_world-cel:
+                            enabled: true
+                            streams:
+                              agentless_hello_world.generic:
+                                enabled: true
+                                vars:
+                                  url: https://epr.elastic.co
+                              agentless_hello_world.mock_counter:
+                                enabled: false
+                                vars:
+                                  events_per_second: 10
+                                  mode: constant
+                                  spike_events: 100
+                                  spike_every_seconds: 60
+                          agentless_hello_world-httpjson:
+                            enabled: false
+                            streams:
+                              agentless_hello_world.generic:
+                                enabled: false
+                                vars:
+                                  url: https://epr.elastic.co
+                        name: agentless_hello_world-16
+                        namespace: default
+                        package:
+                          name: agentless_hello_world
+                          title: Agentless Hello World
+                          version: 0.5.0
+                        updated_at: '2026-07-01T16:02:14.067Z'
+                        updated_by: admin
+                      proposedVersion: 0.5.0
+                    - body:
+                        message: Agentless policy 9300464c-6cfc-4566-850d-e9e7927457fe not found
+                      hasErrors: true
+                      id: 9300464c-6cfc-4566-850d-e9e7927457fe
+                      statusCode: 404
+                    - body:
+                        message: Agentless policy 5b8763e9-791a-4038-be29-b384d578200e not found
+                      hasErrors: true
+                      id: 5b8763e9-791a-4038-be29-b384d578200e
+                      statusCode: 404
+                upgradeAgentlessPoliciesDryRunResponseExample:
+                  description: 'Example clean dry-run response (`hasErrors: false`) with the proposed (migrated) policy. `proposedPolicy` is intended for the edit-and-upgrade flow: edit it and submit the edited payload to the update (PUT) endpoint. To apply without edits, use the `_upgrade` endpoint instead.'
+                  value:
+                    - currentVersion: 1.5.0
+                      hasErrors: false
+                      id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      proposedPolicy:
+                        created_at: '2025-11-06T18:27:43.541Z'
+                        created_by: test_user
+                        description: test
+                        id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                        inputs:
+                          ESS Billing-cel:
+                            enabled: true
+                            vars:
+                              organization_id: '1234'
+                        name: ess_billing-1
+                        namespace: default
+                        package:
+                          name: ess_billing
+                          title: Elasticsearch Service Billing
+                          version: 1.6.0
+                        updated_at: '2025-11-06T18:27:43.541Z'
+                        updated_by: test_user
+                      proposedVersion: 1.6.0
+              schema:
+                items:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_result'
+                maxItems: 10000
+                type: array
+          description: 'Indicates a successful response. Each clean item (`hasErrors: false`) previews the migrated policy as a consumable agentless policy (`proposedPolicy`); a missing or non-agentless id, or a migration error, is reported as a per-item failure (`hasErrors: true`, with `proposedPolicy` omitted) without failing the batch. Inspect every item.'
+        '400':
+          content:
+            application/json:
+              examples:
+                genericErrorResponseExample:
+                  description: Example of a generic error response
+                  value:
+                    error: Bad Request
+                    message: An error message describing what went wrong
+                    statusCode: 400
+              schema:
+                additionalProperties: false
+                description: Generic Error
+                type: object
+                properties:
+                  attributes:
+                    nullable: true
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+                  message:
+                    type: string
+                  statusCode:
+                    type: number
+                required:
+                  - message
+                  - attributes
+          description: Bad Request
+      summary: Preview an agentless policies upgrade
+      tags:
+        - Fleet agentless policies
+      x-state: Experimental
+      x-metaTags:
+        - content: Kibana, Elastic Cloud Serverless
+          name: product_name
   /api/fleet/agentless_policies/{policyId}:
     delete:
       description: |-
@@ -69822,6 +70093,73 @@ components:
         - item
       title: agentless_policy_response
       type: object
+    Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_request:
+      additionalProperties: false
+      properties:
+        pkgVersion:
+          description: Target package version to preview the upgrade against. Defaults to the installed package version.
+          maxLength: 256
+          type: string
+        policyIds:
+          description: IDs of the agentless policies to preview upgrading.
+          items:
+            maxLength: 256
+            type: string
+          maxItems: 1000
+          type: array
+      required:
+        - policyIds
+      title: agentless_policy_upgrade_dry_run_request
+      type: object
+    Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_result:
+      additionalProperties: false
+      properties:
+        body:
+          additionalProperties: false
+          type: object
+          properties:
+            message:
+              description: Error message when the dry-run failed for this policy.
+              type: string
+          required:
+            - message
+        currentVersion:
+          description: The current installed package version of the policy.
+          type: string
+        errors:
+          description: Migration errors encountered while computing the upgrade.
+          items:
+            additionalProperties: false
+            type: object
+            properties:
+              message:
+                description: Human-readable migration error.
+                type: string
+            required:
+              - message
+          type: array
+        hasErrors:
+          description: Whether the dry-run migration produced any errors.
+          type: boolean
+        id:
+          description: The ID of the agentless policy.
+          type: string
+        name:
+          description: The name of the agentless policy.
+          type: string
+        proposedPolicy:
+          $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy'
+        proposedVersion:
+          description: The package version the policy would be upgraded to.
+          type: string
+        statusCode:
+          description: HTTP-like status code when the dry-run failed for this policy.
+          type: number
+      required:
+        - id
+        - hasErrors
+      title: agentless_policy_upgrade_dry_run_result
+      type: object
     Kibana_HTTP_APIs_aiops_change_point_chart:
       additionalProperties: false
       description: Change point detection chart embeddable schema
@@ -71135,6 +71473,49 @@ components:
       required:
         - packages
       title: bulk_uninstall_packages_request
+      type: object
+    Kibana_HTTP_APIs_bulk_upgrade_agentless_policies_request:
+      additionalProperties: false
+      properties:
+        policyIds:
+          description: IDs of the agentless policies to upgrade to their installed package version.
+          items:
+            maxLength: 256
+            type: string
+          maxItems: 1000
+          type: array
+      required:
+        - policyIds
+      title: bulk_upgrade_agentless_policies_request
+      type: object
+    Kibana_HTTP_APIs_bulk_upgrade_agentless_policy_result:
+      additionalProperties: false
+      properties:
+        body:
+          additionalProperties: false
+          type: object
+          properties:
+            message:
+              description: Error message when the upgrade failed for this policy.
+              type: string
+          required:
+            - message
+        id:
+          description: The ID of the agentless policy.
+          type: string
+        name:
+          description: The name of the agentless policy.
+          type: string
+        statusCode:
+          description: HTTP-like status code when the upgrade failed for this policy.
+          type: number
+        success:
+          description: Whether the policy's saved object was upgraded successfully. The live workload is reconciled asynchronously in the background.
+          type: boolean
+      required:
+        - id
+        - success
+      title: bulk_upgrade_agentless_policy_result
       type: object
     Kibana_HTTP_APIs_bulk_upgrade_packages_request:
       additionalProperties: false

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -29617,6 +29617,277 @@ paths:
       x-metaTags:
         - content: Kibana
           name: product_name
+  /api/fleet/agentless_policies/_upgrade:
+    post:
+      description: |-
+        **Spaces method and path for this operation:**
+
+        <div><span class="operation-verb post">post</span>&nbsp;<span class="operation-path">/s/{space_id}/api/fleet/agentless_policies/_upgrade</span></div>
+
+        Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
+
+        Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.
+      operationId: post-fleet-agentless-policies-upgrade
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              upgradeAgentlessPoliciesRequestExample:
+                description: Bulk upgrade agentless policies to their installed package version
+                value:
+                  policyIds:
+                    - d52a7812-5736-4fdc-aed8-72152afa1ffa
+                    - aws-policy-12345
+            schema:
+              $ref: '#/components/schemas/Kibana_HTTP_APIs_bulk_upgrade_agentless_policies_request'
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                upgradeAgentlessPoliciesPartialFailureResponseExample:
+                  description: Example response where one policy upgraded and another id was missing or not an agentless policy (the batch still returns 200)
+                  value:
+                    - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      success: true
+                    - body:
+                        message: Agentless policy aws-policy-12345 not found
+                      id: aws-policy-12345
+                      statusCode: 404
+                      success: false
+                upgradeAgentlessPoliciesResponseExample:
+                  description: Example response where every policy was upgraded
+                  value:
+                    - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      success: true
+                    - id: aws-policy-12345
+                      name: cspm-aws-policy
+                      success: true
+              schema:
+                items:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_bulk_upgrade_agentless_policy_result'
+                maxItems: 10000
+                type: array
+          description: 'Indicates a successful response. Each item reports the per-policy upgrade outcome; inspect every item''s `success` flag. A missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch.'
+        '400':
+          content:
+            application/json:
+              examples:
+                genericErrorResponseExample:
+                  description: Example of a generic error response
+                  value:
+                    error: Bad Request
+                    message: An error message describing what went wrong
+                    statusCode: 400
+              schema:
+                additionalProperties: false
+                description: Generic Error
+                type: object
+                properties:
+                  attributes:
+                    nullable: true
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+                  message:
+                    type: string
+                  statusCode:
+                    type: number
+                required:
+                  - message
+                  - attributes
+          description: Bad Request
+      summary: Bulk upgrade agentless policies
+      tags:
+        - Fleet agentless policies
+      x-state: Experimental; added in 9.5.0
+      x-metaTags:
+        - content: Kibana
+          name: product_name
+  /api/fleet/agentless_policies/_upgrade/dryrun:
+    post:
+      description: |-
+        **Spaces method and path for this operation:**
+
+        <div><span class="operation-verb post">post</span>&nbsp;<span class="operation-path">/s/{space_id}/api/fleet/agentless_policies/_upgrade/dryrun</span></div>
+
+        Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
+
+        Preview upgrading multiple agentless policies without applying any change. Targets the installed package version by default; pass `pkgVersion` to preview a specific (for example, not-yet-installed) version. Each result returns the current/proposed version and any migration errors, plus — only on a clean dry-run (`hasErrors: false`) — the migrated `proposedPolicy`. `proposedPolicy` is for the edit-and-upgrade flow (edit it, then save via the update (PUT) endpoint); to apply an upgrade as-is, use `_upgrade`.
+      operationId: post-fleet-agentless-policies-upgrade-dryrun
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              upgradeAgentlessPoliciesDryRunRequestExample:
+                description: Preview the upgrade of agentless policies to their installed package version
+                value:
+                  policyIds:
+                    - d52a7812-5736-4fdc-aed8-72152afa1ffa
+              upgradeAgentlessPoliciesDryRunTargetVersionRequestExample:
+                description: Preview the upgrade against an explicit target package version (for example, before installing the new version). Defaults to the installed package version when omitted.
+                value:
+                  pkgVersion: 1.6.0
+                  policyIds:
+                    - d52a7812-5736-4fdc-aed8-72152afa1ffa
+            schema:
+              $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_request'
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                upgradeAgentlessPoliciesDryRunMigrationErrorsExample:
+                  description: Example dry-run response where migrating the config to the new version produced errors. `hasErrors` is true and `errors` explains why; do not feed the (partial) proposed config into the update endpoint without resolving them.
+                  value:
+                    - currentVersion: 1.5.0
+                      errors:
+                        - message: Variable "organization_id" is required
+                      hasErrors: true
+                      id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      proposedVersion: 1.6.0
+                upgradeAgentlessPoliciesDryRunMixedResponseExample:
+                  description: 'Example dry-run response for a mixed batch: one policy previews cleanly while two ids are missing or not agentless. Missing / non-agentless ids are surfaced as per-item failures (`hasErrors: true` + `statusCode`) without failing the batch, and results stay in request order.'
+                  value:
+                    - currentVersion: 0.5.0
+                      hasErrors: false
+                      id: 2e426392-f856-4ab2-bc31-92d4dbb8d134
+                      name: agentless_hello_world-16
+                      proposedPolicy:
+                        cloud_connector: null
+                        created_at: '2026-07-01T15:59:08.299Z'
+                        created_by: admin
+                        description: ''
+                        id: 2e426392-f856-4ab2-bc31-92d4dbb8d134
+                        inputs:
+                          agentless_hello_world-cel:
+                            enabled: true
+                            streams:
+                              agentless_hello_world.generic:
+                                enabled: true
+                                vars:
+                                  url: https://epr.elastic.co
+                              agentless_hello_world.mock_counter:
+                                enabled: false
+                                vars:
+                                  events_per_second: 10
+                                  mode: constant
+                                  spike_events: 100
+                                  spike_every_seconds: 60
+                          agentless_hello_world-httpjson:
+                            enabled: false
+                            streams:
+                              agentless_hello_world.generic:
+                                enabled: false
+                                vars:
+                                  url: https://epr.elastic.co
+                        name: agentless_hello_world-16
+                        namespace: default
+                        package:
+                          name: agentless_hello_world
+                          title: Agentless Hello World
+                          version: 0.5.0
+                        updated_at: '2026-07-01T16:02:14.067Z'
+                        updated_by: admin
+                      proposedVersion: 0.5.0
+                    - body:
+                        message: Agentless policy 9300464c-6cfc-4566-850d-e9e7927457fe not found
+                      hasErrors: true
+                      id: 9300464c-6cfc-4566-850d-e9e7927457fe
+                      statusCode: 404
+                    - body:
+                        message: Agentless policy 5b8763e9-791a-4038-be29-b384d578200e not found
+                      hasErrors: true
+                      id: 5b8763e9-791a-4038-be29-b384d578200e
+                      statusCode: 404
+                upgradeAgentlessPoliciesDryRunResponseExample:
+                  description: 'Example clean dry-run response (`hasErrors: false`) with the proposed (migrated) policy. `proposedPolicy` is intended for the edit-and-upgrade flow: edit it and submit the edited payload to the update (PUT) endpoint. To apply without edits, use the `_upgrade` endpoint instead.'
+                  value:
+                    - currentVersion: 1.5.0
+                      hasErrors: false
+                      id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                      name: ess_billing-1
+                      proposedPolicy:
+                        created_at: '2025-11-06T18:27:43.541Z'
+                        created_by: test_user
+                        description: test
+                        id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                        inputs:
+                          ESS Billing-cel:
+                            enabled: true
+                            vars:
+                              organization_id: '1234'
+                        name: ess_billing-1
+                        namespace: default
+                        package:
+                          name: ess_billing
+                          title: Elasticsearch Service Billing
+                          version: 1.6.0
+                        updated_at: '2025-11-06T18:27:43.541Z'
+                        updated_by: test_user
+                      proposedVersion: 1.6.0
+              schema:
+                items:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_result'
+                maxItems: 10000
+                type: array
+          description: 'Indicates a successful response. Each clean item (`hasErrors: false`) previews the migrated policy as a consumable agentless policy (`proposedPolicy`); a missing or non-agentless id, or a migration error, is reported as a per-item failure (`hasErrors: true`, with `proposedPolicy` omitted) without failing the batch. Inspect every item.'
+        '400':
+          content:
+            application/json:
+              examples:
+                genericErrorResponseExample:
+                  description: Example of a generic error response
+                  value:
+                    error: Bad Request
+                    message: An error message describing what went wrong
+                    statusCode: 400
+              schema:
+                additionalProperties: false
+                description: Generic Error
+                type: object
+                properties:
+                  attributes:
+                    nullable: true
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+                  message:
+                    type: string
+                  statusCode:
+                    type: number
+                required:
+                  - message
+                  - attributes
+          description: Bad Request
+      summary: Preview an agentless policies upgrade
+      tags:
+        - Fleet agentless policies
+      x-state: Experimental; added in 9.5.0
+      x-metaTags:
+        - content: Kibana
+          name: product_name
   /api/fleet/agentless_policies/{policyId}:
     delete:
       description: |-
@@ -82289,6 +82560,73 @@ components:
         - item
       title: agentless_policy_response
       type: object
+    Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_request:
+      additionalProperties: false
+      properties:
+        pkgVersion:
+          description: Target package version to preview the upgrade against. Defaults to the installed package version.
+          maxLength: 256
+          type: string
+        policyIds:
+          description: IDs of the agentless policies to preview upgrading.
+          items:
+            maxLength: 256
+            type: string
+          maxItems: 1000
+          type: array
+      required:
+        - policyIds
+      title: agentless_policy_upgrade_dry_run_request
+      type: object
+    Kibana_HTTP_APIs_agentless_policy_upgrade_dry_run_result:
+      additionalProperties: false
+      properties:
+        body:
+          additionalProperties: false
+          type: object
+          properties:
+            message:
+              description: Error message when the dry-run failed for this policy.
+              type: string
+          required:
+            - message
+        currentVersion:
+          description: The current installed package version of the policy.
+          type: string
+        errors:
+          description: Migration errors encountered while computing the upgrade.
+          items:
+            additionalProperties: false
+            type: object
+            properties:
+              message:
+                description: Human-readable migration error.
+                type: string
+            required:
+              - message
+          type: array
+        hasErrors:
+          description: Whether the dry-run migration produced any errors.
+          type: boolean
+        id:
+          description: The ID of the agentless policy.
+          type: string
+        name:
+          description: The name of the agentless policy.
+          type: string
+        proposedPolicy:
+          $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy'
+        proposedVersion:
+          description: The package version the policy would be upgraded to.
+          type: string
+        statusCode:
+          description: HTTP-like status code when the dry-run failed for this policy.
+          type: number
+      required:
+        - id
+        - hasErrors
+      title: agentless_policy_upgrade_dry_run_result
+      type: object
     Kibana_HTTP_APIs_aiops_change_point_chart:
       additionalProperties: false
       description: Change point detection chart embeddable schema
@@ -83602,6 +83940,49 @@ components:
       required:
         - packages
       title: bulk_uninstall_packages_request
+      type: object
+    Kibana_HTTP_APIs_bulk_upgrade_agentless_policies_request:
+      additionalProperties: false
+      properties:
+        policyIds:
+          description: IDs of the agentless policies to upgrade to their installed package version.
+          items:
+            maxLength: 256
+            type: string
+          maxItems: 1000
+          type: array
+      required:
+        - policyIds
+      title: bulk_upgrade_agentless_policies_request
+      type: object
+    Kibana_HTTP_APIs_bulk_upgrade_agentless_policy_result:
+      additionalProperties: false
+      properties:
+        body:
+          additionalProperties: false
+          type: object
+          properties:
+            message:
+              description: Error message when the upgrade failed for this policy.
+              type: string
+          required:
+            - message
+        id:
+          description: The ID of the agentless policy.
+          type: string
+        name:
+          description: The name of the agentless policy.
+          type: string
+        statusCode:
+          description: HTTP-like status code when the upgrade failed for this policy.
+          type: number
+        success:
+          description: Whether the policy's saved object was upgraded successfully. The live workload is reconciled asynchronously in the background.
+          type: boolean
+      required:
+        - id
+        - success
+      title: bulk_upgrade_agentless_policy_result
       type: object
     Kibana_HTTP_APIs_bulk_upgrade_packages_request:
       additionalProperties: false

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -29626,7 +29626,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.
+        Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Policies already at the installed version are a genuine no-op: they still report `success: true` (calls stay idempotent) but nothing is re-persisted or redeployed. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.
       operationId: post-fleet-agentless-policies-upgrade
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -82587,11 +82587,13 @@ components:
           properties:
             message:
               description: Error message when the dry-run failed for this policy.
+              maxLength: 4096
               type: string
           required:
             - message
         currentVersion:
           description: The current installed package version of the policy.
+          maxLength: 256
           type: string
         errors:
           description: Migration errors encountered while computing the upgrade.
@@ -82601,23 +82603,28 @@ components:
             properties:
               message:
                 description: Human-readable migration error.
+                maxLength: 4096
                 type: string
             required:
               - message
+          maxItems: 1000
           type: array
         hasErrors:
           description: Whether the dry-run migration produced any errors.
           type: boolean
         id:
           description: The ID of the agentless policy.
+          maxLength: 256
           type: string
         name:
           description: The name of the agentless policy.
+          maxLength: 256
           type: string
         proposedPolicy:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_agentless_policy'
         proposedVersion:
           description: The package version the policy would be upgraded to.
+          maxLength: 256
           type: string
         statusCode:
           description: HTTP-like status code when the dry-run failed for this policy.
@@ -83964,14 +83971,17 @@ components:
           properties:
             message:
               description: Error message when the upgrade failed for this policy.
+              maxLength: 4096
               type: string
           required:
             - message
         id:
           description: The ID of the agentless policy.
+          maxLength: 256
           type: string
         name:
           description: The name of the agentless policy.
+          maxLength: 256
           type: string
         statusCode:
           description: HTTP-like status code when the upgrade failed for this policy.

--- a/x-pack/platform/plugins/shared/fleet/common/constants/routes.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/routes.ts
@@ -221,6 +221,8 @@ export const AGENTLESS_POLICIES_ROUTES = {
   GET_PATTERN: `${API_ROOT}/agentless_policies/{policyId}`,
   UPDATE_PATTERN: `${API_ROOT}/agentless_policies/{policyId}`,
   DELETE_PATTERN: `${API_ROOT}/agentless_policies/{policyId}`,
+  UPGRADE_PATTERN: `${API_ROOT}/agentless_policies/_upgrade`,
+  UPGRADE_DRYRUN_PATTERN: `${API_ROOT}/agentless_policies/_upgrade/dryrun`,
   SYNC_PATTERN: `${INTERNAL_ROOT}/agentless_policies/_sync`,
   BULK_THROUGHPUT_PATTERN: `${INTERNAL_ROOT}/agentless_policies/bulk_throughput`,
 };

--- a/x-pack/platform/plugins/shared/fleet/common/services/routes.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/routes.ts
@@ -240,6 +240,12 @@ export const agentlessPolicyRouteService = {
   getDeletePath: (policyId: string) => {
     return AGENTLESS_POLICIES_ROUTES.DELETE_PATTERN.replace('{policyId}', policyId);
   },
+  getUpgradePath: () => {
+    return AGENTLESS_POLICIES_ROUTES.UPGRADE_PATTERN;
+  },
+  getUpgradeDryRunPath: () => {
+    return AGENTLESS_POLICIES_ROUTES.UPGRADE_DRYRUN_PATTERN;
+  },
   getBulkThroughputPath: () => {
     return AGENTLESS_POLICIES_ROUTES.BULK_THROUGHPUT_PATTERN;
   },

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -345,6 +345,36 @@ export const BulkUpgradeAgentlessPoliciesRequestSchema = {
 };
 
 /**
+ * Request body for the upgrade dry-run endpoint. Extends the bulk-upgrade body with an
+ * optional `pkgVersion` so callers can preview a migration to a *not-yet-installed* target
+ * version — the UI upgrade flow computes the preview before installing the new package
+ * (mirrors the package-policy dry-run's `packageVersion`). When omitted, the target
+ * defaults to the installed package version.
+ */
+export const AgentlessPolicyUpgradeDryRunRequestSchema = {
+  body: schema.object(
+    {
+      policyIds: schema.arrayOf(schema.string({ maxLength: 256 }), {
+        maxSize: 1000,
+        meta: {
+          description: 'IDs of the agentless policies to preview upgrading.',
+        },
+      }),
+      pkgVersion: schema.maybe(
+        schema.string({
+          maxLength: 256,
+          meta: {
+            description:
+              'Target package version to preview the upgrade against. Defaults to the installed package version.',
+          },
+        })
+      ),
+    },
+    { meta: { id: 'agentless_policy_upgrade_dry_run_request' } }
+  ),
+};
+
+/**
  * Per-policy result of a bulk upgrade. Mirrors the package-policy
  * `UpgradePackagePolicyResponseItem`: a `success` flag plus an optional
  * `statusCode`/`body` carrying the per-policy failure. As with package-policy,

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -10,7 +10,10 @@ import { schema, type TypeOf } from '@kbn/config-schema';
 import { SO_SEARCH_LIMIT } from '../../constants';
 
 import { SimplifiedCreatePackagePolicyRequestBodySchema } from '../models/package_policy_schema';
-import type { AgentlessPolicyResponseSchema } from '../models/agentless_policy_schema';
+import {
+  AgentlessPolicySchema,
+  type AgentlessPolicyResponseSchema,
+} from '../models/agentless_policy_schema';
 import type { AgentlessPolicy } from '../models/agentless_policy';
 
 import type { ListResult } from './common';
@@ -317,3 +320,145 @@ export interface ListAgentlessPoliciesRequest {
 }
 
 export type ListAgentlessPoliciesResponse = ListResult<AgentlessPolicy>;
+
+/**
+ * Request body shared by the bulk upgrade and the upgrade dry-run endpoints.
+ *
+ * Only `policyIds` is accepted: the target is always the *installed* package version
+ * (mirrors the package-policy bulk upgrade default), so no explicit `pkgVersion` is
+ * exposed. Stays in agentless vocabulary (`policyIds`, matching the `bulk_throughput`
+ * endpoint) rather than the package-policy `packagePolicyIds` wording.
+ */
+export const BulkUpgradeAgentlessPoliciesRequestSchema = {
+  body: schema.object(
+    {
+      policyIds: schema.arrayOf(schema.string({ maxLength: 256 }), {
+        maxSize: 1000,
+        meta: {
+          description:
+            'IDs of the agentless policies to upgrade to their installed package version.',
+        },
+      }),
+    },
+    { meta: { id: 'bulk_upgrade_agentless_policies_request' } }
+  ),
+};
+
+/**
+ * Per-policy result of a bulk upgrade. Mirrors the package-policy
+ * `UpgradePackagePolicyResponseItem`: a `success` flag plus an optional
+ * `statusCode`/`body` carrying the per-policy failure. As with package-policy,
+ * `success: true` means the policy's saved object was upgraded; the live agentless
+ * workload is reconciled asynchronously by a background deploy task (with the
+ * deployment-sync task as a backstop), so success does not guarantee the workload
+ * is already running the new version.
+ */
+export const BulkUpgradeAgentlessPolicyResultSchema = schema.object(
+  {
+    id: schema.string({ meta: { description: 'The ID of the agentless policy.' } }),
+    name: schema.maybe(
+      schema.string({ meta: { description: 'The name of the agentless policy.' } })
+    ),
+    success: schema.boolean({
+      meta: {
+        description:
+          "Whether the policy's saved object was upgraded successfully. The live workload is reconciled asynchronously in the background.",
+      },
+    }),
+    statusCode: schema.maybe(
+      schema.number({
+        meta: { description: 'HTTP-like status code when the upgrade failed for this policy.' },
+      })
+    ),
+    body: schema.maybe(
+      schema.object({
+        message: schema.string({
+          meta: { description: 'Error message when the upgrade failed for this policy.' },
+        }),
+      })
+    ),
+  },
+  { meta: { id: 'bulk_upgrade_agentless_policy_result' } }
+);
+
+export const BulkUpgradeAgentlessPoliciesResponseSchema = schema.arrayOf(
+  BulkUpgradeAgentlessPolicyResultSchema,
+  { maxSize: 10000 }
+);
+
+/**
+ * Per-policy result of an upgrade dry-run. Instead of exposing the underlying
+ * `[PackagePolicy, DryRunPackagePolicy]` diff (Fleet internals), it returns the
+ * migrated config as a clean {@link AgentlessPolicy} in `proposedPolicy`, designed so
+ * it can be fed straight into the agentless PUT (`sendUpdateAgentlessPolicy`) for the
+ * UI edit-and-upgrade flow. `currentVersion`/`proposedVersion` and `hasErrors`/`errors`
+ * summarize the change without leaking internal input/stream shapes.
+ */
+export const AgentlessPolicyUpgradeDryRunResultSchema = schema.object(
+  {
+    id: schema.string({ meta: { description: 'The ID of the agentless policy.' } }),
+    name: schema.maybe(
+      schema.string({ meta: { description: 'The name of the agentless policy.' } })
+    ),
+    hasErrors: schema.boolean({
+      meta: { description: 'Whether the dry-run migration produced any errors.' },
+    }),
+    currentVersion: schema.maybe(
+      schema.string({
+        meta: { description: 'The current installed package version of the policy.' },
+      })
+    ),
+    proposedVersion: schema.maybe(
+      schema.string({
+        meta: { description: 'The package version the policy would be upgraded to.' },
+      })
+    ),
+    proposedPolicy: schema.maybe(AgentlessPolicySchema),
+    errors: schema.maybe(
+      schema.arrayOf(
+        schema.object({
+          message: schema.string({ meta: { description: 'Human-readable migration error.' } }),
+        }),
+        { meta: { description: 'Migration errors encountered while computing the upgrade.' } }
+      )
+    ),
+    statusCode: schema.maybe(
+      schema.number({
+        meta: { description: 'HTTP-like status code when the dry-run failed for this policy.' },
+      })
+    ),
+    body: schema.maybe(
+      schema.object({
+        message: schema.string({
+          meta: { description: 'Error message when the dry-run failed for this policy.' },
+        }),
+      })
+    ),
+  },
+  { meta: { id: 'agentless_policy_upgrade_dry_run_result' } }
+);
+
+export const AgentlessPolicyUpgradeDryRunResponseSchema = schema.arrayOf(
+  AgentlessPolicyUpgradeDryRunResultSchema,
+  { maxSize: 10000 }
+);
+
+export interface BulkUpgradeAgentlessPoliciesRequest {
+  body: TypeOf<typeof BulkUpgradeAgentlessPoliciesRequestSchema.body>;
+}
+
+export type BulkUpgradeAgentlessPolicyResult = TypeOf<
+  typeof BulkUpgradeAgentlessPolicyResultSchema
+>;
+
+export type BulkUpgradeAgentlessPoliciesResponse = TypeOf<
+  typeof BulkUpgradeAgentlessPoliciesResponseSchema
+>;
+
+export type AgentlessPolicyUpgradeDryRunResult = TypeOf<
+  typeof AgentlessPolicyUpgradeDryRunResultSchema
+>;
+
+export type AgentlessPolicyUpgradeDryRunResponse = TypeOf<
+  typeof AgentlessPolicyUpgradeDryRunResponseSchema
+>;

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -385,9 +385,9 @@ export const AgentlessPolicyUpgradeDryRunRequestSchema = {
  */
 export const BulkUpgradeAgentlessPolicyResultSchema = schema.object(
   {
-    id: schema.string({ meta: { description: 'The ID of the agentless policy.' } }),
+    id: schema.string({ maxLength: 256, meta: { description: 'The ID of the agentless policy.' } }),
     name: schema.maybe(
-      schema.string({ meta: { description: 'The name of the agentless policy.' } })
+      schema.string({ maxLength: 256, meta: { description: 'The name of the agentless policy.' } })
     ),
     success: schema.boolean({
       meta: {
@@ -403,6 +403,7 @@ export const BulkUpgradeAgentlessPolicyResultSchema = schema.object(
     body: schema.maybe(
       schema.object({
         message: schema.string({
+          maxLength: 4096,
           meta: { description: 'Error message when the upgrade failed for this policy.' },
         }),
       })
@@ -426,20 +427,22 @@ export const BulkUpgradeAgentlessPoliciesResponseSchema = schema.arrayOf(
  */
 export const AgentlessPolicyUpgradeDryRunResultSchema = schema.object(
   {
-    id: schema.string({ meta: { description: 'The ID of the agentless policy.' } }),
+    id: schema.string({ maxLength: 256, meta: { description: 'The ID of the agentless policy.' } }),
     name: schema.maybe(
-      schema.string({ meta: { description: 'The name of the agentless policy.' } })
+      schema.string({ maxLength: 256, meta: { description: 'The name of the agentless policy.' } })
     ),
     hasErrors: schema.boolean({
       meta: { description: 'Whether the dry-run migration produced any errors.' },
     }),
     currentVersion: schema.maybe(
       schema.string({
+        maxLength: 256,
         meta: { description: 'The current installed package version of the policy.' },
       })
     ),
     proposedVersion: schema.maybe(
       schema.string({
+        maxLength: 256,
         meta: { description: 'The package version the policy would be upgraded to.' },
       })
     ),
@@ -450,9 +453,15 @@ export const AgentlessPolicyUpgradeDryRunResultSchema = schema.object(
     errors: schema.maybe(
       schema.arrayOf(
         schema.object({
-          message: schema.string({ meta: { description: 'Human-readable migration error.' } }),
+          message: schema.string({
+            maxLength: 4096,
+            meta: { description: 'Human-readable migration error.' },
+          }),
         }),
-        { meta: { description: 'Migration errors encountered while computing the upgrade.' } }
+        {
+          maxSize: 1000,
+          meta: { description: 'Migration errors encountered while computing the upgrade.' },
+        }
       )
     ),
     statusCode: schema.maybe(
@@ -463,6 +472,7 @@ export const AgentlessPolicyUpgradeDryRunResultSchema = schema.object(
     body: schema.maybe(
       schema.object({
         message: schema.string({
+          maxLength: 4096,
           meta: { description: 'Error message when the dry-run failed for this policy.' },
         }),
       })

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -417,12 +417,12 @@ export const BulkUpgradeAgentlessPoliciesResponseSchema = schema.arrayOf(
 );
 
 /**
- * Per-policy result of an upgrade dry-run. Instead of exposing the underlying
- * `[PackagePolicy, DryRunPackagePolicy]` diff (Fleet internals), it returns the
- * migrated config as a clean {@link AgentlessPolicy} in `proposedPolicy`, designed so
- * it can be fed straight into the agentless PUT (`sendUpdateAgentlessPolicy`) for the
- * UI edit-and-upgrade flow. `currentVersion`/`proposedVersion` and `hasErrors`/`errors`
- * summarize the change without leaking internal input/stream shapes.
+ * Per-policy result of an upgrade dry-run. Rather than leaking the raw Fleet-internal
+ * `[PackagePolicy, DryRunPackagePolicy]` diff, it summarizes the change via
+ * `currentVersion`/`proposedVersion` and `hasErrors`/`errors`. Only on a clean dry-run
+ * (`hasErrors: false`) does it also include the migrated config as a clean {@link AgentlessPolicy}
+ * in `proposedPolicy`, meant to be edited and saved via the agentless PUT — not applied as-is
+ * (to apply an upgrade untouched, use `_upgrade`). On error, `proposedPolicy` is omitted.
  */
 export const AgentlessPolicyUpgradeDryRunResultSchema = schema.object(
   {
@@ -443,6 +443,9 @@ export const AgentlessPolicyUpgradeDryRunResultSchema = schema.object(
         meta: { description: 'The package version the policy would be upgraded to.' },
       })
     ),
+    // Returned only when the dry-run is clean (`hasErrors: false`); omitted on migration errors.
+    // Intended for the edit-and-upgrade flow (edit it, then submit via PUT), not a no-edit apply
+    // of `_upgrade`. See the schema-level doc comment above for the full contract.
     proposedPolicy: schema.maybe(AgentlessPolicySchema),
     errors: schema.maybe(
       schema.arrayOf(

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
@@ -11,6 +11,8 @@ import { API_VERSIONS } from '../../../common';
 
 import { agentlessPolicyRouteService } from '../../../common/services';
 import type {
+  AgentlessPolicyUpgradeDryRunResponse,
+  BulkUpgradeAgentlessPoliciesResponse,
   CreateAgentlessPolicyRequest,
   CreateAgentlessPolicyResponse,
   DeleteAgentlessPolicyRequest,
@@ -56,6 +58,24 @@ export const sendDeleteAgentlessPolicy = (
     method: 'delete',
     version: API_VERSIONS.public.v1,
     query,
+  });
+};
+
+export const sendBulkUpgradeAgentlessPolicies = (policyIds: string[]) => {
+  return sendRequestForRq<BulkUpgradeAgentlessPoliciesResponse>({
+    path: agentlessPolicyRouteService.getUpgradePath(),
+    method: 'post',
+    version: API_VERSIONS.public.v1,
+    body: JSON.stringify({ policyIds }),
+  });
+};
+
+export const sendUpgradeAgentlessPoliciesDryRun = (policyIds: string[]) => {
+  return sendRequestForRq<AgentlessPolicyUpgradeDryRunResponse>({
+    path: agentlessPolicyRouteService.getUpgradeDryRunPath(),
+    method: 'post',
+    version: API_VERSIONS.public.v1,
+    body: JSON.stringify({ policyIds }),
   });
 };
 

--- a/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
@@ -327,6 +327,8 @@ export const createMockAgentlessPoliciesService = (): jest.Mocked<AgentlessPolic
     listAgentlessPolicies: jest
       .fn()
       .mockReturnValue(Promise.resolve({ items: [], total: 0, page: 1, perPage: 20 })),
+    bulkUpgradeAgentlessPolicies: jest.fn().mockReturnValue(Promise.resolve([])),
+    getAgentlessPolicyUpgradeDryRunDiff: jest.fn().mockReturnValue(Promise.resolve([])),
   };
 };
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies.yaml
@@ -1,0 +1,47 @@
+requestBody:
+  content:
+    application/json:
+      examples:
+        upgradeAgentlessPoliciesRequestExample:
+          description: 'Bulk upgrade agentless policies to their installed package version'
+          value:
+            policyIds:
+              - d52a7812-5736-4fdc-aed8-72152afa1ffa
+              - aws-policy-12345
+responses:
+  200:
+    description: 'Indicates a successful response. Each item reports the per-policy upgrade outcome; inspect every item''s `success` flag.'
+    content:
+      application/json:
+        examples:
+          upgradeAgentlessPoliciesResponseExample:
+            description: 'Example response where every policy was upgraded'
+            value:
+              - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                name: ess_billing-1
+                success: true
+              - id: aws-policy-12345
+                name: cspm-aws-policy
+                success: true
+  400:
+    description: 'Bad Request'
+    content:
+      application/json:
+        examples:
+          genericErrorResponseExample:
+            description: 'Example of a generic error response'
+            value:
+              statusCode: 400
+              error: 'Bad Request'
+              message: 'An error message describing what went wrong'
+  404:
+    description: 'Returned when a requested policy does not exist or is not an agentless policy. The first such per-policy failure in the batch is returned as a top-level error.'
+    content:
+      application/json:
+        examples:
+          notFoundResponseExample:
+            description: 'Example of a not-found error response'
+            value:
+              statusCode: 404
+              error: 'Not Found'
+              message: 'Agentless policy aws-policy-12345 not found'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies.yaml
@@ -10,7 +10,7 @@ requestBody:
               - aws-policy-12345
 responses:
   200:
-    description: 'Indicates a successful response. Each item reports the per-policy upgrade outcome; inspect every item''s `success` flag.'
+    description: 'Indicates a successful response. Each item reports the per-policy upgrade outcome; inspect every item''s `success` flag. A missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch.'
     content:
       application/json:
         examples:
@@ -23,6 +23,17 @@ responses:
               - id: aws-policy-12345
                 name: cspm-aws-policy
                 success: true
+          upgradeAgentlessPoliciesPartialFailureResponseExample:
+            description: 'Example response where one policy upgraded and another id was missing or not an agentless policy (the batch still returns 200)'
+            value:
+              - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                name: ess_billing-1
+                success: true
+              - id: aws-policy-12345
+                success: false
+                statusCode: 404
+                body:
+                  message: 'Agentless policy aws-policy-12345 not found'
   400:
     description: 'Bad Request'
     content:
@@ -34,14 +45,3 @@ responses:
               statusCode: 400
               error: 'Bad Request'
               message: 'An error message describing what went wrong'
-  404:
-    description: 'Returned when a requested policy does not exist or is not an agentless policy. The first such per-policy failure in the batch is returned as a top-level error.'
-    content:
-      application/json:
-        examples:
-          notFoundResponseExample:
-            description: 'Example of a not-found error response'
-            value:
-              statusCode: 404
-              error: 'Not Found'
-              message: 'Agentless policy aws-policy-12345 not found'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
@@ -1,0 +1,73 @@
+requestBody:
+  content:
+    application/json:
+      examples:
+        upgradeAgentlessPoliciesDryRunRequestExample:
+          description: 'Preview the upgrade of agentless policies to their installed package version'
+          value:
+            policyIds:
+              - d52a7812-5736-4fdc-aed8-72152afa1ffa
+responses:
+  200:
+    description: 'Indicates a successful response. Each item previews the migrated policy as a consumable agentless policy.'
+    content:
+      application/json:
+        examples:
+          upgradeAgentlessPoliciesDryRunResponseExample:
+            description: 'Example dry-run response with the proposed (migrated) policy. `proposedPolicy` can be fed back into the update (PUT) endpoint.'
+            value:
+              - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                name: ess_billing-1
+                hasErrors: false
+                currentVersion: 1.5.0
+                proposedVersion: 1.6.0
+                proposedPolicy:
+                  id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                  name: ess_billing-1
+                  description: test
+                  namespace: default
+                  package:
+                    name: ess_billing
+                    title: Elasticsearch Service Billing
+                    version: 1.6.0
+                  inputs:
+                    ESS Billing-cel:
+                      enabled: true
+                      vars:
+                        organization_id: '1234'
+                  created_at: '2025-11-06T18:27:43.541Z'
+                  created_by: test_user
+                  updated_at: '2025-11-06T18:27:43.541Z'
+                  updated_by: test_user
+          upgradeAgentlessPoliciesDryRunMigrationErrorsExample:
+            description: 'Example dry-run response where migrating the config to the new version produced errors. `hasErrors` is true and `errors` explains why; do not feed the (partial) proposed config into the update endpoint without resolving them.'
+            value:
+              - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                name: ess_billing-1
+                hasErrors: true
+                currentVersion: 1.5.0
+                proposedVersion: 1.6.0
+                errors:
+                  - message: 'Variable "organization_id" is required'
+  400:
+    description: 'Bad Request'
+    content:
+      application/json:
+        examples:
+          genericErrorResponseExample:
+            description: 'Example of a generic error response'
+            value:
+              statusCode: 400
+              error: 'Bad Request'
+              message: 'An error message describing what went wrong'
+  404:
+    description: 'Returned when a requested policy does not exist or is not an agentless policy. The first such per-policy failure in the batch is returned as a top-level error.'
+    content:
+      application/json:
+        examples:
+          notFoundResponseExample:
+            description: 'Example of a not-found error response'
+            value:
+              statusCode: 404
+              error: 'Not Found'
+              message: 'Agentless policy d52a7812-5736-4fdc-aed8-72152afa1ffa not found'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
@@ -9,7 +9,7 @@ requestBody:
               - d52a7812-5736-4fdc-aed8-72152afa1ffa
 responses:
   200:
-    description: 'Indicates a successful response. Each item previews the migrated policy as a consumable agentless policy.'
+    description: 'Indicates a successful response. Each item previews the migrated policy as a consumable agentless policy; a missing or non-agentless id is reported as a per-item failure (`hasErrors: true` + `statusCode`) without failing the batch. Inspect every item.'
     content:
       application/json:
         examples:
@@ -49,6 +49,60 @@ responses:
                 proposedVersion: 1.6.0
                 errors:
                   - message: 'Variable "organization_id" is required'
+          upgradeAgentlessPoliciesDryRunMixedResponseExample:
+            description: 'Example dry-run response for a mixed batch: one policy previews cleanly while two ids are missing or not agentless. Missing / non-agentless ids are surfaced as per-item failures (`hasErrors: true` + `statusCode`) without failing the batch, and results stay in request order.'
+            value:
+              - id: 2e426392-f856-4ab2-bc31-92d4dbb8d134
+                name: agentless_hello_world-16
+                hasErrors: false
+                currentVersion: 0.5.0
+                proposedVersion: 0.5.0
+                proposedPolicy:
+                  id: 2e426392-f856-4ab2-bc31-92d4dbb8d134
+                  name: agentless_hello_world-16
+                  description: ''
+                  namespace: default
+                  package:
+                    name: agentless_hello_world
+                    title: Agentless Hello World
+                    version: 0.5.0
+                  inputs:
+                    agentless_hello_world-cel:
+                      enabled: true
+                      streams:
+                        agentless_hello_world.generic:
+                          enabled: true
+                          vars:
+                            url: https://epr.elastic.co
+                        agentless_hello_world.mock_counter:
+                          enabled: false
+                          vars:
+                            mode: constant
+                            events_per_second: 10
+                            spike_events: 100
+                            spike_every_seconds: 60
+                    agentless_hello_world-httpjson:
+                      enabled: false
+                      streams:
+                        agentless_hello_world.generic:
+                          enabled: false
+                          vars:
+                            url: https://epr.elastic.co
+                  cloud_connector: null
+                  created_at: '2026-07-01T15:59:08.299Z'
+                  created_by: admin
+                  updated_at: '2026-07-01T16:02:14.067Z'
+                  updated_by: admin
+              - id: 9300464c-6cfc-4566-850d-e9e7927457fe
+                hasErrors: true
+                statusCode: 404
+                body:
+                  message: 'Agentless policy 9300464c-6cfc-4566-850d-e9e7927457fe not found'
+              - id: 5b8763e9-791a-4038-be29-b384d578200e
+                hasErrors: true
+                statusCode: 404
+                body:
+                  message: 'Agentless policy 5b8763e9-791a-4038-be29-b384d578200e not found'
   400:
     description: 'Bad Request'
     content:
@@ -60,14 +114,3 @@ responses:
               statusCode: 400
               error: 'Bad Request'
               message: 'An error message describing what went wrong'
-  404:
-    description: 'Returned when a requested policy does not exist or is not an agentless policy. The first such per-policy failure in the batch is returned as a top-level error.'
-    content:
-      application/json:
-        examples:
-          notFoundResponseExample:
-            description: 'Example of a not-found error response'
-            value:
-              statusCode: 404
-              error: 'Not Found'
-              message: 'Agentless policy d52a7812-5736-4fdc-aed8-72152afa1ffa not found'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
@@ -15,12 +15,12 @@ requestBody:
             pkgVersion: 1.6.0
 responses:
   200:
-    description: 'Indicates a successful response. Each item previews the migrated policy as a consumable agentless policy; a missing or non-agentless id is reported as a per-item failure (`hasErrors: true` + `statusCode`) without failing the batch. Inspect every item.'
+    description: 'Indicates a successful response. Each clean item (`hasErrors: false`) previews the migrated policy as a consumable agentless policy (`proposedPolicy`); a missing or non-agentless id, or a migration error, is reported as a per-item failure (`hasErrors: true`, with `proposedPolicy` omitted) without failing the batch. Inspect every item.'
     content:
       application/json:
         examples:
           upgradeAgentlessPoliciesDryRunResponseExample:
-            description: 'Example dry-run response with the proposed (migrated) policy. `proposedPolicy` can be fed back into the update (PUT) endpoint.'
+            description: 'Example clean dry-run response (`hasErrors: false`) with the proposed (migrated) policy. `proposedPolicy` is intended for the edit-and-upgrade flow: edit it and submit the edited payload to the update (PUT) endpoint. To apply without edits, use the `_upgrade` endpoint instead.'
             value:
               - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
                 name: ess_billing-1

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/upgrade_agentless_policies_dryrun.yaml
@@ -7,6 +7,12 @@ requestBody:
           value:
             policyIds:
               - d52a7812-5736-4fdc-aed8-72152afa1ffa
+        upgradeAgentlessPoliciesDryRunTargetVersionRequestExample:
+          description: 'Preview the upgrade against an explicit target package version (for example, before installing the new version). Defaults to the installed package version when omitted.'
+          value:
+            policyIds:
+              - d52a7812-5736-4fdc-aed8-72152afa1ffa
+            pkgVersion: 1.6.0
 responses:
   200:
     description: 'Indicates a successful response. Each item previews the migrated policy as a consumable agentless policy; a missing or non-agentless id is reported as a per-item failure (`hasErrors: true` + `statusCode`) without failing the batch. Inspect every item.'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -7,12 +7,14 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import pMap from 'p-map';
+import { uniq } from 'lodash';
 
 import type { CreateAgentlessPolicyRequestSchema } from '../../../common/types';
 import { appContextService, packagePolicyService } from '../../services';
 import type { FleetRequestHandler, ListAgentlessPoliciesRequestSchema } from '../../types';
 import { AgentlessPoliciesServiceImpl } from '../../services/agentless/agentless_policies';
 import type {
+  BulkUpgradeAgentlessPoliciesRequestSchema,
   DeleteAgentlessPolicyRequestSchema,
   GetBulkAgentlessPolicyThroughputRequestSchema,
   GetAgentlessPolicyRequestSchema,
@@ -115,6 +117,81 @@ export const updateAgentlessPolicyHandler: FleetRequestHandler<
       item,
     },
   });
+};
+
+export const bulkUpgradeAgentlessPoliciesHandler: FleetRequestHandler<
+  undefined,
+  undefined,
+  TypeOf<typeof BulkUpgradeAgentlessPoliciesRequestSchema.body>
+> = async (context, request, response) => {
+  const [coreContext, fleetContext] = await Promise.all([context.core, context.fleet]);
+
+  const soClient = coreContext.savedObjects.client;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
+
+  const logger = appContextService.getLogger().get('agentless');
+
+  const agentlessPoliciesService = new AgentlessPoliciesServiceImpl(
+    fleetContext.packagePolicyService.asCurrentUser,
+    soClient,
+    esClient,
+    logger
+  );
+
+  const policyIds = uniq(request.body.policyIds);
+  const body = await agentlessPoliciesService.bulkUpgradeAgentlessPolicies(policyIds, request);
+
+  // Mirror the package-policy bulk upgrade handler: promote the first per-policy fatal
+  // error (a 404 guard failure or an ineligible-upgrade error) to a top-level HTTP error
+  // so consumers and error-rate monitoring see a non-2xx. Note this returns a message-only
+  // body: the per-policy array is only returned on the 200 path, so any ids that upgraded
+  // successfully in the same batch are persisted but not reported back to the caller here.
+  const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
+  if (firstFatalError?.statusCode) {
+    return response.customError({
+      statusCode: firstFatalError.statusCode,
+      body: { message: firstFatalError.body?.message ?? 'Bulk upgrade failed' },
+    });
+  }
+
+  return response.ok({ body });
+};
+
+export const upgradeAgentlessPoliciesDryRunHandler: FleetRequestHandler<
+  undefined,
+  undefined,
+  TypeOf<typeof BulkUpgradeAgentlessPoliciesRequestSchema.body>
+> = async (context, request, response) => {
+  const [coreContext, fleetContext] = await Promise.all([context.core, context.fleet]);
+
+  const soClient = coreContext.savedObjects.client;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
+
+  const logger = appContextService.getLogger().get('agentless');
+
+  const agentlessPoliciesService = new AgentlessPoliciesServiceImpl(
+    fleetContext.packagePolicyService.asCurrentUser,
+    soClient,
+    esClient,
+    logger
+  );
+
+  const policyIds = uniq(request.body.policyIds);
+  const body = await agentlessPoliciesService.getAgentlessPolicyUpgradeDryRunDiff(policyIds);
+
+  // Mirror the package-policy dry-run handler: a per-policy hard failure (guard 404 or a
+  // fatal dry-run error) is promoted to a top-level HTTP error with a message-only body,
+  // so the per-policy previews are only returned on the 200 path. Soft migration errors
+  // (which carry `errors`/`proposedPolicy` but no `statusCode`) keep the batch at 200.
+  const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
+  if (firstFatalError?.statusCode) {
+    return response.customError({
+      statusCode: firstFatalError.statusCode,
+      body: { message: firstFatalError.body?.message ?? 'Upgrade dry-run failed' },
+    });
+  }
+
+  return response.ok({ body });
 };
 
 export const getAgentlessPolicyHandler: FleetRequestHandler<

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -141,19 +141,11 @@ export const bulkUpgradeAgentlessPoliciesHandler: FleetRequestHandler<
   const policyIds = uniq(request.body.policyIds);
   const body = await agentlessPoliciesService.bulkUpgradeAgentlessPolicies(policyIds, request);
 
-  // Mirror the package-policy bulk upgrade handler: promote the first per-policy fatal
-  // error (a 404 guard failure or an ineligible-upgrade error) to a top-level HTTP error
-  // so consumers and error-rate monitoring see a non-2xx. Note this returns a message-only
-  // body: the per-policy array is only returned on the 200 path, so any ids that upgraded
-  // successfully in the same batch are persisted but not reported back to the caller here.
-  const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
-  if (firstFatalError?.statusCode) {
-    return response.customError({
-      statusCode: firstFatalError.statusCode,
-      body: { message: firstFatalError.body?.message ?? 'Bulk upgrade failed' },
-    });
-  }
-
+  // Unlike the package-policy bulk upgrade handler, we deliberately do NOT promote the first
+  // per-policy fatal error to a top-level HTTP status. The batch always returns 200 with the
+  // full per-policy array, so a caller sees every outcome — which ids upgraded and which
+  // failed (with their per-item `success: false` / `statusCode` / `body`) — instead of a
+  // single top-level error that would hide a partially-successful batch.
   return response.ok({ body });
 };
 
@@ -179,18 +171,11 @@ export const upgradeAgentlessPoliciesDryRunHandler: FleetRequestHandler<
   const policyIds = uniq(request.body.policyIds);
   const body = await agentlessPoliciesService.getAgentlessPolicyUpgradeDryRunDiff(policyIds);
 
-  // Mirror the package-policy dry-run handler: a per-policy hard failure (guard 404 or a
-  // fatal dry-run error) is promoted to a top-level HTTP error with a message-only body,
-  // so the per-policy previews are only returned on the 200 path. Soft migration errors
-  // (which carry `errors`/`proposedPolicy` but no `statusCode`) keep the batch at 200.
-  const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
-  if (firstFatalError?.statusCode) {
-    return response.customError({
-      statusCode: firstFatalError.statusCode,
-      body: { message: firstFatalError.body?.message ?? 'Upgrade dry-run failed' },
-    });
-  }
-
+  // Unlike the package-policy dry-run handler, we deliberately do NOT promote a per-policy
+  // hard failure (guard 404 or fatal dry-run error) to a top-level HTTP status. The batch
+  // always returns 200 with the full per-policy array, so a caller sees every preview
+  // alongside any per-item failures (`statusCode` / `body`) and soft migration errors
+  // (`errors`).
   return response.ok({ body });
 };
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -14,6 +14,7 @@ import { appContextService, packagePolicyService } from '../../services';
 import type { FleetRequestHandler, ListAgentlessPoliciesRequestSchema } from '../../types';
 import { AgentlessPoliciesServiceImpl } from '../../services/agentless/agentless_policies';
 import type {
+  AgentlessPolicyUpgradeDryRunRequestSchema,
   BulkUpgradeAgentlessPoliciesRequestSchema,
   DeleteAgentlessPolicyRequestSchema,
   GetBulkAgentlessPolicyThroughputRequestSchema,
@@ -152,7 +153,7 @@ export const bulkUpgradeAgentlessPoliciesHandler: FleetRequestHandler<
 export const upgradeAgentlessPoliciesDryRunHandler: FleetRequestHandler<
   undefined,
   undefined,
-  TypeOf<typeof BulkUpgradeAgentlessPoliciesRequestSchema.body>
+  TypeOf<typeof AgentlessPolicyUpgradeDryRunRequestSchema.body>
 > = async (context, request, response) => {
   const [coreContext, fleetContext] = await Promise.all([context.core, context.fleet]);
 
@@ -169,7 +170,10 @@ export const upgradeAgentlessPoliciesDryRunHandler: FleetRequestHandler<
   );
 
   const policyIds = uniq(request.body.policyIds);
-  const body = await agentlessPoliciesService.getAgentlessPolicyUpgradeDryRunDiff(policyIds);
+  const body = await agentlessPoliciesService.getAgentlessPolicyUpgradeDryRunDiff(
+    policyIds,
+    request.body.pkgVersion
+  );
 
   // Unlike the package-policy dry-run handler, we deliberately do NOT promote a per-policy
   // hard failure (guard 404 or fatal dry-run error) to a top-level HTTP status. The batch

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -9,6 +9,9 @@ import path from 'node:path';
 import { schema } from '@kbn/config-schema';
 
 import {
+  BulkUpgradeAgentlessPoliciesRequestSchema,
+  BulkUpgradeAgentlessPoliciesResponseSchema,
+  AgentlessPolicyUpgradeDryRunResponseSchema,
   CreateAgentlessPolicyRequestSchema,
   DeleteAgentlessPolicyRequestSchema,
   DeleteAgentlessPolicyResponseSchema,
@@ -26,6 +29,7 @@ import { FLEET_API_PRIVILEGES } from '../../constants/api_privileges';
 import { genericErrorResponse, notFoundResponse } from '../schema/errors';
 
 import {
+  bulkUpgradeAgentlessPoliciesHandler,
   createAgentlessPolicyHandler,
   deleteAgentlessPolicyHandler,
   getAgentlessPolicyHandler,
@@ -33,6 +37,7 @@ import {
   syncAgentlessPoliciesHandler,
   getBulkAgentlessPolicyThroughputHandler,
   updateAgentlessPolicyHandler,
+  upgradeAgentlessPoliciesDryRunHandler,
 } from './handler';
 
 export const registerRoutes = (router: FleetAuthzRouter) => {
@@ -311,6 +316,92 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         },
       },
       deleteAgentlessPolicyHandler
+    );
+
+  // Bulk upgrade
+  router.versioned
+    // @ts-ignore https://github.com/elastic/kibana/issues/203170
+    .post({
+      path: AGENTLESS_POLICIES_ROUTES.UPGRADE_PATTERN,
+      summary: 'Bulk upgrade agentless policies',
+      description:
+        "Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. On success, returns a per-policy result array; the first per-policy failure (for example a missing or non-agentless id) is returned as a top-level HTTP error. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.",
+      options: {
+        tags: ['oas-tag:Fleet agentless policies'],
+        availability: {
+          since: '9.5.0',
+          stability: 'experimental',
+        },
+      },
+      fleetAuthz: {
+        integrations: { writeIntegrationPolicies: true },
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.public.v1,
+        options: {
+          oasOperationObject: () =>
+            path.join(__dirname, 'examples/upgrade_agentless_policies.yaml'),
+        },
+        validate: {
+          request: BulkUpgradeAgentlessPoliciesRequestSchema,
+          response: {
+            200: {
+              description: 'OK: A successful request.',
+              body: () => BulkUpgradeAgentlessPoliciesResponseSchema,
+            },
+            400: {
+              description: 'A bad request.',
+              body: genericErrorResponse,
+            },
+          },
+        },
+      },
+      bulkUpgradeAgentlessPoliciesHandler
+    );
+
+  // Bulk upgrade dry-run
+  router.versioned
+    // @ts-ignore https://github.com/elastic/kibana/issues/203170
+    .post({
+      path: AGENTLESS_POLICIES_ROUTES.UPGRADE_DRYRUN_PATTERN,
+      summary: 'Preview an agentless policies upgrade',
+      description:
+        'Preview upgrading multiple agentless policies to their installed package version without applying any change. Each result returns the migrated config as a consumable agentless policy (`proposedPolicy`) plus the current/proposed version and any migration errors.',
+      options: {
+        tags: ['oas-tag:Fleet agentless policies'],
+        availability: {
+          since: '9.5.0',
+          stability: 'experimental',
+        },
+      },
+      fleetAuthz: {
+        integrations: { readIntegrationPolicies: true },
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.public.v1,
+        options: {
+          oasOperationObject: () =>
+            path.join(__dirname, 'examples/upgrade_agentless_policies_dryrun.yaml'),
+        },
+        validate: {
+          request: BulkUpgradeAgentlessPoliciesRequestSchema,
+          response: {
+            200: {
+              description: 'OK: A successful request.',
+              body: () => AgentlessPolicyUpgradeDryRunResponseSchema,
+            },
+            400: {
+              description: 'A bad request.',
+              body: genericErrorResponse,
+            },
+          },
+        },
+      },
+      upgradeAgentlessPoliciesDryRunHandler
     );
 
   // Bulk throughput

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -325,7 +325,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       path: AGENTLESS_POLICIES_ROUTES.UPGRADE_PATTERN,
       summary: 'Bulk upgrade agentless policies',
       description:
-        "Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. On success, returns a per-policy result array; the first per-policy failure (for example a missing or non-agentless id) is returned as a top-level HTTP error. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.",
+        "Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.",
       options: {
         tags: ['oas-tag:Fleet agentless policies'],
         availability: {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -11,6 +11,7 @@ import { schema } from '@kbn/config-schema';
 import {
   BulkUpgradeAgentlessPoliciesRequestSchema,
   BulkUpgradeAgentlessPoliciesResponseSchema,
+  AgentlessPolicyUpgradeDryRunRequestSchema,
   AgentlessPolicyUpgradeDryRunResponseSchema,
   CreateAgentlessPolicyRequestSchema,
   DeleteAgentlessPolicyRequestSchema,
@@ -368,7 +369,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       path: AGENTLESS_POLICIES_ROUTES.UPGRADE_DRYRUN_PATTERN,
       summary: 'Preview an agentless policies upgrade',
       description:
-        'Preview upgrading multiple agentless policies to their installed package version without applying any change. Each result returns the migrated config as a consumable agentless policy (`proposedPolicy`) plus the current/proposed version and any migration errors.',
+        'Preview upgrading multiple agentless policies without applying any change. By default the target is the installed package version; pass `pkgVersion` to preview a migration to a specific (for example, not-yet-installed) version. Each result returns the migrated config as a consumable agentless policy (`proposedPolicy`) plus the current/proposed version and any migration errors.',
       options: {
         tags: ['oas-tag:Fleet agentless policies'],
         availability: {
@@ -388,7 +389,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
             path.join(__dirname, 'examples/upgrade_agentless_policies_dryrun.yaml'),
         },
         validate: {
-          request: BulkUpgradeAgentlessPoliciesRequestSchema,
+          request: AgentlessPolicyUpgradeDryRunRequestSchema,
           response: {
             200: {
               description: 'OK: A successful request.',

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -369,7 +369,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       path: AGENTLESS_POLICIES_ROUTES.UPGRADE_DRYRUN_PATTERN,
       summary: 'Preview an agentless policies upgrade',
       description:
-        'Preview upgrading multiple agentless policies without applying any change. By default the target is the installed package version; pass `pkgVersion` to preview a migration to a specific (for example, not-yet-installed) version. Each result returns the migrated config as a consumable agentless policy (`proposedPolicy`) plus the current/proposed version and any migration errors.',
+        'Preview upgrading multiple agentless policies without applying any change. Targets the installed package version by default; pass `pkgVersion` to preview a specific (for example, not-yet-installed) version. Each result returns the current/proposed version and any migration errors, plus — only on a clean dry-run (`hasErrors: false`) — the migrated `proposedPolicy`. `proposedPolicy` is for the edit-and-upgrade flow (edit it, then save via the update (PUT) endpoint); to apply an upgrade as-is, use `_upgrade`.',
       options: {
         tags: ['oas-tag:Fleet agentless policies'],
         availability: {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -326,7 +326,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       path: AGENTLESS_POLICIES_ROUTES.UPGRADE_PATTERN,
       summary: 'Bulk upgrade agentless policies',
       description:
-        "Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.",
+        "Upgrade multiple agentless policies to their installed package version, migrating each package policy's config onto the new schema. Always returns 200 with a per-policy result array; a missing or non-agentless id is reported as a per-item failure (`success: false` + `statusCode`) without failing the batch, so valid ids are still upgraded. A successful result means the policy's saved object was upgraded, while the agentless deployment is reconciled asynchronously in the background. Policies already at the installed version are a genuine no-op: they still report `success: true` (calls stay idempotent) but nothing is re-persisted or redeployed. Note: agent-policy-level agentless settings (resources, ownership tags) are not re-derived from the new package version — use the update (PUT) endpoint for those.",
       options: {
         tags: ['oas-tag:Fleet agentless policies'],
         availability: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -1053,6 +1053,265 @@ describe('AgentlessPoliciesService', () => {
     });
   });
 
+  describe('bulkUpgradeAgentlessPolicies', () => {
+    let packagePolicyService: ReturnType<typeof createPackagePolicyServiceMock>;
+
+    const createService = () =>
+      new AgentlessPoliciesServiceImpl(
+        packagePolicyService,
+        savedObjectsClientMock.create(),
+        elasticsearchServiceMock.createClusterClient().asInternalUser,
+        loggingSystemMock.createLogger()
+      );
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      packagePolicyService = createPackagePolicyServiceMock();
+    });
+
+    it('should upgrade each agentless policy and let the engine schedule the deploy', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({ id: 'a' }),
+        buildAgentlessPackagePolicy({ id: 'b' }),
+      ]);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([
+        { id: 'a', name: 'A', success: true },
+        { id: 'b', name: 'B', success: true },
+      ]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a', 'b']);
+
+      // Only the (guarded) agentless ids are forwarded to the package-policy engine.
+      expect(packagePolicyService.bulkUpgrade).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['a', 'b'],
+        expect.objectContaining({})
+      );
+      // The deploy is scheduled asynchronously by the engine (mirrors package-policy),
+      // so this path does not deploy synchronously itself.
+      expect(jest.mocked(agentPolicyService.deployPolicy)).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'a', name: 'A', success: true },
+        { id: 'b', name: 'B', success: true },
+      ]);
+    });
+
+    it('should collect missing and non-agentless ids as per-policy 404 failures without failing the batch', async () => {
+      // 'a' is agentless, 'b' is a regular package policy, 'c' is missing.
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({ id: 'a' }),
+        buildAgentlessPackagePolicy({ id: 'b', supports_agentless: false }),
+      ]);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([{ id: 'a', name: 'A', success: true }]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a', 'b', 'c']);
+
+      expect(packagePolicyService.bulkUpgrade).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['a'],
+        expect.objectContaining({})
+      );
+      // Results are returned in the requested id order, not grouped by guard failures.
+      expect(result).toEqual([
+        { id: 'a', name: 'A', success: true },
+        {
+          id: 'b',
+          success: false,
+          statusCode: 404,
+          body: { message: 'Agentless policy b not found' },
+        },
+        {
+          id: 'c',
+          success: false,
+          statusCode: 404,
+          body: { message: 'Agentless policy c not found' },
+        },
+      ]);
+    });
+
+    it('should return results in the requested id order when guard failures are interleaved', async () => {
+      // 'missing' fails the guard; 'a' and 'b' are agentless and upgrade successfully.
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({ id: 'a' }),
+        buildAgentlessPackagePolicy({ id: 'b' }),
+      ]);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([
+        { id: 'a', name: 'A', success: true },
+        { id: 'b', name: 'B', success: true },
+      ]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a', 'missing', 'b']);
+
+      expect(result.map((item) => item.id)).toEqual(['a', 'missing', 'b']);
+    });
+
+    it('should pass through a bulkUpgrade per-policy failure without rolling back the saved object', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([
+        { id: 'a', name: 'A', success: false, statusCode: 400, body: { message: 'ineligible' } },
+      ]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a']);
+
+      // The engine owns the deploy; no synchronous deploy or SO rollback happens here
+      // (matches package-policy bulk upgrade).
+      expect(jest.mocked(agentPolicyService.deployPolicy)).not.toHaveBeenCalled();
+      expect(packagePolicyService.update).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'a', name: 'A', success: false, statusCode: 400, body: { message: 'ineligible' } },
+      ]);
+    });
+
+    it('should not call bulkUpgrade when every id fails the agentless guard', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['x']);
+
+      expect(packagePolicyService.bulkUpgrade).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          id: 'x',
+          success: false,
+          statusCode: 404,
+          body: { message: 'Agentless policy x not found' },
+        },
+      ]);
+    });
+  });
+
+  describe('getAgentlessPolicyUpgradeDryRunDiff', () => {
+    let packagePolicyService: ReturnType<typeof createPackagePolicyServiceMock>;
+
+    const createService = () =>
+      new AgentlessPoliciesServiceImpl(
+        packagePolicyService,
+        savedObjectsClientMock.create(),
+        elasticsearchServiceMock.createClusterClient().asInternalUser,
+        loggingSystemMock.createLogger()
+      );
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      packagePolicyService = createPackagePolicyServiceMock();
+    });
+
+    it('should project the diff into a clean, PUT-consumable agentless policy', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      packagePolicyService.getUpgradeDryRunDiff.mockResolvedValue({
+        name: 'Test Agentless Policy',
+        hasErrors: false,
+        diff: [
+          buildAgentlessPackagePolicy({ id: 'a' }),
+          {
+            name: 'Test Agentless Policy',
+            namespace: 'default',
+            package: { name: 'test_agentless', title: 'Test Agentless', version: '2.0.0' },
+            inputs: [],
+            vars: {},
+          },
+        ],
+      } as any);
+
+      const result = await createService().getAgentlessPolicyUpgradeDryRunDiff(['a']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'a',
+          name: 'Test Agentless Policy',
+          hasErrors: false,
+          currentVersion: '1.0.0',
+          proposedVersion: '2.0.0',
+          proposedPolicy: expect.objectContaining({
+            id: 'a',
+            package: expect.objectContaining({ version: '2.0.0' }),
+          }),
+        })
+      );
+      // The proposed policy must be the clean agentless shape, never Fleet internals.
+      expect(result[0].proposedPolicy).not.toHaveProperty('supports_agentless');
+      expect(result[0].proposedPolicy).not.toHaveProperty('policy_ids');
+      expect(result[0].proposedPolicy).not.toHaveProperty('revision');
+    });
+
+    it('should surface migration errors and mark the item as having errors', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      packagePolicyService.getUpgradeDryRunDiff.mockResolvedValue({
+        name: 'Test Agentless Policy',
+        hasErrors: true,
+        diff: [
+          buildAgentlessPackagePolicy({ id: 'a' }),
+          {
+            name: 'Test Agentless Policy',
+            namespace: 'default',
+            package: { name: 'test_agentless', title: 'Test Agentless', version: '2.0.0' },
+            inputs: [],
+            vars: {},
+            errors: [{ key: 'some.input', message: 'bad var' }],
+          },
+        ],
+      } as any);
+
+      const result = await createService().getAgentlessPolicyUpgradeDryRunDiff(['a']);
+
+      expect(result[0].hasErrors).toBe(true);
+      // Only the human-readable message is exposed (the internal input key is dropped).
+      expect(result[0].errors).toEqual([{ message: 'bad var' }]);
+    });
+
+    it('should surface a non-throwing fatal dry-run item statusCode and message', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      // getUpgradeDryRunDiff reports a per-policy fatal error without throwing and without a
+      // `diff` pair (e.g. package not installed / ineligible upgrade).
+      packagePolicyService.getUpgradeDryRunDiff.mockResolvedValue({
+        hasErrors: true,
+        statusCode: 400,
+        body: { message: 'Package test_agentless is not installed' },
+      } as any);
+
+      const result = await createService().getAgentlessPolicyUpgradeDryRunDiff(['a']);
+
+      expect(result).toEqual([
+        {
+          id: 'a',
+          name: undefined,
+          hasErrors: true,
+          statusCode: 400,
+          body: { message: 'Package test_agentless is not installed' },
+        },
+      ]);
+    });
+
+    it('should surface guard failures as dry-run items without calling getUpgradeDryRunDiff', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([]);
+
+      const result = await createService().getAgentlessPolicyUpgradeDryRunDiff(['x']);
+
+      expect(packagePolicyService.getUpgradeDryRunDiff).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          id: 'x',
+          hasErrors: true,
+          statusCode: 404,
+          body: { message: 'Agentless policy x not found' },
+        },
+      ]);
+    });
+
+    it('should demote a dry-run error to a per-policy failure', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      packagePolicyService.getUpgradeDryRunDiff.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await createService().getAgentlessPolicyUpgradeDryRunDiff(['a']);
+
+      expect(result).toEqual([
+        { id: 'a', hasErrors: true, statusCode: 500, body: { message: 'boom' } },
+      ]);
+    });
+  });
+
   describe('createAgentlessPolicy with cloud connectors', () => {
     let packagePolicyService: ReturnType<typeof createPackagePolicyServiceMock>;
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -14,7 +14,7 @@ import { cloudMock } from '@kbn/cloud-plugin/server/mocks';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 
 import { createAppContextStartContractMock, createPackagePolicyServiceMock } from '../../mocks';
-import { getPackageInfo } from '../epm/packages';
+import { getInstallation, getPackageInfo } from '../epm/packages';
 import { appContextService, cloudConnectorService } from '..';
 import { agentPolicyService } from '../agent_policy';
 import { agentlessAgentService } from '../agents/agentless_agent';
@@ -1177,6 +1177,111 @@ describe('AgentlessPoliciesService', () => {
           statusCode: 404,
           body: { message: 'Agentless policy x not found' },
         },
+      ]);
+    });
+
+    it('should short-circuit an already-latest policy to a no-op success without calling bulkUpgrade', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({
+          id: 'a',
+          name: 'A',
+          package: { name: 'pkg', version: '1.0.0' },
+        }),
+      ]);
+      // Installed version matches the policy version, so there is nothing to upgrade.
+      jest.mocked(getInstallation).mockResolvedValue({ version: '1.0.0' } as any);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a']);
+
+      expect(packagePolicyService.bulkUpgrade).not.toHaveBeenCalled();
+      // Idempotent-success without the redeploy churn.
+      expect(result).toEqual([{ id: 'a', name: 'A', success: true }]);
+    });
+
+    it('should forward only non-latest ids to the engine and keep no-ops in request order', async () => {
+      // 'a' is already latest (no-op), 'b' needs an upgrade, 'c' is missing (guard 404).
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({
+          id: 'a',
+          name: 'A',
+          package: { name: 'pkg', version: '1.0.0' },
+        }),
+        buildAgentlessPackagePolicy({
+          id: 'b',
+          name: 'B',
+          package: { name: 'pkg', version: '0.9.0' },
+        }),
+      ]);
+      jest.mocked(getInstallation).mockResolvedValue({ version: '1.0.0' } as any);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([{ id: 'b', name: 'B', success: true }]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a', 'b', 'c']);
+
+      // Only the non-latest id reaches the shared engine.
+      expect(packagePolicyService.bulkUpgrade).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['b'],
+        expect.objectContaining({})
+      );
+      expect(result).toEqual([
+        { id: 'a', name: 'A', success: true },
+        { id: 'b', name: 'B', success: true },
+        {
+          id: 'c',
+          success: false,
+          statusCode: 404,
+          body: { message: 'Agentless policy c not found' },
+        },
+      ]);
+    });
+
+    it('should forward to the engine when the package is not installed (no resolved version)', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({
+          id: 'a',
+          name: 'A',
+          package: { name: 'pkg', version: '1.0.0' },
+        }),
+      ]);
+      // No installation resolved -> let the engine surface its "package not installed" error.
+      jest.mocked(getInstallation).mockResolvedValue(undefined as any);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([{ id: 'a', name: 'A', success: true }]);
+
+      await createService().bulkUpgradeAgentlessPolicies(['a']);
+
+      expect(packagePolicyService.bulkUpgrade).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['a'],
+        expect.objectContaining({})
+      );
+    });
+
+    it('should forward a policy ahead of the installed version to the engine (not a no-op)', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([
+        buildAgentlessPackagePolicy({
+          id: 'a',
+          name: 'A',
+          package: { name: 'pkg', version: '2.0.0' },
+        }),
+      ]);
+      // Installed is older than the policy -> engine returns its ineligible-for-upgrade error.
+      jest.mocked(getInstallation).mockResolvedValue({ version: '1.0.0' } as any);
+      packagePolicyService.bulkUpgrade.mockResolvedValue([
+        { id: 'a', name: 'A', success: false, statusCode: 400, body: { message: 'ineligible' } },
+      ]);
+
+      const result = await createService().bulkUpgradeAgentlessPolicies(['a']);
+
+      expect(packagePolicyService.bulkUpgrade).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['a'],
+        expect.objectContaining({})
+      );
+      expect(result).toEqual([
+        { id: 'a', name: 'A', success: false, statusCode: 400, body: { message: 'ineligible' } },
       ]);
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -1310,6 +1310,62 @@ describe('AgentlessPoliciesService', () => {
         { id: 'a', hasErrors: true, statusCode: 500, body: { message: 'boom' } },
       ]);
     });
+
+    it('should forward an explicit pkgVersion to getUpgradeDryRunDiff as the target version', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      packagePolicyService.getUpgradeDryRunDiff.mockResolvedValue({
+        name: 'Test Agentless Policy',
+        hasErrors: false,
+        diff: [
+          buildAgentlessPackagePolicy({ id: 'a' }),
+          {
+            name: 'Test Agentless Policy',
+            namespace: 'default',
+            package: { name: 'test_agentless', title: 'Test Agentless', version: '2.0.0' },
+            inputs: [],
+            vars: {},
+          },
+        ],
+      } as any);
+
+      await createService().getAgentlessPolicyUpgradeDryRunDiff(['a'], '2.0.0');
+
+      // The target version is passed as the 4th argument (the 3rd, `packagePolicy`, stays
+      // undefined so the engine loads the policy itself).
+      expect(packagePolicyService.getUpgradeDryRunDiff).toHaveBeenCalledWith(
+        expect.anything(),
+        'a',
+        undefined,
+        '2.0.0'
+      );
+    });
+
+    it('should default to the installed version (undefined pkgVersion) when none is provided', async () => {
+      packagePolicyService.getByIDs.mockResolvedValue([buildAgentlessPackagePolicy({ id: 'a' })]);
+      packagePolicyService.getUpgradeDryRunDiff.mockResolvedValue({
+        name: 'Test Agentless Policy',
+        hasErrors: false,
+        diff: [
+          buildAgentlessPackagePolicy({ id: 'a' }),
+          {
+            name: 'Test Agentless Policy',
+            namespace: 'default',
+            package: { name: 'test_agentless', title: 'Test Agentless', version: '2.0.0' },
+            inputs: [],
+            vars: {},
+          },
+        ],
+      } as any);
+
+      await createService().getAgentlessPolicyUpgradeDryRunDiff(['a']);
+
+      expect(packagePolicyService.getUpgradeDryRunDiff).toHaveBeenCalledWith(
+        expect.anything(),
+        'a',
+        undefined,
+        undefined
+      );
+    });
   });
 
   describe('createAgentlessPolicy with cloud connectors', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -1259,6 +1259,9 @@ describe('AgentlessPoliciesService', () => {
       expect(result[0].hasErrors).toBe(true);
       // Only the human-readable message is exposed (the internal input key is dropped).
       expect(result[0].errors).toEqual([{ message: 'bad var' }]);
+      // Contract: `proposedPolicy` is withheld on any migration error (apply path is
+      // "edited payloads only" — the incomplete/unsafe config must not be applied as-is).
+      expect(result[0].proposedPolicy).toBeUndefined();
     });
 
     it('should surface a non-throwing fatal dry-run item statusCode and message', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -109,7 +109,8 @@ export interface AgentlessPoliciesService {
   ) => Promise<BulkUpgradeAgentlessPoliciesResponse>;
 
   getAgentlessPolicyUpgradeDryRunDiff: (
-    policyIds: string[]
+    policyIds: string[],
+    pkgVersion?: string
   ) => Promise<AgentlessPolicyUpgradeDryRunResponse>;
 }
 
@@ -749,7 +750,8 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
   }
 
   async getAgentlessPolicyUpgradeDryRunDiff(
-    policyIds: string[]
+    policyIds: string[],
+    pkgVersion?: string
   ): Promise<AgentlessPolicyUpgradeDryRunResponse> {
     this.logger.debug(`Computing upgrade dry-run for ${policyIds.length} agentless policies`);
 
@@ -776,7 +778,15 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
     await runWithCache(async () => {
       for (const id of agentlessIds) {
         try {
-          const diff = await this.packagePolicyService.getUpgradeDryRunDiff(this.soClient, id);
+          // `pkgVersion` lets the caller preview a migration to a not-yet-installed target
+          // version (the UI computes the dry-run before installing the new package). When
+          // undefined, `getUpgradeDryRunDiff` defaults to the installed package version.
+          const diff = await this.packagePolicyService.getUpgradeDryRunDiff(
+            this.soClient,
+            id,
+            undefined,
+            pkgVersion
+          );
           results.push(this.projectUpgradeDryRunDiff(id, diff));
         } catch (err) {
           this.logger.error(

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -15,7 +15,9 @@ import {
   SavedObjectsErrorHelpers,
 } from '@kbn/core/server';
 import { v4 as uuidv4 } from 'uuid';
-import { omit } from 'lodash';
+import { omit, uniq } from 'lodash';
+import pMap from 'p-map';
+import semverEq from 'semver/functions/eq';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 
 import type {
@@ -50,10 +52,11 @@ import {
 import type { PackagePolicyClient } from '../package_policy_service';
 
 import { agentPolicyService } from '../agent_policy';
-import { getPackageInfo } from '../epm/packages';
+import { getInstallation, getPackageInfo } from '../epm/packages';
 import { runWithCache } from '../epm/packages/cache';
 import { appContextService, cloudConnectorService } from '..';
 import { FleetNotFoundError, PackagePolicyRequestError } from '../../errors';
+import { MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10 } from '../../constants';
 
 import type { PackageInfo } from '../../types';
 import {
@@ -702,45 +705,43 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
       : undefined;
 
     // Batched agentless guard: missing or non-agentless ids become per-policy 404
-    // failures rather than failing the whole batch (mirrors package-policy bulk upgrade,
-    // which collects per-policy failures into the result array).
-    const { agentlessIds, guardFailures } = await this.partitionAgentlessPolicyIds(policyIds);
+    // failures rather than failing the whole batch 
+    const { agentlessPackagePolicies, guardFailures } = await this.partitionAgentlessPolicyIds(
+      policyIds
+    );
 
     const results: BulkUpgradeAgentlessPolicyResult[] = [...guardFailures];
 
-    if (agentlessIds.length === 0) {
+    if (agentlessPackagePolicies.length === 0) {
       return results;
     }
 
-    // Reuse the package-policy bulk upgrade engine: it resolves the installed target
-    // version, applies the eligibility guard, migrates the existing config onto the new
-    // schema (`updatePackageInputs`), persists the saved objects and emits upgrade
-    // telemetry. Like the package-policy path, the live reconcile (deploy) is scheduled
-    // as a background task and the deployment-sync task is the backstop, so `success`
-    // reflects the saved-object upgrade, not that the workload is already running the
-    // new version. Deploying synchronously here would not scale (up to 1000 external
-    // calls per request) and would duplicate the deploy the engine already schedules.
-    //
-    // Known limitation (parity with package-policy): this migrates the package policy
-    // config only. It does NOT re-derive the backing agent policy's agentless config
-    // (resources) or ownership `global_data_tags` from the new package manifest — only
-    // create / PUT do that. If a new package version changes those agent-policy-level
-    // fields, the update (PUT) endpoint must be used to pick them up. Tracked as a follow-up.
-    const upgradeResults = await this.packagePolicyService.bulkUpgrade(
-      this.soClient,
-      this.esClient,
-      agentlessIds,
-      { user }
+    // Skip already-latest policies: report `success: true` without the engine's needless SO re-persist + redeploy churn.
+    const { upgradeIds, noopResults } = await this.partitionAlreadyLatestPolicies(
+      agentlessPackagePolicies
     );
+    results.push(...noopResults);
 
-    for (const result of upgradeResults) {
-      results.push({
-        id: result.id,
-        name: result.name,
-        success: result.success,
-        statusCode: result.statusCode,
-        body: result.body,
-      });
+    if (upgradeIds.length > 0) {
+      // Reuse the package-policy bulk upgrade engine: it migrates the config and persists the
+      // saved objects. `success` reflects that SO upgrade; the deploy is scheduled in the
+      // background (like package-policy), not run synchronously here.
+      const upgradeResults = await this.packagePolicyService.bulkUpgrade(
+        this.soClient,
+        this.esClient,
+        upgradeIds,
+        { user }
+      );
+
+      for (const result of upgradeResults) {
+        results.push({
+          id: result.id,
+          name: result.name,
+          success: result.success,
+          statusCode: result.statusCode,
+          body: result.body,
+        });
+      }
     }
 
     // Return results in the caller's requested order (guard failures and engine
@@ -755,7 +756,9 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
   ): Promise<AgentlessPolicyUpgradeDryRunResponse> {
     this.logger.debug(`Computing upgrade dry-run for ${policyIds.length} agentless policies`);
 
-    const { agentlessIds, guardFailures } = await this.partitionAgentlessPolicyIds(policyIds);
+    const { agentlessPackagePolicies, guardFailures } = await this.partitionAgentlessPolicyIds(
+      policyIds
+    );
 
     // A guard failure (missing / non-agentless) is surfaced as a dry-run item with
     // `hasErrors: true` plus the per-policy statusCode/body, keeping the response a flat
@@ -768,7 +771,7 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
       body: failure.body,
     }));
 
-    if (agentlessIds.length === 0) {
+    if (agentlessPackagePolicies.length === 0) {
       return results;
     }
 
@@ -776,7 +779,7 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
     // batch (matches the package-policy dry-run handler), avoiding repeated fetches when
     // policies share a package.
     await runWithCache(async () => {
-      for (const id of agentlessIds) {
+      for (const { id } of agentlessPackagePolicies) {
         try {
           // `pkgVersion` lets the caller preview a migration to a not-yet-installed target
           // version (the UI computes the dry-run before installing the new package). When
@@ -822,20 +825,14 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
   }
 
   /**
-   * Splits the requested ids into agentless ids (safe to upgrade) and per-policy guard
-   * failures. Missing and non-agentless package policies are both collapsed into a 404
-   * failure so this endpoint never confirms the existence of, or operates on, regular
-   * Fleet package policies — the batched equivalent of {@link getExistingAgentlessPackagePolicy}.
-   *
-   * This performs one bulk `getByIDs` purely for the agentless guard. It is intentionally
-   * separate from (and slightly redundant with) the fetch that `bulkUpgrade` /
-   * `getUpgradeDryRunDiff` do internally: the guard must reject non-agentless ids *before*
-   * anything is handed to the shared engine, and the engine owns its own fetch for version
-   * resolution and chunking. The cost is a single extra batched read, which is the price of
-   * reusing the shared upgrade engine rather than re-implementing it here.
+   * Splits the requested ids into agentless package policies and per-policy 404 guard failures.
+   * Missing and non-agentless policies both become a 404 so this endpoint never operates on
+   * regular Fleet package policies (batched equivalent of {@link getExistingAgentlessPackagePolicy}).
+   * Returns the full policies (not just ids) so callers can reuse the loaded package name/version
+   * (e.g. the already-latest short-circuit) without a second `getByIDs`.
    */
   private async partitionAgentlessPolicyIds(policyIds: string[]): Promise<{
-    agentlessIds: string[];
+    agentlessPackagePolicies: PackagePolicy[];
     guardFailures: BulkUpgradeAgentlessPolicyResult[];
   }> {
     const packagePolicies = await this.packagePolicyService.getByIDs(this.soClient, policyIds, {
@@ -843,7 +840,7 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
     });
     const packagePolicyById = new Map(packagePolicies.map((pp) => [pp.id, pp]));
 
-    const agentlessIds: string[] = [];
+    const agentlessPackagePolicies: PackagePolicy[] = [];
     const guardFailures: BulkUpgradeAgentlessPolicyResult[] = [];
 
     for (const id of policyIds) {
@@ -857,10 +854,61 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
         });
         continue;
       }
-      agentlessIds.push(id);
+      agentlessPackagePolicies.push(packagePolicy);
     }
 
-    return { agentlessIds, guardFailures };
+    return { agentlessPackagePolicies, guardFailures };
+  }
+
+  /**
+   * Splits guarded agentless policies into ids that need a real upgrade and no-op results for
+   * policies already at the installed package version.
+   */
+  private async partitionAlreadyLatestPolicies(agentlessPackagePolicies: PackagePolicy[]): Promise<{
+    upgradeIds: string[];
+    noopResults: BulkUpgradeAgentlessPolicyResult[];
+  }> {
+    const packageNames = uniq(
+      agentlessPackagePolicies
+        .map((pp) => pp.package?.name)
+        .filter((name): name is string => typeof name === 'string')
+    );
+
+    const installedVersionByPackage = new Map<string, string>();
+    await pMap(
+      packageNames,
+      async (pkgName) => {
+        const installation = await getInstallation({
+          savedObjectsClient: this.soClient,
+          pkgName,
+        });
+        if (installation) {
+          installedVersionByPackage.set(pkgName, installation.version);
+        }
+      },
+      { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10 }
+    );
+
+    const upgradeIds: string[] = [];
+    const noopResults: BulkUpgradeAgentlessPolicyResult[] = [];
+
+    for (const packagePolicy of agentlessPackagePolicies) {
+      const installedVersion = installedVersionByPackage.get(packagePolicy.package?.name ?? '');
+      const policyVersion = packagePolicy.package?.version;
+      if (installedVersion && policyVersion && semverEq(installedVersion, policyVersion)) {
+        noopResults.push({ id: packagePolicy.id, name: packagePolicy.name, success: true });
+      } else {
+        upgradeIds.push(packagePolicy.id);
+      }
+    }
+
+    if (noopResults.length > 0) {
+      this.logger.debug(
+        `Skipping ${noopResults.length} already-latest agentless policies (no-op, no redeploy)`
+      );
+    }
+
+    return { upgradeIds, noopResults };
   }
 
   /**

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -865,11 +865,12 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
 
   /**
    * Projects the package-policy dry-run diff into the clean agentless shape. Instead of
-   * exposing the raw `[PackagePolicy, DryRunPackagePolicy]` diff, it returns the migrated
-   * config as a consumable {@link AgentlessPolicy} (`proposedPolicy`) plus the current and
-   * proposed versions and any migration errors. The proposed policy is a `NewPackagePolicy`
-   * (no saved-object id/timestamps), so it is overlaid onto the current stored package
-   * policy to recover the metadata `packagePolicyToAgentlessPolicy` needs.
+   * exposing the raw `[PackagePolicy, DryRunPackagePolicy]` diff, it returns the current and
+   * proposed versions and any migration errors, plus — only when the migration is clean
+   * (`hasErrors: false`) — the migrated config as a consumable {@link AgentlessPolicy}
+   * (`proposedPolicy`). The proposed policy is a `NewPackagePolicy` (no saved-object
+   * id/timestamps), so it is overlaid onto the current stored package policy to recover the
+   * metadata `packagePolicyToAgentlessPolicy` needs.
    */
   private projectUpgradeDryRunDiff(
     id: string,
@@ -891,8 +892,11 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
 
     const [currentPackagePolicy, proposedPackagePolicy] = diff.diff;
 
+    // Only return `proposedPolicy` when the dry-run is clean. On errors the proposed config is
+    // incomplete, so we send just the error summary. It's meant to be edited and saved via PUT,
+    // not applied as-is — to apply an upgrade untouched, use `_upgrade`.
     let proposedPolicy: AgentlessPolicy | undefined;
-    if (currentPackagePolicy && proposedPackagePolicy) {
+    if (!diff.hasErrors && currentPackagePolicy && proposedPackagePolicy) {
       proposedPolicy = packagePolicyToAgentlessPolicy({
         ...currentPackagePolicy,
         ...proposedPackagePolicy,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -705,7 +705,7 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
       : undefined;
 
     // Batched agentless guard: missing or non-agentless ids become per-policy 404
-    // failures rather than failing the whole batch 
+    // failures rather than failing the whole batch
     const { agentlessPackagePolicies, guardFailures } = await this.partitionAgentlessPolicyIds(
       policyIds
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -27,7 +27,14 @@ import type {
   PackagePolicy,
   ListWithKuery,
   ListResult,
+  UpgradePackagePolicyDryRunResponseItem,
 } from '../../../common/types';
+import type {
+  BulkUpgradeAgentlessPoliciesResponse,
+  BulkUpgradeAgentlessPolicyResult,
+  AgentlessPolicyUpgradeDryRunResponse,
+  AgentlessPolicyUpgradeDryRunResult,
+} from '../../../common/types/rest_spec/agentless_policy';
 
 import {
   AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT,
@@ -44,6 +51,7 @@ import type { PackagePolicyClient } from '../package_policy_service';
 
 import { agentPolicyService } from '../agent_policy';
 import { getPackageInfo } from '../epm/packages';
+import { runWithCache } from '../epm/packages/cache';
 import { appContextService, cloudConnectorService } from '..';
 import { FleetNotFoundError, PackagePolicyRequestError } from '../../errors';
 
@@ -94,6 +102,15 @@ export interface AgentlessPoliciesService {
   listAgentlessPolicies: (
     options?: ListAgentlessPoliciesOptions
   ) => Promise<ListResult<AgentlessPolicy>>;
+
+  bulkUpgradeAgentlessPolicies: (
+    policyIds: string[],
+    request?: KibanaRequest
+  ) => Promise<BulkUpgradeAgentlessPoliciesResponse>;
+
+  getAgentlessPolicyUpgradeDryRunDiff: (
+    policyIds: string[]
+  ) => Promise<AgentlessPolicyUpgradeDryRunResponse>;
 }
 
 const getAgentlessAgentPolicyConfig = (
@@ -670,6 +687,221 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
       total: result.total,
       page: result.page,
       perPage: result.perPage,
+    };
+  }
+
+  async bulkUpgradeAgentlessPolicies(
+    policyIds: string[],
+    request?: KibanaRequest
+  ): Promise<BulkUpgradeAgentlessPoliciesResponse> {
+    this.logger.debug(`Bulk upgrading ${policyIds.length} agentless policies`);
+
+    const user = request
+      ? appContextService.getSecurityCore().authc.getCurrentUser(request) || undefined
+      : undefined;
+
+    // Batched agentless guard: missing or non-agentless ids become per-policy 404
+    // failures rather than failing the whole batch (mirrors package-policy bulk upgrade,
+    // which collects per-policy failures into the result array).
+    const { agentlessIds, guardFailures } = await this.partitionAgentlessPolicyIds(policyIds);
+
+    const results: BulkUpgradeAgentlessPolicyResult[] = [...guardFailures];
+
+    if (agentlessIds.length === 0) {
+      return results;
+    }
+
+    // Reuse the package-policy bulk upgrade engine: it resolves the installed target
+    // version, applies the eligibility guard, migrates the existing config onto the new
+    // schema (`updatePackageInputs`), persists the saved objects and emits upgrade
+    // telemetry. Like the package-policy path, the live reconcile (deploy) is scheduled
+    // as a background task and the deployment-sync task is the backstop, so `success`
+    // reflects the saved-object upgrade, not that the workload is already running the
+    // new version. Deploying synchronously here would not scale (up to 1000 external
+    // calls per request) and would duplicate the deploy the engine already schedules.
+    //
+    // Known limitation (parity with package-policy): this migrates the package policy
+    // config only. It does NOT re-derive the backing agent policy's agentless config
+    // (resources) or ownership `global_data_tags` from the new package manifest — only
+    // create / PUT do that. If a new package version changes those agent-policy-level
+    // fields, the update (PUT) endpoint must be used to pick them up. Tracked as a follow-up.
+    const upgradeResults = await this.packagePolicyService.bulkUpgrade(
+      this.soClient,
+      this.esClient,
+      agentlessIds,
+      { user }
+    );
+
+    for (const result of upgradeResults) {
+      results.push({
+        id: result.id,
+        name: result.name,
+        success: result.success,
+        statusCode: result.statusCode,
+        body: result.body,
+      });
+    }
+
+    // Return results in the caller's requested order (guard failures and engine
+    // results are otherwise interleaved), so a client can zip the response against
+    // its input list positionally as well as by `id`.
+    return this.orderResultsByRequest(policyIds, results);
+  }
+
+  async getAgentlessPolicyUpgradeDryRunDiff(
+    policyIds: string[]
+  ): Promise<AgentlessPolicyUpgradeDryRunResponse> {
+    this.logger.debug(`Computing upgrade dry-run for ${policyIds.length} agentless policies`);
+
+    const { agentlessIds, guardFailures } = await this.partitionAgentlessPolicyIds(policyIds);
+
+    // A guard failure (missing / non-agentless) is surfaced as a dry-run item with
+    // `hasErrors: true` plus the per-policy statusCode/body, keeping the response a flat
+    // per-policy array (200 even on partial failure).
+    const results: AgentlessPolicyUpgradeDryRunResult[] = guardFailures.map((failure) => ({
+      id: failure.id,
+      name: failure.name,
+      hasErrors: true,
+      statusCode: failure.statusCode,
+      body: failure.body,
+    }));
+
+    if (agentlessIds.length === 0) {
+      return results;
+    }
+
+    // `runWithCache` shares EPM asset/package-info lookups across all policies in the
+    // batch (matches the package-policy dry-run handler), avoiding repeated fetches when
+    // policies share a package.
+    await runWithCache(async () => {
+      for (const id of agentlessIds) {
+        try {
+          const diff = await this.packagePolicyService.getUpgradeDryRunDiff(this.soClient, id);
+          results.push(this.projectUpgradeDryRunDiff(id, diff));
+        } catch (err) {
+          this.logger.error(
+            `Failed to compute upgrade dry-run for agentless policy ${id}: ${err.message}`,
+            { error: err }
+          );
+          results.push({
+            id,
+            hasErrors: true,
+            statusCode: 500,
+            body: { message: err.message },
+          });
+        }
+      }
+    });
+
+    return this.orderResultsByRequest(policyIds, results);
+  }
+
+  /**
+   * Reorders per-policy results to match the caller's requested id order. Guard failures
+   * and engine results are produced in separate passes, so without this the response would
+   * group all guard failures first. Ordering by request keeps the response positionally
+   * aligned with the input `policyIds`. Any id without a result is dropped (defensive; in
+   * practice every requested id yields exactly one result).
+   */
+  private orderResultsByRequest<T extends { id: string }>(policyIds: string[], results: T[]): T[] {
+    const resultById = new Map(results.map((result) => [result.id, result]));
+    return policyIds.flatMap((id) => {
+      const result = resultById.get(id);
+      return result ? [result] : [];
+    });
+  }
+
+  /**
+   * Splits the requested ids into agentless ids (safe to upgrade) and per-policy guard
+   * failures. Missing and non-agentless package policies are both collapsed into a 404
+   * failure so this endpoint never confirms the existence of, or operates on, regular
+   * Fleet package policies — the batched equivalent of {@link getExistingAgentlessPackagePolicy}.
+   *
+   * This performs one bulk `getByIDs` purely for the agentless guard. It is intentionally
+   * separate from (and slightly redundant with) the fetch that `bulkUpgrade` /
+   * `getUpgradeDryRunDiff` do internally: the guard must reject non-agentless ids *before*
+   * anything is handed to the shared engine, and the engine owns its own fetch for version
+   * resolution and chunking. The cost is a single extra batched read, which is the price of
+   * reusing the shared upgrade engine rather than re-implementing it here.
+   */
+  private async partitionAgentlessPolicyIds(policyIds: string[]): Promise<{
+    agentlessIds: string[];
+    guardFailures: BulkUpgradeAgentlessPolicyResult[];
+  }> {
+    const packagePolicies = await this.packagePolicyService.getByIDs(this.soClient, policyIds, {
+      ignoreMissing: true,
+    });
+    const packagePolicyById = new Map(packagePolicies.map((pp) => [pp.id, pp]));
+
+    const agentlessIds: string[] = [];
+    const guardFailures: BulkUpgradeAgentlessPolicyResult[] = [];
+
+    for (const id of policyIds) {
+      const packagePolicy = packagePolicyById.get(id);
+      if (!packagePolicy || packagePolicy.supports_agentless !== true) {
+        guardFailures.push({
+          id,
+          success: false,
+          statusCode: 404,
+          body: { message: `Agentless policy ${id} not found` },
+        });
+        continue;
+      }
+      agentlessIds.push(id);
+    }
+
+    return { agentlessIds, guardFailures };
+  }
+
+  /**
+   * Projects the package-policy dry-run diff into the clean agentless shape. Instead of
+   * exposing the raw `[PackagePolicy, DryRunPackagePolicy]` diff, it returns the migrated
+   * config as a consumable {@link AgentlessPolicy} (`proposedPolicy`) plus the current and
+   * proposed versions and any migration errors. The proposed policy is a `NewPackagePolicy`
+   * (no saved-object id/timestamps), so it is overlaid onto the current stored package
+   * policy to recover the metadata `packagePolicyToAgentlessPolicy` needs.
+   */
+  private projectUpgradeDryRunDiff(
+    id: string,
+    diff: UpgradePackagePolicyDryRunResponseItem
+  ): AgentlessPolicyUpgradeDryRunResult {
+    // A fatal per-policy dry-run error (e.g. the package is not installed, or the policy is
+    // ineligible for upgrade) is returned by `getUpgradeDryRunDiff` *without throwing* and
+    // without a `diff` pair, carrying only `statusCode`/`body`. Surface those directly instead
+    // of projecting an empty result that would drop the reason for the failure.
+    if (!diff.diff) {
+      return {
+        id,
+        name: diff.name,
+        hasErrors: true,
+        statusCode: diff.statusCode,
+        body: diff.body,
+      };
+    }
+
+    const [currentPackagePolicy, proposedPackagePolicy] = diff.diff;
+
+    let proposedPolicy: AgentlessPolicy | undefined;
+    if (currentPackagePolicy && proposedPackagePolicy) {
+      proposedPolicy = packagePolicyToAgentlessPolicy({
+        ...currentPackagePolicy,
+        ...proposedPackagePolicy,
+        id: currentPackagePolicy.id,
+        created_at: currentPackagePolicy.created_at,
+        created_by: currentPackagePolicy.created_by,
+        updated_at: currentPackagePolicy.updated_at,
+        updated_by: currentPackagePolicy.updated_by,
+      } as PackagePolicy);
+    }
+
+    return {
+      id,
+      name: diff.name,
+      hasErrors: diff.hasErrors,
+      currentVersion: currentPackagePolicy?.package?.version,
+      proposedVersion: proposedPackagePolicy?.package?.version,
+      proposedPolicy,
+      errors: proposedPackagePolicy?.errors?.map((error) => ({ message: error.message })),
     };
   }
 

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -930,7 +930,7 @@ export default function (providerContext: FtrProviderContext) {
         expect(res.map((item) => item.id).sort()).to.eql([policyId1, policyId2].sort());
       });
 
-      it('should reject the batch with a 404 when an id is missing or non-agentless', async () => {
+      it('should return 200 with per-policy failures for missing/non-agentless ids while upgrading valid ids', async () => {
         const policyId = uuidv4();
         await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);
 
@@ -956,17 +956,28 @@ export default function (providerContext: FtrProviderContext) {
 
         const missingId = uuidv4();
 
-        // Mirrors package-policy bulk upgrade: the first per-policy guard failure is promoted
-        // to a top-level HTTP error, even when other ids in the batch are valid.
-        await expectToRejectWithError(
-          () =>
-            apiClient.bulkUpgradeAgentlessPolicies([
-              policyId,
-              regularPackagePolicyRes.item.id,
-              missingId,
-            ]),
-          /404/
-        );
+        // No top-level promotion: the batch returns 200 with a per-policy array, so valid
+        // ids upgrade while missing / non-agentless ids surface a per-item 404. Results stay
+        // in request order.
+        const res = await apiClient.bulkUpgradeAgentlessPolicies([
+          policyId,
+          regularPackagePolicyRes.item.id,
+          missingId,
+        ]);
+
+        expect(res.length).to.be(3);
+        expect(res.map((item) => item.id)).to.eql([
+          policyId,
+          regularPackagePolicyRes.item.id,
+          missingId,
+        ]);
+
+        const [validRes, regularRes, missingRes] = res;
+        expect(validRes.success).to.be(true);
+        expect(regularRes.success).to.be(false);
+        expect(regularRes.statusCode).to.be(404);
+        expect(missingRes.success).to.be(false);
+        expect(missingRes.statusCode).to.be(404);
 
         // The non-agentless policy must remain untouched (not upgraded through this API).
         await apiClient.getPackagePolicy(regularPackagePolicyRes.item.id);
@@ -994,15 +1005,18 @@ export default function (providerContext: FtrProviderContext) {
         expect(item.proposedPolicy).to.not.have.property('supports_agentless');
       });
 
-      it('should reject the dry-run with a 404 for a missing policy', async () => {
+      it('should return 200 with a per-policy failure for a missing policy in the dry-run', async () => {
         const missingId = uuidv4();
 
-        // A per-policy guard failure is promoted to a top-level HTTP error (mirrors
-        // package-policy dry-run).
-        await expectToRejectWithError(
-          () => apiClient.upgradeAgentlessPoliciesDryRun([missingId]),
-          /404/
-        );
+        // A per-policy guard failure is surfaced as a dry-run item (`hasErrors: true` +
+        // per-item 404), not promoted to a top-level HTTP error.
+        const res = await apiClient.upgradeAgentlessPoliciesDryRun([missingId]);
+
+        expect(res.length).to.be(1);
+        const [item] = res;
+        expect(item.id).to.be(missingId);
+        expect(item.hasErrors).to.be(true);
+        expect(item.statusCode).to.be(404);
       });
 
       it('should reject the bulk upgrade for a user without writeIntegrationPolicies', async () => {

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -936,6 +936,23 @@ export default function (providerContext: FtrProviderContext) {
         expect(res.map((item) => item.id).sort()).to.eql([policyId1, policyId2].sort());
       });
 
+      it('should be a genuine no-op (idempotent success, no revision bump) when already at the installed version', async () => {
+        const policyId = uuidv4();
+        await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);
+
+        // The policy is created at the installed version (1.0.0), so `_upgrade` has nothing
+        // to do. It must stay idempotent-success without re-persisting the saved object.
+        const before = await apiClient.getPackagePolicy(policyId);
+        const revisionBefore = before.item.revision;
+
+        const res = await apiClient.bulkUpgradeAgentlessPolicies([policyId]);
+        expect(res.length).to.be(1);
+        expect(res[0].success).to.be(true);
+
+        const after = await apiClient.getPackagePolicy(policyId);
+        expect(after.item.revision).to.be(revisionBefore);
+      });
+
       it('should return 200 with per-policy failures for missing/non-agentless ids while upgrading valid ids', async () => {
         const policyId = uuidv4();
         await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -859,7 +859,13 @@ export default function (providerContext: FtrProviderContext) {
       }> = [];
 
       // A user with integrations read (but not write) to assert the routes' authz split.
-      const readOnlyApiClient = new SpaceTestApiClient(supertest, testUsers.fleet_all_int_read);
+      // Must use `supertestWithoutAuth` so the request runs as this user rather than the
+      // superuser (plain `supertest` is pre-authenticated as the superuser and ignores
+      // `.auth()`, which would let the write-guarded bulk upgrade return 200 instead of 403).
+      const readOnlyApiClient = new SpaceTestApiClient(
+        supertestWithoutAuth,
+        testUsers.fleet_all_int_read
+      );
 
       const createTestAgentlessPolicy = (id: string, name: string) =>
         apiClient.createAgentlessPolicy({

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -851,6 +851,180 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
+    describe('Upgrade Agentless Policies', () => {
+      let apiCalls: Array<{
+        url: string;
+        method: string;
+        data?: any;
+      }> = [];
+
+      // A user with integrations read (but not write) to assert the routes' authz split.
+      const readOnlyApiClient = new SpaceTestApiClient(supertest, testUsers.fleet_all_int_read);
+
+      const createTestAgentlessPolicy = (id: string, name: string) =>
+        apiClient.createAgentlessPolicy({
+          id,
+          package: { name: 'test_agentless', version: '1.0.0' },
+          name,
+          description: 'test agentless policy',
+          namespace: 'default',
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: { api_key: 'TEST_VALUE_API_KEY' },
+              streams: {},
+            },
+          },
+        });
+
+      before(async () => {
+        await setupTestUsers(getService('security'));
+        const mockAgentlessApiService = setupMockServer();
+        mockApiServer = await mockAgentlessApiService.listen(8089);
+        mockApiServer.addListener('request', (request) => {
+          if (request.method === 'POST') {
+            request.on('data', (data) => {
+              apiCalls.push({
+                url: request.url || '',
+                method: request.method || '',
+                data: JSON.parse(data.toString()),
+              });
+            });
+          }
+        });
+      });
+
+      after(async () => {
+        await mockApiServer.close();
+      });
+
+      beforeEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        apiCalls = [];
+        await cleanFleetIndices(es);
+        await apiClient.setup();
+      });
+
+      afterEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanFleetIndices(es);
+      });
+
+      it('should return a per-policy success for each upgraded policy', async () => {
+        const policyId1 = uuidv4();
+        const policyId2 = uuidv4();
+        await createTestAgentlessPolicy(policyId1, `test_agentless-a-${Date.now()}`);
+        await createTestAgentlessPolicy(policyId2, `test_agentless-b-${Date.now()}`);
+
+        apiCalls = [];
+
+        const res = await apiClient.bulkUpgradeAgentlessPolicies([policyId1, policyId2]);
+
+        // `success` reflects the saved-object upgrade; the live workload is reconciled
+        // asynchronously by a background deploy task (mirrors package-policy bulk
+        // upgrade), so the deploy is intentionally not asserted synchronously here.
+        expect(res.length).to.be(2);
+        for (const item of res) {
+          expect(item.success).to.be(true);
+        }
+        expect(res.map((item) => item.id).sort()).to.eql([policyId1, policyId2].sort());
+      });
+
+      it('should reject the batch with a 404 when an id is missing or non-agentless', async () => {
+        const policyId = uuidv4();
+        await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);
+
+        // A regular (non-agentless) package policy that must not be upgradable here.
+        const agentPolicyRes = await apiClient.createAgentPolicy(undefined, {
+          name: `standard-policy-${Date.now()}`,
+          namespace: 'default',
+          description: '',
+        });
+        const regularPackagePolicyRes = await apiClient.createPackagePolicy(undefined, {
+          package: { name: 'test_agentless', version: '1.0.0' },
+          name: `regular-package-policy-${Date.now()}`,
+          namespace: 'default',
+          policy_ids: [agentPolicyRes.item.id],
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: { api_key: 'TEST_VALUE_API_KEY' },
+              streams: {},
+            },
+          },
+        });
+
+        const missingId = uuidv4();
+
+        // Mirrors package-policy bulk upgrade: the first per-policy guard failure is promoted
+        // to a top-level HTTP error, even when other ids in the batch are valid.
+        await expectToRejectWithError(
+          () =>
+            apiClient.bulkUpgradeAgentlessPolicies([
+              policyId,
+              regularPackagePolicyRes.item.id,
+              missingId,
+            ]),
+          /404/
+        );
+
+        // The non-agentless policy must remain untouched (not upgraded through this API).
+        await apiClient.getPackagePolicy(regularPackagePolicyRes.item.id);
+      });
+
+      it('should preview the upgrade as a clean, PUT-consumable agentless policy', async () => {
+        const policyId = uuidv4();
+        await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);
+
+        const res = await apiClient.upgradeAgentlessPoliciesDryRun([policyId]);
+
+        expect(res.length).to.be(1);
+        const [item] = res;
+        expect(item.id).to.be(policyId);
+        expect(item.hasErrors).to.be(false);
+        expect(item.currentVersion).to.be('1.0.0');
+        expect(item.proposedVersion).to.be('1.0.0');
+        expect(item.proposedPolicy).not.to.be(undefined);
+        expect(item.proposedPolicy?.id).to.be(policyId);
+        expect(item.proposedPolicy?.package.name).to.be('test_agentless');
+
+        // The proposed policy must be the clean agentless shape, never Fleet internals.
+        expect(item.proposedPolicy).to.not.have.property('policy_ids');
+        expect(item.proposedPolicy).to.not.have.property('revision');
+        expect(item.proposedPolicy).to.not.have.property('supports_agentless');
+      });
+
+      it('should reject the dry-run with a 404 for a missing policy', async () => {
+        const missingId = uuidv4();
+
+        // A per-policy guard failure is promoted to a top-level HTTP error (mirrors
+        // package-policy dry-run).
+        await expectToRejectWithError(
+          () => apiClient.upgradeAgentlessPoliciesDryRun([missingId]),
+          /404/
+        );
+      });
+
+      it('should reject the bulk upgrade for a user without writeIntegrationPolicies', async () => {
+        const policyId = uuidv4();
+        await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);
+
+        await expectToRejectWithError(
+          () => readOnlyApiClient.bulkUpgradeAgentlessPolicies([policyId]),
+          /403/
+        );
+      });
+
+      it('should allow the dry-run for a user with only readIntegrationPolicies', async () => {
+        const policyId = uuidv4();
+        await createTestAgentlessPolicy(policyId, `test_agentless-${Date.now()}`);
+
+        const res = await readOnlyApiClient.upgradeAgentlessPoliciesDryRun([policyId]);
+        expect(res.length).to.be(1);
+        expect(res[0].id).to.be(policyId);
+      });
+    });
+
     describe('Sync Agentless Policies', () => {
       let apiCalls: Array<{
         url: string;

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -50,6 +50,8 @@ import type {
   ListAgentlessPoliciesResponse,
   UpdateAgentlessPolicyRequest,
   UpdateAgentlessPolicyResponse,
+  BulkUpgradeAgentlessPoliciesResponse,
+  AgentlessPolicyUpgradeDryRunResponse,
   PutDownloadSourceRequest,
 } from '@kbn/fleet-plugin/common/types';
 import type {
@@ -143,6 +145,36 @@ export class SpaceTestApiClient {
       .auth(this.auth.username, this.auth.password)
       .set('kbn-xsrf', 'xxxx')
       .send(data);
+
+    expectStatusCode200(res);
+
+    return res.body;
+  }
+
+  async bulkUpgradeAgentlessPolicies(
+    policyIds: string[],
+    spaceId?: string
+  ): Promise<BulkUpgradeAgentlessPoliciesResponse> {
+    const res = await this.supertest
+      .post(`${this.getBaseUrl(spaceId)}/api/fleet/agentless_policies/_upgrade`)
+      .auth(this.auth.username, this.auth.password)
+      .set('kbn-xsrf', 'xxxx')
+      .send({ policyIds });
+
+    expectStatusCode200(res);
+
+    return res.body;
+  }
+
+  async upgradeAgentlessPoliciesDryRun(
+    policyIds: string[],
+    spaceId?: string
+  ): Promise<AgentlessPolicyUpgradeDryRunResponse> {
+    const res = await this.supertest
+      .post(`${this.getBaseUrl(spaceId)}/api/fleet/agentless_policies/_upgrade/dryrun`)
+      .auth(this.auth.username, this.auth.password)
+      .set('kbn-xsrf', 'xxxx')
+      .send({ policyIds });
 
     expectStatusCode200(res);
 


### PR DESCRIPTION
## Summary

Adds two public endpoints to bulk-upgrade agentless policies to their installed package version, with a dry-run preview:

- `POST /api/fleet/agentless_policies/_upgrade`
- `POST /api/fleet/agentless_policies/_upgrade/dryrun`

Both take `{ policyIds: string[] }` (max 1000) and reuse the shared package-policy bulk-upgrade engine (`packagePolicyService.bulkUpgrade` / `getUpgradeDryRunDiff`) for version resolution, the eligibility guard, config migration (`updatePackageInputs`) and telemetry. The agentless layer adds a per-policy **agentless guard** (missing / non-agentless ids can't leak through) and, crucially, returns everything in the **clean `AgentlessPolicy` shape** — no Fleet internals.

This unblocks migrating the UI upgrade flow to the agentless API.

## Why this isn't redundant with the PUT (#8070)

The PUT changes **one** policy with full-replace semantics — the caller must send the complete desired config for the new version. This endpoint is the complementary operation:

- **Bulk** — upgrade many policies in one call (mirrors `POST /api/fleet/package_policies/upgrade`).
- **Keep-current-config** — auto-migrates the existing config onto the new package schema; the caller doesn't need to know what changed between versions.
- **Dry-run preview** + **eligibility guard** (no downgrade-below-installed) + **upgrade telemetry**.

## ⭐ Highlight: the dry-run output contract

The legacy package-policy dry-run (`/api/fleet/package_policies/upgrade/dryrun`) returns the raw Fleet-internal diff — a `diff: [currentPackagePolicy, upgradedPackagePolicy]` pair of full `PackagePolicy` objects (compiled inputs/streams, `revision`, `secret_references`, ES metadata, `agent_diff`, …).

This endpoint deliberately **does not** expose that. Instead each dry-run result is projected into the clean agentless shape:

```jsonc
{
  "id": "292251b7-…-9cda26a56b40",
  "name": "agentless_hello_world-15",
  "hasErrors": false,
  "currentVersion": "0.4.0",
  "proposedVersion": "0.5.0",
  "proposedPolicy": {            // a full, consumable AgentlessPolicy
    "id": "…",
    "name": "agentless_hello_world-15",
    "package": { "name": "agentless_hello_world", "title": "…", "version": "0.5.0" },
    "inputs": { /* migrated, simplified inputs — no compiled_* */ },
    "cloud_connector": null,
    "created_at": "…", "created_by": "…", "updated_at": "…", "updated_by": "…"
  }
}
```

### Mixed-batch example (partial failure stays 200)

A dry-run over three ids — one upgradeable policy and two missing/non-agentless ids — returns 200 with every outcome in request order. Failures are per-item, not a top-level error:

```json
[
  {
    "id": "2e426392-f856-4ab2-bc31-92d4dbb8d134",
    "name": "agentless_hello_world-16",
    "hasErrors": false,
    "currentVersion": "0.5.0",
    "proposedVersion": "0.5.0",
    "proposedPolicy": {
      "id": "2e426392-f856-4ab2-bc31-92d4dbb8d134",
      "name": "agentless_hello_world-16",
      "description": "",
      "namespace": "default",
      "package": {
        "name": "agentless_hello_world",
        "title": "Agentless Hello World",
        "version": "0.5.0"
      },
      "inputs": {
        "agentless_hello_world-cel": {
          "enabled": true,
          "streams": {
            "agentless_hello_world.generic": {
              "enabled": true,
              "vars": { "url": "https://epr.elastic.co" }
            },
            "agentless_hello_world.mock_counter": {
              "enabled": false,
              "vars": {
                "mode": "constant",
                "events_per_second": 10,
                "spike_events": 100,
                "spike_every_seconds": 60
              }
            }
          }
        },
        "agentless_hello_world-httpjson": {
          "enabled": false,
          "streams": {
            "agentless_hello_world.generic": {
              "enabled": false,
              "vars": { "url": "https://epr.elastic.co" }
            }
          }
        }
      },
      "cloud_connector": null,
      "created_at": "2026-07-01T15:59:08.299Z",
      "created_by": "admin",
      "updated_at": "2026-07-01T16:02:14.067Z",
      "updated_by": "admin"
    }
  },
  {
    "id": "9300464c-6cfc-4566-850d-e9e7927457fe",
    "hasErrors": true,
    "statusCode": 404,
    "body": { "message": "Agentless policy 9300464c-6cfc-4566-850d-e9e7927457fe not found" }
  },
  {
    "id": "5b8763e9-791a-4038-be29-b384d578200e",
    "hasErrors": true,
    "statusCode": 404,
    "body": { "message": "Agentless policy 5b8763e9-791a-4038-be29-b384d578200e not found" }
  }
]
```

### Rationale

- **No leaked Fleet internals.** The whole point of the agentless API redesign is a clean external contract; re-exposing raw `PackagePolicy` diffs would defeat it.
- **Same envelope everywhere.** `proposedPolicy` is the identical `AgentlessPolicy` shape used by GET / LIST / POST / PUT, so it round-trips: **dry-run → (optionally edit) → PUT**.
- **Explicit version delta** via `currentVersion` / `proposedVersion`; migration problems via `hasErrors` / `errors`.

### Tradeoff to be aware of (reviewers)

The response carries only the **after** state (`proposedPolicy`), not a paired before/after like the legacy `[current, proposed]` diff. A before/after diff view is still fully possible — the "before" is the current policy from `GET /agentless_policies/{id}` (or the list row the UI already has), in the **same** shape, so a client-side field diff is actually cleaner than diffing two raw package policies. If we want the dry-run to be **self-contained** for a diff view, the cheap follow-up is to add a sibling `currentPolicy: AgentlessPolicy` next to `proposedPolicy`. (Open question below.)

## Behavior & semantics

- **Agentless guard (per policy).** Missing or non-agentless ids are collapsed into a per-policy `404` (batched equivalent of the PUT's `getExistingAgentlessPackagePolicy`), so this API never confirms the existence of, or operates on, regular Fleet package policies.
- **Deploy is asynchronous.** After the saved objects are upgraded, the live reconcile is the background Task-Manager deploy (with the deployment-sync task as backstop) — exactly like package-policy. `success: true` therefore means **"saved object upgraded"**, not "workload already running the new version". (An earlier iteration reconciled synchronously with `throwOnAgentlessError`; that was dropped because it double-deployed with the engine's own async deploy and didn't scale to 1000 sequential external calls.)
- **Error contract: always 200 + per-policy array (deliberate divergence from package-policy).** Unlike the package-policy bulk upgrade/dry-run handlers — which promote the first per-policy fatal `statusCode` to a top-level HTTP error and drop the array — these endpoints **always return 200 with the full per-policy result array**. A missing / non-agentless id (or an ineligible / fatal dry-run item) is reported as a **per-item failure** (`success: false` + `statusCode` + `body`, or for dry-run `hasErrors: true` + `statusCode` + `body`) *without* failing the batch, so valid ids are still upgraded/previewed and every outcome is visible to the caller. This keeps partial-batch results transparent instead of masking a partial success behind a single top-level error. (Top-level `400` is still returned for request-schema validation failures.) See the mixed-batch example under the dry-run highlight below.
- **Result ordering.** Results are returned in the caller's (deduped) request order via `orderResultsByRequest`, so consumers can zip positionally as well as by `id`.
- **Authz.** `_upgrade` requires `writeIntegrationPolicies`; `_upgrade/dryrun` requires `readIntegrationPolicies`.
- **Versioning.** Public `v1`, `since: 9.5.0`, `experimental` — matching the other new agentless endpoints.

## Naming: why `_upgrade` (not `upgrade`)

The underscore is intentional. It matches the sibling agentless action route `_sync` (`/agentless_policies/_sync`) and the broader Elastic `_action` convention (`_bulk_upgrade`, `_bulk_uninstall`, `_bulk_get`, …), clearly marking an operation on the collection distinct from the `{policyId}` resource routes. `package_policies` uses the bare `upgrade` only because it predates this convention. (It's a naming choice, not a router necessity — `POST /agentless_policies/upgrade` wouldn't actually collide with anything.)

## Known limitation (parity with package-policy) → follow-up

Bulk upgrade migrates the **package policy** config only. It does **not** re-derive the backing **agent policy**'s agentless config (`resources`) or ownership `global_data_tags` from the new package manifest — only create / PUT do that. If a new package version changes those agent-policy-level fields, use the PUT endpoint to pick them up. This is `[EXISTING]`-parity with the shared engine; documented inline in the service + route description and tracked as a follow-up issue.


## Decisions taken

- **Error contract → always 200 + per-policy array (diverges from package-policy).** We initially aligned with package-policy (promote the first per-policy fatal `statusCode` to a top-level error). We reverted that: a batch with an invalid id was returning a top-level 4xx while valid ids in the same batch had *already been upgraded*, hiding the partial success. The endpoints now always return 200 with the full per-policy array, and per-item failures carry `success: false` + `statusCode` + `body` (dry-run: `hasErrors: true` + `statusCode` + `body`). This also settles the "now-vestigial per-item fields" question — those fields are now the primary way failures are reported, not dead weight. `hasErrors` on a dry-run item is `true` for both guard failures and config-migration errors (distinguish via the presence of `statusCode`/`body` vs `errors`).

## Open questions for reviewers (please weigh in)

1. **Dry-run diff view.** Add `currentPolicy: AgentlessPolicy` so the dry-run is self-contained for a before/after diff, or rely on the client's existing GET/list data?
2. **`proposedPolicy` apply path.** Dry-run builds `proposedPolicy` via `updatePackageInputs` while PUT rebuilds via `simplifiedPackagePolicytoNewPackagePolicy`; an **unedited** `proposedPolicy` sent to PUT may not be byte-identical to the `_upgrade` outcome. Should we document the apply path as "edited payloads only", or guarantee equivalence?
3. **Idempotency of re-upgrading an already-latest policy.** The endpoint is idempotent-success: calling `_upgrade` repeatedly with the same id keeps returning `success: true` even after the policy already reached the installed version. This is `[EXISTING]` engine behavior — the eligibility guard only rejects when the policy is *ahead* of the installed version (`isInstalledVersionLessThanPolicyVersion`); an equal version is treated as eligible and re-runs `doUpgrade` + `bulkUpdate`. The catch is that a repeat call is **not a true no-op**: it re-persists the SO (**bumps the policy revision**) and, via `asyncDeploy: true`, **reschedules a background deploy** — for agentless that's a redundant reconcile / agentless-API POST for an unchanged workload. Idempotent *success* is desirable (safe retries against the async deploy), so returning a 4xx for "already up to date" is not proposed. Decision to take: (a) leave as-is for full package-policy parity and accept the revision/redeploy churn, (b) just document the behavior, or (c) short-circuit already-latest ids to a genuine no-op result (skip `bulkUpdate`/redeploy) — cleaner for agentless but diverges from the shared engine, so arguably belongs as a fix in the package-policy path rather than only here.
4. **cc @nchaulet / @nkvoll** — the dry-run output contract was flagged for your confirmation in the kickoff.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



