### PR TITLE
[9.3] [Security Solution] Preserve rule revision across prebuilt rule type upgrades (#275627)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.ts
@@ -43,6 +43,7 @@ import { validateScheduleLimit } from '../get_schedule_frequency';
 
 export interface CreateRuleOptions {
   id?: string;
+  initialRevision?: number;
 }
 
 export interface CreateRuleParams<Params extends RuleParams = never> {
@@ -218,7 +219,7 @@ export async function createRule<Params extends RuleParams = never>(
       throttle,
       executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
       monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
-      revision: 0,
+      revision: options?.initialRevision ?? 0,
       running: false,
     },
     params: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.upgrade_prebuilt_rule.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.upgrade_prebuilt_rule.test.ts
@@ -155,6 +155,18 @@ describe('DetectionRulesClient.upgradePrebuiltRule', () => {
         })
       );
     });
+
+    it('creates a new rule with initialRevision bumped by 1 from the existing rule revision', async () => {
+      await detectionRulesClient.upgradePrebuiltRule({ ruleAsset });
+
+      expect(rulesClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            initialRevision: installedRule.revision + 1,
+          }),
+        })
+      );
+    });
   });
 
   describe('if the new version has the same type than the existing version', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.upgrade_prebuilt_rule.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.upgrade_prebuilt_rule.test.ts
@@ -149,9 +149,9 @@ describe('DetectionRulesClient.upgradePrebuiltRule', () => {
               exceptionsList: installedRule.exceptions_list,
             }),
           }),
-          options: {
+          options: expect.objectContaining({
             id: installedRule.id, // id is maintained
-          },
+          }),
         })
       );
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/create_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/create_rule.ts
@@ -26,6 +26,7 @@ interface CreateRuleOptions {
   mlAuthz: MlAuthz;
   rule: RuleCreateProps & { immutable: boolean };
   id?: string;
+  initialRevision?: number;
   allowMissingConnectorSecrets?: boolean;
 }
 
@@ -35,6 +36,7 @@ export const createRule = async ({
   mlAuthz,
   rule,
   id,
+  initialRevision,
   allowMissingConnectorSecrets,
 }: CreateRuleOptions): Promise<RuleResponse> => {
   await validateMlAuth(mlAuthz, rule.type);
@@ -50,7 +52,10 @@ export const createRule = async ({
 
   const createdRule = await rulesClient.create<RuleParams>({
     data: payload,
-    options: { id },
+    options: {
+      id,
+      initialRevision,
+    },
     allowMissingConnectorSecrets,
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/upgrade_prebuilt_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/upgrade_prebuilt_rule.ts
@@ -63,6 +63,10 @@ export const upgradePrebuiltRule = async ({
         timeline_title: existingRule.timeline_title,
       },
       id: existingRule.id,
+      // Preserve the revision counter: the same-type upgrade path (rulesClient.update)
+      // increments revision automatically when content changes. To keep both paths
+      // consistent, bump the revision by 1 here as well.
+      initialRevision: existingRule.revision + 1,
     });
 
     return createdRule;

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/upgrade_single_prebuilt_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/upgrade_single_prebuilt_rule.ts
@@ -359,6 +359,59 @@ export default ({ getService }: FtrProviderContext): void => {
               });
             });
           }
