### PR TITLE
[9.4] [Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)

### DIFF
--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
@@ -9,7 +9,7 @@ metadata:
       title: Pipeline link
 spec:
   type: buildkite-pipeline
-  owner: 'group:obs-ai-team'
+  owner: 'group:nightshift-context-and-research-team'
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -39,7 +39,7 @@ spec:
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ
-        obs-ai-team:
+        nightshift-context-and-research-team:
           access_level: MANAGE_BUILD_AND_READ
         security-generative_ai:
           access_level: MANAGE_BUILD_AND_READ

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -537,7 +537,7 @@ src/platform/packages/shared/kbn-discover-utils @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-doc-links @elastic/docs
 src/platform/packages/shared/kbn-dom-drag-drop @elastic/kibana-visualizations @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-ebt-tools @elastic/kibana-core
-src/platform/packages/shared/kbn-edot-collector @elastic/obs-ai-team
+src/platform/packages/shared/kbn-edot-collector @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-elastic-agent-utils @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-encrypted-saved-objects-shared @elastic/kibana-security
 src/platform/packages/shared/kbn-es @elastic/kibana-operations
@@ -548,7 +548,7 @@ src/platform/packages/shared/kbn-es-query @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-constants @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-server @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-types @elastic/kibana-core
-src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/obs-ai-team
+src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-esql-language @elastic/kibana-esql
 src/platform/packages/shared/kbn-esql-resource-browser @elastic/kibana-management
 src/platform/packages/shared/kbn-esql-resource-browser/.storybook @elastic/kibana-management
@@ -580,7 +580,7 @@ src/platform/packages/shared/kbn-lens-common @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-lens-common-2 @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
-src/platform/packages/shared/kbn-lock-manager @elastic/obs-ai-team
+src/platform/packages/shared/kbn-lock-manager @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-logging @elastic/kibana-core
 src/platform/packages/shared/kbn-logging-mocks @elastic/kibana-core
 src/platform/packages/shared/kbn-management/autoops_promotion_callout @elastic/kibana-management
@@ -649,15 +649,15 @@ src/platform/packages/shared/kbn-shared-svg @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-shared-ux-utility @elastic/appex-sharedux
 src/platform/packages/shared/kbn-sort-predicates @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-spaces-utils @elastic/kibana-security
-src/platform/packages/shared/kbn-sse-utils @elastic/obs-ai-team
-src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-ai-team
-src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-ai-team
+src/platform/packages/shared/kbn-sse-utils @elastic/nightshift-context-and-research-team
+src/platform/packages/shared/kbn-sse-utils-client @elastic/nightshift-context-and-research-team
+src/platform/packages/shared/kbn-sse-utils-server @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
-src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team @elastic/obs-ai-team
+src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-synthtrace-client @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/obs-ai-team
+src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-telemetry-config @elastic/kibana-core
 src/platform/packages/shared/kbn-test @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-test-docker-servers @elastic/kibana-operations @elastic/appex-qa
@@ -670,7 +670,7 @@ src/platform/packages/shared/kbn-timerange @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-tooling-log @elastic/kibana-operations
 src/platform/packages/shared/kbn-tour-queue @elastic/appex-sharedux
 src/platform/packages/shared/kbn-traced-es-client @elastic/observability-ui
-src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/obs-ai-team
+src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 src/platform/packages/shared/kbn-tracing-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-triggers-actions-ui-types @elastic/response-ops
@@ -990,7 +990,7 @@ x-pack/platform/packages/shared/file-upload-common @elastic/ml-ui
 x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared @elastic/kibana-management
 x-pack/platform/packages/shared/index-management/index_management_shared_types @elastic/kibana-management
 x-pack/platform/packages/shared/ingest-pipelines @elastic/kibana-management
-x-pack/platform/packages/shared/kbn-ai-assistant @elastic/search-kibana @elastic/obs-ai-team
+x-pack/platform/packages/shared/kbn-ai-assistant @elastic/search-kibana @elastic/nightshift-context-and-research-team
 x-pack/platform/packages/shared/kbn-ai-tools @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-ai-tools-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
@@ -1004,11 +1004,11 @@ x-pack/platform/packages/shared/kbn-elastic-assistant @elastic/security-generati
 x-pack/platform/packages/shared/kbn-elastic-assistant-common @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-elastic-assistant-shared-state @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-entities-schema @elastic/core-analysis
