### PR TITLE
docs: document deferBelowFold setting disabled in 9.4.3

### DIFF
--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -627,7 +627,7 @@ groups:
         datatype: bool
         default: false
         applies_to:
-          stack: ga
+          stack: experimental
           ech: ga
           ece: ga
           eck: ga
@@ -635,7 +635,7 @@ groups:
           serverless: unavailable
         note: |
           :applies_to: stack: ga 9.4.3!+
-          This setting currently has no effect. Deferred loading of below-the-fold panels is temporarily disabled because enabling it could cause some dashboards to fail to load, so all panels load immediately regardless of this setting.
+          From version 9.4.3, all panels load immediately regardless of this setting. Deferred loading of below-the-fold panels is disabled because enabling it can cause some dashboards to fail to load.
 
       - setting: "labs:canvas:byValueEmbeddable"
         id: labs-canvas-by-value-embeddable

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -635,7 +635,7 @@ groups:
           serverless: unavailable
         note: |
           :applies_to: stack: ga 9.4.3!+
-          This setting currently has no effect. Deferred loading of below-the-fold panels is temporarily disabled while a known issue is fixed, so all panels load immediately regardless of this setting.
+          This setting currently has no effect. Deferred loading of below-the-fold panels is temporarily disabled because enabling it could prevent dashboards from loading correctly, so all panels load immediately regardless of this setting.
 
       - setting: "labs:canvas:byValueEmbeddable"
         id: labs-canvas-by-value-embeddable

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -635,7 +635,7 @@ groups:
           serverless: unavailable
         note: |
           :applies_to: stack: ga 9.4.3!+
-          This setting currently has no effect. Deferred loading of below-the-fold panels is temporarily disabled because enabling it could prevent dashboards from loading correctly, so all panels load immediately regardless of this setting.
+          This setting currently has no effect. Deferred loading of below-the-fold panels is temporarily disabled because enabling it could cause some dashboards to fail to load, so all panels load immediately regardless of this setting.
 
       - setting: "labs:canvas:byValueEmbeddable"
         id: labs-canvas-by-value-embeddable

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -633,6 +633,9 @@ groups:
           eck: ga
           self: ga
           serverless: unavailable
