### PR TITLE
[ES|QL] fix prettifying bottom comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@elastic/ecs": "9.3.0",
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/ems-client": "8.7.0",
-    "@elastic/esql": "4.9.0",
+    "@elastic/esql": "4.9.1",
     "@elastic/eui": "116.5.0",
     "@elastic/eui-theme-borealis": "8.0.0",
     "@elastic/filesaver": "1.1.2",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -15,12 +15,12 @@
 @base2/pretty-print-object@1.0.1
 @elastic/apm-rum-core@5.25.2
 @elastic/charts@71.8.0
-@elastic/esql@4.9.0
+@elastic/esql@4.9.1
 @elastic/eui-theme-borealis@8.0.0
 @elastic/eui-theme-common@10.0.0
 @elastic/eui@116.5.0
 @elastic/numeral@2.5.1
-@elastic/pretty-printer@4.9.0
+@elastic/pretty-printer@4.9.1
 @elastic/prismjs-esql@1.1.2
 @emotion/babel-plugin@11.13.5
 @emotion/cache@11.14.0

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -263,6 +263,12 @@ describe('esql query helpers', () => {
       }
     });
 
+    it('should preserve final own-line comments', function () {
+      expect(prettifyQuery('FROM logs* | WHERE KQL("term")\n// KEEP meow')).toEqual(
+        'FROM logs*\n  | WHERE KQL("term")\n  // KEEP meow'
+      );
+    });
+
     it('should respect custom lineWidth when provided', function () {
       const query =
         'FROM kibana_sample_data_logs | STATS count = COUNT(*), avg = AVG(bytes), p95 = PERCENTILE(bytes, 95), ext = VALUES(tags.keyword) BY ip | EVAL newField = CASE(count < 100, "groupA", count > 100 AND count < 500, "groupB", "Other") | KEEP newField';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,12 +2305,12 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-2.13.0.tgz#b9c079532257b7d4c46e3004ecb7b1f78f00a6b9"
   integrity sha512-Itl7zn88GEYRAqfmuRzViNy03nVHkIVLAvtjIC0b3lhjBnJgUbEG8ImfdYUExMiGraFE+2/k6v/Z8LbWXxO+JA==
 
-"@elastic/esql@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@elastic/esql/-/esql-4.9.0.tgz#de881abce1c6e5acc3d94bf7d2f5d977aa22ef03"
-  integrity sha512-5tF6MsYHFJHroUq1//F0TetbIu0A7s37xZKTRUb4VfKVrhJyyEZmMEIrW92OWEoE49qKofhe443TzYpf52+1RA==
+"@elastic/esql@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@elastic/esql/-/esql-4.9.1.tgz#8d28d056926fb6282b5bf6fa88c2d075199921e1"
+  integrity sha512-pdOR21qr80GmdNa+OzXhMLdd7eXyylmCP2uNEDrTy2uAFFH7ylKS4WB8pEuHBZl+ZfBS9IAIFJFpi6uA7mOoaQ==
   dependencies:
-    "@elastic/pretty-printer" "^4.9.0"
+    "@elastic/pretty-printer" "^4.9.1"
     antlr4 "4.13.2"
     tree-dump "1.1.0"
     tslib "2.8.1"
@@ -2493,10 +2493,10 @@
     import-in-the-middle "^3.0.0"
     safe-stable-stringify "^2.4.3"
 
-"@elastic/pretty-printer@^4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@elastic/pretty-printer/-/pretty-printer-4.9.0.tgz#39643018bbfb2e2157444f7caf6aad924077aeb0"
-  integrity sha512-SRBBozRA1a7gUs6ccM6D9BjiY0ymwMbSS/b/w+ib8TIqEuUlpL+l27NSL6WtC7lhdE/gEINrXFRXEeHi66JXRw==
+"@elastic/pretty-printer@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@elastic/pretty-printer/-/pretty-printer-4.9.1.tgz#a16ff90a23a497167065ede138933b5593d364e0"
+  integrity sha512-LzBbvrX0mVx6mZhBiAe/l0fdeXRRPvQc/WoUOMGshkTy0EIE96dMhG3K3hbKfeeR2Nq0LyiKvasVp/5yDMsSXw==
   dependencies:
     tree-dump "1.1.0"
     tslib "2.8.1"


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/275288

## Summary
Comments on the bottom of a query on their own line were dropped when query was prettified.

after fix:
<img width="724" height="308" alt="image" src="https://github.com/user-attachments/assets/d2302daa-4cef-495a-b952-f006fde39baa" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

