### PR TITLE
[Entity Store] Update entity_store plugin code owners to security-entity-analytics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1391,7 +1391,7 @@ x-pack/solutions/security/plugins/cloud_security_posture @elastic/contextual-sec
 x-pack/solutions/security/plugins/ecs_data_quality_dashboard @elastic/security-threat-hunting
 x-pack/solutions/security/plugins/elastic_assistant @elastic/security-threat-hunting
 x-pack/solutions/security/plugins/elastic_assistant_shared_state @elastic/security-threat-hunting
-x-pack/solutions/security/plugins/entity_store @elastic/core-analysis
+x-pack/solutions/security/plugins/entity_store @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/kubernetes_security @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/plugins/lists @elastic/security-detection-engineering
 x-pack/solutions/security/plugins/security_solution @elastic/security-solution
@@ -2968,7 +2968,7 @@ x-pack/platform/test/api_integration/apis/entity_manager @elastic/core-analysis
 x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store @elastic/core-analysis
 x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store @elastic/core-analysis
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/ @elastic/core-analysis
-x-pack/solutions/security/plugins/entity_store @elastic/core-analysis
+x-pack/solutions/security/plugins/entity_store @elastic/security-entity-analytics
 
 ## Security Solution sub teams - Threat Hunting
 

--- a/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/entity-store",
-  "owner": "@elastic/core-analysis",
+  "owner": "@elastic/security-entity-analytics",
   "description": "Central place for Entities management and logs extraction",
   "group": "security",
   "visibility": "private",

--- a/x-pack/solutions/security/plugins/entity_store/moon.yml
+++ b/x-pack/solutions/security/plugins/entity_store/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/entity-store'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/core-analysis'
+  defaultOwner: '@elastic/security-entity-analytics'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/entity-store'
   description: Moon project for @kbn/entity-store
   channel: ''
-  owner: '@elastic/core-analysis'
+  owner: '@elastic/security-entity-analytics'
   sourceRoot: x-pack/solutions/security/plugins/entity_store
 dependsOn:
   - '@kbn/core'


### PR DESCRIPTION
## Summary

Updates the code owners of the `entity_store` plugin (`x-pack/solutions/security/plugins/entity_store`) from `@elastic/core-analysis` to `@elastic/security-entity-analytics`.

Changes:
- `x-pack/solutions/security/plugins/entity_store/kibana.jsonc`: set `owner` to `@elastic/security-entity-analytics` (drives the auto-generated `.github/CODEOWNERS` entry).
- `.github/CODEOWNERS`: update the auto-generated entry and the manual "Security Entity Store" section entry for the plugin.

Scope is limited to the `entity_store` plugin only; other entries in the "Security Entity Store" section (e.g. `entity_manager`, `kbn-entities-schema`, and the `security_solution` entity_analytics/entity_store paths) are left unchanged.

## Test plan

- [ ] CODEOWNERS validation check passes in CI.

Made with [Cursor](https://cursor.com)