### PR TITLE
[Cases] Add search and author filtering to user actions _find API

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -189,6 +189,8 @@ export const MAX_TAGS_PER_TEMPLATE = 10 as const;
 export const MAX_FIELD_DEFINITIONS_PER_OWNER = 200 as const;
 export const MAX_FILENAME_LENGTH = 160 as const;
 export const MAX_CUSTOM_OBSERVABLE_TYPES_LABEL_LENGTH = 50 as const;
+export const MAX_USER_ACTION_SEARCH_LENGTH = 256 as const;
+export const MAX_USER_ACTION_AUTHOR_LENGTH = 256 as const;
 
 /**
  * Cases features

--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -152,6 +152,14 @@ export const MAX_BULK_GET_CASES = 1000 as const;
 export const MAX_COMMENTS_PER_PAGE = 100 as const;
 export const MAX_CASES_PER_PAGE = 100 as const;
 export const MAX_USER_ACTIONS_PER_PAGE = 100 as const;
+/**
+ * Upper bound on how many user actions are pulled into memory when performing a
+ * free-text `search` over a case's user actions (see `UserActionFinder.findAll`).
+ * This keeps the request bounded for cases with very large activity logs; cases
+ * with more user actions than this will only be searched over their most recently
+ * fetched actions.
+ */
+export const MAX_USER_ACTIONS_FOR_SEARCH = 5000 as const;
 export const MAX_CATEGORY_FILTER_LENGTH = 100 as const;
 export const MAX_TAGS_FILTER_LENGTH = 100 as const;
 export const MAX_ASSIGNEES_FILTER_LENGTH = 100 as const;

--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.test.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import { PathReporter } from 'io-ts/lib/PathReporter';
 import { AttachmentType } from '../../domain/attachment/v1';
 import { UserActionTypes } from '../../domain/user_action/action/v1';
