### PR TITLE
[9.3] [Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -495,7 +495,7 @@ src/platform/packages/shared/kbn-discover-utils @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-doc-links @elastic/docs
 src/platform/packages/shared/kbn-dom-drag-drop @elastic/kibana-visualizations @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-ebt-tools @elastic/kibana-core
-src/platform/packages/shared/kbn-edot-collector @elastic/obs-ai-team
+src/platform/packages/shared/kbn-edot-collector @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-elastic-agent-utils @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-encrypted-saved-objects-shared @elastic/kibana-security
 src/platform/packages/shared/kbn-es @elastic/kibana-operations
@@ -507,7 +507,7 @@ src/platform/packages/shared/kbn-es-query-constants @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-es-query-server @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-types @elastic/kibana-core @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-esql-ast @elastic/kibana-esql
-src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/obs-ai-team
+src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-esql-types @elastic/kibana-esql
 src/platform/packages/shared/kbn-esql-utils @elastic/kibana-esql
 src/platform/packages/shared/kbn-event-annotation-common @elastic/kibana-visualizations
@@ -533,7 +533,7 @@ src/platform/packages/shared/kbn-lens-common @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-lens-common-2 @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-lens-embeddable-utils @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-licensing-types @elastic/kibana-core
-src/platform/packages/shared/kbn-lock-manager @elastic/obs-ai-team
+src/platform/packages/shared/kbn-lock-manager @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-logging @elastic/kibana-core
 src/platform/packages/shared/kbn-logging-mocks @elastic/kibana-core
 src/platform/packages/shared/kbn-management/autoops_promotion_callout @elastic/kibana-management
@@ -607,9 +607,9 @@ src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
-src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team @elastic/obs-ai-team
+src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-synthtrace-client @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/obs-ai-team
+src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-telemetry-config @elastic/kibana-core
 src/platform/packages/shared/kbn-test @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-test-docker-servers @elastic/kibana-operations @elastic/appex-qa
@@ -622,7 +622,7 @@ src/platform/packages/shared/kbn-timerange @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-tooling-log @elastic/kibana-operations
 src/platform/packages/shared/kbn-tour-queue @elastic/appex-sharedux
 src/platform/packages/shared/kbn-traced-es-client @elastic/observability-ui
-src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/obs-ai-team
+src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 src/platform/packages/shared/kbn-tracing-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-triggers-actions-ui-types @elastic/response-ops
@@ -939,7 +939,7 @@ x-pack/platform/packages/shared/file-upload-common @elastic/ml-ui
 x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared @elastic/kibana-management
 x-pack/platform/packages/shared/index-management/index_management_shared_types @elastic/kibana-management
 x-pack/platform/packages/shared/ingest-pipelines @elastic/kibana-management
-x-pack/platform/packages/shared/kbn-ai-assistant @elastic/search-kibana @elastic/obs-ai-team
+x-pack/platform/packages/shared/kbn-ai-assistant @elastic/search-kibana @elastic/nightshift-context-and-research-team
 x-pack/platform/packages/shared/kbn-ai-tools @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-ai-tools-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
@@ -952,7 +952,7 @@ x-pack/platform/packages/shared/kbn-elastic-assistant @elastic/security-generati
 x-pack/platform/packages/shared/kbn-elastic-assistant-common @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-elastic-assistant-shared-state @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-entities-schema @elastic/obs-entities
-x-pack/platform/packages/shared/kbn-es-snapshot-loader @elastic/obs-ai-team
+x-pack/platform/packages/shared/kbn-es-snapshot-loader @elastic/nightshift-context-and-research-team
 x-pack/platform/packages/shared/kbn-evals @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-evals-suite-streams @elastic/obs-onboarding-team @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-team @elastic/obs-exploration-team
@@ -1026,7 +1026,7 @@ x-pack/platform/plugins/private/license_api_guard @elastic/kibana-management
 x-pack/platform/plugins/private/logstash @elastic/logstash
 x-pack/platform/plugins/private/monitoring @elastic/stack-monitoring
 x-pack/platform/plugins/private/monitoring_collection @elastic/stack-monitoring
-x-pack/platform/plugins/private/observability_ai_assistant_management @elastic/obs-ai-team
+x-pack/platform/plugins/private/observability_ai_assistant_management @elastic/nightshift-context-and-research-team
 x-pack/platform/plugins/private/otel_telemetry_collection @elastic/observability-bi
 x-pack/platform/plugins/private/painless_lab @elastic/kibana-management
 x-pack/platform/plugins/private/product_intercept @elastic/appex-sharedux
@@ -1084,7 +1084,7 @@ x-pack/platform/plugins/shared/maintenance_windows @elastic/response-ops
 x-pack/platform/plugins/shared/maps @elastic/kibana-presentation
 x-pack/platform/plugins/shared/ml @elastic/ml-ui
 x-pack/platform/plugins/shared/notifications @elastic/appex-sharedux
-x-pack/platform/plugins/shared/observability_ai_assistant @elastic/obs-ai-team
+x-pack/platform/plugins/shared/observability_ai_assistant @elastic/nightshift-context-and-research-team
 x-pack/platform/plugins/shared/onechat @elastic/workchat-eng
 x-pack/platform/plugins/shared/osquery @elastic/security-defend-workflows
 x-pack/platform/plugins/shared/osquery/cypress @elastic/security-defend-workflows
@@ -1147,14 +1147,14 @@ x-pack/solutions/observability/packages/alert-details @elastic/actionable-obs-te
 x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
-x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/obs-ai-team
+x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-knowledge-team
 x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/kbn-synthetics-forge @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/nav-icons @elastic/obs-presentation-team
-x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/obs-ai-team
-x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/obs-ai-team
+x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/synthetics-test-data @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/utils-browser @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-common @elastic/observability-ui
@@ -1166,8 +1166,8 @@ x-pack/solutions/observability/plugins/exploratory_view @elastic/actionable-obs-
 x-pack/solutions/observability/plugins/infra @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/metrics_data_access @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/observability @elastic/observability-ui
-x-pack/solutions/observability/plugins/observability_agent_builder @elastic/obs-ai-team
-x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/obs-ai-team
+x-pack/solutions/observability/plugins/observability_agent_builder @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/plugins/observability_logs_explorer @elastic/obs-exploration-team
 x-pack/solutions/observability/plugins/observability_onboarding @elastic/obs-onboarding-team
 x-pack/solutions/observability/plugins/observability_shared @elastic/observability-ui
@@ -1498,21 +1498,21 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/serverless/api_integration/test_suites/data_usage @elastic/kibana-management
 /x-pack/platform/test/serverless/functional/test_suites/data_usage @elastic/kibana-management
 /x-pack/platform/test/serverless/functional/page_objects/svl_data_usage.ts @elastic/kibana-management
-/x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.index.ts  @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.serverless.config.ts  @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.index.ts  @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.stateful.config.ts  @elastic/obs-ai-team
+/x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.index.ts  @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.serverless.config.ts  @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.index.ts  @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.stateful.config.ts  @elastic/nightshift-context-and-research-team
 
 # Observability Agent Builder
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts @elastic/nightshift-context-and-research-team
 
 # Infra Obs
 ## This plugin mostly contains the codebase for the infra services, but also includes some code for the Logs UI app.
@@ -2644,18 +2644,18 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 
 ## Generative AI owner connectors
 # OpenAI
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
-/src/platform/packages/shared/kbn-connector-schemas/openai @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/src/platform/packages/shared/kbn-connector-schemas/openai @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
 # Bedrock
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
-/src/platform/packages/shared/kbn-connector-schemas/bedrock @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/src/platform/packages/shared/kbn-connector-schemas/bedrock @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
 
 # Gemini
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/gemini @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
-/src/platform/packages/shared/kbn-connector-schemas/gemini @elastic/security-generative-ai @elastic/obs-ai-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/gemini @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/src/platform/packages/shared/kbn-connector-schemas/gemini @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
 
 # MCP
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/mcp @elastic/workchat-eng
@@ -2663,10 +2663,10 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /src/platform/packages/shared/kbn-connector-schemas/mcp @elastic/workchat-eng
 
 # Inference API
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-team
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-team
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
 /x-pack/platform/plugins/shared/stack_connectors/server/usage/inference @elastic/appex-ai-infra
-/src/platform/packages/shared/kbn-connector-schemas/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-team
+/src/platform/packages/shared/kbn-connector-schemas/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
 
 # Token tracking
 x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/security-generative-ai

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -54,7 +54,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
   search: ['elastic/search-design', 'elastic/search-kibana'],
   observability: [
     'elastic/actionable-obs-team',
-    'elastic/obs-ai-team',
+    'elastic/nightshift-context-and-research-team',
     'elastic/obs-cloudnative-monitoring',
     'elastic/obs-docs',
     'elastic/obs-entities',

--- a/src/platform/packages/shared/kbn-edot-collector/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-edot-collector/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/edot-collector",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-edot-collector/moon.yml
+++ b/src/platform/packages/shared/kbn-edot-collector/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/edot-collector'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/edot-collector'
   description: Moon project for @kbn/edot-collector
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-edot-collector
 dependsOn:
   - '@kbn/tooling-log'

--- a/src/platform/packages/shared/kbn-esql-composer/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-esql-composer/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/esql-composer",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/obs-presentation-team", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-lock-manager/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-lock-manager/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/lock-manager",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-lock-manager/moon.yml
+++ b/src/platform/packages/shared/kbn-lock-manager/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/lock-manager'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/lock-manager'
   description: Moon project for @kbn/lock-manager
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/packages/shared/kbn-lock-manager
 dependsOn:
   - '@kbn/logging'

--- a/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
@@ -5,7 +5,7 @@
     "@elastic/obs-presentation-team",
     "@elastic/obs-onboarding-team",
     "@elastic/obs-exploration-team",
-    "@elastic/obs-ai-team"
+    "@elastic/nightshift-context-and-research-team"
   ],
   "group": "platform",
   "visibility": "shared",

--- a/src/platform/packages/shared/kbn-telemetry/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-telemetry/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/telemetry",
-  "owner": ["@elastic/kibana-core", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/kibana-core", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-tracing/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-tracing/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/tracing",
-  "owner": ["@elastic/kibana-core", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/kibana-core", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "id": "@kbn/ai-assistant",
-  "owner": ["@elastic/search-kibana", "@elastic/obs-ai-team"],
+  "owner": ["@elastic/search-kibana", "@elastic/nightshift-context-and-research-team"],
   "type": "shared-browser",
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/packages/shared/kbn-es-snapshot-loader/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-es-snapshot-loader/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/es-snapshot-loader",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/x-pack/platform/packages/shared/kbn-es-snapshot-loader/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-es-snapshot-loader/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/es-snapshot-loader'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/es-snapshot-loader'
   description: Moon project for @kbn/es-snapshot-loader
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-es-snapshot-loader
 dependsOn:
   - '@kbn/dev-cli-runner'

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/kibana.jsonc
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-management-plugin",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "platform",
   "visibility": "private",
   "plugin": {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/moon.yml
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-management-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-management-plugin'
   description: Moon project for @kbn/observability-ai-assistant-management-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/private/observability_ai_assistant_management
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-plugin",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/moon.yml
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-plugin'
   description: Moon project for @kbn/observability-ai-assistant-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/shared/observability_ai_assistant
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "functional-tests",
   "id": "@kbn/evals-suite-obs-ai-assistant",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-suite-obs-ai-assistant'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-suite-obs-ai-assistant'
   description: Moon project for @kbn/evals-suite-obs-ai-assistant
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant
 dependsOn:
   - '@kbn/synthtrace-client'

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/observability-ai-common",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/moon.yml
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-common'
   description: Moon project for @kbn/observability-ai-common
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/observability-ai/observability-ai-common
 dependsOn: []
 tags:

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/observability-ai-server",
-  "owner": "@elastic/obs-ai-team",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/moon.yml
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-server'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-server'
   description: Moon project for @kbn/observability-ai-server
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/observability-ai/observability-ai-server
 dependsOn:
   - '@kbn/observability-utils-common'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-agent-builder-plugin",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-agent-builder-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-agent-builder-plugin'
   description: Moon project for @kbn/observability-agent-builder-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/plugins/observability_agent_builder
 dependsOn:
   - '@kbn/core'

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-app-plugin",
-  "owner": ["@elastic/obs-ai-team"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-app-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-team'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-app-plugin'
   description: Moon project for @kbn/observability-ai-assistant-app-plugin
   channel: ''
-  owner: '@elastic/obs-ai-team'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/plugins/observability_ai_assistant_app
 dependsOn:
   - '@kbn/es-types'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)](https://github.com/elastic/kibana/pull/275485)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2026-06-30T18:48:40Z","message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","ci:project-deploy-observability","Team:obs-ai","Team:obs-presentation","v9.5.0","Team:nightshift-context-and-research"],"title":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research`","number":275485,"url":"https://github.com/elastic/kibana/pull/275485","mergeCommit":{"message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275485","number":275485,"mergeCommit":{"message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61"}},{"url":"https://github.com/elastic/kibana/pull/276093","number":276093,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->