-x-pack/platform/packages/shared/kbn-es-snapshot-loader @elastic/obs-ai-team
-x-pack/platform/packages/shared/kbn-evals @elastic/obs-ai-team @elastic/security-generative-ai
-x-pack/platform/packages/shared/kbn-evals-common @elastic/obs-ai-team @elastic/security-generative-ai
-x-pack/platform/packages/shared/kbn-evals-extensions @elastic/obs-ai-team @elastic/security-generative-ai
-x-pack/platform/packages/shared/kbn-evals-phoenix-executor @elastic/obs-ai-team
+x-pack/platform/packages/shared/kbn-es-snapshot-loader @elastic/nightshift-context-and-research-team
+x-pack/platform/packages/shared/kbn-evals @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
+x-pack/platform/packages/shared/kbn-evals-common @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
+x-pack/platform/packages/shared/kbn-evals-extensions @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
+x-pack/platform/packages/shared/kbn-evals-phoenix-executor @elastic/nightshift-context-and-research-team
 x-pack/platform/packages/shared/kbn-evals-suite-significant-events @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-evals-suite-streams @elastic/obs-onboarding-team
 x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-team @elastic/obs-exploration-team
@@ -1098,7 +1098,7 @@ x-pack/platform/plugins/private/license_api_guard @elastic/kibana-management
 x-pack/platform/plugins/private/logstash @elastic/logstash
 x-pack/platform/plugins/private/monitoring @elastic/stack-monitoring
 x-pack/platform/plugins/private/monitoring_collection @elastic/stack-monitoring
-x-pack/platform/plugins/private/observability_ai_assistant_management @elastic/obs-ai-team
+x-pack/platform/plugins/private/observability_ai_assistant_management @elastic/nightshift-context-and-research-team
 x-pack/platform/plugins/private/otel_telemetry_collection @elastic/observability-bi
 x-pack/platform/plugins/private/painless_lab @elastic/kibana-management
 x-pack/platform/plugins/private/product_intercept @elastic/appex-sharedux
@@ -1136,7 +1136,7 @@ x-pack/platform/plugins/shared/elastic_console @elastic/obs-elastic-brain-team
 x-pack/platform/plugins/shared/embeddable_alerts_table @elastic/response-ops
 x-pack/platform/plugins/shared/encrypted_saved_objects @elastic/kibana-security
 x-pack/platform/plugins/shared/entity_manager @elastic/core-analysis
-x-pack/platform/plugins/shared/evals @elastic/obs-ai-team @elastic/security-generative-ai
+x-pack/platform/plugins/shared/evals @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 x-pack/platform/plugins/shared/event_log @elastic/response-ops
 x-pack/platform/plugins/shared/features @elastic/kibana-core
 x-pack/platform/plugins/shared/fields_metadata @elastic/obs-onboarding-team
@@ -1157,7 +1157,7 @@ x-pack/platform/plugins/shared/maintenance_windows @elastic/response-ops
 x-pack/platform/plugins/shared/maps @elastic/kibana-presentation
 x-pack/platform/plugins/shared/ml @elastic/ml-ui
 x-pack/platform/plugins/shared/notifications @elastic/appex-sharedux
-x-pack/platform/plugins/shared/observability_ai_assistant @elastic/obs-ai-team
+x-pack/platform/plugins/shared/observability_ai_assistant @elastic/nightshift-context-and-research-team
 x-pack/platform/plugins/shared/osquery @elastic/security-defend-workflows
 x-pack/platform/plugins/shared/osquery/cypress @elastic/security-defend-workflows
 x-pack/platform/plugins/shared/query_activity @elastic/kibana-management
@@ -1222,16 +1222,16 @@ x-pack/solutions/observability/packages/alert-details @elastic/actionable-obs-te
 x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
-x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/obs-ai-team
-x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai @elastic/obs-ai-team
-x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-ai-team
+x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/packages/kbn-genai-cli @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/kbn-synthetics-forge @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli @elastic/observability-ui
 x-pack/solutions/observability/packages/nav-icons @elastic/obs-presentation-team
-x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/obs-ai-team
-x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/obs-ai-team
+x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/synthetics-test-data @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/utils-browser @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-common @elastic/observability-ui
@@ -1243,8 +1243,8 @@ x-pack/solutions/observability/plugins/exploratory_view @elastic/actionable-obs-
 x-pack/solutions/observability/plugins/infra @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/metrics_data_access @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/observability @elastic/observability-ui
