### PR TITLE
[Alerting] Re-enable UIAM-dependent Scout alerting API suites

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/test/scout/.meta/api/standard.json
+++ b/x-pack/platform/plugins/shared/alerting/test/scout/.meta/api/standard.json
@@ -342,56 +342,56 @@
     {
       "id": "d477aadf04adbc2-d5bf7aa0c833ea4",
       "title": "API key invalidation on rule operations enable rule preserves existing API keys without invalidation",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-serverless-observability_complete",
         "@cloud-serverless-observability_complete"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/alerting/test/scout/api/tests/api_key_invalidation.spec.ts",
-        "line": 56,
+        "line": 55,
         "column": 12
       }
     },
     {
       "id": "d477aadf04adbc2-a91a1d94d723dae",
       "title": "API key invalidation on rule operations update rule rotates both apiKey and uiamApiKey",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-serverless-observability_complete",
         "@cloud-serverless-observability_complete"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/alerting/test/scout/api/tests/api_key_invalidation.spec.ts",
-        "line": 105,
+        "line": 104,
         "column": 12
       }
     },
     {
       "id": "d477aadf04adbc2-32d3d50cf3d8948",
       "title": "API key invalidation on rule operations update_api_key rotates both apiKey and uiamApiKey",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-serverless-observability_complete",
         "@cloud-serverless-observability_complete"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/alerting/test/scout/api/tests/api_key_invalidation.spec.ts",
-        "line": 171,
+        "line": 170,
         "column": 12
       }
     },
     {
       "id": "d477aadf04adbc2-7bf0ffd8af69858",
       "title": "API key invalidation on rule operations bulk enable preserves existing API keys without invalidation",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-serverless-observability_complete",
         "@cloud-serverless-observability_complete"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/alerting/test/scout/api/tests/api_key_invalidation.spec.ts",
-        "line": 230,
+        "line": 229,
         "column": 12
       }
     },

--- a/x-pack/platform/plugins/shared/alerting/test/scout/api/tests/api_key_invalidation.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout/api/tests/api_key_invalidation.spec.ts
@@ -34,8 +34,7 @@ const getAlertAttrs = async (
   return (_source as Record<string, unknown>)?.alert as Record<string, unknown>;
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/264184
-apiTest.describe.skip(
+apiTest.describe(
   'API key invalidation on rule operations',
   { tag: tags.serverless.observability.complete },
   () => {

--- a/x-pack/platform/plugins/shared/alerting/test/scout/api/tests/rules.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout/api/tests/rules.spec.ts
@@ -24,8 +24,7 @@ const INDEX_THRESHOLD_PARAMS = {
 
 const RULE_NAME = 'scout-create-rule';
 
-// Failing: See https://github.com/elastic/kibana/issues/261886
-apiTest.describe.skip('Alerting Rule', { tag: tags.serverless.observability.complete }, () => {
+apiTest.describe('Alerting Rule', { tag: tags.serverless.observability.complete }, () => {
   let createdRuleId: string;
 
   apiTest.beforeAll(async ({ apiClient, samlAuth }) => {


### PR DESCRIPTION
## Summary

Re-enable two Scout API suites in the alerting plugin that had been skipped for weeks: `Alerting Rule` (rules.spec.ts) and `API key invalidation on rule operations` (api_key_invalidation.spec.ts). The two suites were skipped for different reasons; both have since been fixed in `main`.

## rules.spec.ts — #261885, #261886, #261887

Historical failure signatures (`uiamApiKey` undefined on the alert SO / only the ES key queued for invalidation on rotation) are consistent with UIAM grant being rejected upstream. Recent QA logs from build 1480 (2026-07-01) captured the actual reason: every UIAM `_grant` call was returning

```json
{"type":"VALIDATION.REQUEST","code":"0x3196F8"}
```

`0x3196F8` maps to `TOO_MANY_INTERNAL_API_KEYS` in the UIAM `ErrorCode.java` catalog — the regional UIAM tenant had reached its 100k internal-API-key quota. Kibana swallows the grant failure at `RulesClientFactory.createUiamApiKey`, so the rule saved object was written without a `uiamApiKey` field and the suite's assertions failed deterministically.

**Fix:** The accumulated internal API keys have been pruned on the QA region and the UIAM team is following up on a longer-term retention policy so this does not recur silently.

## api_key_invalidation.spec.ts — #264184, #264241

This suite went through two distinct failure modes:

1. **`Expected length: 2 / Received length: 4`** (2026-04-08 → 2026-04-22): the rule's first scheduled run raced with `_update_api_key`; the resulting 409 caused `retryIfConflicts` to orphan a set of pre-retry keys, doubling the `api_key_pending_invalidation` count. **Fixed on 2026-04-29 by #265852** — schedule bumped to `1h`; rotation gated on `waitForSuccessfulEventLogEntry`.
2. **`Rule <id> did not execute successfully within 30s`** (2026-04-29 → 2026-05-05): the polling helper's 30s ceiling (15 × 2s) was too tight for serverless task-claim + event-log write latency. **Fixed on 2026-06-17 by #273036** — added `_run_soon` immediately after capturing `dateStart`, raised `maxAttempts` from 15 → 60 (~120s), exactly what the 2026-05-05 automated flakiness investigation had proposed.

Both fixes have been live in `main` since 2026-06-17 and no fresh failures have been reported on #264184 since. #273036 un-skipped `rules.spec.ts` as part of the same change but left this suite skipped — reads as an oversight, since the polling helper fix is what unblocks this suite.

## Risks

- **UIAM quota shared risk.** If the region hits the 100k internal-key ceiling again, any UIAM-dependent test will fail. Retention policy work is in flight with the UIAM team.
- **`_run_soon` vs SO-write race.** The polling helper considers the run finished when an `event.action: 'execute'` entry lands in `.kibana-event-log-*`; that happens after the task's post-execution SO write, following the same pattern FTR uses. No evidence of a race in practice.

Closes #261885
Closes #261886
Closes #261887
Closes #264184
Closes #264241

## Test plan

- [ ] Buildkite Scout run on `cloud-serverless-observability_complete` executes both suites without the UIAM `_grant` failure and without polling-helper timeouts.
- [ ] Manifest regeneration is limited to the alerting Scout config; no unrelated meta files are touched.