### PR TITLE
[Security Solution][Entity Analytics] Fix entity attachment crash on single-value keyword fields

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.test.ts
@@ -132,4 +132,33 @@ describe('useEntityForAttachment', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  // Elasticsearch serialises a single-value `keyword` field as a bare string,
+  // so an entity in exactly one watchlist comes back as a string, not an array.
+  // Before the fix this reached `WatchlistsCell.map(...)` and crashed the UI.
+  it('normalises a single-string watchlists value into a one-element array', async () => {
+    mockFetch.mockResolvedValue({
+      records: [
+        {
+          entity: {
+            id: 'host:server1',
+            name: 'server1',
+            attributes: { watchlists: '4be6078f-d987-471d-bd8f-41dd280437fb' },
+          },
+        },
+      ],
+    });
+
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'host',
+      identifier: 'server1',
+    };
+
+    const { result } = renderHook(() => useEntityForAttachment(identifier), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.isEntityInStore).toBe(true));
+    expect(result.current.data?.watchlistIds).toEqual(['4be6078f-d987-471d-bd8f-41dd280437fb']);
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.ts
@@ -11,6 +11,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useQuery } from '@kbn/react-query';
 import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/common';
 import { EntityType } from '../../../../common/entity_analytics/types';
+import { normalizeMultiValueField } from '../normalize_multi_value_field';
 import type { CriticalityLevelWithUnassigned } from '../../../../common/entity_analytics/asset_criticality/types';
 import type { RiskSeverity, RiskStats } from '../../../../common/search_strategy';
 import type { EntityAttachmentIdentifier } from './types';