-x-pack/solutions/observability/plugins/observability_agent_builder @elastic/obs-ai-team
-x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/obs-ai-team
+x-pack/solutions/observability/plugins/observability_agent_builder @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/plugins/observability_logs_explorer @elastic/obs-exploration-team
 x-pack/solutions/observability/plugins/observability_onboarding @elastic/obs-onboarding-team
 x-pack/solutions/observability/plugins/observability_shared @elastic/observability-ui
@@ -1635,21 +1635,21 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/serverless/api_integration/test_suites/data_usage @elastic/kibana-management
 /x-pack/platform/test/serverless/functional/test_suites/data_usage @elastic/kibana-management
 /x-pack/platform/test/serverless/functional/page_objects/svl_data_usage.ts @elastic/kibana-management
-/x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.index.ts  @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.serverless.config.ts  @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.index.ts  @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.stateful.config.ts  @elastic/obs-ai-team
+/x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.index.ts  @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.serverless.config.ts  @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.index.ts  @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.stateful.config.ts  @elastic/nightshift-context-and-research-team
 
 # Observability Agent Builder
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts @elastic/nightshift-context-and-research-team
 
 # Infra Obs
 ## This plugin mostly contains the codebase for the infra services, but also includes some code for the Logs UI app.
@@ -2887,10 +2887,10 @@ src/platform/packages/shared/kbn-connector-schemas/thehive @elastic/kibana-cases
 /src/platform/packages/shared/kbn-connector-schemas/mcp @elastic/workchat-eng
 
 # Inference API
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
 /x-pack/platform/plugins/shared/stack_connectors/server/usage/inference @elastic/search-kibana
