### PR TITLE
[9.3] Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33168,9 +33168,9 @@ undici@6.27.0, undici@^6.21.1, undici@^6.21.2:
   integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 undici@^7.19.1:
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.4.tgz#873bce680d7c6354c941399fd4e8ea4563de4ea7"
-  integrity sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)](https://github.com/elastic/kibana/pull/276165)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-03T09:38:46Z","message":"Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)\n\n## Summary\n\nRe-locks the transitive `undici` v6.x dependency from `6.24.1` to\n`6.27.0` (latest in the 6.x line). No resolution override was needed —\nboth consumers already declare compatible ranges:\n\n- `@elastic/opamp-client-node@0.5.0` → `undici \"^6.21.2\"`\n- `@elastic/transport@8.9.6` → `undici \"^6.21.1\"`\n\n`6.27.0` satisfies both. The lock file entry was updated to point at the\ncorrect tarball and integrity hash.\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` completes cleanly\n- [ ] CI green (no runtime changes; only lock file updated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"61beccc270a744711963d1528c0b3839afcc5735","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0","v9.4.4"],"title":"Bump undici v6.x from 6.24.1 to 6.27.0","number":276165,"url":"https://github.com/elastic/kibana/pull/276165","mergeCommit":{"message":"Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)\n\n## Summary\n\nRe-locks the transitive `undici` v6.x dependency from `6.24.1` to\n`6.27.0` (latest in the 6.x line). No resolution override was needed —\nboth consumers already declare compatible ranges:\n\n- `@elastic/opamp-client-node@0.5.0` → `undici \"^6.21.2\"`\n- `@elastic/transport@8.9.6` → `undici \"^6.21.1\"`\n\n`6.27.0` satisfies both. The lock file entry was updated to point at the\ncorrect tarball and integrity hash.\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` completes cleanly\n- [ ] CI green (no runtime changes; only lock file updated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"61beccc270a744711963d1528c0b3839afcc5735"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276165","number":276165,"mergeCommit":{"message":"Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)\n\n## Summary\n\nRe-locks the transitive `undici` v6.x dependency from `6.24.1` to\n`6.27.0` (latest in the 6.x line). No resolution override was needed —\nboth consumers already declare compatible ranges:\n\n- `@elastic/opamp-client-node@0.5.0` → `undici \"^6.21.2\"`\n- `@elastic/transport@8.9.6` → `undici \"^6.21.1\"`\n\n`6.27.0` satisfies both. The lock file entry was updated to point at the\ncorrect tarball and integrity hash.\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` completes cleanly\n- [ ] CI green (no runtime changes; only lock file updated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"61beccc270a744711963d1528c0b3839afcc5735"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276181","number":276181,"state":"MERGED","mergeCommit":{"sha":"6017ae4d9a1dcfb384388912bf6c3bf3eb16034a","message":"[9.4] Bump undici v6.x from 6.24.1 to 6.27.0 (#276165) (#276181)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Bump undici v6.x from 6.24.1 to 6.27.0\n(#276165)](https://github.com/elastic/kibana/pull/276165)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"}}]}] BACKPORT-->