### PR TITLE
[Discover] fix controls flacky test

### DIFF
--- a/src/platform/test/functional/apps/discover/esql_4/_esql_controls.ts
+++ b/src/platform/test/functional/apps/discover/esql_4/_esql_controls.ts
@@ -27,8 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'timePicker',
   ]);
 
-  // Failing: See https://github.com/elastic/kibana/issues/271826
-  describe.skip('discover esql controls', () => {
+  describe('discover esql controls', () => {
     before(async () => {
       await kibanaServer.uiSettings.replace({
         defaultIndex: 'logstash-*',
@@ -77,6 +76,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         // Verify that the control exists in discover
         const control = await dashboardControls.getControlElementById('esql-control-1');
         expect(control).to.be.ok();
+
+        await discover.waitUntilTabIsLoaded();
         await discover.expectDocTableToBeLoaded();
       });
     });

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -668,12 +668,13 @@ export class DiscoverPageObject extends FtrService {
   }
 
   public async expectDocTableToBeLoaded() {
-    const renderComplete = await this.testSubjects.getAttribute(
-      'discoverDocTable',
-      'data-render-complete'
-    );
-
-    expect(renderComplete).to.be('true');
+    await this.retry.waitFor('doc table to finish rendering', async () => {
+      const renderComplete = await this.testSubjects.getAttribute(
+        'discoverDocTable',
+        'data-render-complete'
+      );
+      return renderComplete === 'true';
+    });
   }
 
   public async findFieldByNameOrValueInDocViewer(name: string) {


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/271826
## Summary
We were not waiting for the data table to be rendered, so sometimes the check failed before it was fully visible.

* Added `discover.waitUntilTabIsLoaded()` which is widely used in these kind of checks.
* Added retries to check for the table.


### Checklist
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


