### PR TITLE
[Vector DB] Optimize deployment stats request on the home page

### DIFF
--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/common/constants.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/common/constants.ts
@@ -8,3 +8,4 @@
 export const VECTORDB_APP_ID = 'vectordb';
 export const TUTORIALS_DEEP_LINK_ID = 'tutorials';
 export const DEPLOYMENT_STATS_PATH = '/internal/serverless_vectordb/deployment_stats';
+export const WORKFLOWS_STATS_PATH = '/api/workflows/stats';

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
@@ -25,7 +25,8 @@ import {
 import { TrialUsageBadge, CloudLinks } from '@kbn/shared-components';
 import { ConnectToProject, useOnboardingCredentials } from '@kbn/vectordb-onboarding';
 import { i18n } from '@kbn/i18n';
-import { formatBytes, formatNumber, useDeploymentStats } from '../hooks/use_deployment_stats';
+import { useDeploymentStats } from '../hooks/use_deployment_stats';
+import { formatBytes, formatNumber } from '../utils/format';
 import { useAgentsCount } from '../hooks/use_agents_count';
 import { HomePageBanner } from './home_page_banner';
 import { DocumentationQuickLinks } from './documentation_quick_links';

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_agents_count.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_agents_count.ts
@@ -24,6 +24,9 @@ export const useAgentsCount = () => {
       return response?.results?.length ?? null;
     },
     refetchOnWindowFocus: false,
+    // This is the slowest of the home-page stat calls, so cache it for 60s to avoid re-incurring it
+    // on every remount/navigation. Matches the staleTime used by useDeploymentStats.
+    staleTime: 60_000,
   });
 
   return { agentsCount: data ?? initialAgentsCount, isLoading };

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_agents_count.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_agents_count.ts
@@ -24,8 +24,6 @@ export const useAgentsCount = () => {
       return response?.results?.length ?? null;
     },
     refetchOnWindowFocus: false,
-    // This is the slowest of the home-page stat calls, so cache it for 60s to avoid re-incurring it
-    // on every remount/navigation. Matches the staleTime used by useDeploymentStats.
     staleTime: 60_000,
   });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
@@ -7,9 +7,12 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useKibana } from './use_kibana';
-import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
+import { DEPLOYMENT_STATS_PATH, WORKFLOWS_STATS_PATH } from '../../common/constants';
 
-export interface DeploymentStats {
+interface WorkflowsStats {
+  workflows?: { enabled?: number; disabled?: number };
+}
+interface DeploymentStats {
   indicesCount: number | null;
   vectorDocsCount: number | null;
   storeSizeBytes: number | null;
@@ -34,17 +37,8 @@ export const useDeploymentStats = () => {
     queryKey: ['deploymentStats'],
     queryFn: async () => {
       const [esStats, workflowsResponse] = await Promise.all([
-        http
-          .get<{
-            indicesCount: number;
-            vectorDocsCount: number;
-            storeSizeBytes: number;
-            dashboardsCount: number;
-          }>(DEPLOYMENT_STATS_PATH)
-          .catch(() => null),
-        http
-          .get<{ workflows?: { enabled?: number; disabled?: number } }>('/api/workflows/stats')
-          .catch(() => null),
+        http.get<DeploymentStats>(DEPLOYMENT_STATS_PATH).catch(() => null),
+        http.get<WorkflowsStats>(WORKFLOWS_STATS_PATH).catch(() => null),
       ]);
 
       return {
@@ -58,19 +52,10 @@ export const useDeploymentStats = () => {
       };
     },
     refetchOnWindowFocus: false,
+    // These are slow-moving, eventually-consistent deployment aggregates, so treat a result as
+    // fresh for 60s to avoid refetching metering + mappings + ES|QL on every remount/navigation.
+    staleTime: 60_000,
   });
 
   return { stats: data ?? initialStats, isLoading };
 };
-
-export const formatBytes = (bytes: number | null): string => {
-  if (bytes === null) return '—';
-  if (bytes === 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
-  const value = bytes / Math.pow(1024, i);
-  return `${value.toFixed(value >= 100 || i === 0 ? 0 : 1)} ${units[i]}`;
-};
-
-export const formatNumber = (n: number | null): string =>
-  n === null ? '—' : new Intl.NumberFormat().format(n);

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
@@ -12,12 +12,15 @@ import { DEPLOYMENT_STATS_PATH, WORKFLOWS_STATS_PATH } from '../../common/consta
 interface WorkflowsStats {
   workflows?: { enabled?: number; disabled?: number };
 }
-interface DeploymentStats {
+
+interface DeploymentStatsResponse {
   indicesCount: number | null;
   vectorDocsCount: number | null;
   storeSizeBytes: number | null;
-  workflowsCount: number | null;
   dashboardsCount: number | null;
+}
+interface DeploymentStats extends DeploymentStatsResponse {
+  workflowsCount: number | null;
 }
 
 const initialStats: DeploymentStats = {
@@ -37,7 +40,7 @@ export const useDeploymentStats = () => {
     queryKey: ['deploymentStats'],
     queryFn: async () => {
       const [esStats, workflowsResponse] = await Promise.all([
-        http.get<DeploymentStats>(DEPLOYMENT_STATS_PATH).catch(() => null),
+        http.get<DeploymentStatsResponse>(DEPLOYMENT_STATS_PATH).catch(() => null),
         http.get<WorkflowsStats>(WORKFLOWS_STATS_PATH).catch(() => null),
       ]);
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
@@ -55,8 +55,6 @@ export const useDeploymentStats = () => {
       };
     },
     refetchOnWindowFocus: false,
-    // These are slow-moving, eventually-consistent deployment aggregates, so treat a result as
-    // fresh for 60s to avoid refetching metering + mappings + ES|QL on every remount/navigation.
     staleTime: 60_000,
   });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.test.ts
@@ -12,29 +12,31 @@ describe('formatBytes', () => {
     expect(formatBytes(null)).toBe('—');
   });
 
-  it('formats zero', () => {
-    expect(formatBytes(0)).toBe('0.00 B');
+  it('formats zero without decimals', () => {
+    expect(formatBytes(0)).toBe('0 B');
   });
 
-  it('formats bytes', () => {
-    expect(formatBytes(500)).toBe('500.00 B');
+  it('formats bytes without trailing zeros', () => {
+    expect(formatBytes(500)).toBe('500 B');
   });
 
   it('formats kilobytes', () => {
-    expect(formatBytes(1024)).toBe('1.00 KB');
-    expect(formatBytes(1536)).toBe('1.50 KB');
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
   });
 
   it('formats megabytes', () => {
-    expect(formatBytes(1024 * 1024)).toBe('1.00 MB');
+    expect(formatBytes(1024 * 1024)).toBe('1 MB');
+    expect(formatBytes(1024 * 1024 * 2.5)).toBe('2.5 MB');
   });
 
-  it('formats gigabytes', () => {
-    expect(formatBytes(1024 ** 3)).toBe('1.00 GB');
+  it('formats gigabytes without trailing zeros', () => {
+    expect(formatBytes(1024 ** 3)).toBe('1 GB');
+    expect(formatBytes(1024 ** 3 * 100)).toBe('100 GB');
   });
 
   it('formats terabytes', () => {
-    expect(formatBytes(1024 ** 4)).toBe('1.00 TB');
+    expect(formatBytes(1024 ** 4)).toBe('1 TB');
   });
 });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.test.ts
@@ -5,48 +5,36 @@
  * 2.0.
  */
 
-import { formatBytes, formatNumber } from './use_deployment_stats';
+import { formatBytes, formatNumber } from './format';
 
 describe('formatBytes', () => {
   it('returns the dash for null', () => {
     expect(formatBytes(null)).toBe('—');
   });
 
-  it('returns "0 B" for zero', () => {
-    expect(formatBytes(0)).toBe('0 B');
+  it('formats zero', () => {
+    expect(formatBytes(0)).toBe('0.00 B');
   });
 
-  it('formats bytes without a decimal', () => {
-    expect(formatBytes(1)).toBe('1 B');
-    expect(formatBytes(500)).toBe('500 B');
-    expect(formatBytes(1023)).toBe('1023 B');
+  it('formats bytes', () => {
+    expect(formatBytes(500)).toBe('500.00 B');
   });
 
   it('formats kilobytes', () => {
-    expect(formatBytes(1024)).toBe('1.0 KB');
-    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(1024)).toBe('1.00 KB');
+    expect(formatBytes(1536)).toBe('1.50 KB');
   });
 
   it('formats megabytes', () => {
-    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
-    expect(formatBytes(1024 * 1024 * 2.5)).toBe('2.5 MB');
+    expect(formatBytes(1024 * 1024)).toBe('1.00 MB');
   });
 
   it('formats gigabytes', () => {
-    expect(formatBytes(1024 ** 3)).toBe('1.0 GB');
+    expect(formatBytes(1024 ** 3)).toBe('1.00 GB');
   });
 
   it('formats terabytes', () => {
-    expect(formatBytes(1024 ** 4)).toBe('1.0 TB');
-  });
-
-  it('omits the decimal when the value is >= 100', () => {
-    expect(formatBytes(1024 ** 3 * 100)).toBe('100 GB');
-  });
-
-  it('caps at terabytes for very large values', () => {
-    const result = formatBytes(1024 ** 5);
-    expect(result).toMatch(/TB$/);
+    expect(formatBytes(1024 ** 4)).toBe('1.00 TB');
   });
 });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.ts
@@ -9,10 +9,11 @@ import numeral from '@elastic/numeral';
 
 /**
  * Formats a byte count for display, returning an em dash for `null` (used to signal that the value
- * could not be fetched, as opposed to a genuine `0`).
+ * could not be fetched, as opposed to a genuine `0`). Shows up to two decimals, dropping trailing
+ * zeros (`500 B`, `1.5 KB`, `100 GB`).
  */
 export const formatBytes = (bytes: number | null): string =>
-  bytes === null ? '—' : numeral(bytes).format('0.00 b');
+  bytes === null ? '—' : numeral(bytes).format('0,0.[00] b');
 
 /**
  * Formats a number with locale-aware thousands separators, returning an em dash for `null`.

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/utils/format.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import numeral from '@elastic/numeral';
+
+/**
+ * Formats a byte count for display, returning an em dash for `null` (used to signal that the value
+ * could not be fetched, as opposed to a genuine `0`).
+ */
+export const formatBytes = (bytes: number | null): string =>
+  bytes === null ? '—' : numeral(bytes).format('0.00 b');
+
+/**
+ * Formats a number with locale-aware thousands separators, returning an em dash for `null`.
+ */
+export const formatNumber = (n: number | null): string =>
+  n === null ? '—' : new Intl.NumberFormat().format(n);

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -93,7 +93,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
     );
     expect(result.vectorDocsCount).toBe(10);
   });
@@ -112,7 +112,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
     );
     expect(result.vectorDocsCount).toBe(10);
   });
@@ -130,7 +130,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
     );
     expect(result.vectorDocsCount).toBe(10);
   });
@@ -158,7 +158,7 @@ describe('fetchIndexStats', () => {
     await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
     );
   });
 
