### PR TITLE
[CI] remove sparse checkout plugin from security-solution-quality-gate pipelines

### DIFF
--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-ai4dsoc.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-ai4dsoc.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
@@ -17,11 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
-            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/275796 introduced sparse checkout plugin for every yaml-upload kind of pipeline.

It seems the plugin is having issues when triggered from a pipeline external to `elastic/kibana` or maybe it's the specific sha target set. For now, let's just revert this change, and investigate later.