### PR TITLE
[8.19] [Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ x-pack/platform/packages/shared/ai-assistant/common @elastic/search-kibana
 x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action @elastic/appex-sharedux
 x-pack/platform/packages/shared/ai-assistant-default-llm-setting @elastic/security-generative-ai
 x-pack/platform/packages/shared/ai-assistant/icon @elastic/appex-sharedux
-src/platform/plugins/shared/ai_assistant_management/selection @elastic/obs-ai-assistant
+src/platform/plugins/shared/ai_assistant_management/selection @elastic/nightshift-context-and-research-team
 x-pack/solutions/security/packages/ai-security-labs-content @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-ai-tools-cli @elastic/appex-ai-infra
 x-pack/platform/packages/private/ml/aiops_change_point_detection @elastic/ml-ui
@@ -381,7 +381,7 @@ x-pack/platform/plugins/shared/data_quality @elastic/obs-onboarding-team
 src/platform/test/plugin_functional/plugins/data_search @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-data-service @elastic/kibana-visualizations @elastic/kibana-data-discovery
 x-pack/solutions/security/packages/data-stream-adapter @elastic/security-threat-hunting
-x-pack/platform/plugins/private/data_usage @elastic/obs-ai-assistant @elastic/security-solution
+x-pack/platform/plugins/private/data_usage @elastic/nightshift-context-and-research-team @elastic/security-solution
 src/platform/plugins/shared/data_view_editor @elastic/kibana-data-discovery
 examples/data_view_field_editor_example @elastic/kibana-data-discovery
 src/platform/plugins/shared/data_view_field_editor @elastic/kibana-data-discovery
@@ -563,7 +563,7 @@ src/platform/test/plugin_functional/plugins/index_patterns @elastic/kibana-data-
 x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/ai-infra/inference-common @elastic/appex-ai-infra
 x-pack/platform/plugins/shared/inference_endpoint @elastic/ml-ui
-x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/response-ops @elastic/appex-ai-infra @elastic/obs-ai-assistant @elastic/security-generative-ai
+x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/response-ops @elastic/appex-ai-infra @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 x-pack/platform/packages/shared/ai-infra/inference-langchain @elastic/appex-ai-infra
 x-pack/platform/plugins/shared/inference @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-tracing @elastic/appex-ai-infra
@@ -616,7 +616,7 @@ x-pack/solutions/security/plugins/lists @elastic/security-detection-engine
 x-pack/platform/plugins/shared/ai_infra/llm_tasks @elastic/appex-ai-infra
 examples/locator_examples @elastic/appex-sharedux
 examples/locator_explorer @elastic/appex-sharedux
-packages/kbn-lock-manager @elastic/obs-ai-assistant
+packages/kbn-lock-manager @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-kbn-client @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-logging @elastic/kibana-core
 src/platform/packages/shared/kbn-logging-mocks @elastic/kibana-core
@@ -697,11 +697,11 @@ x-pack/platform/plugins/shared/notifications @elastic/appex-sharedux
 src/platform/packages/shared/kbn-object-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-object-versioning @elastic/appex-sharedux
 src/platform/packages/shared/kbn-object-versioning-utils @elastic/appex-sharedux
-x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/obs-ai-assistant
-x-pack/solutions/observability/plugins/observability_ai_assistant_management @elastic/obs-ai-assistant
-x-pack/platform/plugins/shared/observability_ai_assistant @elastic/obs-ai-assistant
-x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/obs-ai-assistant
-x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/obs-ai-assistant
+x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/plugins/observability_ai_assistant_management @elastic/nightshift-context-and-research-team
+x-pack/platform/plugins/shared/observability_ai_assistant @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/nightshift-context-and-research-team
+x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/alert-details @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/alerting-test-data @elastic/obs-ux-management-team
 x-pack/platform/test/cases_api_integration/common/plugins/observability @elastic/kibana-cases
@@ -1021,7 +1021,7 @@ x-pack/platform/plugins/private/task_manager_dependencies @elastic/response-ops
 x-pack/platform/test/alerting_api_integration/common/plugins/task_manager_fixture @elastic/response-ops
 x-pack/platform/test/plugin_api_perf/plugins/task_manager_performance @elastic/response-ops
 x-pack/platform/plugins/shared/task_manager @elastic/response-ops
-src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/obs-ai-assistant
+src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/plugins/shared/telemetry_collection_manager @elastic/kibana-core
 x-pack/platform/plugins/private/telemetry_collection_xpack @elastic/kibana-core
 src/platform/packages/shared/kbn-telemetry-config @elastic/kibana-core
@@ -1049,7 +1049,7 @@ src/platform/packages/shared/kbn-timerange @elastic/obs-onboarding-team
 src/platform/packages/private/kbn-tinymath @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-tooling-log @elastic/kibana-operations
 src/platform/packages/shared/kbn-traced-es-client @elastic/observability-ui
-src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/obs-ai-assistant
+src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 x-pack/platform/plugins/private/transform @elastic/ml-ui
 x-pack/platform/plugins/private/translations @elastic/kibana-localization
@@ -1338,10 +1338,10 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ### Observability Plugins
 
 # Observability AI Assistant
-/x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/obs-ai-assistant
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/obs-ai-assistant
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts @elastic/obs-ai-assistant
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts @elastic/obs-ai-assistant
+/x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts @elastic/nightshift-context-and-research-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts @elastic/nightshift-context-and-research-team
 # Infra Obs
 ## This plugin mostly contains the codebase for the infra services, but also includes some code for the Logs UI app.
 ## To keep @elastic/obs-onboarding-team as codeowner of the plugin manifest without requiring a review for all the other code changes
@@ -1937,7 +1937,7 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 #CC# /x-pack/plugins/global_search_providers/ @elastic/kibana-core
 
 # AppEx AI Infra
-/x-pack/platform/plugins/shared/inference @elastic/appex-ai-infra @elastic/obs-ai-assistant @elastic/security-generative-ai
+/x-pack/platform/plugins/shared/inference @elastic/appex-ai-infra @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 /x-pack/platform/test/functional_gen_ai/inference @elastic/appex-ai-infra
 
 # AppEx Platform Services Security
@@ -2402,23 +2402,23 @@ x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/expandabl
 
 ## Generative AI owner connectors
 # OpenAI
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/common/openai @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/common/openai @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
 # Bedrock
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/common/bedrock @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/common/bedrock @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
 
 # Gemini
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/gemini @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
-/x-pack/platform/plugins/shared/stack_connectors/common/gemini @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/gemini @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
+/x-pack/platform/plugins/shared/stack_connectors/common/gemini @elastic/security-generative-ai @elastic/nightshift-context-and-research-team @elastic/appex-ai-infra
 
 # Inference API
-/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-assistant
-/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-assistant
-/x-pack/platform/plugins/shared/stack_connectors/common/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-assistant
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
+/x-pack/platform/plugins/shared/stack_connectors/common/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/nightshift-context-and-research-team
 
 # Token tracking
 x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/security-generative-ai

--- a/packages/kbn-lock-manager/kibana.jsonc
+++ b/packages/kbn-lock-manager/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-server",
   "id": "@kbn/lock-manager",
-  "owner": ["@elastic/obs-ai-assistant"],  
+  "owner": ["@elastic/nightshift-context-and-research-team"],  
   "devOnly": false
 }

