### PR TITLE
[Fleet] Intersect Observability + OpenTelemetry categories (AND) on browse page

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.test.tsx
@@ -407,6 +407,37 @@ describe('useBrowseIntegrationHook', () => {
     });
   });
 
+  describe('Multi-category (AND) filter', () => {
+    it('shows only cards that belong to ALL selected default categories (intersection)', () => {
+      const cards = [
+        {
+          id: '1',
+          name: 'both',
+          title: 'Both',
+          categories: ['observability', 'opentelemetry'],
+        },
+        { id: '2', name: 'obs-only', title: 'Obs only', categories: ['observability'] },
+        { id: '3', name: 'otel-only', title: 'OTel only', categories: ['opentelemetry'] },
+      ];
+
+      mockUseAvailablePackages(cards as IntegrationCardItem[]);
+      (useUrlDefaultCategories as jest.Mock).mockReturnValue(['observability', 'opentelemetry']);
+      (useUrlFilters as jest.Mock).mockReturnValue({
+        q: undefined,
+        sort: undefined,
+        status: undefined,
+      });
+
+      const { result } = renderHook(() =>
+        useBrowseIntegrationHook({ prereleaseIntegrationsEnabled: false })
+      );
+
+      // Only the card present in BOTH categories should remain
+      expect(result.current.filteredCards).toHaveLength(1);
+      expect(result.current.filteredCards[0].name).toBe('both');
+    });
+  });
+
   describe('Combined filters', () => {
     it('applies deprecated filter and sorting together', () => {
       const cards = [

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -133,12 +133,13 @@ export function useBrowseIntegrationHook({
   ]);
 
   // Apply category filter on top of non-category filters.
-  // When multiple effective categories are active, show cards matching ANY of them (OR logic).
+  // When multiple effective categories are active, show cards matching ALL of them
+  // (AND logic / intersection).
   const filteredCards = useMemo(() => {
     if (effectiveCategories.length > 0 || selectedSubCategory) {
       return nonCategoryFilteredCards.filter((c) => {
         if (selectedSubCategory) return c.categories.includes(selectedSubCategory);
-        return effectiveCategories.some((cat) => c.categories.includes(cat));
+        return effectiveCategories.every((cat) => c.categories.includes(cat));
       });
     }
     return nonCategoryFilteredCards;


### PR DESCRIPTION
## Summary

Follows up on #274147, which defaulted the Integrations Browse page to both the `observability` and `opentelemetry` categories in serverless observability projects.

That PR used **OR / union** logic — an integration was shown if it belonged to any of the selected categories. This PR changes it to **AND / intersection** — an integration is shown only if it belongs to **all** selected categories, i.e. it must be in both Observability *and* OpenTelemetry.

**Change:** one character in [hooks/index.tsx](x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx):
```diff
-return effectiveCategories.some((cat) => c.categories.includes(cat));
+return effectiveCategories.every((cat) => c.categories.includes(cat));
```

Single-category sidebar clicks are unaffected — `every()` on a one-element array behaves identically to `some()`.

Relates https://github.com/elastic/ingest-dev/issues/8162

## Test plan

- [x] Start Kibana in serverless observability mode
- [x] Navigate to `/app/integrations/browse` — verify redirect to `?category=opentelemetry&category=observability`
- [x] Confirm the grid shows only integrations that are tagged with **both** `observability` and `opentelemetry` (not the union)
- [x] Click any single category in the sidebar — confirm it still filters to just that category as before
- [x] Unit tests: `node scripts/jest --config x-pack/platform/plugins/shared/fleet/jest.config.dev.js x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1725" height="1373" alt="image" src="https://github.com/user-attachments/assets/db646145-d104-4546-ae0f-7f45897a7417" />