@@ -63,7 +64,13 @@ interface EntityRecordShape {
      * downstream.
      */
     source?: string | string[];
-    attributes?: { watchlists?: string[] };
+    /**
+     * `entity.attributes.watchlists` is a `keyword` field. Elasticsearch only
+     * serialiZes it as an array when the document has multiple values; a single
+     * watchlist membership comes back as a bare string. Accept either shape and
+     * normaliZe downstream via `normalizeMultiValueField`.
+     */
+    attributes?: { watchlists?: string | string[] };
     lifecycle?: { first_seen?: string; last_activity?: string };
     risk?: Partial<RiskStats> & {
       calculated_level?: string;
@@ -157,12 +164,7 @@ const shapeRecord = (
       } as RiskStats)
     : undefined;
 
-  const rawSource = entityField?.source;
-  const sources = Array.isArray(rawSource)
-    ? rawSource.filter((s): s is string => typeof s === 'string' && s.length > 0)
-    : typeof rawSource === 'string' && rawSource.length > 0
-    ? [rawSource]
-    : [];
+  const sources = normalizeMultiValueField(entityField?.source);
 
   return {
     entityType: toEntityType(identifier.identifierType),
@@ -176,7 +178,7 @@ const shapeRecord = (
     riskLevel,
     riskStats,
     assetCriticality,
-    watchlistIds: entityField?.attributes?.watchlists?.slice() ?? [],
+    watchlistIds: normalizeMultiValueField(entityField?.attributes?.watchlists),
     sources,
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.test.tsx
@@ -84,6 +84,41 @@ describe('EntityListTable', () => {
     expect(screen.getByText('bob')).toBeInTheDocument();
   });
 
+  describe('Source column', () => {
+    // `entity.source` is a `keyword` field: Elasticsearch returns a bare string
+    // for a single value and an array only for multiple. Before normalization a
+    // single-value source would flow into the badge list as a raw string and
+    // could crash the render, so cover both shapes here.
+    it('renders a single data source when entity.source is a bare string', () => {
+      renderTable([
+        {
+          entity_type: 'host',
+          entity_id: 'host:web-01@default',
+          entity_name: 'web-01',
+          source: 'crowdstrike',
+        },
+      ]);
+
+      expect(screen.getByText('Crowdstrike')).toBeInTheDocument();
+      // Only one value, so no `+N` overflow badge.
+      expect(screen.queryByText('+1')).not.toBeInTheDocument();
+    });
+
+    it('renders the first data source inline and collapses the rest into an overflow badge when entity.source is an array', () => {
+      renderTable([
+        {
+          entity_type: 'host',
+          entity_id: 'host:web-01@default',
+          entity_name: 'web-01',
+          source: ['crowdstrike', 'island_browser'],
+        },
+      ]);
+
+      expect(screen.getByText('Crowdstrike')).toBeInTheDocument();
+      expect(screen.getByText('+1')).toBeInTheDocument();
+    });
+  });
+
   describe('Name-column Open entity in Entity Analytics button', () => {
     it('opens the flyout with the HostPanelKey payload for host rows with an entity id', () => {
       const { application } = renderTable([

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
@@ -31,6 +31,7 @@ import { RiskScoreLevel } from '../../entity_analytics/components/severity/commo
 import { EntityIconByType } from '../../entity_analytics/components/entity_store/helpers';
 import { TruncatedBadgeList } from '../../flyout/entity_details/shared/components/entity_source_value';
 import { formatEntitySource } from './entity_attachment/entity_table/entity_data_source_utils';
+import { normalizeMultiValueField } from './normalize_multi_value_field';
 
 export interface EntityListRow {
   entity_type: 'host' | 'user' | 'service' | 'generic';
@@ -75,23 +76,6 @@ const OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA = i18n.translate(
   'xpack.securitySolution.agentBuilder.entityListAttachment.openEntityInEntityAnalyticsAria',
   { defaultMessage: 'Open entity in Entity Analytics' }
 );
-
-/**
- * Coerce the `source` column value into the multi-value string array shape of
- * `entity.source`. Rows from the entity store project `entity.source` as
- * either a single string (legacy) or an array of strings. We accept either
- * and drop anything non-string so the badge renderer only has to deal with
- * `string[]`.
- */
-const normalizeEntitySources = (source: unknown): string[] => {
-  if (typeof source === 'string') {
-    return source ? [source] : [];
-  }
-  if (Array.isArray(source)) {
-    return source.filter((v): v is string => typeof v === 'string' && v.length > 0);
-  }
-  return [];
-};
 
 const NAME_COLUMN_WIDTH = '260px';
 
@@ -249,7 +233,7 @@ export const EntityListTable: React.FC<{
         ),
         width: '140px',
         render: (source: unknown) => {
-          const list = normalizeEntitySources(source);
+          const list = normalizeMultiValueField(source);
           if (list.length === 0) {
             return getEmptyTagValue();
           }

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/normalize_multi_value_field.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/normalize_multi_value_field.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { normalizeMultiValueField } from './normalize_multi_value_field';
+
+describe('normalizeMultiValueField', () => {
+  it('wraps a single non-empty string in a one-element array', () => {
+    expect(normalizeMultiValueField('one')).toEqual(['one']);
+  });
+
+  it('returns a filtered copy of an array of strings', () => {
+    expect(normalizeMultiValueField(['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('drops empty strings and non-string entries from an array', () => {
+    expect(normalizeMultiValueField(['a', '', null, 1, undefined, 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(normalizeMultiValueField('')).toEqual([]);
+  });
+
+  it('returns an empty array for null or undefined', () => {
+    expect(normalizeMultiValueField(undefined)).toEqual([]);
+    expect(normalizeMultiValueField(null)).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/normalize_multi_value_field.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/normalize_multi_value_field.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Returns the values of a multi-value entity-store attribute as a list.
+ *
+ * Some entity attributes are conceptually collections: an entity can be seen in
+ * several data sources and can belong to several watchlists. Callers always
+ * want to work with these as a list, regardless of whether the entity currently
+ * has none, one, or many values — so this is the single place that guarantees a
+ * clean `string[]` for any such attribute.
+ *
+ * (Implementation note: Elasticsearch serializes these attributes as a bare
+ * string when the entity has a single value and as an array only when it has
+ * multiple. Reading one without normalizing here risks a `.map is not a
+ * function` crash on the single-value case.)
+ */
+export const normalizeMultiValueField = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string' && v.length > 0)
+    : typeof value === 'string' && value.length > 0
+    ? [value]
+    : [];


### PR DESCRIPTION
## Summary

Solves: https://github.com/elastic/kibana/issues/276185

## Changes

- Extract the single-vs-array normalization into a shared helper,  `normalizeMultiValueField`, documented in domain terms (some entity-store attributes are conceptually collections; always return them as a clean list).
- Route all three call sites through it: `watchlists` and `sources` in `use_entity_for_attachment.ts`, and `source` in `entity_list_table.tsx` (removing the duplicated `normalizeEntitySources`).
- Correct the `EntityRecordShape` type so `watchlists` is `string | string[]`,
  matching how ES actually serializes the field.

## Testing
- New unit tests for `normalizeMultiValueField` (single string, array, empty/non-string filtering, empty string, null/undefined).
- New hook-level regression test: a single-string `watchlists` value normalizes to a one-element array (the exact crash repro from the issue).
- New `Source column` tests for the entity list table covering the single-string
  and array shapes (this column previously had no coverage).

## How to test
1. Enable Agent Builder + the watchlists feature flag; ensure the entity store is on with at least one host entity.
2. Add the host to **exactly one** watchlist (single-value keyword case).
3. In Agent Builder, attach that host entity to a conversation and open it.
4. **Before (Bug):** UI crashes with `t.map is not a function`. **After (expected):** the entity card renders and the Watchlists row shows the single watchlist.
5. **Regression check:** repeat with zero and with multiple watchlists — both render correctly (empty placeholder / `+N` overflow).

## Notes
- A near-identical `toEntitySourceArray` exists in the entity details flyout (`entity_source_value.tsx`) with slightly different behavior. It's out of scope here but is a follow-up candidate for a single shared normalizer.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->