+        note: |
+          :applies_to: stack: ga 9.4.3!+
+          This setting currently has no effect. Deferred loading of below-the-fold panels is temporarily disabled while a known issue is fixed, so all panels load immediately regardless of this setting.
 
       - setting: "labs:canvas:byValueEmbeddable"
         id: labs-canvas-by-value-embeddable

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -46,7 +46,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Increases the maximum number of combined panels, sections, and controls on a dashboard from 100 to 1,000 [#272931]({{kib-pull}}272931).
 * Fixes **Save and return** not working for Maps visualizations opened from the **Visualize** library [#274002]({{kib-pull}}274002).
 * Fixes a stale closure in the Canvas autoplay timer that could skip pages after slides are added or removed [#268398]({{kib-pull}}268398).
-* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it can cause some dashboards to fail to load. The option remains in **Advanced Settings** but has no effect from this version [#275632]({{kib-pull}}275632).
+* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it can cause some dashboards to fail to load. The option remains in **Advanced Settings** but has no effect from this version. It might be enabled again in a future version [#275632]({{kib-pull}}275632).
 
 **Connectivity**:
 * Removes the **Content Connectors** page from the menu for users who didn't have the appropriate role privileges [#271709]({{kib-pull}}271709).

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -46,7 +46,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Increases the maximum number of combined panels, sections, and controls on a dashboard from 100 to 1,000 [#272931]({{kib-pull}}272931).
 * Fixes **Save and return** not working for Maps visualizations opened from the **Visualize** library [#274002]({{kib-pull}}274002).
 * Fixes a stale closure in the Canvas autoplay timer that could skip pages after slides are added or removed [#268398]({{kib-pull}}268398).
-* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because its deferred-loading behavior was broken. The setting still appears in **Advanced Settings** but has no effect until the underlying issue is fixed [#275632]({{kib-pull}}275632).
+* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it could prevent dashboards from loading correctly. The toggle remains in **Advanced Settings** but currently has no effect [#275632]({{kib-pull}}275632).
 
 **Connectivity**:
 * Removes the **Content Connectors** page from the menu for users who didn't have the appropriate role privileges [#271709]({{kib-pull}}271709).

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -46,7 +46,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Increases the maximum number of combined panels, sections, and controls on a dashboard from 100 to 1,000 [#272931]({{kib-pull}}272931).
 * Fixes **Save and return** not working for Maps visualizations opened from the **Visualize** library [#274002]({{kib-pull}}274002).
 * Fixes a stale closure in the Canvas autoplay timer that could skip pages after slides are added or removed [#268398]({{kib-pull}}268398).
-* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it could prevent dashboards from loading correctly. The toggle remains in **Advanced Settings** but currently has no effect [#275632]({{kib-pull}}275632).
+* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it could cause some dashboards to fail to load. The toggle remains in **Advanced Settings** but currently has no effect [#275632]({{kib-pull}}275632).
 
 **Connectivity**:
 * Removes the **Content Connectors** page from the menu for users who didn't have the appropriate role privileges [#271709]({{kib-pull}}271709).

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -46,7 +46,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Increases the maximum number of combined panels, sections, and controls on a dashboard from 100 to 1,000 [#272931]({{kib-pull}}272931).
 * Fixes **Save and return** not working for Maps visualizations opened from the **Visualize** library [#274002]({{kib-pull}}274002).
 * Fixes a stale closure in the Canvas autoplay timer that could skip pages after slides are added or removed [#268398]({{kib-pull}}268398).
-* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it could cause some dashboards to fail to load. The toggle remains in **Advanced Settings** but currently has no effect [#275632]({{kib-pull}}275632).
+* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because enabling it can cause some dashboards to fail to load. The option remains in **Advanced Settings** but has no effect from this version [#275632]({{kib-pull}}275632).
 
 **Connectivity**:
 * Removes the **Content Connectors** page from the menu for users who didn't have the appropriate role privileges [#271709]({{kib-pull}}271709).

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -46,6 +46,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Increases the maximum number of combined panels, sections, and controls on a dashboard from 100 to 1,000 [#272931]({{kib-pull}}272931).
 * Fixes **Save and return** not working for Maps visualizations opened from the **Visualize** library [#274002]({{kib-pull}}274002).
 * Fixes a stale closure in the Canvas autoplay timer that could skip pages after slides are added or removed [#268398]({{kib-pull}}268398).
+* Disables the experimental **Defer loading panels below "the fold"** dashboard setting (`labs:dashboard:deferBelowFold`) because its deferred-loading behavior was broken. The setting still appears in **Advanced Settings** but has no effect until the underlying issue is fixed [#275632]({{kib-pull}}275632).
 
 **Connectivity**:
 * Removes the **Content Connectors** page from the menu for users who didn't have the appropriate role privileges [#271709]({{kib-pull}}271709).


### PR DESCRIPTION
## Summary

Documents the disabling of the experimental **Defer loading panels below "the fold"** dashboard advanced setting (`labs:dashboard:deferBelowFold`) in [#275632](https://github.com/elastic/kibana/pull/275632), which was missed in the release notes because it merged after the 9.4.3 notes were generated.

- **`docs/release-notes/index.md`**: adds a 9.4.3 fix entry under **Dashboards and Visualizations** noting the setting was disabled and now has no effect.
- **`docs/reference/advanced-settings-space.yml`**: adds a `9.4.3+` note to the `labs:dashboard:deferBelowFold` reference entry explaining that the setting currently has no effect while a known issue is fixed.

Scope is limited to 9.4.3 and the advanced settings reference; the 9.5.0 release notes don't exist yet, so the 9.5.0 entry will be added separately.

## Resolves

Tracked by elastic/docs-content#7184.

Related:
- Fix that disabled the setting: [#275632](https://github.com/elastic/kibana/pull/275632) (backport [#275642](https://github.com/elastic/kibana/pull/275642))
- Follow-up to re-enable: [#271580](https://github.com/elastic/kibana/pull/271580)

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.
