### PR TITLE
[kbn-code-owners] Add `elastic/context-eng` team under Platform area

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -29,6 +29,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/appex-ai-infra',
     'elastic/appex-qa',
     'elastic/appex-sharedux',
+    'elastic/context-eng',
     'elastic/docs',
     'elastic/eui-team',
     'elastic/fleet',


### PR DESCRIPTION
This PR adds the `elastic/context-eng` team to the `platform` code owner <> area mapping. Adding the team here ensures their tests are correctly attributed to the platform area by our Scout Reporter.

Made with [Cursor](https://cursor.com)