### PR TITLE
[Fleet] Hide Settings tab for OpAMP collectors

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.test.tsx
@@ -127,6 +127,18 @@ describe('AgentDetailsPage', () => {
     expect(result.queryByText('Diagnostics')).not.toBeNull();
   });
 
+  it('should not show Settings tab for OPAMP collector', async () => {
+    setupMocks({ agent: mockAgent({ type: 'OPAMP' }), enableOtelUI: true });
+    const result = await render();
+    expect(result.queryByText('Settings')).toBeNull();
+  });
+
+  it('should show Settings tab for non-collector agents', async () => {
+    setupMocks({ agent: mockAgent({ type: 'PERMANENT' }), enableOtelUI: true });
+    const result = await render();
+    expect(result.queryByText('Settings')).not.toBeNull();
+  });
+
   it('should render AgentDetailsContent for non-OPAMP agent', async () => {
     setupMocks({ agent: mockAgent({ type: 'PERMANENT' }), enableOtelUI: true });
     const result = await render();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -253,14 +253,18 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
             },
           ]
         : []),
-      {
-        id: 'settings',
-        name: i18n.translate('xpack.fleet.agentDetails.subTabs.settingsTab', {
-          defaultMessage: 'Settings',
-        }),
-        href: getHref('agent_details_settings', { agentId, tabId: 'settings' }),
-        isSelected: tabId === 'settings',
-      },
+      ...(!isCollector
+        ? [
+            {
+              id: 'settings',
+              name: i18n.translate('xpack.fleet.agentDetails.subTabs.settingsTab', {
+                defaultMessage: 'Settings',
+              }),
+              href: getHref('agent_details_settings', { agentId, tabId: 'settings' }),
+              isSelected: tabId === 'settings',
+            },
+          ]
+        : []),
     ];
   }, [getHref, agentId, tabId, isCollector]);
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -371,12 +371,14 @@ const AgentDetailsPageContent: React.FunctionComponent<{
           }}
         />
       )}
-      <Route
-        path={FLEET_ROUTING_PATHS.agent_details_settings}
-        render={() => {
-          return <AgentSettings agent={agent} agentPolicy={agentPolicy} />;
-        }}
-      />
+      {!isCollector && (
+        <Route
+          path={FLEET_ROUTING_PATHS.agent_details_settings}
+          render={() => {
+            return <AgentSettings agent={agent} agentPolicy={agentPolicy} />;
+          }}
+        />
+      )}
       <Route
         path={FLEET_ROUTING_PATHS.agent_details}
         render={() => {


### PR DESCRIPTION
## Summary

Fixes #273506.

The **Settings** tab on the agent details page contains only the **Agent Logging Level** selector, which is not supported for OTel (OpAMP) collectors. The tab was unconditionally rendered for all agent types.

The fix hides the Settings tab for OpAMP collectors when the OTel UI feature flag is on, using the same `!isCollector` spread pattern already applied to the **Diagnostics** tab.

### Change

**`agent_details_page/index.tsx`** — wrap the Settings tab entry in `!isCollector ? [...] : []`, mirroring the Diagnostics tab:

```ts
// before
{
  id: 'settings',
  ...
},

// after
...(!isCollector
  ? [{ id: 'settings', ... }]
  : []),
```

### Tests

Added two tests to `index.test.tsx` (matching the existing Diagnostics tab test pair):
- `should not show Settings tab for OPAMP collector`
- `should show Settings tab for non-collector agents`

All 21 tests pass.

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Collector:
<img width="1726" height="644" alt="image" src="https://github.com/user-attachments/assets/12456e5e-7f62-42dc-810f-a450732296a7" />

Elastic Agent:
<img width="1719" height="376" alt="image" src="https://github.com/user-attachments/assets/23e4d15c-2eb5-426b-9070-9ccc50a94df8" />
