### PR TITLE
[Security Solution] Fix flaky alerts_charts histogram legend test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_charts.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_charts.cy.ts
@@ -109,7 +109,7 @@ describe('KPI visualizations in Alerts Page', { tags: ['@ess', '@serverless'] },
     it('should should add a filter in to KQL bar', () => {
       selectAlertsHistogram();
       const expectedNumberOfAlerts = 1;
-      clickAlertsHistogramLegend();
+      clickAlertsHistogramLegend(ruleConfigs.name);
       clickAlertsHistogramLegendFilterFor(ruleConfigs.name);
       cy.get(GLOBAL_SEARCH_BAR_FILTER_ITEM).should(
         'have.text',
@@ -120,7 +120,7 @@ describe('KPI visualizations in Alerts Page', { tags: ['@ess', '@serverless'] },
 
     it('should add a filter out to KQL bar', () => {
       selectAlertsHistogram();
-      clickAlertsHistogramLegend();
+      clickAlertsHistogramLegend(ruleConfigs.name);
       clickAlertsHistogramLegendFilterOut(ruleConfigs.name);
       cy.get(GLOBAL_SEARCH_BAR_FILTER_ITEM).should(
         'have.text',
@@ -134,7 +134,7 @@ describe('KPI visualizations in Alerts Page', { tags: ['@ess', '@serverless'] },
 
     it('should add To Timeline', () => {
       selectAlertsHistogram();
-      clickAlertsHistogramLegend();
+      clickAlertsHistogramLegend(ruleConfigs.name);
       clickAlertsHistogramLegendAddToTimeline(ruleConfigs.name);
 
       cy.get(TOASTER).should('have.text', `Added ${ruleConfigs.name} to Timeline`);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/alerts.ts
@@ -149,10 +149,10 @@ export const ALERT_SUMMARY_CHARTS_COLLAPSED = getDataTestSubjectSelector('chart-
 
 export const ALERTS_HISTOGRAM = getDataTestSubjectSelector('alerts-histogram-panel');
 
-export const ALERTS_HISTOGRAM_LEGEND =
-  '[data-test-subj="alerts-histogram-panel"] .echLegendItem__action';
-
 export const ALERTS_HISTOGRAM_SERIES = '[data-ech-series-name]';
+
+export const ALERTS_HISTOGRAM_LEGEND_BUTTON = (ruleName: string) =>
+  `[data-test-subj="alerts-histogram-panel"] [data-test-subj="legend-${ruleName}"]`;
 
 export const SELECT_HISTOGRAM = '[data-test-subj="chart-select-trend"]';
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -25,7 +25,9 @@ import {
   ALERT_TAGGING_CONTEXT_MENU,
   ALERT_TAGGING_CONTEXT_MENU_ITEM,
   ALERT_TAGGING_UPDATE_BUTTON,
-  ALERTS_HISTOGRAM_LEGEND,
+  ALERTS_HISTOGRAM,
+  ALERTS_HISTOGRAM_LEGEND_BUTTON,
+  ALERTS_HISTOGRAM_SERIES,
   ALERTS_TABLE_ROW_LOADER,
   CELL_ADD_TO_TIMELINE_BUTTON,
   CELL_FILTER_IN_BUTTON,
@@ -394,8 +396,19 @@ export const openAnalyzerForFirstAlertInTimeline = () => {
   cy.get(OPEN_ANALYZER_BTN).first().click({ force: true });
 };
 
-export const clickAlertsHistogramLegend = () => {
-  cy.get(ALERTS_HISTOGRAM_LEGEND).click();
+export const clickAlertsHistogramLegend = (ruleName: string) => {
+  cy.get(ALERTS_HISTOGRAM)
+    .find(ALERTS_HISTOGRAM_SERIES)
+    .should('contain.text', ruleName);
+
+  recurse(
+    () => {
+      cy.get('body').type('{esc}');
+      cy.get(ALERTS_HISTOGRAM).contains(ruleName).realHover();
+      return cy.get(ALERTS_HISTOGRAM_LEGEND_BUTTON(ruleName));
+    },
+    ($el) => $el.is(':visible')
+  ).click();
 };
 
 export const clickAlertsHistogramLegendAddToTimeline = (ruleName: string) => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -397,9 +397,7 @@ export const openAnalyzerForFirstAlertInTimeline = () => {
 };
 
 export const clickAlertsHistogramLegend = (ruleName: string) => {
-  cy.get(ALERTS_HISTOGRAM)
-    .find(ALERTS_HISTOGRAM_SERIES)
-    .should('contain.text', ruleName);
+  cy.get(ALERTS_HISTOGRAM).find(ALERTS_HISTOGRAM_SERIES).should('contain.text', ruleName);
 
   recurse(
     () => {


### PR DESCRIPTION
## Summary

Fixes flaky `alerts_charts.cy.ts` histogram legend hover actions by hardening the `clickAlertsHistogramLegend` Cypress helper.

- Wait for histogram series data to render after switching to the trend chart (table alerts existing does not guarantee the Lens chart has loaded).
- Hover legend items before clicking the action button (`legendActionOnHover` in Elastic Charts).
- Use stable `data-test-subj="legend-${ruleName}"` selector with `recurse` retry, matching the pattern used for table cell hover actions.

Fixes #237743

## Test plan

- [ ] Run Cypress locally:
  ```bash
  cd x-pack/solutions/security/test/security_solution_cypress
  yarn cypress:ess --spec './cypress/e2e/investigations/alerts/alerts_charts.cy.ts'
  ```
- [ ] Trigger [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) on `alerts_charts.cy.ts`


Made with [Cursor](https://cursor.com)