### PR TITLE
chore(agent builder): update default agent copy

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/default_agent_definition.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/default_agent_definition.ts
@@ -16,7 +16,7 @@ export const getDefaultAgentCreateRequest = (): AgentCreateRequest => ({
   }),
   description: i18n.translate('xpack.agentBuilder.builtin.defaultAgent.description', {
     defaultMessage:
-      'The built-in agent for interacting with Elastic. Leverages built in skills, tools, and plugins, customizable as your use cases evolve. Use it for day-to-day work over your Elastic data, configuration, and capabilities (debugging, analysis, retrieval, operations, and more).',
+      'The default agent for everyday work across your data and configurations. It has access to all current and future Elastic-built capabilities by default. You can customize it for specific tasks with custom skills, tools, plugins, and connectors.',
   }),
   access_control: { access_mode: AgentAccessControlMode.Public },
   configuration: {


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/15090

Updates the description of the default Elastic AI Agent. 