@@ -183,8 +183,44 @@ describe('fetchIndexStats', () => {
     await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM vectordb-a,vectordb-b | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb-a","vectordb-b" | STATS count()' })
     );
+  });
+
+  it('batches the ES|QL count when there are more than 500 vector indices', async () => {
+    const indices = Array.from({ length: 501 }, (_, i) => ({
+      name: `vectordb-${i}`,
+      num_docs: 1,
+      size_in_bytes: 10,
+    }));
+    mockMetering(indices);
+    // A uniform vector field means every index is a vector index.
+    mockFieldCaps({
+      embedding: {
+        dense_vector: { type: 'dense_vector', searchable: true, aggregatable: false },
+      },
+    });
+    client.asCurrentUser.esql.query
+      .mockResolvedValueOnce({
+        columns: [{ name: 'count()', type: 'long' }],
+        values: [[500]],
+      } as any)
+      .mockResolvedValueOnce({
+        columns: [{ name: 'count()', type: 'long' }],
+        values: [[1]],
+      } as any);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledTimes(2);
+    const queries = client.asCurrentUser.esql.query.mock.calls.map(
+      ([request]) => (request as { query: string }).query
+    );
+    expect(queries[0]).toContain('"vectordb-0"');
+    expect(queries[0]).toContain('"vectordb-499"');
+    expect(queries[0]).not.toContain('"vectordb-500"');
+    expect(queries[1]).toBe('FROM "vectordb-500" | STATS count()');
+    expect(result.vectorDocsCount).toBe(501);
   });
 
   it('returns a null vectorDocsCount (not 0) when the vector lookup fails', async () => {

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScopedClusterClientMock } from '@kbn/core/server/mocks';
+import {
+  elasticsearchServiceMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+} from '@kbn/core/server/mocks';
+import { containsVectorField, fetchDashboardsCount, fetchIndexStats } from './deployment_stats';
+
+describe('containsVectorField', () => {
+  it('returns false for undefined properties', () => {
+    expect(containsVectorField(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty properties map', () => {
+    expect(containsVectorField({})).toBe(false);
+  });
+
+  it('returns true when a top-level field is dense_vector', () => {
+    expect(containsVectorField({ embedding: { type: 'dense_vector' } })).toBe(true);
+  });
+
+  it('returns true when a top-level field is semantic_text', () => {
+    expect(containsVectorField({ body: { type: 'semantic_text' } })).toBe(true);
+  });
+
+  it('returns true when a top-level field is sparse_vector', () => {
+    expect(containsVectorField({ ml_tokens: { type: 'sparse_vector' } })).toBe(true);
+  });
+
+  it('returns false when no vector fields are present', () => {
+    expect(
+      containsVectorField({
+        title: { type: 'text' },
+        count: { type: 'integer' },
+      })
+    ).toBe(false);
+  });
+
+  it('returns true when a vector field is nested inside an object', () => {
+    expect(
+      containsVectorField({
+        metadata: {
+          properties: {
+            embedding: { type: 'dense_vector' },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when a vector field is deeply nested', () => {
+    expect(
+      containsVectorField({
+        level1: {
+          properties: {
+            level2: {
+              properties: {
+                vector: { type: 'dense_vector' },
+              },
+            },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when nested properties contain no vector fields', () => {
+    expect(
+      containsVectorField({
+        metadata: {
+          properties: {
+            author: { type: 'keyword' },
+          },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('returns true on first match and short-circuits', () => {
+    expect(
+      containsVectorField({
+        title: { type: 'text' },
+        embedding: { type: 'dense_vector' },
+        body: { type: 'text' },
+      })
+    ).toBe(true);
+  });
+});
+
+describe('fetchIndexStats', () => {
+  let client: ScopedClusterClientMock;
+  const logger = loggingSystemMock.createLogger();
+
+  beforeEach(() => {
+    client = elasticsearchServiceMock.createScopedClusterClient();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockMetering = (
+    indices: Array<{ name: string; num_docs: number; size_in_bytes: number }>
+  ) => {
+    client.asSecondaryAuthUser.transport.request.mockResolvedValue({
+      _total: {
+        num_docs: indices.reduce((sum, i) => sum + i.num_docs, 0),
+        size_in_bytes: indices.reduce((sum, i) => sum + i.size_in_bytes, 0),
+      },
+      indices,
+    });
+  };
+
+  it('excludes dot-prefixed indices and aggregates count/size', async () => {
+    mockMetering([
+      { name: 'products', num_docs: 10, size_in_bytes: 100 },
+      { name: '.kibana', num_docs: 999, size_in_bytes: 999 },
+    ]);
+    // No vector indices in the mappings.
+    client.asCurrentUser.indices.getMapping.mockResolvedValue({
+      products: { mappings: { properties: { title: { type: 'text' } } } },
+    } as any);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 100, vectorDocsCount: 0 });
+    expect(client.asCurrentUser.esql.query).not.toHaveBeenCalled();
+  });
+
+  it('counts vector docs via ES|QL (avoiding nested-doc inflation from metering)', async () => {
+    // metering over-reports num_docs (20) for the semantic_text index; ES|QL returns the real 10.
+    mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
+    client.asCurrentUser.indices.getMapping.mockResolvedValue({
+      vectordb: { mappings: { properties: { semantic_content: { type: 'semantic_text' } } } },
+    } as any);
+    client.asCurrentUser.esql.query.mockResolvedValue({
+      columns: [{ name: 'count()', type: 'long' }],
+      values: [[10]],
+    } as any);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+    );
+    expect(result.vectorDocsCount).toBe(10);
+  });
+
+  it('only queries the vector indices, not every user index', async () => {
+    mockMetering([
+      { name: 'vectordb', num_docs: 10, size_in_bytes: 500 },
+      { name: 'plain-text', num_docs: 5, size_in_bytes: 50 },
+    ]);
+    client.asCurrentUser.indices.getMapping.mockResolvedValue({
+      vectordb: { mappings: { properties: { embedding: { type: 'dense_vector' } } } },
+      'plain-text': { mappings: { properties: { title: { type: 'text' } } } },
+    } as any);
+    client.asCurrentUser.esql.query.mockResolvedValue({
+      columns: [{ name: 'count()', type: 'long' }],
+      values: [[10]],
+    } as any);
+
+    await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+    );
+  });
+
+  it('returns a null vectorDocsCount (not 0) when mapping/ES|QL lookup fails', async () => {
+    mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
+    client.asCurrentUser.indices.getMapping.mockRejectedValue(new Error('boom'));
+
+    const result = await fetchIndexStats(client, logger);
+
+    // index/size counts are still valid; only the vector doc count is unavailable
+    expect(result).toEqual({ indicesCount: 1, storeSizeBytes: 500, vectorDocsCount: null });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('returns all-null (not zeros) when the metering call fails', async () => {
+    client.asSecondaryAuthUser.transport.request.mockRejectedValue(new Error('metering down'));
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(result).toEqual({
+      indicesCount: null,
+      storeSizeBytes: null,
+      vectorDocsCount: null,
+    });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('skips mapping/ES|QL lookups when there are no user indices', async () => {
+    mockMetering([]);
+
+    const result = await fetchIndexStats(client, logger);
+
+    // a genuinely empty deployment reports real zeros, not null
+    expect(result).toEqual({ indicesCount: 0, storeSizeBytes: 0, vectorDocsCount: 0 });
+    expect(client.asCurrentUser.indices.getMapping).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchDashboardsCount', () => {
+  const logger = loggingSystemMock.createLogger();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the total from the saved objects client', async () => {
+    const soClient = savedObjectsClientMock.create();
+    soClient.find.mockResolvedValue({ total: 7, page: 1, per_page: 0, saved_objects: [] });
+
+    await expect(fetchDashboardsCount(soClient, logger)).resolves.toBe(7);
+    expect(soClient.find).toHaveBeenCalledWith({ type: 'dashboard', perPage: 0 });
+  });
+
+  it('returns null (not 0) and logs when the lookup fails', async () => {
+    const soClient = savedObjectsClientMock.create();
+    soClient.find.mockRejectedValue(new Error('nope'));
+
+    await expect(fetchDashboardsCount(soClient, logger)).resolves.toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -43,7 +43,7 @@ describe('fetchIndexStats', () => {
 
   const mockEsqlCount = (count: number) => {
     client.asCurrentUser.esql.query.mockResolvedValue({
-      columns: [{ name: 'count()', type: 'long' }],
+      columns: [{ name: 'doc_count', type: 'long' }],
       values: [[count]],
     } as any);
   };
@@ -76,6 +76,8 @@ describe('fetchIndexStats', () => {
       // `text` is included because `semantic_text` may be reported as `text` + `inference: true`
       types: ['dense_vector', 'sparse_vector', 'semantic_text', 'semantic', 'text'],
       filters: '-metadata',
+      // Required so partially-mapped fields carry an explicit `indices` list.
+      include_unmapped: true,
     });
   });
 
@@ -93,7 +95,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
     );
     expect(result.vectorDocsCount).toBe(10);
   });
@@ -112,7 +114,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
     );
     expect(result.vectorDocsCount).toBe(10);
   });
@@ -130,7 +132,7 @@ describe('fetchIndexStats', () => {
     const result = await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
     );
     expect(result.vectorDocsCount).toBe(10);
   });
@@ -158,8 +160,44 @@ describe('fetchIndexStats', () => {
     await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb" | STATS count()' })
+      expect.objectContaining({ query: 'FROM "vectordb" | STATS doc_count = COUNT(*)' })
     );
+  });
+
+  it('does not classify indices where the vector field is unmapped', async () => {
+    mockMetering([
+      { name: 'test-vector', num_docs: 10, size_in_bytes: 500 },
+      { name: 'test-plain', num_docs: 5000, size_in_bytes: 50 },
+    ]);
+    // Real response shape with `include_unmapped: true` when `embedding` only exists in
+    // `test-vector`: the mapped entry carries `indices`, plus an `unmapped` pseudo-entry for the
+    // indices where the field does not exist (verified against a serverless cluster).
+    mockFieldCaps({
+      embedding: {
+        unmapped: {
+          type: 'unmapped',
+          searchable: false,
+          aggregatable: false,
+          inference: false,
+          indices: ['test-plain'],
+        },
+        dense_vector: {
+          type: 'dense_vector',
+          searchable: true,
+          aggregatable: false,
+          inference: false,
+          indices: ['test-vector'],
+        },
+      },
+    });
+    mockEsqlCount(10);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM "test-vector" | STATS doc_count = COUNT(*)' })
+    );
+    expect(result.vectorDocsCount).toBe(10);
   });
 
   it('treats a vector field with no `indices` as present in every requested index', async () => {
@@ -183,7 +221,9 @@ describe('fetchIndexStats', () => {
     await fetchIndexStats(client, logger);
 
     expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'FROM "vectordb-a","vectordb-b" | STATS count()' })
+      expect.objectContaining({
+        query: 'FROM "vectordb-a","vectordb-b" | STATS doc_count = COUNT(*)',
+      })
     );
   });
 
@@ -202,11 +242,11 @@ describe('fetchIndexStats', () => {
     });
     client.asCurrentUser.esql.query
       .mockResolvedValueOnce({
-        columns: [{ name: 'count()', type: 'long' }],
+        columns: [{ name: 'doc_count', type: 'long' }],
         values: [[500]],
       } as any)
       .mockResolvedValueOnce({
-        columns: [{ name: 'count()', type: 'long' }],
+        columns: [{ name: 'doc_count', type: 'long' }],
         values: [[1]],
       } as any);
 
@@ -219,7 +259,7 @@ describe('fetchIndexStats', () => {
     expect(queries[0]).toContain('"vectordb-0"');
     expect(queries[0]).toContain('"vectordb-499"');
     expect(queries[0]).not.toContain('"vectordb-500"');
-    expect(queries[1]).toBe('FROM "vectordb-500" | STATS count()');
+    expect(queries[1]).toBe('FROM "vectordb-500" | STATS doc_count = COUNT(*)');
     expect(result.vectorDocsCount).toBe(501);
   });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -119,12 +119,11 @@ describe('fetchIndexStats', () => {
     expect(result.vectorDocsCount).toBe(10);
   });
 
-  it('detects a `semantic` field via the field caps inference flag', async () => {
+  it('detects a `semantic` field by its own reported type', async () => {
     mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
-    // `semantic` and `semantic_text` are both inference fields, flagged via `inference: true`.
     mockFieldCaps({
       body: {
-        semantic: { type: 'semantic', searchable: true, aggregatable: false, inference: true },
+        semantic: { type: 'semantic', searchable: true, aggregatable: false },
       },
     });
     mockEsqlCount(10);
@@ -169,9 +168,6 @@ describe('fetchIndexStats', () => {
       { name: 'test-vector', num_docs: 10, size_in_bytes: 500 },
       { name: 'test-plain', num_docs: 5000, size_in_bytes: 50 },
     ]);
-    // Real response shape with `include_unmapped: true` when `embedding` only exists in
-    // `test-vector`: the mapped entry carries `indices`, plus an `unmapped` pseudo-entry for the
-    // indices where the field does not exist (verified against a serverless cluster).
     mockFieldCaps({
       embedding: {
         unmapped: {

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.test.ts
@@ -11,88 +11,7 @@ import {
   loggingSystemMock,
   savedObjectsClientMock,
 } from '@kbn/core/server/mocks';
-import { containsVectorField, fetchDashboardsCount, fetchIndexStats } from './deployment_stats';
-
-describe('containsVectorField', () => {
-  it('returns false for undefined properties', () => {
-    expect(containsVectorField(undefined)).toBe(false);
-  });
-
-  it('returns false for an empty properties map', () => {
-    expect(containsVectorField({})).toBe(false);
-  });
-
-  it('returns true when a top-level field is dense_vector', () => {
-    expect(containsVectorField({ embedding: { type: 'dense_vector' } })).toBe(true);
-  });
-
-  it('returns true when a top-level field is semantic_text', () => {
-    expect(containsVectorField({ body: { type: 'semantic_text' } })).toBe(true);
-  });
-
-  it('returns true when a top-level field is sparse_vector', () => {
-    expect(containsVectorField({ ml_tokens: { type: 'sparse_vector' } })).toBe(true);
-  });
-
-  it('returns false when no vector fields are present', () => {
-    expect(
-      containsVectorField({
-        title: { type: 'text' },
-        count: { type: 'integer' },
-      })
-    ).toBe(false);
-  });
-
-  it('returns true when a vector field is nested inside an object', () => {
-    expect(
-      containsVectorField({
-        metadata: {
-          properties: {
-            embedding: { type: 'dense_vector' },
-          },
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('returns true when a vector field is deeply nested', () => {
-    expect(
-      containsVectorField({
-        level1: {
-          properties: {
-            level2: {
-              properties: {
-                vector: { type: 'dense_vector' },
-              },
-            },
-          },
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('returns false when nested properties contain no vector fields', () => {
-    expect(
-      containsVectorField({
-        metadata: {
-          properties: {
-            author: { type: 'keyword' },
-          },
-        },
-      })
-    ).toBe(false);
-  });
-
-  it('returns true on first match and short-circuits', () => {
-    expect(
-      containsVectorField({
-        title: { type: 'text' },
-        embedding: { type: 'dense_vector' },
-        body: { type: 'text' },
-      })
-    ).toBe(true);
-  });
-});
+import { fetchDashboardsCount, fetchIndexStats } from './deployment_stats';
 
 describe('fetchIndexStats', () => {
   let client: ScopedClusterClientMock;
@@ -118,15 +37,26 @@ describe('fetchIndexStats', () => {
     });
   };
 
+  const mockFieldCaps = (fields: Record<string, Record<string, unknown>>) => {
+    client.asCurrentUser.fieldCaps.mockResolvedValue({ indices: [], fields } as any);
+  };
+
+  const mockEsqlCount = (count: number) => {
+    client.asCurrentUser.esql.query.mockResolvedValue({
+      columns: [{ name: 'count()', type: 'long' }],
+      values: [[count]],
+    } as any);
+  };
+
   it('excludes dot-prefixed indices and aggregates count/size', async () => {
     mockMetering([
       { name: 'products', num_docs: 10, size_in_bytes: 100 },
       { name: '.kibana', num_docs: 999, size_in_bytes: 999 },
     ]);
-    // No vector indices in the mappings.
-    client.asCurrentUser.indices.getMapping.mockResolvedValue({
-      products: { mappings: { properties: { title: { type: 'text' } } } },
-    } as any);
+    // No vector fields.
+    mockFieldCaps({
+      title: { text: { type: 'text', searchable: true, aggregatable: false, inference: false } },
+    });
 
     const result = await fetchIndexStats(client, logger);
 
@@ -134,16 +64,31 @@ describe('fetchIndexStats', () => {
     expect(client.asCurrentUser.esql.query).not.toHaveBeenCalled();
   });
 
-  it('counts vector docs via ES|QL (avoiding nested-doc inflation from metering)', async () => {
+  it('restricts field caps to vector-relevant field types and skips metadata fields', async () => {
+    mockMetering([{ name: 'products', num_docs: 10, size_in_bytes: 100 }]);
+    mockFieldCaps({});
+
+    await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.fieldCaps).toHaveBeenCalledWith({
+      index: ['products'],
+      fields: '*',
+      // `text` is included because `semantic_text` may be reported as `text` + `inference: true`
+      types: ['dense_vector', 'sparse_vector', 'semantic_text', 'semantic', 'text'],
+      filters: '-metadata',
+    });
+  });
+
+  it('detects semantic_text via the field caps inference flag and counts docs via ES|QL', async () => {
     // metering over-reports num_docs (20) for the semantic_text index; ES|QL returns the real 10.
+    // `semantic_text` is reported as `text` by field caps, so it is detected via `inference: true`.
     mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
-    client.asCurrentUser.indices.getMapping.mockResolvedValue({
-      vectordb: { mappings: { properties: { semantic_content: { type: 'semantic_text' } } } },
-    } as any);
-    client.asCurrentUser.esql.query.mockResolvedValue({
-      columns: [{ name: 'count()', type: 'long' }],
-      values: [[10]],
-    } as any);
+    mockFieldCaps({
+      semantic_content: {
+        text: { type: 'text', searchable: true, aggregatable: false, inference: true },
+      },
+    });
+    mockEsqlCount(10);
 
     const result = await fetchIndexStats(client, logger);
 
@@ -153,19 +98,62 @@ describe('fetchIndexStats', () => {
     expect(result.vectorDocsCount).toBe(10);
   });
 
-  it('only queries the vector indices, not every user index', async () => {
+  it('detects an inference field reported by its own `type` (no inference flag)', async () => {
+    // In some versions/formats field caps reports `semantic_text` by its own type rather than as
+    // `text` + `inference: true`, so the type set must also catch it.
+    mockMetering([{ name: 'vectordb', num_docs: 20, size_in_bytes: 500 }]);
+    mockFieldCaps({
+      semantic_content: {
+        semantic_text: { type: 'semantic_text', searchable: true, aggregatable: false },
+      },
+    });
+    mockEsqlCount(10);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+    );
+    expect(result.vectorDocsCount).toBe(10);
+  });
+
+  it('detects a `semantic` field via the field caps inference flag', async () => {
+    mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
+    // `semantic` and `semantic_text` are both inference fields, flagged via `inference: true`.
+    mockFieldCaps({
+      body: {
+        semantic: { type: 'semantic', searchable: true, aggregatable: false, inference: true },
+      },
+    });
+    mockEsqlCount(10);
+
+    const result = await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM vectordb | STATS count()' })
+    );
+    expect(result.vectorDocsCount).toBe(10);
+  });
+
+  it('only queries indices whose field caps report a vector field', async () => {
     mockMetering([
       { name: 'vectordb', num_docs: 10, size_in_bytes: 500 },
       { name: 'plain-text', num_docs: 5, size_in_bytes: 50 },
     ]);
-    client.asCurrentUser.indices.getMapping.mockResolvedValue({
-      vectordb: { mappings: { properties: { embedding: { type: 'dense_vector' } } } },
-      'plain-text': { mappings: { properties: { title: { type: 'text' } } } },
-    } as any);
-    client.asCurrentUser.esql.query.mockResolvedValue({
-      columns: [{ name: 'count()', type: 'long' }],
-      values: [[10]],
-    } as any);
+    // `embedding` (dense_vector) only exists in `vectordb`, so field caps scopes it via `indices`.
+    mockFieldCaps({
+      embedding: {
+        dense_vector: {
+          type: 'dense_vector',
+          searchable: true,
+          aggregatable: false,
+          inference: false,
+          indices: ['vectordb'],
+        },
+      },
+      title: { text: { type: 'text', searchable: true, aggregatable: false, inference: false } },
+    });
+    mockEsqlCount(10);
 
     await fetchIndexStats(client, logger);
 
@@ -174,9 +162,34 @@ describe('fetchIndexStats', () => {
     );
   });
 
-  it('returns a null vectorDocsCount (not 0) when mapping/ES|QL lookup fails', async () => {
+  it('treats a vector field with no `indices` as present in every requested index', async () => {
+    mockMetering([
+      { name: 'vectordb-a', num_docs: 10, size_in_bytes: 500 },
+      { name: 'vectordb-b', num_docs: 10, size_in_bytes: 500 },
+    ]);
+    // `indices` is omitted when the field is uniform across all requested indices.
+    mockFieldCaps({
+      embedding: {
+        dense_vector: {
+          type: 'dense_vector',
+          searchable: true,
+          aggregatable: false,
+          inference: false,
+        },
+      },
+    });
+    mockEsqlCount(20);
+
+    await fetchIndexStats(client, logger);
+
+    expect(client.asCurrentUser.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM vectordb-a,vectordb-b | STATS count()' })
+    );
+  });
+
+  it('returns a null vectorDocsCount (not 0) when the vector lookup fails', async () => {
     mockMetering([{ name: 'vectordb', num_docs: 10, size_in_bytes: 500 }]);
-    client.asCurrentUser.indices.getMapping.mockRejectedValue(new Error('boom'));
+    client.asCurrentUser.fieldCaps.mockRejectedValue(new Error('boom'));
 
     const result = await fetchIndexStats(client, logger);
 
@@ -198,14 +211,14 @@ describe('fetchIndexStats', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  it('skips mapping/ES|QL lookups when there are no user indices', async () => {
+  it('skips vector lookups when there are no user indices', async () => {
     mockMetering([]);
 
     const result = await fetchIndexStats(client, logger);
 
     // a genuinely empty deployment reports real zeros, not null
     expect(result).toEqual({ indicesCount: 0, storeSizeBytes: 0, vectorDocsCount: 0 });
-    expect(client.asCurrentUser.indices.getMapping).not.toHaveBeenCalled();
+    expect(client.asCurrentUser.fieldCaps).not.toHaveBeenCalled();
   });
 });
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+
+interface MappingProperty {
+  type?: string;
+  properties?: Record<string, MappingProperty>;
+}
+
+interface MeteringIndexStat {
+  name: string;
+  num_docs: number;
+  size_in_bytes: number;
+}
+
+interface MeteringStatsResponse {
+  _total: { num_docs: number; size_in_bytes: number };
+  indices: MeteringIndexStat[];
+}
+
+export interface IndexStats {
+  indicesCount: number | null;
+  storeSizeBytes: number | null;
+  vectorDocsCount: number | null;
+}
+
+const INDEX_STATS_UNAVAILABLE: IndexStats = {
+  indicesCount: null,
+  storeSizeBytes: null,
+  vectorDocsCount: null,
+};
+
+const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_text']);
+
+export const containsVectorField = (properties?: Record<string, MappingProperty>): boolean => {
+  if (!properties) return false;
+  for (const value of Object.values(properties)) {
+    if (value.type && VECTOR_FIELD_TYPES.has(value.type)) return true;
+    if (value.properties && containsVectorField(value.properties)) return true;
+  }
+  return false;
+};
+
+/**
+ * Fetches index-level stats for the deployment: total user index count, aggregate store size, and
+ * the number of documents living in indices that contain a vector field.
+ *
+ * Never throws: any failure is logged and surfaced as `null` for the affected value so callers can
+ * distinguish "unavailable" from a genuine `0`, and so a single failing call doesn't fail the whole
+ * stats response.
+ */
+export const fetchIndexStats = async (
+  client: IScopedClusterClient,
+  logger: Logger
+): Promise<IndexStats> => {
+  try {
+    // Serverless-only `_metering/stats` returns docs + size for all user indices.
+    // Requires asSecondaryAuthUser.
+    const meteringStats = await client.asSecondaryAuthUser.transport.request<MeteringStatsResponse>(
+      {
+        method: 'GET',
+        path: '/_metering/stats',
+      }
+    );
+
+    const userIndices = (meteringStats.indices ?? []).filter(
+      (index) => !index.name.startsWith('.')
+    );
+
+    const indicesCount = userIndices.length;
+    const storeSizeBytes = userIndices.reduce((sum, index) => sum + (index.size_in_bytes ?? 0), 0);
+
+    // A deployment with no user indices genuinely has 0 vector docs.
+    let vectorDocsCount: number | null = 0;
+    if (indicesCount > 0) {
+      const indexNames = userIndices.map((i) => i.name);
+
+      try {
+        const mappings = await client.asCurrentUser.indices.getMapping({ index: indexNames });
+        const vectorIndexNames = Object.entries(mappings)
+          .filter(([, mapping]) =>
+            containsVectorField(mapping.mappings?.properties as Record<string, MappingProperty>)
+          )
+          .map(([name]) => name);
+
+        if (vectorIndexNames.length > 0) {
+          // `_metering/stats` num_docs counts Lucene documents, which includes the nested chunk
+          // documents that `semantic_text` fields generate — inflating the count (e.g. 10 docs
+          // reported as 20). Count top-level documents with ES|QL instead, matching the workaround
+          // used by the index management plugin.
+          const esqlResult = await client.asCurrentUser.esql.query({
+            query: `FROM ${vectorIndexNames.join(',')} | STATS count()`,
+            // return partial results instead of failing when some shards are unavailable
+            allow_partial_results: true,
+          });
+          const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'count()');
+          vectorDocsCount = (esqlResult.values ?? []).reduce(
+            (sum, row) => sum + ((row[countColumnIndex] as number) ?? 0),
+            0
+          );
+        }
+      } catch (error) {
+        // Index/size counts are still valid; only the vector doc count is unavailable.
+        logger.warn(
+          `Failed to compute vector doc count for vectordb deployment stats. Returning partial stats: ${error.message}`
+        );
+        vectorDocsCount = null;
+      }
+    }
+
+    return { indicesCount, storeSizeBytes, vectorDocsCount };
+  } catch (error) {
+    logger.warn(`Failed to fetch index stats for vectordb deployment stats: ${error.message}`);
+    return INDEX_STATS_UNAVAILABLE;
+  }
+};
+
+/**
+ * Fetches the number of dashboards in the current space. Never throws: returns `null` (and logs) on
+ * failure so a dashboard lookup error is distinguishable from "0 dashboards" and doesn't fail the
+ * whole stats response.
+ */
+export const fetchDashboardsCount = async (
+  savedObjectsClient: SavedObjectsClientContract,
+  logger: Logger
+): Promise<number | null> => {
+  try {
+    const result = await savedObjectsClient.find({ type: 'dashboard', perPage: 0 });
+    return result.total;
+  } catch (error) {
+    logger.warn(`Failed to fetch dashboard count for vectordb deployment stats: ${error.message}`);
+    return null;
+  }
+};

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -8,7 +8,7 @@
 import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
 
-// Extend the field capability type to include the `inference` flag until the Elasticsearch package version is updated.
+// The `inference` flag isn't yet in the Elasticsearch package types.
 type FieldCapability = FieldCapsFieldCapability & {
   inference?: boolean;
 };
@@ -43,12 +43,8 @@ const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_t
 const FIELD_CAPS_TYPES = [...VECTOR_FIELD_TYPES, 'text'];
 
 /**
- * Determines which of the given indices contain a vector field (`dense_vector`, `sparse_vector`, or
- * an inference field such as `semantic_text` / `semantic`).
- *
- * Uses `_field_caps`, which is far lighter than pulling full mappings: it aggregates fields across
- * indices and dedupes shared ones, and flattens nested/multi-fields for free. Inference fields are
- * detected via the `inference` flag, which serverless Elasticsearch always reports.
+ * Returns which of the given indices contain a vector field. Uses `_field_caps` rather than full
+ * mappings as it's far lighter and flattens nested/multi-fields for free.
  */
 const getVectorIndexNames = async (
   client: IScopedClusterClient,
@@ -59,10 +55,8 @@ const getVectorIndexNames = async (
     fields: '*',
     types: FIELD_CAPS_TYPES,
     filters: '-metadata',
-    // Without this, a field mapped in only a subset of the indices is reported with no `indices`
-    // list — indistinguishable from a field mapped in every index — so all requested indices would
-    // be misclassified as vector indices. With it, partially-mapped fields always carry an explicit
-    // `indices` list on the mapped entry.
+    // Forces partially-mapped fields to carry an explicit `indices` list. Without it a field mapped
+    // in a subset of indices looks identical to one mapped everywhere, misclassifying all indices.
     include_unmapped: true,
   });
 
@@ -70,17 +64,14 @@ const getVectorIndexNames = async (
 
   for (const capabilitiesByType of Object.values(fieldCaps.fields)) {
     for (const capability of Object.values(capabilitiesByType) as FieldCapability[]) {
-      // `include_unmapped: true` adds pseudo-entries (type `unmapped`) listing the indices where
-      // the field does not exist; they must never count as matches.
+      // `include_unmapped: true` adds pseudo-entries listing indices where the field is absent.
       if (capability.type === 'unmapped') continue;
 
       const isVectorField =
         VECTOR_FIELD_TYPES.has(capability.type) || capability.inference === true;
       if (!isVectorField) continue;
 
-      // With `include_unmapped: true`, `indices` is absent only when the field (with this
-      // capability) is mapped in every requested index, so all of them qualify and there is
-      // nothing left to discover.
+      // Absent `indices` means the field is mapped in every requested index.
       if (capability.indices === undefined) return indexNames;
 
       const capabilityIndices = Array.isArray(capability.indices)
@@ -88,7 +79,6 @@ const getVectorIndexNames = async (
         : [capability.indices];
       capabilityIndices.forEach((name) => vectorIndexNames.add(name));
 
-      // Every requested index is already known to contain a vector field so exit early and return all indexes.
       if (vectorIndexNames.size === indexNames.length) return indexNames;
     }
   }
@@ -96,14 +86,9 @@ const getVectorIndexNames = async (
   return [...vectorIndexNames];
 };
 
-// Caps the number of indices per ES|QL query so the `FROM` clause cannot grow unbounded on
-// deployments with very many vector indices.
+// Caps indices per ES|QL query so the `FROM` clause can't grow unbounded.
 const ESQL_INDICES_PER_QUERY = 500;
 
-/**
- * Counts top-level documents across the given indices with ES|QL, batching the index list so a
- * single query never targets an unbounded number of indices.
- */
 const countTopLevelDocs = async (
   client: IScopedClusterClient,
   indexNames: string[]
@@ -113,16 +98,10 @@ const countTopLevelDocs = async (
   for (let i = 0; i < indexNames.length; i += ESQL_INDICES_PER_QUERY) {
     const batch = indexNames.slice(i, i + ESQL_INDICES_PER_QUERY);
     const esqlResult = await client.asCurrentUser.esql.query({
-      // Each index name is wrapped in double quotes so characters that are special in ES|QL
-      // (e.g. dashes) can't break the query. Index names can never contain a double quote,
-      // so no escaping is needed.
       query: `FROM ${batch.map((name) => `"${name}"`).join(',')} | STATS doc_count = COUNT(*)`,
-      // return partial results instead of failing when some shards are unavailable
       allow_partial_results: true,
     });
 
-    // The count is aliased to `doc_count` in the query so this lookup doesn't depend on
-    // ES|QL's auto-generated column naming.
     const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'doc_count');
     const [row] = esqlResult.values ?? [];
     total += (row?.[countColumnIndex] as number) ?? 0;
@@ -132,20 +111,16 @@ const countTopLevelDocs = async (
 };
 
 /**
- * Fetches index-level stats for the deployment: total user index count, aggregate store size, and
- * the number of documents living in indices that contain a vector field.
- *
- * Never throws: any failure is logged and surfaced as `null` for the affected value so callers can
- * distinguish "unavailable" from a genuine `0`, and so a single failing call doesn't fail the whole
- * stats response.
+ * Fetches index-level stats: user index count, aggregate store size, and doc count across indices
+ * with a vector field. Failures are logged and surfaced as `null` so callers can
+ * distinguish "unavailable" from a genuine `0`.
  */
 export const fetchIndexStats = async (
   client: IScopedClusterClient,
   logger: Logger
 ): Promise<IndexStats> => {
   try {
-    // Serverless-only `_metering/stats` returns docs + size for all user indices.
-    // Requires asSecondaryAuthUser.
+    // Serverless-only `_metering/stats` requires asSecondaryAuthUser.
     const meteringStats = await client.asSecondaryAuthUser.transport.request<MeteringStatsResponse>(
       {
         method: 'GET',
@@ -160,7 +135,6 @@ export const fetchIndexStats = async (
     const indicesCount = userIndices.length;
     const storeSizeBytes = userIndices.reduce((sum, index) => sum + (index.size_in_bytes ?? 0), 0);
 
-    // A deployment with no user indices genuinely has 0 vector docs.
     let vectorDocsCount: number | null = 0;
     if (indicesCount > 0) {
       const indexNames = userIndices.map((i) => i.name);
@@ -170,9 +144,8 @@ export const fetchIndexStats = async (
 
         if (vectorIndexNames.length > 0) {
           // `_metering/stats` num_docs counts Lucene documents, which includes the nested chunk
-          // documents that `semantic_text` fields generate — inflating the count (e.g. 10 docs
-          // reported as 20). Count top-level documents with ES|QL instead, matching the workaround
-          // used by the index management plugin.
+          // documents that `semantic_text` fields generate, inflating the count. Count top-level
+          // documents with ES|QL instead, matching the index management plugin's workaround.
           vectorDocsCount = await countTopLevelDocs(client, vectorIndexNames);
         }
       } catch (error) {
@@ -192,9 +165,8 @@ export const fetchIndexStats = async (
 };
 
 /**
- * Fetches the number of dashboards in the current space. Never throws: returns `null` (and logs) on
- * failure so a dashboard lookup error is distinguishable from "0 dashboards" and doesn't fail the
- * whole stats response.
+ * Fetches the number of dashboards in the current space. Returns `null` on failure so
+ * a lookup error is distinguishable from "0 dashboards".
  */
 export const fetchDashboardsCount = async (
   savedObjectsClient: SavedObjectsClientContract,

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -87,6 +87,38 @@ const getVectorIndexNames = async (
   return [...vectorIndexNames];
 };
 
+// Caps the number of indices per ES|QL query so the `FROM` clause cannot grow unbounded on
+// deployments with very many vector indices.
+const ESQL_INDICES_PER_QUERY = 500;
+
+/**
+ * Counts top-level documents across the given indices with ES|QL, batching the index list so a
+ * single query never targets an unbounded number of indices.
+ */
+const countTopLevelDocs = async (
+  client: IScopedClusterClient,
+  indexNames: string[]
+): Promise<number> => {
+  let total = 0;
+
+  for (let i = 0; i < indexNames.length; i += ESQL_INDICES_PER_QUERY) {
+    const batch = indexNames.slice(i, i + ESQL_INDICES_PER_QUERY);
+    const esqlResult = await client.asCurrentUser.esql.query({
+      // Index names are quoted so names requiring ES|QL quoting cannot break the query. Double
+      // quotes cannot appear in index names, so no escaping is needed.
+      query: `FROM ${batch.map((name) => `"${name}"`).join(',')} | STATS count()`,
+      // return partial results instead of failing when some shards are unavailable
+      allow_partial_results: true,
+    });
+
+    const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'count()');
+    const [row] = esqlResult.values ?? [];
+    total += (row?.[countColumnIndex] as number) ?? 0;
+  }
+
+  return total;
+};
+
 /**
  * Fetches index-level stats for the deployment: total user index count, aggregate store size, and
  * the number of documents living in indices that contain a vector field.
@@ -129,16 +161,7 @@ export const fetchIndexStats = async (
           // documents that `semantic_text` fields generate — inflating the count (e.g. 10 docs
           // reported as 20). Count top-level documents with ES|QL instead, matching the workaround
           // used by the index management plugin.
-          const esqlResult = await client.asCurrentUser.esql.query({
-            query: `FROM ${vectorIndexNames.join(',')} | STATS count()`,
-            // return partial results instead of failing when some shards are unavailable
-            allow_partial_results: true,
-          });
-          const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'count()');
-          vectorDocsCount = (esqlResult.values ?? []).reduce(
-            (sum, row) => sum + ((row[countColumnIndex] as number) ?? 0),
-            0
-          );
+          vectorDocsCount = await countTopLevelDocs(client, vectorIndexNames);
         }
       } catch (error) {
         // Index/size counts are still valid; only the vector doc count is unavailable.

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -59,19 +59,28 @@ const getVectorIndexNames = async (
     fields: '*',
     types: FIELD_CAPS_TYPES,
     filters: '-metadata',
+    // Without this, a field mapped in only a subset of the indices is reported with no `indices`
+    // list — indistinguishable from a field mapped in every index — so all requested indices would
+    // be misclassified as vector indices. With it, partially-mapped fields always carry an explicit
+    // `indices` list on the mapped entry.
+    include_unmapped: true,
   });
 
   const vectorIndexNames = new Set<string>();
 
   for (const capabilitiesByType of Object.values(fieldCaps.fields)) {
     for (const capability of Object.values(capabilitiesByType) as FieldCapability[]) {
+      // `include_unmapped: true` adds pseudo-entries (type `unmapped`) listing the indices where
+      // the field does not exist; they must never count as matches.
+      if (capability.type === 'unmapped') continue;
+
       const isVectorField =
         VECTOR_FIELD_TYPES.has(capability.type) || capability.inference === true;
       if (!isVectorField) continue;
 
-      // `indices` is only populated when the field is not uniform across the requested indices; when
-      // absent, the field (with this capability) exists in every requested index, so all of them
-      // qualify and there is nothing left to discover.
+      // With `include_unmapped: true`, `indices` is absent only when the field (with this
+      // capability) is mapped in every requested index, so all of them qualify and there is
+      // nothing left to discover.
       if (capability.indices === undefined) return indexNames;
 
       const capabilityIndices = Array.isArray(capability.indices)
@@ -104,14 +113,17 @@ const countTopLevelDocs = async (
   for (let i = 0; i < indexNames.length; i += ESQL_INDICES_PER_QUERY) {
     const batch = indexNames.slice(i, i + ESQL_INDICES_PER_QUERY);
     const esqlResult = await client.asCurrentUser.esql.query({
-      // Index names are quoted so names requiring ES|QL quoting cannot break the query. Double
-      // quotes cannot appear in index names, so no escaping is needed.
-      query: `FROM ${batch.map((name) => `"${name}"`).join(',')} | STATS count()`,
+      // Each index name is wrapped in double quotes so characters that are special in ES|QL
+      // (e.g. dashes) can't break the query. Index names can never contain a double quote,
+      // so no escaping is needed.
+      query: `FROM ${batch.map((name) => `"${name}"`).join(',')} | STATS doc_count = COUNT(*)`,
       // return partial results instead of failing when some shards are unavailable
       allow_partial_results: true,
     });
 
-    const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'count()');
+    // The count is aliased to `doc_count` in the query so this lookup doesn't depend on
+    // ES|QL's auto-generated column naming.
+    const countColumnIndex = esqlResult.columns.findIndex((col) => col.name === 'doc_count');
     const [row] = esqlResult.values ?? [];
     total += (row?.[countColumnIndex] as number) ?? 0;
   }

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/lib/deployment_stats.ts
@@ -6,11 +6,12 @@
  */
 
 import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
 
-interface MappingProperty {
-  type?: string;
-  properties?: Record<string, MappingProperty>;
-}
+// Extend the field capability type to include the `inference` flag until the Elasticsearch package version is updated.
+type FieldCapability = FieldCapsFieldCapability & {
+  inference?: boolean;
+};
 
 interface MeteringIndexStat {
   name: string;
@@ -23,7 +24,7 @@ interface MeteringStatsResponse {
   indices: MeteringIndexStat[];
 }
 
-export interface IndexStats {
+interface IndexStats {
   indicesCount: number | null;
   storeSizeBytes: number | null;
   vectorDocsCount: number | null;
@@ -35,15 +36,55 @@ const INDEX_STATS_UNAVAILABLE: IndexStats = {
   vectorDocsCount: null,
 };
 
-const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_text']);
+const VECTOR_FIELD_TYPES = new Set(['dense_vector', 'sparse_vector', 'semantic_text', 'semantic']);
 
-export const containsVectorField = (properties?: Record<string, MappingProperty>): boolean => {
-  if (!properties) return false;
-  for (const value of Object.values(properties)) {
-    if (value.type && VECTOR_FIELD_TYPES.has(value.type)) return true;
-    if (value.properties && containsVectorField(value.properties)) return true;
+// `semantic_text` fields may be reported by field caps as `text` with `inference: true`, so `text`
+// must be requested alongside the vector types.
+const FIELD_CAPS_TYPES = [...VECTOR_FIELD_TYPES, 'text'];
+
+/**
+ * Determines which of the given indices contain a vector field (`dense_vector`, `sparse_vector`, or
+ * an inference field such as `semantic_text` / `semantic`).
+ *
+ * Uses `_field_caps`, which is far lighter than pulling full mappings: it aggregates fields across
+ * indices and dedupes shared ones, and flattens nested/multi-fields for free. Inference fields are
+ * detected via the `inference` flag, which serverless Elasticsearch always reports.
+ */
+const getVectorIndexNames = async (
+  client: IScopedClusterClient,
+  indexNames: string[]
+): Promise<string[]> => {
+  const fieldCaps = await client.asCurrentUser.fieldCaps({
+    index: indexNames,
+    fields: '*',
+    types: FIELD_CAPS_TYPES,
+    filters: '-metadata',
+  });
+
+  const vectorIndexNames = new Set<string>();
+
+  for (const capabilitiesByType of Object.values(fieldCaps.fields)) {
+    for (const capability of Object.values(capabilitiesByType) as FieldCapability[]) {
+      const isVectorField =
+        VECTOR_FIELD_TYPES.has(capability.type) || capability.inference === true;
+      if (!isVectorField) continue;
+
+      // `indices` is only populated when the field is not uniform across the requested indices; when
+      // absent, the field (with this capability) exists in every requested index, so all of them
+      // qualify and there is nothing left to discover.
+      if (capability.indices === undefined) return indexNames;
+
+      const capabilityIndices = Array.isArray(capability.indices)
+        ? capability.indices
+        : [capability.indices];
+      capabilityIndices.forEach((name) => vectorIndexNames.add(name));
+
+      // Every requested index is already known to contain a vector field so exit early and return all indexes.
+      if (vectorIndexNames.size === indexNames.length) return indexNames;
+    }
   }
-  return false;
+
+  return [...vectorIndexNames];
 };
 
 /**
@@ -81,12 +122,7 @@ export const fetchIndexStats = async (
       const indexNames = userIndices.map((i) => i.name);
 
       try {
-        const mappings = await client.asCurrentUser.indices.getMapping({ index: indexNames });
-        const vectorIndexNames = Object.entries(mappings)
-          .filter(([, mapping]) =>
-            containsVectorField(mapping.mappings?.properties as Record<string, MappingProperty>)
-          )
-          .map(([name]) => name);
+        const vectorIndexNames = await getVectorIndexNames(client, indexNames);
 
         if (vectorIndexNames.length > 0) {
           // `_metering/stats` num_docs counts Lucene documents, which includes the nested chunk

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
@@ -5,81 +5,135 @@
  * 2.0.
  */
 
-import { containsVectorField } from './deployment_stats';
+import type { RequestHandlerContext } from '@kbn/core/server';
+import {
+  elasticsearchServiceMock,
+  httpServerMock,
+  httpServiceMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+} from '@kbn/core/server/mocks';
+import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
+import { fetchDashboardsCount, fetchIndexStats } from '../lib/deployment_stats';
+import { registerDeploymentStatsRoute } from './deployment_stats';
 
-describe('containsVectorField', () => {
-  it('returns false for undefined properties', () => {
-    expect(containsVectorField(undefined)).toBe(false);
+jest.mock('../lib/deployment_stats');
+
+const mockFetchIndexStats = fetchIndexStats as jest.MockedFunction<typeof fetchIndexStats>;
+const mockFetchDashboardsCount = fetchDashboardsCount as jest.MockedFunction<
+  typeof fetchDashboardsCount
+>;
+
+describe('registerDeploymentStatsRoute', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    router = httpServiceMock.createRouter();
+    logger = loggingSystemMock.createLogger();
+    esClient = elasticsearchServiceMock.createScopedClusterClient();
+    soClient = savedObjectsClientMock.create();
+
+    registerDeploymentStatsRoute(router, logger);
   });
 
-  it('returns false for an empty properties map', () => {
-    expect(containsVectorField({})).toBe(false);
+  const getHandler = () => router.get.mock.calls[0][1];
+
+  // Builds a request handler context whose `core` resolves to the scoped ES + SO clients.
+  const createContext = (coreOverride?: Promise<never>) =>
+    ({
+      core:
+        coreOverride ??
+        Promise.resolve({
+          elasticsearch: { client: esClient },
+          savedObjects: { getClient: () => soClient },
+        }),
+    } as unknown as RequestHandlerContext);
+
+  it('registers a GET route at the deployment stats path with ES-delegated authz', () => {
+    const [config] = router.get.mock.calls[0];
+    expect(config.path).toBe(DEPLOYMENT_STATS_PATH);
+    expect(config.security?.authz).toBeDefined();
   });
 
-  it('returns true when a top-level field is dense_vector', () => {
-    expect(containsVectorField({ embedding: { type: 'dense_vector' } })).toBe(true);
+  it('returns index stats and dashboard count combined in a single body', async () => {
+    mockFetchIndexStats.mockResolvedValue({
+      indicesCount: 3,
+      storeSizeBytes: 1024,
+      vectorDocsCount: 5,
+    });
+    mockFetchDashboardsCount.mockResolvedValue(2);
+
+    const request = httpServerMock.createKibanaRequest();
+    const response = httpServerMock.createResponseFactory();
+
+    await getHandler()(createContext(), request, response);
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: {
+        indicesCount: 3,
+        storeSizeBytes: 1024,
+        vectorDocsCount: 5,
+        dashboardsCount: 2,
+      },
+    });
   });
 
-  it('returns true when a top-level field is semantic_text', () => {
-    expect(containsVectorField({ body: { type: 'semantic_text' } })).toBe(true);
+  it('passes the scoped ES and saved objects clients to the respective lib helpers', async () => {
+    mockFetchIndexStats.mockResolvedValue({
+      indicesCount: 0,
+      storeSizeBytes: 0,
+      vectorDocsCount: 0,
+    });
+    mockFetchDashboardsCount.mockResolvedValue(0);
+
+    const request = httpServerMock.createKibanaRequest();
+    const response = httpServerMock.createResponseFactory();
+
+    await getHandler()(createContext(), request, response);
+
+    expect(mockFetchIndexStats).toHaveBeenCalledWith(esClient, logger);
+    expect(mockFetchDashboardsCount).toHaveBeenCalledWith(soClient, logger);
   });
 
-  it('returns false when no vector fields are present', () => {
-    expect(
-      containsVectorField({
-        title: { type: 'text' },
-        count: { type: 'integer' },
-      })
-    ).toBe(false);
+  it('surfaces null values (unavailable) without failing the response', async () => {
+    mockFetchIndexStats.mockResolvedValue({
+      indicesCount: null,
+      storeSizeBytes: null,
+      vectorDocsCount: null,
+    });
+    mockFetchDashboardsCount.mockResolvedValue(null);
+
+    const request = httpServerMock.createKibanaRequest();
+    const response = httpServerMock.createResponseFactory();
+
+    await getHandler()(createContext(), request, response);
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: {
+        indicesCount: null,
+        storeSizeBytes: null,
+        vectorDocsCount: null,
+        dashboardsCount: null,
+      },
+    });
+    expect(response.customError).not.toHaveBeenCalled();
   });
 
-  it('returns true when a vector field is nested inside an object', () => {
-    expect(
-      containsVectorField({
-        metadata: {
-          properties: {
-            embedding: { type: 'dense_vector' },
-          },
-        },
-      })
-    ).toBe(true);
-  });
+  it('returns a custom error when resolving the core context throws', async () => {
+    const request = httpServerMock.createKibanaRequest();
+    const response = httpServerMock.createResponseFactory();
 
-  it('returns true when a vector field is deeply nested', () => {
-    expect(
-      containsVectorField({
-        level1: {
-          properties: {
-            level2: {
-              properties: {
-                vector: { type: 'dense_vector' },
-              },
-            },
-          },
-        },
-      })
-    ).toBe(true);
-  });
+    await getHandler()(
+      createContext(Promise.reject(new Error('core unavailable')) as Promise<never>),
+      request,
+      response
+    );
 
-  it('returns false when nested properties contain no vector fields', () => {
-    expect(
-      containsVectorField({
-        metadata: {
-          properties: {
-            author: { type: 'keyword' },
-          },
-        },
-      })
-    ).toBe(false);
-  });
-
-  it('returns true on first match and short-circuits', () => {
-    expect(
-      containsVectorField({
-        title: { type: 'text' },
-        embedding: { type: 'dense_vector' },
-        body: { type: 'text' },
-      })
-    ).toBe(true);
+    expect(response.customError).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 500 }));
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.test.ts
@@ -42,7 +42,6 @@ describe('registerDeploymentStatsRoute', () => {
 
   const getHandler = () => router.get.mock.calls[0][1];
 
-  // Builds a request handler context whose `core` resolves to the scoped ES + SO clients.
   const createContext = (coreOverride?: Promise<never>) =>
     ({
       core:

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
@@ -25,8 +25,6 @@ export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) =>
         const client = core.elasticsearch.client;
         const savedObjectsClient = core.savedObjects.getClient();
 
-        // Index stats (metering + vector classification) and the dashboard count are independent,
-        // so run them in parallel rather than chaining the two round trips.
         const [{ indicesCount, storeSizeBytes, vectorDocsCount }, dashboardsCount] =
           await Promise.all([
             fetchIndexStats(client, logger),

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
@@ -8,31 +8,7 @@
 import type { IRouter, Logger } from '@kbn/core/server';
 import { AuthzDisabled } from '@kbn/core-security-server';
 import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
-
-interface MappingProperty {
-  type?: string;
-  properties?: Record<string, MappingProperty>;
-}
-
-interface MeteringIndexStat {
-  name: string;
-  num_docs: number;
-  size_in_bytes: number;
-}
-
-interface MeteringStatsResponse {
-  _total: { num_docs: number; size_in_bytes: number };
-  indices: MeteringIndexStat[];
-}
-
-export const containsVectorField = (properties?: Record<string, MappingProperty>): boolean => {
-  if (!properties) return false;
-  for (const value of Object.values(properties)) {
-    if (value.type === 'dense_vector' || value.type === 'semantic_text') return true;
-    if (value.properties && containsVectorField(value.properties)) return true;
-  }
-  return false;
-};
+import { fetchDashboardsCount, fetchIndexStats } from '../lib/deployment_stats';
 
 export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) => {
   router.get(
@@ -47,63 +23,15 @@ export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) =>
       try {
         const core = await context.core;
         const client = core.elasticsearch.client;
+        const savedObjectsClient = core.savedObjects.getClient();
 
-        // Serverless-only `_metering/stats` returns docs + size for all user indices.
-        // Requires asSecondaryAuthUser.
-        const meteringStats =
-          await client.asSecondaryAuthUser.transport.request<MeteringStatsResponse>({
-            method: 'GET',
-            path: '/_metering/stats',
-          });
-
-        const userIndices = (meteringStats.indices ?? []).filter(
-          (index) => !index.name.startsWith('.')
-        );
-
-        const indicesCount = userIndices.length;
-        const storeSizeBytes = userIndices.reduce(
-          (sum, index) => sum + (index.size_in_bytes ?? 0),
-          0
-        );
-
-        let vectorDocsCount = 0;
-        if (indicesCount > 0) {
-          const indexNames = userIndices.map((i) => i.name);
-
-          try {
-            const mappings = await client.asCurrentUser.indices.getMapping({
-              index: indexNames,
-            });
-            const vectorIndexNames = new Set(
-              Object.entries(mappings)
-                .filter(([, mapping]) =>
-                  containsVectorField(
-                    mapping.mappings?.properties as Record<string, MappingProperty>
-                  )
-                )
-                .map(([name]) => name)
-            );
-
-            vectorDocsCount = userIndices
-              .filter((i) => vectorIndexNames.has(i.name))
-              .reduce((sum, i) => sum + (i.num_docs ?? 0), 0);
-          } catch (error) {
-            logger.warn(
-              `Failed to fetch mappings for vectordb deployment stats. Returning partial stats: ${error.message}`
-            );
-          }
-        }
-
-        let dashboardsCount = 0;
-        try {
-          const savedObjectsClient = core.savedObjects.getClient();
-          const result = await savedObjectsClient.find({ type: 'dashboard', perPage: 0 });
-          dashboardsCount = result.total;
-        } catch (dashboardError) {
-          logger.warn(
-            `Failed to fetch dashboard count for vectordb deployment stats: ${dashboardError.message}`
-          );
-        }
+        // Index stats (metering + vector classification) and the dashboard count are independent,
+        // so run them in parallel rather than chaining the two round trips.
+        const [{ indicesCount, storeSizeBytes, vectorDocsCount }, dashboardsCount] =
+          await Promise.all([
+            fetchIndexStats(client, logger),
+            fetchDashboardsCount(savedObjectsClient, logger),
+          ]);
 
         return response.ok({
           body: {


### PR DESCRIPTION
## Summary

Refactors and optimizes the deployment-stats endpoint behind the Vector DB serverless home page's stat tiles.

### Server

* Moves logic out of the route into a testable `server/lib/deployment_stats.ts` module. The route now only handles request/response wiring.
* Runs the index stats and dashboard count fetches in parallel via `Promise.all`.
* Fixes inflated vector doc counts (`_metering/stats` double-counts `semantic_text` chunk docs) by using an ES|QL `STATS COUNT(*)` over vector-bearing indices instead — same workaround used by index management.
* Detects vector indices via `_field_caps` instead of `getMapping`, so field-type filtering happens server-side in ES and we no longer download every index's full mapping. 
  * Covers vectors from `dense_vector`, `sparse_vector`, `semantic_text`, and `semantic` fields. `text` fields with `inference: true` are also covered as this is how `semantic_text` fields need to be detected. 
  * Requests `include_unmapped: true` so partially-mapped fields carry an explicit `indices` list — otherwise they'd be indistinguishable from fields mapped in every index, and all indices would be misclassified as vector indices.
* Batches the ES|QL doc count query (500 indices per `FROM` clause) and quotes index names, so deployments with very many vector indices or unusual index names can't break the query. Uses `allow_partial_results: true` so a few unavailable shards don't fail the whole count.
* Each fetch helper catches its own errors so the endpoint always responds; unavailable values return `null` (not `0`) to distinguish "failed" from "zero."

### Client

* Adds `staleTime: 60_000` to the stats/agents-count queries to stop refetching slow-moving aggregates on every navigation.
* Renders `null` as `—` instead of `0`.
* Moves `formatBytes`/`formatNumber` into `public/utils/format.ts`; `formatBytes` now uses `@elastic/numeral` to match Kibana conventions (up to two decimals, trailing zeros dropped: `500 B`, `1.5 KB`, `100 GB`).

### Notes

* Workflow stats stay a separate client request — merging server-side would couple to the workflows plugin and bypass its privilege gate, for minimal gain.
* The endpoint always returns `200`; failures surface as `null` values (logged server-side) rather than HTTP errors.
* Inference-field detection via `_field_caps` relies on the ES enhancement that exposes the `inference` flag, which serverless Elasticsearch now always reports.