-/src/platform/packages/shared/kbn-connector-schemas/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
+/src/platform/packages/shared/kbn-connector-schemas/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
 
 # HTTP
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/http @elastic/workflows-eng
@@ -3297,8 +3297,8 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.agents/skills/scout-ui-testing/** @elastic/appex-qa
 /.agents/skills/enzyme-to-rtl/** @elastic/appex-qa
 /.agents/skills/buildkite-logs @elastic/appex-qa
-/.agents/skills/evals-create-suite/** @elastic/obs-ai-team @elastic/security-generative-ai
-/.agents/skills/evals-write-spec/** @elastic/obs-ai-team @elastic/security-generative-ai
+/.agents/skills/evals-create-suite/** @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
+/.agents/skills/evals-write-spec/** @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 
 # Security team skills: API authorization, CodeQL, and privilege deprecation guidance.
 /.agents/skills/api-authz/** @elastic/kibana-security
@@ -3327,8 +3327,8 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.buildkite/ftr-manifests/
 
 # Evals (Buildkite + scripts)
-/.buildkite/pipelines/evals/ @elastic/obs-ai-team @elastic/security-generative-ai
-/.buildkite/scripts/steps/evals/ @elastic/obs-ai-team @elastic/security-generative-ai
+/.buildkite/pipelines/evals/ @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
+/.buildkite/scripts/steps/evals/ @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 /.coderabbit.yml @elastic/kibana-operations
 /moon.yml @elastic/kibana-operations
 

--- a/renovate.json
+++ b/renovate.json
@@ -128,11 +128,11 @@
       "minimumReleaseAge": "14 days"
     },
     {
-      "groupName": "@elastic/obs-ai-team dependencies",
+      "groupName": "@elastic/nightshift-context-and-research-team dependencies",
       "matchDepNames": ["@arizeai/phoenix-client", "simple-statistics"],
-      "reviewers": ["team:obs-ai-team"],
+      "reviewers": ["team:nightshift-context-and-research-team"],
       "matchBaseBranches": ["main"],
-      "labels": ["Team:obs-ai-team", "release_note:skip", "backport:all-open"],
+      "labels": ["Team:nightshift-context-and-research", "release_note:skip", "backport:all-open"],
       "enabled": true,
       "minimumReleaseAge": "14 days"
     },

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -55,7 +55,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
   search: ['elastic/jinastic', 'elastic/search-design', 'elastic/search-kibana'],
   observability: [
     'elastic/actionable-obs-team',
-    'elastic/obs-ai-team',
+    'elastic/nightshift-context-and-research-team',
     'elastic/obs-cloudnative-monitoring',
     'elastic/obs-docs',
     'elastic/obs-exploration-team',

--- a/src/platform/packages/shared/kbn-edot-collector/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-edot-collector/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/edot-collector",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-edot-collector/moon.yml
+++ b/src/platform/packages/shared/kbn-edot-collector/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/edot-collector'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/edot-collector'
   description: Moon project for @kbn/edot-collector
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-edot-collector
 dependsOn:
   - '@kbn/tooling-log'

--- a/src/platform/packages/shared/kbn-esql-composer/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-esql-composer/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/esql-composer",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/obs-presentation-team", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-lock-manager/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-lock-manager/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/lock-manager",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-lock-manager/moon.yml
+++ b/src/platform/packages/shared/kbn-lock-manager/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/lock-manager'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/lock-manager'
   description: Moon project for @kbn/lock-manager
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-lock-manager
 dependsOn:
   - '@kbn/logging'

--- a/src/platform/packages/shared/kbn-sse-utils-client/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-sse-utils-client/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/sse-utils-client",
   "owner": [
-    "@elastic/obs-ai-team"
+    "@elastic/nightshift-context-and-research-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-sse-utils-client/moon.yml
+++ b/src/platform/packages/shared/kbn-sse-utils-client/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sse-utils-client'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/sse-utils-client'
   description: Moon project for @kbn/sse-utils-client
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-sse-utils-client
 dependsOn:
   - '@kbn/sse-utils'

--- a/src/platform/packages/shared/kbn-sse-utils-server/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-sse-utils-server/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/sse-utils-server",
   "owner": [
-    "@elastic/obs-ai-team"
+    "@elastic/nightshift-context-and-research-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-sse-utils-server/moon.yml
+++ b/src/platform/packages/shared/kbn-sse-utils-server/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sse-utils-server'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/sse-utils-server'
   description: Moon project for @kbn/sse-utils-server
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-sse-utils-server
 dependsOn:
   - '@kbn/sse-utils'

--- a/src/platform/packages/shared/kbn-sse-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-sse-utils/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/sse-utils",
   "owner": [
-    "@elastic/obs-ai-team"
+    "@elastic/nightshift-context-and-research-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-sse-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-sse-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sse-utils'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/sse-utils'
   description: Moon project for @kbn/sse-utils
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-sse-utils
 dependsOn:
   - '@kbn/i18n'

--- a/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
@@ -5,7 +5,7 @@
     "@elastic/obs-presentation-team",
     "@elastic/obs-onboarding-team",
     "@elastic/obs-exploration-team",
-    "@elastic/obs-ai-team"
+    "@elastic/nightshift-context-and-research-team"
   ],
   "group": "platform",
   "visibility": "shared",

--- a/src/platform/packages/shared/kbn-telemetry/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-telemetry/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/telemetry",
-  "owner": ["@elastic/kibana-core", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/kibana-core", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-tracing/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-tracing/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/tracing",
-  "owner": ["@elastic/kibana-core", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/kibana-core", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "id": "@kbn/ai-assistant",
-  "owner": ["@elastic/search-kibana", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/search-kibana", "@elastic/nightshift-context-and-research-team"],
   "type": "shared-browser",
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/packages/shared/kbn-es-snapshot-loader/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-es-snapshot-loader/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/es-snapshot-loader",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/x-pack/platform/packages/shared/kbn-es-snapshot-loader/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-es-snapshot-loader/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/es-snapshot-loader'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/es-snapshot-loader'
   description: Moon project for @kbn/es-snapshot-loader
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-es-snapshot-loader
 dependsOn:
   - '@kbn/dev-cli-runner'

--- a/x-pack/platform/packages/shared/kbn-evals-common/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-evals-common/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/evals-common",
   "owner": [
-    "@elastic/obs-ai-team",
+    "@elastic/nightshift-context-and-research-team",
     "@elastic/security-generative-ai"
   ],
   "group": "platform",

--- a/x-pack/platform/packages/shared/kbn-evals-common/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-common'
   description: Moon project for @kbn/evals-common
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-evals-common
 dependsOn:
   - '@kbn/zod'

--- a/x-pack/platform/packages/shared/kbn-evals-extensions/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-evals-extensions/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/evals-extensions",
-  "owner": ["@elastic/obs-ai-team", "@elastic/security-generative-ai"],
+  "owner": ["@elastic/nightshift-context-and-research-team", "@elastic/security-generative-ai"],
   "description": "Advanced evaluation capabilities for @kbn/evals - standalone extensions package. Home for features ported from cursor-plugin-evals and Phases 3-5 of evals roadmap.",
   "devOnly": true
 }

--- a/x-pack/platform/packages/shared/kbn-evals-extensions/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-extensions/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-extensions'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-extensions'
   description: Moon project for @kbn/evals-extensions
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-evals-extensions
 dependsOn:
   - '@kbn/evals'

--- a/x-pack/platform/packages/shared/kbn-evals-phoenix-executor/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-evals-phoenix-executor/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/evals-phoenix-executor",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/x-pack/platform/packages/shared/kbn-evals-phoenix-executor/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-phoenix-executor/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-phoenix-executor'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-phoenix-executor'
   description: Moon project for @kbn/evals-phoenix-executor
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-evals-phoenix-executor
 dependsOn:
   - '@kbn/evals'

--- a/x-pack/platform/packages/shared/kbn-evals/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-evals/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/evals",
-  "owner": ["@elastic/obs-ai-team", "@elastic/security-generative-ai"],
+  "owner": ["@elastic/nightshift-context-and-research-team", "@elastic/security-generative-ai"],
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/x-pack/platform/packages/shared/kbn-evals/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals'
   description: Moon project for @kbn/evals
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-evals
 dependsOn:
   - '@kbn/dev-cli-runner'

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/kibana.jsonc
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-management-plugin",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "private",
   "plugin": {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/moon.yml
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-management-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-management-plugin'
   description: Moon project for @kbn/observability-ai-assistant-management-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/private/observability_ai_assistant_management
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/evals/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/evals/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/evals-plugin",
-  "owner": ["@elastic/obs-ai-team", "@elastic/security-generative-ai"],
+  "owner": ["@elastic/nightshift-context-and-research-team", "@elastic/security-generative-ai"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/evals/moon.yml
+++ b/x-pack/platform/plugins/shared/evals/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-plugin'
   description: Moon project for @kbn/evals-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/shared/evals
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-plugin",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/moon.yml
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-plugin'
   description: Moon project for @kbn/observability-ai-assistant-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/shared/observability_ai_assistant
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "functional-tests",
   "id": "@kbn/evals-suite-obs-ai-assistant",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-suite-obs-ai-assistant'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-suite-obs-ai-assistant'
   description: Moon project for @kbn/evals-suite-obs-ai-assistant
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant
 dependsOn:
   - '@kbn/synthtrace-client'

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "functional-tests",
   "id": "@kbn/evals-suite-observability-ai",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-suite-observability-ai'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-suite-observability-ai'
   description: Moon project for @kbn/evals-suite-observability-ai
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai
 dependsOn:
   - '@kbn/evals'

--- a/x-pack/solutions/observability/packages/kbn-genai-cli/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-genai-cli/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/kbn-genai-cli",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/packages/kbn-genai-cli/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-genai-cli/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/kbn-genai-cli'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/kbn-genai-cli'
   description: Moon project for @kbn/kbn-genai-cli
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/kbn-genai-cli
 dependsOn:
   - '@kbn/inference-common'

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/observability-ai-common",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/moon.yml
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-common'
   description: Moon project for @kbn/observability-ai-common
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/observability-ai/observability-ai-common
 dependsOn: []
 tags:

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/observability-ai-server",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/moon.yml
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-server'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-server'
   description: Moon project for @kbn/observability-ai-server
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/observability-ai/observability-ai-server
 dependsOn:
   - '@kbn/observability-utils-common'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-agent-builder-plugin",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-agent-builder-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-agent-builder-plugin'
   description: Moon project for @kbn/observability-agent-builder-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/plugins/observability_agent_builder
 dependsOn:
   - '@kbn/core'

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-app-plugin",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-app-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-app-plugin'
   description: Moon project for @kbn/observability-ai-assistant-app-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/plugins/observability_ai_assistant_app
 dependsOn:
   - '@kbn/es-types'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)](https://github.com/elastic/kibana/pull/275485)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2026-06-30T18:48:40Z","message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","ci:project-deploy-observability","Team:obs-ai","Team:obs-presentation","v9.5.0","Team:nightshift-context-and-research"],"title":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research`","number":275485,"url":"https://github.com/elastic/kibana/pull/275485","mergeCommit":{"message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275485","number":275485,"mergeCommit":{"message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61"}}]}] BACKPORT-->