### PR TITLE
[ES|QL] fix Monaco range wrongly calculated when positioned at new line

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/shared/utils.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/shared/utils.test.ts
@@ -68,4 +68,17 @@ describe('offsetRangeToMonacoRange', () => {
       endLineNumber: 1,
     });
   });
+
+  test('empty range on a newline resolves to the end of the current line, not the next one', () => {
+    const expression = 'FROM \n\n';
+    const range = { start: 5, end: 5 };
+    const monacoRange = offsetRangeToMonacoRange(expression, range);
+
+    expect(monacoRange).toEqual({
+      startColumn: 6,
+      endColumn: 6,
+      startLineNumber: 1,
+      endLineNumber: 1,
+    });
+  });
 });

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/shared/utils.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/shared/utils.ts
@@ -52,15 +52,15 @@ export const offsetRangeToMonacoRange = (
 
   // find the line and start column
   for (let i = 0; i <= expression.length; i++) {
-    if (i < expression.length && expression[i] === '\n') {
-      currentLine++;
-      startOfCurrentLine = i + 1;
-    }
-
     if (i === range.start) {
       startColumn = i + 1 - startOfCurrentLine;
       endColumn = startColumn + range.end - range.start;
       break;
+    }
+
+    if (i < expression.length && expression[i] === '\n') {
+      currentLine++;
+      startOfCurrentLine = i + 1;
     }
   }
 


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/275789
## Summary
When the cursor was positioned before a new line, we were wrongly calculating the Monaco range, positioning it at the next line and setting the `startColumn` at the 0 position (Monaco starts counting at 1, that broke the suggestions).

<img width="1713" height="871" alt="range-bug-3" src="https://github.com/user-attachments/assets/697a5076-acc1-4e7e-9c7e-e5d1aa010e04" />
