### PR TITLE
[ci][flaky] Parse `/flaky` command from the first comment line only

### DIFF
--- a/.github/workflows/trigger-flaky.yml
+++ b/.github/workflows/trigger-flaky.yml
@@ -40,7 +40,7 @@ jobs:
           # command — validating and extracting the configs in one step.
           # Pattern: type:path[:count] where path cannot contain .., start with ./ or /, or end with /
           config_token='(ftrConfig|scoutConfig|config):[a-zA-Z0-9_-]+([/.][a-zA-Z0-9_-]+)*(:[0-9]+)?'
-          if [[ ! "$COMMENT_BODY" =~ ^/flaky[[:space:]]+(${config_token}([[:space:]]+${config_token})*) ]]; then
+          if [[ ! "$COMMENT_BODY" =~ ^/flaky[[:blank:]]+(${config_token}([[:blank:]]+${config_token})*) ]]; then
             echo "::error::Invalid comment format. Use: /flaky <type>:<config>[:count] [<type>:<config>[:count] ...]"
             echo "::error::Where <type> is one of: ftrConfig, scoutConfig, config"
             echo "::error::And <count> is an optional positive integer"

--- a/.github/workflows/trigger-flaky.yml
+++ b/.github/workflows/trigger-flaky.yml
@@ -34,12 +34,13 @@ jobs:
           COMMENT_BODY: ${{github.event.comment.body}}
           ISSUE_NUMBER: ${{github.event.issue.number}}
         run: |
-          # Extract configs (everything after '/flaky ')
-          configs="${COMMENT_BODY#/flaky }"
-
-          # Validate comment body format
+          # Match `/flaky` and capture only the config list. Tokens are
+          # `type:path[:count]` and never span lines, so the match stops before any
+          # footer, markers, trailing CR, or prose the comment carries below the
+          # command — validating and extracting the configs in one step.
           # Pattern: type:path[:count] where path cannot contain .., start with ./ or /, or end with /
-          if [[ ! "$configs" =~ ^[[:space:]]*(ftrConfig|scoutConfig|config):[a-zA-Z0-9_-]+([/.][a-zA-Z0-9_-]+)*(:[0-9]+)?([[:space:]]+(ftrConfig|scoutConfig|config):[a-zA-Z0-9_-]+([/.][a-zA-Z0-9_-]+)*(:[0-9]+)?)*[[:space:]]*$ ]]; then
+          config_token='(ftrConfig|scoutConfig|config):[a-zA-Z0-9_-]+([/.][a-zA-Z0-9_-]+)*(:[0-9]+)?'
+          if [[ ! "$COMMENT_BODY" =~ ^/flaky[[:space:]]+(${config_token}([[:space:]]+${config_token})*) ]]; then
             echo "::error::Invalid comment format. Use: /flaky <type>:<config>[:count] [<type>:<config>[:count] ...]"
             echo "::error::Where <type> is one of: ftrConfig, scoutConfig, config"
             echo "::error::And <count> is an optional positive integer"
@@ -47,6 +48,7 @@ jobs:
             echo "::error::Example: /flaky config:x-pack/test:5 ftrConfig:functional/apps"
             exit 1
           fi
+          configs="${BASH_REMATCH[1]}"
 
           npm ci --omit=dev
           node trigger-flaky-test-runner $ISSUE_NUMBER "$configs"


### PR DESCRIPTION
I noticed the `/flaky` test command posted by the flaky test verifier automation isn't being picked up correctly because it has a footer under it (added by the GitHub Agentic workflow itself). See comment here: https://github.com/elastic/kibana/pull/275943#issuecomment-4866945162. This PR updates the `trigger-flaky.yml` workflow so that we only parse the first line.