### PR TITLE
[Fleet] [Identity Federation] Permission-verification backend (aggregation task, API, version-gate shim)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -31262,10 +31262,72 @@ paths:
                             nullable: true
                           type: object
                         verification_failed_at:
+                          maxLength: 40
                           type: string
+                        verification_permissions:
+                          items:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              last_verified_at:
+                                maxLength: 40
+                                type: string
+                              package_name:
+                                maxLength: 100
+                                type: string
+                              package_policy_id:
+                                maxLength: 64
+                                type: string
+                              permissions:
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    action:
+                                      maxLength: 256
+                                      type: string
+                                    error_code:
+                                      maxLength: 100
+                                      type: string
+                                    message:
+                                      maxLength: 2000
+                                      type: string
+                                    required:
+                                      type: boolean
+                                    status:
+                                      enum:
+                                        - verified
+                                        - required
+                                        - denied
+                                        - error
+                                        - skipped
+                                      type: string
+                                  required:
+                                    - action
+                                    - status
+                                    - required
+                                maxItems: 1000
+                                type: array
+                              policy_id:
+                                maxLength: 64
+                                type: string
+                              policy_template:
+                                maxLength: 100
+                                type: string
+                            required:
+                              - package_policy_id
+                              - policy_id
+                              - policy_template
+                              - package_name
+                              - last_verified_at
+                              - permissions
+                          maxItems: 1000
+                          type: array
                         verification_started_at:
+                          maxLength: 40
                           type: string
                         verification_status:
+                          maxLength: 32
                           type: string
                       required:
                         - id
@@ -31451,10 +31513,72 @@ paths:
                           nullable: true
                         type: object
                       verification_failed_at:
+                        maxLength: 40
                         type: string
+                      verification_permissions:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            last_verified_at:
+                              maxLength: 40
+                              type: string
+                            package_name:
+                              maxLength: 100
+                              type: string
+                            package_policy_id:
+                              maxLength: 64
+                              type: string
+                            permissions:
+                              items:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  action:
+                                    maxLength: 256
+                                    type: string
+                                  error_code:
+                                    maxLength: 100
+                                    type: string
+                                  message:
+                                    maxLength: 2000
+                                    type: string
+                                  required:
+                                    type: boolean
+                                  status:
+                                    enum:
+                                      - verified
+                                      - required
+                                      - denied
+                                      - error
+                                      - skipped
+                                    type: string
+                                required:
+                                  - action
+                                  - status
+                                  - required
+                              maxItems: 1000
+                              type: array
+                            policy_id:
+                              maxLength: 64
+                              type: string
+                            policy_template:
+                              maxLength: 100
+                              type: string
+                          required:
+                            - package_policy_id
+                            - policy_id
+                            - policy_template
+                            - package_name
+                            - last_verified_at
+                            - permissions
+                        maxItems: 1000
+                        type: array
                       verification_started_at:
+                        maxLength: 40
                         type: string
                       verification_status:
+                        maxLength: 32
                         type: string
                     required:
                       - id
@@ -31651,10 +31775,72 @@ paths:
                           nullable: true
                         type: object
                       verification_failed_at:
+                        maxLength: 40
                         type: string
+                      verification_permissions:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            last_verified_at:
+                              maxLength: 40
+                              type: string
+                            package_name:
+                              maxLength: 100
+                              type: string
+                            package_policy_id:
+                              maxLength: 64
+                              type: string
+                            permissions:
+                              items:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  action:
+                                    maxLength: 256
+                                    type: string
+                                  error_code:
+                                    maxLength: 100
+                                    type: string
+                                  message:
+                                    maxLength: 2000
+                                    type: string
+                                  required:
+                                    type: boolean
+                                  status:
+                                    enum:
+                                      - verified
+                                      - required
+                                      - denied
+                                      - error
+                                      - skipped
+                                    type: string
+                                required:
+                                  - action
+                                  - status
+                                  - required
+                              maxItems: 1000
+                              type: array
+                            policy_id:
+                              maxLength: 64
+                              type: string
+                            policy_template:
+                              maxLength: 100
+                              type: string
+                          required:
+                            - package_policy_id
+                            - policy_id
+                            - policy_template
+                            - package_name
+                            - last_verified_at
+                            - permissions
+                        maxItems: 1000
+                        type: array
                       verification_started_at:
+                        maxLength: 40
                         type: string
                       verification_status:
+                        maxLength: 32
                         type: string
                     required:
                       - id
@@ -31831,10 +32017,72 @@ paths:
                           nullable: true
                         type: object
                       verification_failed_at:
+                        maxLength: 40
                         type: string
+                      verification_permissions:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            last_verified_at:
+                              maxLength: 40
+                              type: string
+                            package_name:
+                              maxLength: 100
+                              type: string
+                            package_policy_id:
+                              maxLength: 64
+                              type: string
+                            permissions:
+                              items:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  action:
+                                    maxLength: 256
+                                    type: string
+                                  error_code:
+                                    maxLength: 100
+                                    type: string
+                                  message:
+                                    maxLength: 2000
+                                    type: string
+                                  required:
+                                    type: boolean
+                                  status:
+                                    enum:
+                                      - verified
+                                      - required
+                                      - denied
+                                      - error
+                                      - skipped
+                                    type: string
+                                required:
+                                  - action
+                                  - status
+                                  - required
+                              maxItems: 1000
+                              type: array
+                            policy_id:
+                              maxLength: 64
+                              type: string
+                            policy_template:
+                              maxLength: 100
+                              type: string
+                          required:
+                            - package_policy_id
+                            - policy_id
+                            - policy_template
+                            - package_name
+                            - last_verified_at
+                            - permissions
+                        maxItems: 1000
+                        type: array
                       verification_started_at:
+                        maxLength: 40
                         type: string
                       verification_status:
+                        maxLength: 32
                         type: string
                     required:
                       - id
@@ -31906,6 +32154,7 @@ paths:
           name: page
           required: false
           schema:
+            maximum: 10000
             minimum: 1
             type: number
         - description: The number of items per page.
@@ -31913,6 +32162,7 @@ paths:
           name: perPage
           required: false
           schema:
+            maximum: 25
             minimum: 1
             type: number
       responses:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -34551,10 +34551,72 @@ paths:
                             nullable: true
                           type: object
                         verification_failed_at:
+                          maxLength: 40
                           type: string
+                        verification_permissions:
+                          items:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              last_verified_at:
+                                maxLength: 40
+                                type: string
+                              package_name:
+                                maxLength: 100
+                                type: string
+                              package_policy_id:
+                                maxLength: 64
+                                type: string
+                              permissions:
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    action:
+                                      maxLength: 256
+                                      type: string
+                                    error_code:
+                                      maxLength: 100
+                                      type: string
+                                    message:
+                                      maxLength: 2000
+                                      type: string
+                                    required:
+                                      type: boolean
+                                    status:
+                                      enum:
+                                        - verified
+                                        - required
+                                        - denied
+                                        - error
+                                        - skipped
+                                      type: string
+                                  required:
+                                    - action
+                                    - status
+                                    - required
+                                maxItems: 1000
+                                type: array
+                              policy_id:
+                                maxLength: 64
+                                type: string
+                              policy_template:
+                                maxLength: 100
+                                type: string
+                            required:
+                              - package_policy_id
+                              - policy_id
+                              - policy_template
+                              - package_name
+                              - last_verified_at
+                              - permissions
+                          maxItems: 1000
+                          type: array
                         verification_started_at:
+                          maxLength: 40
                           type: string
                         verification_status:
+                          maxLength: 32
                           type: string
                       required:
                         - id
@@ -34740,10 +34802,72 @@ paths:
                           nullable: true
                         type: object
                       verification_failed_at:
+                        maxLength: 40
                         type: string
+                      verification_permissions:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            last_verified_at:
+                              maxLength: 40
+                              type: string
+                            package_name:
+                              maxLength: 100
+                              type: string
+                            package_policy_id:
+                              maxLength: 64
+                              type: string
+                            permissions:
+                              items:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  action:
+                                    maxLength: 256
+                                    type: string
+                                  error_code:
+                                    maxLength: 100
+                                    type: string
+                                  message:
+                                    maxLength: 2000
+                                    type: string
+                                  required:
+                                    type: boolean
+                                  status:
+                                    enum:
+                                      - verified
+                                      - required
+                                      - denied
+                                      - error
+                                      - skipped
+                                    type: string
+                                required:
+                                  - action
+                                  - status
+                                  - required
+                              maxItems: 1000
+                              type: array
+                            policy_id:
+                              maxLength: 64
+                              type: string
+                            policy_template:
+                              maxLength: 100
+                              type: string
+                          required:
+                            - package_policy_id
+                            - policy_id
+                            - policy_template
+                            - package_name
+                            - last_verified_at
+                            - permissions
+                        maxItems: 1000
+                        type: array
                       verification_started_at:
+                        maxLength: 40
                         type: string
                       verification_status:
+                        maxLength: 32
                         type: string
                     required:
                       - id
@@ -34940,10 +35064,72 @@ paths:
                           nullable: true
                         type: object
                       verification_failed_at:
+                        maxLength: 40
                         type: string
+                      verification_permissions:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            last_verified_at:
+                              maxLength: 40
+                              type: string
+                            package_name:
+                              maxLength: 100
+                              type: string
+                            package_policy_id:
+                              maxLength: 64
+                              type: string
+                            permissions:
+                              items:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  action:
+                                    maxLength: 256
+                                    type: string
+                                  error_code:
+                                    maxLength: 100
+                                    type: string
+                                  message:
+                                    maxLength: 2000
+                                    type: string
+                                  required:
+                                    type: boolean
+                                  status:
+                                    enum:
+                                      - verified
+                                      - required
+                                      - denied
+                                      - error
+                                      - skipped
+                                    type: string
+                                required:
+                                  - action
+                                  - status
+                                  - required
+                              maxItems: 1000
+                              type: array
+                            policy_id:
+                              maxLength: 64
+                              type: string
+                            policy_template:
+                              maxLength: 100
+                              type: string
+                          required:
+                            - package_policy_id
+                            - policy_id
+                            - policy_template
+                            - package_name
+                            - last_verified_at
+                            - permissions
+                        maxItems: 1000
+                        type: array
                       verification_started_at:
+                        maxLength: 40
                         type: string
                       verification_status:
+                        maxLength: 32
                         type: string
                     required:
                       - id
@@ -35120,10 +35306,72 @@ paths:
                           nullable: true
                         type: object
                       verification_failed_at:
+                        maxLength: 40
                         type: string
+                      verification_permissions:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            last_verified_at:
+                              maxLength: 40
+                              type: string
+                            package_name:
+                              maxLength: 100
+                              type: string
+                            package_policy_id:
+                              maxLength: 64
+                              type: string
+                            permissions:
+                              items:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  action:
+                                    maxLength: 256
+                                    type: string
+                                  error_code:
+                                    maxLength: 100
+                                    type: string
+                                  message:
+                                    maxLength: 2000
+                                    type: string
+                                  required:
+                                    type: boolean
+                                  status:
+                                    enum:
+                                      - verified
+                                      - required
+                                      - denied
+                                      - error
+                                      - skipped
+                                    type: string
+                                required:
+                                  - action
+                                  - status
+                                  - required
+                              maxItems: 1000
+                              type: array
+                            policy_id:
+                              maxLength: 64
+                              type: string
+                            policy_template:
+                              maxLength: 100
+                              type: string
+                          required:
+                            - package_policy_id
+                            - policy_id
+                            - policy_template
+                            - package_name
+                            - last_verified_at
+                            - permissions
+                        maxItems: 1000
+                        type: array
                       verification_started_at:
+                        maxLength: 40
                         type: string
                       verification_status:
+                        maxLength: 32
                         type: string
                     required:
                       - id
@@ -35195,6 +35443,7 @@ paths:
           name: page
           required: false
           schema:
+            maximum: 10000
             minimum: 1
             type: number
         - description: The number of items per page.
@@ -35202,6 +35451,7 @@ paths:
           name: perPage
           required: false
           schema:
+            maximum: 25
             minimum: 1
             type: number
       responses:

--- a/x-pack/platform/plugins/shared/fleet/common/constants/cloud_connector.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/cloud_connector.ts
@@ -46,6 +46,23 @@ export const VERIFIER_INPUT_TYPE = 'otelcol';
 export const VERIFIER_DATA_STREAM_TYPE = 'logs';
 export const VERIFIER_DATASET = `${VERIFIER_PKG_NAME}.${VERIFIER_POLICY_TEMPLATE}`;
 
+/**
+ * Minimum verifier_otel package version that supports the parallel-array multi-target
+ * shape (`policy_id[]`, `package_policy_id[]`, etc. all `multi: true`). Below this
+ * version the manifest declared `multi: false` and accepted only single scalars,
+ * supporting exactly one target integration per verifier deployment.
+ *
+ * `createVerifierPolicy` uses this gate (via `semver.gte`) to decide between the
+ * parallel-array stream-var shape (>= this version) and the legacy scalar shape
+ * (< this version). This makes Kibana producer code compatible with both manifest
+ * eras, so releasing the new package version doesn't break existing 9.5+ clusters
+ * that haven't yet picked up the parallel-array producer code.
+ *
+ * Must match the verifier_otel package version that introduces the `multi: true`
+ * shape — elastic/integrations#19965 (verifier_otel 0.2.0).
+ */
+export const VERIFIER_MULTI_TARGET_MIN_VERSION = '0.2.0';
+
 // Packages that should be hidden from the Identity Federation Flyout usage list.
 // These are internal integrations (e.g. the permission verifier) that attach a
 // cloud_connector_id but should not be surfaced to users.
