### PR TITLE
[9.4] [Lens as code] Fix panel/attributes title overwrite (#274361)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
@@ -14,8 +14,10 @@ import { getTransformOut } from './transform_out';
 describe('getTransformOut', () => {
   const transformDrilldownsOut = jest.fn(<T extends { drilldowns?: unknown }>(state: T) => state);
 
-  it.each(['panel title', '', undefined])(
-    'should use panel title for "%s" and ignore attributes title',
+  // A defined panel-level title (including an explicit empty string) always wins over the
+  // attributes title.
+  it.each(['Panel title', ''])(
+    'should use the panel title "%s" and ignore the attributes title',
     (title) => {
       const builder = new LensConfigBuilder(undefined, true);
       const transformOut = getTransformOut(builder, transformDrilldownsOut, false);
@@ -24,7 +26,7 @@ describe('getTransformOut', () => {
         title,
         attributes: {
           ...simpleMetricAttributes,
-          title: 'attributes title', // always ignored
+          title: 'Attributes title', // ignored: the panel defines its own title
         },
         references: [],
       };
@@ -34,4 +36,47 @@ describe('getTransformOut', () => {
       expect(result.title).toEqual(title);
     }
   );
+
+  // When the panel has no title (key absent or `undefined`), fall back to the attributes
+  // title so legacy by-value panels keep their title through the apiFormat round-trip.
+  // See https://github.com/elastic/kibana/issues/268821
+  it('falls back to the attributes title when the panel title is undefined', () => {
+    const builder = new LensConfigBuilder(undefined, true);
+    const transformOut = getTransformOut(builder, transformDrilldownsOut, false);
+
+    const storedState: LensByValueSerializedState = {
+      title: undefined,
+      attributes: {
+        ...simpleMetricAttributes,
+        title: 'Attributes title',
+      },
+      references: [],
+    };
+
+    const result = transformOut(storedState, []);
+
+    expect(result.title).toEqual('Attributes title');
+  });
+
+  // Regression coverage for https://github.com/elastic/kibana/issues/268821.
+  // Legacy by-value dashboard panels were persisted with the title only inside
+  // `attributes` and no panel-level `title` key at all. The apiFormat round-trip must
+  // keep that title (the non-apiFormat path renders it via `defaultTitle$`).
+  it('falls back to the attributes title for legacy by-value panels with no panel title key', () => {
+    const builder = new LensConfigBuilder(undefined, true);
+    const transformOut = getTransformOut(builder, transformDrilldownsOut, true);
+
+    const storedState = {
+      // NOTE: intentionally no top-level `title` key (legacy shape).
+      attributes: {
+        ...simpleMetricAttributes,
+        title: 'Attributes title',
+      },
+      references: [],
+    } as LensByValueSerializedState;
+
+    const result = transformOut(storedState, []);
+
+    expect(result.title).toEqual('Attributes title');
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
@@ -71,14 +71,34 @@ export const getTransformOut = (
     }
 
     const {
-      title: _, // ignore attributes title
+      title: attributesTitle, // attributes title is only a legacy fallback (see below)
+      description: attributesDescription,
       ...apiConfig
     } = builder.toAPIFormat({
       ...migratedAttributes,
       visualizationType: migratedAttributes.visualizationType ?? LENS_UNKNOWN_VIS,
     });
 
+    // For by-value panels the panel-level title/description take precedence and the
+    // attributes title/description are ignored. Legacy by-value panels, however, were
+    // sometimes persisted with the title only inside `attributes` and no panel-level title.
+    // Without a fallback those panels would lose their title through the apiFormat
+    // round-trip (the non-apiFormat path keeps it via `defaultTitle$ = attributes.title`).
+    //
+    // `stripInheritedContext` already dropped any `undefined` title/description key, so a
+    // missing key here means the panel has no title (either absent or explicitly
+    // `undefined`) and we fall back to the attributes title. An explicit empty string
+    // survives stripping, so it is a real panel title and the fallback is NOT applied.
+    // See https://github.com/elastic/kibana/issues/268821
+    const titleFallback = !('title' in state) && attributesTitle ? { title: attributesTitle } : {};
+    const descriptionFallback =
+      !('description' in state) && attributesDescription
+        ? { description: attributesDescription }
+        : {};
+
     return {
+      ...titleFallback,
+      ...descriptionFallback,
       ...state,
       ...apiConfig,
     } satisfies LensByValueTransformOutResult;

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -181,7 +181,10 @@ export function loadEmbeddableData(
           type: 'lens',
           name: lastState.attributes.visualizationType ?? '',
           id: uuid || 'new',
-          description: lastState.attributes.title || lastState.title || '',
+          // Prefer the panel-level title when it is set, falling back to the
+          // chart's own title. With the `lens.apiFormat` path the chart title is
+          // stripped from the wire format, so the panel title is the source of truth.
+          description: lastState.title ?? lastState.attributes.title ?? '',
           url: `${services.coreStart.application.getUrlForApp('lens')}${getEditPath(
             lastState.ref_id
           )}`,

--- a/x-pack/platform/test/functional_execution_context/tests/browser.ts
+++ b/x-pack/platform/test/functional_execution_context/tests/browser.ts
@@ -274,7 +274,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
                   type: 'lens',
                   name: 'lnsDatatable',
                   id: 'fb86b32f-fb7a-45cf-9511-f366fef51bbd',
-                  description: 'Cities by delay, cancellation',
+                  description: '[Flights] Most delayed cities',
                   url: '/app/lens#/edit_by_value',
                 },
               }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens as code] Fix panel/attributes title overwrite (#274361)](https://github.com/elastic/kibana/pull/274361)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-06-30T14:11:34Z","message":"[Lens as code] Fix panel/attributes title overwrite (#274361)\n\n# Summary\n\nFixes [#268823](https://github.com/elastic/kibana/issues/268823) —\nexecution context not propagated for Lens panels when the lens.apiFormat\nfeature flag is enabled.\n\n# Root cause\nThe execution context was being propagated correctly; the FTR\n`functional_execution_context` test failed because of a title mismatch\nin the Lens child context description.\n\nWith `lens.apiFormat` on, the server-side `transformOut` unconditionally\nstripped the chart-level (attributes) title/description before sending\nthe flat dashboard wire format. The flat wire shape has a single title\nslot (the panel's), so the chart title was lost on the round-trip. As a\nresult the execution-context description (and the panel's\ndefault/placeholder title) silently changed between the flag-on and\nflag-off paths.\n\n### Title precedence rule\n\nIf the panel title exists (even an empty string) → use it; otherwise\nfall back to the chart (attributes) title.\n\n## Changes\n`transform_out.ts`: keep the attributes title/description as a fallback,\napplied only when the panel has no title key. A defined panel title\n(including an explicit empty string) always wins; an absent/undefined\npanel title falls back to the chart title. This restores the legacy\nbehavior for by-value panels through the apiFormat round-trip and is the\ncanonical, source-level fix.\n\n`data_loader.ts`: align the Lens execution-context description with the\nsame rule — prefer the panel title, fall back to the chart title\n(lastState.title ?? lastState.attributes.title ?? '').\n\n`transform_out.test.ts`: unit coverage for panel-title-wins (incl. empty\nstring), undefined panel title fallback, and legacy no-title-key\nfallback.\n\n`functional_execution_context/tests/browser.ts`: update the lnsDatatable\nexpectation to the panel title ([Flights] Most delayed cities),\nconsistent for both flag states.","sha":"1f8024435098e817890baf4b878c78415829468a","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Visualizations","release_note:skip","backport missing","backport:version","v9.5.0","v9.4.4"],"title":"[Lens as code] Fix panel/attributes title overwrite","number":274361,"url":"https://github.com/elastic/kibana/pull/274361","mergeCommit":{"message":"[Lens as code] Fix panel/attributes title overwrite (#274361)\n\n# Summary\n\nFixes [#268823](https://github.com/elastic/kibana/issues/268823) —\nexecution context not propagated for Lens panels when the lens.apiFormat\nfeature flag is enabled.\n\n# Root cause\nThe execution context was being propagated correctly; the FTR\n`functional_execution_context` test failed because of a title mismatch\nin the Lens child context description.\n\nWith `lens.apiFormat` on, the server-side `transformOut` unconditionally\nstripped the chart-level (attributes) title/description before sending\nthe flat dashboard wire format. The flat wire shape has a single title\nslot (the panel's), so the chart title was lost on the round-trip. As a\nresult the execution-context description (and the panel's\ndefault/placeholder title) silently changed between the flag-on and\nflag-off paths.\n\n### Title precedence rule\n\nIf the panel title exists (even an empty string) → use it; otherwise\nfall back to the chart (attributes) title.\n\n## Changes\n`transform_out.ts`: keep the attributes title/description as a fallback,\napplied only when the panel has no title key. A defined panel title\n(including an explicit empty string) always wins; an absent/undefined\npanel title falls back to the chart title. This restores the legacy\nbehavior for by-value panels through the apiFormat round-trip and is the\ncanonical, source-level fix.\n\n`data_loader.ts`: align the Lens execution-context description with the\nsame rule — prefer the panel title, fall back to the chart title\n(lastState.title ?? lastState.attributes.title ?? '').\n\n`transform_out.test.ts`: unit coverage for panel-title-wins (incl. empty\nstring), undefined panel title fallback, and legacy no-title-key\nfallback.\n\n`functional_execution_context/tests/browser.ts`: update the lnsDatatable\nexpectation to the panel title ([Flights] Most delayed cities),\nconsistent for both flag states.","sha":"1f8024435098e817890baf4b878c78415829468a"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274361","number":274361,"mergeCommit":{"message":"[Lens as code] Fix panel/attributes title overwrite (#274361)\n\n# Summary\n\nFixes [#268823](https://github.com/elastic/kibana/issues/268823) —\nexecution context not propagated for Lens panels when the lens.apiFormat\nfeature flag is enabled.\n\n# Root cause\nThe execution context was being propagated correctly; the FTR\n`functional_execution_context` test failed because of a title mismatch\nin the Lens child context description.\n\nWith `lens.apiFormat` on, the server-side `transformOut` unconditionally\nstripped the chart-level (attributes) title/description before sending\nthe flat dashboard wire format. The flat wire shape has a single title\nslot (the panel's), so the chart title was lost on the round-trip. As a\nresult the execution-context description (and the panel's\ndefault/placeholder title) silently changed between the flag-on and\nflag-off paths.\n\n### Title precedence rule\n\nIf the panel title exists (even an empty string) → use it; otherwise\nfall back to the chart (attributes) title.\n\n## Changes\n`transform_out.ts`: keep the attributes title/description as a fallback,\napplied only when the panel has no title key. A defined panel title\n(including an explicit empty string) always wins; an absent/undefined\npanel title falls back to the chart title. This restores the legacy\nbehavior for by-value panels through the apiFormat round-trip and is the\ncanonical, source-level fix.\n\n`data_loader.ts`: align the Lens execution-context description with the\nsame rule — prefer the panel title, fall back to the chart title\n(lastState.title ?? lastState.attributes.title ?? '').\n\n`transform_out.test.ts`: unit coverage for panel-title-wins (incl. empty\nstring), undefined panel title fallback, and legacy no-title-key\nfallback.\n\n`functional_execution_context/tests/browser.ts`: update the lnsDatatable\nexpectation to the panel title ([Flights] Most delayed cities),\nconsistent for both flag states.","sha":"1f8024435098e817890baf4b878c78415829468a"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->