### PR TITLE
Agentless policies consume new api

### DIFF
--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -21283,7 +21283,6 @@
     "xpack.fleet.integrations.packageUninstallErrorTitle": "Das Paket {title} konnte nicht deinstalliert werden",
     "xpack.fleet.integrations.packageUninstallSuccessDescription": "{title} wurde erfolgreich deinstalliert",
     "xpack.fleet.integrations.packageUninstallSuccessTitle": "Deinstalliert {title}",
-    "xpack.fleet.integrations.packageUpdateSuccessDescription": "{title} erfolgreich aktualisiert und Richtlinien aktualisiert",
     "xpack.fleet.integrations.packageUpdateSuccessTitle": "Aktualisierte {title} und aufgerüstete Richtlinien",
     "xpack.fleet.integrations.packageUpgradeSuccessDescription": "Erfolgreich aktualisiert {title}.",
     "xpack.fleet.integrations.packageUpgradeSuccessTitle": "Aktualisiert {title}",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -21234,7 +21234,6 @@
     "xpack.fleet.integrations.packageUninstallErrorTitle": "Échec de la désinstallation du package {title}",
     "xpack.fleet.integrations.packageUninstallSuccessDescription": "Désinstallation de {title} terminée",
     "xpack.fleet.integrations.packageUninstallSuccessTitle": "{title} désinstallé",
-    "xpack.fleet.integrations.packageUpdateSuccessDescription": "Mise à jour de {title} et mise à niveau des politiques réussies",
     "xpack.fleet.integrations.packageUpdateSuccessTitle": "{title} mis à jour et politiques mises à niveau",
     "xpack.fleet.integrations.packageUpgradeSuccessDescription": "Mise à niveau de {title} réussie",
     "xpack.fleet.integrations.packageUpgradeSuccessTitle": "{title} mis à niveau",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -21354,7 +21354,6 @@
     "xpack.fleet.integrations.packageUninstallErrorTitle": "{title}パッケージをアンインストールできませんでした",
     "xpack.fleet.integrations.packageUninstallSuccessDescription": "正常に{title}をアンインストールしました",
     "xpack.fleet.integrations.packageUninstallSuccessTitle": "{title}をアンインストールしました",
-    "xpack.fleet.integrations.packageUpdateSuccessDescription": "{title}の更新とポリシーのアップグレードが正常に実行されました",
     "xpack.fleet.integrations.packageUpdateSuccessTitle": "{title}の更新とポリシーのアップグレード",
     "xpack.fleet.integrations.packageUpgradeSuccessDescription": "正常にアップグレードされました{title}",
     "xpack.fleet.integrations.packageUpgradeSuccessTitle": "{title}がアップグレードされました",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -21357,7 +21357,6 @@
     "xpack.fleet.integrations.packageUninstallErrorTitle": "无法卸载 {title} 软件包",
     "xpack.fleet.integrations.packageUninstallSuccessDescription": "已成功卸载 {title}",
     "xpack.fleet.integrations.packageUninstallSuccessTitle": "已卸载 {title}",
-    "xpack.fleet.integrations.packageUpdateSuccessDescription": "已成功更新 {title} 并升级了策略",
     "xpack.fleet.integrations.packageUpdateSuccessTitle": "已更新 {title} 并升级了策略",
     "xpack.fleet.integrations.packageUpgradeSuccessDescription": "已成功升级 {title}",
     "xpack.fleet.integrations.packageUpgradeSuccessTitle": "已升级 {title}",

--- a/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
@@ -9,6 +9,13 @@ import type { MonitoringType } from '../types';
 
 import { outputType } from './output';
 
+// Query-param hint appended to the integration-policy edit/copy links from agentless surfaces.
+// It lets the edit/copy pages select the agentless read/write API before their first read, since
+// the route only carries the `packagePolicyId` (shared with agent-based policies). Used as
+// `?isAgentless=true`. Provisional detect-before-read mechanism — see the task4 "consume new API"
+// follow-ups.
+export const IS_AGENTLESS_QUERY_PARAM = 'isAgentless';
+
 export const AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT = 3600;
 export const AGENTLESS_AGENT_POLICY_MONITORING: MonitoringType = ['logs', 'metrics'];
 export const AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION = 'organization';

--- a/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
@@ -11,9 +11,7 @@ import { outputType } from './output';
 
 // Query-param hint appended to the integration-policy edit/copy links from agentless surfaces.
 // It lets the edit/copy pages select the agentless read/write API before their first read, since
-// the route only carries the `packagePolicyId` (shared with agent-based policies). Used as
-// `?isAgentless=true`. Provisional detect-before-read mechanism — see the task4 "consume new API"
-// follow-ups.
+// the route only carries the `packagePolicyId` (shared with agent-based policies).
 export const IS_AGENTLESS_QUERY_PARAM = 'isAgentless';
 
 export const AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT = 3600;