--- a/packages/kbn-lock-manager/moon.yml
+++ b/packages/kbn-lock-manager/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/lock-manager'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/lock-manager'
   description: Moon project for @kbn/lock-manager
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: packages/kbn-lock-manager
 dependsOn:
   - '@kbn/logging'

--- a/renovate.json
+++ b/renovate.json
@@ -1732,7 +1732,7 @@
     {
       "groupName": "p-timeout",
       "matchDepNames": ["p-timeout"],
-      "reviewers": ["team:obs-ai-assistant"],
+      "reviewers": ["team:nightshift-context-and-research-team"],
       "matchBaseBranches": ["main"],
       "labels": ["backport:all-open", "release_note:skip"],
       "minimumReleaseAge": "7 days",
@@ -2041,7 +2041,7 @@
     {
       "groupName": "json-schema-to-ts",
       "matchDepNames": ["json-schema-to-ts"],
-      "reviewers": ["team:obs-ai-assistant"],
+      "reviewers": ["team:nightshift-context-and-research-team"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:all-open"],
       "minimumReleaseAge": "7 days",

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -46,7 +46,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
   ],
   search: ['elastic/search-design', 'elastic/search-kibana'],
   observability: [
-    'elastic/obs-ai-assistant',
+    'elastic/nightshift-context-and-research-team',
     'elastic/obs-cloudnative-monitoring',
     'elastic/obs-docs',
     'elastic/obs-entities',

--- a/src/platform/packages/shared/kbn-telemetry/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-telemetry/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/telemetry",
-  "owner": ["@elastic/kibana-core", "@elastic/obs-ai-assistant"],
+  "owner": ["@elastic/kibana-core", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-tracing/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-tracing/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/tracing",
-  "owner": ["@elastic/kibana-core", "@elastic/obs-ai-assistant"],
+  "owner": ["@elastic/kibana-core", "@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/plugins/shared/ai_assistant_management/selection/kibana.jsonc
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/ai-assistant-management-plugin",
-  "owner": ["@elastic/obs-ai-assistant"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   // This should probably be platform. While the code owner is currently observability, the package is a platform AI assistant selector.
   "group": "platform",
   "visibility": "shared",

--- a/src/platform/plugins/shared/ai_assistant_management/selection/moon.yml
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/ai-assistant-management-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/ai-assistant-management-plugin'
   description: Moon project for @kbn/ai-assistant-management-plugin
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: src/platform/plugins/shared/ai_assistant_management/selection
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/kibana.jsonc
@@ -4,7 +4,7 @@
   "owner": [
     "@elastic/response-ops",
     "@elastic/appex-ai-infra",
-    "@elastic/obs-ai-assistant",
+    "@elastic/nightshift-context-and-research-team",
     "@elastic/security-generative-ai"
   ],
   "group": "platform",

--- a/x-pack/platform/plugins/private/data_usage/kibana.jsonc
+++ b/x-pack/platform/plugins/private/data_usage/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/data-usage-plugin",
   "owner": [
-    "@elastic/obs-ai-assistant",
+    "@elastic/nightshift-context-and-research-team",
     "@elastic/security-solution"
   ],
   "group": "platform",

--- a/x-pack/platform/plugins/private/data_usage/moon.yml
+++ b/x-pack/platform/plugins/private/data_usage/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/data-usage-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/data-usage-plugin'
   description: Moon project for @kbn/data-usage-plugin
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/private/data_usage
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-plugin",
-  "owner": ["@elastic/obs-ai-assistant"],
+  "owner": ["@elastic/nightshift-context-and-research-team"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/moon.yml
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-plugin'
   description: Moon project for @kbn/observability-ai-assistant-plugin
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/platform/plugins/shared/observability_ai_assistant
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/observability-ai-common",
-  "owner": "@elastic/obs-ai-assistant",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/moon.yml
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-common'
   description: Moon project for @kbn/observability-ai-common
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/observability-ai/observability-ai-common
 dependsOn: []
 tags:

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/observability-ai-server",
-  "owner": "@elastic/obs-ai-assistant",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/moon.yml
+++ b/x-pack/solutions/observability/packages/observability-ai/observability-ai-server/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-server'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-server'
   description: Moon project for @kbn/observability-ai-server
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/packages/observability-ai/observability-ai-server
 dependsOn:
   - '@kbn/observability-utils-common'

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-app-plugin",
   "owner": [
-    "@elastic/obs-ai-assistant"
+    "@elastic/nightshift-context-and-research-team"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-app-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-app-plugin'
   description: Moon project for @kbn/observability-ai-assistant-app-plugin
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/plugins/observability_ai_assistant_app
 dependsOn:
   - '@kbn/es-types'

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-management-plugin",
-  "owner": "@elastic/obs-ai-assistant",
+  "owner": "@elastic/nightshift-context-and-research-team",
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-ai-assistant-management-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-ai-assistant'
+  defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-ai-assistant-management-plugin'
   description: Moon project for @kbn/observability-ai-assistant-management-plugin
   channel: ''
-  owner: '@elastic/obs-ai-assistant'
+  owner: '@elastic/nightshift-context-and-research-team'
   sourceRoot: x-pack/solutions/observability/plugins/observability_ai_assistant_management
 dependsOn:
   - '@kbn/core'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)](https://github.com/elastic/kibana/pull/275485)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2026-06-30T18:48:40Z","message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","ci:project-deploy-observability","Team:obs-ai","Team:obs-presentation","v9.5.0","Team:nightshift-context-and-research"],"title":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research`","number":275485,"url":"https://github.com/elastic/kibana/pull/275485","mergeCommit":{"message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275485","number":275485,"mergeCommit":{"message":"[Obs AI] Update `obs-ai` codeowners to `nightshift-context-and-research` (#275485)\n\n## Summary\n\nReassigns code ownership from `@elastic/obs-ai-team` to\n`@elastic/nightshift-context-and-research-team` across the Obs AI area\n(AI Assistant, Observability Agent Builder, `kbn-evals*`, and shared\npackages such as `kbn-sse-utils`, `kbn-tracing`, `kbn-telemetry`,\n`kbn-synthtrace`). The handle is changed in the 27 package manifests\n(`kibana.jsonc`), and `.github/CODEOWNERS` plus the affected `moon.yml`\nfiles are regenerated from those manifests. Also updated the kbn-evals\nbuildkite pipeline ownership.\n\n## Prerequisites\n\nThe GitHub team `@elastic/nightshift-context-and-research-team`, the\n`Team:nightshift-context-and-research-team` label, and the matching\nBuildkite group must exist for review routing, Renovate\nlabels/reviewers, and the evals pipelines to resolve.\n\n## Test plan\n\n- [ ] `node scripts/generate codeowners` reports `already up-to-date`\n- [ ] `node scripts/regenerate_moon_projects.js --update` reports `0\nupdated`\n- [ ] `git grep '@elastic/obs-ai-team' -- '*kibana.jsonc'` returns\nnothing\n- [ ] CI CODEOWNERS and Moon verification checks pass\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3db0268a9b78d5008e89d7aaa5f3d404331d9a61"}},{"url":"https://github.com/elastic/kibana/pull/276093","number":276093,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/276097","number":276097,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->