### PR TITLE
[9.4] fix(a11y): add aria-hidden to decorative EuiIcon instances in response-ops files (#275349)

### DIFF
--- a/x-pack/examples/alerting_example/public/components/create_alert.tsx
+++ b/x-pack/examples/alerting_example/public/components/create_alert.tsx
@@ -43,7 +43,7 @@ export const CreateAlert = ({
     <EuiFlexGroup>
       <EuiFlexItem grow={false}>
         <EuiCard
-          icon={<EuiIcon size="xxl" type={`bell`} />}
+          icon={<EuiIcon size="xxl" type={`bell`} aria-hidden={true} />}
           title={`Create Rule`}
           description="Create a new Rule based on one of our example Rule Types ."
           onClick={() => setRuleFlyoutVisibility(true)}

--- a/x-pack/examples/gen_ai_streaming_response_example/public/components/setup_connector.tsx
+++ b/x-pack/examples/gen_ai_streaming_response_example/public/components/setup_connector.tsx
@@ -20,7 +20,7 @@ export const SetupConnector = ({ setIsConnectorModalVisible }: SetupConnectorPro
       <EuiFlexItem grow={false}>
         <EuiCard
           layout="horizontal"
-          icon={<EuiIcon size="xl" type={OpenAILogo} />}
+          icon={<EuiIcon size="xl" type={OpenAILogo} aria-hidden={true} />}
           title={i18n.translate(
             'genAiStreamingResponseExample.app.component.addConnectorCardTitle',
             {

--- a/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
+++ b/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
@@ -134,7 +134,7 @@ export const StreamingResponse = ({
     inner = (
       <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
-          <EuiIcon color="danger" type="warning" />
+          <EuiIcon color="danger" type="warning" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{content}</EuiText>

--- a/x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_solution_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_solution_selector.tsx
@@ -44,7 +44,7 @@ export const AlertsSolutionSelector = forwardRef<
       inputDisplay: (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type={featuresIcons[sol]} />
+            <EuiIcon type={featuresIcons[sol]} aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem>{capitalize(sol)}</EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/error_cell.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/error_cell.tsx
@@ -29,7 +29,7 @@ export const ErrorCell = ({ error }: { error: Error }) => (
       data-test-subj="errorCell"
     >
       <EuiFlexItem grow={false}>
-        <EuiIcon type="error" color="danger" />
+        <EuiIcon type="error" color="danger" aria-hidden={true} />
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiText

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/tags/edit_tags_selectable.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/tags/edit_tags_selectable.tsx
@@ -83,6 +83,7 @@ const EditTagsSelectableComponent: React.FC<Props> = ({
             type={option.itemIcon}
             data-test-subj={dataTestSubj}
             css={{ flexShrink: 0, marginRight: euiTheme.size.m }}
+            aria-hidden={true}
           />
           <EuiHighlight search={search}>{option.label}</EuiHighlight>
         </>

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/tags/use_tags_action.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/tags/use_tags_action.test.tsx
@@ -75,6 +75,7 @@ describe('useTagsAction', () => {
         "data-test-subj": "alerts-bulk-action-tags",
         "disabled": false,
         "icon": <EuiIcon
+          aria-hidden={true}
           size="m"
           type="tag"
         />,

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/tags/use_tags_action.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/tags/use_tags_action.tsx
@@ -76,7 +76,7 @@ export const useTagsAction = ({
       onClick: () => openFlyout(alerts),
       disabled: isDisabled,
       'data-test-subj': 'alerts-bulk-action-tags',
-      icon: <EuiIcon type="tag" size="m" />,
+      icon: <EuiIcon type="tag" size="m" aria-hidden={true} />,
       key: 'alerts-bulk-action-tags',
     };
   };

--- a/x-pack/platform/plugins/private/reporting/public/management/components/report_status_indicator.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/report_status_indicator.tsx
@@ -63,15 +63,15 @@ export const ReportStatusIndicator: FC<Props> = ({ job }) => {
   switch (job.status) {
     case JOB_STATUS.COMPLETED:
       if (hasIssues) {
-        icon = <EuiIcon type="warning" color="warning" />;
+        icon = <EuiIcon type="warning" color="warning" aria-hidden={true} />;
         statusText = i18nTexts.completedWithWarnings;
         break;
       }
-      icon = <EuiIcon type="checkCircleFill" color="success" />;
+      icon = <EuiIcon type="checkCircleFill" color="success" aria-hidden={true} />;
       statusText = i18nTexts.completed;
       break;
     case JOB_STATUS.WARNINGS:
-      icon = <EuiIcon type="warning" color="warning" />;
+      icon = <EuiIcon type="warning" color="warning" aria-hidden={true} />;
       statusText = i18nTexts.completedWithWarnings;
       break;
     case JOB_STATUS.PENDING:
@@ -83,11 +83,11 @@ export const ReportStatusIndicator: FC<Props> = ({ job }) => {
       statusText = i18nTexts.processing({ attempt: job.attempts, of: job.max_attempts });
       break;
     case JOB_STATUS.FAILED:
-      icon = <EuiIcon type="error" color="danger" />;
+      icon = <EuiIcon type="error" color="danger" aria-hidden={true} />;
       statusText = i18nTexts.failed;
       break;
     default:
-      icon = <EuiIcon type="cross" color="subdued" />;
+      icon = <EuiIcon type="cross" color="subdued" aria-hidden={true} />;
       statusText = i18nTexts.unknown;
   }
 

--- a/x-pack/platform/plugins/shared/maintenance_windows/public/components/link_icon.tsx
+++ b/x-pack/platform/plugins/shared/maintenance_windows/public/components/link_icon.tsx
@@ -72,6 +72,7 @@ export const LinkIcon = React.memo<LinkIconProps>(
           data-test-subj="link-icon"
           size={iconSize}
           type={iconType}
+          aria-hidden={true}
         />
         <span data-test-subj="link-icon-label">{children}</span>
       </EuiLink>

--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/header_type_options.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/header_type_options.tsx
@@ -15,7 +15,7 @@ export const headerTypeOptions = [
     inputDisplay: (
       <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="controls" size="s" />
+          <EuiIcon type="controls" size="s" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <span>{i18n.CONFIG_OPTION}</span>
@@ -29,7 +29,7 @@ export const headerTypeOptions = [
     inputDisplay: (
       <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="lock" size="s" />
+          <EuiIcon type="lock" size="s" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <span>{i18n.SECRET_OPTION}</span>

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index_params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index_params.tsx
@@ -123,7 +123,7 @@ export const IndexParamsFields = ({
             setAlertHistoryIndexSuffix(defaultAlertHistoryIndexSuffix);
           }}
         >
-          <EuiIcon type="refresh" />
+          <EuiIcon type="refresh" aria-hidden={true} />
           <FormattedMessage
             id="xpack.stackConnectors.components.index.resetDefaultIndexLabel"
             defaultMessage="Reset default index"

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/prompts/empty_connectors_prompt.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/prompts/empty_connectors_prompt.tsx
@@ -41,18 +41,21 @@ export const EmptyConnectorsPrompt = ({
             size="xl"
             className="actEmptyConnectorsPrompt__logo"
             css={emptyConnectorsLogoCss}
+            aria-hidden={true}
           />
           <EuiIcon
             type="logoGmail"
             size="xl"
             className="actEmptyConnectorsPrompt__logo"
             css={emptyConnectorsLogoCss}
+            aria-hidden={true}
           />
           <EuiIcon
             type="logoWebhook"
             size="xl"
             className="actEmptyConnectorsPrompt__logo"
             css={emptyConnectorsLogoCss}
+            aria-hidden={true}
           />
           <EuiSpacer size="s" />
           <EuiTitle size="m">

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.tsx
@@ -257,7 +257,7 @@ const ConnectorAddModal = ({
           <EuiFlexGroup gutterSize="m" alignItems="center">
             {actionTypeModel && actionTypeModel.iconClass ? (
               <EuiFlexItem grow={false}>
-                <EuiIcon type={actionTypeModel.iconClass} size="xl" />
+                <EuiIcon type={actionTypeModel.iconClass} size="xl" aria-hidden={true} />
               </EuiFlexItem>
             ) : null}
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/header.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/header.tsx
@@ -41,7 +41,7 @@ const FlyoutHeaderComponent: React.FC<Props> = ({
       <EuiFlexGroup gutterSize="m" alignItems="center">
         {icon ? (
           <EuiFlexItem grow={false} data-test-subj="create-connector-flyout-header-icon">
-            <EuiIcon type={icon} size="xl" />
+            <EuiIcon type={icon} size="xl" aria-hidden={true} />
           </EuiFlexItem>
         ) : null}
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
@@ -75,7 +75,12 @@ const FlyoutHeaderComponent: React.FC<{
       <EuiFlexGroup gutterSize="s" alignItems="center">
         {icon ? (
           <EuiFlexItem grow={false}>
-            <EuiIcon type={icon} size="m" data-test-subj="edit-connector-flyout-header-icon" />
+            <EuiIcon
+              type={icon}
+              size="m"
+              data-test-subj="edit-connector-flyout-header-icon"
+              aria-hidden={true}
+            />
           </EuiFlexItem>
         ) : null}
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alert_summary_widget/components/alert_item.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alert_summary_widget/components/alert_item.tsx
@@ -49,7 +49,7 @@ export const AlertItem = ({
           {count > 0 && showWarningIcon ? (
             <>
               &nbsp;
-              <EuiIcon type="warning" ascent={10} />
+              <EuiIcon type="warning" ascent={10} aria-hidden={true} />
             </>
           ) : null}
         </EuiTextColor>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_status.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_status.tsx
@@ -57,7 +57,7 @@ export const EventLogListStatus = (props: EventLogListStatusProps) => {
 
   return (
     <span style={statusContainerStyles} data-test-subj="eventLogListStatus">
-      <EuiIcon type="dot" color={color} style={iconStyles} />
+      <EuiIcon type="dot" color={color} style={iconStyles} aria-hidden={true} />
       {statusString}
     </span>
   );

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_actions.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_actions.tsx
@@ -103,6 +103,7 @@ export function RuleActions({
                   data-test-subj={`ruleActionIcon${
                     typeof iconType === 'string' ? `-${iconType}` : ''
                   }`}
+                  aria-hidden={true}
                 />
               </EuiFlexItem>
               <EuiFlexItem>
@@ -115,7 +116,7 @@ export function RuleActions({
                 <EuiFlexGroup alignItems="center" gutterSize="xs" component="span">
                   <EuiSpacer size="xs" />
                   <EuiFlexItem grow={false}>
-                    <EuiIcon size="s" type="bell" />
+                    <EuiIcon size="s" type="bell" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiText

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/panel/base_snooze_panel.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/panel/base_snooze_panel.tsx
@@ -241,7 +241,7 @@ export const BaseSnoozePanel: React.FunctionComponent<BaseSnoozePanelProps> = ({
                             {scheduleSummary(schedule as SnoozeSchedule)}
                           </EuiFlexItem>
                           <EuiFlexItem grow={false}>
-                            <EuiIcon type="chevronSingleRight" />
+                            <EuiIcon type="chevronSingleRight" aria-hidden={true} />
                           </EuiFlexItem>
                         </EuiFlexGroup>
                       </EuiButton>
@@ -303,7 +303,7 @@ export const BaseSnoozePanel: React.FunctionComponent<BaseSnoozePanelProps> = ({
         <EuiPopoverTitle data-test-subj="snoozePanelTitle">
           <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="bellSlash" />
+              <EuiIcon type="bellSlash" aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem>
               {i18n.translate('xpack.triggersActionsUI.sections.rulesList.snoozePanelTitle', {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_clear_rule_filter_banner.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_clear_rule_filter_banner.tsx
@@ -20,7 +20,7 @@ export const RulesListClearRuleFilterBanner = ({
     <>
       <EuiCallOut color="primary" size="s" data-test-subj="rulesListClearRuleFilterBanner">
         <p>
-          <EuiIcon color="primary" type="info" />{' '}
+          <EuiIcon color="primary" type="info" aria-hidden={true} />{' '}
           <FormattedMessage
             id="xpack.triggersActionsUI.sections.rulesList.ruleParamBannerTitle"
             defaultMessage="Rule list filtered by url parameters."

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_error_banner.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_error_banner.tsx
@@ -37,7 +37,7 @@ export const RulesListErrorBanner = (props: RulesListErrorBannerProps) => {
     <>
       <EuiCallOut color="danger" size="s" data-test-subj="rulesErrorBanner">
         <p>
-          <EuiIcon color="danger" type="warning" />
+          <EuiIcon color="danger" type="warning" aria-hidden={true} />
           &nbsp;
           <FormattedMessage
             id="xpack.triggersActionsUI.sections.rulesList.attentionBannerTitle"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(a11y): add aria-hidden to decorative EuiIcon instances in response-ops files (#275349)](https://github.com/elastic/kibana/pull/275349)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-06-29T12:48:32Z","message":"fix(a11y): add aria-hidden to decorative EuiIcon instances in response-ops files (#275349)\n\n## Summary\n\nFixes `@elastic/eui/icon-accessibility-rules` ESLint violations across\n21 files owned by `@elastic/response-ops`.\n\nAll `EuiIcon` instances in these files are **decorative** — they appear\nnext to visible text labels, inside buttons/links with descriptive text,\nor within components that already carry accessible names via surrounding\ncontext. The correct fix per the [accessibility\nskill](/.agents/skills/accessibility/SKILL.md) is `aria-hidden={true}`.\n\nNo `aria-label`/i18n strings or `EuiIconTip` migrations were needed.\n\nCloses #275343\n\n## PR checklist\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"65eaa2bdec8945edb70701bc3d394cd55d8dbd57","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","backport:version","a11y:agent-pr","v9.5.0","v9.4.4"],"title":"fix(a11y): add aria-hidden to decorative EuiIcon instances in response-ops files","number":275349,"url":"https://github.com/elastic/kibana/pull/275349","mergeCommit":{"message":"fix(a11y): add aria-hidden to decorative EuiIcon instances in response-ops files (#275349)\n\n## Summary\n\nFixes `@elastic/eui/icon-accessibility-rules` ESLint violations across\n21 files owned by `@elastic/response-ops`.\n\nAll `EuiIcon` instances in these files are **decorative** — they appear\nnext to visible text labels, inside buttons/links with descriptive text,\nor within components that already carry accessible names via surrounding\ncontext. The correct fix per the [accessibility\nskill](/.agents/skills/accessibility/SKILL.md) is `aria-hidden={true}`.\n\nNo `aria-label`/i18n strings or `EuiIconTip` migrations were needed.\n\nCloses #275343\n\n## PR checklist\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"65eaa2bdec8945edb70701bc3d394cd55d8dbd57"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275349","number":275349,"mergeCommit":{"message":"fix(a11y): add aria-hidden to decorative EuiIcon instances in response-ops files (#275349)\n\n## Summary\n\nFixes `@elastic/eui/icon-accessibility-rules` ESLint violations across\n21 files owned by `@elastic/response-ops`.\n\nAll `EuiIcon` instances in these files are **decorative** — they appear\nnext to visible text labels, inside buttons/links with descriptive text,\nor within components that already carry accessible names via surrounding\ncontext. The correct fix per the [accessibility\nskill](/.agents/skills/accessibility/SKILL.md) is `aria-hidden={true}`.\n\nNo `aria-label`/i18n strings or `EuiIconTip` migrations were needed.\n\nCloses #275343\n\n## PR checklist\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"65eaa2bdec8945edb70701bc3d394cd55d8dbd57"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->