+import { MAX_USER_ACTION_AUTHOR_LENGTH, MAX_USER_ACTION_SEARCH_LENGTH } from '../../../constants';
 import {
   type CaseUserActionStatsResponse,
   CaseUserActionStatsResponseRt,
@@ -66,6 +68,42 @@ describe('User actions APIs', () => {
         const result = UserActionFindRequestSchema.safeParse({ ...defaultRequest, foo: 'bar' });
         expect(result.success).toBe(true);
         expect(result.data).toStrictEqual({ ...defaultRequest, page: 1, perPage: 10 });
+      });
+
+      it(`throws an error when the search is more than ${MAX_USER_ACTION_SEARCH_LENGTH} characters`, () => {
+        const search = 'a'.repeat(MAX_USER_ACTION_SEARCH_LENGTH + 1);
+
+        expect(
+          PathReporter.report(UserActionFindRequestRt.decode({ ...defaultRequest, search }))
+        ).toContain(
+          `The length of the search is too long. The maximum length is ${MAX_USER_ACTION_SEARCH_LENGTH}.`
+        );
+      });
+
+      it(`throws an error when the author is more than ${MAX_USER_ACTION_AUTHOR_LENGTH} characters`, () => {
+        const author = 'a'.repeat(MAX_USER_ACTION_AUTHOR_LENGTH + 1);
+
+        expect(
+          PathReporter.report(UserActionFindRequestRt.decode({ ...defaultRequest, author }))
+        ).toContain(
+          `The length of the author is too long. The maximum length is ${MAX_USER_ACTION_AUTHOR_LENGTH}.`
+        );
+      });
+
+      it('zod: throws an error when the search is too long', () => {
+        const result = UserActionFindRequestSchema.safeParse({
+          ...defaultRequest,
+          search: 'a'.repeat(MAX_USER_ACTION_SEARCH_LENGTH + 1),
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('zod: throws an error when the author is too long', () => {
+        const result = UserActionFindRequestSchema.safeParse({
+          ...defaultRequest,
+          author: 'a'.repeat(MAX_USER_ACTION_AUTHOR_LENGTH + 1),
+        });
+        expect(result.success).toBe(false);
       });
     });
 

--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.test.ts
@@ -14,11 +14,13 @@ import {
   CaseUserActionStatsResponseRt,
   CaseUserActionStatsRt,
   UserActionFindRequestRt,
+  UserActionInternalFindRequestRt,
   UserActionFindResponseRt,
 } from './v1';
 import {
   CaseUserActionStatsSchema,
   UserActionFindRequestSchema,
+  UserActionInternalFindRequestSchema,
   UserActionFindResponseSchema,
 } from '../../api_zod/user_action/v1';
 
@@ -70,11 +72,79 @@ describe('User actions APIs', () => {
         expect(result.data).toStrictEqual({ ...defaultRequest, page: 1, perPage: 10 });
       });
 
+      it('strips search and author params (internal-only)', () => {
+        const query = UserActionFindRequestRt.decode({
+          ...defaultRequest,
+          search: 'test',
+          author: 'elastic',
+        });
+
+        expect(query).toStrictEqual({
+          _tag: 'Right',
+          right: {
+            ...defaultRequest,
+            page: 1,
+            perPage: 10,
+          },
+        });
+      });
+
+      it('zod: strips search and author params (internal-only)', () => {
+        const result = UserActionFindRequestSchema.safeParse({
+          ...defaultRequest,
+          search: 'test',
+          author: 'elastic',
+        });
+        expect(result.success).toBe(true);
+        expect(result.data).toStrictEqual({ ...defaultRequest, page: 1, perPage: 10 });
+      });
+    });
+
+    describe('UserActionInternalFindRequestRt', () => {
+      const defaultRequest = {
+        types: [UserActionTypes.comment],
+        sortOrder: 'desc',
+        page: '1',
+        perPage: '10',
+      };
+
+      it('has expected attributes in request', () => {
+        const query = UserActionInternalFindRequestRt.decode({
+          ...defaultRequest,
+          search: 'test',
+          author: 'elastic',
+        });
+
+        expect(query).toStrictEqual({
+          _tag: 'Right',
+          right: {
+            ...defaultRequest,
+            page: 1,
+            perPage: 10,
+            search: 'test',
+            author: 'elastic',
+          },
+        });
+      });
+
+      it('removes foo:bar attributes from request', () => {
+        const query = UserActionInternalFindRequestRt.decode({ ...defaultRequest, foo: 'bar' });
+
+        expect(query).toStrictEqual({
+          _tag: 'Right',
+          right: {
+            ...defaultRequest,
+            page: 1,
+            perPage: 10,
+          },
+        });
+      });
+
       it(`throws an error when the search is more than ${MAX_USER_ACTION_SEARCH_LENGTH} characters`, () => {
         const search = 'a'.repeat(MAX_USER_ACTION_SEARCH_LENGTH + 1);
 
         expect(
-          PathReporter.report(UserActionFindRequestRt.decode({ ...defaultRequest, search }))
+          PathReporter.report(UserActionInternalFindRequestRt.decode({ ...defaultRequest, search }))
         ).toContain(
           `The length of the search is too long. The maximum length is ${MAX_USER_ACTION_SEARCH_LENGTH}.`
         );
@@ -84,14 +154,30 @@ describe('User actions APIs', () => {
         const author = 'a'.repeat(MAX_USER_ACTION_AUTHOR_LENGTH + 1);
 
         expect(
-          PathReporter.report(UserActionFindRequestRt.decode({ ...defaultRequest, author }))
+          PathReporter.report(UserActionInternalFindRequestRt.decode({ ...defaultRequest, author }))
         ).toContain(
           `The length of the author is too long. The maximum length is ${MAX_USER_ACTION_AUTHOR_LENGTH}.`
         );
       });
 
+      it('zod: has expected attributes in request', () => {
+        const result = UserActionInternalFindRequestSchema.safeParse({
+          ...defaultRequest,
+          search: 'test',
+          author: 'elastic',
+        });
+        expect(result.success).toBe(true);
+        expect(result.data).toStrictEqual({
+          ...defaultRequest,
+          page: 1,
+          perPage: 10,
+          search: 'test',
+          author: 'elastic',
+        });
+      });
+
       it('zod: throws an error when the search is too long', () => {
-        const result = UserActionFindRequestSchema.safeParse({
+        const result = UserActionInternalFindRequestSchema.safeParse({
           ...defaultRequest,
           search: 'a'.repeat(MAX_USER_ACTION_SEARCH_LENGTH + 1),
         });
@@ -99,7 +185,7 @@ describe('User actions APIs', () => {
       });
 
       it('zod: throws an error when the author is too long', () => {
-        const result = UserActionFindRequestSchema.safeParse({
+        const result = UserActionInternalFindRequestSchema.safeParse({
           ...defaultRequest,
           author: 'a'.repeat(MAX_USER_ACTION_AUTHOR_LENGTH + 1),
         });

--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
@@ -6,8 +6,12 @@
  */
 
 import * as rt from 'io-ts';
-import { paginationSchema } from '../../../schema';
-import { MAX_USER_ACTIONS_PER_PAGE } from '../../../constants';
+import { limitedStringSchema, paginationSchema } from '../../../schema';
+import {
+  MAX_USER_ACTIONS_PER_PAGE,
+  MAX_USER_ACTION_SEARCH_LENGTH,
+  MAX_USER_ACTION_AUTHOR_LENGTH,
+} from '../../../constants';
 import { UserActionTypes } from '../../domain/user_action/action/v1';
 import type { CaseUserActionInjectedIdsRt } from '../../domain/user_action/v1';
 import {
@@ -76,8 +80,16 @@ export const UserActionFindRequestRt = rt.intersection([
     rt.partial({
       types: rt.array(UserActionFindRequestTypesRt),
       sortOrder: rt.union([rt.literal('desc'), rt.literal('asc')]),
-      author: rt.string,
-      search: rt.string,
+      author: limitedStringSchema({
+        fieldName: 'author',
+        min: 1,
+        max: MAX_USER_ACTION_AUTHOR_LENGTH,
+      }),
+      search: limitedStringSchema({
+        fieldName: 'search',
+        min: 1,
+        max: MAX_USER_ACTION_SEARCH_LENGTH,
+      }),
     })
   ),
   paginationSchema({ maxPerPage: MAX_USER_ACTIONS_PER_PAGE }),

--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
@@ -80,6 +80,18 @@ export const UserActionFindRequestRt = rt.intersection([
     rt.partial({
       types: rt.array(UserActionFindRequestTypesRt),
       sortOrder: rt.union([rt.literal('desc'), rt.literal('asc')]),
+    })
+  ),
+  paginationSchema({ maxPerPage: MAX_USER_ACTIONS_PER_PAGE }),
+]);
+
+export type UserActionFindRequest = rt.TypeOf<typeof UserActionFindRequestRt>;
+
+export const UserActionInternalFindRequestRt = rt.intersection([
+  rt.exact(
+    rt.partial({
+      types: rt.array(UserActionFindRequestTypesRt),
+      sortOrder: rt.union([rt.literal('desc'), rt.literal('asc')]),
       author: limitedStringSchema({
         fieldName: 'author',
         min: 1,
@@ -95,7 +107,7 @@ export const UserActionFindRequestRt = rt.intersection([
   paginationSchema({ maxPerPage: MAX_USER_ACTIONS_PER_PAGE }),
 ]);
 
-export type UserActionFindRequest = rt.TypeOf<typeof UserActionFindRequestRt>;
+export type UserActionInternalFindRequest = rt.TypeOf<typeof UserActionInternalFindRequestRt>;
 
 export const UserActionFindResponseRt = rt.strict({
   userActions: UserActionsRt,

--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
@@ -76,6 +76,8 @@ export const UserActionFindRequestRt = rt.intersection([
     rt.partial({
       types: rt.array(UserActionFindRequestTypesRt),
       sortOrder: rt.union([rt.literal('desc'), rt.literal('asc')]),
+      author: rt.string,
+      search: rt.string,
     })
   ),
   paginationSchema({ maxPerPage: MAX_USER_ACTIONS_PER_PAGE }),

--- a/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
@@ -48,6 +48,9 @@ export const UserActionFindRequestSchema = paginationSchema({
 }).extend({
   types: z.array(z.enum(UserActionFindRequestTypesValues)).optional(),
   sortOrder: z.enum(['desc', 'asc']).optional(),
+});
+
+export const UserActionInternalFindRequestSchema = UserActionFindRequestSchema.extend({
   author: z.string().max(MAX_USER_ACTION_AUTHOR_LENGTH).optional(),
   search: z.string().max(MAX_USER_ACTION_SEARCH_LENGTH).optional(),
 });
@@ -61,4 +64,5 @@ export const UserActionFindResponseSchema = z.object({
 
 export type CaseUserActionStats = z.infer<typeof CaseUserActionStatsSchema>;
 export type UserActionFindRequest = z.infer<typeof UserActionFindRequestSchema>;
+export type UserActionInternalFindRequest = z.infer<typeof UserActionInternalFindRequestSchema>;
 export type UserActionFindResponse = z.infer<typeof UserActionFindResponseSchema>;

--- a/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
@@ -6,7 +6,11 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { MAX_USER_ACTIONS_PER_PAGE } from '../../../constants';
+import {
+  MAX_USER_ACTIONS_PER_PAGE,
+  MAX_USER_ACTION_SEARCH_LENGTH,
+  MAX_USER_ACTION_AUTHOR_LENGTH,
+} from '../../../constants';
 import { paginationSchema } from '../../../schema_zod';
 import { UserActionsSchema } from '../../domain_zod/user_action/v1';
 import { UserActionTypes } from '../../domain/user_action/action/v1';
@@ -44,8 +48,8 @@ export const UserActionFindRequestSchema = paginationSchema({
 }).extend({
   types: z.array(z.enum(UserActionFindRequestTypesValues)).optional(),
   sortOrder: z.enum(['desc', 'asc']).optional(),
-  author: z.string().max(256).optional(),
-  search: z.string().max(256).optional(),
+  author: z.string().max(MAX_USER_ACTION_AUTHOR_LENGTH).optional(),
+  search: z.string().max(MAX_USER_ACTION_SEARCH_LENGTH).optional(),
 });
 
 export const UserActionFindResponseSchema = z.object({

--- a/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
@@ -44,8 +44,8 @@ export const UserActionFindRequestSchema = paginationSchema({
 }).extend({
   types: z.array(z.enum(UserActionFindRequestTypesValues)).optional(),
   sortOrder: z.enum(['desc', 'asc']).optional(),
-  author: z.string().optional(),
-  search: z.string().optional(),
+  author: z.string().max(256).optional(),
+  search: z.string().max(256).optional(),
 });
 
 export const UserActionFindResponseSchema = z.object({

--- a/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
@@ -44,6 +44,8 @@ export const UserActionFindRequestSchema = paginationSchema({
 }).extend({
   types: z.array(z.enum(UserActionFindRequestTypesValues)).optional(),
   sortOrder: z.enum(['desc', 'asc']).optional(),
+  author: z.string().optional(),
+  search: z.string().optional(),
 });
 
 export const UserActionFindResponseSchema = z.object({

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.test.ts
@@ -52,4 +52,321 @@ describe('findUserActions', () => {
       );
     });
   });
+
+  describe('search', () => {
+    const createMockUserActionSO = (overrides: Record<string, unknown> = {}) => ({
+      id: 'ua-1',
+      version: 'abc',
+      attributes: {
+        action: 'create',
+        created_at: '2024-01-01T00:00:00Z',
+        created_by: { username: 'testuser', full_name: 'Test User', email: 'test@test.com' },
+        type: 'comment',
+        payload: { comment: { type: 'user', comment: 'Hello world', owner: 'securitySolution' } },
+        owner: 'securitySolution',
+        comment_id: 'comment-1',
+        ...overrides,
+      },
+      references: [],
+    });
+
+    beforeEach(() => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO(),
+        createMockUserActionSO({
+          payload: {
+            comment: { type: 'user', comment: 'Goodbye world', owner: 'securitySolution' },
+          },
+          created_by: { username: 'otheruser', full_name: 'Other User', email: 'other@test.com' },
+        }),
+        createMockUserActionSO({
+          payload: { title: 'Important case title' },
+          type: 'title',
+        }),
+      ]);
+    });
+
+    it('uses findAll when search param is provided', async () => {
+      await find({ caseId: 'test-case', params: { search: 'Hello' } }, client, clientArgs);
+
+      expect(clientArgs.services.userActionService.finder.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ caseId: 'test-case' })
+      );
+      expect(clientArgs.services.userActionService.finder.find).not.toHaveBeenCalled();
+    });
+
+    it('filters user actions by search term in payload', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'Hello' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.userActions[0].payload).toEqual(
+        expect.objectContaining({ comment: expect.objectContaining({ comment: 'Hello world' }) })
+      );
+    });
+
+    it('search is case-insensitive', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'hello' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+
+    it('filters user actions by search term matching author username', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'otheruser' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.userActions[0].created_by.username).toBe('otheruser');
+    });
+
+    it('filters user actions by search term matching author full_name', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'Other User' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.userActions[0].created_by.full_name).toBe('Other User');
+    });
+
+    it('returns all results when search matches multiple', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'world' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(2);
+    });
+
+    it('returns empty results when search matches nothing', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'nonexistent' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(0);
+      expect(result.userActions).toEqual([]);
+    });
+
+    it('paginates filtered results correctly', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'world', page: 1, perPage: 1 } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.userActions).toHaveLength(1);
+      expect(result.page).toBe(1);
+      expect(result.perPage).toBe(1);
+    });
+
+    it('returns second page of paginated results', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'world', page: 2, perPage: 1 } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.userActions).toHaveLength(1);
+      expect(result.page).toBe(2);
+    });
+
+    it('uses standard find when search is not provided', async () => {
+      clientArgs.services.userActionService.finder.find = jest.fn().mockResolvedValue({
+        saved_objects: [createMockUserActionSO()],
+        page: 1,
+        per_page: 20,
+        total: 1,
+      });
+
+      await find({ caseId: 'test-case', params: {} }, client, clientArgs);
+
+      expect(clientArgs.services.userActionService.finder.find).toHaveBeenCalled();
+      expect(clientArgs.services.userActionService.finder.findAll).not.toHaveBeenCalled();
+    });
+
+    it('does not match JSON keys in payload, only values', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'type' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(0);
+    });
+
+    it('does not match internal enum values in payload', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'securitySolution' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(0);
+    });
+
+    it('handles user actions with null created_by fields', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          created_by: { username: null, full_name: null, email: null },
+          payload: {
+            comment: { type: 'user', comment: 'test comment', owner: 'securitySolution' },
+          },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'test comment' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+
+    it('does not match null created_by fields against search term', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          created_by: { username: null, full_name: null, email: null },
+          payload: { title: 'some title' },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'null' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(0);
+    });
+
+    it('matches text custom field values', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'customFields',
+          payload: {
+            customFields: [
+              { key: 'field_1', type: 'text', value: 'root cause analysis' },
+              { key: 'field_2', type: 'toggle', value: true },
+            ],
+          },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'root cause' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+
+    it('does not match toggle or number custom field values', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'customFields',
+          payload: {
+            customFields: [
+              { key: 'field_1', type: 'toggle', value: true },
+              { key: 'field_2', type: 'number', value: 42 },
+            ],
+          },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'true' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(0);
+    });
+
+    it('matches extended field values', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'extended_fields',
+          payload: {
+            extended_fields: {
+              summary: 'incident summary text',
+              priority: 'high',
+            },
+          },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'incident summary' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+
+    it('matches custom field values in create_case payload', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'create_case',
+          payload: {
+            title: 'New case',
+            description: 'A description',
+            tags: [],
+            status: 'open',
+            severity: 'low',
+            owner: 'securitySolution',
+            assignees: [],
+            connector: { id: 'none', name: 'none', type: '.none', fields: null },
+            settings: { syncAlerts: false },
+            customFields: [{ key: 'field_1', type: 'text', value: 'deployment failure' }],
+          },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'deployment failure' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe('author filter', () => {
+    beforeEach(() => {
+      clientArgs.services.userActionService.finder.find = jest.fn().mockResolvedValue({
+        saved_objects: [],
+        page: 1,
+        per_page: 20,
+        total: 0,
+      });
+    });
+
+    it('passes author to the finder service', async () => {
+      await find({ caseId: 'test-case', params: { author: 'testuser' } }, client, clientArgs);
+
+      expect(clientArgs.services.userActionService.finder.find).toHaveBeenCalledWith(
+        expect.objectContaining({ author: 'testuser' })
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.test.ts
@@ -349,6 +349,67 @@ describe('findUserActions', () => {
 
       expect(result.total).toBe(1);
     });
+
+    it('matches severity user action values', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'severity',
+          payload: { severity: 'critical' },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'critical' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+
+    it('matches severity values in create_case payload', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'create_case',
+          payload: {
+            title: 'New case',
+            description: 'A description',
+            tags: [],
+            status: 'open',
+            severity: 'critical',
+            owner: 'securitySolution',
+            assignees: [],
+            connector: { id: 'none', name: 'none', type: '.none', fields: null },
+            settings: { syncAlerts: false },
+          },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'critical' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
+
+    it('matches assignee profile uids', async () => {
+      clientArgs.services.userActionService.finder.findAll = jest.fn().mockResolvedValue([
+        createMockUserActionSO({
+          type: 'assignees',
+          payload: { assignees: [{ uid: 'assignee-profile-uid' }] },
+        }),
+      ]);
+
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'assignee-profile-uid' } },
+        client,
+        clientArgs
+      );
+
+      expect(result.total).toBe(1);
+    });
   });
 
   describe('author filter', () => {

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.test.ts
@@ -95,6 +95,31 @@ describe('findUserActions', () => {
       expect(clientArgs.services.userActionService.finder.find).not.toHaveBeenCalled();
     });
 
+    it('fetches undecoded results and only decodes the returned page', async () => {
+      const result = await find(
+        { caseId: 'test-case', params: { search: 'world', page: 1, perPage: 1 } },
+        client,
+        clientArgs
+      );
+
+      expect(clientArgs.services.userActionService.finder.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ decode: false })
+      );
+      expect(clientArgs.services.userActionService.finder.decodeUserActions).toHaveBeenCalledTimes(
+        1
+      );
+      // only the single paginated result is decoded, not both matches
+      expect(clientArgs.services.userActionService.finder.decodeUserActions).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.anything()])
+      );
+      expect(
+        (clientArgs.services.userActionService.finder.decodeUserActions as jest.Mock).mock
+          .calls[0][0]
+      ).toHaveLength(1);
+      expect(result.total).toBe(2);
+      expect(result.userActions).toHaveLength(1);
+    });
+
     it('filters user actions by search term in payload', async () => {
       const result = await find(
         { caseId: 'test-case', params: { search: 'Hello' } },

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
@@ -6,8 +6,14 @@
  */
 
 import type { KueryNode } from '@kbn/es-query';
-import type { UserActionFindRequest, UserActionFindResponse } from '../../../common/types/api';
-import { UserActionFindRequestRt, UserActionFindResponseRt } from '../../../common/types/api';
+import type {
+  UserActionInternalFindRequest,
+  UserActionFindResponse,
+} from '../../../common/types/api';
+import {
+  UserActionInternalFindRequestRt,
+  UserActionFindResponseRt,
+} from '../../../common/types/api';
 import { decodeWithExcessOrThrow, decodeOrThrow } from '../../common/runtime_types';
 import type { CasesClientArgs } from '../types';
 import type { UserActionFind } from './types';
@@ -21,7 +27,7 @@ import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from '../../routes/api';
 interface FindWithSearchParams {
   caseId: string;
   search: string;
-  queryParams: Omit<UserActionFindRequest, 'search'>;
+  queryParams: Omit<UserActionInternalFindRequest, 'search'>;
   authorizationFilter?: KueryNode;
   ensureSavedObjectsAreAuthorized: (entities: Array<{ owner: string; id: string }>) => void;
   userActionService: CasesClientArgs['services']['userActionService'];
@@ -41,7 +47,10 @@ export const find = async (
   try {
     const types = asArray(params.types);
 
-    const queryParams = decodeWithExcessOrThrow(UserActionFindRequestRt)({ ...params, types });
+    const queryParams = decodeWithExcessOrThrow(UserActionInternalFindRequestRt)({
+      ...params,
+      types,
+    });
 
     const [authorizationFilterRes] = await Promise.all([
       authorization.getAuthorizationFilter(Operations.findUserActions),

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
@@ -5,16 +5,27 @@
  * 2.0.
  */
 
-import type { UserActionFindResponse } from '../../../common/types/api';
+import type { KueryNode } from '@kbn/es-query';
+import type { UserActionFindRequest, UserActionFindResponse } from '../../../common/types/api';
 import { UserActionFindRequestRt, UserActionFindResponseRt } from '../../../common/types/api';
 import { decodeWithExcessOrThrow, decodeOrThrow } from '../../common/runtime_types';
 import type { CasesClientArgs } from '../types';
 import type { UserActionFind } from './types';
 import { Operations } from '../../authorization';
-import { formatSavedObjects } from './utils';
+import { formatSavedObject, formatSavedObjects, matchesSearch } from './utils';
 import { createCaseError } from '../../common/error';
 import { asArray } from '../../common/utils';
 import type { CasesClient } from '../client';
+import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from '../../routes/api';
+
+interface FindWithSearchParams {
+  caseId: string;
+  search: string;
+  queryParams: Omit<UserActionFindRequest, 'search'>;
+  authorizationFilter?: KueryNode;
+  ensureSavedObjectsAreAuthorized: (entities: Array<{ owner: string; id: string }>) => void;
+  userActionService: CasesClientArgs['services']['userActionService'];
+}
 
 export const find = async (
   { caseId, params }: UserActionFind,
@@ -28,18 +39,28 @@ export const find = async (
   } = clientArgs;
 
   try {
-    // supertest and query-string encode a single entry in an array as just a string so make sure we have an array
     const types = asArray(params.types);
 
     const queryParams = decodeWithExcessOrThrow(UserActionFindRequestRt)({ ...params, types });
 
     const [authorizationFilterRes] = await Promise.all([
       authorization.getAuthorizationFilter(Operations.findUserActions),
-      // ensure that we have authorization for reading the case
       casesClient.cases.resolve({ id: caseId, includeComments: false }),
     ]);
 
     const { filter: authorizationFilter, ensureSavedObjectsAreAuthorized } = authorizationFilterRes;
+
+    if (queryParams.search) {
+      const { search, ...rest } = queryParams;
+      return findWithSearch({
+        caseId,
+        search,
+        queryParams: rest,
+        authorizationFilter,
+        ensureSavedObjectsAreAuthorized,
+        userActionService,
+      });
+    }
 
     const userActions = await userActionService.finder.find({
       caseId,
@@ -66,4 +87,41 @@ export const find = async (
       logger,
     });
   }
+};
+
+const findWithSearch = async ({
+  caseId,
+  search,
+  queryParams,
+  authorizationFilter,
+  ensureSavedObjectsAreAuthorized,
+  userActionService,
+}: FindWithSearchParams): Promise<UserActionFindResponse> => {
+  const { page, perPage, ...findAllParams } = queryParams;
+
+  const allUserActions = await userActionService.finder.findAll({
+    caseId,
+    ...findAllParams,
+    filter: authorizationFilter,
+  });
+
+  ensureSavedObjectsAreAuthorized(
+    allUserActions.map((so) => ({ owner: so.attributes.owner, id: so.id }))
+  );
+
+  const filtered = allUserActions.filter((so) => matchesSearch(so.attributes, search));
+
+  const currentPage = page ?? DEFAULT_PAGE;
+  const currentPerPage = perPage ?? DEFAULT_PER_PAGE;
+  const start = (currentPage - 1) * currentPerPage;
+  const paged = filtered.slice(start, start + currentPerPage);
+
+  const res = {
+    userActions: paged.map(formatSavedObject),
+    page: currentPage,
+    perPage: currentPerPage,
+    total: filtered.length,
+  };
+
+  return decodeOrThrow(UserActionFindResponseRt)(res);
 };

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
@@ -23,6 +23,7 @@ import { createCaseError } from '../../common/error';
 import { asArray } from '../../common/utils';
 import type { CasesClient } from '../client';
 import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from '../../routes/api';
+import { MAX_USER_ACTIONS_FOR_SEARCH } from '../../../common/constants';
 
 interface FindWithSearchParams {
   caseId: string;
@@ -45,6 +46,7 @@ export const find = async (
   } = clientArgs;
 
   try {
+    // supertest and query-string encode a single entry in an array as just a string so make sure we have an array
     const types = asArray(params.types);
 
     const queryParams = decodeWithExcessOrThrow(UserActionInternalFindRequestRt)({
@@ -112,6 +114,7 @@ const findWithSearch = async ({
     caseId,
     ...findAllParams,
     filter: authorizationFilter,
+    limit: MAX_USER_ACTIONS_FOR_SEARCH,
   });
 
   ensureSavedObjectsAreAuthorized(

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/find.ts
@@ -110,11 +110,19 @@ const findWithSearch = async ({
 }: FindWithSearchParams): Promise<UserActionFindResponse> => {
   const { page, perPage, ...findAllParams } = queryParams;
 
+  /**
+   * `matchesSearch` only reads `type`, `payload`, and `created_by` off the raw
+   * (transformed but undecoded) attributes, so we skip `decodeOrThrow` here and
+   * only decode the page of results we actually return. Otherwise we'd pay the
+   * io-ts decode cost for every user action in the case just to discard most of
+   * them during filtering/pagination.
+   */
   const allUserActions = await userActionService.finder.findAll({
     caseId,
     ...findAllParams,
     filter: authorizationFilter,
     limit: MAX_USER_ACTIONS_FOR_SEARCH,
+    decode: false,
   });
 
   ensureSavedObjectsAreAuthorized(
@@ -126,7 +134,9 @@ const findWithSearch = async ({
   const currentPage = page ?? DEFAULT_PAGE;
   const currentPerPage = perPage ?? DEFAULT_PER_PAGE;
   const start = (currentPage - 1) * currentPerPage;
-  const paged = filtered.slice(start, start + currentPerPage);
+  const paged = userActionService.finder.decodeUserActions(
+    filtered.slice(start, start + currentPerPage)
+  );
 
   const res = {
     userActions: paged.map(formatSavedObject),

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { UserActionFindRequest } from '../../../common/types/api';
+import type { UserActionInternalFindRequest } from '../../../common/types/api';
 
 /**
  * Parameters for retrieving user actions for a particular case
@@ -21,6 +21,6 @@ export type GetConnectorsRequest = UserActionGet;
 export type GetUsersRequest = UserActionGet;
 
 export interface UserActionFind {
-  params: UserActionFindRequest;
+  params: UserActionInternalFindRequest;
   caseId: string;
 }

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/utils.ts
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import type { SavedObjectsFindResponse } from '@kbn/core-saved-objects-api-server';
+import type { SavedObject, SavedObjectsFindResponse } from '@kbn/core-saved-objects-api-server';
 import type {
   CaseUserActionDeprecatedResponse,
   CaseUserActionsDeprecatedResponse,
 } from '../../../common/types/api';
 import type { UserActionAttributes, UserActions } from '../../../common/types/domain';
+import { UserActionTypes } from '../../../common/types/domain';
+import type { UserActionTransformedAttributes } from '../../common/types/user_actions';
 
 export const extractAttributes = (
   userActions: SavedObjectsFindResponse<CaseUserActionDeprecatedResponse>
@@ -18,7 +20,116 @@ export const extractAttributes = (
   return userActions.saved_objects.map((so) => so.attributes);
 };
 
+export const formatSavedObject = (so: SavedObject<UserActionAttributes>) => ({
+  id: so.id,
+  version: so.version ?? '',
+  ...so.attributes,
+});
+
 export const formatSavedObjects = (
   response: SavedObjectsFindResponse<UserActionAttributes>
-): UserActions =>
-  response.saved_objects.map((so) => ({ id: so.id, version: so.version ?? '', ...so.attributes }));
+): UserActions => response.saved_objects.map(formatSavedObject);
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+
+const extractCustomFieldValues = (customFields: unknown): string[] => {
+  if (!Array.isArray(customFields)) {
+    return [];
+  }
+
+  return customFields
+    .filter(
+      (cf): cf is { type: string; value: string } =>
+        cf != null && cf.type === 'text' && typeof cf.value === 'string'
+    )
+    .map((cf) => cf.value);
+};
+
+export const getSearchableContent = (attributes: UserActionTransformedAttributes): string[] => {
+  const payload = attributes.payload as Record<string, unknown>;
+  const texts: string[] = [];
+
+  switch (attributes.type) {
+    case UserActionTypes.comment: {
+      const comment = payload.comment as Record<string, unknown> | undefined;
+      const text = asString(comment?.comment);
+      if (text) texts.push(text);
+      break;
+    }
+    case UserActionTypes.title: {
+      const text = asString(payload.title);
+      if (text) texts.push(text);
+      break;
+    }
+    case UserActionTypes.description: {
+      const text = asString(payload.description);
+      if (text) texts.push(text);
+      break;
+    }
+    case UserActionTypes.tags: {
+      texts.push(...asStringArray(payload.tags));
+      break;
+    }
+    case UserActionTypes.category: {
+      const text = asString(payload.category);
+      if (text) texts.push(text);
+      break;
+    }
+    case UserActionTypes.customFields: {
+      texts.push(...extractCustomFieldValues(payload.customFields));
+      break;
+    }
+    case UserActionTypes.extended_fields: {
+      const extendedFields = payload.extended_fields;
+      if (extendedFields != null && typeof extendedFields === 'object') {
+        texts.push(...asStringArray(Object.values(extendedFields)));
+      }
+      break;
+    }
+    case UserActionTypes.create_case: {
+      const title = asString(payload.title);
+      const description = asString(payload.description);
+      if (title) texts.push(title);
+      if (description) texts.push(description);
+      texts.push(...asStringArray(payload.tags));
+      texts.push(...extractCustomFieldValues(payload.customFields));
+      break;
+    }
+    default:
+      break;
+  }
+
+  return texts;
+};
+
+export const matchesSearch = (
+  attributes: UserActionTransformedAttributes,
+  search: string
+): boolean => {
+  if (!search) {
+    return true;
+  }
+
+  const term = search.toLowerCase();
+
+  const searchableTexts = getSearchableContent(attributes);
+  if (searchableTexts.some((text) => text.toLowerCase().includes(term))) {
+    return true;
+  }
+
+  const createdBy = attributes.created_by;
+  if (createdBy) {
+    const username = createdBy.username?.toLowerCase() ?? '';
+    const fullName = createdBy.full_name?.toLowerCase() ?? '';
+
+    if (username.includes(term) || fullName.includes(term)) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/utils.ts
@@ -36,6 +36,19 @@ const asString = (value: unknown): string | undefined =>
 const asStringArray = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 
+const extractAssigneeUids = (assignees: unknown): string[] => {
+  if (!Array.isArray(assignees)) {
+    return [];
+  }
+
+  return assignees
+    .filter(
+      (assignee): assignee is { uid: string } =>
+        assignee != null && typeof assignee.uid === 'string'
+    )
+    .map((assignee) => assignee.uid);
+};
+
 const extractCustomFieldValues = (customFields: unknown): string[] => {
   if (!Array.isArray(customFields)) {
     return [];
@@ -79,6 +92,15 @@ export const getSearchableContent = (attributes: UserActionTransformedAttributes
       if (text) texts.push(text);
       break;
     }
+    case UserActionTypes.severity: {
+      const text = asString(payload.severity);
+      if (text) texts.push(text);
+      break;
+    }
+    case UserActionTypes.assignees: {
+      texts.push(...extractAssigneeUids(payload.assignees));
+      break;
+    }
     case UserActionTypes.customFields: {
       texts.push(...extractCustomFieldValues(payload.customFields));
       break;
@@ -93,10 +115,13 @@ export const getSearchableContent = (attributes: UserActionTransformedAttributes
     case UserActionTypes.create_case: {
       const title = asString(payload.title);
       const description = asString(payload.description);
+      const severity = asString(payload.severity);
       if (title) texts.push(title);
       if (description) texts.push(description);
+      if (severity) texts.push(severity);
       texts.push(...asStringArray(payload.tags));
       texts.push(...extractCustomFieldValues(payload.customFields));
+      texts.push(...extractAssigneeUids(payload.assignees));
       break;
     }
     default:

--- a/x-pack/platform/plugins/shared/cases/server/client/user_actions/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/user_actions/utils.ts
@@ -10,7 +10,11 @@ import type {
   CaseUserActionDeprecatedResponse,
   CaseUserActionsDeprecatedResponse,
 } from '../../../common/types/api';
-import type { UserActionAttributes, UserActions } from '../../../common/types/domain';
+import type {
+  UserActionAttributes,
+  UserActions,
+  UserActionType,
+} from '../../../common/types/domain';
 import { UserActionTypes } from '../../../common/types/domain';
 import type { UserActionTransformedAttributes } from '../../common/types/user_actions';
 
@@ -62,73 +66,74 @@ const extractCustomFieldValues = (customFields: unknown): string[] => {
     .map((cf) => cf.value);
 };
 
+type SearchableContentExtractor = (payload: Record<string, unknown>) => string[];
+
+const extractField =
+  (field: string): SearchableContentExtractor =>
+  (payload) => {
+    const text = asString(payload[field]);
+    return text ? [text] : [];
+  };
+
+const extractArrayField =
+  (field: string): SearchableContentExtractor =>
+  (payload) =>
+    asStringArray(payload[field]);
+
+const extractCommentContent: SearchableContentExtractor = (payload) => {
+  const comment = payload.comment as Record<string, unknown> | undefined;
+  const text = asString(comment?.comment);
+  return text ? [text] : [];
+};
+
+const extractCustomFields: SearchableContentExtractor = (payload) =>
+  extractCustomFieldValues(payload.customFields);
+
+const extractAssignees: SearchableContentExtractor = (payload) =>
+  extractAssigneeUids(payload.assignees);
+
+const extractExtendedFields: SearchableContentExtractor = (payload) => {
+  const extendedFields = payload.extended_fields;
+  return extendedFields != null && typeof extendedFields === 'object'
+    ? asStringArray(Object.values(extendedFields))
+    : [];
+};
+
+const combineExtractors =
+  (...extractors: SearchableContentExtractor[]): SearchableContentExtractor =>
+  (payload) =>
+    extractors.flatMap((extractor) => extractor(payload));
+
+/**
+ * Maps a user action type to the function that pulls its free-text-searchable
+ * content out of the payload. Types not present here (e.g. `connector`,
+ * `pushed`, `settings`, `status`, `observables`, `template`) either carry no
+ * meaningful free text or only reference IDs, so they're excluded from search.
+ */
+const SEARCHABLE_CONTENT_EXTRACTORS: Partial<Record<UserActionType, SearchableContentExtractor>> = {
+  [UserActionTypes.comment]: extractCommentContent,
+  [UserActionTypes.title]: extractField('title'),
+  [UserActionTypes.description]: extractField('description'),
+  [UserActionTypes.tags]: extractArrayField('tags'),
+  [UserActionTypes.category]: extractField('category'),
+  [UserActionTypes.severity]: extractField('severity'),
+  [UserActionTypes.assignees]: extractAssignees,
+  [UserActionTypes.customFields]: extractCustomFields,
+  [UserActionTypes.extended_fields]: extractExtendedFields,
+  [UserActionTypes.create_case]: combineExtractors(
+    extractField('title'),
+    extractField('description'),
+    extractField('severity'),
+    extractArrayField('tags'),
+    extractCustomFields,
+    extractAssignees
+  ),
+};
+
 export const getSearchableContent = (attributes: UserActionTransformedAttributes): string[] => {
   const payload = attributes.payload as Record<string, unknown>;
-  const texts: string[] = [];
-
-  switch (attributes.type) {
-    case UserActionTypes.comment: {
-      const comment = payload.comment as Record<string, unknown> | undefined;
-      const text = asString(comment?.comment);
-      if (text) texts.push(text);
-      break;
-    }
-    case UserActionTypes.title: {
-      const text = asString(payload.title);
-      if (text) texts.push(text);
-      break;
-    }
-    case UserActionTypes.description: {
-      const text = asString(payload.description);
-      if (text) texts.push(text);
-      break;
-    }
-    case UserActionTypes.tags: {
-      texts.push(...asStringArray(payload.tags));
-      break;
-    }
-    case UserActionTypes.category: {
-      const text = asString(payload.category);
-      if (text) texts.push(text);
-      break;
-    }
-    case UserActionTypes.severity: {
-      const text = asString(payload.severity);
-      if (text) texts.push(text);
-      break;
-    }
-    case UserActionTypes.assignees: {
-      texts.push(...extractAssigneeUids(payload.assignees));
-      break;
-    }
-    case UserActionTypes.customFields: {
-      texts.push(...extractCustomFieldValues(payload.customFields));
-      break;
-    }
-    case UserActionTypes.extended_fields: {
-      const extendedFields = payload.extended_fields;
-      if (extendedFields != null && typeof extendedFields === 'object') {
-        texts.push(...asStringArray(Object.values(extendedFields)));
-      }
-      break;
-    }
-    case UserActionTypes.create_case: {
-      const title = asString(payload.title);
-      const description = asString(payload.description);
-      const severity = asString(payload.severity);
-      if (title) texts.push(title);
-      if (description) texts.push(description);
-      if (severity) texts.push(severity);
-      texts.push(...asStringArray(payload.tags));
-      texts.push(...extractCustomFieldValues(payload.customFields));
-      texts.push(...extractAssigneeUids(payload.assignees));
-      break;
-    }
-    default:
-      break;
-  }
-
-  return texts;
+  const extractor = SEARCHABLE_CONTENT_EXTRACTORS[attributes.type];
+  return extractor ? extractor(payload) : [];
 };
 
 export const matchesSearch = (

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.test.ts
@@ -181,7 +181,7 @@ describe('findUserActionsRoute', () => {
       params: {
         case_id: 'my_fake_case_id',
       },
-      query: '',
+      query: {},
     };
 
     // @ts-expect-error: mocking necessary properties for handler logic only, no Kibana platform
@@ -244,7 +244,7 @@ describe('findUserActionsRoute', () => {
       params: {
         case_id: 'my_fake_case_id',
       },
-      query: '',
+      query: {},
     };
 
     // @ts-expect-error: Kibana platform types are mocked for testing, only implementing necessary properties for handler logic
@@ -274,7 +274,7 @@ describe('findUserActionsRoute', () => {
       params: {
         case_id: 'my_fake_case_id',
       },
-      query: '',
+      query: {},
     };
 
     // @ts-expect-error: mocking necessary properties for handler logic only, no Kibana platform

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.ts
@@ -33,7 +33,7 @@ export const findUserActionsRoute = createCasesRoute({
       const caseContext = await context.cases;
       const casesClient = await caseContext.getCasesClient();
       const caseId = request.params.case_id;
-      const options = request.query as userActionApiV1.UserActionFindRequest;
+      const options = request.query as userActionApiV1.UserActionInternalFindRequest;
 
       const userActionsResponse: userActionApiV1.UserActionFindResponse =
         await casesClient.userActions.find({

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.ts
@@ -9,8 +9,10 @@ import { schema } from '@kbn/config-schema';
 
 import { isCommentUserAction } from '../../../../common/utils/user_actions';
 import type { attachmentApiV2, userActionApiV1 } from '../../../../common/types/api';
+import { UserActionInternalFindRequestRt } from '../../../../common/types/api';
 import { INTERNAL_CASE_FIND_USER_ACTIONS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
+import { decodeWithExcessOrThrow } from '../../../common/runtime_types';
 import { createCasesRoute } from '../create_cases_route';
 import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
@@ -33,7 +35,7 @@ export const findUserActionsRoute = createCasesRoute({
       const caseContext = await context.cases;
       const casesClient = await caseContext.getCasesClient();
       const caseId = request.params.case_id;
-      const options = request.query as userActionApiV1.UserActionInternalFindRequest;
+      const options = decodeWithExcessOrThrow(UserActionInternalFindRequestRt)(request.query);
 
       const userActionsResponse: userActionApiV1.UserActionFindResponse =
         await casesClient.userActions.find({

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/find_user_actions.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { castArray } from 'lodash';
 import { schema } from '@kbn/config-schema';
 
 import { isCommentUserAction } from '../../../../common/utils/user_actions';
@@ -35,7 +36,12 @@ export const findUserActionsRoute = createCasesRoute({
       const caseContext = await context.cases;
       const casesClient = await caseContext.getCasesClient();
       const caseId = request.params.case_id;
-      const options = decodeWithExcessOrThrow(UserActionInternalFindRequestRt)(request.query);
+      const query = request.query as Record<string, unknown>;
+      const { types, ...restQuery } = query;
+      const options = decodeWithExcessOrThrow(UserActionInternalFindRequestRt)({
+        ...restQuery,
+        ...(types != null ? { types: castArray(types) } : {}),
+      });
 
       const userActionsResponse: userActionApiV1.UserActionFindResponse =
         await casesClient.userActions.find({

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/user_actions/find_user_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/user_actions/find_user_actions.ts
@@ -7,9 +7,11 @@
 
 import { schema } from '@kbn/config-schema';
 import type { userActionApiV1 } from '../../../../common/types/api';
+import { UserActionFindRequestRt } from '../../../../common/types/api';
 
 import { CASE_FIND_USER_ACTIONS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
+import { decodeWithExcessOrThrow } from '../../../common/runtime_types';
 import { createCasesRoute } from '../create_cases_route';
 import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
@@ -36,7 +38,7 @@ export const findUserActionsRoute = createCasesRoute({
       const caseContext = await context.cases;
       const casesClient = await caseContext.getCasesClient();
       const caseId = request.params.case_id;
-      const options = request.query as userActionApiV1.UserActionFindRequest;
+      const options = decodeWithExcessOrThrow(UserActionFindRequestRt)(request.query);
 
       const res: userActionApiV1.UserActionFindResponse = await casesClient.userActions.find({
         caseId,

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/user_actions/find_user_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/user_actions/find_user_actions.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { castArray } from 'lodash';
 import { schema } from '@kbn/config-schema';
 import type { userActionApiV1 } from '../../../../common/types/api';
 import { UserActionFindRequestRt } from '../../../../common/types/api';
@@ -38,7 +39,12 @@ export const findUserActionsRoute = createCasesRoute({
       const caseContext = await context.cases;
       const casesClient = await caseContext.getCasesClient();
       const caseId = request.params.case_id;
-      const options = decodeWithExcessOrThrow(UserActionFindRequestRt)(request.query);
+      const query = request.query as Record<string, unknown>;
+      const { types, ...restQuery } = query;
+      const options = decodeWithExcessOrThrow(UserActionFindRequestRt)({
+        ...restQuery,
+        ...(types != null ? { types: castArray(types) } : {}),
+      });
 
       const res: userActionApiV1.UserActionFindResponse = await casesClient.userActions.find({
         caseId,

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -120,6 +120,7 @@ const createUserActionPersisterServiceMock = (): CaseUserActionPersisterServiceM
 const createUserActionFinderServiceMock = (): CaseUserActionFinderServiceMock => {
   const service: PublicMethodsOf<UserActionFinder> = {
     find: jest.fn(),
+    findAll: jest.fn(),
     findStatusChanges: jest.fn(),
   };
 

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -122,6 +122,7 @@ const createUserActionFinderServiceMock = (): CaseUserActionFinderServiceMock =>
     find: jest.fn(),
     findAll: jest.fn(),
     findStatusChanges: jest.fn(),
+    decodeUserActions: jest.fn((userActions) => userActions),
   };
 
   return service as unknown as CaseUserActionFinderServiceMock;

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/__snapshots__/find.test.ts.snap
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/__snapshots__/find.test.ts.snap
@@ -37,6 +37,38 @@ Object {
 }
 `;
 
+exports[`UserActionsService: Finder Decoding: findAll strips out excess attributes 1`] = `
+Array [
+  Object {
+    "attributes": Object {
+      "action": "create",
+      "comment_id": null,
+      "created_at": "abc",
+      "created_by": Object {
+        "email": "a",
+        "full_name": "abc",
+        "username": "b",
+      },
+      "owner": "securitySolution",
+      "payload": Object {
+        "title": "a new title",
+      },
+      "type": "title",
+    },
+    "id": "100",
+    "references": Array [
+      Object {
+        "id": "1",
+        "name": "associated-cases",
+        "type": "cases",
+      },
+    ],
+    "score": 0,
+    "type": "cases-user-actions",
+  },
+]
+`;
+
 exports[`UserActionsService: Finder Decoding: findStatusChanges strips out excess attributes 1`] = `
 Array [
   Object {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
@@ -144,6 +144,36 @@ describe('UserActionsService: Finder', () => {
         const callFilter = unsecuredSavedObjectsClient.find.mock.calls[0][0].filter;
         expect(callFilter).toBeUndefined();
       });
+
+      /**
+       * `username` is not guaranteed to be set on `created_by` (e.g. API key
+       * authenticated requests only reliably populate `profile_uid`, see
+       * `CasesClientFactory.getUserInfo`). Filtering by `author` is username-based,
+       * so such user actions simply won't match the filter — this test guards
+       * against that scenario ever throwing or otherwise breaking the response,
+       * even though it's a known limitation that those user actions can't
+       * currently be found via the `author` filter.
+       */
+      it('does not throw when a user action has a null created_by.username', async () => {
+        const userAction = createUserActionSO({
+          attributesOverrides: {
+            created_by: { email: 'a', username: null, full_name: 'abc', profile_uid: 'uid-1' },
+          },
+        });
+        mockFind(createSOFindResponse([createUserActionFindSO(userAction)]));
+
+        await expect(finder.find({ caseId: '1', author: 'testuser' })).resolves.toEqual(
+          expect.objectContaining({
+            saved_objects: expect.arrayContaining([
+              expect.objectContaining({
+                attributes: expect.objectContaining({
+                  created_by: expect.objectContaining({ username: null }),
+                }),
+              }),
+            ]),
+          })
+        );
+      });
     });
   });
 
@@ -182,6 +212,49 @@ describe('UserActionsService: Finder', () => {
           }),
         })
       );
+    });
+
+    it('stops fetching once the limit is reached and closes the PIT early', async () => {
+      const close = jest.fn();
+      const batch = (count: number) =>
+        createSOFindResponse(
+          Array.from({ length: count }, () => createUserActionFindSO(createUserActionSO()))
+        );
+
+      unsecuredSavedObjectsClient.createPointInTimeFinder.mockReturnValue({
+        close,
+        // @ts-expect-error
+        find: function* asyncGenerator() {
+          yield batch(3);
+          yield batch(3);
+          yield batch(3);
+        },
+      });
+
+      const res = await finder.findAll({ caseId: '1', limit: 4 });
+
+      expect(res).toHaveLength(4);
+      expect(close).toHaveBeenCalled();
+    });
+
+    it('does not cap results when no limit is provided', async () => {
+      const batch = (count: number) =>
+        createSOFindResponse(
+          Array.from({ length: count }, () => createUserActionFindSO(createUserActionSO()))
+        );
+
+      unsecuredSavedObjectsClient.createPointInTimeFinder.mockReturnValue({
+        close: jest.fn(),
+        // @ts-expect-error
+        find: function* asyncGenerator() {
+          yield batch(3);
+          yield batch(3);
+        },
+      });
+
+      const res = await finder.findAll({ caseId: '1' });
+
+      expect(res).toHaveLength(6);
     });
 
     it('applies types filter in findAll', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
@@ -52,6 +52,7 @@ describe('UserActionsService: Finder', () => {
     [keyof UserActionFinder, (soFindRes: SavedObjectsFindResponse) => void]
   > = [
     ['find', mockFind],
+    ['findAll', mockFinder],
     ['findStatusChanges', mockFinder],
   ];
 
@@ -107,6 +108,105 @@ describe('UserActionsService: Finder', () => {
           })
         );
       });
+    });
+
+    describe('author filter', () => {
+      beforeEach(() => {
+        const userAction = createUserActionSO();
+        const soFindRes = createSOFindResponse([createUserActionFindSO(userAction)]);
+        mockFind(soFindRes);
+      });
+
+      it('applies author filter on created_by.username', async () => {
+        await finder.find({ caseId: '1', author: 'testuser' });
+
+        expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filter: expect.objectContaining({
+              type: 'function',
+              function: 'is',
+              arguments: expect.arrayContaining([
+                expect.objectContaining({
+                  value: 'cases-user-actions.attributes.created_by.username',
+                }),
+                expect.objectContaining({
+                  value: 'testuser',
+                }),
+              ]),
+            }),
+          })
+        );
+      });
+
+      it('does not apply author filter when author is not provided', async () => {
+        await finder.find({ caseId: '1' });
+
+        const callFilter = unsecuredSavedObjectsClient.find.mock.calls[0][0].filter;
+        expect(callFilter).toBeUndefined();
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('uses createPointInTimeFinder to fetch all user actions', async () => {
+      const userAction = createUserActionSO();
+      const soFindRes = createSOFindResponse([createUserActionFindSO(userAction)]);
+      mockFinder(soFindRes);
+
+      const res = await finder.findAll({ caseId: '1' });
+
+      expect(unsecuredSavedObjectsClient.createPointInTimeFinder).toHaveBeenCalled();
+      expect(res).toHaveLength(1);
+    });
+
+    it('applies author filter in findAll', async () => {
+      const userAction = createUserActionSO();
+      const soFindRes = createSOFindResponse([createUserActionFindSO(userAction)]);
+      mockFinder(soFindRes);
+
+      await finder.findAll({ caseId: '1', author: 'testuser' });
+
+      expect(unsecuredSavedObjectsClient.createPointInTimeFinder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: expect.objectContaining({
+            type: 'function',
+            function: 'is',
+            arguments: expect.arrayContaining([
+              expect.objectContaining({
+                value: 'cases-user-actions.attributes.created_by.username',
+              }),
+              expect.objectContaining({
+                value: 'testuser',
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it('applies types filter in findAll', async () => {
+      const userAction = createUserActionSO();
+      const soFindRes = createSOFindResponse([createUserActionFindSO(userAction)]);
+      mockFinder(soFindRes);
+
+      await finder.findAll({ caseId: '1', types: ['status'] });
+
+      expect(unsecuredSavedObjectsClient.createPointInTimeFinder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: expect.objectContaining({
+            type: 'function',
+            function: 'is',
+            arguments: expect.arrayContaining([
+              expect.objectContaining({
+                value: 'cases-user-actions.attributes.type',
+              }),
+              expect.objectContaining({
+                value: 'status',
+              }),
+            ]),
+          }),
+        })
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
@@ -49,7 +49,7 @@ describe('UserActionsService: Finder', () => {
     mockPointInTimeFinder(unsecuredSavedObjectsClient)(soFindRes);
 
   const decodingTests: Array<
-    [keyof UserActionFinder, (soFindRes: SavedObjectsFindResponse) => void]
+    ['find' | 'findAll' | 'findStatusChanges', (soFindRes: SavedObjectsFindResponse) => void]
   > = [
     ['find', mockFind],
     ['findAll', mockFinder],

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.test.ts
@@ -235,6 +235,36 @@ describe('UserActionsService: Finder', () => {
 
       expect(res).toHaveLength(4);
       expect(close).toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Reached the limit of 4 user actions')
+      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('case id: 1'));
+    });
+
+    it('does not warn when the limit is not reached', async () => {
+      const userAction = createUserActionSO();
+      const soFindRes = createSOFindResponse([createUserActionFindSO(userAction)]);
+      mockFinder(soFindRes);
+
+      await finder.findAll({ caseId: '1', limit: 10 });
+
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('skips decoding when decode is false, allowing otherwise-invalid attributes through', async () => {
+      const invalidUserAction = createUserActionSO({
+        type: 'title',
+        payload: {},
+      });
+      mockFinder(createSOFindResponse([createUserActionFindSO(invalidUserAction)]));
+
+      await expect(finder.findAll({ caseId: '1' })).rejects.toThrow();
+
+      mockFinder(createSOFindResponse([createUserActionFindSO(invalidUserAction)]));
+
+      const res = await finder.findAll({ caseId: '1', decode: false });
+      expect(res).toHaveLength(1);
+      expect(res[0].attributes).toEqual(expect.objectContaining({ type: 'title', payload: {} }));
     });
 
     it('does not cap results when no limit is provided', async () => {
@@ -294,6 +324,28 @@ describe('UserActionsService: Finder', () => {
       const commentId = res[0].attributes.comment_id;
 
       expect(commentId).toBe(null);
+    });
+  });
+
+  describe('decodeUserActions', () => {
+    it('decodes valid attributes', async () => {
+      const userAction = createUserActionSO();
+      mockFinder(createSOFindResponse([createUserActionFindSO(userAction)]));
+      const [undecoded] = await finder.findAll({ caseId: '1', decode: false });
+
+      const [res] = finder.decodeUserActions([undecoded]);
+
+      expect(res.attributes).toEqual(
+        expect.objectContaining({ type: 'title', payload: { title: 'a new title' } })
+      );
+    });
+
+    it('throws when attributes are invalid', async () => {
+      const invalidUserAction = createUserActionSO({ type: 'title', payload: {} });
+      mockFinder(createSOFindResponse([createUserActionFindSO(invalidUserAction)]));
+      const [undecoded] = await finder.findAll({ caseId: '1', decode: false });
+
+      expect(() => finder.decodeUserActions([undecoded])).toThrow();
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.ts
@@ -7,7 +7,10 @@
 
 import type { KueryNode } from '@kbn/es-query';
 import { fromKueryExpression } from '@kbn/es-query';
-import type { SavedObjectsFindResponse } from '@kbn/core-saved-objects-api-server';
+import type {
+  SavedObjectsCreatePointInTimeFinderOptions,
+  SavedObjectsFindResponse,
+} from '@kbn/core-saved-objects-api-server';
 import type { UserActionFindRequestTypes } from '../../../../common/types/api';
 import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from '../../../routes/api';
 import { defaultSortField } from '../../../common/utils';
@@ -46,11 +49,16 @@ export class UserActionFinder {
     page,
     perPage,
     filter,
+    author,
   }: FindOptions): Promise<SavedObjectsFindResponse<UserActionTransformedAttributes>> {
     try {
       this.context.log.debug(`Attempting to find user actions for case id: ${caseId}`);
 
-      const finalFilter = combineFilters([filter, UserActionFinder.buildFilter(types)]);
+      const finalFilter = combineFilters([
+        filter,
+        UserActionFinder.buildFilter(types),
+        UserActionFinder.buildAuthorFilter(author),
+      ]);
 
       const userActions =
         await this.context.unsecuredSavedObjectsClient.find<UserActionPersistedAttributes>({
@@ -79,6 +87,43 @@ export class UserActionFinder {
       };
     } catch (error) {
       this.context.log.error(`Error finding user actions for case id: ${caseId}: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Fetches all user actions for a case using a point-in-time finder.
+   * The `search` field from FindOptions is intentionally excluded — text search
+   * is handled via in-memory filtering at the client layer.
+   */
+  public async findAll({
+    caseId,
+    sortOrder,
+    types,
+    filter,
+    author,
+  }: Omit<FindOptions, 'page' | 'perPage' | 'search'>): Promise<
+    UserActionSavedObjectTransformed[]
+  > {
+    try {
+      this.context.log.debug(`Attempting to find all user actions for case id: ${caseId}`);
+
+      const finalFilter = combineFilters([
+        filter,
+        UserActionFinder.buildFilter(types),
+        UserActionFinder.buildAuthorFilter(author),
+      ]);
+
+      return await this.collectFromPIT({
+        type: CASE_USER_ACTION_SAVED_OBJECT,
+        hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
+        sortField: defaultSortField,
+        sortOrder: sortOrder ?? 'asc',
+        filter: finalFilter,
+        perPage: MAX_DOCS_PER_PAGE,
+      });
+    } catch (error) {
+      this.context.log.error(`Error finding all user actions for case id: ${caseId}: ${error}`);
       throw error;
     }
   }
@@ -177,6 +222,19 @@ export class UserActionFinder {
     );
   }
 
+  private static buildAuthorFilter(author?: string): KueryNode | undefined {
+    if (!author) {
+      return undefined;
+    }
+
+    return buildFilter({
+      filters: [author],
+      field: 'created_by.username',
+      operator: 'or',
+      type: CASE_USER_ACTION_SAVED_OBJECT,
+    });
+  }
+
   private static buildGenericTypeFilter(type: UserActionType): KueryNode | undefined {
     return buildFilter({
       filters: [type],
@@ -212,39 +270,42 @@ export class UserActionFinder {
 
       const combinedFilters = combineFilters([updateActionFilter, statusChangeFilter, filter]);
 
-      const finder =
-        this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<UserActionPersistedAttributes>(
-          {
-            type: CASE_USER_ACTION_SAVED_OBJECT,
-            hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
-            sortField: defaultSortField,
-            sortOrder: 'asc',
-            filter: combinedFilters,
-            perPage: MAX_DOCS_PER_PAGE,
-          }
-        );
-
-      let userActions: UserActionSavedObjectTransformed[] = [];
-
-      for await (const findResults of finder.find()) {
-        userActions = userActions.concat(
-          findResults.saved_objects.map((so) => {
-            const res = transformToExternalModel(so);
-
-            const decodeRes = decodeOrThrow(UserActionTransformedAttributesRt)(res.attributes);
-
-            return {
-              ...res,
-              attributes: decodeRes,
-            };
-          })
-        );
-      }
-
-      return userActions;
+      return await this.collectFromPIT({
+        type: CASE_USER_ACTION_SAVED_OBJECT,
+        hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
+        sortField: defaultSortField,
+        sortOrder: 'asc',
+        filter: combinedFilters,
+        perPage: MAX_DOCS_PER_PAGE,
+      });
     } catch (error) {
       this.context.log.error(`Error finding status changes: ${error}`);
       throw error;
     }
+  }
+
+  private async collectFromPIT(
+    options: SavedObjectsCreatePointInTimeFinderOptions
+  ): Promise<UserActionSavedObjectTransformed[]> {
+    const finder =
+      this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<UserActionPersistedAttributes>(
+        options
+      );
+
+    let results: UserActionSavedObjectTransformed[] = [];
+
+    for await (const batch of finder.find()) {
+      results = results.concat(
+        batch.saved_objects.map((so) => {
+          const res = transformToExternalModel(so);
+          return {
+            ...res,
+            attributes: decodeOrThrow(UserActionTransformedAttributesRt)(res.attributes),
+          };
+        })
+      );
+    }
+
+    return results;
   }
 }

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.ts
@@ -99,7 +99,14 @@ export class UserActionFinder {
    * `limit` bounds how many user actions are collected before the PIT is closed,
    * to avoid unbounded memory/CPU usage for cases with very large activity logs
    * (see `MAX_USER_ACTIONS_FOR_SEARCH`). Callers that pass a `limit` should be
-   * aware that any user actions beyond it will not be considered.
+   * aware that any user actions beyond it will not be considered; a warning is
+   * logged whenever the cap is actually hit so truncation isn't silent.
+   *
+   * `decode` (defaults to `true`) controls whether each attribute is validated
+   * with `decodeOrThrow` as it's collected. Callers that only need a subset of
+   * the results (e.g. after filtering + pagination) can pass `decode: false` and
+   * call `decodeUserActions` themselves on just that subset, avoiding paying the
+   * io-ts decode cost for records that end up discarded.
    */
   public async findAll({
     caseId,
@@ -108,9 +115,11 @@ export class UserActionFinder {
     filter,
     author,
     limit,
-  }: Omit<FindOptions, 'page' | 'perPage' | 'search'> & { limit?: number }): Promise<
-    UserActionSavedObjectTransformed[]
-  > {
+    decode,
+  }: Omit<FindOptions, 'page' | 'perPage' | 'search'> & {
+    limit?: number;
+    decode?: boolean;
+  }): Promise<UserActionSavedObjectTransformed[]> {
     try {
       this.context.log.debug(`Attempting to find all user actions for case id: ${caseId}`);
 
@@ -129,12 +138,27 @@ export class UserActionFinder {
           filter: finalFilter,
           perPage: MAX_DOCS_PER_PAGE,
         },
-        limit
+        { limit, decode, caseId }
       );
     } catch (error) {
       this.context.log.error(`Error finding all user actions for case id: ${caseId}: ${error}`);
       throw error;
     }
+  }
+
+  /**
+   * Validates the attributes of user actions that were previously collected with
+   * `decode: false`. Kept separate from `findAll` so callers can filter/paginate
+   * an undecoded result set first and only pay the decode cost for what they
+   * actually return.
+   */
+  public decodeUserActions(
+    userActions: UserActionSavedObjectTransformed[]
+  ): UserActionSavedObjectTransformed[] {
+    return userActions.map((so) => ({
+      ...so,
+      attributes: decodeOrThrow(UserActionTransformedAttributesRt)(so.attributes),
+    }));
   }
 
   private static buildFilter(types: FindOptions['types'] = []) {
@@ -295,7 +319,7 @@ export class UserActionFinder {
 
   private async collectFromPIT(
     options: SavedObjectsCreatePointInTimeFinderOptions,
-    limit?: number
+    { limit, decode = true, caseId }: { limit?: number; decode?: boolean; caseId?: string } = {}
   ): Promise<UserActionSavedObjectTransformed[]> {
     const finder =
       this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<UserActionPersistedAttributes>(
@@ -303,6 +327,7 @@ export class UserActionFinder {
       );
 
     let results: UserActionSavedObjectTransformed[] = [];
+    let hitLimit = false;
 
     for await (const batch of finder.find()) {
       results = results.concat(
@@ -310,7 +335,9 @@ export class UserActionFinder {
           const res = transformToExternalModel(so);
           return {
             ...res,
-            attributes: decodeOrThrow(UserActionTransformedAttributesRt)(res.attributes),
+            attributes: decode
+              ? decodeOrThrow(UserActionTransformedAttributesRt)(res.attributes)
+              : (res.attributes as UserActionTransformedAttributes),
           };
         })
       );
@@ -319,9 +346,18 @@ export class UserActionFinder {
         // Stop pulling further pages once we've hit the cap. The PIT must be
         // explicitly closed here since we're breaking out before the finder's
         // generator naturally drains and auto-closes it.
+        hitLimit = true;
         await finder.close();
         break;
       }
+    }
+
+    if (hitLimit) {
+      this.context.log.warn(
+        `Reached the limit of ${limit} user actions while collecting user actions${
+          caseId ? ` for case id: ${caseId}` : ''
+        }. Results were truncated and may not reflect the case's full activity log.`
+      );
     }
 
     return limit != null ? results.slice(0, limit) : results;

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/find.ts
@@ -95,6 +95,11 @@ export class UserActionFinder {
    * Fetches all user actions for a case using a point-in-time finder.
    * The `search` field from FindOptions is intentionally excluded — text search
    * is handled via in-memory filtering at the client layer.
+   *
+   * `limit` bounds how many user actions are collected before the PIT is closed,
+   * to avoid unbounded memory/CPU usage for cases with very large activity logs
+   * (see `MAX_USER_ACTIONS_FOR_SEARCH`). Callers that pass a `limit` should be
+   * aware that any user actions beyond it will not be considered.
    */
   public async findAll({
     caseId,
@@ -102,7 +107,8 @@ export class UserActionFinder {
     types,
     filter,
     author,
-  }: Omit<FindOptions, 'page' | 'perPage' | 'search'>): Promise<
+    limit,
+  }: Omit<FindOptions, 'page' | 'perPage' | 'search'> & { limit?: number }): Promise<
     UserActionSavedObjectTransformed[]
   > {
     try {
@@ -114,14 +120,17 @@ export class UserActionFinder {
         UserActionFinder.buildAuthorFilter(author),
       ]);
 
-      return await this.collectFromPIT({
-        type: CASE_USER_ACTION_SAVED_OBJECT,
-        hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
-        sortField: defaultSortField,
-        sortOrder: sortOrder ?? 'asc',
-        filter: finalFilter,
-        perPage: MAX_DOCS_PER_PAGE,
-      });
+      return await this.collectFromPIT(
+        {
+          type: CASE_USER_ACTION_SAVED_OBJECT,
+          hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
+          sortField: defaultSortField,
+          sortOrder: sortOrder ?? 'asc',
+          filter: finalFilter,
+          perPage: MAX_DOCS_PER_PAGE,
+        },
+        limit
+      );
     } catch (error) {
       this.context.log.error(`Error finding all user actions for case id: ${caseId}: ${error}`);
       throw error;
@@ -285,7 +294,8 @@ export class UserActionFinder {
   }
 
   private async collectFromPIT(
-    options: SavedObjectsCreatePointInTimeFinderOptions
+    options: SavedObjectsCreatePointInTimeFinderOptions,
+    limit?: number
   ): Promise<UserActionSavedObjectTransformed[]> {
     const finder =
       this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<UserActionPersistedAttributes>(
@@ -304,8 +314,16 @@ export class UserActionFinder {
           };
         })
       );
+
+      if (limit != null && results.length >= limit) {
+        // Stop pulling further pages once we've hit the cap. The PIT must be
+        // explicitly closed here since we're breaking out before the finder's
+        // generator naturally drains and auto-closes it.
+        await finder.close();
+        break;
+      }
     }
 
-    return results;
+    return limit != null ? results.slice(0, limit) : results;
   }
 }

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
@@ -37,7 +37,7 @@ import type { PatchCasesArgs } from '../cases/types';
 import type {
   AttachmentRequestV2,
   CasePostRequest,
-  UserActionFindRequest,
+  UserActionInternalFindRequest,
 } from '../../../common/types/api';
 import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
 import type {
@@ -354,7 +354,7 @@ export interface GetUsersResponse {
   assignedAndUnassignedUsers: Set<string>;
 }
 
-export interface FindOptions extends UserActionFindRequest {
+export interface FindOptions extends UserActionInternalFindRequest {
   caseId: string;
   filter?: KueryNode;
 }

--- a/x-pack/platform/test/cases_api_integration/common/lib/api/index.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/api/index.ts
@@ -52,7 +52,7 @@ import type {
   GetRelatedCasesByAlertResponse,
   SimilarCasesSearchRequest,
   UpdateObservableRequest,
-  UserActionFindRequest,
+  UserActionInternalFindRequest,
   UserActionInternalFindResponse,
 } from '@kbn/cases-plugin/common/types/api';
 import {
@@ -934,7 +934,7 @@ export const findInternalCaseUserActions = async ({
 }: {
   supertest: SuperTest.Agent;
   caseID: string;
-  options?: UserActionFindRequest;
+  options?: UserActionInternalFindRequest;
   expectedHttpCode?: number;
   auth?: { user: User; space: string | null };
 }): Promise<UserActionInternalFindResponse> => {

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
@@ -990,7 +990,7 @@ export default ({ getService }: FtrProviderContext): void => {
         it('paginates search results correctly', async () => {
           const theCase = await createCase(supertest, getPostCaseRequest());
 
-          await createComment({
+          const updatedCase = await createComment({
             supertest,
             caseId: theCase.id,
             params: postCommentUserReq,
@@ -1002,7 +1002,7 @@ export default ({ getService }: FtrProviderContext): void => {
               cases: [
                 {
                   id: theCase.id,
-                  version: theCase.version,
+                  version: updatedCase.version,
                   title: 'This is a cool title',
                 },
               ],

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
@@ -8,7 +8,11 @@
 import expect from '@kbn/expect';
 import type { Case } from '@kbn/cases-plugin/common/types/domain';
 import { AttachmentType, CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
-import { MAX_USER_ACTIONS_PER_PAGE } from '@kbn/cases-plugin/common/constants';
+import {
+  MAX_USER_ACTIONS_PER_PAGE,
+  MAX_USER_ACTION_SEARCH_LENGTH,
+  MAX_USER_ACTION_AUTHOR_LENGTH,
+} from '@kbn/cases-plugin/common/constants';
 import type { CommentUserAction } from '@kbn/cases-plugin/common/types/domain';
 import { UserActionTypes, ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import {
@@ -289,6 +293,24 @@ export default ({ getService }: FtrProviderContext): void => {
           caseID: theCase.id,
           supertest,
           options: { page: 209, perPage: 100 },
+          expectedHttpCode: 400,
+        });
+      });
+
+      it('400s when the search term is too long', async () => {
+        await findInternalCaseUserActions({
+          caseID: theCase.id,
+          supertest,
+          options: { search: 'a'.repeat(MAX_USER_ACTION_SEARCH_LENGTH + 1) },
+          expectedHttpCode: 400,
+        });
+      });
+
+      it('400s when the author is too long', async () => {
+        await findInternalCaseUserActions({
+          caseID: theCase.id,
+          supertest,
+          options: { author: 'a'.repeat(MAX_USER_ACTION_AUTHOR_LENGTH + 1) },
           expectedHttpCode: 400,
         });
       });

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
@@ -863,6 +863,170 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
+      describe('author filter', () => {
+        it('filters user actions by author username', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          await createComment({
+            supertest,
+            caseId: theCase.id,
+            params: postCommentUserReq,
+          });
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              author: 'elastic',
+            },
+          });
+
+          for (const userAction of response.userActions) {
+            expect(userAction.created_by.username).to.be('elastic');
+          }
+        });
+
+        it('returns empty results when author does not match', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              author: 'nonexistent_user',
+            },
+          });
+
+          expect(response.total).to.be(0);
+          expect(response.userActions.length).to.be(0);
+        });
+      });
+
+      describe('search filter', () => {
+        it('filters user actions by search term in comment payload', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          await createComment({
+            supertest,
+            caseId: theCase.id,
+            params: postCommentUserReq,
+          });
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              search: 'cool comment',
+            },
+          });
+
+          expect(response.total).to.be(1);
+          expect(response.userActions[0].type).to.eql('comment');
+        });
+
+        it('returns empty results when search term does not match', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          await createComment({
+            supertest,
+            caseId: theCase.id,
+            params: postCommentUserReq,
+          });
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              search: 'xyz_no_match_term',
+            },
+          });
+
+          expect(response.total).to.be(0);
+          expect(response.userActions.length).to.be(0);
+        });
+
+        it('search is case-insensitive', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          await createComment({
+            supertest,
+            caseId: theCase.id,
+            params: postCommentUserReq,
+          });
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              search: 'COOL COMMENT',
+            },
+          });
+
+          expect(response.total).to.be(1);
+        });
+
+        it('paginates search results correctly', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          await createComment({
+            supertest,
+            caseId: theCase.id,
+            params: postCommentUserReq,
+          });
+
+          await updateCase({
+            supertest,
+            params: {
+              cases: [
+                {
+                  id: theCase.id,
+                  version: theCase.version,
+                  title: 'This is a cool title',
+                },
+              ],
+            },
+          });
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              search: 'cool',
+              page: 1,
+              perPage: 1,
+            },
+          });
+
+          expect(response.perPage).to.be(1);
+          expect(response.page).to.be(1);
+          expect(response.total).to.be(2);
+          expect(response.userActions.length).to.be(1);
+        });
+
+        it('combines search and author filters', async () => {
+          const theCase = await createCase(supertest, getPostCaseRequest());
+
+          await createComment({
+            supertest,
+            caseId: theCase.id,
+            params: postCommentUserReq,
+          });
+
+          const response = await findInternalCaseUserActions({
+            caseID: theCase.id,
+            supertest,
+            options: {
+              search: 'cool comment',
+              author: 'elastic',
+            },
+          });
+
+          expect(response.total).to.be(1);
+          expect(response.userActions[0].type).to.eql('comment');
+          expect(response.userActions[0].created_by.username).to.be('elastic');
+        });
+      });
+
       describe('rbac', () => {
         const supertestWithoutAuth = getService('supertestWithoutAuth');
 


### PR DESCRIPTION
## What & Why

Adds `search` (free-text) and `author` (exact username) query parameters to the internal `_find` user actions API. This enables the upcoming case activity timeline redesign to support searching through user actions by content (comments, titles, descriptions, tags, custom fields, extended fields) and filtering by author — without requiring any frontend changes in this PR.

## How to Test

1. Start Kibana, create a case, add a few comments and change the title
2. Call `GET /internal/cases/<caseId>/user_actions/_find?search=<comment text>` — verify only matching user actions are returned
3. Call `GET /internal/cases/<caseId>/user_actions/_find?author=<username>` — verify filtering by author works
4. Combine both: `?search=hello&author=elastic` — verify both filters apply together
5. Verify pagination works with search: `?search=cool&page=1&perPage=1` returns correct `total` and single-item page

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)
