### PR TITLE
[Chrome][AppHeader] Add tab overflow actions API (AppHeaderTab.actions)

### DIFF
--- a/src/core/packages/chrome/app-header/index.ts
+++ b/src/core/packages/chrome/app-header/index.ts
@@ -22,6 +22,8 @@ export type {
   AppHeaderBadge,
   AppHeaderBadgeItem,
   AppHeaderTab,
+  AppHeaderTabAction,
+  AppHeaderTabActions,
   AppHeaderEditableTitle,
   AppHeaderMetadataButtonItem,
   AppHeaderMetadataHealthItem,

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -53,13 +53,13 @@ const tabs: AppHeaderTab[] = [
         {
           id: 'copy',
           label: 'Copy API request',
-          icon: 'copy',
+          iconType: 'copy',
           onClick: action('tab-overview-copy'),
         },
         {
           id: 'edit',
           label: 'Edit configuration',
-          icon: 'gear',
+          iconType: 'gear',
           onClick: action('tab-overview-edit'),
         },
       ],

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -42,7 +42,29 @@ const badges: AppHeaderBadge[] = [
 ];
 
 const tabs: AppHeaderTab[] = [
-  { id: 'overview', label: 'Overview', isSelected: true, onClick: action('tab-overview') },
+  {
+    id: 'overview',
+    label: 'Overview',
+    isSelected: true,
+    onClick: action('tab-overview'),
+    actions: {
+      ariaLabel: 'More actions',
+      items: [
+        {
+          id: 'copy',
+          label: 'Copy API request',
+          icon: 'copy',
+          onClick: action('tab-overview-copy'),
+        },
+        {
+          id: 'edit',
+          label: 'Edit configuration',
+          icon: 'gear',
+          onClick: action('tab-overview-edit'),
+        },
+      ],
+    },
+  },
   { id: 'alerts', label: 'Alerts', badge: 3, onClick: action('tab-alerts') },
   {
     id: 'insights',

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
@@ -199,7 +199,7 @@ describe('AppHeaderView', () => {
                 {
                   id: 'copy',
                   label: 'Copy API request',
-                  icon: 'copy',
+                  iconType: 'copy',
                   onClick: onCopy,
                   'data-test-subj': 'lifecycleTabCopy',
                 },

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
@@ -179,6 +179,66 @@ describe('AppHeaderView', () => {
     expect(screen.getByText('3')).toBeInTheDocument();
   });
 
+  it('renders tab actions in an ellipsis popover without triggering tab navigation', () => {
+    const onTabClick = jest.fn();
+    const onCopy = jest.fn();
+
+    renderAppHeader(
+      <AppHeaderView
+        tabs={[
+          {
+            id: 'lifecycle',
+            label: 'Data lifecycle',
+            'data-test-subj': 'lifecycleTab',
+            isSelected: true,
+            onClick: onTabClick,
+            actions: {
+              ariaLabel: 'Data lifecycle tab actions',
+              'data-test-subj': 'lifecycleTabActionsButton',
+              items: [
+                {
+                  id: 'copy',
+                  label: 'Copy API request',
+                  icon: 'copy',
+                  onClick: onCopy,
+                  'data-test-subj': 'lifecycleTabCopy',
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('lifecycleTabActionsButton'));
+    expect(onTabClick).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('lifecycleTabCopy'));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+    expect(onTabClick).not.toHaveBeenCalled();
+  });
+
+  it('only renders tab actions for the selected tab', () => {
+    renderAppHeader(
+      <AppHeaderView
+        tabs={[
+          {
+            id: 'lifecycle',
+            label: 'Data lifecycle',
+            isSelected: false,
+            actions: {
+              ariaLabel: 'More actions',
+              'data-test-subj': 'lifecycleTabActionsButton',
+              items: [{ id: 'copy', label: 'Copy API request', onClick: jest.fn() }],
+            },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryByTestId('lifecycleTabActionsButton')).not.toBeInTheDocument();
+  });
+
   it('only treats exact base path prefixes as already prepended for back links', () => {
     const chrome = chromeServiceMock.createStartContract();
     chrome.componentDeps.basePath.get.mockReturnValue('/base');

--- a/src/core/packages/chrome/app-header/src/app_header/app_tabs.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_tabs.tsx
@@ -46,14 +46,17 @@ const renderTabBadge = (badge: AppHeaderTab['badge']) => {
   );
 };
 
+// a11y caveat: EuiTab renders `append` inside the tab's own `<button role="tab">`/`<a href>`, so
+// this trigger is an interactive element nested in an interactive element (invalid HTML, imperfect
+// a11y tree). `append` is EuiTab's only slot; a proper fix needs EUI-level support. Accepted for now.
 const TabActions = ({ actions }: { actions: AppHeaderTabActions }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const items = actions.items.map((item) => (
     <EuiContextMenuItem
       key={item.id}
-      icon={item.icon}
-      disabled={item.disabled}
+      icon={item.iconType}
+      disabled={typeof item.disabled === 'function' ? item.disabled() : item.disabled}
       data-test-subj={item['data-test-subj']}
       onClick={(event) => {
         // Portaled popover content still bubbles through the React tree to the tab.

--- a/src/core/packages/chrome/app-header/src/app_header/app_tabs.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_tabs.tsx
@@ -7,16 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiIcon,
   EuiIconTip,
   EuiNotificationBadge,
+  EuiPopover,
   EuiTab,
   EuiTabs,
   EuiToolTip,
 } from '@elastic/eui';
-import type { AppHeaderTab } from '../types';
+import type { AppHeaderTab, AppHeaderTabActions } from '../types';
 
 export interface AppTabsProps {
   tabs?: AppHeaderTab[];
@@ -40,6 +46,75 @@ const renderTabBadge = (badge: AppHeaderTab['badge']) => {
   );
 };
 
+const TabActions = ({ actions }: { actions: AppHeaderTabActions }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const items = actions.items.map((item) => (
+    <EuiContextMenuItem
+      key={item.id}
+      icon={item.icon}
+      disabled={item.disabled}
+      data-test-subj={item['data-test-subj']}
+      onClick={(event) => {
+        // Portaled popover content still bubbles through the React tree to the tab.
+        event.preventDefault();
+        event.stopPropagation();
+        setIsOpen(false);
+        item.onClick();
+      }}
+    >
+      {item.label}
+    </EuiContextMenuItem>
+  ));
+
+  return (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="downLeft"
+      panelPaddingSize="none"
+      aria-label={actions.ariaLabel}
+      button={
+        <EuiToolTip content={actions.ariaLabel} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="ellipsis"
+            size="xs"
+            display="empty"
+            aria-label={actions.ariaLabel}
+            data-test-subj={actions['data-test-subj']}
+            onClick={(event: React.MouseEvent) => {
+              // The trigger lives inside the tab element, so prevent tab navigation/selection.
+              event.preventDefault();
+              event.stopPropagation();
+              setIsOpen((open) => !open);
+            }}
+          />
+        </EuiToolTip>
+      }
+    >
+      <EuiContextMenuPanel items={items} />
+    </EuiPopover>
+  );
+};
+
+const renderTabAppend = (tab: AppHeaderTab) => {
+  const badge = renderTabBadge(tab.badge);
+
+  // Tab actions are only surfaced for the selected tab.
+  if (!tab.actions || !tab.isSelected) {
+    return badge;
+  }
+
+  return (
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+      {badge !== undefined && <EuiFlexItem grow={false}>{badge}</EuiFlexItem>}
+      <EuiFlexItem grow={false}>
+        <TabActions actions={tab.actions} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
 export const AppTabs = React.memo<AppTabsProps>(({ tabs }) => {
   if (!tabs?.length) return null;
 
@@ -53,7 +128,7 @@ export const AppTabs = React.memo<AppTabsProps>(({ tabs }) => {
           href={tab.href}
           data-test-subj={tab['data-test-subj']}
           disabled={tab.disabled}
-          append={renderTabBadge(tab.badge)}
+          append={renderTabAppend(tab)}
         >
           {tab.toolTipContent !== undefined ? (
             <EuiToolTip content={tab.toolTipContent} position="bottom">

--- a/src/core/packages/chrome/app-header/src/index.ts
+++ b/src/core/packages/chrome/app-header/src/index.ts
@@ -21,6 +21,8 @@ export type {
   AppHeaderBadge,
   AppHeaderBadgeItem,
   AppHeaderTab,
+  AppHeaderTabAction,
+  AppHeaderTabActions,
   AppHeaderTabBadge,
   AppHeaderTabIconBadge,
   AppHeaderEditableTitle,

--- a/src/core/packages/chrome/app-header/src/types.ts
+++ b/src/core/packages/chrome/app-header/src/types.ts
@@ -19,6 +19,8 @@ import type {
   AppHeaderMetadataItems as CoreAppHeaderMetadataItems,
   AppHeaderMetadataTextItem as CoreAppHeaderMetadataTextItem,
   AppHeaderTab as CoreAppHeaderTab,
+  AppHeaderTabAction as CoreAppHeaderTabAction,
+  AppHeaderTabActions as CoreAppHeaderTabActions,
   AppHeaderTabBadge as CoreAppHeaderTabBadge,
   AppHeaderTabIconBadge as CoreAppHeaderTabIconBadge,
   AppHeaderTitle as CoreAppHeaderTitle,
@@ -37,6 +39,8 @@ export type AppHeaderMetadataItem = CoreAppHeaderMetadataItem;
 export type AppHeaderMetadataItems = CoreAppHeaderMetadataItems;
 export type AppHeaderMetadataTextItem = CoreAppHeaderMetadataTextItem;
 export type AppHeaderTab = CoreAppHeaderTab;
+export type AppHeaderTabAction = CoreAppHeaderTabAction;
+export type AppHeaderTabActions = CoreAppHeaderTabActions;
 export type AppHeaderTabBadge = CoreAppHeaderTabBadge;
 export type AppHeaderTabIconBadge = CoreAppHeaderTabIconBadge;
 export type AppHeaderTitle = CoreAppHeaderTitle;

--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -21,6 +21,8 @@ export type {
   AppHeaderMetadataItems,
   AppHeaderMetadataTextItem,
   AppHeaderTab,
+  AppHeaderTabAction,
+  AppHeaderTabActions,
   AppHeaderTabBadge,
   AppHeaderTabIconBadge,
   AppHeaderTitle,

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ReactElement, ReactNode, MouseEventHandler } from 'react';
+import type { IconType } from '@elastic/eui';
 import type { Observable } from 'rxjs';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import type { GlobalHeaderAiButton } from './ai_button';
@@ -75,14 +76,21 @@ export interface AppHeaderTabAction {
   id: string;
   label: string;
   /** EUI icon type rendered next to the action label. */
-  icon?: string;
-  disabled?: boolean;
+  iconType?: IconType;
+  /** Disables the action if `true` or if the function returns `true`. */
+  disabled?: boolean | (() => boolean);
   onClick: () => void;
   'data-test-subj'?: string;
 }
 
 /**
  * Optional overflow actions for a tab, rendered as an ellipsis popover appended to the tab.
+ *
+ * @remarks
+ * Actions are intentionally flat (a single level of items). Nested submenus, modals/flyouts and
+ * focus return are not supported yet; when a use case arises, mirror the AppMenu approach
+ * (`AppMenuRunActionParams` in `@kbn/core-chrome-app-menu-components`) by adding a nested `items`
+ * prop and passing an anchor/`returnFocus` handler down to `onClick`.
  *
  * @public
  */

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -71,6 +71,30 @@ export interface AppHeaderTabIconBadge {
 export type AppHeaderTabBadge = number | AppHeaderTabIconBadge;
 
 /** @public */
+export interface AppHeaderTabAction {
+  id: string;
+  label: string;
+  /** EUI icon type rendered next to the action label. */
+  icon?: string;
+  disabled?: boolean;
+  onClick: () => void;
+  'data-test-subj'?: string;
+}
+
+/**
+ * Optional overflow actions for a tab, rendered as an ellipsis popover appended to the tab.
+ *
+ * @public
+ */
+export interface AppHeaderTabActions {
+  /** Accessible label and tooltip for the ellipsis trigger. */
+  ariaLabel: string;
+  items: AppHeaderTabAction[];
+  /** `data-test-subj` for the ellipsis trigger button. */
+  'data-test-subj'?: string;
+}
+
+/** @public */
 export interface AppHeaderTab {
   id: string;
   label: string;
@@ -81,6 +105,11 @@ export interface AppHeaderTab {
   'data-test-subj'?: string;
   disabled?: boolean;
   toolTipContent?: string;
+  /**
+   * Optional overflow actions rendered as an ellipsis popover appended to the tab. Only surfaced
+   * for the selected tab (`isSelected`); may be provided unconditionally.
+   */
+  actions?: AppHeaderTabActions;
 }
 
 /** @public */

--- a/src/core/packages/chrome/browser/src/chrome_next/index.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/index.ts
@@ -19,6 +19,8 @@ export type {
   AppHeaderMetadataItems,
   AppHeaderMetadataTextItem,
   AppHeaderTab,
+  AppHeaderTabAction,
+  AppHeaderTabActions,
   AppHeaderTabBadge,
   AppHeaderTabIconBadge,
   AppHeaderTitle,

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -24,6 +24,8 @@ export type {
   AppHeaderMetadataItems,
   AppHeaderMetadataTextItem,
   AppHeaderTab,
+  AppHeaderTabAction,
+  AppHeaderTabActions,
   AppHeaderTabBadge,
   AppHeaderTabIconBadge,
   AppHeaderTitle,


### PR DESCRIPTION
Part of elastic/kibana-team#3549

## Summary

Adds a small, opt-in API to the shared `@kbn/app-header` for rendering **overflow actions on a tab**. This is a prerequisite for the chrome-next Streams migration, where the "Data lifecycle" tab needs contextual actions (e.g. copy API request, edit index template) that previously lived inside a bespoke rich tab label.

- New types `AppHeaderTabAction` / `AppHeaderTabActions` and an optional `AppHeaderTab.actions` field, re-exported through `@kbn/core-chrome-browser` and `@kbn/app-header`.
- `AppTabs` renders `actions` as an ellipsis popover appended next to any existing tab badge.
- Actions are only surfaced for the **selected** tab; consumers can pass `actions` unconditionally and the component enforces visibility.
- Clicks on the ellipsis trigger and its menu items are prevented from bubbling into tab navigation/selection.
- Adds a Storybook variant on the `Overview` tab and unit tests covering both the selected (rendered) and unselected (hidden) cases.

Extracted from the Streams `AppHeader` migration so the shared component change can be reviewed independently.


<img width="963" height="261" alt="Screenshot 2026-07-02 at 17 06 51" src="https://github.com/user-attachments/assets/23ea3942-0483-4bc4-9ebd-e32b7b1b3e0a" />
