### PR TITLE
[Alertingv2] [ES|QL rule form] Rule description visible field

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.test.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OptionalFieldLabel } from './optional_field_label';
+
+describe('OptionalFieldLabel', () => {
+  it('renders the optional label with consistent styling', () => {
+    render(<>{OptionalFieldLabel}</>);
+
+    expect(screen.getByTestId('form-optional-field-label')).toHaveTextContent('optional');
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.test.tsx
@@ -11,7 +11,7 @@ import { OptionalFieldLabel } from './optional_field_label';
 
 describe('OptionalFieldLabel', () => {
   it('renders the optional label with consistent styling', () => {
-    render(<>{OptionalFieldLabel}</>);
+    render(<OptionalFieldLabel />);
 
     expect(screen.getByTestId('form-optional-field-label')).toHaveTextContent('optional');
   });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-export const OptionalFieldLabel = (
+export const OptionalFieldLabel: React.FC = () => (
   <EuiText color="subdued" size="xs" data-test-subj="form-optional-field-label">
     {i18n.translate('xpack.alertingV2.ruleForm.optionalFieldLabel', {
       defaultMessage: 'optional',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/optional_field_label.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export const OptionalFieldLabel = (
+  <EuiText color="subdued" size="xs" data-test-subj="form-optional-field-label">
+    {i18n.translate('xpack.alertingV2.ruleForm.optionalFieldLabel', {
+      defaultMessage: 'optional',
+    })}
+  </EuiText>
+);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/related_dashboard_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/related_dashboard_selector.tsx
@@ -28,6 +28,7 @@ import type { DashboardStart } from '@kbn/dashboard-plugin/public';
 import { useDebounceFn } from '@kbn/react-hooks';
 import { useController, useFormContext } from 'react-hook-form';
 import { useRuleFormServices } from '../contexts';
+import { OptionalFieldLabel } from '../components/optional_field_label';
 import type { FormValues } from '../types';
 import {
   resolveDashboardsByIds,
@@ -332,14 +333,7 @@ export const RelatedDashboardSelector: React.FC = () => {
           </span>
         }
         fullWidth
-        labelAppend={
-          <EuiText size="xs">
-            <FormattedMessage
-              id="xpack.alertingV2.ruleForm.artifactFieldOptional"
-              defaultMessage="optional"
-            />
-          </EuiText>
-        }
+        labelAppend={OptionalFieldLabel}
       >
         <RelatedDashboardsComboBox
           dashboard={dashboard}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/related_dashboard_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/related_dashboard_selector.tsx
@@ -333,7 +333,7 @@ export const RelatedDashboardSelector: React.FC = () => {
           </span>
         }
         fullWidth
-        labelAppend={OptionalFieldLabel}
+        labelAppend={<OptionalFieldLabel />}
       >
         <RelatedDashboardsComboBox
           dashboard={dashboard}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
@@ -36,7 +36,7 @@ describe('RuleDetailsFieldGroup', () => {
     );
 
     expect(screen.getByText('Tags')).toBeInTheDocument();
-    expect(screen.getByText('optional')).toBeInTheDocument();
+    expect(screen.getByTestId('form-optional-field-label')).toHaveTextContent('optional');
   });
 
   it('renders the description field immediately', () => {
@@ -50,6 +50,7 @@ describe('RuleDetailsFieldGroup', () => {
 
     expect(screen.getByText('Description')).toBeInTheDocument();
     expect(screen.queryByText('Add description')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('form-optional-field-label')).toHaveLength(2);
   });
 
   it('does not render enabled or kind fields', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
@@ -36,7 +36,7 @@ describe('RuleDetailsFieldGroup', () => {
     );
 
     expect(screen.getByText('Tags')).toBeInTheDocument();
-    expect(screen.getByTestId('form-optional-field-label')).toHaveTextContent('optional');
+    expect(screen.getAllByTestId('form-optional-field-label')).toHaveLength(2);
   });
 
   it('renders the description field immediately', () => {
@@ -50,7 +50,6 @@ describe('RuleDetailsFieldGroup', () => {
 
     expect(screen.getByText('Description')).toBeInTheDocument();
     expect(screen.queryByText('Add description')).not.toBeInTheDocument();
-    expect(screen.getAllByTestId('form-optional-field-label')).toHaveLength(2);
   });
 
   it('does not render enabled or kind fields', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
@@ -38,8 +38,14 @@ describe('DescriptionField', () => {
     render(<DescriptionField />, { wrapper: createFormWrapper() });
 
     expect(
-      screen.getByPlaceholderText('Add an optional description for this rule...')
+      screen.getByPlaceholderText('Add a description for this rule...')
     ).toBeInTheDocument();
+  });
+
+  it('renders the optional field label', () => {
+    render(<DescriptionField />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('form-optional-field-label')).toHaveTextContent('optional');
   });
 
   it('updates value when user types in textarea', async () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -11,6 +11,7 @@ import { EuiFormRow, EuiTextArea } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
+import { OptionalFieldLabel } from '../components/optional_field_label';
 
 const DESCRIPTION_ROW_ID = 'ruleV2FormDescriptionField';
 
@@ -28,6 +29,7 @@ export const DescriptionField = () => {
           label={i18n.translate('xpack.alertingV2.ruleForm.descriptionLabel', {
             defaultMessage: 'Description',
           })}
+          labelAppend={OptionalFieldLabel}
           fullWidth
           isInvalid={!!error}
           error={error?.message}
@@ -40,7 +42,7 @@ export const DescriptionField = () => {
             isInvalid={!!error}
             compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.descriptionPlaceholder', {
-              defaultMessage: 'Add an optional description for this rule...',
+              defaultMessage: 'Add a description for this rule...',
             })}
             data-test-subj="ruleDescriptionInput"
           />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -29,7 +29,7 @@ export const DescriptionField = () => {
           label={i18n.translate('xpack.alertingV2.ruleForm.descriptionLabel', {
             defaultMessage: 'Description',
           })}
-          labelAppend={OptionalFieldLabel}
+          labelAppend={<OptionalFieldLabel />}
           fullWidth
           isInvalid={!!error}
           error={error?.message}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
@@ -12,6 +12,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { MAX_TAG_LENGTH } from '@kbn/alerting-v2-constants';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
+import { OptionalFieldLabel } from '../components/optional_field_label';
 
 export const TagsField = () => {
   const { control } = useFormContext<FormValues>();
@@ -41,9 +42,7 @@ export const TagsField = () => {
             label={i18n.translate('xpack.alertingV2.ruleForm.tagsLabel', {
               defaultMessage: 'Tags',
             })}
-            labelAppend={i18n.translate('xpack.alertingV2.ruleForm.tagsOptional', {
-              defaultMessage: 'optional',
-            })}
+            labelAppend={OptionalFieldLabel}
             isInvalid={!!error}
             error={error?.message}
             fullWidth

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
@@ -42,7 +42,7 @@ export const TagsField = () => {
             label={i18n.translate('xpack.alertingV2.ruleForm.tagsLabel', {
               defaultMessage: 'Tags',
             })}
-            labelAppend={OptionalFieldLabel}
+            labelAppend={<OptionalFieldLabel />}
             isInvalid={!!error}
             error={error?.message}
             fullWidth


### PR DESCRIPTION
Closes [rna-539](https://github.com/elastic/rna-program/issues/539) in the Alerting v2 compose-discover flyout.

- Adds an optional label to the Description field (matching Tags and Related dashboards)
- Updates the description placeholder to remove redundant "optional" text (Add a description for this rule...)
- Introduces a shared OptionalFieldLabel component in @kbn/alerting-v2-rule-form for consistent optional-label styling across Tags, Description, and Related dashboards
- Fixes a React rendering issue where reusing a single pre-built element for labelAppend caused the optional label to only appear on the first field (Tags), not Description
