### PR TITLE
[Security] Fix Kerberos Scout fixture crash on rspack bundle fetch errors

### DIFF
--- a/x-pack/platform/plugins/shared/security/test/scout_kerberos/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_kerberos/ui/fixtures/index.ts
@@ -16,7 +16,15 @@ import { SPNEGO_TOKEN } from './constants';
 export const test = baseTest.extend({
   page: async ({ page }, use) => {
     await page.route('**/*', async (route) => {
-      const response = await route.fetch({ maxRedirects: 0 });
+      let response;
+      try {
+        response = await route.fetch({ maxRedirects: 0 });
+      } catch {
+        // Static assets (e.g. rspack bundle chunks) can produce network errors during fetch
+        // interception. Fall back to normal browser handling — they don't need SPNEGO auth.
+        await route.continue();
+        return;
+      }
       if (
         response.status() === 401 &&
         response.headers()['www-authenticate']?.toLowerCase().includes('negotiate')


### PR DESCRIPTION
## Summary

- The `page.route('**/*', ...)` handler in the Kerberos Scout fixture called `route.fetch()` on every intercepted request with no error handling.
- With the rspack optimizer, bundle chunk requests (e.g. `plugin-developerToolbar.*.js`) can produce a `socket hang up` network error during `route.fetch()`, which crashed the handler and caused the test to fail.
- Added a try/catch around the initial `route.fetch()`: on error, fall back to `route.continue()` so the browser handles the request normally. Static assets don't need SPNEGO injection, so this is safe.

## Test plan

- [ ] Kerberos logout test (`kerberos_logout.spec.ts`) passes with the rspack optimizer enabled
- [ ] Kerberos login and no-role-mapping tests are unaffected
- [ ] On a 401 + `WWW-Authenticate: Negotiate` response, the SPNEGO token is still injected correctly