+
+          describe('revision', () => {
+            for (const isCustomized of [false, true]) {
+              for (const targetType of ['query', 'eql'] as const) {
+                const sameType = targetType === 'query';
+
+                it(`sets a rule revision + 1 when upgrading a ${
+                  isCustomized ? 'customized' : 'non-customized'
+                } rule to ${sameType ? 'the same' : 'a different'} rule type`, async () => {
+                  await setUpRuleUpgrade({
+                    assets: {
+                      installed: {
+                        type: 'query',
+                        name: 'Initial name',
+                        version: 1,
+                      },
+                      patch: isCustomized ? { name: 'Customized name' } : {},
+                      upgrade: {
+                        type: targetType,
+                        name: 'Updated name',
+                        version: 2,
+                      },
+                    },
+                    removeInstalledAssets: !withHistoricalVersions,
+                    deps,
+                  });
+
+                  const ruleBeforeUpgrade = await detectionsApi.readRule({
+                    query: { rule_id: DEFAULT_TEST_RULE_ID },
+                  });
+                  const revisionBeforeUpgrade = ruleBeforeUpgrade.body.revision;
+
+                  await performUpgradePrebuiltRules(es, supertest, {
+                    mode: ModeEnum.SPECIFIC_RULES,
+                    rules: [
+                      {
+                        rule_id: DEFAULT_TEST_RULE_ID,
+                        revision: revisionBeforeUpgrade,
+                        version: 2,
+                        pick_version: 'TARGET',
+                      },
+                    ],
+                  });
+
+                  const upgradedRule = await detectionsApi.readRule({
+                    query: { rule_id: DEFAULT_TEST_RULE_ID },
+                  });
+
+                  expect(upgradedRule.body.revision).toBe(revisionBeforeUpgrade + 1);
+                });
+              }
+            }
+          });
         }
       );
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution] Preserve rule revision across prebuilt rule type upgrades (#275627)](https://github.com/elastic/kibana/pull/275627)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2026-07-02T07:57:23Z","message":"[Security Solution] Preserve rule revision across prebuilt rule type upgrades (#275627)\n\n**Epic:** https://github.com/elastic/security-team/issues/12367 (internal)\n**Related to:** https://github.com/elastic/kibana/pull/269617\n\n## Summary\n\nAligns rule revision bump between prebuilt rule upgrade to a different rule type with an upgrade to the same rule type. Rule revision gets bumped +1 upon any kind of prebuilt rule upgrade.\n\n## Details\n\nWhen a prebuilt rule is upgraded to a different rule type, the alerting framework internally deletes the existing rule and creates a new one. Before this fix, the newly created rule started with a fresh `revision` counter, discarding the revision accumulated before the upgrade. This PR passes `initialRevision: existingRule.revision + 1` to the `createRule` call so the revision is preserved in a way that is consistent with the same-type upgrade path, where the alerting framework increments the revision automatically on `update`.\n\n### Changes\n\n- `create_rule.ts`: Added optional `initialRevision` parameter to `CreateRuleOptions` and threaded it through to `rulesClient.create`.\n- `upgrade_prebuilt_rule.ts`: Passes `initialRevision: existingRule.revision + 1` when re-creating the rule after a type-change upgrade.\n- Unit tests: Added tests verifying `rulesClient.create` is called with `initialRevision` equal to the previous rule's `revision + 1`, and that `rulesClient.update` is not called with a `shouldIncrementRevision` override (relying on the alerting default).\n- Integration tests: Two new tests confirming the upgraded rule's `revision` equals `revisionBeforeUpgrade + 1` for both non-customized and customized rules when changing rule type.\n\n## Screenshots\n\n**Before**\n\n<img width=\"1572\" height=\"1176\" alt=\"Screenshot 2026-06-30 at 18 17 03\" src=\"https://github.com/user-attachments/assets/7da9ce4d-7767-48bf-a15c-9c13a51d5b91\" />\n\n**After**\n\n<img width=\"1575\" height=\"1177\" alt=\"image\" src=\"https://github.com/user-attachments/assets/78ac92c7-ce34-4401-91a4-b24d14c60c27\" />\n\n## Release note\n\nPrebuilt rule `revision` is now correctly preserved (incremented by 1) when upgrading a rule to a different type, matching the behavior of same-type upgrades.","sha":"fea9e5b2464f754396d3834b58d1a9d58f9d944c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team: SecuritySolution","Feature:Prebuilt Detection Rules","backport:version","v9.5.0","Team:Detection Engineering","v9.4.3","v9.3.7"],"title":"[Security Solution] Preserve rule revision across prebuilt rule type upgrades","number":275627,"url":"https://github.com/elastic/kibana/pull/275627","mergeCommit":{"message":"[Security Solution] Preserve rule revision across prebuilt rule type upgrades (#275627)\n\n**Epic:** https://github.com/elastic/security-team/issues/12367 (internal)\n**Related to:** https://github.com/elastic/kibana/pull/269617\n\n## Summary\n\nAligns rule revision bump between prebuilt rule upgrade to a different rule type with an upgrade to the same rule type. Rule revision gets bumped +1 upon any kind of prebuilt rule upgrade.\n\n## Details\n\nWhen a prebuilt rule is upgraded to a different rule type, the alerting framework internally deletes the existing rule and creates a new one. Before this fix, the newly created rule started with a fresh `revision` counter, discarding the revision accumulated before the upgrade. This PR passes `initialRevision: existingRule.revision + 1` to the `createRule` call so the revision is preserved in a way that is consistent with the same-type upgrade path, where the alerting framework increments the revision automatically on `update`.\n\n### Changes\n\n- `create_rule.ts`: Added optional `initialRevision` parameter to `CreateRuleOptions` and threaded it through to `rulesClient.create`.\n- `upgrade_prebuilt_rule.ts`: Passes `initialRevision: existingRule.revision + 1` when re-creating the rule after a type-change upgrade.\n- Unit tests: Added tests verifying `rulesClient.create` is called with `initialRevision` equal to the previous rule's `revision + 1`, and that `rulesClient.update` is not called with a `shouldIncrementRevision` override (relying on the alerting default).\n- Integration tests: Two new tests confirming the upgraded rule's `revision` equals `revisionBeforeUpgrade + 1` for both non-customized and customized rules when changing rule type.\n\n## Screenshots\n\n**Before**\n\n<img width=\"1572\" height=\"1176\" alt=\"Screenshot 2026-06-30 at 18 17 03\" src=\"https://github.com/user-attachments/assets/7da9ce4d-7767-48bf-a15c-9c13a51d5b91\" />\n\n**After**\n\n<img width=\"1575\" height=\"1177\" alt=\"image\" src=\"https://github.com/user-attachments/assets/78ac92c7-ce34-4401-91a4-b24d14c60c27\" />\n\n## Release note\n\nPrebuilt rule `revision` is now correctly preserved (incremented by 1) when upgrading a rule to a different type, matching the behavior of same-type upgrades.","sha":"fea9e5b2464f754396d3834b58d1a9d58f9d944c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275627","number":275627,"mergeCommit":{"message":"[Security Solution] Preserve rule revision across prebuilt rule type upgrades (#275627)\n\n**Epic:** https://github.com/elastic/security-team/issues/12367 (internal)\n**Related to:** https://github.com/elastic/kibana/pull/269617\n\n## Summary\n\nAligns rule revision bump between prebuilt rule upgrade to a different rule type with an upgrade to the same rule type. Rule revision gets bumped +1 upon any kind of prebuilt rule upgrade.\n\n## Details\n\nWhen a prebuilt rule is upgraded to a different rule type, the alerting framework internally deletes the existing rule and creates a new one. Before this fix, the newly created rule started with a fresh `revision` counter, discarding the revision accumulated before the upgrade. This PR passes `initialRevision: existingRule.revision + 1` to the `createRule` call so the revision is preserved in a way that is consistent with the same-type upgrade path, where the alerting framework increments the revision automatically on `update`.\n\n### Changes\n\n- `create_rule.ts`: Added optional `initialRevision` parameter to `CreateRuleOptions` and threaded it through to `rulesClient.create`.\n- `upgrade_prebuilt_rule.ts`: Passes `initialRevision: existingRule.revision + 1` when re-creating the rule after a type-change upgrade.\n- Unit tests: Added tests verifying `rulesClient.create` is called with `initialRevision` equal to the previous rule's `revision + 1`, and that `rulesClient.update` is not called with a `shouldIncrementRevision` override (relying on the alerting default).\n- Integration tests: Two new tests confirming the upgraded rule's `revision` equals `revisionBeforeUpgrade + 1` for both non-customized and customized rules when changing rule type.\n\n## Screenshots\n\n**Before**\n\n<img width=\"1572\" height=\"1176\" alt=\"Screenshot 2026-06-30 at 18 17 03\" src=\"https://github.com/user-attachments/assets/7da9ce4d-7767-48bf-a15c-9c13a51d5b91\" />\n\n**After**\n\n<img width=\"1575\" height=\"1177\" alt=\"image\" src=\"https://github.com/user-attachments/assets/78ac92c7-ce34-4401-91a4-b24d14c60c27\" />\n\n## Release note\n\nPrebuilt rule `revision` is now correctly preserved (incremented by 1) when upgrading a rule to a different type, matching the behavior of same-type upgrades.","sha":"fea9e5b2464f754396d3834b58d1a9d58f9d944c"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->