### PR TITLE
[9.3] Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3 (#275828)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1205,7 +1205,7 @@
     "@mapbox/mapbox-gl-rtl-text": "0.2.3",
     "@mapbox/mapbox-gl-supported": "2.0.1",
     "@mapbox/vector-tile": "1.3.1",
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@moonrepo/cli": "2.1.0",
     "@n8n/json-schema-to-zod": "1.1.0",
     "@openfeature/core": "1.11.0",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -210,7 +210,7 @@ evp_bytestokey@1.0.3
 extend@3.0.2
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
-fast-uri@3.1.2
+fast-uri@3.1.3
 fastest-levenshtein@1.0.16
 file-selector@0.4.0
 find-root@1.1.0

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
@@ -68,7 +68,7 @@ events@3.3.0
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
 fast-shallow-equal@1.0.0
-fast-uri@3.1.2
+fast-uri@3.1.3
 fastest-stable-stringify@2.0.2
 find-cache-dir@4.0.0
 find-up@6.3.0

--- a/src/platform/packages/shared/kbn-monaco/version_dependencies.txt
+++ b/src/platform/packages/shared/kbn-monaco/version_dependencies.txt
@@ -51,7 +51,7 @@ estraverse@5.3.0
 events@3.3.0
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
-fast-uri@3.1.2
+fast-uri@3.1.3
 find-cache-dir@4.0.0
 find-up@6.3.0
 glob-to-regexp@0.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -9646,10 +9646,10 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@modelcontextprotocol/sdk@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz#5b35d73062125f126cc70b0be83cbab53bcdde74"
-  integrity sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==
+"@modelcontextprotocol/sdk@1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
   dependencies:
     "@hono/node-server" "^1.19.9"
     ajv "^8.17.1"
@@ -21096,9 +21096,9 @@ fast-stream-to-buffer@^1.0.0:
     end-of-stream "^1.4.1"
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
+  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
 
 fast-xml-builder@^1.1.4:
   version "1.2.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3 (#275828)](https://github.com/elastic/kibana/pull/275828)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2026-07-02T12:50:36Z","message":"Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3 (#275828)","sha":"a9ebf34a6712e600012b23a46da4da4b4aa29742","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:all-open","v9.5.0"],"title":"Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3","number":275828,"url":"https://github.com/elastic/kibana/pull/275828","mergeCommit":{"message":"Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3 (#275828)","sha":"a9ebf34a6712e600012b23a46da4da4b4aa29742"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275828","number":275828,"mergeCommit":{"message":"Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3 (#275828)","sha":"a9ebf34a6712e600012b23a46da4da4b4aa29742"}}]}] BACKPORT-->