### PR TITLE
[8.19] [ML] [9.3] Adding size limits to file upload and index_exists endpoints (#274566)

### DIFF
--- a/x-pack/platform/packages/shared/file-upload-common/src/constants.ts
+++ b/x-pack/platform/packages/shared/file-upload-common/src/constants.ts
@@ -22,6 +22,8 @@ export const MAX_FILE_SIZE_BYTES = 524288000; // 500MB
 export const ABSOLUTE_MAX_FILE_SIZE_BYTES = 1073741274; // 1GB
 export const FILE_SIZE_DISPLAY_FORMAT = '0,0.[0] b';
 export const MAX_TIKA_FILE_SIZE_BYTES = 62914560; // 60MB
+export const INITIALIZE_IMPORT_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
+export const MAX_FILE_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
 
 export const NO_TIME_FORMAT = 'null';
 export const MB = Math.pow(2, 20);

--- a/x-pack/platform/plugins/private/file_upload/server/routes.ts
+++ b/x-pack/platform/plugins/private/file_upload/server/routes.ts
@@ -8,7 +8,8 @@
 import { schema } from '@kbn/config-schema';
 import type { CoreSetup, Logger } from '@kbn/core/server';
 import {
-  MAX_FILE_SIZE_BYTES,
+  INITIALIZE_IMPORT_SIZE_BYTES,
+  MAX_FILE_UPLOAD_SIZE_BYTES,
   MAX_TIKA_FILE_SIZE_BYTES,
 } from '@kbn/file-upload-common/src/constants';
 import { wrapError } from './error_wrapper';
@@ -102,7 +103,7 @@ export function fileUploadRoutes(coreSetup: CoreSetup<StartDeps, unknown>, logge
       options: {
         body: {
           accepts: ['text/*', 'application/json'],
-          maxBytes: MAX_FILE_SIZE_BYTES,
+          maxBytes: MAX_FILE_UPLOAD_SIZE_BYTES,
         },
       },
     })
@@ -143,7 +144,7 @@ export function fileUploadRoutes(coreSetup: CoreSetup<StartDeps, unknown>, logge
       options: {
         body: {
           accepts: ['application/json'],
-          maxBytes: MAX_FILE_SIZE_BYTES,
+          maxBytes: INITIALIZE_IMPORT_SIZE_BYTES,
         },
       },
     })
@@ -202,7 +203,7 @@ export function fileUploadRoutes(coreSetup: CoreSetup<StartDeps, unknown>, logge
       options: {
         body: {
           accepts: ['application/json'],
-          maxBytes: MAX_FILE_SIZE_BYTES,
+          maxBytes: MAX_FILE_UPLOAD_SIZE_BYTES,
         },
       },
     })

--- a/x-pack/platform/plugins/shared/ml/server/routes/system.ts
+++ b/x-pack/platform/plugins/shared/ml/server/routes/system.ts
@@ -264,7 +264,11 @@ export function systemRoutes(
       {
         version: '1',
         validate: {
-          request: { body: schema.object({ indices: schema.arrayOf(schema.string()) }) },
+          request: {
+            body: schema.object({
+              indices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 100 }),
+            }),
+          },
         },
       },
       routeGuard.basicLicenseAPIGuard(async ({ client, request, response }) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.3` to `8.19`:
 - [[ML] [9.3] Adding size limits to file upload and index_exists endpoints (#274566)](https://github.com/elastic/kibana/pull/274566)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"James Gowdy","email":"jgowdy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-03T10:38:29Z","message":"[ML] [9.3] Adding size limits to file upload and index_exists endpoints (#274566)\n\nManual backport of https://github.com/elastic/kibana/pull/267954 and a\nsmall part of https://github.com/elastic/kibana/pull/274342\n\nReduces `maxBytes` for the file upload endpoints.\n`/internal/file_upload/analyze_file` and `/internal/file_upload/import`\nreduced to 100MB\n`/internal/file_upload/initialize_import` reduced to 20MB\n\nUpdates the size limits for `/internal/ml/index_exists` to only allow an\narray of 100 indices. and a character limit of 1000 chars.","sha":"09e5c54f81c1bb1af567fb0b26468172fa45f313","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","v9.3.7","v8.19.18"],"title":"[ML] [9.3] Adding size limits to file upload and index_exists endpoints","number":274566,"url":"https://github.com/elastic/kibana/pull/274566","mergeCommit":{"message":"[ML] [9.3] Adding size limits to file upload and index_exists endpoints (#274566)\n\nManual backport of https://github.com/elastic/kibana/pull/267954 and a\nsmall part of https://github.com/elastic/kibana/pull/274342\n\nReduces `maxBytes` for the file upload endpoints.\n`/internal/file_upload/analyze_file` and `/internal/file_upload/import`\nreduced to 100MB\n`/internal/file_upload/initialize_import` reduced to 20MB\n\nUpdates the size limits for `/internal/ml/index_exists` to only allow an\narray of 100 indices. and a character limit of 1000 chars.","sha":"09e5c54f81c1bb1af567fb0b26468172fa45f313"}},"sourceBranch":"9.3","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274566","number":274566,"mergeCommit":{"message":"[ML] [9.3] Adding size limits to file upload and index_exists endpoints (#274566)\n\nManual backport of https://github.com/elastic/kibana/pull/267954 and a\nsmall part of https://github.com/elastic/kibana/pull/274342\n\nReduces `maxBytes` for the file upload endpoints.\n`/internal/file_upload/analyze_file` and `/internal/file_upload/import`\nreduced to 100MB\n`/internal/file_upload/initialize_import` reduced to 20MB\n\nUpdates the size limits for `/internal/ml/index_exists` to only allow an\narray of 100 indices. and a character limit of 1000 chars.","sha":"09e5c54f81c1bb1af567fb0b26468172fa45f313"}},{"branch":"8.19","label":"v8.19.18","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->