### PR TITLE
[Reporting] apply more precision when processing access rules

### DIFF
--- a/x-pack/platform/plugins/shared/screenshotting/server/browsers/network_policy.test.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/browsers/network_policy.test.ts
@@ -33,8 +33,8 @@ describe('allowRequest', () => {
     expect(allowRequest(url, rules)).toEqual(false);
   });
 
-  it('denies requests when a rule matches tasking into account port', () => {
-    const url = 'https://bad.com:80/cool/route/broå';
+  it('denies requests when a rule matches, when the url has a port', () => {
+    const url = 'https://bad.com:80/cool/route/bro';
     const rules = [{ allow: false, host: 'bad.com' }, { allow: true }];
 
     expect(allowRequest(url, rules)).toEqual(false);

--- a/x-pack/platform/plugins/shared/screenshotting/server/browsers/network_policy.test.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/browsers/network_policy.test.ts
@@ -33,6 +33,13 @@ describe('allowRequest', () => {
     expect(allowRequest(url, rules)).toEqual(false);
   });
 
+  it('denies requests when a rule matches tasking into account port', () => {
+    const url = 'https://bad.com:80/cool/route/broå';
+    const rules = [{ allow: false, host: 'bad.com' }, { allow: true }];
+
+    expect(allowRequest(url, rules)).toEqual(false);
+  });
+
   it('allows complex rules', () => {
     const url = 'https://kibana.com/cool/route/bro';
     const rules = [{ allow: true, host: 'kibana.com', protocol: 'https:' }, { allow: false }];

--- a/x-pack/platform/plugins/shared/screenshotting/server/browsers/network_policy.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/browsers/network_policy.ts
@@ -42,7 +42,7 @@ export function allowRequest(url: string, rules: NetworkPolicyRule[]): boolean {
       return result;
     }
 
-    const hostMatch = rule.host ? isHostMatch(parsed.host || '', rule.host) : true;
+    const hostMatch = rule.host ? isHostMatch(parsed.hostname || '', rule.host) : true;
 
     const protocolMatch = rule.protocol ? parsed.protocol === rule.protocol : true;
 


### PR DESCRIPTION
resolves: https://github.com/elastic/response-ops-team/issues/639

## Summary

Changes comparsion in the access rules from `parsedUrl.host` to `parsedUrl.hostname`, as the `host` version includes a port but we don't want to compare that.

### Checklist

Check the PR satisfies following conditions.  

Reviewers should verify this PR satisfies this list as well.

 If you change the runtime code back to the original, and run the new test, you'll see that it fails.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->