### PR TITLE
[Security Solution][Flyout] Restructure v2 entity host flyout content into tabs

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
@@ -31,7 +31,7 @@ import {
   type RiskStats,
 } from '../../../common/search_strategy';
 import { useUiSetting, useKibana } from '../../common/lib/kibana';
-import { Content as HostPanelContent } from '../../flyout_v2/entity/host/main/content';
+import { OverviewTab as HostPanelContent } from '../../flyout_v2/entity/host/main/tabs/overview_tab';
 import { Header as HostPanelHeader } from '../../flyout_v2/entity/host/main/header';
 import { useObservedHost } from '../../flyout_v2/entity/host/main/hooks/use_observed_host';
 import { EntityType } from '../../../common/entity_analytics/types';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -27,7 +27,7 @@ import { buildHostNamesFilter, type RiskSeverity } from '../../../../common/sear
 import { useUiSetting, useKibana } from '../../../common/lib/kibana';
 import { FlyoutNavigation } from '../../shared/components/flyout_navigation';
 import { Footer } from '../../../flyout_v2/entity/host/main/footer';
-import { Content } from '../../../flyout_v2/entity/host/main/content';
+import { OverviewTab } from '../../../flyout_v2/entity/host/main/tabs/overview_tab';
 import { Header } from '../../../flyout_v2/entity/host/main/header';
 import { EntityDetailsLeftPanelTab } from '../shared/components/left_panel/left_panel_header';
 import { HostPreviewPanelFooter } from '../host_preview/footer';
