### PR TITLE
[data federation] Add safeguard for unknown types

### DIFF
--- a/x-pack/platform/plugins/private/data_federation/public/main.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.test.tsx
@@ -82,4 +82,41 @@ describe('Main', () => {
       expect(getByTestId('dataSetsSetsCreateButton')).toBeDisabled();
     });
   });
+
+  it('disables the edit action for a data source with an unsupported type', async () => {
+    const http = createHttpMock();
+    (http.get as jest.Mock).mockImplementation(async (path: string) => {
+      if (path === DATA_SOURCES_LIST_ROUTE_PATH) {
+        return {
+          data_sources: [
+            { name: 'supported', type: 's3', description: '', settings: {} },
+            // The backend can return a type outside DataSourceType (e.g. added on the ES
+            // side before the UI knows about it), which is what the edit action guards against.
+            { name: 'unsupported', type: 'http', description: '', settings: {} },
+          ],
+        };
+      }
+      if (path === DATA_SETS_LIST_ROUTE_PATH) {
+        return { data_sets: [] };
+      }
+      throw new Error(`Unexpected GET: ${path}`);
+    });
+
+    const { getByRole, getAllByTestId } = render(
+      <EuiProvider>
+        <Main httpClient={http as unknown as HttpSetup} toasts={createToastsMock()} />
+      </EuiProvider>
+    );
+
+    fireEvent.click(getByRole('tab', { name: mainTranslations.tabs.sources }));
+
+    let editButtons: HTMLElement[] = [];
+    await waitFor(() => {
+      editButtons = getAllByTestId('dataSetsEditButton');
+      expect(editButtons).toHaveLength(2);
+    });
+
+    expect(editButtons[0]).toBeEnabled();
+    expect(editButtons[1]).toBeDisabled();
+  });
 });

--- a/x-pack/platform/plugins/private/data_federation/public/main.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.tsx
@@ -11,6 +11,7 @@ import type { EuiBasicTableColumn, EuiTabbedContentTab } from '@elastic/eui';
 import {
   EuiBetaBadge,
   EuiButton,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiInMemoryTable,
@@ -20,10 +21,16 @@ import {
   EuiSelect,
   EuiSpacer,
   EuiTabbedContent,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import type { HttpSetup, ToastsStart } from '@kbn/core/public';
-import type { DataSetWithName, DataSourceWithSecrets, DataSource } from '../common';
+import {
+  ALL_DATA_SOURCE_TYPES,
+  type DataSetWithName,
+  type DataSourceWithSecrets,
+  type DataSource,
+} from '../common';
 import type { FederatedIdentityClusterInfo } from './create_data_source_flyout/federated_identity_cluster_info';
 import { CreateDatasetFlyout } from './create_dataset_flyout';
 import { dataSetFromListItem } from './create_dataset_flyout/dataset_flyout_initial_values';
@@ -445,14 +452,29 @@ export const Main: FunctionComponent<MainProps> = ({
         width: '8%',
         actions: [
           {
-            name: mainTranslations.columns.dataSources.editAction,
-            description: mainTranslations.columns.dataSources.editActionDescription,
-            icon: 'pencil',
-            type: 'icon',
-            onClick: (item) => {
-              handleEditDataSource(item);
-            },
-            'data-test-subj': 'dataSetsEditButton',
+            enabled: (item) => ALL_DATA_SOURCE_TYPES.includes(item.type),
+            render: (item: DataSource, isSupportedType: boolean) => (
+              // EUI's default item action can't show a tooltip on a disabled icon button
+              // (aria-disabled sets pointer-events: none, which blocks hover), so this
+              // wraps the button manually to explain why editing is disabled.
+              <EuiToolTip
+                content={
+                  isSupportedType
+                    ? mainTranslations.columns.dataSources.editActionDescription
+                    : mainTranslations.columns.dataSources.editActionUnsupportedTypeDescription
+                }
+              >
+                <span>
+                  <EuiButtonIcon
+                    aria-label={mainTranslations.columns.dataSources.editAction}
+                    iconType="pencil"
+                    isDisabled={!isSupportedType}
+                    onClick={() => handleEditDataSource(item)}
+                    data-test-subj="dataSetsEditButton"
+                  />
+                </span>
+              </EuiToolTip>
+            ),
           },
           {
             name: mainTranslations.columns.dataSources.deleteAction,

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -48,6 +48,12 @@ export const mainTranslations = {
       editActionDescription: i18n.translate('xpack.dataFederation.table.editActionDescription', {
         defaultMessage: 'Edit data source',
       }),
+      editActionUnsupportedTypeDescription: i18n.translate(
+        'xpack.dataFederation.table.editActionUnsupportedTypeDescription',
+        {
+          defaultMessage: 'This data source type is not supported for editing in this view',
+        }
+      ),
       deleteAction: i18n.translate('xpack.dataFederation.table.deleteAction', {
         defaultMessage: 'Delete',
       }),

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -51,7 +51,7 @@ export const mainTranslations = {
       editActionUnsupportedTypeDescription: i18n.translate(
         'xpack.dataFederation.table.editActionUnsupportedTypeDescription',
         {
-          defaultMessage: 'This data source type is not supported for editing in this view',
+          defaultMessage: 'This data source type is not supported for editing in this view.',
         }
       ),
       deleteAction: i18n.translate('xpack.dataFederation.table.deleteAction', {


### PR DESCRIPTION
## Summary

Followup from https://github.com/elastic/kibana/pull/265681. When creating a datasource with an unknown type directly through console, editing the data source breaks the UI. This pr adds a safeguard to disable editing when that is the case.

<img width="296" height="160" alt="Screenshot 2026-07-03 at 10 41 48" src="https://github.com/user-attachments/assets/8b6e30e6-f136-4d4d-b7fb-48c5bb0ae6fb" />



### How to test

Start es and kibana, then in console run the following command

```
PUT /_query/data_source/web_csv
{
  "type": "http",
  "settings": {}
}
```

Attempt to edit the data source in the data federation UI, but the edit icon should be disabled.
