### PR TITLE
[Agent Builder] keep track of cached tokens

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -367,6 +367,11 @@ export interface RoundModelUsageStats {
    */
   output_tokens: number;
   /**
+   * Number of input tokens served from cache this round, when reported by the provider.
+   * Subset of `input_tokens` (cache reads), not additive.
+   */
+  cached_input_tokens?: number;
+  /**
    * Model identifier from the provider response, if available.
    */
   model?: string;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
@@ -91,6 +91,7 @@ export interface ReportRoundCompleteParams {
   conversation_id?: string;
   execution_id?: string;
   input_tokens: number;
+  cached_input_tokens?: number;
   llm_calls: number;
   message_length: number;
   model?: string;
@@ -825,6 +826,14 @@ const ROUND_COMPLETE_EVENT: AgentBuilderTelemetryEvent = {
       _meta: {
         description: 'Total number of input tokens sent during this round',
         optional: false,
+      },
+    },
+    cached_input_tokens: {
+      type: 'integer',
+      _meta: {
+        description:
+          'Number of input tokens served from cache during this round (subset of input_tokens), when reported by the provider',
+        optional: true,
       },
     },
     llm_calls: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
@@ -490,9 +490,15 @@ const createToolCallStep = ({
 const getModelUsage = (stats: ModelProviderStats): RoundModelUsageStats => {
   let inputTokens = 0;
   let outputTokens = 0;
+  let cachedInputTokens = 0;
+  let hasCachedInputTokens = false;
   for (const call of stats.calls) {
     inputTokens += call.tokens?.prompt ?? 0;
     outputTokens += call.tokens?.completion ?? 0;
+    if (call.tokens?.cached !== undefined) {
+      cachedInputTokens += call.tokens.cached;
+      hasCachedInputTokens = true;
+    }
   }
   const modelFromResponse = stats.calls.find((call) => call.model)?.model;
 
@@ -502,6 +508,7 @@ const getModelUsage = (stats: ModelProviderStats): RoundModelUsageStats => {
     llm_calls: stats.calls.length,
     input_tokens: inputTokens,
     output_tokens: outputTokens,
+    ...(hasCachedInputTokens ? { cached_input_tokens: cachedInputTokens } : {}),
     ...(modelFromResponse ? { model: modelFromResponse } : {}),
   };
 };
@@ -571,6 +578,9 @@ const mergeModelUsage = (
     llm_calls: a.llm_calls + b.llm_calls,
     input_tokens: a.input_tokens + b.input_tokens,
     output_tokens: a.output_tokens + b.output_tokens,
+    ...(a.cached_input_tokens !== undefined || b.cached_input_tokens !== undefined
+      ? { cached_input_tokens: (a.cached_input_tokens ?? 0) + (b.cached_input_tokens ?? 0) }
+      : {}),
     model: a.model ?? b.model,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
@@ -230,6 +230,7 @@ Fired at the end of each successful conversation round.
 | `conversation_id` | keyword | no | Conversation ID. |
 | `execution_id` | keyword | no | Agent execution ID. |
 | `input_tokens` | integer | yes | Input tokens consumed in this round. |
+| `cached_input_tokens` | integer | no | Input tokens served from cache in this round (subset of `input_tokens`), when reported by the provider. |
 | `llm_calls` | integer | yes | Number of LLM calls made during the round. |
 | `message_length` | integer | yes | Character length of the user's input message. |
 | `model` | keyword | no | LLM model identifier. |

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
@@ -305,6 +305,9 @@ export class AnalyticsService {
           conversation_id: conversationId,
           execution_id: executionId,
           input_tokens: round.model_usage.input_tokens,
+          ...(round.model_usage.cached_input_tokens !== undefined
+            ? { cached_input_tokens: round.model_usage.cached_input_tokens }
+            : {}),
           llm_calls: round.model_usage.llm_calls,
           message_length: round.input.message.length,
           model: round.model_usage.model,

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
@@ -305,9 +305,7 @@ export class AnalyticsService {
           conversation_id: conversationId,
           execution_id: executionId,
           input_tokens: round.model_usage.input_tokens,
-          ...(round.model_usage.cached_input_tokens !== undefined
-            ? { cached_input_tokens: round.model_usage.cached_input_tokens }
-            : {}),
+          cached_input_tokens: round.model_usage.cached_input_tokens,
           llm_calls: round.model_usage.llm_calls,
           message_length: round.input.message.length,
           model: round.model_usage.model,


### PR DESCRIPTION
## Summary

Add `cached_input_tokens` to `RoundModelUsageStats`, collect it, and emit it via telemetry as we do for other token counts. (but do not surface it anywhere in the UI)

<img width="754" height="116" alt="Screenshot 2026-07-02 at 13 42 38" src="https://github.com/user-attachments/assets/5bb1ad37-4130-4953-a043-fc55caf334c5" />