@@ -341,7 +341,7 @@ export const HostPanel = memo(function HostPanel({
         {tabs && selectedTabId === TABLE_TAB_ID && observedHost.entityRecord ? (
           <EntityStoreTableTab entityRecord={observedHost.entityRecord} />
         ) : (
-          <Content
+          <OverviewTab
             identityFields={documentEntityIdentifiers}
             observedHost={observedHost}
             riskScoreState={effectiveRiskScoreState}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
@@ -41,8 +41,9 @@ import { MisconfigurationInsights } from '../tools/misconfiguration_insights';
 import { VulnerabilityInsights } from '../tools/vulnerability_insights';
 import { AlertsInsights } from '../tools/alerts_insights';
 import { Header } from './header';
-import { Content } from './content';
+import { OverviewTab, type OverviewTabProps } from './tabs/overview_tab';
 import { Footer } from './footer';
+import { getTabsDisplayed } from './tabs';
 import { useObservedHost } from './hooks/use_observed_host';
 import { EntityType } from '../../../../../common/entity_analytics/types';
 import {
@@ -60,12 +61,8 @@ import {
   type IdentityFields,
 } from '../../../../flyout/document_details/shared/utils';
 import { HOST_PANEL_RISK_SCORE_QUERY_ID } from './constants';
-import {
-  useEntityPanelTabs,
-  TABLE_TAB_ID,
-} from '../../../../flyout/entity_details/shared/hooks/use_entity_panel_tabs';
+import { useEntityPanelTabs } from '../../../../flyout/entity_details/shared/hooks/use_entity_panel_tabs';
 import { EntityPanelHeaderTabs } from '../../../../flyout/entity_details/shared/components/entity_panel_tabs';
-import { EntityStoreTableTab } from '../../../../flyout/entity_details/shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../../../../flyout/entity_details/shared/components/entity_summary_grid';
 
 export interface HostProps {
@@ -251,17 +248,11 @@ export const Host: FC<HostProps> = memo(function Host({
   const noEntityInStore =
     entityStoreV2Enabled && !entityFromStoreResult.isLoading && !observedHost.entityRecord;
 
-  const { tabs, selectedTabId, setSelectedTabId } = useEntityPanelTabs({
-    entityRecord: observedHost.entityRecord ?? null,
-  });
-
-  const tabsNode = tabs ? (
-    <EntityPanelHeaderTabs
-      tabs={tabs}
-      selectedTabId={selectedTabId}
-      setSelectedTabId={setSelectedTabId}
-    />
-  ) : undefined;
+  const {
+    tabs: entityPanelTabs,
+    selectedTabId,
+    setSelectedTabId,
+  } = useEntityPanelTabs({ entityRecord: observedHost.entityRecord ?? null });
 
   const onShowHost = useCallback(() => {
     overlays.openSystemFlyout(
@@ -352,6 +343,69 @@ export const Host: FC<HostProps> = memo(function Host({
         'Unknown') as RiskSeverity)
     : undefined;
 
+  const overviewTabProps = useMemo<OverviewTabProps>(
+    () => ({
+      identityFields: documentEntityIdentifiers,
+      observedHost,
+      riskScoreState: effectiveRiskScoreState,
+      entityRiskScores,
+      contextID: safeContextID,
+      scopeId,
+      openDetailsPanel,
+      recalculatingScore,
+      onAssetCriticalityChange: onAssetCriticalityChanged,
+      isPreviewMode: false,
+      entityRecord: entityStoreV2Enabled ? observedHost.entityRecord ?? undefined : undefined,
+      skipRiskAndCriticality: noEntityInStore,
+      entityStoreEntityId,
+      // The v2 flyout does not yet wire up the graph view / resolution group tabs, so hide their
+      // navigation here. v1 HostPanel and the agent-builder canvas keep it (default).
+      // TODO: remove this (and `enableGraphAndResolutionNavigation` in content.tsx) once
+      // `openDetailsPanel` handles the GRAPH_VIEW and RESOLUTION_GROUP tabs in this flyout.
+      enableGraphAndResolutionNavigation: false,
+    }),
+    [
+      documentEntityIdentifiers,
+      observedHost,
+      effectiveRiskScoreState,
+      entityRiskScores,
+      safeContextID,
+      scopeId,
+      openDetailsPanel,
+      recalculatingScore,
+      onAssetCriticalityChanged,
+      entityStoreV2Enabled,
+      noEntityInStore,
+      entityStoreEntityId,
+    ]
+  );
+
+  const tabs = useMemo(
+    () =>
+      entityPanelTabs
+        ? getTabsDisplayed({
+            entityPanelTabs,
+            entityStoreRecord: observedHost.entityRecord ?? null,
+            overviewTabProps,
+          })
+        : null,
+    [entityPanelTabs, observedHost.entityRecord, overviewTabProps]
+  );
+
+  const tabsNode = tabs ? (
+    <EntityPanelHeaderTabs
+      tabs={tabs}
+      selectedTabId={selectedTabId}
+      setSelectedTabId={setSelectedTabId}
+    />
+  ) : undefined;
+
+  const selectedTabContent = tabs ? (
+    tabs.find((tab) => tab.id === selectedTabId)?.content
+  ) : (
+    <OverviewTab {...overviewTabProps} />
+  );
+
   return (
     <>
       <EuiFlyoutHeader hasBorder>
@@ -374,30 +428,7 @@ export const Host: FC<HostProps> = memo(function Host({
         )}
         {tabsNode}
         {tabs && <EuiSpacer size="l" />}
-        {tabs && selectedTabId === TABLE_TAB_ID && observedHost.entityRecord ? (
-          <EntityStoreTableTab entityRecord={observedHost.entityRecord} />
-        ) : (
-          <Content
-            identityFields={documentEntityIdentifiers}
-            observedHost={observedHost}
-            riskScoreState={effectiveRiskScoreState}
-            entityRiskScores={entityRiskScores}
-            contextID={safeContextID}
-            scopeId={scopeId}
-            openDetailsPanel={openDetailsPanel}
-            recalculatingScore={recalculatingScore}
-            onAssetCriticalityChange={onAssetCriticalityChanged}
-            isPreviewMode={false}
-            entityRecord={entityStoreV2Enabled ? observedHost.entityRecord ?? undefined : undefined}
-            skipRiskAndCriticality={noEntityInStore}
-            entityStoreEntityId={entityStoreEntityId}
-            // The v2 flyout does not yet wire up the graph view / resolution group tabs, so hide
-            // their navigation here. v1 HostPanel and the agent-builder canvas keep it (default).
-            // TODO: remove this prop (and `enableGraphAndResolutionNavigation` in content.tsx) once
-            // `openDetailsPanel` handles the GRAPH_VIEW and RESOLUTION_GROUP tabs in this flyout.
-            enableGraphAndResolutionNavigation={false}
-          />
-        )}
+        {selectedTabContent}
       </EuiFlyoutBody>
       {assetInventoryEnabled && (
         <EuiFlyoutFooter>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/index.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { EntityPanelTabType } from '../../../../../flyout/entity_details/shared/components/entity_panel_tabs';
+import {
+  OVERVIEW_TAB_ID,
+  TABLE_TAB_ID,
+} from '../../../../../flyout/entity_details/shared/hooks/use_entity_panel_tabs';
+import type { EntityStoreRecord } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+import type { OverviewTabProps } from './overview_tab';
+import { getTabsDisplayed } from '.';
+
+jest.mock('./overview_tab', () => ({
+  OverviewTab: () => <div data-test-subj="overview-content" />,
+}));
+
+jest.mock('../../../../../flyout/entity_details/shared/components/entity_store_table_tab', () => ({
+  EntityStoreTableTab: () => <div data-test-subj="table-content" />,
+}));
+
+const entityPanelTabs: EntityPanelTabType[] = [
+  { id: OVERVIEW_TAB_ID, name: <>{'Overview'}</>, 'data-test-subj': 'overview-tab' },
+  { id: TABLE_TAB_ID, name: <>{'Fields'}</>, 'data-test-subj': 'table-tab' },
+];
+
+const overviewTabProps = {} as OverviewTabProps;
+const entityStoreRecord = { entity: { id: 'host-1' } } as unknown as EntityStoreRecord;
+
+describe('host getTabsDisplayed', () => {
+  it('preserves the tab ids and names from the entity panel tabs', () => {
+    const tabs = getTabsDisplayed({ entityPanelTabs, entityStoreRecord, overviewTabProps });
+    expect(tabs.map((tab) => tab.id)).toEqual([OVERVIEW_TAB_ID, TABLE_TAB_ID]);
+  });
+
+  it('renders the overview content for the overview tab', () => {
+    const tabs = getTabsDisplayed({ entityPanelTabs, entityStoreRecord, overviewTabProps });
+    const overview = tabs.find((tab) => tab.id === OVERVIEW_TAB_ID);
+    const { getByTestId } = render(<>{overview?.content}</>);
+    expect(getByTestId('overview-content')).toBeInTheDocument();
+  });
+
+  it('renders the entity store table for the table tab when a record is present', () => {
+    const tabs = getTabsDisplayed({ entityPanelTabs, entityStoreRecord, overviewTabProps });
+    const table = tabs.find((tab) => tab.id === TABLE_TAB_ID);
+    const { getByTestId } = render(<>{table?.content}</>);
+    expect(getByTestId('table-content')).toBeInTheDocument();
+  });
+
+  it('falls back to overview content for the table tab when no record is present', () => {
+    const tabs = getTabsDisplayed({ entityPanelTabs, entityStoreRecord: null, overviewTabProps });
+    const table = tabs.find((tab) => tab.id === TABLE_TAB_ID);
+    const { getByTestId } = render(<>{table?.content}</>);
+    expect(getByTestId('overview-content')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/index.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { EntityPanelTabType } from '../../../../../flyout/entity_details/shared/components/entity_panel_tabs';
+import { TABLE_TAB_ID } from '../../../../../flyout/entity_details/shared/hooks/use_entity_panel_tabs';
+import { EntityStoreTableTab } from '../../../../../flyout/entity_details/shared/components/entity_store_table_tab';
+import type { EntityStoreRecord } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+import { OverviewTab, type OverviewTabProps } from './overview_tab';
+
+interface HostTabType extends EntityPanelTabType {
+  /** Content rendered when this tab is selected. */
+  content: ReactElement;
+}
+
+export interface GetTabsDisplayedOptions {
+  /**
+   * Tab definitions (id + name) from `useEntityPanelTabs`. The set of tabs is entity-store driven,
+   * so this is only non-empty when the host is in the entity store.
+   */
+  entityPanelTabs: EntityPanelTabType[];
+  /**
+   * Entity store record backing the Table tab. When absent the Table tab is not shown by
+   * `useEntityPanelTabs`, so this is only used to render the Table tab's content.
+   */
+  entityStoreRecord: EntityStoreRecord | null;
+  /**
+   * Props forwarded to the Overview tab content.
+   */
+  overviewTabProps: OverviewTabProps;
+}
+
+/**
+ * Maps the entity-panel tab definitions to their rendered content for the host flyout:
+ * the Table tab renders the entity-store field table, every other tab renders the overview.
+ */
+export const getTabsDisplayed = ({
+  entityPanelTabs,
+  entityStoreRecord,
+  overviewTabProps,
+}: GetTabsDisplayedOptions): HostTabType[] =>
+  entityPanelTabs.map((tab) => ({
+    ...tab,
+    content:
+      tab.id === TABLE_TAB_ID && entityStoreRecord ? (
+        <EntityStoreTableTab entityRecord={entityStoreRecord} />
+      ) : (
+        <OverviewTab {...overviewTabProps} />
+      ),
+  }));

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/overview_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/overview_tab.test.tsx
@@ -7,49 +7,52 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { TestProviders } from '../../../../common/mock';
-import { RESOLUTION_SECTION_TEST_ID } from '../../../../entity_analytics/components/entity_resolution/test_ids';
-import { useHasEntityResolutionLicense } from '../../../../common/hooks/use_has_entity_resolution_license';
-import { Content } from './content';
-import { mockHostEntityRiskScores } from '../../../../flyout/entity_details/mocks';
+import { TestProviders } from '../../../../../common/mock';
+import { RESOLUTION_SECTION_TEST_ID } from '../../../../../entity_analytics/components/entity_resolution/test_ids';
+import { useHasEntityResolutionLicense } from '../../../../../common/hooks/use_has_entity_resolution_license';
+import { OverviewTab } from './overview_tab';
+import { mockHostEntityRiskScores } from '../../../../../flyout/entity_details/mocks';
 
 const mockResolutionSection = jest.fn((_props: { openDetailsPanel?: unknown }) => (
   <div data-test-subj="securitySolutionFlyoutResolutionSection" />
 ));
 const mockVisualizationsSection = jest.fn((_props: { openDetailsPanel?: unknown }) => null);
 
-jest.mock('../../../../entity_analytics/components/entity_resolution/resolution_section', () => ({
-  ResolutionSection: (props: { openDetailsPanel?: unknown }) => mockResolutionSection(props),
-}));
-jest.mock('../../../../common/hooks/use_has_entity_resolution_license', () => ({
+jest.mock(
+  '../../../../../entity_analytics/components/entity_resolution/resolution_section',
+  () => ({
+    ResolutionSection: (props: { openDetailsPanel?: unknown }) => mockResolutionSection(props),
+  })
+);
+jest.mock('../../../../../common/hooks/use_has_entity_resolution_license', () => ({
   useHasEntityResolutionLicense: jest.fn(() => false),
 }));
-jest.mock('../../../../entity_analytics/components/risk_summary_flyout/risk_summary', () => ({
+jest.mock('../../../../../entity_analytics/components/risk_summary_flyout/risk_summary', () => ({
   FlyoutRiskSummary: () => null,
 }));
 jest.mock(
-  '../../../../flyout/entity_details/shared/components/right/visualizations_section',
+  '../../../../../flyout/entity_details/shared/components/right/visualizations_section',
   () => ({
     VisualizationsSection: (props: { openDetailsPanel?: unknown }) =>
       mockVisualizationsSection(props),
   })
 );
 jest.mock(
-  '../../../../entity_analytics/components/asset_criticality/asset_criticality_selector',
+  '../../../../../entity_analytics/components/asset_criticality/asset_criticality_selector',
   () => ({
     AssetCriticalityAccordion: () => null,
   })
 );
 jest.mock(
-  '../../../../entity_analytics/components/entity_details_flyout/components/entity_highlights',
+  '../../../../../entity_analytics/components/entity_details_flyout/components/entity_highlights',
   () => ({
     EntityHighlightsAccordion: () => null,
   })
 );
-jest.mock('../../../../cloud_security_posture/components/entity_insight', () => ({
+jest.mock('../../../../../cloud_security_posture/components/entity_insight', () => ({
   EntityInsight: () => null,
 }));
-jest.mock('./components/observed_data_section', () => ({
+jest.mock('../components/observed_data_section', () => ({
   ObservedDataSection: () => null,
 }));
 
@@ -67,24 +70,24 @@ const defaultProps = {
   entityStoreEntityId: 'host:host-1@okta',
 };
 
-describe('Content — resolution license gating', () => {
+describe('OverviewTab — resolution license gating', () => {
   beforeEach(() => {
     (useHasEntityResolutionLicense as jest.Mock).mockReturnValue(false);
   });
 
   it('does not render ResolutionSection when license is inactive', () => {
-    render(<Content {...defaultProps} />, { wrapper: TestProviders });
+    render(<OverviewTab {...defaultProps} />, { wrapper: TestProviders });
     expect(screen.queryByTestId(RESOLUTION_SECTION_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders ResolutionSection when license is active and entityStoreEntityId is set', () => {
     (useHasEntityResolutionLicense as jest.Mock).mockReturnValue(true);
-    render(<Content {...defaultProps} />, { wrapper: TestProviders });
+    render(<OverviewTab {...defaultProps} />, { wrapper: TestProviders });
     expect(screen.getByTestId(RESOLUTION_SECTION_TEST_ID)).toBeInTheDocument();
   });
 });
 
-describe('Content — graph/resolution navigation gating', () => {
+describe('OverviewTab — graph/resolution navigation gating', () => {
   const openDetailsPanel = jest.fn();
 
   beforeEach(() => {
@@ -93,7 +96,7 @@ describe('Content — graph/resolution navigation gating', () => {
   });
 
   it('forwards openDetailsPanel to the graph and resolution sections by default', () => {
-    render(<Content {...defaultProps} openDetailsPanel={openDetailsPanel} />, {
+    render(<OverviewTab {...defaultProps} openDetailsPanel={openDetailsPanel} />, {
       wrapper: TestProviders,
     });
     expect(mockVisualizationsSection).toHaveBeenLastCalledWith(
@@ -106,7 +109,7 @@ describe('Content — graph/resolution navigation gating', () => {
 
   it('withholds openDetailsPanel from the graph and resolution sections when navigation is disabled', () => {
     render(
-      <Content
+      <OverviewTab
         {...defaultProps}
         openDetailsPanel={openDetailsPanel}
         enableGraphAndResolutionNavigation={false}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/tabs/overview_tab.tsx
@@ -7,31 +7,34 @@
 
 import React from 'react';
 import { EuiHorizontalRule } from '@elastic/eui';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import type { Entity } from '../../../../../common/api/entity_analytics';
-import { ObservedDataSection } from './components/observed_data_section';
-import { useAnomalyOverview } from '../../../../entity_analytics/api/hooks/use_anomaly_overview';
-import { useAnomalyPrivileges } from '../../../../entity_analytics/api/hooks/use_anomaly_privileges';
-import { useHasEntityResolutionLicense } from '../../../../common/hooks/use_has_entity_resolution_license';
-import { EntityHighlightsAccordion } from '../../../../entity_analytics/components/entity_details_flyout/components/entity_highlights';
-import { EntityInsight } from '../../../../cloud_security_posture/components/entity_insight';
-import { AssetCriticalityAccordion } from '../../../../entity_analytics/components/asset_criticality/asset_criticality_selector';
-import { FlyoutRiskSummary } from '../../../../entity_analytics/components/risk_summary_flyout/risk_summary';
-import type { RiskScoreState } from '../../../../entity_analytics/api/hooks/use_risk_score';
-import type { EntityRiskScoresState } from '../../../../entity_analytics/api/hooks/use_entity_risk_scores';
-import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
-import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from './constants';
-import type { EntityDetailsPath } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
-import type { IdentityFields } from '../../../../flyout/document_details/shared/utils';
-import type { ObservedEntityData } from '../../../../flyout/entity_details/shared/components/observed_entity/types';
-import type { EntityRiskScore, HostItem } from '../../../../../common/search_strategy';
-import { VisualizationsSection } from '../../../../flyout/entity_details/shared/components/right/visualizations_section';
-import { ResolutionSection } from '../../../../entity_analytics/components/entity_resolution/resolution_section';
-import { AnomaliesSection } from '../../../../entity_analytics/components/anomalies/anomalies_section';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import type { Entity } from '../../../../../../common/api/entity_analytics';
+import { ObservedDataSection } from '../components/observed_data_section';
+import { useAnomalyOverview } from '../../../../../entity_analytics/api/hooks/use_anomaly_overview';
+import { useAnomalyPrivileges } from '../../../../../entity_analytics/api/hooks/use_anomaly_privileges';
+import { useHasEntityResolutionLicense } from '../../../../../common/hooks/use_has_entity_resolution_license';
+import { EntityHighlightsAccordion } from '../../../../../entity_analytics/components/entity_details_flyout/components/entity_highlights';
+import { EntityInsight } from '../../../../../cloud_security_posture/components/entity_insight';
+import { AssetCriticalityAccordion } from '../../../../../entity_analytics/components/asset_criticality/asset_criticality_selector';
+import { FlyoutRiskSummary } from '../../../../../entity_analytics/components/risk_summary_flyout/risk_summary';
+import type { RiskScoreState } from '../../../../../entity_analytics/api/hooks/use_risk_score';
+import type { EntityRiskScoresState } from '../../../../../entity_analytics/api/hooks/use_entity_risk_scores';
+import {
+  EntityIdentifierFields,
+  EntityType,
+} from '../../../../../../common/entity_analytics/types';
+import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from '../constants';
+import type { EntityDetailsPath } from '../../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
+import type { IdentityFields } from '../../../../../flyout/document_details/shared/utils';
+import type { ObservedEntityData } from '../../../../../flyout/entity_details/shared/components/observed_entity/types';
+import type { EntityRiskScore, HostItem } from '../../../../../../common/search_strategy';
+import { VisualizationsSection } from '../../../../../flyout/entity_details/shared/components/right/visualizations_section';
+import { ResolutionSection } from '../../../../../entity_analytics/components/entity_resolution/resolution_section';
+import { AnomaliesSection } from '../../../../../entity_analytics/components/anomalies/anomalies_section';
 
 type ObservedHostData = Omit<ObservedEntityData<HostItem>, 'anomalies'>;
 
-export interface ContentProps {
+export interface OverviewTabProps {
   /** Observed host data (anomalies excluded). */
   observedHost: ObservedHostData;
   /** Current risk score state for the host. */
@@ -72,7 +75,7 @@ export interface ContentProps {
 /**
  * Host details flyout content section.
  */
-export const Content = ({
+export const OverviewTab = ({
   identityFields,
   observedHost,
   riskScoreState,
@@ -88,7 +91,7 @@ export const Content = ({
   entityStoreEntityId,
   prefetchedResolutionRisk,
   enableGraphAndResolutionNavigation = true,
-}: ContentProps) => {
+}: OverviewTabProps) => {
   const hasEntityResolutionLicense = useHasEntityResolutionLicense();
   const isAnomalyDetailsEnabled = useIsExperimentalFeatureEnabled('entityAnalyticsAnomalyDetails');
   const { data: anomalyPrivilegesData } = useAnomalyPrivileges(isAnomalyDetailsEnabled);


### PR DESCRIPTION
## Summary

**Part 3 of 3** — split out of #268071.

Restructures the v2 entity host flyout:
- renames the `content` component to `tabs/overview_tab`
- introduces a `tabs/index` module
- updates the external importers (agent_builder host canvas and the v1 `host_right` panel)

**Independent** of the shared tab foundation — it uses the existing v1 `useEntityPanelTabs`, so it can be reviewed and merged in any order relative to #276131 and the v2 tabs PR.

## Split series
- 1/3 — shared tab foundation (#276131)
- 2/3 — v2 attack/document/ioc flyout tabs
- **3/3 (this PR)** — v2 entity host restructure *(independent)*

## Testing
- `node scripts/type_check --project x-pack/solutions/security/plugins/security_solution/tsconfig.json` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)