--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -22,6 +22,7 @@ const _allowedExperimentalValues = {
   enableFleetPolicyRevisionsCleanupTask: true,
   enableAgentRollback: true, // When enabled, agent upgrade rollback will be available in the API and UI.
   disableAgentlessLegacyAPI: false, // When enabled, it will disable creating agentless policies via agent or package policies API.
+  enableAgentlessPoliciesUI: true, // When enabled, the UI reads/writes agentless integration policies through the agentless policies API. Disable as a kill switch to fall back to the legacy package-policy/agent-policy APIs.
   enableEsqlViewInstall: false,
   enableSloTemplates: true,
   newBrowseIntegrationUx: true, // When enabled integrations, browse integrations page will use the new UX.

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -54,6 +54,7 @@ export {
 export {
   syncDataStreamTypeFromVar,
   toNewAgentlessPolicy,
+  agentlessPolicyToPackagePolicy,
 } from './simplified_package_policy_helper';
 export {
   addUseAPMVarIfNotPresent,

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -861,6 +861,68 @@ describe('agentlessPolicyToPackagePolicy', () => {
     });
   });
 
+  describe('multi-template packages', () => {
+    const findInput = (
+      packagePolicy: ReturnType<typeof agentlessPolicyToPackagePolicy>,
+      policyTemplate: string,
+      type: string
+    ) =>
+      packagePolicy.inputs.find(
+        (input) => input.policy_template === policyTemplate && input.type === type
+      );
+
+    const multiTemplateAgentlessPolicy = (inputs: Record<string, { enabled?: boolean }>) =>
+      baseAgentlessPolicy({
+        package: { name: 'good_v3', title: 'Good v3', version: '1.0.0' },
+        inputs,
+      });
+
+    it('derives the active template and keeps the full-inputs contract a no-op', () => {
+      // Full GET payload: every input present, only the active template's input enabled.
+      const result = agentlessPolicyToPackagePolicy(
+        multiTemplateAgentlessPolicy({
+          'apache-agentless-aws/s3': { enabled: true },
+          'otel-otelcol': { enabled: false },
+          'mixed-httpjson': { enabled: false },
+          'mixed-cel': { enabled: false },
+        }),
+        multiTemplatePkgInfo
+      );
+
+      expect(findInput(result, 'apache-agentless', 'aws/s3')?.enabled).toBe(true);
+      expect(findInput(result, 'otel', 'otelcol')?.enabled).toBe(false);
+      expect(findInput(result, 'mixed', 'httpjson')?.enabled).toBe(false);
+      expect(findInput(result, 'mixed', 'cel')?.enabled).toBe(false);
+    });
+
+    it('does not leak other templates default-enabled inputs on a partial-inputs response', () => {
+      // Partial GET payload: only the active template's input is present. Other templates'
+      // default-enabled inputs (otel-otelcol, mixed-httpjson) must not leak in as enabled.
+      const result = agentlessPolicyToPackagePolicy(
+        multiTemplateAgentlessPolicy({ 'apache-agentless-aws/s3': { enabled: true } }),
+        multiTemplatePkgInfo
+      );
+
+      expect(findInput(result, 'apache-agentless', 'aws/s3')?.enabled).toBe(true);
+      expect(findInput(result, 'otel', 'otelcol')?.enabled).toBe(false);
+      expect(findInput(result, 'mixed', 'httpjson')?.enabled).toBe(false);
+      expect(findInput(result, 'mixed', 'cel')?.enabled).toBe(false);
+    });
+
+    it('honors an explicit policyTemplate over the derived one', () => {
+      const result = agentlessPolicyToPackagePolicy(
+        multiTemplateAgentlessPolicy({ 'apache-agentless-aws/s3': { enabled: true } }),
+        multiTemplatePkgInfo,
+        { policyTemplate: 'otel' }
+      );
+
+      // Forcing `otel` keeps otel's default-enabled input on, even though the response's only
+      // enabled input belongs to `apache-agentless` (which derivation would have selected,
+      // disabling otel-otelcol instead).
+      expect(findInput(result, 'otel', 'otelcol')?.enabled).toBe(true);
+    });
+  });
+
   describe('round trip with toNewAgentlessPolicy (load then save is a no-op)', () => {
     // Build a realistic simplified GET payload by running the create-side
     // converters first, so the fixture matches the actual wire format rather

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -7,6 +7,7 @@
 
 import type { NewPackagePolicy, PackageInfo } from '../../server/types';
 import { PackagePolicyValidationError } from '../errors';
+import type { AgentlessPolicy } from '../types/models/agentless_policy';
 
 import nginxPackageInfo from '../../server/services/package_policies/fixtures/package_info/nginx_1.5.0.json';
 
@@ -15,6 +16,7 @@ import {
   packagePolicyToSimplifiedPackagePolicy,
   generateInputId,
   toNewAgentlessPolicy,
+  agentlessPolicyToPackagePolicy,
 } from './simplified_package_policy_helper';
 
 jest.mock('./cloud_connectors', () => ({
@@ -768,6 +770,183 @@ describe('toNewAgentlessPolicy', () => {
       toNewAgentlessPolicy(policy, varGroups);
 
       expect(detectTargetCsp).toHaveBeenCalledWith(policy, varGroups);
+    });
+  });
+});
+
+describe('agentlessPolicyToPackagePolicy', () => {
+  const baseAgentlessPolicy = (overrides: Partial<AgentlessPolicy> = {}): AgentlessPolicy =>
+    ({
+      id: 'agentless-1',
+      name: 'my-agentless',
+      namespace: 'default',
+      description: 'a description',
+      package: { name: 'nginx', title: 'Nginx', version: '1.5.0' },
+      inputs: {},
+      created_at: '2026-06-30T00:00:00.000Z',
+      created_by: 'elastic',
+      updated_at: '2026-06-30T00:00:00.000Z',
+      updated_by: 'elastic',
+      ...overrides,
+    } as AgentlessPolicy);
+
+  it('expands the agentless policy into the full package policy form shape', () => {
+    const result = agentlessPolicyToPackagePolicy(
+      baseAgentlessPolicy(),
+      nginxPackageInfo as unknown as PackageInfo
+    );
+
+    expect(result.id).toBe('agentless-1');
+    expect(result.name).toBe('my-agentless');
+    expect(result.namespace).toBe('default');
+    expect(result.description).toBe('a description');
+    expect(result.supports_agentless).toBe(true);
+    // No user-managed agent policy is attached to an agentless deployment.
+    expect(result.policy_ids).toEqual([]);
+    // Inputs are expanded back to the array shape the form components expect.
+    expect(Array.isArray(result.inputs)).toBe(true);
+    expect(result.package).toEqual({ name: 'nginx', title: 'Nginx', version: '1.5.0' });
+  });
+
+  it('defaults the namespace when the policy has none', () => {
+    const result = agentlessPolicyToPackagePolicy(
+      baseAgentlessPolicy({ namespace: undefined }),
+      nginxPackageInfo as unknown as PackageInfo
+    );
+
+    expect(result.namespace).toBe('default');
+  });
+
+  it('preserves global_data_tags and additional_datastreams_permissions', () => {
+    const result = agentlessPolicyToPackagePolicy(
+      baseAgentlessPolicy({
+        global_data_tags: [{ name: 'team', value: 'fleet' }],
+        additional_datastreams_permissions: ['logs-test-123'],
+      }),
+      nginxPackageInfo as unknown as PackageInfo
+    );
+
+    expect(result.global_data_tags).toEqual([{ name: 'team', value: 'fleet' }]);
+    expect(result.additional_datastreams_permissions).toEqual(['logs-test-123']);
+  });
+
+  describe('cloud_connector', () => {
+    it('maps an enabled connector to supports_cloud_connector + cloud_connector_id', () => {
+      const result = agentlessPolicyToPackagePolicy(
+        baseAgentlessPolicy({ cloud_connector: { enabled: true, cloud_connector_id: 'cc-1' } }),
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      expect(result.supports_cloud_connector).toBe(true);
+      expect(result.cloud_connector_id).toBe('cc-1');
+    });
+
+    it('treats a null connector as disabled', () => {
+      const result = agentlessPolicyToPackagePolicy(
+        baseAgentlessPolicy({ cloud_connector: null }),
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      expect(result.supports_cloud_connector).toBe(false);
+      expect(result.cloud_connector_id).toBeNull();
+    });
+
+    it('treats an absent connector as disabled', () => {
+      const result = agentlessPolicyToPackagePolicy(
+        baseAgentlessPolicy(),
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      expect(result.supports_cloud_connector).toBe(false);
+    });
+  });
+
+  describe('round trip with toNewAgentlessPolicy (load then save is a no-op)', () => {
+    // Build a realistic simplified GET payload by running the create-side
+    // converters first, so the fixture matches the actual wire format rather
+    // than being hand-authored.
+    const buildGetResponse = (): AgentlessPolicy => {
+      const fullPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(
+        {
+          name: 'nginx-1',
+          namespace: 'default',
+          policy_ids: [],
+          supports_agentless: true,
+          inputs: {
+            'nginx-logfile': {
+              streams: {
+                'nginx.error': { vars: { tags: ['test', 'nginx-error'] } },
+              },
+            },
+          },
+        },
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      const requestBody = toNewAgentlessPolicy(
+        { ...fullPackagePolicy, id: 'agentless-1' },
+        undefined,
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      return {
+        id: 'agentless-1',
+        name: requestBody.name,
+        namespace: requestBody.namespace,
+        description: requestBody.description,
+        package: { ...requestBody.package, title: 'Nginx' },
+        inputs: requestBody.inputs,
+        vars: requestBody.vars,
+        global_data_tags: requestBody.global_data_tags,
+        cloud_connector: null,
+        created_at: '2026-06-30T00:00:00.000Z',
+        created_by: 'elastic',
+        updated_at: '2026-06-30T00:00:00.000Z',
+        updated_by: 'elastic',
+      } as AgentlessPolicy;
+    };
+
+    it('round-trips the agentless-relevant fields unchanged', () => {
+      const getResponse = buildGetResponse();
+
+      // Same request body produced when the GET payload is mapped to the form
+      // and immediately mapped back to a PUT body without edits.
+      const expectedRequestBody = toNewAgentlessPolicy(
+        {
+          ...simplifiedPackagePolicytoNewPackagePolicy(
+            {
+              name: 'nginx-1',
+              namespace: 'default',
+              policy_ids: [],
+              supports_agentless: true,
+              inputs: {
+                'nginx-logfile': {
+                  streams: {
+                    'nginx.error': { vars: { tags: ['test', 'nginx-error'] } },
+                  },
+                },
+              },
+            },
+            nginxPackageInfo as unknown as PackageInfo
+          ),
+          id: 'agentless-1',
+        },
+        undefined,
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      const roundTripped = toNewAgentlessPolicy(
+        agentlessPolicyToPackagePolicy(getResponse, nginxPackageInfo as unknown as PackageInfo),
+        undefined,
+        nginxPackageInfo as unknown as PackageInfo
+      );
+
+      expect(roundTripped.inputs).toEqual(expectedRequestBody.inputs);
+      expect(roundTripped.vars).toEqual(expectedRequestBody.vars);
+      expect(roundTripped.name).toBe(expectedRequestBody.name);
+      expect(roundTripped.namespace).toBe(expectedRequestBody.namespace);
+      expect(roundTripped.package).toEqual(expectedRequestBody.package);
+      expect(roundTripped.id).toBe('agentless-1');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -806,7 +806,11 @@ describe('agentlessPolicyToPackagePolicy', () => {
     expect(result.policy_ids).toEqual([]);
     // Inputs are expanded back to the array shape the form components expect.
     expect(Array.isArray(result.inputs)).toBe(true);
-    expect(result.package).toEqual({ name: 'agentless_hello_world', title: 'Agentless Hello World', version: '0.5.0' });
+    expect(result.package).toEqual({
+      name: 'agentless_hello_world',
+      title: 'Agentless Hello World',
+      version: '0.5.0',
+    });
   });
 
   it('defaults the namespace when the policy has none', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -10,6 +10,7 @@ import { PackagePolicyValidationError } from '../errors';
 import type { AgentlessPolicy } from '../types/models/agentless_policy';
 
 import nginxPackageInfo from '../../server/services/package_policies/fixtures/package_info/nginx_1.5.0.json';
+import agentlessHelloWorldPackageInfo from '../../server/services/package_policies/fixtures/package_info/agentless_hello_world_0.5.0.json';
 
 import {
   simplifiedPackagePolicytoNewPackagePolicy,
@@ -781,7 +782,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
       name: 'my-agentless',
       namespace: 'default',
       description: 'a description',
-      package: { name: 'nginx', title: 'Nginx', version: '1.5.0' },
+      package: { name: 'agentless_hello_world', title: 'Agentless Hello World', version: '0.5.0' },
       inputs: {},
       created_at: '2026-06-30T00:00:00.000Z',
       created_by: 'elastic',
@@ -793,7 +794,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
   it('expands the agentless policy into the full package policy form shape', () => {
     const result = agentlessPolicyToPackagePolicy(
       baseAgentlessPolicy(),
-      nginxPackageInfo as unknown as PackageInfo
+      agentlessHelloWorldPackageInfo as unknown as PackageInfo
     );
 
     expect(result.id).toBe('agentless-1');
@@ -805,13 +806,13 @@ describe('agentlessPolicyToPackagePolicy', () => {
     expect(result.policy_ids).toEqual([]);
     // Inputs are expanded back to the array shape the form components expect.
     expect(Array.isArray(result.inputs)).toBe(true);
-    expect(result.package).toEqual({ name: 'nginx', title: 'Nginx', version: '1.5.0' });
+    expect(result.package).toEqual({ name: 'agentless_hello_world', title: 'Agentless Hello World', version: '0.5.0' });
   });
 
   it('defaults the namespace when the policy has none', () => {
     const result = agentlessPolicyToPackagePolicy(
       baseAgentlessPolicy({ namespace: undefined }),
-      nginxPackageInfo as unknown as PackageInfo
+      agentlessHelloWorldPackageInfo as unknown as PackageInfo
     );
 
     expect(result.namespace).toBe('default');
@@ -823,7 +824,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
         global_data_tags: [{ name: 'team', value: 'fleet' }],
         additional_datastreams_permissions: ['logs-test-123'],
       }),
-      nginxPackageInfo as unknown as PackageInfo
+      agentlessHelloWorldPackageInfo as unknown as PackageInfo
     );
 
     expect(result.global_data_tags).toEqual([{ name: 'team', value: 'fleet' }]);
@@ -834,7 +835,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
     it('maps an enabled connector to supports_cloud_connector + cloud_connector_id', () => {
       const result = agentlessPolicyToPackagePolicy(
         baseAgentlessPolicy({ cloud_connector: { enabled: true, cloud_connector_id: 'cc-1' } }),
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       expect(result.supports_cloud_connector).toBe(true);
@@ -844,7 +845,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
     it('treats a null connector as disabled', () => {
       const result = agentlessPolicyToPackagePolicy(
         baseAgentlessPolicy({ cloud_connector: null }),
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       expect(result.supports_cloud_connector).toBe(false);
@@ -854,7 +855,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
     it('treats an absent connector as disabled', () => {
       const result = agentlessPolicyToPackagePolicy(
         baseAgentlessPolicy(),
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       expect(result.supports_cloud_connector).toBe(false);
@@ -927,28 +928,32 @@ describe('agentlessPolicyToPackagePolicy', () => {
     // Build a realistic simplified GET payload by running the create-side
     // converters first, so the fixture matches the actual wire format rather
     // than being hand-authored.
+    // Shared simplified GET/create input for both the built GET payload and the expected PUT body,
+    // so any divergence is produced by the converters under test, not by hand-authored drift.
+    const simplifiedInputs = {
+      'agentless_hello_world-cel': {
+        streams: {
+          'agentless_hello_world.generic': { vars: { url: 'https://custom.example.com' } },
+        },
+      },
+    };
+
     const buildGetResponse = (): AgentlessPolicy => {
       const fullPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(
         {
-          name: 'nginx-1',
+          name: 'hello_world-1',
           namespace: 'default',
           policy_ids: [],
           supports_agentless: true,
-          inputs: {
-            'nginx-logfile': {
-              streams: {
-                'nginx.error': { vars: { tags: ['test', 'nginx-error'] } },
-              },
-            },
-          },
+          inputs: simplifiedInputs,
         },
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       const requestBody = toNewAgentlessPolicy(
         { ...fullPackagePolicy, id: 'agentless-1' },
         undefined,
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       return {
@@ -956,7 +961,7 @@ describe('agentlessPolicyToPackagePolicy', () => {
         name: requestBody.name,
         namespace: requestBody.namespace,
         description: requestBody.description,
-        package: { ...requestBody.package, title: 'Nginx' },
+        package: { ...requestBody.package, title: 'Agentless Hello World' },
         inputs: requestBody.inputs,
         vars: requestBody.vars,
         global_data_tags: requestBody.global_data_tags,
@@ -977,30 +982,27 @@ describe('agentlessPolicyToPackagePolicy', () => {
         {
           ...simplifiedPackagePolicytoNewPackagePolicy(
             {
-              name: 'nginx-1',
+              name: 'hello_world-1',
               namespace: 'default',
               policy_ids: [],
               supports_agentless: true,
-              inputs: {
-                'nginx-logfile': {
-                  streams: {
-                    'nginx.error': { vars: { tags: ['test', 'nginx-error'] } },
-                  },
-                },
-              },
+              inputs: simplifiedInputs,
             },
-            nginxPackageInfo as unknown as PackageInfo
+            agentlessHelloWorldPackageInfo as unknown as PackageInfo
           ),
           id: 'agentless-1',
         },
         undefined,
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       const roundTripped = toNewAgentlessPolicy(
-        agentlessPolicyToPackagePolicy(getResponse, nginxPackageInfo as unknown as PackageInfo),
+        agentlessPolicyToPackagePolicy(
+          getResponse,
+          agentlessHelloWorldPackageInfo as unknown as PackageInfo
+        ),
         undefined,
-        nginxPackageInfo as unknown as PackageInfo
+        agentlessHelloWorldPackageInfo as unknown as PackageInfo
       );
 
       expect(roundTripped.inputs).toEqual(expectedRequestBody.inputs);

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -19,6 +19,7 @@ import type {
 import { DATASET_VAR_NAME, DATA_STREAM_TYPE_VAR_NAME } from '../constants';
 import type { RegistryVarGroup } from '../types/models/package_spec';
 import type { NewAgentlessPolicy } from '../types/rest_spec/agentless_policy';
+import type { AgentlessPolicy } from '../types/models/agentless_policy';
 
 import { PackagePolicyValidationError } from '../errors';
 
@@ -119,16 +120,22 @@ export function formatInputs(
       acc = {};
     }
 
+    const isInputAllowed = isInputAllowedForDeploymentMode(
+      input,
+      supportsAgentless ? 'agentless' : 'default',
+      packageInfo
+    );
+
     acc[inputId] = {
-      enabled: isInputAllowedForDeploymentMode(
-        input,
-        supportsAgentless ? 'agentless' : 'default',
-        packageInfo
-      )
-        ? input.enabled
-        : false,
+      enabled: isInputAllowed ? input.enabled : false,
       vars: formatVars(input.vars),
-      streams: formatStreams(input.streams),
+      // Mirror the read path (`simplifiedPackagePolicytoNewPackagePolicy`, where a
+      // disallowed input forces its streams off): keep the stream enablement the
+      // write emits consistent with what a subsequent read produces, so a
+      // load→save round trip is idempotent regardless of how many streams the
+      // source happened to list. For `default` mode `isInputAllowed` is always
+      // true, so this is a no-op there.
+      streams: formatStreams(input.streams, isInputAllowed),
       ...(input.condition !== undefined ? { condition: input.condition } : {}),
     };
 
@@ -153,13 +160,16 @@ export function formatVars(vars: NewPackagePolicy['inputs'][number]['vars']) {
   }, {} as SimplifiedVars);
 }
 
-function formatStreams(streams: NewPackagePolicy['inputs'][number]['streams']) {
+function formatStreams(
+  streams: NewPackagePolicy['inputs'][number]['streams'],
+  isInputAllowed: boolean = true
+) {
   return streams.reduce((acc, stream) => {
     if (!acc) {
       acc = {};
     }
     acc[stream.data_stream.dataset] = {
-      enabled: stream.enabled,
+      enabled: isInputAllowed === false ? false : stream.enabled,
       vars: formatVars(stream.vars),
       ...(stream.condition !== undefined ? { condition: stream.condition } : {}),
     };
@@ -349,10 +359,17 @@ type AgentlessPolicyInput = NewPackagePolicy & {
  * payload leak-proof as `NewPackagePolicy` evolves — any new/unknown property
  * (e.g. `overrides`, `elasticsearch`, `is_managed`) is dropped instead of being
  * silently sent and potentially rejected by the server.
+ *
+ * Pass `packageInfo` whenever it is available so the agentless input allow-check
+ * (`isInputAllowedForDeploymentMode`) uses the same package-template-aware logic as
+ * the read path ({@link agentlessPolicyToPackagePolicy}). Without it the check falls
+ * back to the coarse `AGENTLESS_DISABLED_INPUTS` blocklist, which can disagree with
+ * the read path and make a load→save round trip non-idempotent.
  */
 export const toNewAgentlessPolicy = (
   packagePolicy: AgentlessPolicyInput,
-  varGroups?: RegistryVarGroup[]
+  varGroups?: RegistryVarGroup[],
+  packageInfo?: PackageInfo
 ): NewAgentlessPolicy => {
   const targetCsp = detectTargetCsp(packagePolicy, varGroups);
 
@@ -369,7 +386,7 @@ export const toNewAgentlessPolicy = (
     ]),
     package: omit(packagePolicy.package, 'title'),
     id: packagePolicy.id ? String(packagePolicy.id) : undefined,
-    inputs: formatInputs(packagePolicy.inputs, true),
+    inputs: formatInputs(packagePolicy.inputs, true, packageInfo),
     vars: formatVars(packagePolicy.vars),
     ...(packagePolicy.supports_cloud_connector && {
       cloud_connector: {
@@ -384,5 +401,53 @@ export const toNewAgentlessPolicy = (
           }),
       },
     }),
+  };
+};
+
+/**
+ * Inverse of {@link toNewAgentlessPolicy}: expand a clean {@link AgentlessPolicy}
+ * (as returned by the GET/LIST agentless API, with simplified object-style `inputs`)
+ * back into the full {@link NewPackagePolicy} shape that the shared edit/copy form
+ * components and `validatePackagePolicy` expect (array-based `inputs`).
+ *
+ * Reuses {@link simplifiedPackagePolicytoNewPackagePolicy} — the same converter create
+ * uses — so the GET -> form -> PUT round trip is lossless on the agentless-relevant
+ * fields (composing this with {@link toNewAgentlessPolicy} is a no-op when the user
+ * makes no edits).
+ *
+ * `packageInfo` must be loaded for `agentlessPolicy.package.version` (the form fetches
+ * it from the EPM/registry API). For multi-template packages, pass `policyTemplate` so
+ * the converter selects the right template — it is not carried on the API response.
+ */
+export const agentlessPolicyToPackagePolicy = (
+  agentlessPolicy: AgentlessPolicy,
+  packageInfo: PackageInfo,
+  options?: { policyTemplate?: string }
+): NewPackagePolicy => {
+  const { cloud_connector: cloudConnector } = agentlessPolicy;
+
+  const simplified: SimplifiedPackagePolicy = {
+    name: agentlessPolicy.name,
+    namespace: agentlessPolicy.namespace ?? 'default',
+    description: agentlessPolicy.description,
+    // Agentless deployments are not attached to a user-managed agent policy.
+    policy_ids: [],
+    inputs: agentlessPolicy.inputs as SimplifiedInputs,
+    vars: agentlessPolicy.vars as SimplifiedVars | undefined,
+    var_group_selections: agentlessPolicy.var_group_selections,
+    global_data_tags: agentlessPolicy.global_data_tags,
+    additional_datastreams_permissions: agentlessPolicy.additional_datastreams_permissions,
+    supports_agentless: true,
+    supports_cloud_connector: Boolean(cloudConnector?.enabled),
+    cloud_connector_id: cloudConnector?.cloud_connector_id ?? null,
+  };
+
+  const packagePolicy = simplifiedPackagePolicytoNewPackagePolicy(simplified, packageInfo, {
+    policyTemplate: options?.policyTemplate,
+  });
+
+  return {
+    ...packagePolicy,
+    id: agentlessPolicy.id,
   };
 };

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -130,11 +130,8 @@ export function formatInputs(
       enabled: isInputAllowed ? input.enabled : false,
       vars: formatVars(input.vars),
       // Mirror the read path (`simplifiedPackagePolicytoNewPackagePolicy`, where a
-      // disallowed input forces its streams off): keep the stream enablement the
-      // write emits consistent with what a subsequent read produces, so a
-      // load→save round trip is idempotent regardless of how many streams the
-      // source happened to list. For `default` mode `isInputAllowed` is always
-      // true, so this is a no-op there.
+      // disallowed input forces its streams off)
+      // For `default` mode `isInputAllowed` is always true, so this is a no-op there.
       streams: formatStreams(input.streams, isInputAllowed),
       ...(input.condition !== undefined ? { condition: input.condition } : {}),
     };
@@ -362,9 +359,7 @@ type AgentlessPolicyInput = NewPackagePolicy & {
  *
  * Pass `packageInfo` whenever it is available so the agentless input allow-check
  * (`isInputAllowedForDeploymentMode`) uses the same package-template-aware logic as
- * the read path ({@link agentlessPolicyToPackagePolicy}). Without it the check falls
- * back to the coarse `AGENTLESS_DISABLED_INPUTS` blocklist, which can disagree with
- * the read path and make a load→save round trip non-idempotent.
+ * the read path ({@link agentlessPolicyToPackagePolicy}).
  */
 export const toNewAgentlessPolicy = (
   packagePolicy: AgentlessPolicyInput,
@@ -409,11 +404,6 @@ export const toNewAgentlessPolicy = (
  * (as returned by the GET/LIST agentless API, with simplified object-style `inputs`)
  * back into the full {@link NewPackagePolicy} shape that the shared edit/copy form
  * components and `validatePackagePolicy` expect (array-based `inputs`).
- *
- * Reuses {@link simplifiedPackagePolicytoNewPackagePolicy} — the same converter create
- * uses — so the GET -> form -> PUT round trip is lossless on the agentless-relevant
- * fields (composing this with {@link toNewAgentlessPolicy} is a no-op when the user
- * makes no edits).
  *
  * `packageInfo` must be loaded for `agentlessPolicy.package.version` (the form fetches
  * it from the EPM/registry API). For multi-template packages, pass `policyTemplate` so

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -23,7 +23,11 @@ import type { AgentlessPolicy } from '../types/models/agentless_policy';
 
 import { PackagePolicyValidationError } from '../errors';
 
-import { packageToPackagePolicy, getInputEffectiveName } from './package_to_package_policy';
+import {
+  packageToPackagePolicy,
+  packageToPackagePolicyInputs,
+  getInputEffectiveName,
+} from './package_to_package_policy';
 import { isInputAllowedForDeploymentMode } from './agentless_policy_helper';
 import { detectTargetCsp } from './cloud_connectors';
 
@@ -400,14 +404,61 @@ export const toNewAgentlessPolicy = (
 };
 
 /**
+ * For a multi-template package, work out which `policy_template` an {@link AgentlessPolicy}
+ * belongs to by mapping its enabled input ids back to the manifest. An agentless deployment
+ * enables exactly one integration, so we only disambiguate when a single template is
+ * represented; otherwise we return `undefined` and let the full-inputs contract drive
+ * enablement (see {@link agentlessPolicyToPackagePolicy}).
+ */
+const deriveAgentlessPolicyTemplate = (
+  agentlessPolicy: AgentlessPolicy,
+  packageInfo: PackageInfo
+): string | undefined => {
+  const templates = packageInfo.policy_templates ?? [];
+  // Single-template (or template-less) packages have nothing to disambiguate.
+  if (templates.length <= 1) {
+    return undefined;
+  }
+
+  const inputIdToTemplate = new Map<string, string | undefined>();
+  packageToPackagePolicyInputs(packageInfo).forEach((input) => {
+    inputIdToTemplate.set(generateInputId(input), input.policy_template);
+  });
+
+  const activeTemplates = new Set<string>();
+  Object.entries((agentlessPolicy.inputs as SimplifiedInputs | undefined) ?? {}).forEach(
+    ([inputId, value]) => {
+      // Skip explicitly-disabled inputs: under the full-inputs contract the response carries
+      // every input (including other templates' disabled ones), so only the enabled inputs
+      // identify the active template.
+      if (value?.enabled === false) {
+        return;
+      }
+      const template = inputIdToTemplate.get(inputId);
+      if (template) {
+        activeTemplates.add(template);
+      }
+    }
+  );
+
+  return activeTemplates.size === 1 ? [...activeTemplates][0] : undefined;
+};
+
+/**
  * Inverse of {@link toNewAgentlessPolicy}: expand a clean {@link AgentlessPolicy}
  * (as returned by the GET/LIST agentless API, with simplified object-style `inputs`)
  * back into the full {@link NewPackagePolicy} shape that the shared edit/copy form
  * components and `validatePackagePolicy` expect (array-based `inputs`).
  *
- * `packageInfo` must be loaded for `agentlessPolicy.package.version` (the form fetches
- * it from the EPM/registry API). For multi-template packages, pass `policyTemplate` so
- * the converter selects the right template — it is not carried on the API response.
+ * `packageInfo` must be loaded (with `full: true`) for `agentlessPolicy.package.version` — the
+ * form fetches it from the EPM/registry API — so the scaffold carries every template's inputs.
+ *
+ * `policyTemplate` selects the integration for multi-template packages. The API response does
+ * not carry it, so when the caller omits it we derive it from the enabled inputs
+ * ({@link deriveAgentlessPolicyTemplate}). Today the GET serializes *every* input (full-inputs
+ * contract), so enablement is reconstructed correctly even without the hint; deriving it keeps
+ * the read correct if the API ever returns a partial `inputs` object (otherwise other templates'
+ * default-enabled inputs would leak in as enabled). An explicit `options.policyTemplate` wins.
  */
 export const agentlessPolicyToPackagePolicy = (
   agentlessPolicy: AgentlessPolicy,
@@ -432,8 +483,11 @@ export const agentlessPolicyToPackagePolicy = (
     cloud_connector_id: cloudConnector?.cloud_connector_id ?? null,
   };
 
+  const policyTemplate =
+    options?.policyTemplate ?? deriveAgentlessPolicyTemplate(agentlessPolicy, packageInfo);
+
   const packagePolicy = simplifiedPackagePolicytoNewPackagePolicy(simplified, packageInfo, {
-    policyTemplate: options?.policyTemplate,
+    policyTemplate,
   });
 
   return {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.test.tsx
@@ -10,6 +10,7 @@ import { waitFor } from '@testing-library/react';
 import {
   sendGetAgentlessPolicy,
   sendGetPackageInfoByKeyForRq,
+  sendGetSettings,
   useGetOnePackagePolicyQuery,
 } from '../../../../../../hooks';
 import { createFleetTestRendererMock } from '../../../../../../mock';
@@ -24,6 +25,7 @@ jest.mock('../../../../../../hooks/use_request', () => ({
   useGetOnePackagePolicyQuery: jest.fn(),
   sendGetAgentlessPolicy: jest.fn(),
   sendGetPackageInfoByKeyForRq: jest.fn(),
+  sendGetSettings: jest.fn(),
 }));
 
 describe('useCopyPackagePolicyData', () => {
@@ -40,6 +42,9 @@ describe('useCopyPackagePolicyData', () => {
     jest
       .mocked(useGetOnePackagePolicyQuery)
       .mockReturnValue({ data: undefined, isLoading: false } as any);
+    jest
+      .mocked(sendGetSettings)
+      .mockResolvedValue({ data: { item: { prerelease_integrations_enabled: false } } } as any);
   });
 
   it('reads the package policy directly for a traditional copy', async () => {
@@ -77,6 +82,34 @@ describe('useCopyPackagePolicyData', () => {
     expect(result.current.item?.supports_agentless).toBe(true);
     // The package-policy read is disabled so exactly one API is used for an agentless copy.
     expect(useGetOnePackagePolicyQuery).toHaveBeenCalledWith('agentless-1', { enabled: false });
+    // Prerelease is resolved from settings (here disabled), matching the edit read path rather
+    // than a hardcoded `true`.
+    expect(sendGetPackageInfoByKeyForRq).toHaveBeenCalledWith(
+      'nginx',
+      '1.5.0',
+      expect.objectContaining({ prerelease: false, full: true })
+    );
+  });
+
+  it('hydrates with prerelease enabled when the setting is on', async () => {
+    jest.mocked(sendGetAgentlessPolicy).mockResolvedValue({ item: agentlessPolicy } as any);
+    jest.mocked(sendGetPackageInfoByKeyForRq).mockResolvedValue({ item: nginxPackageInfo } as any);
+    jest
+      .mocked(sendGetSettings)
+      .mockResolvedValue({ data: { item: { prerelease_integrations_enabled: true } } } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      useCopyPackagePolicyData('agentless-prerelease', { isAgentless: true })
+    );
+
+    await waitFor(() => expect(result.current.item?.id).toBe('agentless-1'));
+
+    expect(sendGetPackageInfoByKeyForRq).toHaveBeenCalledWith(
+      'nginx',
+      '1.5.0',
+      expect.objectContaining({ prerelease: true, full: true })
+    );
   });
 
   it('surfaces the error (no item, not loading) when the agentless read fails', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { waitFor } from '@testing-library/react';
+
+import {
+  sendGetAgentlessPolicy,
+  sendGetPackageInfoByKeyForRq,
+  useGetOnePackagePolicyQuery,
+} from '../../../../../../hooks';
+import { createFleetTestRendererMock } from '../../../../../../mock';
+import nginxPackageInfo from '../../../../../../../server/services/package_policies/fixtures/package_info/nginx_1.5.0.json';
+
+import { useCopyPackagePolicyData } from './use_copy_package_policy_data';
+
+// Mock the leaf `use_request` module (like the edit hook test) so the real inverse mapper
+// (`agentlessPolicyToPackagePolicy`) still runs against the nginx fixture below.
+jest.mock('../../../../../../hooks/use_request', () => ({
+  ...jest.requireActual('../../../../../../hooks/use_request'),
+  useGetOnePackagePolicyQuery: jest.fn(),
+  sendGetAgentlessPolicy: jest.fn(),
+  sendGetPackageInfoByKeyForRq: jest.fn(),
+}));
+
+describe('useCopyPackagePolicyData', () => {
+  const agentlessPolicy = {
+    id: 'agentless-1',
+    name: 'agentless-1',
+    namespace: 'default',
+    package: { name: 'nginx', title: 'Nginx', version: '1.5.0' },
+    inputs: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(useGetOnePackagePolicyQuery)
+      .mockReturnValue({ data: undefined, isLoading: false } as any);
+  });
+
+  it('reads the package policy directly for a traditional copy', async () => {
+    jest.mocked(useGetOnePackagePolicyQuery).mockReturnValue({
+      data: { item: { id: 'pp-1', name: 'pp' } },
+      isLoading: false,
+    } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      useCopyPackagePolicyData('pp-1', { isAgentless: false })
+    );
+
+    await waitFor(() => expect(result.current.item).toEqual({ id: 'pp-1', name: 'pp' }));
+
+    expect(useGetOnePackagePolicyQuery).toHaveBeenCalledWith('pp-1', { enabled: true });
+    // The agentless API is never touched for a traditional copy.
+    expect(sendGetAgentlessPolicy).not.toHaveBeenCalled();
+  });
+
+  it('hydrates an agentless copy through the agentless API and inverse mapper', async () => {
+    jest.mocked(sendGetAgentlessPolicy).mockResolvedValue({ item: agentlessPolicy } as any);
+    jest.mocked(sendGetPackageInfoByKeyForRq).mockResolvedValue({ item: nginxPackageInfo } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      useCopyPackagePolicyData('agentless-1', { isAgentless: true })
+    );
+
+    // The inverse mapper carries the source id through onto the expanded package policy.
+    await waitFor(() => expect(result.current.item?.id).toBe('agentless-1'));
+
+    expect(sendGetAgentlessPolicy).toHaveBeenCalledWith('agentless-1');
+    expect(result.current.item?.name).toBe('agentless-1');
+    expect(result.current.item?.supports_agentless).toBe(true);
+    // The package-policy read is disabled so exactly one API is used for an agentless copy.
+    expect(useGetOnePackagePolicyQuery).toHaveBeenCalledWith('agentless-1', { enabled: false });
+  });
+
+  it('returns no item and stops loading when the agentless read fails', async () => {
+    jest.mocked(sendGetAgentlessPolicy).mockRejectedValue(new Error('boom'));
+
+    // Use a distinct id so this doesn't hit the react-query cache from the success case above.
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      useCopyPackagePolicyData('agentless-failure', { isAgentless: true })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.item).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.test.tsx
@@ -79,7 +79,7 @@ describe('useCopyPackagePolicyData', () => {
     expect(useGetOnePackagePolicyQuery).toHaveBeenCalledWith('agentless-1', { enabled: false });
   });
 
-  it('returns no item and stops loading when the agentless read fails', async () => {
+  it('surfaces the error (no item, not loading) when the agentless read fails', async () => {
     jest.mocked(sendGetAgentlessPolicy).mockRejectedValue(new Error('boom'));
 
     // Use a distinct id so this doesn't hit the react-query cache from the success case above.
@@ -88,8 +88,11 @@ describe('useCopyPackagePolicyData', () => {
       useCopyPackagePolicyData('agentless-failure', { isAgentless: true })
     );
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    // The page relies on `isError` to render an error state instead of an infinite spinner.
+    await waitFor(() => expect(result.current.isError).toBe(true));
 
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.item).toBeUndefined();
+    expect(result.current.error).toEqual(new Error('boom'));
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+
+import {
+  sendGetAgentlessPolicy,
+  sendGetPackageInfoByKeyForRq,
+  useGetOnePackagePolicyQuery,
+} from '../../../../hooks';
+import type { PackagePolicy } from '../../../../types';
+import { agentlessPolicyToPackagePolicy } from '../../../../../../../common/services';
+
+/**
+ * Read the policy that a copy is being created from.
+ *
+ * Agentless copies must not touch the package-policy/agent-policy APIs (detect-before-read via the
+ * `isAgentless` link hint), so they hydrate through the agentless API and reuse the same inverse
+ * mapper as the edit read path. Traditional copies keep reading the package policy directly.
+ *
+ * Only one of the two queries is ever enabled, so exactly one API is called per copy.
+ */
+export function useCopyPackagePolicyData(
+  packagePolicyId: string,
+  { isAgentless }: { isAgentless: boolean }
+): { item?: PackagePolicy; isLoading: boolean } {
+  const packagePolicyQuery = useGetOnePackagePolicyQuery(packagePolicyId, {
+    enabled: !isAgentless,
+  });
+
+  const agentlessPolicyQuery = useQuery(
+    ['copyAgentlessPolicy', packagePolicyId],
+    async () => {
+      const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
+      const packageInfo = await sendGetPackageInfoByKeyForRq(
+        agentlessPolicy.package.name,
+        agentlessPolicy.package.version,
+        { prerelease: true, full: true }
+      );
+
+      // `agentlessPolicyToPackagePolicy` already carries the id through; the copy helper strips it
+      // (along with `version`) before creating the fresh policy. `supports_agentless` stays true so
+      // the create page routes the copy write through the agentless create API.
+      return agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo.item) as PackagePolicy;
+    },
+    { enabled: isAgentless, refetchOnWindowFocus: false }
+  );
+
+  if (isAgentless) {
+    return { item: agentlessPolicyQuery.data, isLoading: agentlessPolicyQuery.isLoading };
+  }
+
+  return { item: packagePolicyQuery.data?.item, isLoading: packagePolicyQuery.isLoading };
+}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
@@ -10,6 +10,7 @@ import { useQuery } from '@kbn/react-query';
 import {
   sendGetAgentlessPolicy,
   sendGetPackageInfoByKeyForRq,
+  sendGetSettings,
   useGetOnePackagePolicyQuery,
 } from '../../../../hooks';
 import type { PackagePolicy } from '../../../../types';
@@ -36,10 +37,13 @@ export function useCopyPackagePolicyData(
     ['copyAgentlessPolicy', packagePolicyId],
     async () => {
       const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
+      // Resolve prerelease from settings
+      const { data: settings } = await sendGetSettings();
+      const prerelease = Boolean(settings?.item.prerelease_integrations_enabled);
       const packageInfo = await sendGetPackageInfoByKeyForRq(
         agentlessPolicy.package.name,
         agentlessPolicy.package.version,
-        { prerelease: true, full: true }
+        { prerelease, full: true }
       );
 
       // `agentlessPolicyToPackagePolicy` already carries the id through; the copy helper strips it

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
@@ -27,7 +27,7 @@ import { agentlessPolicyToPackagePolicy } from '../../../../../../../common/serv
 export function useCopyPackagePolicyData(
   packagePolicyId: string,
   { isAgentless }: { isAgentless: boolean }
-): { item?: PackagePolicy; isLoading: boolean } {
+): { item?: PackagePolicy; isLoading: boolean; isError: boolean; error: unknown } {
   const packagePolicyQuery = useGetOnePackagePolicyQuery(packagePolicyId, {
     enabled: !isAgentless,
   });
@@ -51,8 +51,18 @@ export function useCopyPackagePolicyData(
   );
 
   if (isAgentless) {
-    return { item: agentlessPolicyQuery.data, isLoading: agentlessPolicyQuery.isLoading };
+    return {
+      item: agentlessPolicyQuery.data,
+      isLoading: agentlessPolicyQuery.isLoading,
+      isError: agentlessPolicyQuery.isError,
+      error: agentlessPolicyQuery.error,
+    };
   }
 
-  return { item: packagePolicyQuery.data?.item, isLoading: packagePolicyQuery.isLoading };
+  return {
+    item: packagePolicyQuery.data?.item,
+    isLoading: packagePolicyQuery.isLoading,
+    isError: packagePolicyQuery.isError,
+    error: packagePolicyQuery.error,
+  };
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
@@ -13,6 +13,7 @@ import {
   sendGetSettings,
   useGetOnePackagePolicyQuery,
 } from '../../../../hooks';
+import type { RequestError } from '../../../../hooks';
 import type { PackagePolicy } from '../../../../types';
 import { agentlessPolicyToPackagePolicy } from '../../../../../../../common/services';
 
@@ -28,12 +29,12 @@ import { agentlessPolicyToPackagePolicy } from '../../../../../../../common/serv
 export function useCopyPackagePolicyData(
   packagePolicyId: string,
   { isAgentless }: { isAgentless: boolean }
-): { item?: PackagePolicy; isLoading: boolean; isError: boolean; error: Error | null } {
+): { item?: PackagePolicy; isLoading: boolean; isError: boolean; error: RequestError | null } {
   const packagePolicyQuery = useGetOnePackagePolicyQuery(packagePolicyId, {
     enabled: !isAgentless,
   });
 
-  const agentlessPolicyQuery = useQuery<PackagePolicy, Error>(
+  const agentlessPolicyQuery = useQuery<PackagePolicy, RequestError>(
     ['copyAgentlessPolicy', packagePolicyId],
     async () => {
       const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
@@ -63,14 +64,10 @@ export function useCopyPackagePolicyData(
     };
   }
 
-  // Normalize the error to Error | null for consistent typing with the agentless path.
-  const packagePolicyError =
-    packagePolicyQuery.error instanceof Error ? packagePolicyQuery.error : null;
-
   return {
     item: packagePolicyQuery.data?.item,
     isLoading: packagePolicyQuery.isLoading,
     isError: packagePolicyQuery.isError,
-    error: packagePolicyError,
+    error: packagePolicyQuery.error ?? null,
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
@@ -7,15 +7,10 @@
 
 import { useQuery } from '@kbn/react-query';
 
-import {
-  sendGetAgentlessPolicy,
-  sendGetPackageInfoByKeyForRq,
-  sendGetSettings,
-  useGetOnePackagePolicyQuery,
-} from '../../../../hooks';
+import { useGetOnePackagePolicyQuery } from '../../../../hooks';
 import type { RequestError } from '../../../../hooks';
 import type { PackagePolicy } from '../../../../types';
-import { agentlessPolicyToPackagePolicy } from '../../../../../../../common/services';
+import { fetchAgentlessPolicyAsPackagePolicy } from '../../services';
 
 /**
  * Read the policy that a copy is being created from.
@@ -37,20 +32,11 @@ export function useCopyPackagePolicyData(
   const agentlessPolicyQuery = useQuery<PackagePolicy, RequestError>(
     ['copyAgentlessPolicy', packagePolicyId],
     async () => {
-      const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
-      // Resolve prerelease from settings
-      const { data: settings } = await sendGetSettings();
-      const prerelease = Boolean(settings?.item.prerelease_integrations_enabled);
-      const packageInfo = await sendGetPackageInfoByKeyForRq(
-        agentlessPolicy.package.name,
-        agentlessPolicy.package.version,
-        { prerelease, full: true }
-      );
-
-      // `agentlessPolicyToPackagePolicy` already carries the id through; the copy helper strips it
-      // (along with `version`) before creating the fresh policy. `supports_agentless` stays true so
-      // the create page routes the copy write through the agentless create API.
-      return agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo.item) as PackagePolicy;
+      // The expanded policy carries the source id through; the copy helper strips it (along with
+      // `version`) before creating the fresh policy. `supports_agentless` stays true so the
+      // create page routes the copy write through the agentless create API.
+      const { packagePolicy } = await fetchAgentlessPolicyAsPackagePolicy(packagePolicyId);
+      return packagePolicy as PackagePolicy;
     },
     { enabled: isAgentless, refetchOnWindowFocus: false }
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/hooks/use_copy_package_policy_data.tsx
@@ -28,12 +28,12 @@ import { agentlessPolicyToPackagePolicy } from '../../../../../../../common/serv
 export function useCopyPackagePolicyData(
   packagePolicyId: string,
   { isAgentless }: { isAgentless: boolean }
-): { item?: PackagePolicy; isLoading: boolean; isError: boolean; error: unknown } {
+): { item?: PackagePolicy; isLoading: boolean; isError: boolean; error: Error | null } {
   const packagePolicyQuery = useGetOnePackagePolicyQuery(packagePolicyId, {
     enabled: !isAgentless,
   });
 
-  const agentlessPolicyQuery = useQuery(
+  const agentlessPolicyQuery = useQuery<PackagePolicy, Error>(
     ['copyAgentlessPolicy', packagePolicyId],
     async () => {
       const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
@@ -59,14 +59,18 @@ export function useCopyPackagePolicyData(
       item: agentlessPolicyQuery.data,
       isLoading: agentlessPolicyQuery.isLoading,
       isError: agentlessPolicyQuery.isError,
-      error: agentlessPolicyQuery.error,
+      error: agentlessPolicyQuery.error ?? null,
     };
   }
+
+  // Normalize the error to Error | null for consistent typing with the agentless path.
+  const packagePolicyError =
+    packagePolicyQuery.error instanceof Error ? packagePolicyQuery.error : null;
 
   return {
     item: packagePolicyQuery.data?.item,
     isLoading: packagePolicyQuery.isLoading,
     isError: packagePolicyQuery.isError,
-    error: packagePolicyQuery.error,
+    error: packagePolicyError,
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
@@ -105,6 +105,13 @@ export const CopyPackagePolicyPage = memo(() => {
   // Without this, a failed source-policy read leaves `isLoading` false and `sourcePolicy`
   // undefined, which would otherwise render the loading spinner forever with no recovery path.
   if (isError) {
+    // Ensure the error is typed as `string | Error` for the Error component.
+    const displayError: string | Error =
+      error instanceof Error
+        ? error
+        : i18n.translate('xpack.fleet.copyPackagePolicyPage.loadingErrorGenericMessage', {
+            defaultMessage: 'An error occurred while loading the integration policy.',
+          });
     return (
       <ContentWrapper justifyContent="center" alignItems="center">
         <Error
@@ -114,13 +121,7 @@ export const CopyPackagePolicyPage = memo(() => {
               defaultMessage="Unable to load the integration policy to copy"
             />
           }
-          error={
-            error instanceof Error
-              ? error
-              : i18n.translate('xpack.fleet.copyPackagePolicyPage.loadingErrorGenericMessage', {
-                  defaultMessage: 'An error occurred while loading the integration policy.',
-                })
-          }
+          error={displayError}
         />
       </ContentWrapper>
     );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
@@ -12,9 +12,11 @@ import { EuiEmptyPrompt, EuiFlexGroup } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import styled from '@emotion/styled';
 
-import { EXCLUDED_FROM_PACKAGE_POLICY_COPY_PACKAGES } from '../../../../../../common/constants';
+import {
+  EXCLUDED_FROM_PACKAGE_POLICY_COPY_PACKAGES,
+  IS_AGENTLESS_QUERY_PARAM,
+} from '../../../../../../common/constants';
 
-import { useGetOnePackagePolicy } from '../../../../integrations/hooks';
 import { Loading } from '../../../components';
 import type { EditPackagePolicyFrom } from '../create_package_policy_page/types';
 
@@ -22,6 +24,8 @@ import { CreatePackagePolicySinglePage } from '../create_package_policy_page/sin
 import { useBreadcrumbs, useGetOneAgentPolicy } from '../../../hooks';
 import { useBreadcrumbs as useIntegrationsBreadcrumbs } from '../../../../integrations/hooks';
 import { copyPackagePolicy } from '../../../../../../common/services/copy_package_policy_utils';
+
+import { useCopyPackagePolicyData } from './hooks/use_copy_package_policy_data';
 
 const ContentWrapper = styled(EuiFlexGroup)`
   height: 100%;
@@ -57,18 +61,28 @@ export const CopyPackagePolicyPage = memo(() => {
     params: { packagePolicyId, policyId },
   } = useRouteMatch<{ packagePolicyId: string; policyId?: string }>();
 
-  const packagePolicy = useGetOnePackagePolicy(packagePolicyId);
-  const agentPolicy = useGetOneAgentPolicy(policyId);
-
-  const packagePolicyData = useMemo(() => {
-    if (packagePolicy.data?.item) {
-      return copyPackagePolicy(packagePolicy.data.item);
-    }
-  }, [packagePolicy.data?.item]);
-
-  // Parse the 'from' query parameter to determine navigation after save
   const { search } = useLocation();
 
+  // Detect-before-read hint: agentless copies read/hydrate through the agentless API instead of the
+  // package-policy/agent-policy APIs.
+  const isAgentless = useMemo(
+    () => new URLSearchParams(search).get(IS_AGENTLESS_QUERY_PARAM) === 'true',
+    [search]
+  );
+
+  const { item: sourcePolicy, isLoading } = useCopyPackagePolicyData(packagePolicyId, {
+    isAgentless,
+  });
+  // Agentless deployments have no user-facing agent policy, so skip the agent-policy read for them.
+  const agentPolicy = useGetOneAgentPolicy(isAgentless ? undefined : policyId);
+
+  const packagePolicyData = useMemo(() => {
+    if (sourcePolicy) {
+      return copyPackagePolicy(sourcePolicy);
+    }
+  }, [sourcePolicy]);
+
+  // Determine navigation after save from the 'from' query parameter
   const from = useMemo(() => {
     const qs = new URLSearchParams(search);
     const qsFrom = (qs.get('from') as EditPackagePolicyFrom | null) ?? 'fleet-policy-list';
@@ -82,7 +96,7 @@ export const CopyPackagePolicyPage = memo(() => {
     }
   }, [search]);
 
-  if (packagePolicy.isLoading || !packagePolicy.data) {
+  if (isLoading || !sourcePolicy) {
     return (
       <>
         <Loading />
@@ -94,16 +108,16 @@ export const CopyPackagePolicyPage = memo(() => {
     from === 'copy-from-fleet-policy-list' && policyId ? (
       <PoliciesBreadcrumb policyName={agentPolicy.data?.item?.name || ''} policyId={policyId} />
     ) : from === 'copy-from-installed-integrations' ? (
-      <InstalledIntegrationsBreadcrumb policyName={packagePolicy.data?.item?.name || ''} />
+      <InstalledIntegrationsBreadcrumb policyName={sourcePolicy.name || ''} />
     ) : (
       <IntegrationsBreadcrumb
-        pkgTitle={packagePolicy.data?.item?.package?.title || ''}
-        policyName={packagePolicy.data?.item?.name || ''}
-        pkgkey={packagePolicy.data?.item?.package?.name || ''}
+        pkgTitle={sourcePolicy.package?.title || ''}
+        policyName={sourcePolicy.name || ''}
+        pkgkey={sourcePolicy.package?.name || ''}
       />
     );
 
-  const pkgName = packagePolicy.data?.item?.package?.name;
+  const pkgName = sourcePolicy.package?.name;
 
   if (pkgName && EXCLUDED_FROM_PACKAGE_POLICY_COPY_PACKAGES.includes(pkgName)) {
     return (
@@ -128,8 +142,8 @@ export const CopyPackagePolicyPage = memo(() => {
       {breadcrumb}
       <CreatePackagePolicySinglePage
         from={from}
-        pkgName={packagePolicy.data!.item!.package!.name}
-        pkgVersion={packagePolicy.data!.item!.package!.version}
+        pkgName={sourcePolicy.package!.name}
+        pkgVersion={sourcePolicy.package!.version}
         defaultPolicyData={packagePolicyData}
         noBreadcrumb={true}
         prerelease={true}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
@@ -10,6 +10,7 @@ import { useRouteMatch, useLocation } from 'react-router-dom';
 
 import { EuiEmptyPrompt, EuiFlexGroup } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import styled from '@emotion/styled';
 
 import {
@@ -17,7 +18,7 @@ import {
   IS_AGENTLESS_QUERY_PARAM,
 } from '../../../../../../common/constants';
 
-import { Loading } from '../../../components';
+import { Loading, Error } from '../../../components';
 import type { EditPackagePolicyFrom } from '../create_package_policy_page/types';
 
 import { CreatePackagePolicySinglePage } from '../create_package_policy_page/single_page_layout';
@@ -70,7 +71,12 @@ export const CopyPackagePolicyPage = memo(() => {
     [search]
   );
 
-  const { item: sourcePolicy, isLoading } = useCopyPackagePolicyData(packagePolicyId, {
+  const {
+    item: sourcePolicy,
+    isLoading,
+    isError,
+    error,
+  } = useCopyPackagePolicyData(packagePolicyId, {
     isAgentless,
   });
   // Agentless deployments have no user-facing agent policy, so skip the agent-policy read for them.
@@ -95,6 +101,30 @@ export const CopyPackagePolicyPage = memo(() => {
       return 'copy-from-integrations-policy-list';
     }
   }, [search]);
+
+  // Without this, a failed source-policy read leaves `isLoading` false and `sourcePolicy`
+  // undefined, which would otherwise render the loading spinner forever with no recovery path.
+  if (isError) {
+    return (
+      <ContentWrapper justifyContent="center" alignItems="center">
+        <Error
+          title={
+            <FormattedMessage
+              id="xpack.fleet.copyPackagePolicyPage.loadingErrorTitle"
+              defaultMessage="Unable to load the integration policy to copy"
+            />
+          }
+          error={
+            error instanceof Error
+              ? error
+              : i18n.translate('xpack.fleet.copyPackagePolicyPage.loadingErrorGenericMessage', {
+                  defaultMessage: 'An error occurred while loading the integration policy.',
+                })
+          }
+        />
+      </ContentWrapper>
+    );
+  }
 
   if (isLoading || !sourcePolicy) {
     return (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
@@ -13,16 +13,13 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import styled from '@emotion/styled';
 
-import {
-  EXCLUDED_FROM_PACKAGE_POLICY_COPY_PACKAGES,
-  IS_AGENTLESS_QUERY_PARAM,
-} from '../../../../../../common/constants';
+import { EXCLUDED_FROM_PACKAGE_POLICY_COPY_PACKAGES } from '../../../../../../common/constants';
 
 import { Loading, Error as ErrorComponent } from '../../../components';
 import type { EditPackagePolicyFrom } from '../create_package_policy_page/types';
 
 import { CreatePackagePolicySinglePage } from '../create_package_policy_page/single_page_layout';
-import { useBreadcrumbs, useGetOneAgentPolicy } from '../../../hooks';
+import { useBreadcrumbs, useGetOneAgentPolicy, useIsAgentlessQueryParam } from '../../../hooks';
 import { useBreadcrumbs as useIntegrationsBreadcrumbs } from '../../../../integrations/hooks';
 import { copyPackagePolicy } from '../../../../../../common/services/copy_package_policy_utils';
 
@@ -65,11 +62,9 @@ export const CopyPackagePolicyPage = memo(() => {
   const { search } = useLocation();
 
   // Detect-before-read hint: agentless copies read/hydrate through the agentless API instead of the
-  // package-policy/agent-policy APIs.
-  const isAgentless = useMemo(
-    () => new URLSearchParams(search).get(IS_AGENTLESS_QUERY_PARAM) === 'true',
-    [search]
-  );
+  // package-policy/agent-policy APIs. Always false when the agentless policies UI kill switch is
+  // off, so the copy falls back to the legacy APIs.
+  const isAgentless = useIsAgentlessQueryParam();
 
   const {
     item: sourcePolicy,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/copy_package_policy_page/index.tsx
@@ -18,7 +18,7 @@ import {
   IS_AGENTLESS_QUERY_PARAM,
 } from '../../../../../../common/constants';
 
-import { Loading, Error } from '../../../components';
+import { Loading, Error as ErrorComponent } from '../../../components';
 import type { EditPackagePolicyFrom } from '../create_package_policy_page/types';
 
 import { CreatePackagePolicySinglePage } from '../create_package_policy_page/single_page_layout';
@@ -114,7 +114,7 @@ export const CopyPackagePolicyPage = memo(() => {
           });
     return (
       <ContentWrapper justifyContent="center" alignItems="center">
-        <Error
+        <ErrorComponent
           title={
             <FormattedMessage
               id="xpack.fleet.copyPackagePolicyPage.loadingErrorTitle"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
@@ -62,7 +62,8 @@ export function useDevToolsRequest({
               ...packagePolicy,
               create_dataset_templates: createDatasetTemplates,
             },
-            varGroups
+            varGroups,
+            packageInfo
           ),
           i18n.translate(
             'xpack.fleet.editPackagePolicy.devtoolsRequestAgentlessPolicyDescription',
@@ -114,7 +115,12 @@ export function useDevToolsRequest({
     // package-policy update, matching the actual request the edit form now issues.
     if (packagePolicyId && packagePolicy.supports_agentless) {
       return [
-        generateUpdateAgentlessPolicyDevToolsRequest(packagePolicyId, packagePolicy, varGroups),
+        generateUpdateAgentlessPolicyDevToolsRequest(
+          packagePolicyId,
+          packagePolicy,
+          varGroups,
+          packageInfo
+        ),
         i18n.translate(
           'xpack.fleet.editPackagePolicy.devtoolsRequestUpdateAgentlessPolicyDescription',
           {
@@ -150,6 +156,7 @@ export function useDevToolsRequest({
     packagePolicyId,
     createDatasetTemplates,
     varGroups,
+    packageInfo,
   ]);
 
   return { showDevtoolsRequest, devtoolRequest, devtoolRequestDescription };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
@@ -23,7 +23,10 @@ import {
 import type { PackageInfo, NewAgentPolicy, NewPackagePolicy } from '../../../../../types';
 import { ExperimentalFeaturesService } from '../../../../../services';
 import { SelectedPolicyTab } from '../../components';
-import { generateCreateAgentlessPolicyDevToolsRequest } from '../../../services/devtools_request';
+import {
+  generateCreateAgentlessPolicyDevToolsRequest,
+  generateUpdateAgentlessPolicyDevToolsRequest,
+} from '../../../services/devtools_request';
 
 export function useDevToolsRequest({
   newAgentPolicy,
@@ -104,6 +107,20 @@ export function useDevToolsRequest({
                   'These Kibana requests create a new agent policy and a new package policy.',
               }
             ),
+      ];
+    }
+
+    // Editing an existing agentless policy: preview the agentless full-replace PUT rather than the
+    // package-policy update, matching the actual request the edit form now issues.
+    if (packagePolicyId && packagePolicy.supports_agentless) {
+      return [
+        generateUpdateAgentlessPolicyDevToolsRequest(packagePolicyId, packagePolicy, varGroups),
+        i18n.translate(
+          'xpack.fleet.editPackagePolicy.devtoolsRequestUpdateAgentlessPolicyDescription',
+          {
+            defaultMessage: 'This Kibana request updates an agentless policy.',
+          }
+        ),
       ];
     }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
@@ -21,7 +21,7 @@ import {
   HIDDEN_API_REFERENCE_PACKAGES,
 } from '../../../../../../../../common/constants';
 import type { PackageInfo, NewAgentPolicy, NewPackagePolicy } from '../../../../../types';
-import { ExperimentalFeaturesService } from '../../../../../services';
+import { ExperimentalFeaturesService, isAgentlessPoliciesUIEnabled } from '../../../../../services';
 import { SelectedPolicyTab } from '../../components';
 import {
   generateCreateAgentlessPolicyDevToolsRequest,
@@ -50,6 +50,7 @@ export function useDevToolsRequest({
   const { enableVarGroups } = ExperimentalFeaturesService.get();
   const varGroups =
     enableVarGroups && packageInfo?.var_groups ? packageInfo?.var_groups : undefined;
+  const agentlessUIEnabled = isAgentlessPoliciesUIEnabled();
 
   const [devtoolRequest, devtoolRequestDescription] = useMemo(() => {
     if (selectedPolicyTab === SelectedPolicyTab.NEW) {
@@ -112,8 +113,10 @@ export function useDevToolsRequest({
     }
 
     // Editing an existing agentless policy: preview the agentless full-replace PUT rather than the
-    // package-policy update, matching the actual request the edit form now issues.
-    if (packagePolicyId && packagePolicy.supports_agentless) {
+    // package-policy update, matching the actual request the edit form now issues. When the
+    // agentless policies UI kill switch is off, edits go through the legacy package-policy PUT,
+    // so preview that instead (fall-through below).
+    if (packagePolicyId && packagePolicy.supports_agentless && agentlessUIEnabled) {
       return [
         generateUpdateAgentlessPolicyDevToolsRequest(
           packagePolicyId,
@@ -157,6 +160,7 @@ export function useDevToolsRequest({
     createDatasetTemplates,
     varGroups,
     packageInfo,
+    agentlessUIEnabled,
   ]);
 
   return { showDevtoolsRequest, devtoolRequest, devtoolRequestDescription };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -277,6 +277,46 @@ describe('useOnSubmit', () => {
     });
   });
 
+  describe('copy source (defaultPolicyData) field carry-over', () => {
+    // Copying a policy seeds the create form from `defaultPolicyData` via a `pick` allowlist.
+    // Agentless copies hydrate that source through `agentlessPolicyToPackagePolicy`, which carries
+    // `global_data_tags` and `var_group_selections`; the allowlist must forward them or they are
+    // silently dropped before `toNewAgentlessPolicy` ever runs.
+    it('carries global_data_tags and var_group_selections onto the copied base policy', async () => {
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '' },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+          defaultPolicyData: {
+            name: 'copied-policy',
+            supports_agentless: true,
+            additional_datastreams_permissions: ['logs-test-*'],
+            global_data_tags: [{ name: 'team', value: 'fleet' }],
+            var_group_selections: { credential_type: 'cloud_connectors' },
+          },
+        })
+      );
+
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        expect(packagePolicy.name).toBe('copied-policy');
+        expect(packagePolicy.global_data_tags).toEqual([{ name: 'team', value: 'fleet' }]);
+        expect(packagePolicy.var_group_selections).toEqual({
+          credential_type: 'cloud_connectors',
+        });
+        // Regression guard: the pre-existing allowlisted field still carries over.
+        expect(packagePolicy.additional_datastreams_permissions).toEqual(['logs-test-*']);
+      });
+    });
+  });
+
   describe('input deployment mode filtering', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -418,7 +418,9 @@ export function useOnSubmit({
               'overrides',
               'supports_agentless',
               'supports_cloud_connector',
-              'additional_datastreams_permissions'
+              'additional_datastreams_permissions',
+              'global_data_tags',
+              'var_group_selections'
             )
           );
         }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -150,13 +150,20 @@ export const createAgentPolicyIfNeeded = async ({
 
 async function savePackagePolicy(
   pkgPolicy: CreatePackagePolicyRequest['body'],
-  varGroups?: RegistryVarGroup[]
+  varGroups?: RegistryVarGroup[],
+  packageInfo?: PackageInfo
 ): Promise<SavedPolicyResult> {
   const { policy, forceCreateNeeded } = await prepareInputPackagePolicyDataset(pkgPolicy);
 
   // If agentless use agentless policies API
   if (policy.supports_agentless) {
-    const agentlessRequestBody = toNewAgentlessPolicy(pkgPolicy as NewPackagePolicy, varGroups);
+    // Pass `packageInfo` so the create write applies the same template-aware input allow-check as the
+    // edit read path (`agentlessPolicyToPackagePolicy`), keeping create → GET → form → PUT idempotent.
+    const agentlessRequestBody = toNewAgentlessPolicy(
+      pkgPolicy as NewPackagePolicy,
+      varGroups,
+      packageInfo
+    );
     const { item } = await sendCreateAgentlessPolicy(agentlessRequestBody);
     return { type: 'agentless', policy: item };
   }
@@ -706,7 +713,8 @@ export function useOnSubmit({
             force: forceInstall,
             create_dataset_templates: createDatasetTemplates,
           },
-          varGroups
+          varGroups,
+          packageInfo
         );
 
         if (savedPolicyResult.policy.package) {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -745,6 +745,28 @@ describe('usePackagePolicy - agentless', () => {
     expect(saveResult).toEqual({ data: undefined, error: requestError });
   });
 
+  it('normalizes a non-RequestError save throw without fabricating a statusCode', async () => {
+    // A mapping/validation failure (e.g. from `toNewAgentlessPolicy`) surfaces as a plain Error
+    // with no `statusCode`. It must still resolve to the `{ data, error }` shape — not reject —
+    // and must not pretend to be a 409 conflict.
+    const mappingError = new Error('bad mapping');
+    jest.mocked(sendUpdateAgentlessPolicy).mockRejectedValue(mappingError);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-1', { isAgentless: true })
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('agentless-1'));
+
+    let saveResult: any;
+    await act(async () => {
+      saveResult = await result.current.savePackagePolicy();
+    });
+
+    expect(saveResult).toEqual({ data: undefined, error: mappingError });
+    expect((saveResult.error as { statusCode?: number }).statusCode).toBeUndefined();
+  });
+
   it('ignores a superseded agentless response after switching to the legacy mode', async () => {
     // Hold the agentless GET open so it resolves *after* we switch back to the legacy
     // (package-policy) mode. The stale response must not clobber the legacy load.

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -18,6 +18,7 @@ import { omit } from 'lodash';
 import {
   sendGetAgentlessPolicy,
   sendGetPackageInfoByKey,
+  sendGetPackageInfoByKeyForRq,
   sendUpdateAgentlessPolicy,
   sendUpdatePackagePolicy,
   sendUpgradePackagePolicyDryRun,
@@ -56,6 +57,87 @@ const mockPackagePolicy = {
     },
   ],
 };
+
+// A function declaration (hoisted, `mock`-prefixed) so the `jest.mock` factory below — which
+// runs while the imports above are still being evaluated — can build both the envelope
+// (`sendGetPackageInfoByKey`, legacy loader) and throwing (`sendGetPackageInfoByKeyForRq`,
+// agentless read helper) package-info mocks from one definition.
+function mockPackageInfoItem(name: string, version: string) {
+  return {
+    name,
+    title: 'Nginx',
+    version,
+    release: 'ga',
+    description: 'Collect logs and metrics from Nginx HTTP servers with Elastic Agent.',
+    policy_templates: [
+      {
+        name: 'nginx',
+        title: 'Nginx logs and metrics',
+        description: 'Collect logs and metrics from Nginx instances',
+        inputs: [
+          {
+            type: 'logfile',
+            title: 'Collect logs from Nginx instances',
+            description: 'Collecting Nginx access and error logs',
+            vars: [
+              {
+                name: 'new_input_level_var',
+                type: 'text',
+                title: 'Paths',
+                required: false,
+                show_user: true,
+              },
+            ],
+          },
+        ],
+        multiple: true,
+      },
+    ],
+    data_streams: [
+      {
+        type: 'logs',
+        dataset: 'nginx.access',
+        title: 'Nginx access logs',
+        release: 'experimental',
+        ingest_pipeline: 'default',
+        streams: [
+          {
+            input: 'logfile',
+            vars: [
+              {
+                name: 'paths',
+                type: 'text',
+                title: 'Paths',
+                multi: true,
+                required: true,
+                show_user: true,
+                default: ['/var/log/nginx/access.log*'],
+              },
+            ],
+            template_path: 'stream.yml.hbs',
+            title: 'Nginx access logs',
+            description: 'Collect Nginx access logs',
+            enabled: true,
+          },
+        ],
+        package: 'nginx',
+        path: 'access',
+      },
+    ],
+    latestVersion: version,
+    keepPoliciesUpToDate: false,
+    status: 'not_installed',
+    vars: [
+      {
+        name: 'new_package_level_var',
+        type: 'text',
+        title: 'Paths',
+        required: false,
+        show_user: true,
+      },
+    ],
+  };
+}
 
 jest.mock('../../../../../../hooks/use_request', () => ({
   ...jest.requireActual('../../../../../../hooks/use_request'),
@@ -168,87 +250,16 @@ jest.mock('../../../../../../hooks/use_request', () => ({
       };
     }
   },
-  sendGetPackageInfoByKey: jest.fn().mockImplementation((name, version) =>
-    Promise.resolve({
-      data: {
-        item: {
-          name,
-          title: 'Nginx',
-          version,
-          release: 'ga',
-          description: 'Collect logs and metrics from Nginx HTTP servers with Elastic Agent.',
-          policy_templates: [
-            {
-              name: 'nginx',
-              title: 'Nginx logs and metrics',
-              description: 'Collect logs and metrics from Nginx instances',
-              inputs: [
-                {
-                  type: 'logfile',
-                  title: 'Collect logs from Nginx instances',
-                  description: 'Collecting Nginx access and error logs',
-                  vars: [
-                    {
-                      name: 'new_input_level_var',
-                      type: 'text',
-                      title: 'Paths',
-                      required: false,
-                      show_user: true,
-                    },
-                  ],
-                },
-              ],
-              multiple: true,
-            },
-          ],
-          data_streams: [
-            {
-              type: 'logs',
-              dataset: 'nginx.access',
-              title: 'Nginx access logs',
-              release: 'experimental',
-              ingest_pipeline: 'default',
-              streams: [
-                {
-                  input: 'logfile',
-                  vars: [
-                    {
-                      name: 'paths',
-                      type: 'text',
-                      title: 'Paths',
-                      multi: true,
-                      required: true,
-                      show_user: true,
-                      default: ['/var/log/nginx/access.log*'],
-                    },
-                  ],
-                  template_path: 'stream.yml.hbs',
-                  title: 'Nginx access logs',
-                  description: 'Collect Nginx access logs',
-                  enabled: true,
-                },
-              ],
-              package: 'nginx',
-              path: 'access',
-            },
-          ],
-          latestVersion: version,
-          keepPoliciesUpToDate: false,
-          status: 'not_installed',
-          vars: [
-            {
-              name: 'new_package_level_var',
-              type: 'text',
-              title: 'Paths',
-              required: false,
-              show_user: true,
-            },
-          ],
-        },
-      },
-      isLoading: false,
-    })
-  ),
+  sendGetPackageInfoByKey: jest
+    .fn()
+    .mockImplementation((name: string, version: string) =>
+      Promise.resolve({ data: { item: mockPackageInfoItem(name, version) }, isLoading: false })
+    ),
+  sendGetPackageInfoByKeyForRq: jest
+    .fn()
+    .mockImplementation((name: string, version: string) =>
+      Promise.resolve({ item: mockPackageInfoItem(name, version) })
+    ),
   sendUpgradePackagePolicyDryRun: jest.fn().mockResolvedValue({
     data: [
       {
@@ -699,7 +710,7 @@ describe('usePackagePolicy - agentless', () => {
     );
     expect(saveResult).toEqual({ data: { item: { id: 'agentless-1' } }, error: null });
     // Never falls back to the package-policy update API for agentless policies.
-    expect(sendGetPackageInfoByKey).toHaveBeenCalled();
+    expect(sendUpdatePackagePolicy).not.toHaveBeenCalled();
   });
 
   it('detects an agentless policy read without the isAgentless hint and saves through the agentless API', async () => {
@@ -818,12 +829,10 @@ describe('usePackagePolicy - agentless', () => {
   });
 
   it('surfaces a package info load failure through loadingError instead of swallowing it', async () => {
-    // `sendGetPackageInfoByKey` resolves to a `{ data, error }` envelope; the agentless loader
-    // must not drop the error, or the page shows only its generic loading-error copy.
+    // The shared read helper's package-info request throws on failure; the loader must surface
+    // it through `loadingError`, or the page shows only its generic loading-error copy.
     const pkgError = Object.assign(new Error('registry unavailable'), { statusCode: 502 });
-    jest
-      .mocked(sendGetPackageInfoByKey)
-      .mockResolvedValueOnce({ data: undefined, error: pkgError } as any);
+    jest.mocked(sendGetPackageInfoByKeyForRq).mockRejectedValueOnce(pkgError);
 
     const renderer = createFleetTestRendererMock();
     const { result } = renderer.renderHook(() =>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -670,7 +670,9 @@ describe('usePackagePolicy - agentless', () => {
   });
 
   it('saves through the agentless API', async () => {
-    jest.mocked(sendUpdateAgentlessPolicy).mockResolvedValue({ item: { id: 'agentless-1' } } as any);
+    jest
+      .mocked(sendUpdateAgentlessPolicy)
+      .mockResolvedValue({ item: { id: 'agentless-1' } } as any);
 
     const renderer = createFleetTestRendererMock();
     const { result } = renderer.renderHook(() =>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -767,6 +767,56 @@ describe('usePackagePolicy - agentless', () => {
     expect(sendUpdateAgentlessPolicy).not.toHaveBeenCalled();
   });
 
+  it('rejects an agent-policy reassignment of an agentless policy instead of silently dropping it', async () => {
+    // `toNewAgentlessPolicy` drops `policy_ids`, so a save that intends to change them (the
+    // manage-agent-policies modal) must fail loudly rather than report a success that saved
+    // nothing.
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-detect', {})
+    );
+    await waitFor(() =>
+      expect(result.current.packagePolicy?.policy_ids).toEqual(['agentless-agent-policy-1'])
+    );
+
+    let saveResult: any;
+    await act(async () => {
+      saveResult = await result.current.savePackagePolicy({ policy_ids: ['some-other-policy'] });
+    });
+
+    expect(saveResult.data).toBeUndefined();
+    expect(saveResult.error).toBeInstanceOf(Error);
+    expect(saveResult.error.message).toContain('agent policy reassignment');
+    expect(sendUpdateAgentlessPolicy).not.toHaveBeenCalled();
+    expect(sendUpdatePackagePolicy).not.toHaveBeenCalled();
+  });
+
+  it('allows an agentless save that echoes the unchanged policy_ids', async () => {
+    // The edit page always submits `{ policy_ids: packagePolicy.policy_ids }` — an unchanged
+    // echo must not trip the reassignment guard.
+    jest
+      .mocked(sendUpdateAgentlessPolicy)
+      .mockResolvedValue({ item: { id: 'agentless-detect' } } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-detect', {})
+    );
+    await waitFor(() =>
+      expect(result.current.packagePolicy?.policy_ids).toEqual(['agentless-agent-policy-1'])
+    );
+
+    let saveResult: any;
+    await act(async () => {
+      saveResult = await result.current.savePackagePolicy({
+        policy_ids: ['agentless-agent-policy-1'],
+      });
+    });
+
+    expect(sendUpdateAgentlessPolicy).toHaveBeenCalled();
+    expect(saveResult).toEqual({ data: { item: { id: 'agentless-detect' } }, error: null });
+  });
+
   it('normalizes agentless save failures into the { data, error } shape', async () => {
     const requestError = Object.assign(new Error('conflict'), { statusCode: 409 });
     jest.mocked(sendUpdateAgentlessPolicy).mockRejectedValue(requestError);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -127,6 +127,42 @@ jest.mock('../../../../../../hooks/use_request', () => ({
         },
       };
     }
+    // An agentless policy instance read through the package-policy API (i.e. the `isAgentless`
+    // hint was dropped). It carries the authoritative per-instance `supports_agentless` flag.
+    if (packagePolicyId === 'agentless-detect') {
+      return {
+        data: {
+          item: {
+            id: 'nginx-1',
+            name: 'nginx-1',
+            namespace: 'default',
+            description: 'Nginx description',
+            package: { name: 'nginx', title: 'Nginx', version: '1.3.0' },
+            enabled: true,
+            supports_agentless: true,
+            policy_id: 'agentless-agent-policy-1',
+            policy_ids: ['agentless-agent-policy-1'],
+            inputs: [
+              {
+                type: 'logfile',
+                policy_template: 'nginx',
+                enabled: true,
+                streams: [
+                  {
+                    enabled: true,
+                    data_stream: { type: 'logs', dataset: 'nginx.access' },
+                    vars: {
+                      paths: { value: ['/var/log/nginx/access.log*'], type: 'text' },
+                    },
+                  },
+                ],
+                vars: undefined,
+              },
+            ],
+          },
+        },
+      };
+    }
   },
   sendGetPackageInfoByKey: jest.fn().mockImplementation((name, version) =>
     Promise.resolve({
@@ -658,6 +694,35 @@ describe('usePackagePolicy - agentless', () => {
     expect(saveResult).toEqual({ data: { item: { id: 'agentless-1' } }, error: null });
     // Never falls back to the package-policy update API for agentless policies.
     expect(sendGetPackageInfoByKey).toHaveBeenCalled();
+  });
+
+  it('detects an agentless policy read without the isAgentless hint and saves through the agentless API', async () => {
+    // Simulates a refresh / deep link / foreign entry point where the `?isAgentless` hint is
+    // absent: the policy is read via the package-policy API, and its per-instance
+    // `supports_agentless` flag must still route the write through the agentless API.
+    jest
+      .mocked(sendUpdateAgentlessPolicy)
+      .mockResolvedValue({ item: { id: 'agentless-detect' } } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-detect', {})
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('nginx-1'));
+
+    // The fast-path agentless read effect must not run when the hint is missing.
+    expect(sendGetAgentlessPolicy).not.toHaveBeenCalled();
+
+    let saveResult: any;
+    await act(async () => {
+      saveResult = await result.current.savePackagePolicy();
+    });
+
+    expect(sendUpdateAgentlessPolicy).toHaveBeenCalledWith(
+      'agentless-detect',
+      expect.objectContaining({ package: expect.objectContaining({ name: 'nginx' }) })
+    );
+    expect(saveResult).toEqual({ data: { item: { id: 'agentless-detect' } }, error: null });
   });
 
   it('normalizes agentless save failures into the { data, error } shape', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -731,6 +731,42 @@ describe('usePackagePolicy - agentless', () => {
     expect(saveResult).toEqual({ data: { item: { id: 'agentless-detect' } }, error: null });
   });
 
+  it('resets the supports_agentless detection when re-loading a different, non-agentless policy', async () => {
+    // Param-only navigation re-runs this hook with a new `packagePolicyId` without a remount.
+    // A stale detection from the previously loaded (agentless) policy must not route the next
+    // (agent-based) policy's save through the agentless PUT — the server rejects it.
+    jest
+      .mocked(sendUpdatePackagePolicy)
+      .mockResolvedValue({ data: { item: { id: 'nginx-1' } }, error: null } as any);
+
+    let packagePolicyId = 'agentless-detect';
+    const renderer = createFleetTestRendererMock();
+    const { result, rerender } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData(packagePolicyId, {})
+    );
+    // The agentless policy loads and is detected via its `supports_agentless` flag. Both mock
+    // policies are named `nginx-1`, so distinguish the loads by their `policy_ids`.
+    await waitFor(() =>
+      expect(result.current.packagePolicy?.policy_ids).toEqual(['agentless-agent-policy-1'])
+    );
+
+    // Navigate to an agent-based policy without remounting.
+    await act(async () => {
+      packagePolicyId = 'package-policy-1';
+      rerender();
+    });
+    await waitFor(() =>
+      expect(result.current.packagePolicy?.policy_ids).toEqual(['agent-policy-1'])
+    );
+
+    await act(async () => {
+      await result.current.savePackagePolicy();
+    });
+
+    expect(sendUpdatePackagePolicy).toHaveBeenCalledWith('package-policy-1', expect.anything());
+    expect(sendUpdateAgentlessPolicy).not.toHaveBeenCalled();
+  });
+
   it('normalizes agentless save failures into the { data, error } shape', async () => {
     const requestError = Object.assign(new Error('conflict'), { statusCode: 409 });
     jest.mocked(sendUpdateAgentlessPolicy).mockRejectedValue(requestError);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -817,6 +817,23 @@ describe('usePackagePolicy - agentless', () => {
     expect(saveResult).toEqual({ data: { item: { id: 'agentless-detect' } }, error: null });
   });
 
+  it('surfaces a package info load failure through loadingError instead of swallowing it', async () => {
+    // `sendGetPackageInfoByKey` resolves to a `{ data, error }` envelope; the agentless loader
+    // must not drop the error, or the page shows only its generic loading-error copy.
+    const pkgError = Object.assign(new Error('registry unavailable'), { statusCode: 502 });
+    jest
+      .mocked(sendGetPackageInfoByKey)
+      .mockResolvedValueOnce({ data: undefined, error: pkgError } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-1', { isAgentless: true })
+    );
+
+    await waitFor(() => expect(result.current.loadingError).toBe(pkgError));
+    expect(result.current.isLoadingData).toBe(false);
+  });
+
   it('normalizes agentless save failures into the { data, error } shape', async () => {
     const requestError = Object.assign(new Error('conflict'), { statusCode: 409 });
     jest.mocked(sendUpdateAgentlessPolicy).mockRejectedValue(requestError);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -12,10 +12,15 @@
  * 2.0.
  */
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { omit } from 'lodash';
 
-import { sendGetPackageInfoByKey, sendUpgradePackagePolicyDryRun } from '../../../../../../hooks';
+import {
+  sendGetAgentlessPolicy,
+  sendGetPackageInfoByKey,
+  sendUpdateAgentlessPolicy,
+  sendUpgradePackagePolicyDryRun,
+} from '../../../../../../hooks';
 import { createFleetTestRendererMock } from '../../../../../../mock';
 
 import { usePackagePolicyWithRelatedData } from './use_package_policy';
@@ -51,6 +56,8 @@ const mockPackagePolicy = {
 
 jest.mock('../../../../../../hooks/use_request', () => ({
   ...jest.requireActual('../../../../../../hooks/use_request'),
+  sendGetAgentlessPolicy: jest.fn(),
+  sendUpdateAgentlessPolicy: jest.fn(),
   sendGetOnePackagePolicy: (packagePolicyId: string) => {
     if (packagePolicyId === 'package-policy-1') {
       return {
@@ -578,5 +585,96 @@ describe('usePackagePolicy', () => {
         },
       }
     `);
+  });
+});
+
+describe('usePackagePolicy - agentless', () => {
+  // The GET/LIST agentless payload uses simplified object-style inputs. The real inverse mapper
+  // (`agentlessPolicyToPackagePolicy`) runs here against the mocked nginx package info, so these
+  // tests exercise the hook's agentless branching end to end.
+  const agentlessPolicy = {
+    id: 'agentless-1',
+    name: 'agentless-1',
+    namespace: 'default',
+    description: 'Agentless nginx',
+    package: { name: 'nginx', title: 'Nginx', version: '1.3.0' },
+    inputs: {},
+    created_at: '2026-01-01T00:00:00.000Z',
+    created_by: 'creator',
+    updated_at: '2026-02-02T00:00:00.000Z',
+    updated_by: 'updater',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(sendGetAgentlessPolicy).mockResolvedValue({ item: agentlessPolicy } as any);
+  });
+
+  it('reads through the agentless API and skips the upgrade dry-run', async () => {
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-1', { isAgentless: true })
+    );
+
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('agentless-1'));
+
+    expect(sendGetAgentlessPolicy).toHaveBeenCalledWith('agentless-1');
+    // Agentless deployments have no user-facing agent policy and no edit-page upgrade flow.
+    expect(sendUpgradePackagePolicyDryRun).not.toHaveBeenCalled();
+    // The API identifiers/timestamps are carried onto the "original" baseline for edit extensions.
+    expect(result.current.originalPackagePolicy).toEqual(
+      expect.objectContaining({
+        id: 'agentless-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+        created_by: 'creator',
+        updated_at: '2026-02-02T00:00:00.000Z',
+        updated_by: 'updater',
+      })
+    );
+  });
+
+  it('saves through the agentless API', async () => {
+    jest.mocked(sendUpdateAgentlessPolicy).mockResolvedValue({ item: { id: 'agentless-1' } } as any);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-1', { isAgentless: true })
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('agentless-1'));
+
+    let saveResult: any;
+    await act(async () => {
+      saveResult = await result.current.savePackagePolicy();
+    });
+
+    // The full-replace PUT body is produced by `toNewAgentlessPolicy` from the loaded policy.
+    expect(sendUpdateAgentlessPolicy).toHaveBeenCalledWith(
+      'agentless-1',
+      expect.objectContaining({
+        name: 'agentless-1',
+        package: expect.objectContaining({ name: 'nginx' }),
+      })
+    );
+    expect(saveResult).toEqual({ data: { item: { id: 'agentless-1' } }, error: null });
+    // Never falls back to the package-policy update API for agentless policies.
+    expect(sendGetPackageInfoByKey).toHaveBeenCalled();
+  });
+
+  it('normalizes agentless save failures into the { data, error } shape', async () => {
+    const requestError = Object.assign(new Error('conflict'), { statusCode: 409 });
+    jest.mocked(sendUpdateAgentlessPolicy).mockRejectedValue(requestError);
+
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-1', { isAgentless: true })
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('agentless-1'));
+
+    let saveResult: any;
+    await act(async () => {
+      saveResult = await result.current.savePackagePolicy();
+    });
+
+    expect(saveResult).toEqual({ data: undefined, error: requestError });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -19,9 +19,12 @@ import {
   sendGetAgentlessPolicy,
   sendGetPackageInfoByKey,
   sendUpdateAgentlessPolicy,
+  sendUpdatePackagePolicy,
   sendUpgradePackagePolicyDryRun,
 } from '../../../../../../hooks';
 import { createFleetTestRendererMock } from '../../../../../../mock';
+import { allowedExperimentalValues } from '../../../../../../../common/experimental_features';
+import { ExperimentalFeaturesService } from '../../../../../../services';
 
 import { usePackagePolicyWithRelatedData } from './use_package_policy';
 
@@ -58,6 +61,7 @@ jest.mock('../../../../../../hooks/use_request', () => ({
   ...jest.requireActual('../../../../../../hooks/use_request'),
   sendGetAgentlessPolicy: jest.fn(),
   sendUpdateAgentlessPolicy: jest.fn(),
+  sendUpdatePackagePolicy: jest.fn(),
   sendGetOnePackagePolicy: (packagePolicyId: string) => {
     if (packagePolicyId === 'package-policy-1') {
       return {
@@ -802,5 +806,55 @@ describe('usePackagePolicy - agentless', () => {
 
     // The superseded agentless response is discarded — the legacy load still wins.
     expect(result.current.packagePolicy?.name).toBe('nginx-1');
+  });
+});
+
+describe('usePackagePolicy - agentless policies UI kill switch off', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      enableAgentlessPoliciesUI: false,
+    });
+    jest.mocked(sendUpdatePackagePolicy).mockResolvedValue({
+      data: { item: { id: 'nginx-1' } },
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('ignores the isAgentless hint: reads and saves through the package-policy API', async () => {
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('package-policy-1', { isAgentless: true })
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('nginx-1'));
+
+    // The agentless loader must never fire when the kill switch is off.
+    expect(sendGetAgentlessPolicy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.savePackagePolicy();
+    });
+
+    expect(sendUpdatePackagePolicy).toHaveBeenCalledWith('package-policy-1', expect.anything());
+    expect(sendUpdateAgentlessPolicy).not.toHaveBeenCalled();
+  });
+
+  it('ignores the supports_agentless detection: a legacy-loaded agentless policy still saves through the package-policy API', async () => {
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-detect', {})
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('nginx-1'));
+
+    await act(async () => {
+      await result.current.savePackagePolicy();
+    });
+
+    expect(sendUpdatePackagePolicy).toHaveBeenCalledWith('agentless-detect', expect.anything());
+    expect(sendUpdateAgentlessPolicy).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -742,4 +742,41 @@ describe('usePackagePolicy - agentless', () => {
 
     expect(saveResult).toEqual({ data: undefined, error: requestError });
   });
+
+  it('ignores a superseded agentless response after switching to the legacy mode', async () => {
+    // Hold the agentless GET open so it resolves *after* we switch back to the legacy
+    // (package-policy) mode. The stale response must not clobber the legacy load.
+    let resolveAgentless: (value: unknown) => void = () => {};
+    jest.mocked(sendGetAgentlessPolicy).mockReturnValue(
+      new Promise((resolve) => {
+        resolveAgentless = resolve;
+      }) as any
+    );
+
+    let isAgentless = true;
+    const renderer = createFleetTestRendererMock();
+    const { result, rerender } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('package-policy-1', { isAgentless })
+    );
+
+    // Make sure the agentless loader is actually in flight before we switch modes.
+    await waitFor(() => expect(sendGetAgentlessPolicy).toHaveBeenCalledWith('package-policy-1'));
+
+    // Switch to the legacy path; its loader commits the package-policy `nginx-1`.
+    await act(async () => {
+      isAgentless = false;
+      rerender();
+    });
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('nginx-1'));
+
+    // Now let the stale agentless GET resolve. Without the cleanup guard it would hydrate the
+    // form from `agentlessPolicy` and overwrite `packagePolicy` with `agentless-1`.
+    await act(async () => {
+      resolveAgentless({ item: agentlessPolicy });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // The superseded agentless response is discarded — the legacy load still wins.
+    expect(result.current.packagePolicy?.name).toBe('nginx-1');
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -17,19 +17,27 @@ import type {
 } from '../../../../../../../common/types/rest_spec';
 import {
   sendBulkGetAgentPolicies,
+  sendGetAgentlessPolicy,
   sendGetOnePackagePolicy,
   sendGetPackageInfoByKey,
   sendGetSettings,
+  sendUpdateAgentlessPolicy,
   sendUpdatePackagePolicy,
   sendUpgradePackagePolicyDryRun,
 } from '../../../../hooks';
+import type { RequestError } from '../../../../hooks';
 import type {
   PackagePolicyConfigRecord,
   UpdatePackagePolicy,
   AgentPolicy,
+  NewPackagePolicy,
   PackagePolicy,
   PackageInfo,
 } from '../../../../types';
+import {
+  agentlessPolicyToPackagePolicy,
+  toNewAgentlessPolicy,
+} from '../../../../../../../common/services';
 import {
   type PackagePolicyValidationResults,
   validatePackagePolicy,
@@ -37,6 +45,7 @@ import {
 } from '../../create_package_policy_page/services';
 import type { PackagePolicyFormState } from '../../create_package_policy_page/types';
 import { useYaml } from '../../../../../../services';
+import { ExperimentalFeaturesService } from '../../../../services';
 import { fixApmDurationVars, hasUpgradeAvailable } from '../utils';
 import { prepareInputPackagePolicyDataset } from '../../create_package_policy_page/services/prepare_input_pkg_policy_dataset';
 
@@ -68,6 +77,9 @@ export function usePackagePolicyWithRelatedData(
   packagePolicyId: string,
   options: {
     forceUpgrade?: boolean;
+    // When true, read/write this policy through the agentless API instead of the
+    // package-policy/agent-policy APIs. Driven by the edit page's detect-before-read hint.
+    isAgentless?: boolean;
   }
 ) {
   const [packageInfo, setPackageInfo] = useState<PackageInfo>();
@@ -110,6 +122,29 @@ export function usePackagePolicyWithRelatedData(
         'spaceIds'
       )
     );
+
+    // Agentless policies are updated through the agentless API (full-replace PUT), never the
+    // package-policy API. `sendUpdateAgentlessPolicy` throws on failure, so normalize the result
+    // into the `{ data, error }` shape the caller (`onSubmit`) expects from the package-policy path.
+    if (options.isAgentless) {
+      const { enableVarGroups } = ExperimentalFeaturesService.get();
+      const varGroups =
+        enableVarGroups && packageInfo?.var_groups ? packageInfo.var_groups : undefined;
+      try {
+        const { item } = await sendUpdateAgentlessPolicy(
+          packagePolicyId,
+          toNewAgentlessPolicy(restPackagePolicy as NewPackagePolicy, varGroups)
+        );
+        setFormState('SUBMITTED');
+        return { data: { item }, error: null };
+      } catch (error) {
+        setFormState('SUBMITTED');
+        // `sendRequestForRq` rejects with a `RequestError`; keep the shape aligned with the
+        // package-policy path so callers can read `error.statusCode` (e.g. 409 conflict handling).
+        return { data: undefined, error: error as RequestError };
+      }
+    }
+
     const result = await sendUpdatePackagePolicy(packagePolicyId, restPackagePolicy);
 
     setFormState('SUBMITTED');
@@ -170,6 +205,10 @@ export function usePackagePolicyWithRelatedData(
   // Load the package policy and related data
   useEffect(() => {
     const getData = async () => {
+      // Agentless policies are loaded by the dedicated effect below, through the agentless API.
+      if (options.isAgentless) {
+        return;
+      }
       setIsLoadingData(true);
       setLoadingError(undefined);
       try {
@@ -349,7 +388,69 @@ export function usePackagePolicyWithRelatedData(
       setIsLoadingData(false);
     };
     getData();
-  }, [packagePolicyId, options.forceUpgrade, yaml]);
+  }, [packagePolicyId, options.forceUpgrade, options.isAgentless, yaml]);
+
+  // Load the agentless policy through the agentless API. Deliberately skips the agent-policy bulk
+  // read and the upgrade dry-run: agentless deployments have no user-facing agent policy and no
+  // agentless upgrade flow yet (that stays on the legacy path until the bulk `_upgrade` endpoint).
+  useEffect(() => {
+    // Wait for `yaml` before fetching: the whole load (hydration + validation) needs it, so firing
+    // the GET before it's ready would just throw the result away and cause a second, redundant call
+    // once `yaml` resolves.
+    if (!options.isAgentless || !yaml) {
+      return;
+    }
+    const getAgentlessData = async () => {
+      setIsLoadingData(true);
+      setLoadingError(undefined);
+      setIsUpgrade(false);
+      try {
+        const prerelease = await isPreleaseEnabled();
+
+        const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
+
+        const { data: packageData } = await sendGetPackageInfoByKey(
+          agentlessPolicy.package.name,
+          agentlessPolicy.package.version,
+          { prerelease, full: true }
+        );
+
+        if (packageData?.item && yaml) {
+          const hydratedPackagePolicy = agentlessPolicyToPackagePolicy(
+            agentlessPolicy,
+            packageData.item
+          );
+
+          setPackageInfo(packageData.item);
+          setPackagePolicy(hydratedPackagePolicy as UpdatePackagePolicy);
+          // Edit extensions receive the loaded policy as their baseline. Agentless policies carry
+          // no server-only compiled fields at edit time, so the hydrated form policy is the
+          // "original" — enriched with the identifiers/timestamps from the API response.
+          setOriginalPackagePolicy({
+            ...hydratedPackagePolicy,
+            id: agentlessPolicy.id,
+            revision: 1,
+            created_at: agentlessPolicy.created_at,
+            created_by: agentlessPolicy.created_by,
+            updated_at: agentlessPolicy.updated_at,
+            updated_by: agentlessPolicy.updated_by,
+          } as PackagePolicy);
+
+          const newValidationResults = validatePackagePolicy(
+            hydratedPackagePolicy,
+            packageData.item,
+            { safeLoadYaml: yaml.parse, conditionValidator: validateAgentConditionExpression }
+          );
+          setValidationResults(newValidationResults);
+          setFormState(validationHasErrors(newValidationResults) ? 'INVALID' : 'VALID');
+        }
+      } catch (e) {
+        setLoadingError(e);
+      }
+      setIsLoadingData(false);
+    };
+    getAgentlessData();
+  }, [packagePolicyId, options.isAgentless, yaml]);
 
   // Re-run validation when yaml loads (getData may have run before yaml was available)
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -391,8 +391,9 @@ export function usePackagePolicyWithRelatedData(
   }, [packagePolicyId, options.forceUpgrade, options.isAgentless, yaml]);
 
   // Load the agentless policy through the agentless API. Deliberately skips the agent-policy bulk
-  // read and the upgrade dry-run: agentless deployments have no user-facing agent policy and no
-  // agentless upgrade flow yet (that stays on the legacy path until the bulk `_upgrade` endpoint).
+  // read and the upgrade dry-run: agentless deployments have no user-facing agent policy, and the
+  // edit page has no upgrade flow (agentless upgrades go through the dedicated bulk `_upgrade`
+  // surface, not this form).
   useEffect(() => {
     // Wait for `yaml` before fetching: the whole load (hydration + validation) needs it, so firing
     // the GET before it's ready would just throw the result away and cause a second, redundant call

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -101,6 +101,13 @@ export function usePackagePolicyWithRelatedData(
   const [loadingError, setLoadingError] = useState<Error>();
 
   const [isUpgrade, setIsUpgrade] = useState<boolean>(options.forceUpgrade ?? false);
+  // `options.isAgentless` is a fast-path hint carried by links we control. When it is missing
+  // (refresh, deep link, or a foreign entry point) we fall back to detecting agentless from the
+  // loaded package policy's own `supports_agentless` flag. That flag is authoritative per policy
+  // instance (dual-mode packages route correctly), and it drives the write path so an agentless
+  // policy is never saved through the package-policy API.
+  const [detectedAgentless, setDetectedAgentless] = useState(false);
+  const isAgentlessPolicy = (options.isAgentless ?? false) || detectedAgentless;
   const yaml = useYaml();
 
   // Form state
@@ -126,7 +133,7 @@ export function usePackagePolicyWithRelatedData(
     // Agentless policies are updated through the agentless API (full-replace PUT), never the
     // package-policy API. `sendUpdateAgentlessPolicy` throws on failure, so normalize the result
     // into the `{ data, error }` shape the caller (`onSubmit`) expects from the package-policy path.
-    if (options.isAgentless) {
+    if (isAgentlessPolicy) {
       const { enableVarGroups } = ExperimentalFeaturesService.get();
       const varGroups =
         enableVarGroups && packageInfo?.var_groups ? packageInfo.var_groups : undefined;
@@ -222,6 +229,12 @@ export function usePackagePolicyWithRelatedData(
 
         if (packagePolicyError) {
           throw packagePolicyError;
+        }
+
+        // Detect an agentless policy that was opened without the `isAgentless` hint, so the save
+        // routes through the agentless API rather than the package-policy API.
+        if (packagePolicyData?.item?.supports_agentless) {
+          setDetectedAgentless(true);
         }
 
         if (packagePolicyData!.item.policy_ids && packagePolicyData!.item.policy_ids.length > 0) {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -250,10 +250,11 @@ export function usePackagePolicyWithRelatedData(
         }
 
         // Detect an agentless policy that was opened without the `isAgentless` hint, so the save
-        // routes through the agentless API rather than the package-policy API.
-        if (packagePolicyData?.item?.supports_agentless) {
-          setDetectedAgentless(true);
-        }
+        // routes through the agentless API rather than the package-policy API. Set (not just
+        // raised) on every load: this hook can re-run with a different `packagePolicyId` without
+        // a remount, and a stale `true` from a previously loaded agentless policy would route the
+        // next policy's save through the agentless PUT, which the server rejects.
+        setDetectedAgentless(Boolean(packagePolicyData?.item?.supports_agentless));
 
         if (packagePolicyData!.item.policy_ids && packagePolicyData!.item.policy_ids.length > 0) {
           const { data, error: agentPolicyError } = await sendBulkGetAgentPolicies(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -133,7 +133,10 @@ export function usePackagePolicyWithRelatedData(
       try {
         const { item } = await sendUpdateAgentlessPolicy(
           packagePolicyId,
-          toNewAgentlessPolicy(restPackagePolicy as NewPackagePolicy, varGroups)
+          // Pass `packageInfo` so the write-side input/stream allow-check matches the read path
+          // (`agentlessPolicyToPackagePolicy`); without it an unedited load→save could flip input
+          // enablement for deployment-mode-restricted packages.
+          toNewAgentlessPolicy(restPackagePolicy as NewPackagePolicy, varGroups, packageInfo)
         );
         setFormState('SUBMITTED');
         return { data: { item }, error: null };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -73,6 +73,12 @@ async function isPreleaseEnabled() {
   return Boolean(settings?.item.prerelease_integrations_enabled);
 }
 
+// Normalizes an unknown catch value into the `{ error }` shape callers expect. Keeps `statusCode`
+// when the throw already carried it (real API conflicts still hit the 409 branch in `onSubmit`)
+// rather than unsoundly casting to `RequestError` and fabricating that shape for a plain throw.
+const toRequestError = (error: unknown): RequestError =>
+  error instanceof Error ? error : new Error(String(error));
+
 export function usePackagePolicyWithRelatedData(
   packagePolicyId: string,
   options: {
@@ -118,26 +124,26 @@ export function usePackagePolicyWithRelatedData(
 
   const savePackagePolicy = async (packagePolicyOverride?: Partial<PackagePolicy>) => {
     setFormState('LOADING');
-    const {
-      policy: { elasticsearch, ...restPackagePolicy },
-    } = await prepareInputPackagePolicyDataset(
-      omit(
-        {
-          ...packagePolicy,
-          ...(packagePolicyOverride ?? {}),
-        },
-        'spaceIds'
-      )
-    );
+    // Wrap the whole save  so *every* failure resolves to the `{ data, error }` shape `onSubmit` expects.
+    try {
+      const {
+        policy: { elasticsearch, ...restPackagePolicy },
+      } = await prepareInputPackagePolicyDataset(
+        omit(
+          {
+            ...packagePolicy,
+            ...(packagePolicyOverride ?? {}),
+          },
+          'spaceIds'
+        )
+      );
 
-    // Agentless policies are updated through the agentless API (full-replace PUT), never the
-    // package-policy API. `sendUpdateAgentlessPolicy` throws on failure, so normalize the result
-    // into the `{ data, error }` shape the caller (`onSubmit`) expects from the package-policy path.
-    if (isAgentlessPolicy) {
-      const { enableVarGroups } = ExperimentalFeaturesService.get();
-      const varGroups =
-        enableVarGroups && packageInfo?.var_groups ? packageInfo.var_groups : undefined;
-      try {
+      // Agentless policies are updated through the agentless API (full-replace PUT), never the
+      // package-policy API.
+      if (isAgentlessPolicy) {
+        const { enableVarGroups } = ExperimentalFeaturesService.get();
+        const varGroups =
+          enableVarGroups && packageInfo?.var_groups ? packageInfo.var_groups : undefined;
         const { item } = await sendUpdateAgentlessPolicy(
           packagePolicyId,
           // Pass `packageInfo` so the write-side input/stream allow-check matches the read path
@@ -147,19 +153,17 @@ export function usePackagePolicyWithRelatedData(
         );
         setFormState('SUBMITTED');
         return { data: { item }, error: null };
-      } catch (error) {
-        setFormState('SUBMITTED');
-        // `sendRequestForRq` rejects with a `RequestError`; keep the shape aligned with the
-        // package-policy path so callers can read `error.statusCode` (e.g. 409 conflict handling).
-        return { data: undefined, error: error as RequestError };
       }
+
+      const result = await sendUpdatePackagePolicy(packagePolicyId, restPackagePolicy);
+
+      setFormState('SUBMITTED');
+
+      return result;
+    } catch (error) {
+      setFormState('SUBMITTED');
+      return { data: undefined, error: toRequestError(error) };
     }
-
-    const result = await sendUpdatePackagePolicy(packagePolicyId, restPackagePolicy);
-
-    setFormState('SUBMITTED');
-
-    return result;
   };
   // Update package policy validation
   const updatePackagePolicyValidation = useCallback(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -19,7 +19,6 @@ import type {
 } from '../../../../../../../common/types/rest_spec';
 import {
   sendBulkGetAgentPolicies,
-  sendGetAgentlessPolicy,
   sendGetOnePackagePolicy,
   sendGetPackageInfoByKey,
   sendGetSettings,
@@ -36,10 +35,8 @@ import type {
   PackagePolicy,
   PackageInfo,
 } from '../../../../types';
-import {
-  agentlessPolicyToPackagePolicy,
-  toNewAgentlessPolicy,
-} from '../../../../../../../common/services';
+import { toNewAgentlessPolicy } from '../../../../../../../common/services';
+import { fetchAgentlessPolicyAsPackagePolicy } from '../../services';
 import {
   type PackagePolicyValidationResults,
   validatePackagePolicy,
@@ -479,56 +476,41 @@ export function usePackagePolicyWithRelatedData(
       setLoadingError(undefined);
       setIsUpgrade(false);
       try {
-        const prerelease = await isPreleaseEnabled();
-
-        const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
-
-        // `sendGetPackageInfoByKey` resolves to a `{ data, error }` envelope instead of throwing.
-        // Ignoring `error` would leave `loadingError` unset and hide the real failure (status
-        // code, message) behind the page's generic loading-error copy.
-        const { data: packageData, error: packageInfoError } = await sendGetPackageInfoByKey(
-          agentlessPolicy.package.name,
-          agentlessPolicy.package.version,
-          { prerelease, full: true }
-        );
-
-        if (packageInfoError) {
-          throw packageInfoError;
-        }
+        // The shared read helper throws on failure (no `{ data, error }` envelope), so
+        // `loadingError` carries the real failure (status code, message) rather than the page's
+        // generic loading-error copy.
+        const {
+          agentlessPolicy,
+          packageInfo: agentlessPackageInfo,
+          packagePolicy: hydratedPackagePolicy,
+        } = await fetchAgentlessPolicyAsPackagePolicy(packagePolicyId);
 
         if (ignore) {
           return;
         }
 
-        if (packageData?.item && yaml) {
-          const hydratedPackagePolicy = agentlessPolicyToPackagePolicy(
-            agentlessPolicy,
-            packageData.item
-          );
+        setPackageInfo(agentlessPackageInfo);
+        setPackagePolicy(hydratedPackagePolicy as UpdatePackagePolicy);
+        // Edit extensions receive the loaded policy as their baseline. Agentless policies carry
+        // no server-only compiled fields at edit time, so the hydrated form policy is the
+        // "original" — enriched with the identifiers/timestamps from the API response.
+        setOriginalPackagePolicy({
+          ...hydratedPackagePolicy,
+          id: agentlessPolicy.id,
+          revision: 1,
+          created_at: agentlessPolicy.created_at,
+          created_by: agentlessPolicy.created_by,
+          updated_at: agentlessPolicy.updated_at,
+          updated_by: agentlessPolicy.updated_by,
+        } as PackagePolicy);
 
-          setPackageInfo(packageData.item);
-          setPackagePolicy(hydratedPackagePolicy as UpdatePackagePolicy);
-          // Edit extensions receive the loaded policy as their baseline. Agentless policies carry
-          // no server-only compiled fields at edit time, so the hydrated form policy is the
-          // "original" — enriched with the identifiers/timestamps from the API response.
-          setOriginalPackagePolicy({
-            ...hydratedPackagePolicy,
-            id: agentlessPolicy.id,
-            revision: 1,
-            created_at: agentlessPolicy.created_at,
-            created_by: agentlessPolicy.created_by,
-            updated_at: agentlessPolicy.updated_at,
-            updated_by: agentlessPolicy.updated_by,
-          } as PackagePolicy);
-
-          const newValidationResults = validatePackagePolicy(
-            hydratedPackagePolicy,
-            packageData.item,
-            { safeLoadYaml: yaml.parse, conditionValidator: validateAgentConditionExpression }
-          );
-          setValidationResults(newValidationResults);
-          setFormState(validationHasErrors(newValidationResults) ? 'INVALID' : 'VALID');
-        }
+        const newValidationResults = validatePackagePolicy(
+          hydratedPackagePolicy,
+          agentlessPackageInfo,
+          { safeLoadYaml: yaml.parse, conditionValidator: validateAgentConditionExpression }
+        );
+        setValidationResults(newValidationResults);
+        setFormState(validationHasErrors(newValidationResults) ? 'INVALID' : 'VALID');
       } catch (e) {
         if (!ignore) {
           setLoadingError(e);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -483,11 +483,18 @@ export function usePackagePolicyWithRelatedData(
 
         const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
 
-        const { data: packageData } = await sendGetPackageInfoByKey(
+        // `sendGetPackageInfoByKey` resolves to a `{ data, error }` envelope instead of throwing.
+        // Ignoring `error` would leave `loadingError` unset and hide the real failure (status
+        // code, message) behind the page's generic loading-error copy.
+        const { data: packageData, error: packageInfoError } = await sendGetPackageInfoByKey(
           agentlessPolicy.package.name,
           agentlessPolicy.package.version,
           { prerelease, full: true }
         );
+
+        if (packageInfoError) {
+          throw packageInfoError;
+        }
 
         if (ignore) {
           return;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -214,6 +214,11 @@ export function usePackagePolicyWithRelatedData(
 
   // Load the package policy and related data
   useEffect(() => {
+    // Guards against a race with the agentless loader below (both share `packagePolicy`/
+    // `packageInfo`/loading state and both re-run on `options.isAgentless`). On dep change or
+    // unmount the cleanup flips `ignore`, so a superseded/late-resolving request from this run
+    // never overwrites state committed by the newer run.
+    let ignore = false;
     const getData = async () => {
       // Agentless policies are loaded by the dedicated effect below, through the agentless API.
       if (options.isAgentless) {
@@ -231,6 +236,10 @@ export function usePackagePolicyWithRelatedData(
           throw packagePolicyError;
         }
 
+        if (ignore) {
+          return;
+        }
+
         // Detect an agentless policy that was opened without the `isAgentless` hint, so the save
         // routes through the agentless API rather than the package-policy API.
         if (packagePolicyData?.item?.supports_agentless) {
@@ -246,6 +255,10 @@ export function usePackagePolicyWithRelatedData(
             throw agentPolicyError;
           }
 
+          if (ignore) {
+            return;
+          }
+
           setAgentPolicies(data?.items ?? []);
         }
 
@@ -254,6 +267,10 @@ export function usePackagePolicyWithRelatedData(
 
         if (upgradePackagePolicyDryRunError) {
           throw upgradePackagePolicyDryRunError;
+        }
+
+        if (ignore) {
+          return;
         }
 
         const hasUpgrade = upgradePackagePolicyDryRunData
@@ -380,6 +397,10 @@ export function usePackagePolicyWithRelatedData(
               { prerelease, full: true }
             );
 
+            if (ignore) {
+              return;
+            }
+
             if (packageData?.item && yaml) {
               setPackageInfo(packageData.item);
 
@@ -399,11 +420,18 @@ export function usePackagePolicyWithRelatedData(
           }
         }
       } catch (e) {
-        setLoadingError(e);
+        if (!ignore) {
+          setLoadingError(e);
+        }
       }
-      setIsLoadingData(false);
+      if (!ignore) {
+        setIsLoadingData(false);
+      }
     };
     getData();
+    return () => {
+      ignore = true;
+    };
   }, [packagePolicyId, options.forceUpgrade, options.isAgentless, yaml]);
 
   // Load the agentless policy through the agentless API. Deliberately skips the agent-policy bulk
@@ -417,6 +445,9 @@ export function usePackagePolicyWithRelatedData(
     if (!options.isAgentless || !yaml) {
       return;
     }
+    // See the legacy loader above: this flag lets the cleanup discard a superseded/late response
+    // so it can't clobber the state written by the newer run (or the other loader).
+    let ignore = false;
     const getAgentlessData = async () => {
       setIsLoadingData(true);
       setLoadingError(undefined);
@@ -431,6 +462,10 @@ export function usePackagePolicyWithRelatedData(
           agentlessPolicy.package.version,
           { prerelease, full: true }
         );
+
+        if (ignore) {
+          return;
+        }
 
         if (packageData?.item && yaml) {
           const hydratedPackagePolicy = agentlessPolicyToPackagePolicy(
@@ -462,11 +497,18 @@ export function usePackagePolicyWithRelatedData(
           setFormState(validationHasErrors(newValidationResults) ? 'INVALID' : 'VALID');
         }
       } catch (e) {
-        setLoadingError(e);
+        if (!ignore) {
+          setLoadingError(e);
+        }
       }
-      setIsLoadingData(false);
+      if (!ignore) {
+        setIsLoadingData(false);
+      }
     };
     getAgentlessData();
+    return () => {
+      ignore = true;
+    };
   }, [packagePolicyId, options.isAgentless, yaml]);
 
   // Re-run validation when yaml loads (getData may have run before yaml was available)

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -9,6 +9,8 @@ import { useCallback, useEffect, useState } from 'react';
 import deepEqual from 'fast-deep-equal';
 import { omit, pick } from 'lodash';
 
+import { i18n } from '@kbn/i18n';
+
 import { validateAgentConditionExpression } from '@kbn/elastic-agent-condition-language';
 
 import type {
@@ -146,6 +148,20 @@ export function usePackagePolicyWithRelatedData(
       // Agentless policies are updated through the agentless API (full-replace PUT), never the
       // package-policy API.
       if (isAgentlessPolicy) {
+        // The agentless API has no agent-policy reassignment: `toNewAgentlessPolicy` drops
+        // `policy_ids`, so honoring a changed override would report success while saving
+        // nothing (e.g. the manage-agent-policies modal). Fail loudly instead. The edit page
+        // echoes the unchanged ids on every save, which stays allowed.
+        if (
+          packagePolicyOverride?.policy_ids &&
+          !deepEqual(packagePolicyOverride.policy_ids, packagePolicy.policy_ids)
+        ) {
+          throw new Error(
+            i18n.translate('xpack.fleet.editPackagePolicy.agentlessPolicyReassignmentError', {
+              defaultMessage: 'Agentless integrations do not support agent policy reassignment.',
+            })
+          );
+        }
         const { enableVarGroups } = ExperimentalFeaturesService.get();
         const varGroups =
           enableVarGroups && packageInfo?.var_groups ? packageInfo.var_groups : undefined;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -45,7 +45,7 @@ import {
 } from '../../create_package_policy_page/services';
 import type { PackagePolicyFormState } from '../../create_package_policy_page/types';
 import { useYaml } from '../../../../../../services';
-import { ExperimentalFeaturesService } from '../../../../services';
+import { ExperimentalFeaturesService, isAgentlessPoliciesUIEnabled } from '../../../../services';
 import { fixApmDurationVars, hasUpgradeAvailable } from '../utils';
 import { prepareInputPackagePolicyDataset } from '../../create_package_policy_page/services/prepare_input_pkg_policy_dataset';
 
@@ -112,8 +112,13 @@ export function usePackagePolicyWithRelatedData(
   // loaded package policy's own `supports_agentless` flag. That flag is authoritative per policy
   // instance (dual-mode packages route correctly), and it drives the write path so an agentless
   // policy is never saved through the package-policy API.
+  // Both inputs are gated on the agentless-policies-UI kill switch: when it is off, this hook
+  // ignores the hint (even if a caller passes it) and the detection, so read and write both fall
+  // back to the legacy package-policy/agent-policy APIs.
+  const agentlessUIEnabled = isAgentlessPoliciesUIEnabled();
   const [detectedAgentless, setDetectedAgentless] = useState(false);
-  const isAgentlessPolicy = (options.isAgentless ?? false) || detectedAgentless;
+  const isAgentlessOption = agentlessUIEnabled && (options.isAgentless ?? false);
+  const isAgentlessPolicy = isAgentlessOption || (agentlessUIEnabled && detectedAgentless);
   const yaml = useYaml();
 
   // Form state
@@ -219,13 +224,13 @@ export function usePackagePolicyWithRelatedData(
   // Load the package policy and related data
   useEffect(() => {
     // Guards against a race with the agentless loader below (both share `packagePolicy`/
-    // `packageInfo`/loading state and both re-run on `options.isAgentless`). On dep change or
+    // `packageInfo`/loading state and both re-run on `isAgentlessOption`). On dep change or
     // unmount the cleanup flips `ignore`, so a superseded/late-resolving request from this run
     // never overwrites state committed by the newer run.
     let ignore = false;
     const getData = async () => {
       // Agentless policies are loaded by the dedicated effect below, through the agentless API.
-      if (options.isAgentless) {
+      if (isAgentlessOption) {
         return;
       }
       setIsLoadingData(true);
@@ -436,7 +441,7 @@ export function usePackagePolicyWithRelatedData(
     return () => {
       ignore = true;
     };
-  }, [packagePolicyId, options.forceUpgrade, options.isAgentless, yaml]);
+  }, [packagePolicyId, options.forceUpgrade, isAgentlessOption, yaml]);
 
   // Load the agentless policy through the agentless API. Deliberately skips the agent-policy bulk
   // read and the upgrade dry-run: agentless deployments have no user-facing agent policy, and the
@@ -446,7 +451,7 @@ export function usePackagePolicyWithRelatedData(
     // Wait for `yaml` before fetching: the whole load (hydration + validation) needs it, so firing
     // the GET before it's ready would just throw the result away and cause a second, redundant call
     // once `yaml` resolves.
-    if (!options.isAgentless || !yaml) {
+    if (!isAgentlessOption || !yaml) {
       return;
     }
     // See the legacy loader above: this flag lets the cleanup discard a superseded/late response
@@ -513,7 +518,7 @@ export function usePackagePolicyWithRelatedData(
     return () => {
       ignore = true;
     };
-  }, [packagePolicyId, options.isAgentless, yaml]);
+  }, [packagePolicyId, isAgentlessOption, yaml]);
 
   // Re-run validation when yaml loads (getData may have run before yaml was available)
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
@@ -795,4 +795,36 @@ describe('edit package policy page', () => {
       );
     });
   });
+
+  describe('agentless policies UI kill switch', () => {
+    it('skips the package-policy read when the isAgentless hint is set and the switch is on', async () => {
+      jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+        enableVarGroups: true,
+        enableAgentlessPoliciesUI: true,
+      } as any);
+      testRenderer.history.push('?isAgentless=true');
+      render();
+
+      await waitFor(() => {
+        expect(useGetOnePackagePolicyQuery).toHaveBeenCalledWith('nginx-1', { enabled: false });
+      });
+    });
+
+    it('ignores the isAgentless hint and keeps the package-policy read when the switch is off', async () => {
+      jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+        enableVarGroups: true,
+        enableAgentlessPoliciesUI: false,
+      } as any);
+      testRenderer.history.push('?isAgentless=true');
+      render();
+
+      await waitFor(() => {
+        expect(useGetOnePackagePolicyQuery).toHaveBeenCalledWith('nginx-1', { enabled: true });
+      });
+      // The form then loads through the legacy package-policy read path.
+      await waitFor(() => {
+        expect(renderResult.getByDisplayValue('nginx-1')).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
@@ -26,7 +26,7 @@ import {
   useGetPackagePolicies,
   sendBulkGetAgentPoliciesForRq,
 } from '../../../hooks';
-import { useGetOnePackagePolicy } from '../../../../integrations/hooks';
+import { useGetOnePackagePolicyQuery } from '../../../../integrations/hooks';
 
 import { ExperimentalFeaturesService } from '../../../services';
 
@@ -201,7 +201,7 @@ jest.mock('../../../hooks', () => {
 jest.mock('../../../../integrations/hooks', () => {
   return {
     ...jest.requireActual('../../../../integrations/hooks'),
-    useGetOnePackagePolicy: jest.fn(),
+    useGetOnePackagePolicyQuery: jest.fn(),
     useConfirmForceInstall: jest.fn(),
   };
 });
@@ -297,7 +297,7 @@ describe('edit package policy page', () => {
     testRenderer = createFleetTestRendererMock();
     lastStepConfigureProps = undefined;
 
-    (useGetOnePackagePolicy as MockFn).mockReturnValue({
+    (useGetOnePackagePolicyQuery as MockFn).mockReturnValue({
       data: {
         item: mockPackagePolicy,
       },
@@ -544,7 +544,7 @@ describe('edit package policy page', () => {
 
   it('should not show confirmation modal if package is on agentless policy', async () => {
     (sendBulkGetAgentPoliciesForRq as MockFn).mockResolvedValue({ data: [{ agents: 1 }] });
-    (useGetOnePackagePolicy as MockFn).mockReturnValue({
+    (useGetOnePackagePolicyQuery as MockFn).mockReturnValue({
       data: {
         item: mockPackagePolicyAgentless,
       },
@@ -594,7 +594,7 @@ describe('edit package policy page', () => {
   it('passes existing var_group selections to configure step', async () => {
     const varGroupSelections = { auth_method: 'oauth' };
 
-    (useGetOnePackagePolicy as MockFn).mockReturnValueOnce({
+    (useGetOnePackagePolicyQuery as MockFn).mockReturnValueOnce({
       data: {
         item: { ...mockPackagePolicy, var_group_selections: varGroupSelections },
       },

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -88,18 +88,11 @@ export const EditPackagePolicyPage = memo(() => {
 
   // Detect-before-read: the route only carries `packagePolicyId`, shared between agentless and
   // agent-based policies. Agentless surfaces append this hint so we can read/write through the
-  // agentless API without first reading the package policy. Always false when the agentless
-  // policies UI kill switch is off, so the page falls back to the legacy APIs. See task4
-  // follow-ups for the (provisional) mechanism.
+  // agentless API without first reading the package policy.
   const isAgentless = useIsAgentlessQueryParam();
 
   // This read only resolves the edit UI extension, whose `useLatestPackageVersion` flag feeds
-  // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API:
-  // this wrapper is only used for regular (non-upgrade) edit, and the agentless load path forces
-  // `isUpgrade=false` and ignores `forceUpgrade`. Agentless *upgrades* use the separate
-  // `upgrade_package_policy` route, which deliberately omits the `isAgentless` hint and stays on the
-  // legacy package-policy path for now (wiring the agentless `_upgrade` UI is a follow-up / task5).
-  // The form re-resolves the extension from the agentless-loaded policy for rendering.
+  // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API.
   const packagePolicy = useGetOnePackagePolicyQuery(packagePolicyId, { enabled: !isAgentless });
   const extensionView = useUIExtension(
     packagePolicy.data?.item?.package?.name ?? '',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../../hooks';
 import {
   useBreadcrumbs as useIntegrationsBreadcrumbs,
-  useGetOnePackagePolicy,
+  useGetOnePackagePolicyQuery,
 } from '../../../../integrations/hooks';
 import {
   Loading,
@@ -82,26 +82,34 @@ export const EditPackagePolicyPage = memo(() => {
     params: { packagePolicyId, policyId },
   } = useRouteMatch<{ policyId: string; packagePolicyId: string }>();
 
-  const packagePolicy = useGetOnePackagePolicy(packagePolicyId);
-  const extensionView = useUIExtension(
-    packagePolicy.data?.item?.package?.name ?? '',
-    'package-policy-edit'
-  );
-
   // Parse the 'from' query parameter to determine navigation after save
   const { search } = useLocation();
   const qs = new URLSearchParams(search);
-  const fromQs = qs.get('from');
-  let from: EditPackagePolicyFrom | undefined;
-  if (fromQs === 'installed-integrations') {
-    from = 'installed-integrations';
-  }
 
   // Detect-before-read: the route only carries `packagePolicyId`, shared between agentless and
   // agent-based policies. Agentless surfaces append this hint so we can read/write through the
   // agentless API without first reading the package policy. See task4 follow-ups for the
   // (provisional) mechanism.
   const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
+
+  // This read only resolves the edit UI extension, whose `useLatestPackageVersion` flag feeds
+  // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API:
+  // this wrapper is only used for regular (non-upgrade) edit, and the agentless load path forces
+  // `isUpgrade=false` and ignores `forceUpgrade`. Agentless *upgrades* use the separate
+  // `upgrade_package_policy` route, which deliberately omits the `isAgentless` hint and stays on the
+  // legacy package-policy path for now (wiring the agentless `_upgrade` UI is a follow-up / task5).
+  // The form re-resolves the extension from the agentless-loaded policy for rendering.
+  const packagePolicy = useGetOnePackagePolicyQuery(packagePolicyId, { enabled: !isAgentless });
+  const extensionView = useUIExtension(
+    packagePolicy.data?.item?.package?.name ?? '',
+    'package-policy-edit'
+  );
+
+  const fromQs = qs.get('from');
+  let from: EditPackagePolicyFrom | undefined;
+  if (fromQs === 'installed-integrations') {
+    from = 'installed-integrations';
+  }
 
   return (
     <EditPackagePolicyForm

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -28,6 +28,7 @@ import {
   useUIExtension,
   useAuthz,
   sendBulkGetAgentPoliciesForRq,
+  useIsAgentlessQueryParam,
 } from '../../../hooks';
 import {
   useBreadcrumbs as useIntegrationsBreadcrumbs,
@@ -55,7 +56,6 @@ import {
 } from '../create_package_policy_page/services';
 import type { AgentPolicy, PackagePolicyEditExtensionComponentProps } from '../../../types';
 import { pkgKeyFromPackageInfo, ExperimentalFeaturesService } from '../../../services';
-import { IS_AGENTLESS_QUERY_PARAM } from '../../../../../../common/constants';
 
 import {
   getInheritedNamespace,
@@ -88,9 +88,10 @@ export const EditPackagePolicyPage = memo(() => {
 
   // Detect-before-read: the route only carries `packagePolicyId`, shared between agentless and
   // agent-based policies. Agentless surfaces append this hint so we can read/write through the
-  // agentless API without first reading the package policy. See task4 follow-ups for the
-  // (provisional) mechanism.
-  const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
+  // agentless API without first reading the package policy. Always false when the agentless
+  // policies UI kill switch is off, so the page falls back to the legacy APIs. See task4
+  // follow-ups for the (provisional) mechanism.
+  const isAgentless = useIsAgentlessQueryParam();
 
   // This read only resolves the edit UI extension, whose `useLatestPackageVersion` flag feeds
   // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API:

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -55,6 +55,7 @@ import {
 } from '../create_package_policy_page/services';
 import type { AgentPolicy, PackagePolicyEditExtensionComponentProps } from '../../../types';
 import { pkgKeyFromPackageInfo, ExperimentalFeaturesService } from '../../../services';
+import { IS_AGENTLESS_QUERY_PARAM } from '../../../../../../common/constants';
 
 import {
   getInheritedNamespace,
@@ -96,11 +97,18 @@ export const EditPackagePolicyPage = memo(() => {
     from = 'installed-integrations';
   }
 
+  // Detect-before-read: the route only carries `packagePolicyId`, shared between agentless and
+  // agent-based policies. Agentless surfaces append this hint so we can read/write through the
+  // agentless API without first reading the package policy. See task4 follow-ups for the
+  // (provisional) mechanism.
+  const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
+
   return (
     <EditPackagePolicyForm
       packagePolicyId={packagePolicyId}
       policyId={policyId}
       from={from}
+      isAgentless={isAgentless}
       // If an extension opts in to this `useLatestPackageVersion` flag, we want to display
       // the edit form in an "upgrade" state regardless of whether the user intended to
       // "edit" their policy or "upgrade" it. This ensures the new policy generated will be
@@ -115,7 +123,8 @@ export const EditPackagePolicyForm = memo<{
   forceUpgrade?: boolean;
   from?: EditPackagePolicyFrom;
   policyId?: string;
-}>(({ packagePolicyId, policyId, forceUpgrade = false, from = 'edit' }) => {
+  isAgentless?: boolean;
+}>(({ packagePolicyId, policyId, forceUpgrade = false, from = 'edit', isAgentless = false }) => {
   const { application, notifications } = useStartServices();
   const {
     agents: { enabled: isFleetEnabled },
@@ -144,15 +153,25 @@ export const EditPackagePolicyForm = memo<{
     validationResults,
   } = usePackagePolicyWithRelatedData(packagePolicyId, {
     forceUpgrade,
+    isAgentless,
   });
 
   const hasAgentlessAgentPolicy = useMemo(
     () =>
-      existingAgentPolicies.length === 1
+      // When editing through the agentless API we don't fetch an agent policy, so the hint is
+      // authoritative. Otherwise fall back to inspecting the loaded agent policy (legacy path).
+      isAgentless ||
+      (existingAgentPolicies.length === 1
         ? existingAgentPolicies.some((policy) => isAgentlessAgentPolicy(policy)) &&
           getAgentlessStatusForPackage(packageInfo).isAgentless
-        : false,
-    [existingAgentPolicies, isAgentlessAgentPolicy, packageInfo, getAgentlessStatusForPackage]
+        : false),
+    [
+      isAgentless,
+      existingAgentPolicies,
+      isAgentlessAgentPolicy,
+      packageInfo,
+      getAgentlessStatusForPackage,
+    ]
   );
 
   // Derive var_group_selections from policy for edit mode

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
@@ -18,6 +18,7 @@ import type {
   UpdatePackagePolicy,
   UpdateAgentPolicyRequest,
   RegistryVarGroup,
+  PackageInfo,
 } from '../../../types';
 import { canUseMultipleAgentPolicies } from '../../../hooks';
 import {
@@ -71,12 +72,15 @@ export function generateCreatePackagePolicyDevToolsRequest(
 
 export function generateCreateAgentlessPolicyDevToolsRequest(
   packagePolicy: NewPackagePolicy & { force?: boolean; create_dataset_templates?: boolean },
-  varGroups?: RegistryVarGroup[]
+  varGroups?: RegistryVarGroup[],
+  packageInfo?: PackageInfo
 ) {
   return generateKibanaDevToolsRequest(
     'POST',
     agentlessPolicyRouteService.getCreatePath(),
-    toNewAgentlessPolicy(packagePolicy, varGroups)
+    // Pass `packageInfo` so the preview matches the request the form actually sends (template-aware
+    // input allow-check), mirroring the read path (`agentlessPolicyToPackagePolicy`).
+    toNewAgentlessPolicy(packagePolicy, varGroups, packageInfo)
   );
 }
 
@@ -85,17 +89,21 @@ export function generateCreateAgentlessPolicyDevToolsRequest(
  * @param policyId
  * @param packagePolicy
  * @param varGroups
+ * @param packageInfo
  * @returns
  */
 export function generateUpdateAgentlessPolicyDevToolsRequest(
   policyId: string,
   packagePolicy: NewPackagePolicy & { force?: boolean; create_dataset_templates?: boolean },
-  varGroups?: RegistryVarGroup[]
+  varGroups?: RegistryVarGroup[],
+  packageInfo?: PackageInfo
 ) {
   return generateKibanaDevToolsRequest(
     'PUT',
     agentlessPolicyRouteService.getUpdatePath(policyId),
-    toNewAgentlessPolicy(packagePolicy, varGroups)
+    // Pass `packageInfo` so the preview matches the PUT the edit form actually sends (template-aware
+    // input allow-check), mirroring the read path (`agentlessPolicyToPackagePolicy`).
+    toNewAgentlessPolicy(packagePolicy, varGroups, packageInfo)
   );
 }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
@@ -81,6 +81,25 @@ export function generateCreateAgentlessPolicyDevToolsRequest(
 }
 
 /**
+ * Generate a request to update an agentless policy that can be used in Kibana Dev tools
+ * @param policyId
+ * @param packagePolicy
+ * @param varGroups
+ * @returns
+ */
+export function generateUpdateAgentlessPolicyDevToolsRequest(
+  policyId: string,
+  packagePolicy: NewPackagePolicy & { force?: boolean; create_dataset_templates?: boolean },
+  varGroups?: RegistryVarGroup[]
+) {
+  return generateKibanaDevToolsRequest(
+    'PUT',
+    agentlessPolicyRouteService.getUpdatePath(policyId),
+    toNewAgentlessPolicy(packagePolicy, varGroups)
+  );
+}
+
+/**
  * Generate a request to update a package policy that can be used in Kibana Dev tools
  * @param packagePolicyId
  * @param packagePolicy

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/fetch_agentless_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/fetch_agentless_policy.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  sendGetAgentlessPolicy,
+  sendGetPackageInfoByKeyForRq,
+  sendGetSettings,
+} from '../../../hooks';
+import nginxPackageInfo from '../../../../../../server/services/package_policies/fixtures/package_info/nginx_1.5.0.json';
+
+import { fetchAgentlessPolicyAsPackagePolicy } from './fetch_agentless_policy';
+
+// Mock the leaf `use_request` module (like the edit/copy hook tests) so the real inverse mapper
+// (`agentlessPolicyToPackagePolicy`) still runs against the nginx fixture below.
+jest.mock('../../../../../hooks/use_request', () => ({
+  ...jest.requireActual('../../../../../hooks/use_request'),
+  sendGetAgentlessPolicy: jest.fn(),
+  sendGetPackageInfoByKeyForRq: jest.fn(),
+  sendGetSettings: jest.fn(),
+}));
+
+describe('fetchAgentlessPolicyAsPackagePolicy', () => {
+  const agentlessPolicy = {
+    id: 'agentless-1',
+    name: 'agentless-1',
+    namespace: 'default',
+    package: { name: 'nginx', title: 'Nginx', version: '1.5.0' },
+    inputs: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(sendGetAgentlessPolicy).mockResolvedValue({ item: agentlessPolicy } as any);
+    jest.mocked(sendGetPackageInfoByKeyForRq).mockResolvedValue({ item: nginxPackageInfo } as any);
+    jest
+      .mocked(sendGetSettings)
+      .mockResolvedValue({ data: { item: { prerelease_integrations_enabled: false } } } as any);
+  });
+
+  it('hydrates the policy through the inverse mapper against the full package info', async () => {
+    const result = await fetchAgentlessPolicyAsPackagePolicy('agentless-1');
+
+    expect(sendGetAgentlessPolicy).toHaveBeenCalledWith('agentless-1');
+    // The package info must be the `full: true` manifest for the policy's own package version,
+    // with prerelease resolved from settings (here disabled) rather than hardcoded.
+    expect(sendGetPackageInfoByKeyForRq).toHaveBeenCalledWith('nginx', '1.5.0', {
+      prerelease: false,
+      full: true,
+    });
+
+    expect(result.agentlessPolicy).toBe(agentlessPolicy);
+    expect(result.packageInfo).toBe(nginxPackageInfo);
+    // The inverse mapper carries the source id through and keeps the agentless routing flag.
+    expect(result.packagePolicy).toEqual(
+      expect.objectContaining({ id: 'agentless-1', name: 'agentless-1', supports_agentless: true })
+    );
+  });
+
+  it('resolves prerelease from settings when the setting is on', async () => {
+    jest
+      .mocked(sendGetSettings)
+      .mockResolvedValue({ data: { item: { prerelease_integrations_enabled: true } } } as any);
+
+    await fetchAgentlessPolicyAsPackagePolicy('agentless-1');
+
+    expect(sendGetPackageInfoByKeyForRq).toHaveBeenCalledWith(
+      'nginx',
+      '1.5.0',
+      expect.objectContaining({ prerelease: true, full: true })
+    );
+  });
+
+  it('propagates a failed read instead of resolving', async () => {
+    // Both callers (edit loader, copy query) rely on the throw to surface the real error.
+    const notFound = Object.assign(new Error('agentless policy not found'), { statusCode: 404 });
+    jest.mocked(sendGetAgentlessPolicy).mockRejectedValue(notFound);
+
+    await expect(fetchAgentlessPolicyAsPackagePolicy('missing')).rejects.toThrow(
+      'agentless policy not found'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/fetch_agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/fetch_agentless_policy.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  sendGetAgentlessPolicy,
+  sendGetPackageInfoByKeyForRq,
+  sendGetSettings,
+} from '../../../hooks';
+import type { NewPackagePolicy, PackageInfo } from '../../../types';
+import type { AgentlessPolicy } from '../../../../../../common/types/models/agentless_policy';
+import { agentlessPolicyToPackagePolicy } from '../../../../../../common/services';
+
+/**
+ * Read an agentless policy through the agentless API and expand it into the full package-policy
+ * shape the shared form components expect: GET the agentless policy, resolve prerelease from
+ * settings, GET the full package info for the policy's package version, and run the inverse
+ * mapper (`agentlessPolicyToPackagePolicy`).
+ *
+ * Shared by the edit and copy read paths (detect-before-read via the `isAgentless` link hint),
+ * which must not touch the package-policy/agent-policy APIs. The requests throw on failure
+ * (`sendRequestForRq` style) so callers surface the real error rather than a generic one.
+ */
+export const fetchAgentlessPolicyAsPackagePolicy = async (
+  packagePolicyId: string
+): Promise<{
+  agentlessPolicy: AgentlessPolicy;
+  packageInfo: PackageInfo;
+  packagePolicy: NewPackagePolicy;
+}> => {
+  const { item: agentlessPolicy } = await sendGetAgentlessPolicy(packagePolicyId);
+
+  const { data: settings } = await sendGetSettings();
+  const prerelease = Boolean(settings?.item.prerelease_integrations_enabled);
+
+  const { item: packageInfo } = await sendGetPackageInfoByKeyForRq(
+    agentlessPolicy.package.name,
+    agentlessPolicy.package.version,
+    { prerelease, full: true }
+  );
+
+  return {
+    agentlessPolicy,
+    packageInfo,
+    packagePolicy: agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo),
+  };
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/index.tsx
@@ -11,3 +11,5 @@ export {
   generateUpdatePackagePolicyDevToolsRequest,
   generateUpdateAgentPolicyDevToolsRequest,
 } from './devtools_request';
+
+export { fetchAgentlessPolicyAsPackagePolicy } from './fetch_agentless_policy';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.test.ts
@@ -76,4 +76,25 @@ describe('agentlessPolicyToTableItem', () => {
 
     expect(agentPolicies).toEqual([{ id: 'agentless-1', name: 'Nginx agentless' }]);
   });
+
+  it('degrades to a minimal row (no throw) when input expansion fails', () => {
+    // e.g. the policy references a field absent from the loaded manifest, or predates the version.
+    mockAgentlessPolicyToPackagePolicy.mockImplementation(() => {
+      throw new Error('Input not found: nginx-foo');
+    });
+
+    const { packagePolicy, agentPolicies } = agentlessPolicyToTableItem(
+      agentlessPolicy,
+      packageInfo
+    );
+
+    // A single bad policy must never crash the whole deployments table.
+    expect(packagePolicy.id).toBe('agentless-1');
+    expect(packagePolicy.name).toBe('Nginx agentless');
+    expect(packagePolicy.package?.version).toBe('1.0.0');
+    expect(packagePolicy.inputs).toEqual([]);
+    expect(packagePolicy.policy_ids).toEqual(['agentless-1']);
+    expect(packagePolicy.updated_at).toBe('2026-02-02T00:00:00.000Z');
+    expect(agentPolicies).toEqual([{ id: 'agentless-1', name: 'Nginx agentless' }]);
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackageInfo } from '../../../../../types';
+import type { AgentlessPolicy } from '../../../../../../../../common/types/models/agentless_policy';
+import { agentlessPolicyToPackagePolicy } from '../../../../../../../../common/services';
+
+import { agentlessPolicyToTableItem } from './agentless_policy_table_adapter';
+
+jest.mock('../../../../../../../../common/services', () => ({
+  agentlessPolicyToPackagePolicy: jest.fn(),
+}));
+
+const mockAgentlessPolicyToPackagePolicy = agentlessPolicyToPackagePolicy as jest.MockedFunction<
+  typeof agentlessPolicyToPackagePolicy
+>;
+
+describe('agentlessPolicyToTableItem', () => {
+  const packageInfo = { name: 'nginx', version: '1.0.0' } as PackageInfo;
+
+  const agentlessPolicy = {
+    id: 'agentless-1',
+    name: 'Nginx agentless',
+    namespace: 'default',
+    package: { name: 'nginx', title: 'Nginx', version: '1.0.0' },
+    inputs: {},
+    var_group_selections: {},
+    created_at: '2026-01-01T00:00:00.000Z',
+    created_by: 'creator',
+    updated_at: '2026-02-02T00:00:00.000Z',
+    updated_by: 'updater',
+  } as unknown as AgentlessPolicy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAgentlessPolicyToPackagePolicy.mockReturnValue({
+      name: 'Nginx agentless',
+      namespace: 'default',
+      package: { name: 'nginx', title: 'Nginx', version: '1.0.0' },
+      inputs: [],
+      policy_ids: [],
+      enabled: true,
+    } as any);
+  });
+
+  it('expands the policy through agentlessPolicyToPackagePolicy with the package info', () => {
+    agentlessPolicyToTableItem(agentlessPolicy, packageInfo);
+
+    expect(mockAgentlessPolicyToPackagePolicy).toHaveBeenCalledWith(agentlessPolicy, packageInfo);
+  });
+
+  it('enriches the package policy with the agentless identifiers and timestamps', () => {
+    const { packagePolicy } = agentlessPolicyToTableItem(agentlessPolicy, packageInfo);
+
+    expect(packagePolicy.id).toBe('agentless-1');
+    expect(packagePolicy.created_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(packagePolicy.created_by).toBe('creator');
+    expect(packagePolicy.updated_at).toBe('2026-02-02T00:00:00.000Z');
+    expect(packagePolicy.updated_by).toBe('updater');
+    expect(packagePolicy.name).toBe('Nginx agentless');
+    expect(packagePolicy.package?.name).toBe('nginx');
+  });
+
+  it('sets policy_ids to the agentless id (agent-policy id == policy id by server design)', () => {
+    const { packagePolicy } = agentlessPolicyToTableItem(agentlessPolicy, packageInfo);
+
+    expect(packagePolicy.policy_ids).toEqual(['agentless-1']);
+  });
+
+  it('synthesizes a minimal agent policy keyed by the agentless id', () => {
+    const { agentPolicies } = agentlessPolicyToTableItem(agentlessPolicy, packageInfo);
+
+    expect(agentPolicies).toEqual([{ id: 'agentless-1', name: 'Nginx agentless' }]);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.test.ts
@@ -71,10 +71,14 @@ describe('agentlessPolicyToTableItem', () => {
     expect(packagePolicy.policy_ids).toEqual(['agentless-1']);
   });
 
-  it('synthesizes a minimal agent policy keyed by the agentless id', () => {
+  it('synthesizes a minimal agentless agent policy keyed by the agentless id', () => {
     const { agentPolicies } = agentlessPolicyToTableItem(agentlessPolicy, packageInfo);
 
-    expect(agentPolicies).toEqual([{ id: 'agentless-1', name: 'Nginx agentless' }]);
+    // supports_agentless drives shared row consumers: without it the actions menu offers
+    // "Add agent" and the delete modal shows the agent-based wording on agentless rows.
+    expect(agentPolicies).toEqual([
+      { id: 'agentless-1', name: 'Nginx agentless', supports_agentless: true },
+    ]);
   });
 
   it('degrades to a minimal row (no throw) when input expansion fails', () => {
@@ -95,6 +99,8 @@ describe('agentlessPolicyToTableItem', () => {
     expect(packagePolicy.inputs).toEqual([]);
     expect(packagePolicy.policy_ids).toEqual(['agentless-1']);
     expect(packagePolicy.updated_at).toBe('2026-02-02T00:00:00.000Z');
-    expect(agentPolicies).toEqual([{ id: 'agentless-1', name: 'Nginx agentless' }]);
+    expect(agentPolicies).toEqual([
+      { id: 'agentless-1', name: 'Nginx agentless', supports_agentless: true },
+    ]);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
@@ -55,6 +55,10 @@ export const agentlessPolicyToTableItem = (
     packagePolicy = {
       ...agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo),
       ...identity,
+      // Keep each row's own package version: the mapper stamps `package` from the shared
+      // (installed/latest) `packageInfo`, which would misreport an older policy's version and
+      // hide its "upgrade available" indicator. The API returns the policy's real package.
+      package: agentlessPolicy.package,
     } as PackagePolicy;
   } catch {
     // Re-deriving a policy's inputs against the manifest can throw (e.g. the policy references a

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
@@ -35,8 +35,8 @@ export const agentlessPolicyToTableItem = (
   agentlessPolicy: AgentlessPolicy,
   packageInfo: PackageInfo
 ): AgentlessPolicyTableItem => {
-  const packagePolicy = {
-    ...agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo),
+  // Identifiers/timestamps the table renders directly, independent of input expansion.
+  const identity = {
     id: agentlessPolicy.id,
     policy_ids: [agentlessPolicy.id],
     revision: 1,
@@ -44,11 +44,35 @@ export const agentlessPolicyToTableItem = (
     created_by: agentlessPolicy.created_by,
     updated_at: agentlessPolicy.updated_at,
     updated_by: agentlessPolicy.updated_by,
-  } as PackagePolicy;
+  };
 
   const agentPolicies = [
     { id: agentlessPolicy.id, name: agentlessPolicy.name } as GetAgentPoliciesResponseItem,
   ];
+
+  let packagePolicy: PackagePolicy;
+  try {
+    packagePolicy = {
+      ...agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo),
+      ...identity,
+    } as PackagePolicy;
+  } catch {
+    // Re-deriving a policy's inputs against the manifest can throw (e.g. the policy references a
+    // field that is absent from the loaded package info, or the policy predates the installed
+    // package version). Degrade this single row to a minimal package policy so one bad policy
+    // can never crash the whole deployments table.
+    packagePolicy = {
+      name: agentlessPolicy.name,
+      namespace: agentlessPolicy.namespace ?? 'default',
+      description: agentlessPolicy.description,
+      package: agentlessPolicy.package,
+      enabled: true,
+      inputs: [],
+      vars: {},
+      supports_agentless: true,
+      ...identity,
+    } as unknown as PackagePolicy;
+  }
 
   return { packagePolicy, agentPolicies };
 };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  GetAgentPoliciesResponseItem,
+  PackageInfo,
+  PackagePolicy,
+} from '../../../../../types';
+import type { AgentlessPolicy } from '../../../../../../../../common/types/models/agentless_policy';
+import { agentlessPolicyToPackagePolicy } from '../../../../../../../../common/services';
+
+export interface AgentlessPolicyTableItem {
+  packagePolicy: PackagePolicy;
+  agentPolicies: GetAgentPoliciesResponseItem[];
+}
+
+/**
+ * Map an {@link AgentlessPolicy} (from the agentless policies LIST API) onto the
+ * `{ packagePolicy, agentPolicies }` shape the deployments table consumes, so the table
+ * component and its `mapPoliciesData` enrichment stay unchanged.
+ *
+ * - `packagePolicy` is expanded to the full `PackagePolicy` shape via
+ *   `agentlessPolicyToPackagePolicy` (same converter the edit read uses), then enriched with
+ *   the identifiers/timestamps the table renders (`id`, `updated_at`, `updated_by`).
+ * - `policy_ids` is set to `[agentlessPolicy.id]`: the agentless agent-policy id equals the
+ *   policy id by server design, and the enrollment flyout keys the agent lookup off it.
+ * - `agentPolicies` is a minimal `{ id, name }`: the table only reads the id (status lookup,
+ *   agents kuery, upgrade href) and the flyout uses it only for optional error-state details.
+ */
+export const agentlessPolicyToTableItem = (
+  agentlessPolicy: AgentlessPolicy,
+  packageInfo: PackageInfo
+): AgentlessPolicyTableItem => {
+  const packagePolicy = {
+    ...agentlessPolicyToPackagePolicy(agentlessPolicy, packageInfo),
+    id: agentlessPolicy.id,
+    policy_ids: [agentlessPolicy.id],
+    revision: 1,
+    created_at: agentlessPolicy.created_at,
+    created_by: agentlessPolicy.created_by,
+    updated_at: agentlessPolicy.updated_at,
+    updated_by: agentlessPolicy.updated_by,
+  } as PackagePolicy;
+
+  const agentPolicies = [
+    { id: agentlessPolicy.id, name: agentlessPolicy.name } as GetAgentPoliciesResponseItem,
+  ];
+
+  return { packagePolicy, agentPolicies };
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/agentless_policy_table_adapter.ts
@@ -28,8 +28,11 @@ export interface AgentlessPolicyTableItem {
  *   the identifiers/timestamps the table renders (`id`, `updated_at`, `updated_by`).
  * - `policy_ids` is set to `[agentlessPolicy.id]`: the agentless agent-policy id equals the
  *   policy id by server design, and the enrollment flyout keys the agent lookup off it.
- * - `agentPolicies` is a minimal `{ id, name }`: the table only reads the id (status lookup,
- *   agents kuery, upgrade href) and the flyout uses it only for optional error-state details.
+ * - `agentPolicies` is a minimal `{ id, name, supports_agentless }`: the table reads the id
+ *   (status lookup, agents kuery, upgrade href), the flyout uses it only for optional
+ *   error-state details, and shared row consumers (actions menu, delete modal) branch on
+ *   `supports_agentless` — without it they'd offer "Add agent" and show the agent-based
+ *   delete wording on agentless rows.
  */
 export const agentlessPolicyToTableItem = (
   agentlessPolicy: AgentlessPolicy,
@@ -47,7 +50,11 @@ export const agentlessPolicyToTableItem = (
   };
 
   const agentPolicies = [
-    { id: agentlessPolicy.id, name: agentlessPolicy.name } as GetAgentPoliciesResponseItem,
+    {
+      id: agentlessPolicy.id,
+      name: agentlessPolicy.name,
+      supports_agentless: true,
+    } as GetAgentPoliciesResponseItem,
   ];
 
   let packagePolicy: PackagePolicy;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -166,9 +166,7 @@ describe('AgentlessPackagePoliciesTable', () => {
     await act(async () => {
       expect(result.getByText('Unable to load agentless integration policies')).toBeInTheDocument();
       expect(result.getByText('boom')).toBeInTheDocument();
-      expect(
-        result.queryByText('No agentless integration policies')
-      ).not.toBeInTheDocument();
+      expect(result.queryByText('No agentless integration policies')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -15,6 +15,8 @@ import { sendGetAgents } from '../../../../../../hooks';
 // table uses. Import + mock it separately so we can assert the flyout's own agent lookup.
 import { sendGetAgents as sendGetAgentsFromFlyout } from '../../../../../../../../hooks';
 import { createIntegrationsTestRendererMock } from '../../../../../../../../mock';
+import { allowedExperimentalValues } from '../../../../../../../../../common/experimental_features';
+import { ExperimentalFeaturesService } from '../../../../../../services';
 
 import { AgentlessPackagePoliciesTable } from './agentless_table';
 
@@ -196,6 +198,27 @@ describe('AgentlessPackagePoliciesTable', () => {
       expect(result.getByText('Package Policy 1')).toBeInTheDocument();
       expect(result.getByText('user1')).toBeInTheDocument();
     });
+  });
+
+  it('appends the isAgentless hint to edit links when the agentless policies UI is enabled', async () => {
+    const renderer = createIntegrationsTestRendererMock();
+    const result = renderer.render(<AgentlessPackagePoliciesTable {...defaultProps} />);
+
+    const nameLink = await result.findByTestId('agentlessIntegrationNameLink');
+    expect(nameLink.getAttribute('href')).toContain('isAgentless=true');
+  });
+
+  it('does not append the isAgentless hint to edit links when the agentless policies UI is disabled', async () => {
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      enableAgentlessPoliciesUI: false,
+    });
+    const renderer = createIntegrationsTestRendererMock();
+    const result = renderer.render(<AgentlessPackagePoliciesTable {...defaultProps} />);
+
+    const nameLink = await result.findByTestId('agentlessIntegrationNameLink');
+    expect(nameLink.getAttribute('href')).not.toContain('isAgentless');
+    jest.mocked(ExperimentalFeaturesService.get).mockRestore();
   });
 
   it('displays agent health status when agents are loaded', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -153,6 +153,43 @@ describe('AgentlessPackagePoliciesTable', () => {
     });
   });
 
+  it('shows an error prompt (not the empty message) when the list request fails', async () => {
+    const renderer = createIntegrationsTestRendererMock();
+    const result = renderer.render(
+      <AgentlessPackagePoliciesTable
+        {...defaultProps}
+        packagePolicies={[]}
+        packagePoliciesTotal={0}
+        error={new Error('boom')}
+      />
+    );
+    await act(async () => {
+      expect(result.getByText('Unable to load agentless integration policies')).toBeInTheDocument();
+      expect(result.getByText('boom')).toBeInTheDocument();
+      expect(
+        result.queryByText('No agentless integration policies')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('retries the list request when the error prompt retry button is clicked', async () => {
+    const refreshPackagePolicies = jest.fn();
+    const renderer = createIntegrationsTestRendererMock();
+    const result = renderer.render(
+      <AgentlessPackagePoliciesTable
+        {...defaultProps}
+        packagePolicies={[]}
+        packagePoliciesTotal={0}
+        error={new Error('boom')}
+        refreshPackagePolicies={refreshPackagePolicies}
+      />
+    );
+    await act(async () => {
+      fireEvent.click(result.getByTestId('agentlessPoliciesLoadErrorRetryButton'));
+    });
+    expect(refreshPackagePolicies).toHaveBeenCalledTimes(1);
+  });
+
   it('renders the table with package policies', async () => {
     const renderer = createIntegrationsTestRendererMock();
     const result = renderer.render(<AgentlessPackagePoliciesTable {...defaultProps} />);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -218,6 +218,9 @@ describe('AgentlessPackagePoliciesTable', () => {
 
     const nameLink = await result.findByTestId('agentlessIntegrationNameLink');
     expect(nameLink.getAttribute('href')).not.toContain('isAgentless');
+    // With the hint suppressed and no `from`, the query string is empty — the href must not
+    // end in a dangling `?`.
+    expect(nameLink.getAttribute('href')).not.toContain('?');
     jest.mocked(ExperimentalFeaturesService.get).mockRestore();
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -6,7 +6,16 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HorizontalAlignment } from '@elastic/eui';
-import { EuiBadge, EuiBasicTable, EuiFlexGroup, EuiFlexItem, EuiLink, EuiText } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiText,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedRelative, FormattedMessage } from '@kbn/i18n-react';
 
@@ -55,6 +64,7 @@ const isConnectorPolicy = (packagePolicy: InMemoryPackagePolicy) =>
 
 export const AgentlessPackagePoliciesTable = ({
   isLoading,
+  error,
   packagePolicies,
   packagePoliciesTotal,
   refreshPackagePolicies,
@@ -62,6 +72,7 @@ export const AgentlessPackagePoliciesTable = ({
   from,
 }: {
   isLoading: boolean;
+  error?: Error | null;
   packagePolicies: Array<{
     agentPolicies: AgentPolicy[];
     packagePolicy: InMemoryPackagePolicy;
@@ -438,6 +449,34 @@ export const AgentlessPackagePoliciesTable = ({
             <FormattedMessage
               id="xpack.fleet.epm.packageDetails.integrationList.loadingPoliciesMessage"
               defaultMessage="Loading integration policies…"
+            />
+          ) : error ? (
+            <EuiEmptyPrompt
+              color="danger"
+              iconType="error"
+              data-test-subj="agentlessPoliciesLoadError"
+              title={
+                <h3>
+                  <FormattedMessage
+                    id="xpack.fleet.epm.packageDetails.integrationList.agentlessLoadErrorTitle"
+                    defaultMessage="Unable to load agentless integration policies"
+                  />
+                </h3>
+              }
+              body={<p>{error.message}</p>}
+              actions={
+                <EuiButton
+                  color="danger"
+                  iconType="refresh"
+                  onClick={refreshPackagePolicies}
+                  data-test-subj="agentlessPoliciesLoadErrorRetryButton"
+                >
+                  <FormattedMessage
+                    id="xpack.fleet.epm.packageDetails.integrationList.agentlessLoadErrorRetry"
+                    defaultMessage="Retry"
+                  />
+                </EuiButton>
+              }
             />
           ) : (
             <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -193,10 +193,9 @@ export const AgentlessPackagePoliciesTable = ({
   useEffect(() => {
     // The agentless save flow sets openEnrollmentFlyout=<packagePolicyId> via
     // appendOnSaveQueryParamsToPath (AgentlessPolicy has no policy_ids, so
-    // policy.id is used). Match on packagePolicy.id accordingly.
-    // TODO: the flyout now takes a decoupled AgentlessEnrollmentFlyoutProps contract;
-    // the remaining work is to source this table from the AgentlessPolicy API and map
-    // AgentlessPolicy -> AgentlessEnrollmentFlyoutProps instead of PackagePolicy.
+    // policy.id is used). Match on packagePolicy.id accordingly. Rows are sourced from the
+    // agentless policies API (see `useAgentlessPolicies`) and mapped to this table's shape;
+    // `packagePolicy.id` / `policy_ids[0]` both equal the agentless policy id.
     const flyoutPolicyIdFromQuery = queryParams.get('openEnrollmentFlyout');
     if (flyoutPolicyIdFromQuery) {
       const pp = packagePolicies.find((p) => p.packagePolicy.id === flyoutPolicyIdFromQuery);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -22,6 +22,7 @@ import type { AgentlessPolicyThroughput } from '../../../../../../../../../commo
 import {
   AGENTS_PREFIX,
   FLEET_CONNECTORS_PACKAGE,
+  IS_AGENTLESS_QUERY_PARAM,
   SO_SEARCH_LIMIT,
 } from '../../../../../../../../../common/constants';
 import type { usePagination } from '../../../../../../hooks';
@@ -225,11 +226,18 @@ export const AgentlessPackagePoliciesTable = ({
               const editHref = getHref('integration_policy_edit', {
                 packagePolicyId: packagePolicy.id,
               });
+              const editParams = new URLSearchParams();
+              if (from) {
+                editParams.set('from', from);
+              }
+              // Hint that this is an agentless policy so the edit page reads/writes through the
+              // agentless API rather than the package-policy API (detect-before-read).
+              editParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
               return (
                 <EuiLink
                   className="eui-textTruncate"
                   data-test-subj="agentlessIntegrationNameLink"
-                  href={from ? `${editHref}?from=${from}` : editHref}
+                  href={`${editHref}?${editParams.toString()}`}
                 >
                   {packagePolicy.name}
                 </EuiLink>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -158,7 +158,7 @@ export const AgentlessPackagePoliciesTable = ({
   // Polls every 30 seconds
   useEffect(() => {
     const fetchAgents = async () => {
-      const { data: agentsData, error } = await sendGetAgents({
+      const { data: agentsData, error: agentsError } = await sendGetAgents({
         perPage: SO_SEARCH_LIMIT,
         kuery: agentsKuery,
       });
@@ -172,8 +172,8 @@ export const AgentlessPackagePoliciesTable = ({
         }, {} as Record<string, Agent>)
       );
 
-      if (error) {
-        notifications.toasts.addError(error, {
+      if (agentsError) {
+        notifications.toasts.addError(agentsError, {
           title: i18n.translate(
             'xpack.fleet.epm.packageDetails.integrationList.agentlessStatusError',
             {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -44,6 +44,7 @@ import {
   useDiscoverLocator,
 } from '../../../../../../hooks';
 import { getAgentlessThroughputIndexPatterns } from '../../../../../../../../../common/services';
+import { isAgentlessPoliciesUIEnabled } from '../../../../../../services';
 import {
   Loading,
   PackagePolicyActionsMenu,
@@ -241,8 +242,12 @@ export const AgentlessPackagePoliciesTable = ({
                 editParams.set('from', from);
               }
               // Hint that this is an agentless policy so the edit page reads/writes through the
-              // agentless API rather than the package-policy API (detect-before-read).
-              editParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
+              // agentless API rather than the package-policy API (detect-before-read). Suppressed
+              // when the agentless policies UI kill switch is off: rows then come from the legacy
+              // list source and edits must route through the legacy APIs too.
+              if (isAgentlessPoliciesUIEnabled()) {
+                editParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
+              }
               return (
                 <EuiLink
                   className="eui-textTruncate"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -248,11 +248,12 @@ export const AgentlessPackagePoliciesTable = ({
               if (isAgentlessPoliciesUIEnabled()) {
                 editParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
               }
+              const editQueryString = editParams.toString();
               return (
                 <EuiLink
                   className="eui-textTruncate"
                   data-test-subj="agentlessIntegrationNameLink"
-                  href={`${editHref}?${editParams.toString()}`}
+                  href={`${editHref}${editQueryString ? `?${editQueryString}` : ''}`}
                 >
                   {packagePolicy.name}
                 </EuiLink>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
@@ -64,8 +64,9 @@ jest.mock('./components/agent_based_table', () => ({
   AgentBasedPackagePoliciesTable: () => null,
 }));
 
+const mockAgentlessTable = jest.fn().mockReturnValue(null);
 jest.mock('./components/agentless_table', () => ({
-  AgentlessPackagePoliciesTable: () => null,
+  AgentlessPackagePoliciesTable: (props: unknown) => mockAgentlessTable(props),
 }));
 
 const packageInfo = {
@@ -77,6 +78,8 @@ const packageInfo = {
 
 const getInstallStatusMock = jest.requireMock('../../../../../hooks')
   .useGetPackageInstallStatus as jest.Mock;
+const useGetPackageInfoByKeyQueryMock = jest.requireMock('../../../../../hooks')
+  .useGetPackageInfoByKeyQuery as jest.Mock;
 
 const renderPage = () => {
   getInstallStatusMock.mockReturnValue(() => ({
@@ -98,6 +101,18 @@ const legacyAgentlessCall = () =>
     );
 
 describe('PackagePoliciesPage agentless table source', () => {
+  beforeEach(() => {
+    // Re-establish defaults for mocks whose return values are overridden per test
+    // (jest.clearAllMocks does not reset mockReturnValue implementations).
+    useGetPackageInfoByKeyQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+    jest.mocked(useAgentlessPolicies).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      resendRequest: jest.fn(),
+    } as unknown as ReturnType<typeof useAgentlessPolicies>);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -113,6 +128,35 @@ describe('PackagePoliciesPage agentless table source', () => {
     const legacyCall = legacyAgentlessCall();
     expect(legacyCall).toBeDefined();
     expect(legacyCall![1]).toEqual({ enabled: false });
+  });
+
+  it('surfaces a full package info fetch failure in the agentless table and retries it', () => {
+    const manifestError = new Error('registry unavailable');
+    const refetchFullPackageInfo = jest.fn();
+    useGetPackageInfoByKeyQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: manifestError,
+      refetch: refetchFullPackageInfo,
+    });
+    const resendAgentlessRequest = jest.fn();
+    jest.mocked(useAgentlessPolicies).mockReturnValue({
+      data: { items: [], total: 3, page: 1, perPage: 10 },
+      isLoading: false,
+      error: null,
+      resendRequest: resendAgentlessRequest,
+    } as unknown as ReturnType<typeof useAgentlessPolicies>);
+
+    renderPage();
+
+    const tableProps = mockAgentlessTable.mock.calls.at(-1)![0];
+    // The manifest error must reach the table: without it the table would render its
+    // "no policies" empty state while the count badge shows the LIST total.
+    expect(tableProps.error).toBe(manifestError);
+
+    tableProps.refreshPackagePolicies();
+    expect(resendAgentlessRequest).toHaveBeenCalled();
+    expect(refetchFullPackageInfo).toHaveBeenCalled();
   });
 
   it('sources the agentless table from the legacy package-policy API when the agentless policies UI is disabled', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { createIntegrationsTestRendererMock } from '../../../../../../../mock';
+import { allowedExperimentalValues } from '../../../../../../../../common/experimental_features';
+import { ExperimentalFeaturesService } from '../../../../../services';
+import type { PackageInfo } from '../../../../../types';
+import { InstallStatus } from '../../../../../types';
+
+import { usePackagePoliciesWithAgentPolicy } from './use_package_policies_with_agent_policy';
+import { useAgentlessPolicies } from './use_agentless_policies';
+import { PackagePoliciesPage } from './package_policies';
+
+jest.mock('../../../../../hooks', () => ({
+  ...jest.requireActual('../../../../../hooks'),
+  useConfirmForceInstall: jest.fn(),
+  useGetPackageInstallStatus: jest.fn().mockReturnValue(() => ({
+    status: 'installed',
+    version: '1.0.0',
+  })),
+  useGetPackageInfoByKeyQuery: jest.fn().mockReturnValue({ data: undefined, isLoading: false }),
+  useIsPackagePolicyUpgradable: jest.fn().mockReturnValue({
+    isPackagePolicyUpgradable: jest.fn().mockReturnValue(false),
+    getPackagePolicyUpgradeReview: jest.fn().mockReturnValue(undefined),
+    getKeepPoliciesUpToDate: jest.fn().mockReturnValue(false),
+    getUpgradeVersion: jest.fn().mockReturnValue(undefined),
+  }),
+}));
+
+jest.mock(
+  '../../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology',
+  () => ({
+    useAgentless: jest.fn().mockReturnValue({
+      getAgentlessStatusForPackage: jest.fn().mockReturnValue({ isAgentless: true }),
+    }),
+  })
+);
+
+jest.mock('./use_package_policies_with_agent_policy', () => ({
+  usePackagePoliciesWithAgentPolicy: jest.fn().mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    resendRequest: jest.fn(),
+  }),
+}));
+
+jest.mock('./use_agentless_policies', () => ({
+  useAgentlessPolicies: jest.fn().mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    resendRequest: jest.fn(),
+  }),
+}));
+
+jest.mock('./components/agent_based_table', () => ({
+  AgentBasedPackagePoliciesTable: () => null,
+}));
+
+jest.mock('./components/agentless_table', () => ({
+  AgentlessPackagePoliciesTable: () => null,
+}));
+
+const packageInfo = {
+  name: 'cspm',
+  title: 'CSPM',
+  version: '1.0.0',
+  type: 'integration',
+} as PackageInfo;
+
+const getInstallStatusMock = jest.requireMock('../../../../../hooks')
+  .useGetPackageInstallStatus as jest.Mock;
+
+const renderPage = () => {
+  getInstallStatusMock.mockReturnValue(() => ({
+    status: InstallStatus.installed,
+    version: '1.0.0',
+  }));
+  const renderer = createIntegrationsTestRendererMock();
+  return renderer.render(<PackagePoliciesPage packageInfo={packageInfo} />);
+};
+
+// The agent-based table's kuery also contains the substring (as `AND NOT ... supports_agentless:
+// true`), so match only the positive filter of the legacy agentless source.
+const legacyAgentlessCall = () =>
+  jest
+    .mocked(usePackagePoliciesWithAgentPolicy)
+    .mock.calls.find(
+      ([query]) =>
+        query.kuery?.includes('supports_agentless: true') && !query.kuery?.includes('NOT')
+    );
+
+describe('PackagePoliciesPage agentless table source', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('sources the agentless table from the agentless policies API when the agentless policies UI is enabled', () => {
+    renderPage();
+
+    expect(jest.mocked(useAgentlessPolicies)).toHaveBeenCalledWith(
+      expect.objectContaining({ kuery: 'package.name: "cspm"' }),
+      { enabled: true }
+    );
+    const legacyCall = legacyAgentlessCall();
+    expect(legacyCall).toBeDefined();
+    expect(legacyCall![1]).toEqual({ enabled: false });
+  });
+
+  it('sources the agentless table from the legacy package-policy API when the agentless policies UI is disabled', () => {
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      enableAgentlessPoliciesUI: false,
+    });
+
+    renderPage();
+
+    expect(jest.mocked(useAgentlessPolicies)).toHaveBeenCalledWith(expect.anything(), {
+      enabled: false,
+    });
+    const legacyCall = legacyAgentlessCall();
+    expect(legacyCall).toBeDefined();
+    expect(legacyCall![1]).toEqual({ enabled: true });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -40,6 +40,8 @@ import { SideBarColumn } from '../../../components/side_bar_column';
 import { useAgentless } from '../../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
 
 import { usePackagePoliciesWithAgentPolicy } from './use_package_policies_with_agent_policy';
+import { useAgentlessPolicies } from './use_agentless_policies';
+import { agentlessPolicyToTableItem } from './agentless_policy_table_adapter';
 import { AgentBasedPackagePoliciesTable } from './components/agent_based_table';
 import { AgentlessPackagePoliciesTable } from './components/agentless_table';
 
@@ -162,20 +164,28 @@ export const PackagePoliciesPage = ({
       rowIndex: number;
     }>
   >([]);
+  // Agentless deployments are read through the agentless policies LIST API (not the
+  // package-policy LIST + bulk agent-policy reads). The server scopes the result set to
+  // agentless, so we only filter by package name; each AgentlessPolicy is mapped to the
+  // table's `{ packagePolicy, agentPolicies }` row shape before the shared enrichment.
   const {
     data: agentlessData,
     isLoading: agentlessIsLoading,
     resendRequest: refreshAgentlessPolicies,
-  } = usePackagePoliciesWithAgentPolicy({
+  } = useAgentlessPolicies({
     page: agentlessPagination.currentPage,
     perPage: agentlessPagination.pageSize,
-    kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: "${name}" AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.supports_agentless: true`,
+    kuery: `package.name: "${name}"`,
   });
   useEffect(() => {
     setAgentlessPackageAndAgentPolicies(
-      !agentlessData?.items ? [] : agentlessData.items.map(mapPoliciesData)
+      !agentlessData?.items
+        ? []
+        : agentlessData.items.map((agentlessPolicy, index) =>
+            mapPoliciesData(agentlessPolicyToTableItem(agentlessPolicy, packageInfo), index)
+          )
     );
-  }, [agentlessData, mapPoliciesData]);
+  }, [agentlessData, mapPoliciesData, packageInfo]);
 
   // if they arrive at this page and the package is not installed, send them to overview
   // this happens if they arrive with a direct url or they uninstall while on this tab

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -98,6 +98,11 @@ export const PackagePoliciesPage = ({
   } = useGetPackageInfoByKeyQuery(
     name,
     version,
+    // `prerelease` is inert on a specific-version GET: the requested version is returned either
+    // way, and the flag only shapes the `latestVersion` metadata, which this path never reads
+    // (only the manifest's policy templates/inputs, for expansion). Hardcoded so the fetch does
+    // not have to wait on a settings read like the edit/copy paths, whose loaders resolve it
+    // from settings as part of a sequential load.
     { full: true, prerelease: true },
     // Only the agentless-API adapter path needs the full manifest; the legacy source
     // returns full package policies that need no re-expansion.

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -33,6 +33,7 @@ import {
   AgentPolicyRefreshContext,
   useIsPackagePolicyUpgradable,
   usePagination,
+  useGetPackageInfoByKeyQuery,
 } from '../../../../../hooks';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../../../constants';
 import { SideBarColumn } from '../../../components/side_bar_column';
@@ -79,6 +80,20 @@ export const PackagePoliciesPage = ({
     () => getAgentlessStatusForPackage(packageInfo).isAgentless,
     [getAgentlessStatusForPackage, packageInfo]
   );
+
+  // The agentless deployments table re-derives each policy's inputs from the package manifest
+  // (agentless policies come from the LIST API with simplified object inputs). That requires the
+  // FULL package info: the detail page's `packageInfo` is fetched without `full: true`, so its
+  // policy templates carry no `inputs` and the expansion would throw `Input not found`. Fetch the
+  // full manifest only when agentless policies are possible.
+  const { data: agentlessFullPackageInfoData, isLoading: isAgentlessFullPackageInfoLoading } =
+    useGetPackageInfoByKeyQuery(
+      name,
+      version,
+      { full: true, prerelease: true },
+      { enabled: canHaveAgentlessPolicies }
+    );
+  const agentlessFullPackageInfo = agentlessFullPackageInfoData?.item;
 
   // Helper function to map raw policies data for consumption by the table
   const mapPoliciesData = useCallback(
@@ -178,14 +193,21 @@ export const PackagePoliciesPage = ({
     kuery: `package.name: "${name}"`,
   });
   useEffect(() => {
+    // Expansion needs the full manifest (see `agentlessFullPackageInfo` above); wait for it so we
+    // don't hydrate against the input-less detail-page `packageInfo`.
+    if (!agentlessData?.items || !agentlessFullPackageInfo) {
+      setAgentlessPackageAndAgentPolicies([]);
+      return;
+    }
     setAgentlessPackageAndAgentPolicies(
-      !agentlessData?.items
-        ? []
-        : agentlessData.items.map((agentlessPolicy, index) =>
-            mapPoliciesData(agentlessPolicyToTableItem(agentlessPolicy, packageInfo), index)
-          )
+      agentlessData.items.map((agentlessPolicy, index) =>
+        mapPoliciesData(
+          agentlessPolicyToTableItem(agentlessPolicy, agentlessFullPackageInfo),
+          index
+        )
+      )
     );
-  }, [agentlessData, mapPoliciesData, packageInfo]);
+  }, [agentlessData, mapPoliciesData, agentlessFullPackageInfo]);
 
   // if they arrive at this page and the package is not installed, send them to overview
   // this happens if they arrive with a direct url or they uninstall while on this tab
@@ -260,7 +282,7 @@ export const PackagePoliciesPage = ({
                 <EuiSpacer size="m" />
                 <EuiPanel hasBorder={true} hasShadow={false}>
                   <AgentlessPackagePoliciesTable
-                    isLoading={agentlessIsLoading}
+                    isLoading={agentlessIsLoading || isAgentlessFullPackageInfoLoading}
                     packagePolicies={agentlessPackageAndAgentPolicies}
                     packagePoliciesTotal={agentlessData?.total ?? 0}
                     refreshPackagePolicies={refreshAgentlessPolicies}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -186,6 +186,7 @@ export const PackagePoliciesPage = ({
   const {
     data: agentlessData,
     isLoading: agentlessIsLoading,
+    error: agentlessError,
     resendRequest: refreshAgentlessPolicies,
   } = useAgentlessPolicies({
     page: agentlessPagination.currentPage,
@@ -283,6 +284,7 @@ export const PackagePoliciesPage = ({
                 <EuiPanel hasBorder={true} hasShadow={false}>
                   <AgentlessPackagePoliciesTable
                     isLoading={agentlessIsLoading || isAgentlessFullPackageInfoLoading}
+                    error={agentlessError}
                     packagePolicies={agentlessPackageAndAgentPolicies}
                     packagePoliciesTotal={agentlessData?.total ?? 0}
                     refreshPackagePolicies={refreshAgentlessPolicies}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -90,15 +90,19 @@ export const PackagePoliciesPage = ({
   // FULL package info: the detail page's `packageInfo` is fetched without `full: true`, so its
   // policy templates carry no `inputs` and the expansion would throw `Input not found`. Fetch the
   // full manifest only when agentless policies are possible.
-  const { data: agentlessFullPackageInfoData, isLoading: isAgentlessFullPackageInfoLoading } =
-    useGetPackageInfoByKeyQuery(
-      name,
-      version,
-      { full: true, prerelease: true },
-      // Only the agentless-API adapter path needs the full manifest; the legacy source
-      // returns full package policies that need no re-expansion.
-      { enabled: canHaveAgentlessPolicies && agentlessUIEnabled }
-    );
+  const {
+    data: agentlessFullPackageInfoData,
+    isLoading: isAgentlessFullPackageInfoLoading,
+    error: agentlessFullPackageInfoError,
+    refetch: refetchAgentlessFullPackageInfo,
+  } = useGetPackageInfoByKeyQuery(
+    name,
+    version,
+    { full: true, prerelease: true },
+    // Only the agentless-API adapter path needs the full manifest; the legacy source
+    // returns full package policies that need no re-expansion.
+    { enabled: canHaveAgentlessPolicies && agentlessUIEnabled }
+  );
   const agentlessFullPackageInfo = agentlessFullPackageInfoData?.item;
 
   // Helper function to map raw policies data for consumption by the table
@@ -253,8 +257,15 @@ export const PackagePoliciesPage = ({
     ? {
         total: agentlessData?.total ?? 0,
         isLoading: agentlessIsLoading || isAgentlessFullPackageInfoLoading,
-        error: agentlessError as Error | null,
-        refresh: refreshAgentlessPolicies,
+        // The table needs both requests: a failed manifest fetch would otherwise leave the
+        // table silently empty while the LIST-sourced count badge shows the real total.
+        error: agentlessError ?? agentlessFullPackageInfoError ?? null,
+        refresh: () => {
+          refreshAgentlessPolicies();
+          if (agentlessFullPackageInfoError) {
+            refetchAgentlessFullPackageInfo();
+          }
+        },
       }
     : {
         total: legacyAgentlessData?.total ?? 0,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -36,6 +36,7 @@ import {
   useGetPackageInfoByKeyQuery,
 } from '../../../../../hooks';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../../../constants';
+import { isAgentlessPoliciesUIEnabled } from '../../../../../services';
 import { SideBarColumn } from '../../../components/side_bar_column';
 
 import { useAgentless } from '../../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
@@ -80,6 +81,9 @@ export const PackagePoliciesPage = ({
     () => getAgentlessStatusForPackage(packageInfo).isAgentless,
     [getAgentlessStatusForPackage, packageInfo]
   );
+  // Kill switch: when off, the agentless deployments table is sourced from the legacy
+  // package-policy LIST + bulk agent-policy reads instead of the agentless policies API.
+  const agentlessUIEnabled = isAgentlessPoliciesUIEnabled();
 
   // The agentless deployments table re-derives each policy's inputs from the package manifest
   // (agentless policies come from the LIST API with simplified object inputs). That requires the
@@ -91,7 +95,9 @@ export const PackagePoliciesPage = ({
       name,
       version,
       { full: true, prerelease: true },
-      { enabled: canHaveAgentlessPolicies }
+      // Only the agentless-API adapter path needs the full manifest; the legacy source
+      // returns full package policies that need no re-expansion.
+      { enabled: canHaveAgentlessPolicies && agentlessUIEnabled }
     );
   const agentlessFullPackageInfo = agentlessFullPackageInfoData?.item;
 
@@ -188,12 +194,37 @@ export const PackagePoliciesPage = ({
     isLoading: agentlessIsLoading,
     error: agentlessError,
     resendRequest: refreshAgentlessPolicies,
-  } = useAgentlessPolicies({
-    page: agentlessPagination.currentPage,
-    perPage: agentlessPagination.pageSize,
-    kuery: `package.name: "${name}"`,
-  });
+  } = useAgentlessPolicies(
+    {
+      page: agentlessPagination.currentPage,
+      perPage: agentlessPagination.pageSize,
+      kuery: `package.name: "${name}"`,
+    },
+    { enabled: canHaveAgentlessPolicies && agentlessUIEnabled }
+  );
+  // Legacy source for the agentless table, active only when the agentless policies UI kill
+  // switch is off: the pre-migration package-policy LIST (scoped to `supports_agentless`) plus
+  // the bulk agent-policy enrichment.
+  const {
+    data: legacyAgentlessData,
+    isLoading: legacyAgentlessIsLoading,
+    error: legacyAgentlessError,
+    resendRequest: refreshLegacyAgentlessPolicies,
+  } = usePackagePoliciesWithAgentPolicy(
+    {
+      page: agentlessPagination.currentPage,
+      perPage: agentlessPagination.pageSize,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: "${name}" AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.supports_agentless: true`,
+    },
+    { enabled: canHaveAgentlessPolicies && !agentlessUIEnabled }
+  );
   useEffect(() => {
+    if (!agentlessUIEnabled) {
+      setAgentlessPackageAndAgentPolicies(
+        !legacyAgentlessData?.items ? [] : legacyAgentlessData.items.map(mapPoliciesData)
+      );
+      return;
+    }
     // Expansion needs the full manifest (see `agentlessFullPackageInfo` above); wait for it so we
     // don't hydrate against the input-less detail-page `packageInfo`.
     if (!agentlessData?.items || !agentlessFullPackageInfo) {
@@ -208,7 +239,29 @@ export const PackagePoliciesPage = ({
         )
       )
     );
-  }, [agentlessData, mapPoliciesData, agentlessFullPackageInfo]);
+  }, [
+    agentlessUIEnabled,
+    agentlessData,
+    legacyAgentlessData,
+    mapPoliciesData,
+    agentlessFullPackageInfo,
+  ]);
+
+  // Per-flag view of the active agentless source. Never read loading state from the inactive
+  // source: a disabled react-query query reports `isLoading: true` forever.
+  const agentlessTableSource = agentlessUIEnabled
+    ? {
+        total: agentlessData?.total ?? 0,
+        isLoading: agentlessIsLoading || isAgentlessFullPackageInfoLoading,
+        error: agentlessError as Error | null,
+        refresh: refreshAgentlessPolicies,
+      }
+    : {
+        total: legacyAgentlessData?.total ?? 0,
+        isLoading: legacyAgentlessIsLoading,
+        error: legacyAgentlessError,
+        refresh: refreshLegacyAgentlessPolicies,
+      };
 
   // if they arrive at this page and the package is not installed, send them to overview
   // this happens if they arrive with a direct url or they uninstall while on this tab
@@ -228,7 +281,7 @@ export const PackagePoliciesPage = ({
       value={{
         refresh: () => {
           refreshAgentBasedPolicies();
-          refreshAgentlessPolicies();
+          agentlessTableSource.refresh();
         },
       }}
     >
@@ -274,7 +327,7 @@ export const PackagePoliciesPage = ({
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiNotificationBadge color="subdued" size="m">
-                        <h4>{agentlessData?.total ?? 0}</h4>
+                        <h4>{agentlessTableSource.total}</h4>
                       </EuiNotificationBadge>
                     </EuiFlexItem>
                   </EuiFlexGroup>
@@ -283,11 +336,11 @@ export const PackagePoliciesPage = ({
                 <EuiSpacer size="m" />
                 <EuiPanel hasBorder={true} hasShadow={false}>
                   <AgentlessPackagePoliciesTable
-                    isLoading={agentlessIsLoading || isAgentlessFullPackageInfoLoading}
-                    error={agentlessError}
+                    isLoading={agentlessTableSource.isLoading}
+                    error={agentlessTableSource.error}
                     packagePolicies={agentlessPackageAndAgentPolicies}
-                    packagePoliciesTotal={agentlessData?.total ?? 0}
-                    refreshPackagePolicies={refreshAgentlessPolicies}
+                    packagePoliciesTotal={agentlessTableSource.total}
+                    refreshPackagePolicies={agentlessTableSource.refresh}
                     pagination={{
                       pagination: agentlessPagination,
                       pageSizeOptions: agentlessPageSizeOptions,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+
+import { sendListAgentlessPolicies } from '../../../../../hooks';
+
+/**
+ * Read agentless deployments through the agentless policies LIST API instead of the
+ * package-policy LIST + bulk agent-policy reads. The server already scopes the result set to
+ * agentless policies, so callers only pass a package-name `kuery` (fields are prefixed with the
+ * package-policy saved-object type server-side).
+ */
+export const useAgentlessPolicies = ({
+  page,
+  perPage,
+  kuery,
+}: {
+  page: number;
+  perPage: number;
+  kuery?: string;
+}) => {
+  const { data, isLoading, error, refetch } = useQuery(
+    ['agentlessPolicies', page, perPage, kuery],
+    () => sendListAgentlessPolicies({ page, perPage, kuery }),
+    { refetchOnWindowFocus: false }
+  );
+
+  return { data, isLoading, error: error ?? null, resendRequest: refetch };
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
@@ -16,22 +16,25 @@ import type { RequestError } from '../../../../../hooks';
  * agentless policies, so callers only pass a package-name `kuery` (fields are prefixed with the
  * package-policy saved-object type server-side).
  */
-export const useAgentlessPolicies = ({
-  page,
-  perPage,
-  kuery,
-}: {
-  page: number;
-  perPage: number;
-  kuery?: string;
-}) => {
+export const useAgentlessPolicies = (
+  {
+    page,
+    perPage,
+    kuery,
+  }: {
+    page: number;
+    perPage: number;
+    kuery?: string;
+  },
+  options: { enabled?: boolean } = {}
+) => {
   const { data, isLoading, error, refetch } = useQuery<
     Awaited<ReturnType<typeof sendListAgentlessPolicies>>,
     RequestError
   >(
     ['agentlessPolicies', page, perPage, kuery],
     () => sendListAgentlessPolicies({ page, perPage, kuery }),
-    { refetchOnWindowFocus: false }
+    { refetchOnWindowFocus: false, enabled: options.enabled ?? true }
   );
 
   return { data, isLoading, error: error ?? null, resendRequest: refetch };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
@@ -8,6 +8,7 @@
 import { useQuery } from '@kbn/react-query';
 
 import { sendListAgentlessPolicies } from '../../../../../hooks';
+import type { RequestError } from '../../../../../hooks';
 
 /**
  * Read agentless deployments through the agentless policies LIST API instead of the
@@ -26,7 +27,7 @@ export const useAgentlessPolicies = ({
 }) => {
   const { data, isLoading, error, refetch } = useQuery<
     Awaited<ReturnType<typeof sendListAgentlessPolicies>>,
-    Error
+    RequestError
   >(
     ['agentlessPolicies', page, perPage, kuery],
     () => sendListAgentlessPolicies({ page, perPage, kuery }),

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_agentless_policies.ts
@@ -24,7 +24,10 @@ export const useAgentlessPolicies = ({
   perPage: number;
   kuery?: string;
 }) => {
-  const { data, isLoading, error, refetch } = useQuery(
+  const { data, isLoading, error, refetch } = useQuery<
+    Awaited<ReturnType<typeof sendListAgentlessPolicies>>,
+    Error
+  >(
     ['agentlessPolicies', page, perPage, kuery],
     () => sendListAgentlessPolicies({ page, perPage, kuery }),
     { refetchOnWindowFocus: false }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_package_policies_with_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_package_policies_with_agent_policy.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useConditionalRequest } from '../../../../../hooks';
+
+import { usePackagePoliciesWithAgentPolicy } from './use_package_policies_with_agent_policy';
+
+jest.mock('../../../../../hooks', () => ({
+  ...jest.requireActual('../../../../../hooks'),
+  useConditionalRequest: jest.fn().mockReturnValue({
+    data: null,
+    error: null,
+    isLoading: false,
+    sendRequest: jest.fn(),
+  }),
+}));
+
+describe('usePackagePoliciesWithAgentPolicy', () => {
+  beforeEach(() => {
+    jest.mocked(useConditionalRequest).mockClear();
+  });
+
+  it('sends the package-policy list request by default', () => {
+    renderHook(() => usePackagePoliciesWithAgentPolicy({ page: 1, perPage: 10, kuery: 'foo' }));
+
+    expect(jest.mocked(useConditionalRequest)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        query: { page: 1, perPage: 10, kuery: 'foo' },
+        shouldSendRequest: true,
+      })
+    );
+  });
+
+  it('sends no requests when disabled', () => {
+    renderHook(() =>
+      usePackagePoliciesWithAgentPolicy({ page: 1, perPage: 10 }, { enabled: false })
+    );
+
+    // Both the package-policy list request and the bulk agent-policy request are skipped.
+    for (const [config] of jest.mocked(useConditionalRequest).mock.calls) {
+      expect(config.shouldSendRequest).toBe(false);
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_package_policies_with_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_package_policies_with_agent_policy.ts
@@ -15,8 +15,9 @@ import type {
   GetAgentPoliciesResponseItem,
   GetPackagePoliciesResponse,
 } from '../../../../../types';
-import { agentPolicyRouteService } from '../../../../../services';
-import { useGetPackagePolicies, useConditionalRequest } from '../../../../../hooks';
+import { agentPolicyRouteService, packagePolicyRouteService } from '../../../../../services';
+import { useConditionalRequest } from '../../../../../hooks';
+import type { useGetPackagePolicies } from '../../../../../hooks';
 import type { SendConditionalRequestConfig } from '../../../../../hooks';
 
 export interface PackagePolicyAndAgentPolicy {
@@ -35,19 +36,29 @@ type GetPackagePoliciesWithAgentPolicy = Omit<GetPackagePoliciesResponse, 'items
  * @param query
  */
 export const usePackagePoliciesWithAgentPolicy = (
-  query: Parameters<typeof useGetPackagePolicies>[0]
+  query: Parameters<typeof useGetPackagePolicies>[0],
+  // `enabled: false` skips both requests; the agentless deployments table uses this to keep the
+  // legacy source mounted-but-idle while the agentless policies API is the active source.
+  options: { enabled?: boolean } = {}
 ): {
   isLoading: boolean;
   error: Error | null;
   data?: GetPackagePoliciesWithAgentPolicy;
   resendRequest: () => void;
 } => {
+  const enabled = options.enabled ?? true;
   const {
     data: packagePoliciesData,
     error,
     isLoading: isLoadingPackagePolicies,
-    resendRequest,
-  } = useGetPackagePolicies(query);
+    sendRequest: resendRequest,
+  } = useConditionalRequest<GetPackagePoliciesResponse>({
+    method: 'get',
+    path: packagePolicyRouteService.getListPath(),
+    query,
+    version: API_VERSIONS.public.v1,
+    shouldSendRequest: enabled,
+  } as SendConditionalRequestConfig);
 
   const agentPoliciesIds = useMemo<string[]>(() => {
     if (!packagePoliciesData?.items.length) {
@@ -74,7 +85,7 @@ export const usePackagePoliciesWithAgentPolicy = (
         ignoreMissing: true,
       },
       version: API_VERSIONS.public.v1,
-      shouldSendRequest: agentPoliciesIds.length > 0,
+      shouldSendRequest: enabled && agentPoliciesIds.length > 0,
     } as SendConditionalRequestConfig);
 
   const [enrichedData, setEnrichedData] = useState<GetPackagePoliciesWithAgentPolicy | undefined>();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.test.tsx
@@ -36,6 +36,7 @@ jest.mock('../../../../../hooks', () => {
       },
     }),
     useUpgradePackagePolicyDryRunQuery: jest.fn().mockReturnValue({ data: null }),
+    useUpgradeAgentlessPoliciesDryRunQuery: jest.fn().mockReturnValue({ data: null }),
     useUpdatePackageMutation: jest.fn().mockReturnValue({ mutate: jest.fn() }),
     useAuthz: jest.fn(),
     useConfirmForceInstall: jest.fn().mockReturnValue(jest.fn()),
@@ -59,6 +60,7 @@ jest.mock('../../../../../services', () => ({
   ExperimentalFeaturesService: {
     get: jest.fn().mockReturnValue({ enablePackageRollback: true }),
   },
+  isAgentlessPoliciesUIEnabled: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../../installed_integrations/hooks/use_installed_integrations_actions', () => ({
@@ -70,7 +72,14 @@ jest.mock('../../installed_integrations/hooks/use_installed_integrations_actions
 }));
 
 // Import after mocks are defined
-import { useGetPackageInstallStatus, useAuthz } from '../../../../../hooks';
+import {
+  useGetPackageInstallStatus,
+  useAuthz,
+  useGetPackagePoliciesQuery,
+  useUpgradePackagePolicyDryRunQuery,
+  useUpgradeAgentlessPoliciesDryRunQuery,
+} from '../../../../../hooks';
+import { isAgentlessPoliciesUIEnabled } from '../../../../../services';
 
 import { SettingsPage } from './settings';
 
@@ -204,6 +213,60 @@ describe('SettingsPage', () => {
       // Should show version info instead of install section
       expect(result.getByText('Installed version')).toBeInTheDocument();
       expect(result.queryByTestId('installPermissionCallout')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('agentless upgrade partition', () => {
+    const policies = [
+      { id: 'agent-based-policy', supports_agentless: false, policy_ids: [] },
+      { id: 'agentless-policy', supports_agentless: true, policy_ids: [] },
+    ];
+
+    beforeEach(() => {
+      mockUseGetPackageInstallStatus.mockReturnValue(() => ({
+        status: InstallStatus.installed,
+        version: '1.3.0',
+      }));
+      mockUseAuthz.mockReturnValue({
+        fleet: { readSettings: true },
+        integrations: { installPackages: true, writePackageSettings: true },
+      });
+      jest.mocked(useGetPackagePoliciesQuery).mockReturnValue({
+        data: { items: policies },
+      } as any);
+    });
+
+    afterEach(() => {
+      jest.mocked(useGetPackagePoliciesQuery).mockReturnValue({ data: { items: [] } } as any);
+      jest.mocked(isAgentlessPoliciesUIEnabled).mockReturnValue(true);
+    });
+
+    const installedPackageInfo = {
+      ...basePackageInfo,
+      status: 'installed',
+    } as PackageInfo;
+
+    it('routes agentless policies to the agentless dry-run when the agentless policies UI is enabled', () => {
+      renderComponent(installedPackageInfo);
+
+      expect(jest.mocked(useUpgradePackagePolicyDryRunQuery).mock.calls[0][0]).toEqual([
+        'agent-based-policy',
+      ]);
+      expect(jest.mocked(useUpgradeAgentlessPoliciesDryRunQuery).mock.calls[0][0]).toEqual([
+        'agentless-policy',
+      ]);
+    });
+
+    it('routes all policies to the legacy dry-run when the agentless policies UI is disabled', () => {
+      jest.mocked(isAgentlessPoliciesUIEnabled).mockReturnValue(false);
+
+      renderComponent(installedPackageInfo);
+
+      expect(jest.mocked(useUpgradePackagePolicyDryRunQuery).mock.calls[0][0]).toEqual([
+        'agent-based-policy',
+        'agentless-policy',
+      ]);
+      expect(jest.mocked(useUpgradeAgentlessPoliciesDryRunQuery).mock.calls[0][0]).toEqual([]);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -32,6 +32,7 @@ import {
   useLink,
   useStartServices,
   useUpgradePackagePolicyDryRunQuery,
+  useUpgradeAgentlessPoliciesDryRunQuery,
   useUpdatePackageMutation,
   useAuthz,
 } from '../../../../../hooks';
@@ -143,8 +144,22 @@ export const SettingsPage: React.FC<Props> = memo(
       error: changelogError,
     } = useChangelog(name, latestVersion, version);
 
+    // Agentless package policies must upgrade through the agentless API, not the
+    // (deprecated-for-agentless) package-policy API. Partition by `supports_agentless`
+    // so each set goes to its own upgrade + dry-run endpoint.
+    const agentlessPolicyIds = useMemo(
+      () =>
+        packagePoliciesData?.items
+          .filter((packagePolicy) => packagePolicy.supports_agentless === true)
+          .map(({ id }) => id) ?? [],
+      [packagePoliciesData]
+    );
+
     const packagePolicyIds = useMemo(
-      () => packagePoliciesData?.items.map(({ id }) => id),
+      () =>
+        packagePoliciesData?.items
+          .filter((packagePolicy) => packagePolicy.supports_agentless !== true)
+          .map(({ id }) => id) ?? [],
       [packagePoliciesData]
     );
 
@@ -154,10 +169,18 @@ export const SettingsPage: React.FC<Props> = memo(
     );
 
     const { data: dryRunData } = useUpgradePackagePolicyDryRunQuery(
-      packagePolicyIds ?? [],
+      packagePolicyIds,
       latestVersion,
       {
-        enabled: packagePolicyIds && packagePolicyIds.length > 0,
+        enabled: packagePolicyIds.length > 0,
+      }
+    );
+
+    const { data: agentlessDryRunData } = useUpgradeAgentlessPoliciesDryRunQuery(
+      agentlessPolicyIds,
+      latestVersion,
+      {
+        enabled: agentlessPolicyIds.length > 0,
       }
     );
 
@@ -427,7 +450,9 @@ export const SettingsPage: React.FC<Props> = memo(
                           version={latestVersion}
                           agentPolicyIds={agentPolicyIds}
                           packagePolicyIds={packagePolicyIds}
+                          agentlessPolicyIds={agentlessPolicyIds}
                           dryRunData={dryRunData}
+                          agentlessDryRunData={agentlessDryRunData}
                           isUpgradingPackagePolicies={isUpgradingPackagePolicies}
                           setIsUpgradingPackagePolicies={setIsUpgradingPackagePolicies}
                           startServices={startServices}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -49,7 +49,7 @@ import { useSpaceSettingsContext } from '../../../../../../../hooks/use_space_se
 import { KeepPoliciesUpToDateSwitch, NamespaceCustomizationSection } from '../components';
 import { useChangelog } from '../hooks';
 
-import { ExperimentalFeaturesService } from '../../../../../services';
+import { ExperimentalFeaturesService, isAgentlessPoliciesUIEnabled } from '../../../../../services';
 
 import { DeprecationCallout, DeprecatedFeaturesCallout } from '../overview/deprecation_callout';
 
@@ -146,21 +146,28 @@ export const SettingsPage: React.FC<Props> = memo(
 
     // Agentless package policies must upgrade through the agentless API, not the
     // (deprecated-for-agentless) package-policy API. Partition by `supports_agentless`
-    // so each set goes to its own upgrade + dry-run endpoint.
+    // so each set goes to its own upgrade + dry-run endpoint. When the agentless policies UI
+    // kill switch is off, everything stays on the legacy package-policy upgrade path (the
+    // agentless partition is empty, so its dry-run and upgrade calls never fire).
+    const agentlessUIEnabled = isAgentlessPoliciesUIEnabled();
     const agentlessPolicyIds = useMemo(
       () =>
-        packagePoliciesData?.items
-          .filter((packagePolicy) => packagePolicy.supports_agentless === true)
-          .map(({ id }) => id) ?? [],
-      [packagePoliciesData]
+        agentlessUIEnabled
+          ? packagePoliciesData?.items
+              .filter((packagePolicy) => packagePolicy.supports_agentless === true)
+              .map(({ id }) => id) ?? []
+          : [],
+      [packagePoliciesData, agentlessUIEnabled]
     );
 
     const packagePolicyIds = useMemo(
       () =>
         packagePoliciesData?.items
-          .filter((packagePolicy) => packagePolicy.supports_agentless !== true)
+          .filter(
+            (packagePolicy) => !agentlessUIEnabled || packagePolicy.supports_agentless !== true
+          )
           .map(({ id }) => id) ?? [],
-      [packagePoliciesData]
+      [packagePoliciesData, agentlessUIEnabled]
     );
 
     const agentPolicyIds = useMemo(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.test.tsx
@@ -121,6 +121,60 @@ describe('UpdateButton agentless dry-run guard failures', () => {
     expect(toasts.addWarning).not.toHaveBeenCalled();
   });
 
+  it('reports which policies failed a partial bulk upgrade, with the error message', async () => {
+    mockSendBulkUpgradeAgentlessPolicies.mockResolvedValue([
+      { id: 'agentless-ok', name: 'ok-policy', success: true },
+      {
+        id: 'agentless-broken',
+        name: 'broken-policy',
+        success: false,
+        statusCode: 500,
+        body: { message: 'mapping failed' },
+      },
+    ]);
+
+    const { toasts } = await renderAndConfirmUpgrade({
+      agentlessPolicyIds: ['agentless-ok', 'agentless-broken'],
+      agentlessDryRunData: [
+        { id: 'agentless-ok', name: 'ok-policy', hasErrors: false },
+        { id: 'agentless-broken', name: 'broken-policy', hasErrors: false },
+      ],
+    });
+
+    // The toast must name the failed policy and carry the API's error message — a bare count
+    // leaves the operator unable to tell which policies to fix.
+    await waitFor(() =>
+      expect(toasts.addWarning).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining('Error upgrading agentless policies'),
+          text: expect.stringContaining('broken-policy'),
+        })
+      )
+    );
+    expect(toasts.addWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('mapping failed') })
+    );
+    const warningText = (toasts.addWarning as jest.Mock).mock.calls[0][0].text;
+    expect(warningText).not.toContain('ok-policy');
+  });
+
+  it('falls back to the policy id in the partial-failure toast when the result has no name', async () => {
+    mockSendBulkUpgradeAgentlessPolicies.mockResolvedValue([
+      { id: 'agentless-broken', success: false, statusCode: 500 },
+    ]);
+
+    const { toasts } = await renderAndConfirmUpgrade({
+      agentlessPolicyIds: ['agentless-broken'],
+      agentlessDryRunData: [{ id: 'agentless-broken', hasErrors: false }],
+    });
+
+    await waitFor(() => expect(toasts.addWarning).toHaveBeenCalled());
+    const warningText = (toasts.addWarning as jest.Mock).mock.calls[0][0].text;
+    expect(warningText).toContain('agentless-broken');
+    // No per-policy error message in the response — no dangling "Error:" suffix.
+    expect(warningText).not.toContain('Error:');
+  });
+
   it('does not warn about config-migration conflicts (announced in the modal instead)', async () => {
     const { toasts } = await renderAndConfirmUpgrade({
       agentlessPolicyIds: ['agentless-ok', 'agentless-conflict'],

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+
+import { createIntegrationsTestRendererMock } from '../../../../../../../mock';
+
+import { UpdateButton } from './update_button';
+
+const mockInstallPackage = jest.fn();
+const mockSendBulkUpgradeAgentlessPolicies = jest.fn();
+const mockUpgradePoliciesMutateAsync = jest.fn();
+
+jest.mock('../../../../../hooks', () => ({
+  ...jest.requireActual('../../../../../hooks'),
+  useConfirmForceInstall: jest.fn(),
+  useInstallPackage: () => mockInstallPackage,
+  useGetPackageInstallStatus: () => () => ({ status: 'installed', version: '1.0.0' }),
+  useAuthz: () => ({ integrations: { upgradePackages: true } }),
+  useLink: () => ({ getPath: (page: string) => `/mock/${page}` }),
+  useUpgradePackagePoliciesMutation: () => ({ mutateAsync: mockUpgradePoliciesMutateAsync }),
+  useBulkGetAgentPoliciesQuery: () => ({ data: undefined }),
+  sendBulkUpgradeAgentlessPolicies: (...args: unknown[]) =>
+    mockSendBulkUpgradeAgentlessPolicies(...args),
+}));
+
+const defaultProps = {
+  name: 'nginx',
+  title: 'Nginx',
+  version: '2.0.0',
+  packagePolicyIds: [],
+  agentPolicyIds: [],
+};
+
+const renderAndConfirmUpgrade = async (
+  props: Partial<React.ComponentProps<typeof UpdateButton>>
+) => {
+  const renderer = createIntegrationsTestRendererMock();
+  const utils = renderer.render(
+    <UpdateButton {...defaultProps} startServices={renderer.startServices} {...props} />
+  );
+
+  fireEvent.click(utils.getByTestId('updatePackageBtn'));
+  await waitFor(() => expect(utils.getByTestId('confirmModalConfirmButton')).toBeInTheDocument());
+  fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
+
+  return { utils, toasts: renderer.startServices.notifications.toasts };
+};
+
+describe('UpdateButton agentless dry-run guard failures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInstallPackage.mockResolvedValue(true);
+    mockSendBulkUpgradeAgentlessPolicies.mockResolvedValue([{ id: 'agentless-ok', success: true }]);
+  });
+
+  it('warns about skipped guard-failure policies instead of silently omitting them', async () => {
+    const { toasts } = await renderAndConfirmUpgrade({
+      agentlessPolicyIds: ['agentless-ok', 'agentless-gone'],
+      agentlessDryRunData: [
+        { id: 'agentless-ok', name: 'ok-policy', hasErrors: false },
+        // A guard failure: the dry-run itself failed for this policy (e.g. deleted mid-flight).
+        { id: 'agentless-gone', name: 'gone-policy', hasErrors: true, statusCode: 404 },
+      ],
+    });
+
+    // The guard-failure policy stays excluded from the upgrade set.
+    await waitFor(() =>
+      expect(mockSendBulkUpgradeAgentlessPolicies).toHaveBeenCalledWith(['agentless-ok'])
+    );
+
+    // The skip is announced: the success toast alone must not read as a full upgrade.
+    expect(toasts.addWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('1 agentless policy'),
+        text: expect.stringContaining('gone-policy'),
+      })
+    );
+  });
+
+  it('falls back to the policy id in the skip warning when the dry-run entry has no name', async () => {
+    const { toasts } = await renderAndConfirmUpgrade({
+      agentlessPolicyIds: ['agentless-ok', 'agentless-gone'],
+      agentlessDryRunData: [
+        { id: 'agentless-ok', hasErrors: false },
+        { id: 'agentless-gone', hasErrors: true, statusCode: 404 },
+      ],
+    });
+
+    await waitFor(() => expect(toasts.addWarning).toHaveBeenCalled());
+    expect(toasts.addWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('agentless-gone') })
+    );
+  });
+
+  it('does not warn when the dry-run reports no guard failures', async () => {
+    mockSendBulkUpgradeAgentlessPolicies.mockResolvedValue([
+      { id: 'agentless-ok', success: true },
+      { id: 'agentless-also-ok', success: true },
+    ]);
+
+    const { toasts } = await renderAndConfirmUpgrade({
+      agentlessPolicyIds: ['agentless-ok', 'agentless-also-ok'],
+      agentlessDryRunData: [
+        { id: 'agentless-ok', name: 'ok-policy', hasErrors: false },
+        { id: 'agentless-also-ok', name: 'also-ok-policy', hasErrors: false },
+      ],
+    });
+
+    await waitFor(() =>
+      expect(mockSendBulkUpgradeAgentlessPolicies).toHaveBeenCalledWith([
+        'agentless-ok',
+        'agentless-also-ok',
+      ])
+    );
+    expect(toasts.addWarning).not.toHaveBeenCalled();
+  });
+
+  it('does not warn about config-migration conflicts (announced in the modal instead)', async () => {
+    const { toasts } = await renderAndConfirmUpgrade({
+      agentlessPolicyIds: ['agentless-ok', 'agentless-conflict'],
+      agentlessDryRunData: [
+        { id: 'agentless-ok', name: 'ok-policy', hasErrors: false },
+        // A real conflict (no statusCode): the confirm modal's conflict callout covers it.
+        {
+          id: 'agentless-conflict',
+          name: 'conflict-policy',
+          hasErrors: true,
+          errors: [{ message: 'var removed' }],
+        },
+      ],
+    });
+
+    await waitFor(() =>
+      expect(mockSendBulkUpgradeAgentlessPolicies).toHaveBeenCalledWith(['agentless-ok'])
+    );
+    expect(toasts.addWarning).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -28,6 +28,7 @@ import type {
   UpgradePackagePolicyDryRunResponse,
   PackagePolicy,
 } from '../../../../../types';
+import type { AgentlessPolicyUpgradeDryRunResponse } from '../../../../../../../../common/types/rest_spec/agentless_policy';
 import { InstallStatus } from '../../../../../types';
 import {
   useInstallPackage,
@@ -37,11 +38,14 @@ import {
   useLink,
   useUpgradePackagePoliciesMutation,
   useBulkGetAgentPoliciesQuery,
+  sendBulkUpgradeAgentlessPolicies,
 } from '../../../../../hooks';
 
 interface UpdateButtonProps extends Pick<PackageInfo, 'name' | 'title' | 'version'> {
   dryRunData?: UpgradePackagePolicyDryRunResponse | null;
+  agentlessDryRunData?: AgentlessPolicyUpgradeDryRunResponse | null;
   packagePolicyIds?: string[];
+  agentlessPolicyIds?: string[];
   agentPolicyIds: string[];
   isUpgradingPackagePolicies?: boolean;
   setIsUpgradingPackagePolicies?: React.Dispatch<React.SetStateAction<boolean>>;
@@ -71,9 +75,11 @@ interface UpdateButtonProps extends Pick<PackageInfo, 'name' | 'title' | 'versio
 
 export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
   dryRunData,
+  agentlessDryRunData,
   isUpgradingPackagePolicies = false,
   name,
   packagePolicyIds = [],
+  agentlessPolicyIds = [],
   agentPolicyIds = [],
   setIsUpgradingPackagePolicies = () => {},
   title,
@@ -99,11 +105,24 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
 
   const { data: agentPolicyData } = useBulkGetAgentPoliciesQuery(agentPolicyIds, { full: true });
 
-  const packagePolicyCount = useMemo(() => packagePolicyIds.length, [packagePolicyIds]);
+  const agentBasedPolicyCount = packagePolicyIds.length;
+  const agentlessPolicyCount = agentlessPolicyIds.length;
+  const packagePolicyCount = useMemo(
+    () => agentBasedPolicyCount + agentlessPolicyCount,
+    [agentBasedPolicyCount, agentlessPolicyCount]
+  );
+  // Only break the count down by deployment mode when the integration actually has both kinds.
+  const hasMixedPolicyTypes = agentBasedPolicyCount > 0 && agentlessPolicyCount > 0;
 
   function isStringArray(arr: unknown | string[]): arr is string[] {
     return Array.isArray(arr) && arr.every((p) => typeof p === 'string');
   }
+
+  // Count agents across both agent-based and agentless policies for this integration.
+  const allPolicyIds = useMemo(
+    () => [...packagePolicyIds, ...agentlessPolicyIds],
+    [packagePolicyIds, agentlessPolicyIds]
+  );
 
   const agentCount = useMemo(() => {
     if (!agentPolicyData?.items) return 0;
@@ -111,19 +130,23 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
     return agentPolicyData.items.reduce((acc, item) => {
       const existingPolicies = item?.package_policies
         ? isStringArray(item.package_policies)
-          ? (item.package_policies as string[]).filter((p) => packagePolicyIds.includes(p))
-          : (item.package_policies as PackagePolicy[]).filter((p) =>
-              packagePolicyIds.includes(p.id)
-            )
+          ? (item.package_policies as string[]).filter((p) => allPolicyIds.includes(p))
+          : (item.package_policies as PackagePolicy[]).filter((p) => allPolicyIds.includes(p.id))
         : [];
       return (acc += existingPolicies.length > 0 && item?.agents ? item?.agents : 0);
     }, 0);
-  }, [agentPolicyData, packagePolicyIds]);
+  }, [agentPolicyData, allPolicyIds]);
 
-  const conflictCount = useMemo(
-    () => dryRunData?.filter((item) => item.hasErrors).length,
-    [dryRunData]
-  );
+  const conflictCount = useMemo(() => {
+    const packagePolicyConflicts = dryRunData?.filter((item) => item.hasErrors).length ?? 0;
+    // For agentless, `hasErrors` covers both config-migration conflicts (carry `errors`) and
+    // guard failures (carry `statusCode`, e.g. a policy deleted mid-flight). Only the former is a
+    // real "conflict" the user resolves; guard failures are excluded from the conflict count.
+    const agentlessConflicts =
+      agentlessDryRunData?.filter((item) => item.hasErrors && item.statusCode === undefined)
+        .length ?? 0;
+    return packagePolicyConflicts + agentlessConflicts;
+  }, [dryRunData, agentlessDryRunData]);
 
   const handleUpgradePackagePoliciesChange = useCallback(() => {
     setUpgradePackagePolicies((prev) => !prev);
@@ -168,61 +191,150 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
       return;
     }
 
-    // Only upgrade policies that don't have conflicts
+    // Only upgrade agent-based policies that don't have conflicts (package-policy dry-run shape:
+    // conflicts are keyed by the nested `diff[0].id`).
     const packagePolicyIdsToUpdate = packagePolicyIds.filter(
       (id) => !dryRunData?.find((dryRunRecord) => dryRunRecord.diff?.[0].id === id)?.hasErrors
     );
 
-    if (!packagePolicyIdsToUpdate.length) {
+    // Agentless policies upgrade through the agentless API. The agentless dry-run shape exposes a
+    // top-level `id`/`hasErrors`, so conflicts are matched directly by id.
+    const agentlessIdsToUpgrade = agentlessPolicyIds.filter(
+      (id) => !agentlessDryRunData?.find((dryRunRecord) => dryRunRecord.id === id)?.hasErrors
+    );
+
+    if (!packagePolicyIdsToUpdate.length && !agentlessIdsToUpgrade.length) {
       setIsUpgradingPackagePolicies(false);
       navigateToNewSettingsPage();
+      return;
     }
 
-    try {
-      await upgradePackagePoliciesMutation.mutateAsync({
-        packagePolicyIds: packagePolicyIdsToUpdate,
-      });
-      notifications.toasts.addSuccess({
-        title: toMountPoint(
-          <FormattedMessage
-            id="xpack.fleet.integrations.packageUpdateSuccessTitle"
-            defaultMessage="Updated {title} and upgraded policies"
-            values={{ title }}
-          />,
-          startServices
-        ),
-        text: toMountPoint(
-          <FormattedMessage
-            id="xpack.fleet.integrations.packageUpdateSuccessDescription"
-            defaultMessage="Successfully updated {title} and upgraded policies"
-            values={{ title }}
-          />,
-          startServices
-        ),
-      });
+    const upgradeAgentBasedPolicies = async (): Promise<boolean> => {
+      if (!packagePolicyIdsToUpdate.length) {
+        return true;
+      }
+      try {
+        await upgradePackagePoliciesMutation.mutateAsync({
+          packagePolicyIds: packagePolicyIdsToUpdate,
+        });
+        notifications.toasts.addSuccess({
+          title: toMountPoint(
+            <FormattedMessage
+              id="xpack.fleet.integrations.packageUpdateSuccessTitle"
+              defaultMessage="Updated {title} and upgraded agent-based policies"
+              values={{ title }}
+            />,
+            startServices
+          ),
+          text: toMountPoint(
+            <FormattedMessage
+              id="xpack.fleet.integrations.packageUpdateSuccessDescription"
+              defaultMessage="Successfully updated {title} and upgraded agent-based policies"
+              values={{ title }}
+            />,
+            startServices
+          ),
+        });
+        return true;
+      } catch (error) {
+        notifications.toasts.addError(error, {
+          title: i18n.translate(
+            'xpack.fleet.integrations.settings.errorUpdatingPoliciesToast.title',
+            {
+              defaultMessage: 'Error updating agent-based policies',
+            }
+          ),
+          toastMessage: i18n.translate(
+            'xpack.fleet.integrations.settings.errorUpdatingPoliciesToast.message',
+            {
+              defaultMessage:
+                'Agent-based integration policies need to be manually updated. \n Error: {error}',
+              values: {
+                error: error.message,
+              },
+            }
+          ),
+        });
+        return false;
+      }
+    };
 
-      navigateToNewSettingsPage();
-    } catch (error) {
-      notifications.toasts.addError(error, {
-        title: i18n.translate(
-          'xpack.fleet.integrations.settings.errorUpdatingPoliciesToast.title',
-          {
-            defaultMessage: 'Error updating policies',
-          }
-        ),
-        toastMessage: i18n.translate(
-          'xpack.fleet.integrations.settings.errorUpdatingPoliciesToast.message',
-          {
-            defaultMessage: 'Integrations policies, need to be manually updated. \n Error: {error}',
-            values: {
-              error: error.message,
-            },
-          }
-        ),
-      });
-      setIsUpgradingPackagePolicies(false);
-      navigateToNewSettingsPage();
-    }
+    const upgradeAgentlessPolicies = async (): Promise<boolean> => {
+      if (!agentlessIdsToUpgrade.length) {
+        return true;
+      }
+      try {
+        const results = await sendBulkUpgradeAgentlessPolicies(agentlessIdsToUpgrade);
+        const failed = results.filter((result) => !result.success);
+        if (failed.length > 0) {
+          notifications.toasts.addWarning({
+            title: i18n.translate(
+              'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.title',
+              {
+                defaultMessage: 'Error updating agentless policies',
+              }
+            ),
+            text: i18n.translate(
+              'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.message',
+              {
+                defaultMessage:
+                  '{failedCount, plural, one {# agentless policy} other {# agentless policies}} could not be upgraded and need to be manually updated.',
+                values: { failedCount: failed.length },
+              }
+            ),
+          });
+          return false;
+        }
+        notifications.toasts.addSuccess({
+          title: toMountPoint(
+            <FormattedMessage
+              id="xpack.fleet.integrations.agentlessPackageUpdateSuccessTitle"
+              defaultMessage="Updated {title} and upgraded agentless policies"
+              values={{ title }}
+            />,
+            startServices
+          ),
+          text: toMountPoint(
+            <FormattedMessage
+              id="xpack.fleet.integrations.agentlessPackageUpdateSuccessDescription"
+              defaultMessage="Successfully updated {title} and upgraded agentless policies"
+              values={{ title }}
+            />,
+            startServices
+          ),
+        });
+        return true;
+      } catch (error) {
+        notifications.toasts.addError(error, {
+          title: i18n.translate(
+            'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.title',
+            {
+              defaultMessage: 'Error updating agentless policies',
+            }
+          ),
+          toastMessage: i18n.translate(
+            'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.exceptionMessage',
+            {
+              defaultMessage:
+                'Agentless integration policies need to be manually updated. \n Error: {error}',
+              values: {
+                error: error.message,
+              },
+            }
+          ),
+        });
+        return false;
+      }
+    };
+
+    // Toasts (success/warning/error) are surfaced inside each helper. Regardless of the outcome we
+    // must clear the upgrading flag before navigating: the destination is the new (now latest)
+    // version where `updateAvailable` is false, so a lingering flag would keep the button rendered
+    // in a permanent loading (gray) state.
+    await Promise.all([upgradeAgentBasedPolicies(), upgradeAgentlessPolicies()]);
+
+    setIsUpgradingPackagePolicies(false);
+    navigateToNewSettingsPage();
   }, [
     isUpgradingPackagePolicies,
     setIsUpgradingPackagePolicies,
@@ -232,7 +344,9 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
     title,
     upgradePackagePoliciesMutation,
     packagePolicyIds,
+    agentlessPolicyIds,
     dryRunData,
+    agentlessDryRunData,
     notifications.toasts,
     startServices,
     navigateToNewSettingsPage,
@@ -318,6 +432,35 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             ),
           }}
         />
+        {hasMixedPolicyTypes && (
+          <>
+            <EuiSpacer size="m" />
+            <FormattedMessage
+              id="xpack.fleet.integrations.settings.confirmUpdateModal.policyTypeBreakdown"
+              defaultMessage="This includes {agentBasedCountText} and {agentlessCountText}."
+              values={{
+                agentBasedCountText: (
+                  <strong>
+                    <FormattedMessage
+                      id="xpack.fleet.integrations.confirmUpdateModal.body.agentBasedPolicyCount"
+                      defaultMessage="{agentBasedPolicyCount, plural, one {# agent-based policy} other {# agent-based policies}}"
+                      values={{ agentBasedPolicyCount }}
+                    />
+                  </strong>
+                ),
+                agentlessCountText: (
+                  <strong>
+                    <FormattedMessage
+                      id="xpack.fleet.integrations.confirmUpdateModal.body.agentlessPolicyCount"
+                      defaultMessage="{agentlessPolicyCount, plural, one {# agentless policy} other {# agentless policies}}"
+                      values={{ agentlessPolicyCount }}
+                    />
+                  </strong>
+                ),
+              }}
+            />
+          </>
+        )}
       </>
     </EuiConfirmModal>
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -297,19 +297,26 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
         const results = await sendBulkUpgradeAgentlessPolicies(agentlessIdsToUpgrade);
         const failed = results.filter((result) => !result.success);
         if (failed.length > 0) {
+          // The response carries per-policy failure details — surface them so the operator can
+          // tell which policies failed and why, not just how many.
+          const firstErrorMessage = failed.find((result) => result.body?.message)?.body?.message;
           notifications.toasts.addWarning({
             title: i18n.translate(
               'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.title',
               {
-                defaultMessage: 'Error updating agentless policies',
+                defaultMessage: 'Error upgrading agentless policies',
               }
             ),
             text: i18n.translate(
               'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.message',
               {
                 defaultMessage:
-                  '{failedCount, plural, one {# agentless policy could not be upgraded and needs to be manually updated.} other {# agentless policies could not be upgraded and need to be manually updated.}}',
-                values: { failedCount: failed.length },
+                  'Fleet could not upgrade {failedNames}. Upgrade {failedCount, plural, one {it} other {them}} manually.{errorMessage}',
+                values: {
+                  failedCount: failed.length,
+                  failedNames: failed.map((result) => result.name ?? result.id).join(', '),
+                  errorMessage: firstErrorMessage ? `\nError: ${firstErrorMessage}` : '',
+                },
               }
             ),
           });
@@ -339,7 +346,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           title: i18n.translate(
             'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.title',
             {
-              defaultMessage: 'Error updating agentless policies',
+              defaultMessage: 'Error upgrading agentless policies',
             }
           ),
           toastMessage: i18n.translate(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -223,7 +223,10 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
               'Fleet could not check {skippedNames} for upgrade. Upgrade {skippedCount, plural, one {it} other {them}} manually.',
             values: {
               skippedCount: agentlessGuardFailures.length,
-              skippedNames: agentlessGuardFailures.map((item) => item.name ?? item.id).join(', '),
+              skippedNames: i18n.formatList(
+                'conjunction',
+                agentlessGuardFailures.map((item) => item.name ?? item.id)
+              ),
             },
           }
         ),
@@ -256,8 +259,8 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           text: toMountPoint(
             <FormattedMessage
               id="xpack.fleet.integrations.packageUpdateSuccessDescription"
-              defaultMessage="Successfully updated {title} and upgraded agent-based policies"
-              values={{ title }}
+              defaultMessage="Fleet upgraded {agentBasedPolicyCount, plural, one {# agent-based policy} other {# agent-based policies}}."
+              values={{ agentBasedPolicyCount: packagePolicyIdsToUpdate.length }}
             />,
             startServices
           ),
@@ -267,14 +270,13 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           title: i18n.translate(
             'xpack.fleet.integrations.settings.errorUpdatingPoliciesToast.title',
             {
-              defaultMessage: 'Error updating agent-based policies',
+              defaultMessage: 'Error upgrading agent-based policies',
             }
           ),
           toastMessage: i18n.translate(
             'xpack.fleet.integrations.settings.errorUpdatingPoliciesToast.message',
             {
-              defaultMessage:
-                'Agent-based integration policies need to be manually updated. \n Error: {error}',
+              defaultMessage: 'Upgrade agent-based integration policies manually.\nError: {error}',
               values: {
                 error: error.message,
               },
@@ -309,7 +311,10 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
                   'Fleet could not upgrade {failedNames}. Upgrade {failedCount, plural, one {it} other {them}} manually.{errorMessage}',
                 values: {
                   failedCount: failed.length,
-                  failedNames: failed.map((result) => result.name ?? result.id).join(', '),
+                  failedNames: i18n.formatList(
+                    'conjunction',
+                    failed.map((result) => result.name ?? result.id)
+                  ),
                   errorMessage: firstErrorMessage ? `\nError: ${firstErrorMessage}` : '',
                 },
               }
@@ -330,8 +335,8 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           text: toMountPoint(
             <FormattedMessage
               id="xpack.fleet.integrations.agentlessPackageUpdateSuccessDescription"
-              defaultMessage="Successfully updated {title} and upgraded agentless policies"
-              values={{ title }}
+              defaultMessage="Fleet upgraded {agentlessPolicyCount, plural, one {# agentless policy} other {# agentless policies}}."
+              values={{ agentlessPolicyCount: agentlessIdsToUpgrade.length }}
             />,
             startServices
           ),
@@ -347,8 +352,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           toastMessage: i18n.translate(
             'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.exceptionMessage',
             {
-              defaultMessage:
-                'Agentless integration policies need to be manually updated. \n Error: {error}',
+              defaultMessage: 'Upgrade agentless integration policies manually.\nError: {error}',
               values: {
                 error: error.message,
               },
@@ -468,7 +472,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             <EuiSpacer size="m" />
             <FormattedMessage
               id="xpack.fleet.integrations.settings.confirmUpdateModal.policyTypeBreakdown"
-              defaultMessage="This includes {agentBasedCountText} and {agentlessCountText}."
+              defaultMessage="These policies include {agentBasedCountText} and {agentlessCountText}."
               values={{
                 agentBasedCountText: (
                   <strong>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -239,9 +239,9 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
       return;
     }
 
-    const upgradeAgentBasedPolicies = async (): Promise<boolean> => {
+    const upgradeAgentBasedPolicies = async (): Promise<void> => {
       if (!packagePolicyIdsToUpdate.length) {
-        return true;
+        return;
       }
       try {
         await upgradePackagePoliciesMutation.mutateAsync({
@@ -265,7 +265,6 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             startServices
           ),
         });
-        return true;
       } catch (error) {
         notifications.toasts.addError(error, {
           title: i18n.translate(
@@ -285,13 +284,12 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             }
           ),
         });
-        return false;
       }
     };
 
-    const upgradeAgentlessPolicies = async (): Promise<boolean> => {
+    const upgradeAgentlessPolicies = async (): Promise<void> => {
       if (!agentlessIdsToUpgrade.length) {
-        return true;
+        return;
       }
       try {
         const results = await sendBulkUpgradeAgentlessPolicies(agentlessIdsToUpgrade);
@@ -320,7 +318,8 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
               }
             ),
           });
-          return false;
+          // Partial failure: skip the success toast below.
+          return;
         }
         notifications.toasts.addSuccess({
           title: toMountPoint(
@@ -340,7 +339,6 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             startServices
           ),
         });
-        return true;
       } catch (error) {
         notifications.toasts.addError(error, {
           title: i18n.translate(
@@ -360,7 +358,6 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             }
           ),
         });
-        return false;
       }
     };
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -278,7 +278,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
               'xpack.fleet.integrations.settings.errorUpdatingAgentlessPoliciesToast.message',
               {
                 defaultMessage:
-                  '{failedCount, plural, one {# agentless policy} other {# agentless policies}} could not be upgraded and need to be manually updated.',
+                  '{failedCount, plural, one {# agentless policy could not be upgraded and needs to be manually updated.} other {# agentless policies could not be upgraded and need to be manually updated.}}',
                 values: { failedCount: failed.length },
               }
             ),

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -107,10 +107,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
 
   const agentBasedPolicyCount = packagePolicyIds.length;
   const agentlessPolicyCount = agentlessPolicyIds.length;
-  const packagePolicyCount = useMemo(
-    () => agentBasedPolicyCount + agentlessPolicyCount,
-    [agentBasedPolicyCount, agentlessPolicyCount]
-  );
+  const totalPolicyCount = agentBasedPolicyCount + agentlessPolicyCount;
   // Only break the count down by deployment mode when the integration actually has both kinds.
   const hasMixedPolicyTypes = agentBasedPolicyCount > 0 && agentlessPolicyCount > 0;
 
@@ -445,13 +442,13 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           Fleet has detected that {packagePolicyCountText} {packagePolicyCount, plural, one { is} other { are}} ready to be upgraded
           and {packagePolicyCount, plural, one { is} other { are}} already in use by {agentCountText}."
           values={{
-            packagePolicyCount,
+            packagePolicyCount: totalPolicyCount,
             packagePolicyCountText: (
               <strong>
                 <FormattedMessage
                   id="xpack.fleet.integrations.confirmUpdateModal.body.policyCount"
                   defaultMessage="{packagePolicyCount, plural, one {# integration policy} other {# integration policies}}"
-                  values={{ packagePolicyCount }}
+                  values={{ packagePolicyCount: totalPolicyCount }}
                 />
               </strong>
             ),
@@ -517,7 +514,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
             />
           </EuiButton>
         </EuiFlexItem>
-        {packagePolicyCount > 0 && (
+        {totalPolicyCount > 0 && (
           <EuiFlexItem grow={false}>
             <EuiCheckbox
               labelProps={{

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -203,6 +203,36 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
       (id) => !agentlessDryRunData?.find((dryRunRecord) => dryRunRecord.id === id)?.hasErrors
     );
 
+    // Guard failures (dry-run entries with a `statusCode`, e.g. a policy deleted mid-flight or an
+    // API error while checking it) are excluded from the upgrade set like conflicts, but they are
+    // not announced in the confirm modal's conflict callout — they are not user-resolvable config
+    // conflicts. Announce the skip here so the success toast can't read as a full upgrade.
+    const agentlessGuardFailures =
+      agentlessDryRunData?.filter((item) => item.hasErrors && item.statusCode !== undefined) ?? [];
+    if (agentlessGuardFailures.length > 0) {
+      notifications.toasts.addWarning({
+        title: i18n.translate(
+          'xpack.fleet.integrations.settings.skippedAgentlessPoliciesToast.title',
+          {
+            defaultMessage:
+              'Fleet skipped {skippedCount, plural, one {# agentless policy} other {# agentless policies}}',
+            values: { skippedCount: agentlessGuardFailures.length },
+          }
+        ),
+        text: i18n.translate(
+          'xpack.fleet.integrations.settings.skippedAgentlessPoliciesToast.message',
+          {
+            defaultMessage:
+              'Fleet could not check {skippedNames} for upgrade. Upgrade {skippedCount, plural, one {it} other {them}} manually.',
+            values: {
+              skippedCount: agentlessGuardFailures.length,
+              skippedNames: agentlessGuardFailures.map((item) => item.name ?? item.id).join(', '),
+            },
+          }
+        ),
+      });
+    }
+
     if (!packagePolicyIdsToUpdate.length && !agentlessIdsToUpgrade.length) {
       setIsUpgradingPackagePolicies(false);
       navigateToNewSettingsPage();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installed_integrations_search_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installed_integrations_search_bar.tsx
@@ -113,6 +113,7 @@ export const InstalledIntegrationsSearchBar: React.FunctionComponent<{
           <EuiFilterGroup>
             {statuses.map((item) => (
               <EuiFilterButton
+                key={item.status}
                 iconType={item.iconType}
                 iconSide="left"
                 css={css`

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -31,11 +31,7 @@ export const Policy = memo(() => {
   const isAgentless = useIsAgentlessQueryParam();
 
   // This read only resolves the edit UI extension, whose `useLatestPackageVersion` flag feeds
-  // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API:
-  // this screen is only used for regular (non-upgrade) edit, and the agentless load path forces
-  // `isUpgrade=false` and ignores `forceUpgrade`. Agentless *upgrades* use the separate
-  // `upgrade_package_policy` route, which omits the `isAgentless` hint and stays on the legacy
-  // package-policy path for now. The form re-resolves the extension from the loaded policy.
+  // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API.
   const { data: packagePolicyData } = useGetOnePackagePolicyQuery(packagePolicyId, {
     enabled: !isAgentless,
   });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -11,8 +11,11 @@ import { useLocation, useRouteMatch } from 'react-router-dom';
 // TODO: Needs to be moved
 import { EditPackagePolicyForm } from '../../../../../fleet/sections/agent_policy/edit_package_policy_page';
 import type { EditPackagePolicyFrom } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/types';
-import { useGetOnePackagePolicyQuery, useUIExtension } from '../../../../hooks';
-import { IS_AGENTLESS_QUERY_PARAM } from '../../../../../../../common/constants';
+import {
+  useGetOnePackagePolicyQuery,
+  useIsAgentlessQueryParam,
+  useUIExtension,
+} from '../../../../hooks';
 
 export const Policy = memo(() => {
   const {
@@ -23,8 +26,9 @@ export const Policy = memo(() => {
   const qs = new URLSearchParams(search);
 
   // Detect-before-read hint: agentless surfaces append `isAgentless=true` so the edit form
-  // reads/writes through the agentless API instead of the package-policy API.
-  const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
+  // reads/writes through the agentless API instead of the package-policy API. Always false when
+  // the agentless policies UI kill switch is off, so the page falls back to the legacy APIs.
+  const isAgentless = useIsAgentlessQueryParam();
 
   // This read only resolves the edit UI extension, whose `useLatestPackageVersion` flag feeds
   // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API:

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -12,6 +12,7 @@ import { useLocation, useRouteMatch } from 'react-router-dom';
 import { EditPackagePolicyForm } from '../../../../../fleet/sections/agent_policy/edit_package_policy_page';
 import type { EditPackagePolicyFrom } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/types';
 import { useGetOnePackagePolicyQuery, useUIExtension } from '../../../../hooks';
+import { IS_AGENTLESS_QUERY_PARAM } from '../../../../../../../common/constants';
 
 export const Policy = memo(() => {
   const {
@@ -39,10 +40,15 @@ export const Policy = memo(() => {
     from = 'package-edit';
   }
 
+  // Detect-before-read hint: agentless surfaces append `isAgentless=true` so the edit form
+  // reads/writes through the agentless API instead of the package-policy API.
+  const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
+
   return (
     <EditPackagePolicyForm
       packagePolicyId={packagePolicyId}
       from={from}
+      isAgentless={isAgentless}
       forceUpgrade={extensionView?.useLatestPackageVersion}
     />
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -20,14 +20,27 @@ export const Policy = memo(() => {
   } = useRouteMatch<{ packagePolicyId: string }>();
 
   const { search } = useLocation();
-  const { data: packagePolicyData } = useGetOnePackagePolicyQuery(packagePolicyId);
+  const qs = new URLSearchParams(search);
+
+  // Detect-before-read hint: agentless surfaces append `isAgentless=true` so the edit form
+  // reads/writes through the agentless API instead of the package-policy API.
+  const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
+
+  // This read only resolves the edit UI extension, whose `useLatestPackageVersion` flag feeds
+  // `forceUpgrade`. Skipping it for agentless is safe and avoids touching the package-policy API:
+  // this screen is only used for regular (non-upgrade) edit, and the agentless load path forces
+  // `isUpgrade=false` and ignores `forceUpgrade`. Agentless *upgrades* use the separate
+  // `upgrade_package_policy` route, which omits the `isAgentless` hint and stays on the legacy
+  // package-policy path for now. The form re-resolves the extension from the loaded policy.
+  const { data: packagePolicyData } = useGetOnePackagePolicyQuery(packagePolicyId, {
+    enabled: !isAgentless,
+  });
 
   const extensionView = useUIExtension(
     packagePolicyData?.item?.package?.name ?? '',
     'package-policy-edit'
   );
 
-  const qs = new URLSearchParams(search);
   const fromQs = qs.get('from');
 
   let from: EditPackagePolicyFrom | undefined;
@@ -39,10 +52,6 @@ export const Policy = memo(() => {
   } else {
     from = 'package-edit';
   }
-
-  // Detect-before-read hint: agentless surfaces append `isAgentless=true` so the edit form
-  // reads/writes through the agentless API instead of the package-policy API.
-  const isAgentless = qs.get(IS_AGENTLESS_QUERY_PARAM) === 'true';
 
   return (
     <EditPackagePolicyForm

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -264,9 +264,11 @@ describe('PackagePolicyActionsMenu', () => {
       expect(jest.mocked(useLink().getHref)).toHaveBeenCalledWith('integration_policy_edit', {
         packagePolicyId: 'some-uuid2',
       });
+      // Agentless edit links carry the detect-before-read hint so the edit page uses the
+      // agentless API instead of the package-policy API.
       expect(editButton).toHaveAttribute(
         'href',
-        '/mock/app/integrations/edit-integration/some-uuid2'
+        '/mock/app/integrations/edit-integration/some-uuid2?isAgentless=true'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -13,6 +13,8 @@ import type { AgentPolicy, InMemoryPackagePolicy } from '../types';
 import { createIntegrationsTestRendererMock } from '../mock';
 
 import { useMultipleAgentPolicies, useLink, useGetOneAgentPolicy } from '../hooks';
+import { allowedExperimentalValues } from '../../common/experimental_features';
+import { ExperimentalFeaturesService } from '../services';
 
 import { PackagePolicyActionsMenu } from './package_policy_actions_menu';
 
@@ -271,6 +273,28 @@ describe('PackagePolicyActionsMenu', () => {
         '/mock/app/integrations/edit-integration/some-uuid2?isAgentless=true'
       );
     });
+  });
+
+  it('Should not append the isAgentless hint to agentless edit links when the agentless policies UI is disabled', async () => {
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      enableAgentlessPoliciesUI: false,
+    });
+    const agentPolicies = createMockAgentPolicies({});
+    const packagePolicy = createMockPackagePolicy({
+      supports_agentless: true,
+    });
+    const { utils } = renderMenu({ agentPolicies, packagePolicy });
+    await waitFor(() => {
+      const editButton = utils.getByTestId('PackagePolicyActionsEditItem');
+      // Route target is unchanged; only the hint is suppressed so the edit page falls
+      // back to the legacy package-policy APIs.
+      expect(editButton).toHaveAttribute(
+        'href',
+        '/mock/app/integrations/edit-integration/some-uuid2'
+      );
+    });
+    jest.mocked(ExperimentalFeaturesService.get).mockRestore();
   });
 
   it('Should show Edit integration with correct href when there is no agent policy', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -492,6 +492,33 @@ describe('PackagePolicyActionsMenu', () => {
       });
     });
 
+    it('should fall back to useGetOneAgentPolicy for cluster_id when the agent policy is a minimal synthesized one', async () => {
+      useGetOneAgentPolicyMock.mockReturnValue({
+        data: {
+          item: {
+            id: 'policy-uuid',
+            agentless: { cluster_id: 'fetched-cluster' },
+          },
+        },
+        isLoading: false,
+      } as any);
+      // The agentless deployments table synthesizes agent policies without `agentless` details.
+      const agentPolicies = [
+        { id: 'policy-uuid', name: 'Test Policy', supports_agentless: true },
+      ] as AgentPolicy[];
+      const packagePolicy = createMockPackagePolicy({
+        supports_agentless: true,
+        policy_ids: ['policy-uuid'],
+        package: { name: 'cloud_security_posture', version: '1.0.0', title: 'CSPM' },
+      });
+      renderMenu({ agentPolicies, packagePolicy });
+      await waitFor(() => {
+        expect(capturedCopyText).toEqual(
+          'elastic-support-bundle\ndeployment_id=abc123def456\ncluster_id=fetched-cluster\npolicy_id=policy-uuid\nintegration=cloud_security_posture'
+        );
+      });
+    });
+
     it('should use project_id instead of deployment_id on serverless', async () => {
       const { useStartServices } = jest.requireMock('../hooks');
       const serverlessReturnValue = {

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
@@ -15,6 +15,7 @@ import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import {
   EXCLUDED_FROM_PACKAGE_POLICY_COPY_PACKAGES,
   FLEET_CONNECTORS_PACKAGE,
+  IS_AGENTLESS_QUERY_PARAM,
 } from '../../common/constants';
 import type { AgentPolicy, InMemoryPackagePolicy } from '../types';
 import {
@@ -122,6 +123,29 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
     .map((input) => input?.vars?.connector_id?.value)
     .find(Boolean);
 
+  // Build the edit link query string once. For agentless policies we append an
+  // isAgentless hint so the edit page reads/writes through the agentless API
+  // instead of the package-policy API (detect-before-read). Orphaned (non-agentless)
+  // policies keep editing a package policy, so the hint is only added when agentless.
+  const editQueryParams = new URLSearchParams();
+  if (from) {
+    editQueryParams.set('from', from);
+  }
+  if (isAgentlessPolicy) {
+    editQueryParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
+  }
+  const editQueryString = editQueryParams.toString();
+  const editHref = `${
+    isOrphanedPolicy || isAgentlessPolicy
+      ? getHref('integration_policy_edit', {
+          packagePolicyId: packagePolicy.id,
+        })
+      : getHref('edit_integration', {
+          policyId: agentPolicy?.id ?? '',
+          packagePolicyId: packagePolicy.id,
+        })
+  }${editQueryString ? `?${editQueryString}` : ''}`;
+
   const menuItems = [
     // FIXME: implement View package policy action
     // <EuiContextMenuItem
@@ -158,16 +182,7 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
       data-test-subj="PackagePolicyActionsEditItem"
       disabled={!canWriteIntegrationPolicies || (!agentPolicy && !isOrphanedPolicy)}
       icon="pencil"
-      href={`${
-        isOrphanedPolicy || isAgentlessPolicy
-          ? getHref('integration_policy_edit', {
-              packagePolicyId: packagePolicy.id,
-            })
-          : getHref('edit_integration', {
-              policyId: agentPolicy?.id ?? '',
-              packagePolicyId: packagePolicy.id,
-            })
-      }${from ? `?from=${from}` : ''}`}
+      href={editHref}
       key="packagePolicyEdit"
     >
       <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
@@ -26,7 +26,7 @@ import {
   useStartServices,
   useUpgradeReviewActions,
 } from '../hooks';
-import { policyHasFleetServer } from '../services';
+import { isAgentlessPoliciesUIEnabled, policyHasFleetServer } from '../services';
 
 import { scheduleAutoOpenModal } from '../applications/integrations/sections/epm/screens/installed_integrations/components/pending_upgrade_review_status';
 
@@ -127,11 +127,14 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   // isAgentless hint so the edit page reads/writes through the agentless API
   // instead of the package-policy API (detect-before-read). Orphaned (non-agentless)
   // policies keep editing a package policy, so the hint is only added when agentless.
+  // The hint is suppressed when the agentless policies UI kill switch is off, so links
+  // route through the legacy APIs (the pages also ignore the hint when the switch is off).
+  const emitAgentlessHint = isAgentlessPolicy && isAgentlessPoliciesUIEnabled();
   const editQueryParams = new URLSearchParams();
   if (from) {
     editQueryParams.set('from', from);
   }
-  if (isAgentlessPolicy) {
+  if (emitAgentlessHint) {
     editQueryParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
   }
   const editQueryString = editQueryParams.toString();
@@ -152,7 +155,7 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   if (from) {
     copyQueryParams.set('from', from);
   }
-  if (isAgentlessPolicy) {
+  if (emitAgentlessHint) {
     copyQueryParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
   }
   const copyQueryString = copyQueryParams.toString();

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
@@ -72,11 +72,15 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   const isAgentlessPolicy = packagePolicy.supports_agentless;
 
   // For agentless policies the agentPolicies prop may be empty (the parent hook doesn't always
-  // fetch them). Fetch the agent policy directly so we can include cluster_id in the support bundle.
+  // fetch them) or a minimal synthesized policy without `agentless` details (the agentless
+  // deployments table). Fetch the agent policy directly so we can include cluster_id in the
+  // support bundle.
   const agentlessPolicyId =
-    isAgentlessPolicy && !agentPolicy ? packagePolicy.policy_ids[0] : undefined;
+    isAgentlessPolicy && !agentPolicy?.agentless ? packagePolicy.policy_ids[0] : undefined;
   const { data: agentlessPolicyData } = useGetOneAgentPolicy(agentlessPolicyId);
-  const effectiveAgentPolicy = agentPolicy ?? agentlessPolicyData?.item;
+  const effectiveAgentPolicy = agentPolicy?.agentless
+    ? agentPolicy
+    : agentlessPolicyData?.item ?? agentPolicy;
 
   const supportBundleText = useMemo(() => {
     if (!isAgentlessPolicy) return '';

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
@@ -146,6 +146,28 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
         })
   }${editQueryString ? `?${editQueryString}` : ''}`;
 
+  // The copy flow reuses the create page. Agentless copies must read/hydrate through the
+  // agentless API (detect-before-read), so carry the same isAgentless hint on the copy link.
+  const copyQueryParams = new URLSearchParams();
+  if (from) {
+    copyQueryParams.set('from', from);
+  }
+  if (isAgentlessPolicy) {
+    copyQueryParams.set(IS_AGENTLESS_QUERY_PARAM, 'true');
+  }
+  const copyQueryString = copyQueryParams.toString();
+  const copyHref = `${
+    isOrphanedPolicy || isAgentlessPolicy
+      ? getHref('integration_policy_copy', {
+          policyId: agentPolicy?.id || '',
+          packagePolicyId: packagePolicy.id,
+        })
+      : getHref('copy_integration', {
+          policyId: agentPolicy?.id || '',
+          packagePolicyId: packagePolicy.id,
+        })
+  }${copyQueryString ? `?${copyQueryString}` : ''}`;
+
   const menuItems = [
     // FIXME: implement View package policy action
     // <EuiContextMenuItem
@@ -244,17 +266,7 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
           />
         ) : undefined
       }
-      href={
-        isOrphanedPolicy || isAgentlessPolicy
-          ? getHref('integration_policy_copy', {
-              policyId: agentPolicy?.id || '',
-              packagePolicyId: packagePolicy.id,
-            }) + (from ? `?from=${from}` : '')
-          : getHref('copy_integration', {
-              policyId: agentPolicy?.id || '',
-              packagePolicyId: packagePolicy.id,
-            }) + (from ? `?from=${from}` : '')
-      }
+      href={copyHref}
       data-test-subj="PackagePolicyActionsCopyItem"
       icon="copy"
       key="packagePolicyCopy"

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/index.ts
@@ -37,5 +37,6 @@ export * from './use_multiple_agent_policies';
 export * from './use_tour_manager';
 export * from './use_dismissable_tour';
 export * from './use_agentless_resources';
+export * from './use_is_agentless_query_param';
 export * from './use_var_group_cloud_connector';
 export * from './use_upgrade_review_actions';

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_is_agentless_query_param.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_is_agentless_query_param.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { renderHook } from '@testing-library/react';
+
+import { allowedExperimentalValues } from '../../common/experimental_features';
+import { ExperimentalFeaturesService } from '../services';
+
+import { useIsAgentlessQueryParam } from './use_is_agentless_query_param';
+
+const renderWithSearch = (search: string) =>
+  renderHook(() => useIsAgentlessQueryParam(), {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={[{ pathname: '/', search }]}>{children}</MemoryRouter>
+    ),
+  });
+
+describe('useIsAgentlessQueryParam', () => {
+  beforeEach(() => {
+    ExperimentalFeaturesService.init(allowedExperimentalValues);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns true when the isAgentless param is set and the agentless policies UI is enabled', () => {
+    const { result } = renderWithSearch('?isAgentless=true');
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the isAgentless param is absent', () => {
+    const { result } = renderWithSearch('');
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the isAgentless param is not "true"', () => {
+    const { result } = renderWithSearch('?isAgentless=false');
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores the isAgentless param when the agentless policies UI is disabled', () => {
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      enableAgentlessPoliciesUI: false,
+    });
+    const { result } = renderWithSearch('?isAgentless=true');
+    expect(result.current).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_is_agentless_query_param.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_is_agentless_query_param.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { IS_AGENTLESS_QUERY_PARAM } from '../../common/constants';
+import { isAgentlessPoliciesUIEnabled } from '../services';
+
+/**
+ * Reads the `isAgentless=true` detect-before-read hint from the current URL. Always false when
+ * the agentless policies UI is disabled, so bookmarked/shared links carrying the hint fall back
+ * to the legacy package-policy APIs instead of the agentless API.
+ */
+export const useIsAgentlessQueryParam = (): boolean => {
+  const { search } = useLocation();
+  return useMemo(
+    () =>
+      isAgentlessPoliciesUIEnabled() &&
+      new URLSearchParams(search).get(IS_AGENTLESS_QUERY_PARAM) === 'true',
+    [search]
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, waitFor } from '@testing-library/react';
+import { focusManager } from '@kbn/react-query';
+
+import { createFleetTestRendererMock } from '../../mock';
+
+import { sendRequestForRq } from './use_request';
+import { useUpgradeAgentlessPoliciesDryRunQuery } from './agentless_policy';
+
+jest.mock('./use_request', () => ({
+  ...jest.requireActual('./use_request'),
+  sendRequestForRq: jest.fn(),
+}));
+
+// The upgrade dry run is a POST that react-query treats as a query. These tests pin down that it
+// behaves as a point-in-time read: exactly one request per (ids, version) pair, with none of the
+// default refetch triggers (window focus, remount, list reorder) silently repeating the POST.
+describe('useUpgradeAgentlessPoliciesDryRunQuery', () => {
+  beforeEach(() => {
+    jest.mocked(sendRequestForRq).mockClear();
+    jest.mocked(sendRequestForRq).mockResolvedValue([{ id: 'agentless-1', hasErrors: false }]);
+  });
+
+  // NOTE: the Fleet test renderer shares one QueryClient across tests in this file, so each test
+  // uses a distinct policy-id set to get its own cache entry.
+
+  it('fires the dry run once and does not refetch it on window focus', async () => {
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      useUpgradeAgentlessPoliciesDryRunQuery(['focus-1', 'focus-2'], '2.0.0')
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(sendRequestForRq).toHaveBeenCalledTimes(1);
+
+    // Simulate the browser window losing and regaining focus.
+    act(() => {
+      focusManager.setFocused(false);
+      focusManager.setFocused(true);
+    });
+    // Let any (wrongly) scheduled refetch kick off before asserting.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 20)));
+
+    expect(sendRequestForRq).toHaveBeenCalledTimes(1);
+    act(() => {
+      focusManager.setFocused(undefined);
+    });
+  });
+
+  it('does not treat a reordered id list as a new dry run', async () => {
+    let policyIds = ['reorder-b', 'reorder-a'];
+    const renderer = createFleetTestRendererMock();
+    const { result, rerender } = renderer.renderHook(() =>
+      useUpgradeAgentlessPoliciesDryRunQuery(policyIds, '2.0.0')
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // A refetch of the source package-policies list can yield the same ids in another order.
+    policyIds = ['reorder-a', 'reorder-b'];
+    rerender();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 20)));
+
+    expect(sendRequestForRq).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to disabled when there are no policy ids', async () => {
+    const renderer = createFleetTestRendererMock();
+    renderer.renderHook(() => useUpgradeAgentlessPoliciesDryRunQuery([]));
+
+    await act(() => new Promise((resolve) => setTimeout(resolve, 20)));
+
+    expect(sendRequestForRq).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
@@ -70,13 +70,25 @@ export const sendBulkUpgradeAgentlessPolicies = (policyIds: string[]) => {
   });
 };
 
-export const sendUpgradeAgentlessPoliciesDryRun = (policyIds: string[]) => {
+export const sendUpgradeAgentlessPoliciesDryRun = (policyIds: string[], pkgVersion?: string) => {
   return sendRequestForRq<AgentlessPolicyUpgradeDryRunResponse>({
     path: agentlessPolicyRouteService.getUpgradeDryRunPath(),
     method: 'post',
     version: API_VERSIONS.public.v1,
-    body: JSON.stringify({ policyIds }),
+    body: JSON.stringify(pkgVersion ? { policyIds, pkgVersion } : { policyIds }),
   });
+};
+
+export const useUpgradeAgentlessPoliciesDryRunQuery = (
+  policyIds: string[],
+  pkgVersion?: string,
+  { enabled }: Partial<{ enabled: boolean }> = {}
+) => {
+  return useQuery<AgentlessPolicyUpgradeDryRunResponse, RequestError>(
+    ['upgradeAgentlessPoliciesDryRun', policyIds, pkgVersion],
+    () => sendUpgradeAgentlessPoliciesDryRun(policyIds, pkgVersion),
+    { enabled }
+  );
 };
 
 export const useBulkGetAgentlessPolicyThroughput = (policyIds: string[]) => {

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
@@ -82,12 +82,20 @@ export const sendUpgradeAgentlessPoliciesDryRun = (policyIds: string[], pkgVersi
 export const useUpgradeAgentlessPoliciesDryRunQuery = (
   policyIds: string[],
   pkgVersion?: string,
-  { enabled }: Partial<{ enabled: boolean }> = {}
+  { enabled = policyIds.length > 0 }: Partial<{ enabled: boolean }> = {}
 ) => {
   return useQuery<AgentlessPolicyUpgradeDryRunResponse, RequestError>(
-    ['upgradeAgentlessPoliciesDryRun', policyIds, pkgVersion],
+    // The ids are sorted in the key so a refetch of the source list that merely reorders items
+    // doesn't register as a new query (each new key fires another dry-run POST).
+    ['upgradeAgentlessPoliciesDryRun', [...policyIds].sort(), pkgVersion],
     () => sendUpgradeAgentlessPoliciesDryRun(policyIds, pkgVersion),
-    { enabled }
+    {
+      enabled,
+      // Don't refire the dry-run POST every time the browser window regains focus: it gates a
+      // user action, so freshness comes from mounting the settings tab, not from tab switching.
+      // Failure retries and mount refetches keep the react-query defaults.
+      refetchOnWindowFocus: false,
+    }
   );
 };
 

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/package_policy.ts
@@ -126,7 +126,10 @@ export const sendGetPackagePolicies = (query: GetPackagePoliciesRequest['query']
   });
 };
 
-export const useGetOnePackagePolicyQuery = (packagePolicyId: string) => {
+export const useGetOnePackagePolicyQuery = (
+  packagePolicyId: string,
+  options?: { enabled?: boolean }
+) => {
   return useQuery<GetOnePackagePolicyResponse, RequestError>(
     ['packagePolicy', packagePolicyId],
     () =>
@@ -134,7 +137,8 @@ export const useGetOnePackagePolicyQuery = (packagePolicyId: string) => {
         method: 'get',
         version: API_VERSIONS.public.v1,
         path: packagePolicyRouteService.getInfoPath(packagePolicyId),
-      })
+      }),
+    { enabled: options?.enabled }
   );
 };
 

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/package_policy.ts
@@ -172,7 +172,9 @@ export function useUpgradePackagePolicyDryRunQuery(
   }
 
   return useQuery<UpgradePackagePolicyDryRunResponse, RequestError>(
-    ['upgradePackagePolicyDryRun', packagePolicyIds, packageVersion],
+    // Sorted ids + no focus refetching, for the same reasons as
+    // `useUpgradeAgentlessPoliciesDryRunQuery`: each spurious refetch is another dry-run POST.
+    ['upgradePackagePolicyDryRun', [...packagePolicyIds].sort(), packageVersion],
     () =>
       sendRequestForRq<UpgradePackagePolicyDryRunResponse>({
         path: packagePolicyRouteService.getDryRunPath(),
@@ -180,7 +182,10 @@ export function useUpgradePackagePolicyDryRunQuery(
         version: API_VERSIONS.public.v1,
         body: JSON.stringify(body),
       }),
-    { enabled }
+    {
+      enabled,
+      refetchOnWindowFocus: false,
+    }
   );
 }
 

--- a/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExperimentalFeaturesService } from './experimental_features';
+
+/**
+ * Kill switch for the agentless policies UI migration: when true (default), the UI reads/writes
+ * agentless integration policies through the agentless policies API; when false, every migrated
+ * surface falls back to the legacy package-policy/agent-policy APIs. Single source of truth —
+ * all agentless-vs-legacy UI forks must consult this instead of reading the flag directly.
+ */
+export const isAgentlessPoliciesUIEnabled = (): boolean => {
+  return ExperimentalFeaturesService.get().enableAgentlessPoliciesUI;
+};

--- a/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.ts
@@ -12,6 +12,11 @@ import { ExperimentalFeaturesService } from './experimental_features';
  * agentless integration policies through the agentless policies API; when false, every migrated
  * surface falls back to the legacy package-policy/agent-policy APIs. Single source of truth —
  * all agentless-vs-legacy UI forks must consult this instead of reading the flag directly.
+ *
+ * Scope: only the surfaces migrated by this flag's rollout (edit, deployments table, copy, bulk
+ * upgrade) are gated. Agentless policy create and delete are NOT gated — they have been calling
+ * the agentless API in production for a while and predate this switch, so they stay on it even
+ * when the flag is off.
  */
 export const isAgentlessPoliciesUIEnabled = (): boolean => {
   return ExperimentalFeaturesService.get().enableAgentlessPoliciesUI;

--- a/x-pack/platform/plugins/shared/fleet/public/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/services/index.ts
@@ -13,6 +13,7 @@ export type {
   PackagePolicyInputValidationResults,
 } from '../../common/services';
 export { ExperimentalFeaturesService } from './experimental_features';
+export { isAgentlessPoliciesUIEnabled } from './agentless_policies_ui';
 export {
   AgentStatusKueryHelper,
   agentPolicyRouteService,

--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -251,7 +251,7 @@ describe('Config schema', () => {
 
       expect(res.messages).toMatchInlineSnapshot(`
         Array [
-          "Disabling [enableAgentlessPoliciesUI] while [disableAgentlessLegacyAPI] is enabled will cause agentless policy operations from the Fleet UI to be rejected by the server.",
+          "When [enableAgentlessPoliciesUI] is disabled and [disableAgentlessLegacyAPI] is enabled, the server rejects agentless policy operations from the Fleet UI.",
         ]
       `);
     });

--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -240,5 +240,40 @@ describe('Config schema', () => {
 
       expect(res.messages).toMatchInlineSnapshot(`Array []`);
     });
+
+    it('should add a warning when the agentless policies UI is disabled while the agentless legacy API is disabled', () => {
+      const res = applyConfigDeprecations({
+        experimentalFeatures: {
+          enableAgentlessPoliciesUI: false,
+          disableAgentlessLegacyAPI: true,
+        },
+      });
+
+      expect(res.messages).toMatchInlineSnapshot(`
+        Array [
+          "Disabling [enableAgentlessPoliciesUI] while [disableAgentlessLegacyAPI] is enabled will cause agentless policy operations from the Fleet UI to be rejected by the server.",
+        ]
+      `);
+    });
+
+    it('should not warn when only the agentless policies UI is disabled', () => {
+      const res = applyConfigDeprecations({
+        experimentalFeatures: {
+          enableAgentlessPoliciesUI: false,
+        },
+      });
+
+      expect(res.messages).toMatchInlineSnapshot(`Array []`);
+    });
+
+    it('should not warn when only the agentless legacy API is disabled', () => {
+      const res = applyConfigDeprecations({
+        experimentalFeatures: {
+          disableAgentlessLegacyAPI: true,
+        },
+      });
+
+      expect(res.messages).toMatchInlineSnapshot(`Array []`);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -11,7 +11,10 @@ import { schema } from '@kbn/config-schema';
 import type { TypeOf } from '@kbn/config-schema';
 import type { PluginConfigDescriptor } from '@kbn/core/server';
 
-import { isValidExperimentalValue } from '../common/experimental_features';
+import {
+  isValidExperimentalValue,
+  parseExperimentalConfigValue,
+} from '../common/experimental_features';
 
 import {
   PreconfiguredPackagesSchema,
@@ -177,6 +180,31 @@ export const config: PluginConfigDescriptor = {
             level: 'warning',
           });
         }
+      }
+    },
+
+    // Warn on the conflicting combination of disabling the agentless policies UI (which makes the
+    // UI call the legacy package-policy/agent-policy APIs for agentless policies) while blocking
+    // those legacy APIs for agentless via disableAgentlessLegacyAPI.
+    (fullConfig, fromPath, addDeprecation) => {
+      const experimentalFeatures = parseExperimentalConfigValue(
+        fullConfig?.xpack?.fleet?.enableExperimental ?? [],
+        fullConfig?.xpack?.fleet?.experimentalFeatures ?? {}
+      );
+      if (
+        !experimentalFeatures.enableAgentlessPoliciesUI &&
+        experimentalFeatures.disableAgentlessLegacyAPI
+      ) {
+        addDeprecation({
+          configPath: 'xpack.fleet.experimentalFeatures.enableAgentlessPoliciesUI',
+          message: `Disabling [enableAgentlessPoliciesUI] while [disableAgentlessLegacyAPI] is enabled will cause agentless policy operations from the Fleet UI to be rejected by the server.`,
+          correctiveActions: {
+            manualSteps: [
+              `Re-enable [xpack.fleet.experimentalFeatures.enableAgentlessPoliciesUI] or disable [xpack.fleet.experimentalFeatures.disableAgentlessLegacyAPI].`,
+            ],
+          },
+          level: 'warning',
+        });
       }
     },
   ],

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -197,7 +197,7 @@ export const config: PluginConfigDescriptor = {
       ) {
         addDeprecation({
           configPath: 'xpack.fleet.experimentalFeatures.enableAgentlessPoliciesUI',
-          message: `Disabling [enableAgentlessPoliciesUI] while [disableAgentlessLegacyAPI] is enabled will cause agentless policy operations from the Fleet UI to be rejected by the server.`,
+          message: `When [enableAgentlessPoliciesUI] is disabled and [disableAgentlessLegacyAPI] is enabled, the server rejects agentless policy operations from the Fleet UI.`,
           correctiveActions: {
             manualSteps: [
               `Re-enable [xpack.fleet.experimentalFeatures.enableAgentlessPoliciesUI] or disable [xpack.fleet.experimentalFeatures.disableAgentlessLegacyAPI].`,

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/fixtures/package_info/agentless_hello_world_0.5.0.json
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/fixtures/package_info/agentless_hello_world_0.5.0.json
@@ -1,0 +1,201 @@
+{
+  "name": "agentless_hello_world",
+  "title": "Agentless Hello World",
+  "version": "0.5.0",
+  "release": "beta",
+  "description": "A sample integration to exercise the Agentless infrastructure by fetching https://epr.elastic.co every minute. Optionally includes a counter data stream for high-rate mock metric ingestion testing.",
+  "type": "integration",
+  "download": "/epr/agentless_hello_world/agentless_hello_world-0.5.0.zip",
+  "path": "/package/agentless_hello_world/0.5.0",
+  "icons": [
+    {
+      "src": "/img/icon.svg",
+      "path": "/package/agentless_hello_world/0.5.0/img/icon.svg",
+      "title": "Agentless Hello World",
+      "size": "32x32",
+      "type": "image/svg+xml"
+    }
+  ],
+  "conditions": {
+    "kibana": {
+      "version": "^8.18.0 || ^9.0.0"
+    },
+    "elastic": {
+      "subscription": "basic"
+    }
+  },
+  "owner": {
+    "type": "elastic",
+    "github": "elastic/ingest-managed-jobs"
+  },
+  "categories": [
+    "observability"
+  ],
+  "signature_path": "/epr/agentless_hello_world/agentless_hello_world-0.5.0.zip.sig",
+  "format_version": "3.3.2",
+  "readme": "/package/agentless_hello_world/0.5.0/docs/README.md",
+  "license": "basic",
+  "assets": [
+    "/package/agentless_hello_world/0.5.0/LICENSE.txt",
+    "/package/agentless_hello_world/0.5.0/changelog.yml",
+    "/package/agentless_hello_world/0.5.0/manifest.yml",
+    "/package/agentless_hello_world/0.5.0/docs/README.md",
+    "/package/agentless_hello_world/0.5.0/img/icon.svg",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/manifest.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/sample_event.json",
+    "/package/agentless_hello_world/0.5.0/data_stream/mock_counter/manifest.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/mock_counter/sample_event.json",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/fields/base-fields.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/fields/fields.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/mock_counter/fields/base-fields.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/mock_counter/fields/fields.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/agent/stream/cel.yml.hbs",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/agent/stream/httpjson.yml.hbs",
+    "/package/agentless_hello_world/0.5.0/data_stream/generic/elasticsearch/ingest_pipeline/default.yml",
+    "/package/agentless_hello_world/0.5.0/data_stream/mock_counter/agent/stream/cel.yml.hbs",
+    "/package/agentless_hello_world/0.5.0/data_stream/mock_counter/elasticsearch/ingest_pipeline/default.yml"
+  ],
+  "policy_templates": [
+    {
+      "name": "agentless_hello_world",
+      "title": "Agentless Hello World",
+      "description": "Collect data from EPR endpoint every minute.",
+      "inputs": [
+        {
+          "type": "cel",
+          "title": "Collect data from EPR endpoint (CEL)",
+          "description": "Fetches https://epr.elastic.co every 20s using CEL input."
+        },
+        {
+          "type": "httpjson",
+          "title": "Collect data from EPR endpoint (HTTPJSON)",
+          "description": "Fetches https://epr.elastic.co every 20s using HTTPJSON input."
+        }
+      ],
+      "multiple": true,
+      "deployment_modes": {
+        "default": {
+          "enabled": true
+        },
+        "agentless": {
+          "enabled": true,
+          "is_default": true
+        }
+      }
+    }
+  ],
+  "data_streams": [
+    {
+      "type": "logs",
+      "dataset": "agentless_hello_world.generic",
+      "title": "Generic logs",
+      "release": "beta",
+      "ingest_pipeline": "default",
+      "streams": [
+        {
+          "input": "cel",
+          "vars": [
+            {
+              "name": "url",
+              "type": "text",
+              "title": "EPR URL",
+              "description": "URL of the EPR endpoint (internal use only, for testing)",
+              "multi": false,
+              "required": false,
+              "show_user": false,
+              "default": "https://epr.elastic.co"
+            }
+          ],
+          "template_path": "cel.yml.hbs",
+          "title": "Generic logs (CEL)",
+          "description": "Collect generic logs from EPR endpoint using CEL input.",
+          "enabled": true,
+          "ingestion_method": "API"
+        },
+        {
+          "input": "httpjson",
+          "vars": [
+            {
+              "name": "url",
+              "type": "text",
+              "title": "EPR URL",
+              "description": "URL of the EPR endpoint (internal use only, for testing)",
+              "multi": false,
+              "required": false,
+              "show_user": false,
+              "default": "https://epr.elastic.co"
+            }
+          ],
+          "template_path": "httpjson.yml.hbs",
+          "title": "Generic logs (HTTPJSON)",
+          "description": "Collect generic logs from EPR endpoint using HTTPJSON input.",
+          "enabled": false,
+          "ingestion_method": "API"
+        }
+      ],
+      "package": "agentless_hello_world",
+      "path": "generic"
+    },
+    {
+      "type": "metrics",
+      "dataset": "agentless_hello_world.mock_counter",
+      "title": "Mock counter metrics",
+      "release": "beta",
+      "ingest_pipeline": "default",
+      "streams": [
+        {
+          "input": "cel",
+          "vars": [
+            {
+              "name": "mode",
+              "type": "select",
+              "title": "Mode",
+              "description": "Rate pattern: 'constant' for steady rate, 'spike' for periodic bursts.",
+              "multi": false,
+              "required": true,
+              "show_user": true,
+              "default": "constant"
+            },
+            {
+              "name": "events_per_second",
+              "type": "integer",
+              "title": "Events per second",
+              "description": "Number of counter events to generate per second. In spike mode this is the baseline rate between spikes. Maximum allowed value is 200.",
+              "multi": false,
+              "required": true,
+              "show_user": true,
+              "default": 10
+            },
+            {
+              "name": "spike_events",
+              "type": "integer",
+              "title": "Events per spike burst (spike mode)",
+              "description": "Number of events generated in each spike burst. Maximum allowed value is 200.",
+              "multi": false,
+              "required": true,
+              "show_user": false,
+              "default": 100
+            },
+            {
+              "name": "spike_every_seconds",
+              "type": "integer",
+              "title": "Spike every N seconds (spike mode)",
+              "description": "How often a spike occurs, in seconds.",
+              "multi": false,
+              "required": true,
+              "show_user": false,
+              "default": 60
+            }
+          ],
+          "template_path": "cel.yml.hbs",
+          "title": "Mock counter metrics",
+          "description": "Generate mock counter metrics at a configurable rate. Data is generated entirely within the agent; the EPR endpoint is not called.",
+          "enabled": false,
+          "ingestion_method": "API"
+        }
+      ],
+      "package": "agentless_hello_world",
+      "path": "mock_counter"
+    }
+  ]
+}


### PR DESCRIPTION
# Migrate the agentless UI to the agentless_policies API

## Summary

The Fleet/Integrations UI now reads and writes agentless deployments through the new
`agentless_policies` API instead of the package-policy / agent-policy APIs. 
It covers 
* edit integration (GET + PUT)
* deployments table (GET)
* copy (GET + POST)
* bulk upgrade from the integration settings page (POST `upgrade`)

### `enableAgentlessPoliciesUI` Feature flag
Everything **but POST request** is **gated** behind the `enableAgentlessPoliciesUI` feature flag, **enabled by default**.
Turning it off falls back to the legacy package-policy paths, so we can roll back without a
deploy. 

POST request was left intentionally out of the gate as it has been enabled for a while.

**Disabling it while `disableAgentlessLegacyAPI` is on would leave the UI with no working
path — the config layer logs a deprecation warning for that combination.**

## What changed

- **Edit** — reads through the agentless GET and saves through the agentless PUT (Dev Tools
  preview shows the PUT). If the policy was opened without the link hint (deep link, refresh),
  the loaded policy's `supports_agentless` flag still routes the save through the agentless API.
  Agent policy reassignment is rejected for agentless policies: the API doesn't support it, and
  before this it silently saved nothing while reporting success.
- **Deployments table** — sourced from the agentless LIST API and expanded back into the shapes
  the shared table components expect. A failed load shows an error prompt with retry instead of
  an empty table.
- **Copy** — hydrates from the agentless GET, skipping the package-policy and agent-policy reads.
  Edit and copy share one read helper (`fetchAgentlessPolicyAsPackagePolicy`).
- **Bulk upgrade (integration settings)** — policies are partitioned into agent-based and
  agentless, and each set goes through its own dry-run + upgrade endpoint. Agentless policies
  that get skipped (dry-run failure) or fail mid-upgrade are named in a warning toast instead of
  being silently left on the old version.
- **Inverse mapper** — `agentlessPolicyToPackagePolicy` expands a GET/LIST payload into the
  `NewPackagePolicy` shape the shared form/table components use, reusing the create-path
  converters so GET → form → PUT is a no-op when unedited. To keep that round trip idempotent,
  the write path (`toNewAgentlessPolicy`) now takes `packageInfo` and applies the same
  deployment-mode allow-check as the read path. No effect on non-agentless flows.

## Detect-before-read

The edit/copy routes only carry a `packagePolicyId`, so the page can't tell agentless from
agent-based before the first read. Links from agentless surfaces append `?isAgentless=true`
(`IS_AGENTLESS_QUERY_PARAM`) to pick the agentless path up front. When the hint is missing, the
edit page falls back to detecting `supports_agentless` on the loaded policy, so deep links and
refreshes still save through the right API.

## Open discussions

- **[TBD] `isAgentless` link hint mechanism** — the `supports_agentless` detection fallback now
  covers hint-less edits, but that fallback still *reads* through the legacy API, which the
  `disableAgentlessLegacyAPI` roadmap (task 6) will eventually break. Alternatives:
  try-agentless-then-fallback (wasted 404s on traditional edits) or a cheap probe. Param
  name/location also provisional.
- **[TBD] Installed-integrations "View N policies" count** — still a server SO aggregation over
  all package policies (agentless included), not the agentless API. Left as a single combined
  total; a split was prototyped and reverted. Decide whether it's in scope and combined vs split.
- **[TBD] `packageInfo` in the server GET builder** — the UI side is complete (`packageInfo` is
  passed at every write/preview call site), but the server-side response builder
  (`packagePolicyToAgentlessPolicy` → `formatInputs`) still uses the coarse blocklist without it.
  Low risk (server validation guards it); deferred as a follow-up outside this task.
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...
