### PR TITLE
[One Workflow][Bug] Preserve YAML comments when exporting workflows

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.test.ts
@@ -162,9 +162,7 @@ describe('export_workflows', () => {
     it('should fetch YAML from the server and export a single workflow as .yml', async () => {
       const api = createMockWorkflowApi();
       api.exportWorkflows.mockResolvedValue({
-        entries: [
-          { id: 'w-1', yaml: '# preserved comment\nname: Test Workflow\nsteps: []' },
-        ],
+        entries: [{ id: 'w-1', yaml: '# preserved comment\nname: Test Workflow\nsteps: []' }],
         manifest: { exportedCount: 1, exportedAt: '2026-01-01T00:00:00.000Z', version: '1' },
       });
       const result = await exportWorkflows([createWorkflow()], api);

--- a/src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.test.ts
@@ -88,15 +88,60 @@ describe('export_workflows', () => {
       expect(result!.filename).toBe('workflow_export.yml');
     });
 
-    it('should return null when definition is null', () => {
+    it('should return null when definition is null and no yaml provided', () => {
       const result = prepareSingleWorkflowExport(createWorkflow({ definition: null }));
 
       expect(result).toBeNull();
     });
+
+    it('should use the provided yaml verbatim so comments survive the round-trip', () => {
+      const yaml = [
+        '# workflow: transferred between clusters',
+        'name: My Workflow',
+        'enabled: true',
+        'steps:',
+        '  # temporarily disabled',
+        '  # - name: broken',
+        '  #   type: noop',
+        '  - name: ok_step',
+        '    type: noop',
+        '',
+      ].join('\n');
+
+      const result = prepareSingleWorkflowExport(createWorkflow({ name: 'My Workflow' }), yaml);
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe('My_Workflow.yml');
+      expect((result!.content as { content: string }).content).toBe(yaml);
+    });
+
+    it('should return the yaml payload even when definition is null (server-provided)', () => {
+      const yaml = '# comment\nname: Y\n';
+      const result = prepareSingleWorkflowExport(
+        createWorkflow({ name: 'Y', definition: null }),
+        yaml
+      );
+
+      expect(result).not.toBeNull();
+      expect((result!.content as { content: string }).content).toBe(yaml);
+    });
   });
 
   describe('exportSingleWorkflow', () => {
-    it('should call downloadFileAs with .yml extension and yaml content', () => {
+    it('should use the provided yaml verbatim (preserving comments)', () => {
+      exportSingleWorkflow(
+        createWorkflow({ name: 'My Workflow' }),
+        '# top-level comment\nname: My Workflow\nsteps: []\n'
+      );
+
+      expect(mockDownloadFileAs).toHaveBeenCalledTimes(1);
+      const [filename, opts] = mockDownloadFileAs.mock.calls[0];
+      expect(filename).toBe('My_Workflow.yml');
+      expect(opts.type).toBe('text/yaml');
+      expect(opts.content).toContain('# top-level comment');
+    });
+
+    it('should fall back to stringifying the definition when yaml is not provided', () => {
       exportSingleWorkflow(createWorkflow({ name: 'My Workflow' }));
 
       expect(mockDownloadFileAs).toHaveBeenCalledTimes(1);
@@ -106,7 +151,7 @@ describe('export_workflows', () => {
       expect(opts.content).toContain('stringified:');
     });
 
-    it('should no-op when definition is null', () => {
+    it('should no-op when definition is null and no yaml is provided', () => {
       exportSingleWorkflow(createWorkflow({ definition: null }));
 
       expect(mockDownloadFileAs).not.toHaveBeenCalled();
@@ -114,14 +159,21 @@ describe('export_workflows', () => {
   });
 
   describe('exportWorkflows', () => {
-    it('should export single workflow as YAML when array has length 1', async () => {
+    it('should fetch YAML from the server and export a single workflow as .yml', async () => {
       const api = createMockWorkflowApi();
+      api.exportWorkflows.mockResolvedValue({
+        entries: [
+          { id: 'w-1', yaml: '# preserved comment\nname: Test Workflow\nsteps: []' },
+        ],
+        manifest: { exportedCount: 1, exportedAt: '2026-01-01T00:00:00.000Z', version: '1' },
+      });
       const result = await exportWorkflows([createWorkflow()], api);
 
       expect(result).toBe(1);
-      const [filename] = mockDownloadFileAs.mock.calls[0];
+      expect(api.exportWorkflows).toHaveBeenCalledWith({ ids: ['w-1'] });
+      const [filename, opts] = mockDownloadFileAs.mock.calls[0];
       expect(filename).toMatch(/\.yml$/);
-      expect(api.exportWorkflows).not.toHaveBeenCalled();
+      expect(opts.content).toContain('# preserved comment');
     });
 
     it('should fetch entries from API and build ZIP client-side for multiple workflows', async () => {

--- a/src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.ts
@@ -33,24 +33,37 @@ export interface WorkflowExportPayload {
 
 /**
  * Generates the export payload for a single workflow without triggering a
- * download. Returns null when the workflow has no definition.
+ * download. When `yaml` is provided (typically fetched from the server export
+ * API), it is used verbatim so YAML comments in the original source are
+ * preserved. Falls back to serializing the parsed definition, which drops
+ * comments — kept as a last-resort path for callers that don't have server
+ * access. Returns null when neither yaml nor a definition is available.
  */
 export const prepareSingleWorkflowExport = (
-  workflow: WorkflowListItemDto
+  workflow: WorkflowListItemDto,
+  yaml?: string
 ): WorkflowExportPayload | null => {
-  if (!workflow.definition) {
+  let content: string;
+  if (typeof yaml === 'string' && yaml.length > 0) {
+    content = yaml;
+  } else if (workflow.definition) {
+    content = stringifyWorkflowDefinition(workflow.definition);
+  } else {
     return null;
   }
-  const yaml = stringifyWorkflowDefinition(workflow.definition);
   const filename = `${sanitizeFilename(workflow.name)}.yml`;
-  return { filename, content: { content: yaml, type: 'text/yaml' } };
+  return { filename, content: { content, type: 'text/yaml' } };
 };
 
 /**
- * Exports a single workflow as a `.yml` file download.
+ * Exports a single workflow as a `.yml` file download. When called without the
+ * optional `yaml` argument, comments in the original YAML source are lost
+ * because the client-side workflow DTO does not carry the raw YAML — prefer
+ * calling `exportWorkflows` (which fetches the YAML from the server) when
+ * comment preservation matters.
  */
-export const exportSingleWorkflow = (workflow: WorkflowListItemDto): void => {
-  const payload = prepareSingleWorkflowExport(workflow);
+export const exportSingleWorkflow = (workflow: WorkflowListItemDto, yaml?: string): void => {
+  const payload = prepareSingleWorkflowExport(workflow, yaml);
   if (payload) {
     downloadFileAs(payload.filename, payload.content);
   }
@@ -61,6 +74,10 @@ export const exportSingleWorkflow = (workflow: WorkflowListItemDto): void => {
  * For multiple workflows, fetches entries from the server and builds
  * a ZIP archive client-side before triggering the download.
  * Returns the number of exported workflows.
+ *
+ * Both paths fetch the raw YAML from the server export API so that any
+ * comments in the original source are preserved. Re-serializing from the
+ * parsed workflow definition would strip them.
  */
 export const exportWorkflows = async (
   workflows: WorkflowListItemDto[],
@@ -71,13 +88,15 @@ export const exportWorkflows = async (
     return 0;
   }
 
+  const ids = exportable.map((w) => w.id);
+  const { entries, manifest } = await api.exportWorkflows({ ids });
+
   if (exportable.length === 1) {
-    exportSingleWorkflow(exportable[0]);
+    const entry = entries.find((e) => e.id === exportable[0].id) ?? entries[0];
+    exportSingleWorkflow(exportable[0], entry?.yaml);
     return 1;
   }
 
-  const ids = exportable.map((w) => w.id);
-  const { entries, manifest } = await api.exportWorkflows({ ids });
   const blob = await generateWorkflowsZip(entries, manifest);
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/use_export_with_references.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/use_export_with_references.test.ts
@@ -45,13 +45,11 @@ jest.mock('../../../hooks/use_telemetry', () => ({
 
 // Mock export_workflows module
 const mockExportWorkflows = jest.fn();
-const mockExportSingleWorkflow = jest.fn();
 const mockFindMissingReferencedIds = jest.fn();
 const mockResolveAllReferences = jest.fn();
 
 jest.mock('../../../common/lib/export_workflows', () => ({
   exportWorkflows: (...args: unknown[]) => mockExportWorkflows(...args),
-  exportSingleWorkflow: (...args: unknown[]) => mockExportSingleWorkflow(...args),
   findMissingReferencedIds: (...args: unknown[]) => mockFindMissingReferencedIds(...args),
   resolveAllReferences: (...args: unknown[]) => mockResolveAllReferences(...args),
 }));
@@ -90,17 +88,18 @@ describe('useExportWithReferences', () => {
   });
 
   describe('startExport', () => {
-    it('exports a single workflow as YAML without showing a modal', () => {
+    it('exports a single workflow as YAML via the server (preserves comments)', async () => {
       mockFindMissingReferencedIds.mockReturnValue([]);
+      mockExportWorkflows.mockResolvedValue(1);
 
       const workflow = createMockWorkflow();
       const { result } = renderHook(() => useExportWithReferences({ allWorkflowsMap, onComplete }));
 
-      act(() => {
+      await act(async () => {
         result.current.startExport([workflow]);
       });
 
-      expect(mockExportSingleWorkflow).toHaveBeenCalledWith(workflow);
+      expect(mockExportWorkflows).toHaveBeenCalledWith([workflow], mockApi);
       expect(mockNotifications.toasts.addSuccess).toHaveBeenCalled();
       expect(mockReportWorkflowExported).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -154,20 +153,21 @@ describe('useExportWithReferences', () => {
       expect(result.current.exportModalState?.pendingExport).toEqual([mainWorkflow]);
     });
 
-    it('exports without modal when missing IDs are not found in allWorkflowsMap', () => {
+    it('exports without modal when missing IDs are not found in allWorkflowsMap', async () => {
       mockFindMissingReferencedIds.mockReturnValue(['wf-unknown']);
       // allWorkflowsMap does NOT have 'wf-unknown'
+      mockExportWorkflows.mockResolvedValue(1);
 
       const workflow = createMockWorkflow();
       const { result } = renderHook(() => useExportWithReferences({ allWorkflowsMap, onComplete }));
 
-      act(() => {
+      await act(async () => {
         result.current.startExport([workflow]);
       });
 
       // Should fall through to exportWithoutReferences because missingWorkflows is empty
       expect(result.current.exportModalState).toBeNull();
-      expect(mockExportSingleWorkflow).toHaveBeenCalled();
+      expect(mockExportWorkflows).toHaveBeenCalledWith([workflow], mockApi);
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/use_export_with_references.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/use_export_with_references.ts
@@ -13,7 +13,6 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { WorkflowListItemDto } from '@kbn/workflows';
 import { useWorkflowsApi } from '@kbn/workflows-ui';
 import {
-  exportSingleWorkflow,
   exportWorkflows,
   findMissingReferencedIds,
   resolveAllReferences,
@@ -83,7 +82,7 @@ export const useExportWithReferences = ({
       }
       telemetry.reportWorkflowExported({
         workflowCount: workflowsToExport.length,
-        format: 'zip',
+        format: workflowsToExport.length === 1 ? 'yaml' : 'zip',
         referenceResolution,
         error: exportError,
       });
@@ -94,25 +93,9 @@ export const useExportWithReferences = ({
 
   const exportWithoutReferences = useCallback(
     (workflowsToExport: WorkflowListItemDto[]) => {
-      if (workflowsToExport.length === 1) {
-        exportSingleWorkflow(workflowsToExport[0]);
-        notifications?.toasts.addSuccess(
-          i18n.translate('workflows.export.singleSuccess', {
-            defaultMessage: 'Workflow exported successfully.',
-          }),
-          { toastLifeTimeMs: TOAST_LIFE_TIME_MS }
-        );
-        telemetry.reportWorkflowExported({
-          workflowCount: 1,
-          format: 'yaml',
-          referenceResolution: 'none',
-        });
-        onComplete?.();
-      } else {
-        performExport(workflowsToExport, 'none');
-      }
+      performExport(workflowsToExport, 'none');
     },
-    [performExport, notifications, onComplete, telemetry]
+    [performExport]
   );
 
   const startExport = useCallback(

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts
@@ -69,8 +69,15 @@ export function registerExportWorkflowsRoute(deps: RouteDependencies) {
           workflows.forEach((workflow) => assertCanReadManagedWorkflow(request, workflow));
 
           const entries: WorkflowExportEntry[] = workflows.map((workflow) => {
+            // Prefer the workflow's stored YAML source over re-serializing the
+            // parsed definition. Re-serialization strips YAML comments (both
+            // documentation and temporarily-disabled steps), which teams rely
+            // on when transferring workflows between clusters. Fall back to the
+            // serialized definition only when no stored YAML is available.
             const yaml =
-              typeof workflow.definition === 'object' && workflow.definition !== null
+              typeof workflow.yaml === 'string' && workflow.yaml.length > 0
+                ? workflow.yaml
+                : workflow.definition && typeof workflow.definition === 'object'
                 ? stringifyWorkflowDefinition(workflow.definition)
                 : workflow.yaml;
             return { id: workflow.id, yaml };

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
@@ -790,6 +790,49 @@ describe('Workflow routes', () => {
         'Export skipped 1 missing workflow(s): w-missing-1'
       );
     });
+
+    it('should preserve YAML comments when exporting a workflow', async () => {
+      const yamlWithComments = [
+        '# top-level description of this workflow',
+        'name: Commented Workflow',
+        'enabled: true',
+        'steps:',
+        '  # temporarily disabled while we debug the flake',
+        '  # - name: broken_step',
+        '  #   type: noop',
+        '  - name: ok_step',
+        '    type: noop',
+        '',
+      ].join('\n');
+
+      mockApi.getWorkflowsByIds.mockResolvedValue([
+        {
+          id: 'w-commented',
+          name: 'Commented Workflow',
+          yaml: yamlWithComments,
+          definition: {
+            name: 'Commented Workflow',
+            enabled: true,
+            steps: [{ name: 'ok_step', type: 'noop' }],
+          },
+        },
+      ]);
+
+      const request = httpServerMock.createKibanaRequest({ body: { ids: ['w-commented'] } });
+      const response = mockResponse();
+      const context = createLicensingContext() as any;
+
+      await routeHandlers[key].handler(context, request, response);
+      const { body } = (response.ok as jest.Mock).mock.calls[0][0];
+
+      expect(body.entries).toHaveLength(1);
+      expect(body.entries[0].id).toBe('w-commented');
+      expect(body.entries[0].yaml).toContain('# top-level description of this workflow');
+      expect(body.entries[0].yaml).toContain(
+        '# temporarily disabled while we debug the flake'
+      );
+      expect(body.entries[0].yaml).toContain('# - name: broken_step');
+    });
   });
 
   describe('GET:/api/workflows/stats', () => {

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
@@ -828,9 +828,7 @@ describe('Workflow routes', () => {
       expect(body.entries).toHaveLength(1);
       expect(body.entries[0].id).toBe('w-commented');
       expect(body.entries[0].yaml).toContain('# top-level description of this workflow');
-      expect(body.entries[0].yaml).toContain(
-        '# temporarily disabled while we debug the flake'
-      );
+      expect(body.entries[0].yaml).toContain('# temporarily disabled while we debug the flake');
       expect(body.entries[0].yaml).toContain('# - name: broken_step');
     });
   });


### PR DESCRIPTION
## Summary
Fix a data-loss bug where exporting a workflow silently strips every YAML comment (inline docs, commented-out steps) from the exported YAML.

Both the server-side workflow export route and the client-side single-workflow export previously ran the workflow through `stringifyWorkflowDefinition(workflow.definition)`, which builds a fresh YAML document from the parsed JS object. The parsed object has no notion of comments, so the round-trip drops them — even though the original YAML _is_ stored on the workflow document.

This is the same root cause pattern as the cloning bug in elastic/security-team#17846, on a different code path.

## Changes
- **Server** `src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts`: prefer `workflow.yaml` (the stored source, comments intact) over re-serializing `workflow.definition`. Fall back to the serialized definition only when no stored YAML is available.
- **Client** `src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.ts`: route the single-workflow export through the same `POST /api/workflows/export` endpoint so the server-side preservation applies to `.yml` downloads too. `prepareSingleWorkflowExport` / `exportSingleWorkflow` now accept an optional `yaml` argument; when provided it is used verbatim.
- **Client hook** `use_export_with_references.ts`: simplify — always go through `exportWorkflows`; drop the local `exportSingleWorkflow` short-circuit; keep telemetry accurate (`format: 'yaml'` for the single case, `'zip'` for bulk).
- Tests added for the preservation behavior on both the server route and the client library.

Fixes elastic/security-team#18049. Related to elastic/security-team#17846 (cloning).

## Test plan
- [ ] `yarn jest src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts` — new "preserve YAML comments" case passes.
- [ ] `yarn jest src/platform/plugins/shared/workflows_management/public/common/lib/export_workflows.test.ts` — new coverage passes; existing tests still pass.
- [ ] `yarn jest src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/use_export_with_references.test.ts` — single-export path now hits `exportWorkflows`.
- [ ] Manual: create a workflow with a top-level `#` comment and a commented-out step block, export via UI (single `.yml` and multi-file `.zip`) and via `POST /api/workflows/export`, confirm all comments are preserved in the exported YAML.

---
_Created by @1workflow bot on behalf of U08SUNTMWTD_