@@ -55,19 +72,38 @@ export const CLOUD_CONNECTOR_HIDDEN_PACKAGES: readonly string[] = [VERIFIER_PKG_
 export const CLOUD_CONNECTOR_LIST_DEFAULT_PER_PAGE = 20;
 
 /**
+ * Upper bound on the number of package policies (integrations) that can use a
+ * single cloud connector. Derived from the Cloud agentless deployment limit
+ * (5 concurrent agentless agent policies). Cloud connectors require agentless
+ * mode, so at most 5 agent policies can host cloud-connector-using integrations
+ * at one time. Assuming up to ~5 integrations per agent policy can share a
+ * connector, 25 = 5 × 5 gives a comfortable ceiling. Used as:
+ *   - the `perPage` cap for the SO query in `verify_permissions_task`
+ *   - the `max` of the public usage endpoint's `perPage` (no client benefits
+ *     from asking for more than this; the SO can't physically hold more).
+ * Revisit when the agentless concurrency limit grows.
+ */
+export const MAX_CLOUD_CONNECTOR_PACKAGE_POLICIES = 25;
+
+/**
  * Appends NOT package.name filters for {@link CLOUD_CONNECTOR_HIDDEN_PACKAGES} and
  * `latest_revision:true` to a package-policy Kuery fragment (same pattern as usage routes;
  * latest revision excludes rollback snapshot rows such as `:prev`).
+ *
+ * Built via the "collect-and-join" idiom so the resulting Kuery is well-formed
+ * regardless of whether {@link baseFilter} is empty or {@link CLOUD_CONNECTOR_HIDDEN_PACKAGES}
+ * is empty — neither leading nor trailing `AND` can sneak in.
  */
 export function buildPackagePolicyFilterExcludingHiddenPackages(baseFilter: string): string {
-  const hiddenFilter = CLOUD_CONNECTOR_HIDDEN_PACKAGES.map(
-    (pkg) => `NOT ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.attributes.package.name:"${pkg}"`
-  ).join(' AND ');
-  const latestRevision = `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.attributes.latest_revision:true`;
-  if (hiddenFilter) {
-    return `${baseFilter} AND ${hiddenFilter} AND ${latestRevision}`;
+  const clauses: string[] = [];
+  if (baseFilter) {
+    clauses.push(baseFilter);
   }
-  return `${baseFilter} AND ${latestRevision}`;
+  for (const pkg of CLOUD_CONNECTOR_HIDDEN_PACKAGES) {
+    clauses.push(`NOT ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.attributes.package.name:"${pkg}"`);
+  }
+  clauses.push(`${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.attributes.latest_revision:true`);
+  return clauses.join(' AND ');
 }
 
 // Account type variable names for different cloud providers
@@ -131,15 +167,27 @@ export const CLOUD_CONNECTOR_PERMISSION_ALLOWLIST: Record<
 
 /**
  * Returns the policy group that a given integration belongs to, or undefined if not in any group.
+ *
+ * The lookup matches on all three discriminating fields of {@link CloudConnectorAllowlistEntry}.
+ * Omitting `provider` would let an Azure cspm policy collide with the AWS cspm entry — the
+ * function's contract has to be at least as wide as the data's primary key.
  */
 export function getPolicyGroupForIntegration(
+  provider: CloudProvider,
   pkg: string,
   policyTemplate: string
 ): PolicyGroup | undefined {
   for (const [group, entries] of Object.entries(CLOUD_CONNECTOR_PERMISSION_ALLOWLIST) as Array<
     [PolicyGroup, ReadonlyArray<CloudConnectorAllowlistEntry>]
   >) {
-    if (entries.some((entry) => entry.package === pkg && entry.policyTemplate === policyTemplate)) {
+    if (
+      entries.some(
+        (entry) =>
+          entry.provider === provider &&
+          entry.package === pkg &&
+          entry.policyTemplate === policyTemplate
+      )
+    ) {
       return group;
     }
   }

--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -31,7 +31,7 @@ const _allowedExperimentalValues = {
   enableIntegrationInactivityAlerting: true, // When enabled, an inactivity monitoring alerting rule template is created on fresh integration package install.
   enableSimplifiedAgentlessUX: true, // When enabled, the agentless deployment mode will be simplified for single input/datastreams integrations.
   enableOpAMP: true, // When enabled, OpAMP features will be available in the API and UI.
-  enableOTelVerifier: true, // When enabled, OTel-based cloud connector permission verification is active.
+  enableOTelVerifier: false, // When enabled, OTel-based cloud connector permission verification is active.
   enableResolveDependencies: true, // When enabled, the resolve dependencies step will be available during package installation.
   enableOtelUI: false, // When enabled, OTel-specific UI elements (e.g. Collector Config tab) will be shown.
   enableCloudOnboardingDeployments: false, // When enabled, the cloud-onboarding-deployment CRUD API is registered and available.

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/cloud_connector.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/cloud_connector.ts
@@ -81,6 +81,49 @@ export type CloudConnectorVars =
 
 export type VerificationStatus = 'pending' | 'success' | 'failed';
 
+/**
+ * Per-permission status used in `PackagePolicyPermissionSummary.permissions[]`.
+ * Mapping from the OTel verifier's raw `permission.status`:
+ *   - `granted`                          → `verified`
+ *   - `denied` + `permission.required=true`  → `denied`
+ *   - `denied` + `permission.required=false` → `skipped`
+ *   - `error`                            → `error`
+ *   - missing from log but expected      → `required` (derived, not emitted by receiver)
+ */
+export type PermissionStatus = 'verified' | 'required' | 'denied' | 'error' | 'skipped';
+
+/** A single permission's verification result, sourced from one verifier log entry. */
+export interface PermissionResult {
+  action: string;
+  status: PermissionStatus;
+  required: boolean;
+  error_code?: string;
+  /**
+   * Human-readable summary from the verifier log's `body.text` field, e.g.
+   * `"Permission check: aws/arn:aws:iam::aws:policy/SecurityAudit - error"`.
+   * Surfaced in the row-expand "Message" column.
+   */
+  message?: string;
+}
+
+/**
+ * Latest verification result for one (cloud connector, target package policy) pair.
+ * Populated by `fleet:otel_permission_verifier_status_change`. Counts and roll-up
+ * status are computed on the frontend from `permissions[]`; backend stores flat data.
+ *
+ * Descriptive fields (display name, package title, version) are intentionally NOT
+ * stored here — the UI resolves them live from the package policy SO at render time,
+ * which keeps the summary tight and avoids stale snapshots when packages upgrade.
+ */
+export interface PackagePolicyPermissionSummary {
+  package_policy_id: string;
+  policy_id: string;
+  policy_template: string;
+  package_name: string;
+  last_verified_at: string;
+  permissions: PermissionResult[];
+}
+
 export interface CloudConnector {
   id: string;
   name: string;
@@ -94,6 +137,12 @@ export interface CloudConnector {
   verification_status?: VerificationStatus;
   verification_started_at?: string;
   verification_failed_at?: string;
+  /**
+   * Latest per-target-package-policy verification results, written by
+   * `fleet:otel_permission_verifier_status_change`. UI-read only; mapped as
+   * `flattened` on the SO and never queried backend-side.
+   */
+  verification_permissions?: PackagePolicyPermissionSummary[];
 }
 
 export interface CloudConnectorListOptions {
@@ -115,8 +164,34 @@ export interface CloudConnectorPackagePolicy extends NewPackagePolicy {
 }
 
 /**
+ * One target integration that the verifier should check, fully resolved.
+ * Index `i` of every parallel-array stream var corresponds to entry `i` here.
+ */
+export interface VerifiedPackagePolicy {
+  /** The target package policy's id. */
+  package_policy_id: string;
+  /** The first agent policy id this target package policy is assigned to. */
+  policy_id: string;
+  /** Human-readable name of the agent policy referenced by `policy_id`. */
+  policy_name: string;
+  /** The target's policy template (e.g. `cloudtrail`, `guardduty`). */
+  policy_template: string;
+  /** The target's integration package name (e.g. `aws`). */
+  package_name: string;
+  /** The target's integration package title (e.g. `AWS`). */
+  package_title: string;
+  /** The target's integration package version (e.g. `2.17.0`). */
+  package_version: string;
+}
+
+/**
  * Typed stream vars for the verifier_otel package, matching the manifest.
  * Extends PackagePolicyConfigRecord so it can be used directly as stream vars.
+ *
+ * `multi: true` vars hold `string[]` values aligned by index with each other —
+ * see `VerifiedPackagePolicy`. `multi: false` vars hold scalar `string` values shared
+ * across all targets in the deployment.
+ *
  * All `required: true` vars in the manifest are documented in VERIFIER_REQUIRED_VARS.
  */
 export type VerifierStreamVars = PackagePolicyConfigRecord & {
@@ -125,9 +200,14 @@ export type VerifierStreamVars = PackagePolicyConfigRecord & {
   verification_id: PackagePolicyConfigRecordEntry;
   verification_type: PackagePolicyConfigRecordEntry;
   provider: PackagePolicyConfigRecordEntry;
+  // Parallel `multi: true` arrays — index i describes target integration i.
   policy_id: PackagePolicyConfigRecordEntry;
+  policy_name: PackagePolicyConfigRecordEntry;
   policy_templates: PackagePolicyConfigRecordEntry;
+  package_policy_id: PackagePolicyConfigRecordEntry;
   package_name: PackagePolicyConfigRecordEntry;
+  package_title: PackagePolicyConfigRecordEntry;
+  package_version: PackagePolicyConfigRecordEntry;
 };
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/public/components/cloud_connector/hooks/use_get_cloud_connectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/cloud_connector/hooks/use_get_cloud_connectors.ts
@@ -114,10 +114,11 @@ export const useGetCloudConnectors = (filterOptions?: CloudConnectorQueryFilterO
           .join(' AND ')
       : undefined;
 
-  // Determine the current integration's policy group
+  // Determine the current integration's policy group. Requires all three discriminators —
+  // provider, package, and policy template — to match the data's primary key shape.
   const currentPolicyGroup =
-    packageName && policyTemplate
-      ? getPolicyGroupForIntegration(packageName, policyTemplate)
+    packageName && policyTemplate && filterOptions?.cloudProvider
+      ? getPolicyGroupForIntegration(filterOptions.cloudProvider, packageName, policyTemplate)
       : undefined;
 
   return useQuery(

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -170,6 +170,10 @@ import {
   registerVerifyPermissionsTask,
   scheduleVerifyPermissionsTask,
 } from './tasks/agentless/verify_permissions_task';
+import {
+  registerStatusChangeTask,
+  scheduleStatusChangeTask,
+} from './tasks/agentless/otel_permission_verifier_status_change_task';
 import { registerReindexIntegrationKnowledgeTask } from './tasks/reindex_integration_knowledge_task';
 import { registerSyncNamespaceTemplatesTask } from './tasks/sync_namespace_templates_task';
 import { registerSyncIlmPolicyTask } from './tasks/sync_ilm_policy_task';
@@ -711,6 +715,7 @@ export class FleetPlugin
     registerSetupTasks(deps.taskManager);
     registerAgentlessDeploymentSyncTask(deps.taskManager, this.configInitialValue);
     registerVerifyPermissionsTask(deps.taskManager);
+    registerStatusChangeTask(deps.taskManager);
     registerVerifierPolicyCleanupTask(deps.taskManager);
     registerReindexIntegrationKnowledgeTask(deps.taskManager);
     registerSyncNamespaceTemplatesTask(deps.taskManager);
@@ -882,6 +887,7 @@ export class FleetPlugin
       this.configInitialValue as FleetConfigType
     ).catch(() => {});
     scheduleVerifyPermissionsTask(plugins.taskManager).catch(() => {});
+    scheduleStatusChangeTask(plugins.taskManager).catch(() => {});
     scheduleVerifierPolicyCleanupTask(plugins.taskManager).catch((error) => {});
     this.fleetPolicyRevisionsCleanupTask
       ?.start({ taskManager: plugins.taskManager })

--- a/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/handlers.ts
@@ -261,8 +261,8 @@ export const getCloudConnectorUsageHandler: FleetRequestHandler<
   const fleetContext = await context.fleet;
   const { internalSoClient } = fleetContext;
   const cloudConnectorId = request.params.cloudConnectorId;
-  const page = request.query?.page || 1;
-  const perPage = request.query?.perPage || 10;
+  const page = request.query?.page ?? 1;
+  const perPage = request.query?.perPage ?? 10;
   const logger = appContextService
     .getLogger()
     .get('CloudConnectorService getCloudConnectorUsageHandler');

--- a/x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts
@@ -54,6 +54,7 @@ import {
   PackagePolicySchemaV24,
   PackagePolicySchemaV25,
   CloudConnectorSchemaV4,
+  CloudConnectorSchemaV5,
   CloudOnboardingDeploymentSchemaV1,
 } from '../types';
 
@@ -1809,6 +1810,7 @@ export const getSavedObjectTypes = (
           verification_status: { type: 'keyword' },
           verification_started_at: { type: 'date' },
           verification_failed_at: { type: 'date' },
+          verification_permissions: { type: 'flattened', ignore_above: 8191 },
         },
       },
       modelVersions: {
@@ -1922,6 +1924,20 @@ export const getSavedObjectTypes = (
           schemas: {
             forwardCompatibility: CloudConnectorSchemaV4.extends({}, { unknowns: 'ignore' }),
             create: CloudConnectorSchemaV4,
+          },
+        },
+        5: {
+          changes: [
+            {
+              type: 'mappings_addition',
+              addedMappings: {
+                verification_permissions: { type: 'flattened', ignore_above: 8191 },
+              },
+            },
+          ],
+          schemas: {
+            forwardCompatibility: CloudConnectorSchemaV5.extends({}, { unknowns: 'ignore' }),
+            create: CloudConnectorSchemaV5,
           },
         },
       },

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -16,7 +16,10 @@ import type { SavedObjectError } from '@kbn/core-saved-objects-common';
 
 import { createSavedObjectClientMock } from '../mocks';
 
-import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../common/constants';
+import {
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  VERIFIER_MULTI_TARGET_MIN_VERSION,
+} from '../../common/constants';
 
 import {
   PackagePolicyRestrictionRelatedError,
@@ -3332,12 +3335,19 @@ describe('Agent policy', () => {
       },
     };
 
-    const baseVerificationInfo = {
-      policyTemplates: ['cspm'],
-      packageName: 'aws',
-      packageTitle: 'AWS',
-      packageVersion: '2.17.0',
-    };
+    const basePackagePolicies = [
+      {
+        package_policy_id: 'pp-aws-cspm',
+        policy_id: 'agent-policy-1',
+        policy_name: 'AWS CSPM Policy',
+        policy_template: 'cspm',
+        package_name: 'aws',
+        package_title: 'AWS',
+        package_version: '2.17.0',
+      },
+    ];
+
+    const baseVerificationInfo = { verifiedPackagePolicies: basePackagePolicies };
 
     let soClient: ReturnType<typeof createSavedObjectClientMock>;
 
@@ -3348,14 +3358,17 @@ describe('Agent policy', () => {
 
       mockedPackagePolicyService.create.mockResolvedValue({ id: 'pp-id' } as any);
 
+      // Default mock pins the verifier_otel package version to the multi-target min
+      // version, so the default (non-version-specific) tests exercise the parallel-array
+      // branch. Tests that need the legacy scalar branch override this per-test.
       jest.mocked(ensureInstalledPackage).mockResolvedValue({
         status: 'already_installed',
-        package: { version: '0.0.0' },
+        package: { version: VERIFIER_MULTI_TARGET_MIN_VERSION },
       } as any);
       jest.mocked(getPackageInfo).mockResolvedValue({
         name: 'verifier_otel',
         title: 'Permission Verifier',
-        version: '0.0.0',
+        version: VERIFIER_MULTI_TARGET_MIN_VERSION,
       } as any);
 
       mockedAppContextService.getCloud.mockReturnValue({
@@ -3471,9 +3484,9 @@ describe('Agent policy', () => {
       expect(vars.verification_type).toEqual({ type: 'select', value: 'scheduled' });
       expect(vars.provider).toEqual({ type: 'text', value: 'aws' });
       expect(vars.policy_templates).toEqual({ type: 'text', value: ['cspm'] });
-      expect(vars.package_name).toEqual({ type: 'text', value: 'aws' });
-      expect(vars.package_title).toEqual({ type: 'text', value: 'AWS' });
-      expect(vars.package_version).toEqual({ type: 'text', value: '2.17.0' });
+      expect(vars.package_name).toEqual({ type: 'text', value: ['aws'] });
+      expect(vars.package_title).toEqual({ type: 'text', value: ['AWS'] });
+      expect(vars.package_version).toEqual({ type: 'text', value: ['2.17.0'] });
       expect(vars.namespace).toBeUndefined();
       expect(vars.default_region).toBeUndefined();
     });
@@ -3757,6 +3770,165 @@ describe('Agent policy', () => {
       expect(vars.namespace).toBeUndefined();
       expect(vars.cloud_connector_id).toBeUndefined();
       expect(vars.cloud_connector_name).toBeUndefined();
+    });
+
+    // ---------------------------------------------------------------------
+    // Version-gated producer shape — see VERIFIER_MULTI_TARGET_MIN_VERSION.
+    //
+    // `createVerifierPolicy` chooses between parallel-array stream vars
+    // (verifier_otel >= VERIFIER_MULTI_TARGET_MIN_VERSION, multi:true manifest)
+    // and legacy scalar stream vars (below that version, multi:false manifest)
+    // based on the installed package version. These tests reference the constant
+    // rather than a literal so they don't need updating when the min version is
+    // bumped; the legacy tests use a fixed version safely below any real minimum.
+    // ---------------------------------------------------------------------
+    describe('version-gated stream var shape', () => {
+      const multiplePackagePolicies = [
+        basePackagePolicies[0],
+        {
+          package_policy_id: 'pp-aws-asset-inventory',
+          policy_id: 'agent-policy-2',
+          policy_name: 'AWS Asset Inventory Policy',
+          policy_template: 'asset_inventory',
+          package_name: 'cloud_asset_inventory',
+          package_title: 'Cloud Asset Inventory',
+          package_version: '1.2.0',
+        },
+      ];
+
+      it('should emit parallel-array stream vars when verifier_otel is at or above the multi-target min version', async () => {
+        jest.mocked(ensureInstalledPackage).mockResolvedValue({
+          status: 'already_installed',
+          package: { version: VERIFIER_MULTI_TARGET_MIN_VERSION },
+        } as any);
+        jest.mocked(getPackageInfo).mockResolvedValue({
+          name: 'verifier_otel',
+          title: 'Permission Verifier',
+          version: VERIFIER_MULTI_TARGET_MIN_VERSION,
+        } as any);
+
+        await agentPolicyService.createVerifierPolicy(soClient, esClient, baseConnector as any, {
+          verifiedPackagePolicies: multiplePackagePolicies,
+        });
+
+        const { streams } = mockedPackagePolicyService.create.mock.calls[0][2].inputs[0];
+        const vars = streams[0].vars!;
+
+        expect(vars.policy_id).toEqual({
+          type: 'text',
+          value: ['agent-policy-1', 'agent-policy-2'],
+        });
+        expect(vars.policy_name).toEqual({
+          type: 'text',
+          value: ['AWS CSPM Policy', 'AWS Asset Inventory Policy'],
+        });
+        expect(vars.policy_templates).toEqual({
+          type: 'text',
+          value: ['cspm', 'asset_inventory'],
+        });
+        expect(vars.package_policy_id).toEqual({
+          type: 'text',
+          value: ['pp-aws-cspm', 'pp-aws-asset-inventory'],
+        });
+        expect(vars.package_name).toEqual({
+          type: 'text',
+          value: ['aws', 'cloud_asset_inventory'],
+        });
+        expect(vars.package_title).toEqual({
+          type: 'text',
+          value: ['AWS', 'Cloud Asset Inventory'],
+        });
+        expect(vars.package_version).toEqual({
+          type: 'text',
+          value: ['2.17.0', '1.2.0'],
+        });
+      });
+
+      it('should emit scalar stream vars from verifiedPackagePolicies[0] when verifier_otel is below the multi-target min version (legacy single-target manifest)', async () => {
+        jest.mocked(ensureInstalledPackage).mockResolvedValue({
+          status: 'already_installed',
+          package: { version: '0.0.1' },
+        } as any);
+        jest.mocked(getPackageInfo).mockResolvedValue({
+          name: 'verifier_otel',
+          title: 'Permission Verifier',
+          version: '0.0.1',
+        } as any);
+
+        await agentPolicyService.createVerifierPolicy(
+          soClient,
+          esClient,
+          baseConnector as any,
+          baseVerificationInfo
+        );
+
+        const { streams } = mockedPackagePolicyService.create.mock.calls[0][2].inputs[0];
+        const vars = streams[0].vars!;
+
+        // Scalars, not arrays — the legacy manifest declared these `multi: false`.
+        expect(vars.policy_id).toEqual({ type: 'text', value: 'agent-policy-1' });
+        expect(vars.policy_name).toEqual({ type: 'text', value: 'AWS CSPM Policy' });
+        expect(vars.policy_templates).toEqual({ type: 'text', value: 'cspm' });
+        expect(vars.package_policy_id).toEqual({ type: 'text', value: 'pp-aws-cspm' });
+        expect(vars.package_name).toEqual({ type: 'text', value: 'aws' });
+        expect(vars.package_title).toEqual({ type: 'text', value: 'AWS' });
+        expect(vars.package_version).toEqual({ type: 'text', value: '2.17.0' });
+      });
+
+      it('should drop extras and use only verifiedPackagePolicies[0] when verifier_otel is below the multi-target min version with multiple package policies', async () => {
+        jest.mocked(ensureInstalledPackage).mockResolvedValue({
+          status: 'already_installed',
+          package: { version: '0.0.1' },
+        } as any);
+        jest.mocked(getPackageInfo).mockResolvedValue({
+          name: 'verifier_otel',
+          title: 'Permission Verifier',
+          version: '0.0.1',
+        } as any);
+
+        await agentPolicyService.createVerifierPolicy(soClient, esClient, baseConnector as any, {
+          verifiedPackagePolicies: multiplePackagePolicies,
+        });
+
+        const { streams } = mockedPackagePolicyService.create.mock.calls[0][2].inputs[0];
+        const vars = streams[0].vars!;
+
+        // Only the first target is carried into the scalar manifest — second target is silently dropped.
+        expect(vars.policy_id).toEqual({ type: 'text', value: 'agent-policy-1' });
+        expect(vars.package_policy_id).toEqual({ type: 'text', value: 'pp-aws-cspm' });
+        expect(vars.package_name).toEqual({ type: 'text', value: 'aws' });
+        // Sanity check that the second target's values do NOT appear anywhere.
+        expect(JSON.stringify(vars)).not.toContain('agent-policy-2');
+        expect(JSON.stringify(vars)).not.toContain('pp-aws-asset-inventory');
+        expect(JSON.stringify(vars)).not.toContain('asset_inventory');
+      });
+
+      it('should emit parallel-array stream vars exactly at the multi-target min version (gte boundary)', async () => {
+        // Exactly the min version should match the gate (>=), not fall through to the scalar branch.
+        jest.mocked(ensureInstalledPackage).mockResolvedValue({
+          status: 'already_installed',
+          package: { version: VERIFIER_MULTI_TARGET_MIN_VERSION },
+        } as any);
+        jest.mocked(getPackageInfo).mockResolvedValue({
+          name: 'verifier_otel',
+          title: 'Permission Verifier',
+          version: VERIFIER_MULTI_TARGET_MIN_VERSION,
+        } as any);
+
+        await agentPolicyService.createVerifierPolicy(
+          soClient,
+          esClient,
+          baseConnector as any,
+          baseVerificationInfo
+        );
+
+        const { streams } = mockedPackagePolicyService.create.mock.calls[0][2].inputs[0];
+        const vars = streams[0].vars!;
+
+        // Even with a single target, the value is wrapped in an array because the manifest is multi:true.
+        expect(vars.policy_id).toEqual({ type: 'text', value: ['agent-policy-1'] });
+        expect(vars.package_policy_id).toEqual({ type: 'text', value: ['pp-aws-cspm'] });
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -10,7 +10,7 @@ import { escapeKuery, escapeQuotes } from '@kbn/es-query';
 import { groupBy, isEqual, keyBy, omit, pick, uniq } from 'lodash';
 import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
 import pMap from 'p-map';
-import { lt, minVersion, gt } from 'semver';
+import { lt, minVersion, gt, gte } from 'semver';
 import type {
   AuthenticatedUser,
   ElasticsearchClient,
@@ -88,6 +88,7 @@ import {
   VERIFIER_INPUT_TYPE,
   VERIFIER_DATA_STREAM_TYPE,
   VERIFIER_DATASET,
+  VERIFIER_MULTI_TARGET_MIN_VERSION,
 } from '../../common/constants';
 import type {
   AwsCloudConnectorVars,
@@ -104,6 +105,7 @@ import type {
   IntegrationsOutput,
   PackageInfo,
   VerifierStreamVars,
+  VerifiedPackagePolicy,
 } from '../../common/types';
 import {
   AgentPolicyNameExistsError,
@@ -2715,10 +2717,13 @@ class AgentPolicyService {
     esClient: ElasticsearchClient,
     connector: { id: string; attributes: CloudConnectorSOAttributes },
     verificationInfo: {
-      policyTemplates: string[];
-      packageName: string;
-      packageTitle: string;
-      packageVersion: string;
+      /**
+       * One entry per package policy to verify; each entry becomes one index in
+       * the parallel-array stream vars (`policy_id[i]`, `policy_name[i]`,
+       * `policy_templates[i]`, `package_policy_id[i]`, `package_name[i]`,
+       * `package_title[i]`, `package_version[i]`).
+       */
+      verifiedPackagePolicies: VerifiedPackagePolicy[];
     }
   ): Promise<{ policyId: string }> {
     const logger = this.getLogger('createVerifierPolicy');
@@ -2729,10 +2734,9 @@ class AgentPolicyService {
       accountType,
       vars: connectorVars,
     } = connector.attributes;
-    const { policyTemplates, packageName, packageTitle, packageVersion } = verificationInfo;
+    const { verifiedPackagePolicies } = verificationInfo;
     const shortId = uuidv4().slice(0, 8);
     const policyName = `Verifier-Agent-Policy-${connectorName}-${shortId}`;
-    const verificationId = uuidv4();
 
     const agentPolicy = await this.create(
       soClient,
@@ -2782,21 +2786,69 @@ class AgentPolicyService {
       prerelease: true,
     });
 
+    // Version-gated producer shape (see VERIFIER_MULTI_TARGET_MIN_VERSION).
+    //
+    // - >= min version: emit parallel `multi: true` arrays (one index per verified package policy).
+    // - <  min version: emit scalars from `verifiedPackagePolicies[0]` (legacy single-target
+    //   manifest; `multi: false` on those vars). On such a package only the first verified
+    //   package policy is reflected — the old manifest's hard constraint allows nothing else.
+    //
+    // This makes Kibana producer code compatible with both manifest eras, so the
+    // multi-target integration release doesn't break clusters still on an older
+    // verifier_otel package, and a Kibana running this code doesn't break against
+    // either package version in EPR.
+    const supportsMultiTarget = gte(verifierPkgVersion, VERIFIER_MULTI_TARGET_MIN_VERSION);
+
+    const targetVars = supportsMultiTarget
+      ? {
+          // Parallel `multi: true` arrays — index i describes verified package policy i. Aligned by construction.
+          policy_id: { type: 'text', value: verifiedPackagePolicies.map((vpp) => vpp.policy_id) },
+          policy_name: {
+            type: 'text',
+            value: verifiedPackagePolicies.map((vpp) => vpp.policy_name),
+          },
+          policy_templates: {
+            type: 'text',
+            value: verifiedPackagePolicies.map((vpp) => vpp.policy_template),
+          },
+          package_policy_id: {
+            type: 'text',
+            value: verifiedPackagePolicies.map((vpp) => vpp.package_policy_id),
+          },
+          package_name: {
+            type: 'text',
+            value: verifiedPackagePolicies.map((vpp) => vpp.package_name),
+          },
+          package_title: {
+            type: 'text',
+            value: verifiedPackagePolicies.map((vpp) => vpp.package_title),
+          },
+          package_version: {
+            type: 'text',
+            value: verifiedPackagePolicies.map((vpp) => vpp.package_version),
+          },
+        }
+      : {
+          // Legacy scalar shape for the older `multi: false` manifest. First entry only.
+          policy_id: { type: 'text', value: verifiedPackagePolicies[0].policy_id },
+          policy_name: { type: 'text', value: verifiedPackagePolicies[0].policy_name },
+          policy_templates: { type: 'text', value: verifiedPackagePolicies[0].policy_template },
+          package_policy_id: { type: 'text', value: verifiedPackagePolicies[0].package_policy_id },
+          package_name: { type: 'text', value: verifiedPackagePolicies[0].package_name },
+          package_title: { type: 'text', value: verifiedPackagePolicies[0].package_title },
+          package_version: { type: 'text', value: verifiedPackagePolicies[0].package_version },
+        };
+
     const streamVars: VerifierStreamVars = {
       'data_stream.dataset': { type: 'text', value: VERIFIER_DATASET },
       identity_federation_id: { type: 'text', value: connectorId },
       identity_federation_name: { type: 'text', value: connectorName },
-      verification_id: { type: 'text', value: verificationId },
+      verification_id: { type: 'text', value: agentPolicy.id },
       verification_type: { type: 'select', value: 'scheduled' },
       provider: { type: 'text', value: cloudProvider },
       account_type: { type: 'select', value: resolvedAccountType },
       ...credentialVars,
-      policy_id: { type: 'text', value: agentPolicy.id },
-      policy_name: { type: 'text', value: policyName },
-      policy_templates: { type: 'text', value: policyTemplates },
-      package_name: { type: 'text', value: packageName },
-      package_title: { type: 'text', value: packageTitle },
-      package_version: { type: 'text', value: packageVersion },
+      ...targetVars,
     };
 
     const verifierPackagePolicy: CloudConnectorPackagePolicy = {
@@ -2835,7 +2887,9 @@ class AgentPolicyService {
     try {
       logger.info(
         `${VERIFY_PERMISSIONS_TASK} Creating verifier_otel package policy for ` +
-          `connector ${connectorId}, templates [${policyTemplates.join(', ')}]`
+          `connector ${connectorId}, verified package policies [${verifiedPackagePolicies
+            .map((vpp) => `${vpp.package_name}:${vpp.policy_template}`)
+            .join(', ')}]`
       );
       const otelPackagePolicy = await packagePolicyService.create(
         soClient,

--- a/x-pack/platform/plugins/shared/fleet/server/services/cloud_connectors/agentless_policy_integration.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/cloud_connectors/agentless_policy_integration.ts
@@ -112,7 +112,11 @@ export async function createAndIntegrateCloudConnector(params: {
 
       // Enforce policy group scope: connectors can only be reused within the same policy group
       if (policyTemplate && packageInfo.name) {
-        const requestingGroup = getPolicyGroupForIntegration(packageInfo.name, policyTemplate);
+        const requestingGroup = getPolicyGroupForIntegration(
+          cloudProvider,
+          packageInfo.name,
+          policyTemplate
+        );
 
         if (requestingGroup) {
           // Look up the connector's existing package policies to determine its policy group.
@@ -134,6 +138,7 @@ export async function createAndIntegrateCloudConnector(params: {
 
             if (existingPackageName && existingPolicyTemplate) {
               const connectorGroup = getPolicyGroupForIntegration(
+                existingConnector.cloudProvider,
                 existingPackageName,
                 existingPolicyTemplate
               );

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/otel_permission_verifier_status_change_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/otel_permission_verifier_status_change_task.test.ts
@@ -1,0 +1,582 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+
+import { createAppContextStartContractMock } from '../../mocks';
+import { appContextService } from '../../services';
+
+import { CLOUD_CONNECTOR_SAVED_OBJECT_TYPE } from '../../../common/constants';
+
+import {
+  registerStatusChangeTask,
+  scheduleStatusChangeTask,
+} from './otel_permission_verifier_status_change_task';
+
+const mockSoClient = {
+  bulkUpdate: jest.fn(),
+} as any;
+
+const mockEsClient = {
+  search: jest.fn(),
+} as any;
+
+/**
+ * Logical overrides for {@link makeHit}. Each key maps to a flat-dotted OTel
+ * attribute key under `_source.attributes` (or `_source.resource.attributes` for
+ * connector identity). Reflects what the production aggregator reads.
+ */
+interface MakeHitOverrides {
+  identity_federation_id?: string;
+  policyId?: string;
+  policyName?: string;
+  policyTemplate?: string | undefined;
+  packageName?: string;
+  packageTitle?: string;
+  packageVersion?: string;
+  packagePolicyId?: string;
+  permissionAction?: string;
+  permissionStatus?: 'granted' | 'denied' | 'error' | 'skipped';
+  permissionRequired?: boolean;
+  errorCode?: string;
+  verifiedAt?: string;
+  /** Body text — mapped to PermissionResult.message in the row-expand "Message" column. */
+  bodyText?: string;
+  timestamp?: string;
+}
+
+/**
+ * Build one fake top_hits source document representing a single permission check.
+ * The shape matches what the verifier OTel receiver actually emits:
+ *   - `attributes` carries per-record dotted keys (e.g. `'policy.id'`)
+ *   - `resource.attributes` carries per-emitter dotted keys (e.g. `'identity_federation.id'`)
+ *   - `body.text` carries the human-readable summary line
+ */
+const makeHit = (overrides: MakeHitOverrides = {}) => ({
+  _source: {
+    '@timestamp': overrides.timestamp ?? '2026-05-06T10:00:00.000Z',
+    attributes: {
+      'policy.id': overrides.policyId ?? 'agent-policy-1',
+      ...(overrides.policyName !== undefined ? { 'policy.name': overrides.policyName } : {}),
+      // `in` check (not `??`) so callers can explicitly set `policyTemplate: undefined`
+      // to simulate a malformed log doc (missing-field) for the bucket-skip test.
+      policy_template: 'policyTemplate' in overrides ? overrides.policyTemplate : 'cloudtrail',
+      'package.name': overrides.packageName ?? 'aws',
+      ...(overrides.packageTitle !== undefined ? { 'package.title': overrides.packageTitle } : {}),
+      ...(overrides.packageVersion !== undefined
+        ? { 'package.version': overrides.packageVersion }
+        : {}),
+      'package_policy.id': overrides.packagePolicyId ?? 'pp-cloudtrail',
+      'permission.action': overrides.permissionAction ?? 'cloudtrail:LookupEvents',
+      'permission.status': overrides.permissionStatus ?? 'granted',
+      'permission.required': overrides.permissionRequired ?? true,
+      ...(overrides.errorCode !== undefined
+        ? { 'permission.error_code': overrides.errorCode }
+        : {}),
+      'verification.verified_at': overrides.verifiedAt ?? '2026-05-06T10:00:00.000Z',
+    },
+    resource: {
+      attributes: {
+        'identity_federation.id': overrides.identity_federation_id ?? 'cc-1',
+      },
+    },
+    ...(overrides.bodyText !== undefined ? { body: { text: overrides.bodyText } } : {}),
+  },
+});
+
+/**
+ * Build one fake inner package-policy bucket (the leaf of the nested-terms agg).
+ * Production no longer uses a `latest_verified_at` sub-agg — the "latest run"
+ * is determined from the first hit's `verification.verified_at` value, sorted
+ * by `@timestamp` desc.
+ */
+const makePpBucket = (packagePolicyId: string, hits: any[]) => ({
+  key: packagePolicyId,
+  doc_count: hits.length,
+  recent_permission_docs: { hits: { hits } },
+});
+
+/**
+ * Build one fake outer connector bucket containing one or more package-policy buckets.
+ */
+const makeConnectorBucket = (
+  connectorId: string,
+  ppBuckets: ReturnType<typeof makePpBucket>[],
+  ppOverflow = 0
+) => ({
+  key: connectorId,
+  doc_count: ppBuckets.reduce((acc, b) => acc + b.doc_count, 0),
+  by_package_policy: {
+    sum_other_doc_count: ppOverflow,
+    buckets: ppBuckets,
+  },
+});
+
+const makeSearchResponse = (
+  connectorBuckets: ReturnType<typeof makeConnectorBucket>[],
+  connectorOverflow = 0
+) => ({
+  aggregations: {
+    by_connector: {
+      sum_other_doc_count: connectorOverflow,
+      buckets: connectorBuckets,
+    },
+  },
+});
+
+/**
+ * Convenience: build a connector bucket containing a single package-policy bucket.
+ * Used by tests where each connector has only one package policy. Tests that exercise
+ * multiple package policies per connector should call makeConnectorBucket directly with
+ * an array of makePpBucket entries.
+ */
+const makeBucket = (connectorId: string, packagePolicyId: string, hits: any[]) =>
+  makeConnectorBucket(connectorId, [makePpBucket(packagePolicyId, hits)]);
+
+describe('otel_permission_verifier_status_change_task', () => {
+  const logger = loggingSystemMock.createLogger();
+
+  const createTaskRunner = (abortCtrl?: AbortController) => {
+    const taskManager = taskManagerMock.createSetup();
+    registerStatusChangeTask(taskManager);
+    const registeredDef =
+      taskManager.registerTaskDefinitions.mock.calls[0][0][
+        'fleet:otel_permission_verifier_status_change'
+      ];
+    return registeredDef.createTaskRunner({
+      taskInstance: { state: {} } as any,
+      abortController: abortCtrl ?? new AbortController(),
+      executionUuid: 'test-execution-uuid',
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSoClient.bulkUpdate.mockReset();
+    mockEsClient.search.mockReset();
+
+    const mockContext = createAppContextStartContractMock();
+    appContextService.start(mockContext);
+
+    jest.spyOn(appContextService, 'getLogger').mockReturnValue(logger);
+    jest
+      .spyOn(appContextService, 'getInternalUserSOClientWithoutSpaceExtension')
+      .mockReturnValue(mockSoClient);
+    jest.spyOn(appContextService, 'getInternalUserESClient').mockReturnValue(mockEsClient);
+    jest.spyOn(appContextService, 'getExperimentalFeatures').mockReturnValue({
+      enableOTelVerifier: true,
+    } as any);
+  });
+
+  describe('registerStatusChangeTask', () => {
+    it('registers the task definition with the expected type and timeout', () => {
+      const taskManager = taskManagerMock.createSetup();
+      registerStatusChangeTask(taskManager);
+      expect(taskManager.registerTaskDefinitions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'fleet:otel_permission_verifier_status_change': expect.objectContaining({
+            title: 'OTel Permission Verifier Status Change Task',
+            timeout: '5m',
+          }),
+        })
+      );
+    });
+  });
+
+  describe('scheduleStatusChangeTask', () => {
+    it('schedules the task with the expected interval', async () => {
+      const taskManager = taskManagerMock.createStart();
+      await scheduleStatusChangeTask(taskManager);
+      expect(taskManager.ensureScheduled).toHaveBeenCalledWith({
+        id: 'fleet:otel_permission_verifier_status_change:1.0.0',
+        taskType: 'fleet:otel_permission_verifier_status_change',
+        schedule: { interval: '5m' },
+        state: {},
+        params: {},
+      });
+    });
+
+    it('logs an error when scheduling fails', async () => {
+      const taskManager = taskManagerMock.createStart();
+      taskManager.ensureScheduled.mockRejectedValueOnce(new Error('schedule failed'));
+      await scheduleStatusChangeTask(taskManager);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error scheduling status change task'),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('runStatusChangeTask (via task runner)', () => {
+    let taskRunner: ReturnType<typeof createTaskRunner>;
+
+    beforeEach(() => {
+      taskRunner = createTaskRunner();
+    });
+
+    it('skips when enableOTelVerifier is disabled', async () => {
+      jest.spyOn(appContextService, 'getExperimentalFeatures').mockReturnValue({
+        enableOTelVerifier: false,
+      } as any);
+
+      await taskRunner.run();
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('OTel verifier is disabled')
+      );
+      expect(mockEsClient.search).not.toHaveBeenCalled();
+      expect(mockSoClient.bulkUpdate).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when there are no verifier logs', async () => {
+      mockEsClient.search.mockResolvedValueOnce(makeSearchResponse([]));
+      await taskRunner.run();
+      expect(mockSoClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('No verifier logs to aggregate')
+      );
+    });
+
+    it('writes one summary per (connector, package_policy) bucket', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([makeBucket('cc-1', 'pp-cloudtrail', [makeHit()])])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [{ id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+      });
+
+      await taskRunner.run();
+
+      expect(mockSoClient.bulkUpdate).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+          id: 'cc-1',
+          attributes: expect.objectContaining({
+            verification_permissions: expect.arrayContaining([
+              expect.objectContaining({
+                package_policy_id: 'pp-cloudtrail',
+                policy_id: 'agent-policy-1',
+                policy_template: 'cloudtrail',
+                package_name: 'aws',
+                last_verified_at: '2026-05-06T10:00:00.000Z',
+                permissions: [
+                  expect.objectContaining({
+                    action: 'cloudtrail:LookupEvents',
+                    status: 'verified',
+                    required: true,
+                  }),
+                ],
+              }),
+            ]),
+          }),
+        }),
+      ]);
+    });
+
+    it('groups multiple package_policy buckets under one connector', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          makeConnectorBucket('cc-1', [
+            makePpBucket('pp-cloudtrail', [
+              makeHit({ packagePolicyId: 'pp-cloudtrail', policyTemplate: 'cloudtrail' }),
+            ]),
+            makePpBucket('pp-guardduty', [
+              makeHit({
+                packagePolicyId: 'pp-guardduty',
+                policyTemplate: 'guardduty',
+                permissionAction: 'guardduty:GetFindings',
+                permissionStatus: 'denied',
+                permissionRequired: true,
+              }),
+            ]),
+          ]),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [{ id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+      });
+
+      await taskRunner.run();
+
+      expect(mockSoClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      const call = mockSoClient.bulkUpdate.mock.calls[0][0] as any[];
+      expect(call).toHaveLength(1);
+      expect(call[0].id).toBe('cc-1');
+      expect(call[0].attributes.verification_permissions).toHaveLength(2);
+      expect(
+        call[0].attributes.verification_permissions.map((s: any) => s.package_policy_id)
+      ).toEqual(['pp-cloudtrail', 'pp-guardduty']);
+    });
+
+    it('produces separate updates for separate connectors', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          makeBucket('cc-1', 'pp-1', [makeHit({ identity_federation_id: 'cc-1' })]),
+          makeBucket('cc-2', 'pp-2', [
+            makeHit({ identity_federation_id: 'cc-2', packagePolicyId: 'pp-2' }),
+          ]),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [
+          { id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE },
+          { id: 'cc-2', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE },
+        ],
+      });
+
+      await taskRunner.run();
+
+      const call = mockSoClient.bulkUpdate.mock.calls[0][0] as any[];
+      expect(call.map((u) => u.id).sort()).toEqual(['cc-1', 'cc-2']);
+    });
+
+    describe('permission status mapping', () => {
+      it.each([
+        { raw: 'granted', required: true, expected: 'verified' },
+        { raw: 'granted', required: false, expected: 'verified' },
+        { raw: 'denied', required: true, expected: 'denied' },
+        { raw: 'denied', required: false, expected: 'skipped' },
+        { raw: 'error', required: true, expected: 'error' },
+        { raw: 'error', required: false, expected: 'error' },
+        { raw: 'skipped', required: true, expected: 'skipped' },
+        { raw: 'skipped', required: false, expected: 'skipped' },
+      ])('maps raw=$raw required=$required → $expected', async ({ raw, required, expected }) => {
+        mockEsClient.search.mockResolvedValueOnce(
+          makeSearchResponse([
+            makeBucket('cc-1', 'pp-1', [
+              makeHit({
+                permissionAction: 'svc:DoThing',
+                permissionStatus: raw as any,
+                permissionRequired: required,
+              }),
+            ]),
+          ])
+        );
+        mockSoClient.bulkUpdate.mockResolvedValueOnce({
+          saved_objects: [{ id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+        });
+
+        await taskRunner.run();
+
+        const call = mockSoClient.bulkUpdate.mock.calls[0][0] as any[];
+        const summary = call[0].attributes.verification_permissions[0];
+        expect(summary.permissions[0].status).toBe(expected);
+        expect(summary.permissions[0].required).toBe(required);
+      });
+    });
+
+    it('filters out hits older than the latest verification run', async () => {
+      const latestRun = '2026-05-06T10:00:00.000Z';
+      const olderRun = '2026-05-06T09:00:00.000Z';
+
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          makeBucket('cc-1', 'pp-1', [
+            makeHit({
+              verifiedAt: latestRun,
+              permissionAction: 'svc:NewAction',
+              permissionStatus: 'granted',
+              permissionRequired: true,
+            }),
+            makeHit({
+              verifiedAt: olderRun,
+              permissionAction: 'svc:OldAction',
+              permissionStatus: 'granted',
+              permissionRequired: true,
+            }),
+          ]),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [{ id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+      });
+
+      await taskRunner.run();
+
+      const summary = (mockSoClient.bulkUpdate.mock.calls[0][0] as any[])[0].attributes
+        .verification_permissions[0];
+      expect(summary.permissions).toHaveLength(1);
+      expect(summary.permissions[0].action).toBe('svc:NewAction');
+      expect(summary.last_verified_at).toBe(latestRun);
+    });
+
+    it('preserves error_code and message (from body.text) when present', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          makeBucket('cc-1', 'pp-1', [
+            makeHit({
+              permissionAction: 's3:GetObject',
+              permissionStatus: 'denied',
+              permissionRequired: true,
+              errorCode: 'AccessDenied',
+              bodyText: 'Permission check: s3:GetObject - error',
+            }),
+          ]),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [{ id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+      });
+
+      await taskRunner.run();
+
+      const summary = (mockSoClient.bulkUpdate.mock.calls[0][0] as any[])[0].attributes
+        .verification_permissions[0];
+      expect(summary.permissions[0]).toMatchObject({
+        action: 's3:GetObject',
+        status: 'denied',
+        error_code: 'AccessDenied',
+        message: 'Permission check: s3:GetObject - error',
+      });
+    });
+
+    it('runs the aggregation in a single ES request (no pagination)', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          makeBucket('cc-1', 'pp-1', [makeHit()]),
+          makeBucket('cc-2', 'pp-2', [
+            makeHit({ identity_federation_id: 'cc-2', packagePolicyId: 'pp-2' }),
+          ]),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [
+          { id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE },
+          { id: 'cc-2', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE },
+        ],
+      });
+
+      await taskRunner.run();
+
+      expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs a warning when the package-policy terms agg is truncated for a connector', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          makeConnectorBucket('cc-1', [makePpBucket('pp-1', [makeHit()])], /* ppOverflow */ 7),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [{ id: 'cc-1', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+      });
+
+      await taskRunner.run();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Package-policy terms agg truncated for connector=cc-1: 7 doc(s)')
+      );
+    });
+
+    it('writes all summaries in a single bulkUpdate call (no batching)', async () => {
+      // 75 connectors all go through one bulkUpdate — realistic deployments are
+      // well within Kibana's bulk-update capacity; batching would add complexity
+      // without any operational benefit.
+      const buckets = Array.from({ length: 75 }, (_, i) =>
+        makeBucket(`cc-${i}`, `pp-${i}`, [
+          makeHit({ identity_federation_id: `cc-${i}`, packagePolicyId: `pp-${i}` }),
+        ])
+      );
+      mockEsClient.search.mockResolvedValueOnce(makeSearchResponse(buckets));
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: Array.from({ length: 75 }, (_, i) => ({
+          id: `cc-${i}`,
+          type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+        })),
+      });
+
+      await taskRunner.run();
+
+      expect(mockSoClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect((mockSoClient.bulkUpdate.mock.calls[0][0] as any[]).length).toBe(75);
+    });
+
+    it('reports all updates as failed and logs error when bulkUpdate rejects', async () => {
+      const buckets = Array.from({ length: 10 }, (_, i) =>
+        makeBucket(`cc-${i}`, `pp-${i}`, [
+          makeHit({ identity_federation_id: `cc-${i}`, packagePolicyId: `pp-${i}` }),
+        ])
+      );
+      mockEsClient.search.mockResolvedValueOnce(makeSearchResponse(buckets));
+      mockSoClient.bulkUpdate.mockRejectedValueOnce(new Error('bulk update rejected'));
+
+      await taskRunner.run();
+
+      expect(mockSoClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Bulk update failed'));
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Updated 0 connector(s); 10 failed')
+      );
+    });
+
+    it('logs a warning per per-doc update failure inside a successful batch', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([makeBucket('cc-1', 'pp-1', [makeHit()])])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'cc-1',
+            type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+            error: { error: 'NotFound', message: 'connector deleted', statusCode: 404 },
+          },
+        ],
+      });
+
+      await taskRunner.run();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Per-doc update failed for connector cc-1')
+      );
+    });
+
+    it('skips malformed buckets (missing required fields) without crashing', async () => {
+      mockEsClient.search.mockResolvedValueOnce(
+        makeSearchResponse([
+          // Bucket with hit missing policy_template
+          makeBucket('cc-1', 'pp-bad', [makeHit({ policyTemplate: undefined })]),
+          // Healthy bucket
+          makeBucket('cc-2', 'pp-good', [
+            makeHit({ identity_federation_id: 'cc-2', packagePolicyId: 'pp-good' }),
+          ]),
+        ])
+      );
+      mockSoClient.bulkUpdate.mockResolvedValueOnce({
+        saved_objects: [{ id: 'cc-2', type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE }],
+      });
+
+      await taskRunner.run();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping malformed bucket')
+      );
+      const call = mockSoClient.bulkUpdate.mock.calls[0][0] as any[];
+      // Only cc-2 made it through
+      expect(call).toHaveLength(1);
+      expect(call[0].id).toBe('cc-2');
+    });
+
+    it('bails when aborted', async () => {
+      const abortCtrl = new AbortController();
+      abortCtrl.abort();
+      const runner = createTaskRunner(abortCtrl);
+
+      // search is called inside the try; throwIfAborted fires first and short-circuits.
+      await runner.run();
+
+      expect(mockEsClient.search).not.toHaveBeenCalled();
+      expect(mockSoClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Task was aborted'));
+    });
+
+    it('returns task state for reschedule', async () => {
+      mockEsClient.search.mockResolvedValueOnce(makeSearchResponse([]));
+      const result = await taskRunner.run();
+      expect(result).toEqual({ state: {} });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/otel_permission_verifier_status_change_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/otel_permission_verifier_status_change_task.ts
@@ -1,0 +1,512 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import type {
+  ConcreteTaskInstance,
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+
+import { CLOUD_CONNECTOR_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../../common/constants';
+import type {
+  PackagePolicyPermissionSummary,
+  PermissionResult,
+  PermissionStatus,
+} from '../../../common/types/models/cloud_connector';
+import type { CloudConnectorSOAttributes } from '../../types/so_attributes';
+import { appContextService } from '../../services';
+import { throwIfAborted } from '../utils';
+
+const TASK_TYPE = 'fleet:otel_permission_verifier_status_change';
+const TASK_TITLE = 'OTel Permission Verifier Status Change Task';
+const TASK_TIMEOUT = '5m';
+const TASK_ID = `${TASK_TYPE}:1.0.0`;
+const TASK_INTERVAL = '5m';
+export const STATUS_CHANGE_TASK_LOG = '[OTel Permission Verifier Status Change Task]';
+
+const VERIFIER_LOG_INDEX = 'logs-verifierreceiver.otel-*';
+const MAX_PACKAGE_POLICY_BUCKETS_PER_CONNECTOR = 25;
+const PERMISSION_HITS_PER_BUCKET = 100;
+
+/**
+ * The OTel collector flattens nested keys into dotted-key form under `attributes`.
+ * Per-record fields land in `attributes`; resource-level (per-emitter) fields land in
+ * `resource.attributes`. JSON access uses bracket notation because the keys contain dots.
+ */
+interface VerifierLogAttributes {
+  'policy.id'?: string;
+  'policy.name'?: string;
+  policy_template?: string;
+  'package.name'?: string;
+  'package.title'?: string;
+  'package.version'?: string;
+  'package_policy.id'?: string;
+  'permission.action'?: string;
+  'permission.status'?: 'granted' | 'denied' | 'error' | 'skipped';
+  'permission.required'?: boolean;
+  'permission.error_code'?: string;
+  'verification.verified_at'?: string;
+}
+
+interface VerifierLogResourceAttributes {
+  'identity_federation.id'?: string;
+  'identity_federation.name'?: string;
+}
+
+interface VerifierLogSource {
+  '@timestamp'?: string;
+  attributes?: VerifierLogAttributes;
+  resource?: { attributes?: VerifierLogResourceAttributes };
+  body?: { text?: string };
+}
+
+interface PackagePolicyBucket {
+  key: string;
+  doc_count: number;
+  recent_permission_docs: {
+    hits: { hits: Array<{ _source: VerifierLogSource }> };
+  };
+}
+
+interface ConnectorBucket {
+  key: string;
+  doc_count: number;
+  by_package_policy: {
+    sum_other_doc_count?: number;
+    buckets: PackagePolicyBucket[];
+  };
+}
+
+export function registerStatusChangeTask(taskManager: TaskManagerSetupContract) {
+  taskManager.registerTaskDefinitions({
+    [TASK_TYPE]: {
+      title: TASK_TITLE,
+      timeout: TASK_TIMEOUT,
+      createTaskRunner: ({
+        taskInstance,
+        abortController,
+      }: {
+        taskInstance: ConcreteTaskInstance;
+        abortController: AbortController;
+      }) => {
+        return {
+          run: async () => {
+            await runStatusChangeTask(abortController);
+            return { state: taskInstance.state };
+          },
+        };
+      },
+    },
+  });
+}
+
+export async function scheduleStatusChangeTask(taskManager: TaskManagerStartContract) {
+  try {
+    await taskManager.ensureScheduled({
+      id: TASK_ID,
+      taskType: TASK_TYPE,
+      schedule: { interval: TASK_INTERVAL },
+      state: {},
+      params: {},
+    });
+  } catch (error) {
+    appContextService
+      .getLogger()
+      .error(`${STATUS_CHANGE_TASK_LOG} Error scheduling status change task.`, { error });
+  }
+}
+
+/*
+ * Task flow (fires every 5 min):
+ *
+ * Phase 1 — Aggregate verifier logs with nested `terms` aggs:
+ *           outer bucket by `resource.attributes.identity_federation.id` (connector),
+ *           inner bucket by `attributes.package_policy.id`, then a `top_hits` sub-agg
+ *           that returns up to PERMISSION_HITS_PER_BUCKET docs per inner bucket sorted
+ *           by `@timestamp` desc. We take the first hit's `verification.verified_at`
+ *           as the "latest run" marker and filter the rest to that value.
+ *
+ * Phase 2 — Build PackagePolicyPermissionSummary[] per cloud_connector_id from
+ *           the aggregated buckets.
+ *
+ * Phase 3 — Bulk-update Cloud Connector SOs in sequential batches (each batch wrapped
+ *           in try/catch so one batch failure doesn't block subsequent batches).
+ *
+ * The task does not pre-compute counts or roll-up status — the frontend
+ * computes those from `verification_permissions[]`.
+ */
+async function runStatusChangeTask(abortController: AbortController): Promise<void> {
+  const logger = appContextService.getLogger().get('otel-verifier');
+
+  if (!appContextService.getExperimentalFeatures()?.enableOTelVerifier) {
+    logger.debug(`${STATUS_CHANGE_TASK_LOG} OTel verifier is disabled, skipping`);
+    return;
+  }
+
+  logger.debug(`${STATUS_CHANGE_TASK_LOG} Task run started`);
+
+  const soClient = appContextService.getInternalUserSOClientWithoutSpaceExtension();
+  const esClient = appContextService.getInternalUserESClient();
+
+  try {
+    throwIfAborted(abortController);
+
+    // Phase 1: aggregate the verifier log index.
+    const summariesByConnectorId = await aggregateLatestPerPackagePolicy(
+      esClient,
+      logger,
+      abortController
+    );
+
+    if (summariesByConnectorId.size === 0) {
+      logger.debug(`${STATUS_CHANGE_TASK_LOG} No verifier logs to aggregate, skipping update`);
+      logger.debug(`${STATUS_CHANGE_TASK_LOG} Task run completed`);
+      return;
+    }
+
+    logger.debug(
+      `${STATUS_CHANGE_TASK_LOG} Aggregated ${summariesByConnectorId.size} connector(s) with permission summaries`
+    );
+
+    throwIfAborted(abortController);
+
+    // Phase 3: bulk-update Cloud Connector SOs in batches.
+    const { updated, failed } = await bulkUpdateConnectorSummaries(
+      soClient,
+      summariesByConnectorId,
+      logger,
+      abortController
+    );
+
+    logger.info(
+      `${STATUS_CHANGE_TASK_LOG} Updated ${updated} connector(s); ${failed} failed; ${
+        summariesByConnectorId.size - updated - failed
+      } skipped (not found)`
+    );
+    logger.debug(`${STATUS_CHANGE_TASK_LOG} Task run completed`);
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      logger.warn(`${STATUS_CHANGE_TASK_LOG} Task was aborted`);
+      return;
+    }
+    logger.error(`${STATUS_CHANGE_TASK_LOG} Task run failed: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
+ * Aggregate the verifier log index by (identity_federation_id → package_policy.id) using
+ * nested `terms` aggs (the established Fleet idiom — see `fleet_policy_revisions_cleanup`,
+ * `action_status.ts`). Returns a map keyed by `identity_federation_id` whose values are
+ * the per-package-policy summaries built from each bucket's latest verification run.
+ *
+ * Truncation safety: each level emits a `sum_other_doc_count` value when the configured
+ * `size` is exceeded. We log a warning so operators can see and adjust before silent
+ * data loss compounds across runs.
+ */
+async function aggregateLatestPerPackagePolicy(
+  esClient: ElasticsearchClient,
+  logger: ReturnType<typeof appContextService.getLogger>,
+  abortController: AbortController
+): Promise<Map<string, PackagePolicyPermissionSummary[]>> {
+  throwIfAborted(abortController);
+
+  const response = await esClient.search<
+    VerifierLogSource,
+    {
+      by_connector: {
+        sum_other_doc_count?: number;
+        buckets: ConnectorBucket[];
+      };
+    }
+  >(
+    {
+      index: VERIFIER_LOG_INDEX,
+      size: 0,
+      // No coarse `@timestamp` filter — `max(verification.verified_at)` and top_hits
+      // give us the latest verification run's docs regardless of age. If index-cost
+      // becomes a concern, wrap in a multi-day range filter here.
+      aggs: {
+        by_connector: {
+          // Resource-level attribute — connector identity is shared across all log
+          // records emitted by one verifier instance.
+          terms: {
+            field: 'resource.attributes.identity_federation.id',
+            size: SO_SEARCH_LIMIT,
+          },
+          aggs: {
+            by_package_policy: {
+              // Per-record attribute — each log doc is one permission check for one target.
+              terms: {
+                field: 'attributes.package_policy.id',
+                size: MAX_PACKAGE_POLICY_BUCKETS_PER_CONNECTOR,
+              },
+              aggs: {
+                // No `max(verification.verified_at)` sub-agg: that field is mapped as
+                // keyword in the OTel-emitted index. Instead we sort top_hits by @timestamp
+                // desc and take the latest hit's verified_at as the "latest run" marker on
+                // the consumer side, then filter remaining hits to that value.
+                recent_permission_docs: {
+                  top_hits: {
+                    size: PERMISSION_HITS_PER_BUCKET,
+                    sort: [{ '@timestamp': { order: 'desc' } }],
+                    _source: {
+                      includes: [
+                        '@timestamp',
+                        'resource.attributes.identity_federation.id',
+                        'attributes.policy.id',
+                        'attributes.policy.name',
+                        'attributes.policy_template',
+                        'attributes.package.name',
+                        'attributes.package.title',
+                        'attributes.package.version',
+                        'attributes.package_policy.id',
+                        'attributes.permission.action',
+                        'attributes.permission.status',
+                        'attributes.permission.required',
+                        'attributes.verification.verified_at',
+                        'body.text',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    { signal: abortController.signal }
+  );
+
+  const connectorBuckets = response.aggregations?.by_connector?.buckets ?? [];
+
+  const summariesByConnectorId = new Map<string, PackagePolicyPermissionSummary[]>();
+
+  for (const connectorBucket of connectorBuckets) {
+    throwIfAborted(abortController);
+
+    const ppOverflow = connectorBucket.by_package_policy.sum_other_doc_count ?? 0;
+    if (ppOverflow > 0) {
+      logger.warn(
+        `${STATUS_CHANGE_TASK_LOG} Package-policy terms agg truncated for connector=${connectorBucket.key}: ${ppOverflow} doc(s) outside top ${MAX_PACKAGE_POLICY_BUCKETS_PER_CONNECTOR} package policies.`
+      );
+    }
+
+    for (const ppBucket of connectorBucket.by_package_policy.buckets) {
+      const summary = buildSummaryFromBucket(connectorBucket.key, ppBucket, logger);
+      if (!summary) continue;
+
+      const list = summariesByConnectorId.get(connectorBucket.key) ?? [];
+      list.push(summary);
+      summariesByConnectorId.set(connectorBucket.key, list);
+    }
+  }
+
+  logger.debug(
+    `${STATUS_CHANGE_TASK_LOG} Aggregated ${connectorBuckets.length} connector(s) into ${summariesByConnectorId.size} entries`
+  );
+  return summariesByConnectorId;
+}
+
+/**
+ * Build a single PackagePolicyPermissionSummary from one nested-terms bucket.
+ *
+ * The verifier receiver emits one log per permission check, so a single
+ * verification run for one package policy produces N log documents (one per
+ * action) sharing the same `verification.verified_at` value. The bucket's
+ * `recent_permission_docs` returns up to PERMISSION_HITS_PER_BUCKET most recent
+ * docs sorted by `@timestamp` desc; we filter to those whose
+ * `verification.verified_at` matches the bucket's `latest_verified_at` max,
+ * which keeps only the most recent run.
+ *
+ * Returns null when the bucket is empty or missing required fields.
+ */
+function buildSummaryFromBucket(
+  connectorId: string,
+  bucket: PackagePolicyBucket,
+  logger: ReturnType<typeof appContextService.getLogger>
+): PackagePolicyPermissionSummary | null {
+  const packagePolicyId = bucket.key;
+  const allHits = bucket.recent_permission_docs.hits.hits;
+  if (allHits.length === 0) return null;
+
+  // The first hit (sorted by @timestamp desc) carries the latest verification run's
+  // `verified_at` value — use that as the run marker and filter the rest to it.
+  const latestVerifiedAt = allHits[0]._source.attributes?.['verification.verified_at'];
+  if (!latestVerifiedAt) {
+    logger.warn(
+      `${STATUS_CHANGE_TASK_LOG} Skipping bucket for connector=${connectorId} package_policy=${packagePolicyId}: latest hit missing verification.verified_at`
+    );
+    return null;
+  }
+
+  const latestRunHits = allHits.filter(
+    (h) => h._source.attributes?.['verification.verified_at'] === latestVerifiedAt
+  );
+  if (latestRunHits.length === 0) return null;
+
+  const refAttrs = latestRunHits[0]._source.attributes ?? {};
+  const policyId = refAttrs['policy.id'];
+  const policyTemplate = refAttrs.policy_template;
+  const packageName = refAttrs['package.name'];
+
+  if (!policyId || !policyTemplate || !packageName) {
+    logger.warn(
+      `${STATUS_CHANGE_TASK_LOG} Skipping malformed bucket for connector=${connectorId} package_policy=${packagePolicyId}: missing policy/template/package fields`
+    );
+    return null;
+  }
+
+  // Warn if we hit the top_hits cap — the latest run may have more permissions
+  // than we retrieved.
+  if (allHits.length === PERMISSION_HITS_PER_BUCKET) {
+    logger.warn(
+      `${STATUS_CHANGE_TASK_LOG} Bucket connector=${connectorId} package_policy=${packagePolicyId} hit top_hits cap (${PERMISSION_HITS_PER_BUCKET}); some permissions may be truncated`
+    );
+  }
+
+  const permissions: PermissionResult[] = [];
+  for (const hit of latestRunHits) {
+    const mapped = mapPermission(hit._source.attributes, hit._source.body?.text);
+    if (mapped) permissions.push(mapped);
+  }
+
+  if (permissions.length === 0) return null;
+
+  return {
+    package_policy_id: packagePolicyId,
+    policy_id: policyId,
+    policy_template: policyTemplate,
+    package_name: packageName,
+    last_verified_at: latestVerifiedAt,
+    permissions,
+  };
+}
+
+/**
+ * Strip control characters and Unicode bidirectional-override sequences from a
+ * string sourced from the verifier OTel log stream, then trim whitespace.
+ *
+ * The verifier package emits these strings into a system-internal log index, but the
+ * string *content* originates in cloud-provider error responses (AWS / Azure / GCP).
+ * Treating those as untrusted at the ingestion boundary defends against:
+ *   - log-injection via embedded \n (forging fake log lines downstream)
+ *   - bidi-override attacks that visually disguise the rendered text
+ *   - C0/C1 control characters that break log parsers and PDF exports
+ *
+ * Returns `undefined` for non-strings or strings that become empty after cleaning,
+ * so callers can use a single truthiness check.
+ */
+function sanitizeString(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const cleaned = value
+    // Strip ASCII control characters (C0 + DEL) and C1 controls.
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+    // Strip Unicode bidirectional-override characters (LRE/RLE/PDF/LRO/RLO + isolates).
+    .replace(/[\u202A-\u202E\u2066-\u2069]/g, '')
+    .trim();
+  return cleaned.length === 0 ? undefined : cleaned;
+}
+
+/**
+ * Map a raw verifier log doc's `attributes` to the on-disk PermissionResult shape.
+ *
+ * Mapping rules (per epic):
+ *   - granted                              → verified
+ *   - denied + required=true               → denied
+ *   - denied + required=false              → skipped
+ *   - error                                → error
+ *   - skipped                              → skipped (passthrough)
+ *
+ * String fields sourced from the log stream (`action`, `error_code`, `message`) are
+ * sanitized here at the ingestion boundary; their final content rules are also
+ * enforced by `PermissionResultSchema` at SO-write time (defense in depth).
+ *
+ * Returns null when required fields are missing.
+ */
+function mapPermission(
+  attrs: VerifierLogAttributes | undefined,
+  bodyText: string | undefined
+): PermissionResult | null {
+  const action = sanitizeString(attrs?.['permission.action']);
+  const rawStatus = attrs?.['permission.status'];
+  if (!action || !rawStatus) return null;
+
+  const required = attrs?.['permission.required'] ?? false;
+  let status: PermissionStatus;
+  switch (rawStatus) {
+    case 'granted':
+      status = 'verified';
+      break;
+    case 'denied':
+      status = required ? 'denied' : 'skipped';
+      break;
+    case 'error':
+      status = 'error';
+      break;
+    case 'skipped':
+      status = 'skipped';
+      break;
+    default:
+      return null;
+  }
+
+  const errorCode = sanitizeString(attrs?.['permission.error_code']);
+  const message = sanitizeString(bodyText);
+  return {
+    action,
+    status,
+    required,
+    ...(errorCode ? { error_code: errorCode } : {}),
+    ...(message ? { message } : {}),
+  };
+}
+
+/**
+ * Bulk-update Cloud Connector SOs in a single call. Realistic deployments have
+ * tens of connectors (each = one identity), well within `bulkUpdate`'s capacity —
+ * no batching needed. Per-doc errors are reported via `saved_objects[].error`;
+ * a transport-level failure throws and is caught here once.
+ */
+async function bulkUpdateConnectorSummaries(
+  soClient: SavedObjectsClientContract,
+  summariesByConnectorId: Map<string, PackagePolicyPermissionSummary[]>,
+  logger: ReturnType<typeof appContextService.getLogger>,
+  abortController: AbortController
+): Promise<{ updated: number; failed: number }> {
+  throwIfAborted(abortController);
+
+  const updates = [...summariesByConnectorId.entries()].map(([connectorId, summaries]) => ({
+    type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+    id: connectorId,
+    attributes: { verification_permissions: summaries } as Partial<CloudConnectorSOAttributes>,
+  }));
+
+  let updated = 0;
+  let failed = 0;
+
+  try {
+    const result = await soClient.bulkUpdate<CloudConnectorSOAttributes>(updates);
+    for (const so of result.saved_objects) {
+      if (so.error) {
+        failed++;
+        logger.warn(
+          `${STATUS_CHANGE_TASK_LOG} Per-doc update failed for connector ${so.id}: ${so.error.message}`
+        );
+      } else {
+        updated++;
+      }
+    }
+  } catch (err) {
+    failed = updates.length;
+    logger.error(`${STATUS_CHANGE_TASK_LOG} Bulk update failed: ${(err as Error).message ?? err}`);
+  }
+
+  return { updated, failed };
+}

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verifier_policy_cleanup.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verifier_policy_cleanup.test.ts
@@ -130,16 +130,6 @@ describe('verifier_policy_cleanup', () => {
       );
       expect(mockedAgentPolicyService.deleteVerifierPolicy).toHaveBeenCalledTimes(2);
     });
-
-    it('no-ops when OTel verifier feature is disabled', async () => {
-      jest.spyOn(appContextService, 'getExperimentalFeatures').mockReturnValue({
-        enableOTelVerifier: false,
-      } as any);
-
-      await runVerifierPolicyCleanup(new AbortController());
-
-      expect(mockedAgentPolicyService.list).not.toHaveBeenCalled();
-    });
   });
 
   describe('registerVerifierPolicyCleanupTask', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verifier_policy_cleanup.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verifier_policy_cleanup.ts
@@ -20,15 +20,12 @@ export const VERIFICATION_TTL_MS = 5 * 60 * 1000;
  * exceeds {@link VERIFICATION_TTL_MS}. Shared by the verify-permissions task and
  * the dedicated cleanup task.
  *
- * No-ops when `enableOTelVerifier` is disabled (same as verify task).
+ * Always runs regardless of the `enableOTelVerifier` flag: cleanup must reclaim
+ * agentless slots even when the user-facing aggregator (gated by the flag) is off,
+ * otherwise expired verifier policies would leak indefinitely.
  */
 export async function runVerifierPolicyCleanup(abortController: AbortController): Promise<void> {
   const logger = appContextService.getLogger().get('otel-verifier');
-
-  if (!appContextService.getExperimentalFeatures()?.enableOTelVerifier) {
-    logger.debug(`${CLEANUP_TASK_LOG} OTel verifier is disabled, skipping verifier cleanup`);
-    return;
-  }
 
   const soClient = appContextService.getInternalUserSOClientWithoutSpaceExtension();
   const esClient = appContextService.getInternalUserESClient();

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verify_permissions_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verify_permissions_task.test.ts
@@ -51,6 +51,7 @@ const mockedGetAgentPolicySavedObjectType = getAgentPolicySavedObjectType as jes
 const mockSoClient = {
   find: jest.fn(),
   update: jest.fn(),
+  bulkGet: jest.fn(),
 } as any;
 
 const mockEsClient = {} as any;
@@ -61,11 +62,13 @@ const makePackagePolicySO = (
   id: string,
   connectorId: string,
   template: string,
-  enabled = true
+  enabled = true,
+  policyId = 'agent-policy-1'
 ) => ({
   id,
   attributes: {
     cloud_connector_id: connectorId,
+    policy_ids: [policyId],
     inputs: [{ enabled, policy_template: template }],
     package: { name: 'aws', title: 'AWS', version: '2.0.0' },
   },
@@ -89,7 +92,21 @@ describe('verify_permissions_task', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSoClient.find.mockReset();
+    // The cooldown gate ("find all connectors") is the FIRST `soClient.find` call in the
+    // runner; queue an empty result by default so the gate short-circuits to "no
+    // early-exit" and the test's subsequent `.mockResolvedValueOnce` chain (Phase 2 →
+    // Phase 3) lines up correctly. Tests that specifically exercise the cooldown
+    // gate can prepend their own `.mockResolvedValueOnce` ahead of this.
+    mockSoClient.find.mockResolvedValueOnce({ saved_objects: [] });
     mockSoClient.update.mockReset();
+    mockSoClient.bulkGet.mockReset();
+    // Default: bulkGet (used by getAgentPolicyNames) returns each requested policy with a synthetic name.
+    mockSoClient.bulkGet.mockImplementation(async (objects: Array<{ id: string }>) => ({
+      saved_objects: objects.map((o) => ({
+        id: o.id,
+        attributes: { name: `Agent Policy ${o.id}` },
+      })),
+    }));
     mockedAgentPolicyService.list.mockReset();
     mockedAgentPolicyService.createVerifierPolicy.mockReset();
     mockedAgentPolicyService.deleteVerifierPolicy.mockReset();
@@ -130,7 +147,8 @@ describe('verify_permissions_task', () => {
       expect(taskManager.ensureScheduled).toHaveBeenCalledWith({
         id: 'fleet:verify_permissions:1.0.0',
         taskType: 'fleet:verify_permissions',
-        schedule: { interval: '12h' },
+        // TODO(temp): revert to '12h' alongside TASK_INTERVAL in verify_permissions_task.ts
+        schedule: { interval: '5m' },
         state: {},
         params: {},
       });
@@ -165,28 +183,6 @@ describe('verify_permissions_task', () => {
 
     beforeEach(() => {
       taskRunner = createTaskRunner();
-    });
-
-    it('should skip when enableOTelVerifier is disabled', async () => {
-      jest.spyOn(appContextService, 'getExperimentalFeatures').mockReturnValue({
-        enableOTelVerifier: false,
-      } as any);
-
-      await taskRunner.run();
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining('OTel verifier is disabled')
-      );
-      expect(mockedAgentPolicyService.list).not.toHaveBeenCalled();
-    });
-
-    it('should skip when experimental features are undefined', async () => {
-      jest.spyOn(appContextService, 'getExperimentalFeatures').mockReturnValue(undefined as any);
-
-      await taskRunner.run();
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining('OTel verifier is disabled')
-      );
-      expect(mockedAgentPolicyService.list).not.toHaveBeenCalled();
     });
 
     it('should skip verification when an active non-expired verifier policy exists', async () => {
@@ -322,10 +318,16 @@ describe('verify_permissions_task', () => {
         mockEsClient,
         expect.objectContaining({ id: 'conn-1' }),
         expect.objectContaining({
-          policyTemplates: ['cloudtrail'],
-          packageName: 'aws',
-          packageTitle: 'AWS',
-          packageVersion: '2.0.0',
+          verifiedPackagePolicies: [
+            expect.objectContaining({
+              policy_template: 'cloudtrail',
+              package_name: 'aws',
+              package_title: 'AWS',
+              package_version: '2.0.0',
+              policy_id: 'agent-policy-1',
+              policy_name: 'Agent Policy agent-policy-1',
+            }),
+          ],
         })
       );
 
@@ -419,12 +421,15 @@ describe('verify_permissions_task', () => {
         mockEsClient,
         expect.anything(),
         expect.objectContaining({
-          policyTemplates: ['cloudtrail', 'guardduty'],
+          verifiedPackagePolicies: [
+            expect.objectContaining({ package_policy_id: 'pp-1', policy_template: 'cloudtrail' }),
+            expect.objectContaining({ package_policy_id: 'pp-2', policy_template: 'guardduty' }),
+          ],
         })
       );
     });
 
-    it('should deduplicate identical policy templates for the same connector', async () => {
+    it('produces one target per distinct package_policy_id even when templates collide', async () => {
       mockedAgentPolicyService.list.mockResolvedValueOnce({ items: [] } as any);
 
       mockedAgentPolicyService.createVerifierPolicy.mockResolvedValueOnce({
@@ -451,7 +456,10 @@ describe('verify_permissions_task', () => {
         mockEsClient,
         expect.anything(),
         expect.objectContaining({
-          policyTemplates: ['cloudtrail'],
+          verifiedPackagePolicies: [
+            expect.objectContaining({ package_policy_id: 'pp-1', policy_template: 'cloudtrail' }),
+            expect.objectContaining({ package_policy_id: 'pp-2', policy_template: 'cloudtrail' }),
+          ],
         })
       );
     });
@@ -602,15 +610,6 @@ describe('verify_permissions_task', () => {
       // active verifier's TTL elapses (otherwise we'd wait the full 12 h cron).
       expect(result!.runAt.getTime()).toBeGreaterThan(Date.now());
       expect(mockedAgentPolicyService.createVerifierPolicy).not.toHaveBeenCalled();
-    });
-
-    it('should NOT request a follow-up run when the feature flag is off', async () => {
-      jest.spyOn(appContextService, 'getExperimentalFeatures').mockReturnValue({
-        enableOTelVerifier: false,
-      } as any);
-
-      const result = await taskRunner.run();
-      expect(result).toBeUndefined();
     });
 
     it('should NOT request a follow-up run when an earlier verification fails with no other eligibles', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verify_permissions_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agentless/verify_permissions_task.ts
@@ -15,12 +15,14 @@ import type {
 
 import {
   CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+  MAX_CLOUD_CONNECTOR_PACKAGE_POLICIES,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
 } from '../../../common/constants';
+import type { VerifiedPackagePolicy } from '../../../common/types/models/cloud_connector';
 import type { CloudConnectorSOAttributes } from '../../types/so_attributes';
 import { appContextService } from '../../services';
 import { agentPolicyService, getAgentPolicySavedObjectType } from '../../services/agent_policy';
-import { getPackageInfo } from '../../services/epm/packages';
 import { ensureInstalledPackage } from '../../services/epm/packages/install';
 import { throwIfAborted } from '../utils';
 
@@ -30,9 +32,16 @@ const TASK_TYPE = 'fleet:verify_permissions';
 const TASK_TITLE = 'OTel Verify Permission Task';
 const TASK_TIMEOUT = '1d';
 const TASK_ID = `${TASK_TYPE}:1.0.0`;
-const TASK_INTERVAL = '12h';
+// TODO(temp): revert to '12h' before merging — lowered to '5m' for local dev iteration
+const TASK_INTERVAL = '5m';
 export const VERIFY_PERMISSIONS_TASK = '[OTel Verify Permissions Task]';
 const ELIGIBILITY_WINDOW_MS = 5 * 60 * 1000;
+/**
+ * Task-level cooldown: if every connector was verified within this window AND
+ * none are in a failed state, skip the whole task run. Saves the
+ * `getPackagePoliciesByConnector` lookup and the per-connector eligibility loop.
+ */
+const RECENT_VERIFICATION_WINDOW_MS = 60 * 60 * 1000;
 /** Buffer added to VERIFICATION_TTL_MS when computing `runAt` for the next run, so
  *  the verifier-policy cleanup task reliably sees the just-created verifier as expired on the
  *  next fire (protects against clock skew and task-manager polling jitter). */
@@ -98,8 +107,10 @@ export async function scheduleVerifyPermissionsTask(taskManager: TaskManagerStar
  * Phase 1 - Gate: If a non-expired verifier agent policy exists, skip this run.
  *
  * Phase 2 - Pre-filter: Fetch package policies with cloud_connector_id to build
- *           a map of connector ID -> package policy IDs. Then fetch only the
- *           cloud connectors that have installed packages via KQL id filter.
+ *           a map of connector ID -> verified package policies (one entry per
+ *           package policy, carrying the metadata the verifier_otel parallel-array
+ *           stream vars need). Then fetch only the cloud connectors that have
+ *           installed packages via KQL id filter.
  *
  * Phase 3 - Verify exactly one eligible connector per task run (one verifier
  *           deployment active at a time). Eligibility criteria:
@@ -123,11 +134,6 @@ async function runPermissionVerifierTask(
   abortController: AbortController
 ): Promise<{ shouldReschedule: boolean }> {
   const logger = appContextService.getLogger().get('otel-verifier');
-
-  if (!appContextService.getExperimentalFeatures()?.enableOTelVerifier) {
-    logger.debug(`${VERIFY_PERMISSIONS_TASK} OTel verifier is disabled, skipping`);
-    return { shouldReschedule: false };
-  }
 
   logger.debug(`${VERIFY_PERMISSIONS_TASK} Task run started`);
 
@@ -165,16 +171,43 @@ async function runPermissionVerifierTask(
 
     throwIfAborted(abortController);
 
-    // Phase 2: Pre-filter package policies to build connector -> package policy IDs map
-    const packagePolicyMap = await getPackagePolicyMap(soClient);
+    // Phase 1.5 — Cooldown gate: if every connector was verified within the last
+    // RECENT_VERIFICATION_WINDOW_MS AND none are failed, skip the whole task run.
+    // Saves the package-policy lookup and the per-connector eligibility loop.
+    const allConnectorsResult = await soClient.find<CloudConnectorSOAttributes>({
+      type: CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+      perPage: SO_SEARCH_LIMIT,
+    });
 
-    if (packagePolicyMap.size === 0) {
+    if (allConnectorsResult.saved_objects.length > 0) {
+      const cooldownCutoff = Date.now() - RECENT_VERIFICATION_WINDOW_MS;
+      const allRecentlyVerified = allConnectorsResult.saved_objects.every((connector) => {
+        const startedAt = connector.attributes.verification_started_at;
+        if (!startedAt) return false; // never verified — needs verification
+        if (connector.attributes.verification_status === 'failed') return false; // failed — eligible for retry
+        return new Date(startedAt).getTime() >= cooldownCutoff; // recent and not failed
+      });
+
+      if (allRecentlyVerified) {
+        logger.debug(
+          `${VERIFY_PERMISSIONS_TASK} All ${allConnectorsResult.saved_objects.length} connector(s) verified within last hour; skipping task run`
+        );
+        return { shouldReschedule: false };
+      }
+    }
+
+    throwIfAborted(abortController);
+
+    // Phase 2: Pre-filter package policies to build connector -> package-policies map
+    const packagePoliciesByConnector = await getPackagePoliciesByConnector(soClient);
+
+    if (packagePoliciesByConnector.size === 0) {
       logger.info(`${VERIFY_PERMISSIONS_TASK} No connectors with installed packages found`);
       logger.info(`${VERIFY_PERMISSIONS_TASK} Task run completed`);
       return { shouldReschedule: false };
     }
 
-    const connectorIds = [...packagePolicyMap.keys()].filter((id) => id.length > 0);
+    const connectorIds = [...packagePoliciesByConnector.keys()].filter((id) => id.length > 0);
 
     if (connectorIds.length === 0) {
       logger.info(`${VERIFY_PERMISSIONS_TASK} No valid connector IDs found after filtering`);
@@ -221,10 +254,10 @@ async function runPermissionVerifierTask(
         })`
       );
 
-      const policyTemplates = packagePolicyMap.get(connector.id);
-      if (!policyTemplates || policyTemplates.length === 0) {
+      const packagePolicies = packagePoliciesByConnector.get(connector.id);
+      if (!packagePolicies || packagePolicies.length === 0) {
         logger.debug(
-          `${VERIFY_PERMISSIONS_TASK} Connector ${connector.id} has no policy templates, skipping`
+          `${VERIFY_PERMISSIONS_TASK} Connector ${connector.id} has no verified package policies, skipping`
         );
         continue;
       }
@@ -233,7 +266,7 @@ async function runPermissionVerifierTask(
           soClient,
           esClient,
           connector,
-          policyTemplates,
+          packagePolicies,
           abortController
         );
       } catch (error) {
@@ -258,7 +291,7 @@ async function runPermissionVerifierTask(
       (c) =>
         c.id !== verifiedConnectorId &&
         isConnectorEligible(c.attributes) &&
-        (packagePolicyMap.get(c.id)?.length ?? 0) > 0
+        (packagePoliciesByConnector.get(c.id)?.length ?? 0) > 0
     );
 
     // Reschedule when more connectors need verification, or when we created a
@@ -277,44 +310,91 @@ async function runPermissionVerifierTask(
 }
 
 interface ConnectorVerificationInfo {
-  policyTemplates: string[];
-  packageName: string;
-  packageTitle: string;
-  packageVersion: string;
+  /** One entry per package policy to verify; index-aligned across the verifier's parallel-array stream vars. */
+  verifiedPackagePolicies: VerifiedPackagePolicy[];
 }
 
 /**
- * Build a map of connector ID -> policy templates from package policies
- * that have a cloud_connector_id set. Extracts policy_templates from each
- * package policy's enabled input.
+ * Build a map of connector ID -> verified-package-policy tuples from package policies
+ * that have a `cloud_connector_id` set. Each verified package policy carries everything the
+ * verifier_otel package needs to render its parallel-array stream vars:
+ * package_policy_id, agent policy id+name, policy template, and package metadata.
  */
-async function getPackagePolicyMap(
+async function getPackagePoliciesByConnector(
   soClient: SavedObjectsClientContract
-): Promise<Map<string, string[]>> {
+): Promise<Map<string, VerifiedPackagePolicy[]>> {
+  // perPage is capped at MAX_CLOUD_CONNECTOR_PACKAGE_POLICIES — see its definition
+  // for the agentless-concurrency rationale.
   const packagePolicies = await soClient.find<{
     cloud_connector_id?: string;
+    policy_ids?: string[];
     inputs?: Array<{ enabled: boolean; policy_template?: string }>;
+    package?: { name?: string; title?: string; version?: string };
   }>({
     type: PACKAGE_POLICY_SAVED_OBJECT_TYPE,
     filter: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.attributes.cloud_connector_id: *`,
-    perPage: 100,
+    perPage: MAX_CLOUD_CONNECTOR_PACKAGE_POLICIES,
   });
 
-  const map = new Map<string, string[]>();
+  // Gather distinct agent policy ids referenced by these PPs and resolve their names
+  // in one bulk lookup.
+  const agentPolicyIds = new Set<string>();
+  for (const pp of packagePolicies.saved_objects) {
+    pp.attributes.policy_ids?.forEach((id) => agentPolicyIds.add(id));
+  }
+  const agentPolicyNames = await getAgentPolicyNames(soClient, [...agentPolicyIds]);
+
+  const map = new Map<string, VerifiedPackagePolicy[]>();
   for (const pp of packagePolicies.saved_objects) {
     const connectorId = pp.attributes.cloud_connector_id?.trim();
     if (!connectorId) continue;
 
     const enabledInput = pp.attributes.inputs?.find((i) => i.enabled);
-    const template = enabledInput?.policy_template ?? '';
+    const template = enabledInput?.policy_template;
+    if (!template) continue;
+
+    const policyId = pp.attributes.policy_ids?.[0];
+    if (!policyId) continue;
+
+    const verifiedPackagePolicy: VerifiedPackagePolicy = {
+      package_policy_id: pp.id,
+      policy_id: policyId,
+      policy_name: agentPolicyNames.get(policyId) ?? '',
+      policy_template: template,
+      package_name: pp.attributes.package?.name ?? '',
+      package_title: pp.attributes.package?.title ?? '',
+      package_version: pp.attributes.package?.version ?? '',
+    };
 
     const existing = map.get(connectorId) ?? [];
-
-    if (template && !existing.includes(template)) {
-      existing.push(template);
+    // Dedupe by package_policy_id (defensive — find should not return duplicates).
+    if (
+      !existing.some((vpp) => vpp.package_policy_id === verifiedPackagePolicy.package_policy_id)
+    ) {
+      existing.push(verifiedPackagePolicy);
     }
-
     map.set(connectorId, existing);
+  }
+  return map;
+}
+
+/**
+ * Resolve agent-policy SO ids to their names via a single bulkGet. Errors on
+ * individual SOs (not found, etc.) are silently dropped — the caller falls back
+ * to an empty `policy_name` for any unresolved id.
+ */
+async function getAgentPolicyNames(
+  soClient: SavedObjectsClientContract,
+  ids: string[]
+): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const soType = await getAgentPolicySavedObjectType();
+  const result = await soClient.bulkGet<{ name?: string }>(ids.map((id) => ({ type: soType, id })));
+  const map = new Map<string, string>();
+  for (const so of result.saved_objects) {
+    if (!so.error && so.attributes?.name) {
+      map.set(so.id, so.attributes.name);
+    }
   }
   return map;
 }
@@ -390,7 +470,7 @@ async function verifyConnector(
   soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient,
   connector: SavedObject<CloudConnectorSOAttributes>,
-  policyTemplates: string[],
+  verifiedPackagePolicies: VerifiedPackagePolicy[],
   abortController: AbortController
 ): Promise<boolean> {
   const logger = appContextService.getLogger().get('otel-verifier');
@@ -409,24 +489,19 @@ async function verifyConnector(
       } (v${ensureResult.package.version})`
     );
 
-    throwIfAborted(abortController);
-    const pkgInfo = await getPackageInfo({
-      savedObjectsClient: soClient,
-      pkgName: cloudProvider,
-      pkgVersion: ensureResult.package.version,
-      skipArchive: true,
+    const verificationInfo: ConnectorVerificationInfo = { verifiedPackagePolicies };
+
+    const startedAt = new Date().toISOString();
+    await updateConnectorStatus(soClient, connector.id, {
+      verification_started_at: startedAt,
+      verification_status: 'pending',
     });
 
-    const verificationInfo: ConnectorVerificationInfo = {
-      policyTemplates,
-      packageName: pkgInfo.name,
-      packageTitle: pkgInfo.title ?? cloudProvider,
-      packageVersion: pkgInfo.version,
-    };
-
     logger.info(
-      `${VERIFY_PERMISSIONS_TASK} Creating verifier policy for connector ${connector.id} with templates [` +
-        `${verificationInfo.policyTemplates.join(', ')}]`
+      `${VERIFY_PERMISSIONS_TASK} Creating verifier policy for connector ${connector.id} with ${verifiedPackagePolicies.length} verified package policy/policies [` +
+        `${verifiedPackagePolicies
+          .map((vpp) => `${vpp.policy_template}/${vpp.package_policy_id}`)
+          .join(', ')}]`
     );
     throwIfAborted(abortController);
     const { policyId } = await agentPolicyService.createVerifierPolicy(
@@ -436,15 +511,9 @@ async function verifyConnector(
       verificationInfo
     );
 
-    const startedAt = new Date().toISOString();
     logger.info(
       `${VERIFY_PERMISSIONS_TASK} Verifier policy ${policyId} created for connector ${connector.id}`
     );
-
-    await updateConnectorStatus(soClient, connector.id, {
-      verification_started_at: startedAt,
-      verification_status: 'pending',
-    });
     return true;
   } catch (err) {
     logger.error(

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.test.ts
@@ -28,7 +28,12 @@ import {
 
 jest.mock('../services');
 jest.mock('../services/agents');
-jest.mock('../services/epm/packages');
+// Explicit factory: auto-mock of '../services/epm/packages' loses re-exported
+// bindings (e.g. getPackageInfo) when transitive deps in this branch shift the
+// auto-mock resolution order. Spell out what we need.
+jest.mock('../services/epm/packages', () => ({
+  getPackageInfo: jest.fn(),
+}));
 jest.mock('../services/epm/packages/get');
 jest.mock('../services/utils/version_specific_policies');
 

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/cloud_connector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/cloud_connector.ts
@@ -37,3 +37,75 @@ export const CloudConnectorSchemaV4 = CloudConnectorSchemaV3.extends({
   verification_started_at: schema.maybe(schema.string()),
   verification_failed_at: schema.maybe(schema.string()),
 });
+
+// Strict identifier patterns — restrict to characters real cloud providers actually use.
+// Reject anything else at the storage boundary so XSS / log-injection / weird-unicode
+// payloads from the verifier log stream can never reach the SO.
+//   - Action:     starts with letter or wildcard, then [A-Za-z0-9 . _ : / - *]
+//                 e.g. "s3:GetObject", "arn:aws:iam::aws:policy/SecurityAudit",
+//                      "Microsoft.Storage/storageAccounts/read", "storage.buckets.get"
+//   - Error code: starts with letter, then [A-Za-z0-9 . _ /]
+//                 e.g. "AccessDenied", "PERMISSION_DENIED",
+//                      "Microsoft.Storage/InsufficientAccountPermissions", "UnsupportedIntegration"
+const ACTION_PATTERN = /^[A-Za-z*][A-Za-z0-9._:/\-*]*$/;
+const ERROR_CODE_PATTERN = /^[A-Za-z][A-Za-z0-9._/]*$/;
+
+export const PermissionResultSchema = schema.object({
+  // Permission identifiers: AWS ARNs cap ~200 chars; service:Action style ~50.
+  action: schema.string({
+    maxLength: 256,
+    validate: (value) =>
+      ACTION_PATTERN.test(value)
+        ? undefined
+        : 'action must look like a cloud permission action (e.g. "s3:GetObject")',
+  }),
+  status: schema.oneOf([
+    schema.literal('verified'),
+    schema.literal('required'),
+    schema.literal('denied'),
+    schema.literal('error'),
+    schema.literal('skipped'),
+  ]),
+  required: schema.boolean(),
+  // Cloud-provider error codes follow naming conventions: AccessDenied, Throttling, etc.
+  error_code: schema.maybe(
+    schema.string({
+      maxLength: 100,
+      validate: (value) =>
+        ERROR_CODE_PATTERN.test(value)
+          ? undefined
+          : 'error_code must look like a cloud-provider error code (e.g. AccessDenied)',
+    })
+  ),
+  // Human-readable provider messages (e.g. STS errors include assumed-role principal).
+  // Free-form by design — sanitized at ingestion (control chars / bidi-overrides stripped)
+  // and length-bounded here; render-time HTML escaping handled by React/EUI.
+  message: schema.maybe(schema.string({ maxLength: 2000 })),
+});
+
+// Mirrors `PackagePolicyPermissionSummary` in common/types/models/cloud_connector.ts.
+// Only the fields the UI actually reads are stored; descriptive metadata (display
+// name, package title, version) is resolved live from the package policy SO at
+// render time.
+export const PackagePolicyPermissionSummarySchema = schema.object({
+  // SO IDs (UUIDs are 36 chars; 64 leaves headroom for any prefix scheme).
+  package_policy_id: schema.string({ maxLength: 64 }),
+  policy_id: schema.string({ maxLength: 64 }),
+  // Slugs: 'cspm', 'asset_inventory'; package names: 'cloud_security_posture'.
+  policy_template: schema.string({ maxLength: 100 }),
+  package_name: schema.string({ maxLength: 100 }),
+  // ISO-8601 timestamp: '2026-05-27T10:16:00.123Z' = ~25 chars.
+  last_verified_at: schema.string({ maxLength: 40 }),
+  // Each policy template probes a small fixed set (cloudtrail ~5, asset_inventory ~10).
+  // 1000 is ~100× the realistic ceiling while still bounding worst-case validation cost.
+  permissions: schema.arrayOf(PermissionResultSchema, { maxSize: 1000 }),
+});
+
+export const CloudConnectorSchemaV5 = CloudConnectorSchemaV4.extends({
+  // Aligns with MAX_PACKAGE_POLICY_BUCKETS_PER_CONNECTOR (25) × 40 headroom factor;
+  // bounds the array at the schema layer so abusive payloads are rejected before
+  // any aggregator processing.
+  verification_permissions: schema.maybe(
+    schema.arrayOf(PackagePolicyPermissionSummarySchema, { maxSize: 1000 })
+  ),
+});

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/cloud_connector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/cloud_connector.ts
@@ -7,7 +7,13 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { SINGLE_ACCOUNT, ORGANIZATION_ACCOUNT } from '../../../common/constants';
+import {
+  MAX_CLOUD_CONNECTOR_PACKAGE_POLICIES,
+  ORGANIZATION_ACCOUNT,
+  SINGLE_ACCOUNT,
+} from '../../../common/constants';
+
+import { PackagePolicyPermissionSummarySchema } from '../models/cloud_connector';
 
 export const CreateCloudConnectorRequestSchema = {
   body: schema.object({
@@ -56,10 +62,20 @@ export const CreateCloudConnectorRequestSchema = {
 // The actual structure varies based on cloudProvider (AWS vs Azure), so we use a flexible schema
 const CloudConnectorResponseVarsSchema = schema.recordOf(schema.string(), schema.any());
 
+// PackagePolicyPermissionSummarySchema is imported from ../models/cloud_connector so
+// REST responses validate against the same shape the SO stores. Keeping a local copy
+// here caused drift in the past — single source of truth is enforced via the shared import.
+
 const VerificationFieldsSchema = {
-  verification_status: schema.maybe(schema.string()),
-  verification_started_at: schema.maybe(schema.string()),
-  verification_failed_at: schema.maybe(schema.string()),
+  // 'pending' | 'success' | 'failed' — narrow string but bounded for CodeQL.
+  verification_status: schema.maybe(schema.string({ maxLength: 32 })),
+  // ISO-8601 timestamps: ~25 chars.
+  verification_started_at: schema.maybe(schema.string({ maxLength: 40 })),
+  verification_failed_at: schema.maybe(schema.string({ maxLength: 40 })),
+  // Aligns with MAX_PACKAGE_POLICY_BUCKETS_PER_CONNECTOR (25) with 40× headroom.
+  verification_permissions: schema.maybe(
+    schema.arrayOf(PackagePolicyPermissionSummarySchema, { maxSize: 1000 })
+  ),
 };
 
 export const CreateCloudConnectorResponseSchema = schema.object({
@@ -227,13 +243,17 @@ export const GetCloudConnectorUsageRequestSchema = {
   query: schema.object({
     page: schema.maybe(
       schema.number({
+        defaultValue: 1,
         min: 1,
+        max: 10000,
         meta: { description: 'The page number for pagination.' },
       })
     ),
     perPage: schema.maybe(
       schema.number({
+        defaultValue: 10,
         min: 1,
+        max: MAX_CLOUD_CONNECTOR_PACKAGE_POLICIES,
         meta: { description: 'The number of items per page.' },
       })
     ),

--- a/x-pack/platform/plugins/shared/fleet/server/types/so_attributes.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/so_attributes.ts
@@ -46,6 +46,7 @@ import type {
   CloudConnectorVars,
   AccountType,
   VerificationStatus,
+  PackagePolicyPermissionSummary,
 } from '../../common/types/models/cloud_connector';
 import type {
   CloudOnboardingDeploymentMechanism,
@@ -342,6 +343,7 @@ export interface CloudConnectorSOAttributes {
   verification_status?: VerificationStatus;
   verification_started_at?: string;
   verification_failed_at?: string;
+  verification_permissions?: PackagePolicyPermissionSummary[];
 }
 
 export interface CloudOnboardingDeploymentSOAttributes {

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -212,6 +212,7 @@ export default function ({ getService }: FtrProviderContext) {
         'fleet:delete-unenrolled-agents-task',
         'fleet:deploy_agent_policies',
         'fleet:migrate_action:retry',
+        'fleet:otel_permission_verifier_status_change',
         'fleet:packages-bulk-operations',
         'fleet:policy-revisions-cleanup-task',
         'fleet:privilege_level_change:retry',


### PR DESCRIPTION
## Summary

Introduces the backend half of Identity Federation permission-verification status: a new Fleet task that aggregates the OTel verifier's raw permission-check logs into a per-integration summary, exposes it through the Cloud Connector REST API, and version-gates the existing verifier-policy producer so it can emit per-integration data once the paired `verifier_otel` manifest change ships.

This is a straight split of the backend files out of the original #269828 (closed unmerged when its author left the company) — rebuilt on current `main` via a clean 3-way merge, no manual conflict resolution needed. **This PR intentionally does not yet address the red-team review findings** (`.agent-reviews/redteam.md`, included in this branch) — it represents the pre-review implementation as-is so the split/rebase can be validated (CI, tests) before the fixes land as follow-up commits.

Related:
- Story: elastic/security-team#18046
- Depends on (must land before the paired manifest publishes): elastic/security-team#17149
- Stacked child (frontend): #276101
- Epic: elastic/security-team#16847
- Original (closed, unmerged, orphaned): #269828

---

### Design

Two-layer data model on the existing Cloud Connector Saved Object:

| Layer | Field(s) | Owner |
|---|---|---|
| 1 (existing) | `verification_status`, `verification_started_at`, `verification_failed_at` | `verify_permissions_task` |
| 2 (new) | `verification_permissions: PackagePolicyPermissionSummary[]` | new `fleet:otel_permission_verifier_status_change` task |

No backend-computed roll-up status or counts anywhere — the frontend derives both from the raw arrays. `createVerifierPolicy` is version-gated (`VERIFIER_MULTI_TARGET_MIN_VERSION`) to emit either parallel-array or legacy-scalar stream vars depending on the installed `verifier_otel` package version, so this lands safely ahead of that package's manifest change.

### Test plan

#### Unit tests
```bash
node scripts/jest x-pack/platform/plugins/shared/fleet/server/tasks/agentless \
  x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts \
  x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector
```

#### Manual end-to-end (validated locally on serverless)

This validates the full pipeline — aggregator task → SO write → REST API — **without** requiring the agentless deployment infrastructure (`:3000` agentless API / a live verifier agent). The verifier logs are seeded directly into the data stream, which is the only part a real verifier deployment would otherwise produce. This is a dev harness, not the production data path.

1. **Config** (`config/serverless.dev.yml`) — enable the feature and preconfigure the agentless-internal output/fleet-server-host SOs the connector flow expects (their IDs are hardcoded lookups: `es-default-output-internal` / `default-fleet-server-internal`), and set the serverless project id (drives `isServerlessEnabled`, without which agentless output resolution fails):
   ```yaml
   xpack.cloud.serverless.project_id: test-123
   xpack.fleet.enableExperimental: ['enableOTelVerifier']
   xpack.fleet.agentless.enabled: true
   xpack.fleet.agentless.customIntegrations.enabled: true
   xpack.fleet.internal.fleetServerStandalone: true
   xpack.fleet.fleetServerHosts:
     - { id: default-fleet-server-internal, name: Localhost, host_urls: ['http://localhost:8220'], is_default: true }
   xpack.fleet.outputs:
     - { id: es-default-output-internal, name: Default output, type: elasticsearch, is_default: true, is_default_monitoring: true, hosts: ['https://localhost:9200'], ca_trusted_fingerprint: '<your local ES cert sha256>' }
   ```
2. **Start** serverless ES + Kibana (`yarn es serverless --projectType=security --kill`, `yarn serverless-security`).
3. **Create a Cloud Connector** via the API — this writes only the SO (`verification_status: 'pending'`), no agentless deploy:
   ```
   POST kbn:/api/fleet/cloud_connectors
   { "name": "test-connector", "cloudProvider": "aws", "accountType": "single-account",
     "vars": { "role_arn": { "type": "text", "value": "arn:aws:iam::123456789012:role/test" },
               "external_id": { "type": "text", "value": "abcdef1234567890abcdef" } } }
   ```
   Note the returned `id` (= `identity_federation.id` for the logs below).
4. **Seed verifier logs** into the data stream (append-only, so bulk `create`; the `logs-otel@template` data-stream template owns the mapping — do **not** `PUT` a plain index):
   ```
   POST logs-verifierreceiver.otel-default/_bulk
   { "create": {} }
   { "@timestamp": "2026-07-13T20:00:00.000Z", "resource": { "attributes": { "identity_federation.id": "<CONNECTOR_ID>" } }, "attributes": { "policy.id": "test-policy-1", "policy.name": "test-policy", "policy_template": "cloudtrail", "package.name": "aws", "package.title": "AWS", "package.version": "2.17.0", "package_policy.id": "test-pp-id", "permission.action": "cloudtrail:LookupEvents", "permission.status": "granted", "permission.required": true, "verification.verified_at": "2026-07-13T20:00:00.000Z" }, "body": { "text": "" } }
   ```
   Add `denied` / `error` lines (same `verified_at`, different `permission.action`) for a mixed-state result.
5. **Wait ~5 min** for the `fleet:otel_permission_verifier_status_change` task to fire (no run-now endpoint; add `plugins.fleet.otel-verifier` + `plugins.taskManager` at `debug` to watch it).
6. **Verify:** `GET kbn:/api/fleet/cloud_connectors/<CONNECTOR_ID>` returns a populated `verification_permissions` array — one `PackagePolicyPermissionSummary` per `package_policy.id`, each `permission` mapped from the log (`granted → verified`, etc.), with `last_verified_at` set. Confirmed working: aggregator → SO → API.

> Note on `verification_status`: it remains `pending` after this flow, which is expected — the aggregator writes only Layer 2 (`verification_permissions`); Layer 1 `verification_status` is owned by `verify_permissions_task`'s deployment lifecycle, which isn't exercised by the seeded-log harness. See O18 in the review notes.

### Known gaps (tracked in elastic/security-team#18046, not yet fixed here)
- Aggregator's ES query has no `now-7d` time bound
- Outer aggregation-bucket overflow isn't logged
- Task interval undecided (currently 5m, carried over from the original PR)
- `bulkUpdate` is unbatched
- Version-compat shim doesn't yet persist the capability flag the frontend needs for the `unattributable` state
- No independent feature flag yet (task currently only checks the pre-existing `enableOTelVerifier`)

### Checklist
- [ ] Flaky Test Runner used on changed tests
- [ ] Release notes / `release_note:*` label applied
- [ ] Backport labels applied per guidelines

### Identify risks
- **Do not merge before elastic/security-team#17149** (the `verifier_otel` manifest change) without also confirming this PR's version-gate shim is in the release that will serve that manifest's floor version — see O10/O16/O17 in the review log. Publishing the manifest independently of this shim would break verification fleet-wide.