### PR TITLE
[8.19] Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31998,10 +31998,15 @@ undici-types@~6.21.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-undici@6.24.1, undici@^6.21.1, undici@^6.21.2:
+undici@6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
   integrity sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==
+
+undici@^6.21.1, undici@^6.21.2:
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)](https://github.com/elastic/kibana/pull/276165)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-03T09:38:46Z","message":"Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)\n\n## Summary\n\nRe-locks the transitive `undici` v6.x dependency from `6.24.1` to\n`6.27.0` (latest in the 6.x line). No resolution override was needed —\nboth consumers already declare compatible ranges:\n\n- `@elastic/opamp-client-node@0.5.0` → `undici \"^6.21.2\"`\n- `@elastic/transport@8.9.6` → `undici \"^6.21.1\"`\n\n`6.27.0` satisfies both. The lock file entry was updated to point at the\ncorrect tarball and integrity hash.\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` completes cleanly\n- [ ] CI green (no runtime changes; only lock file updated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"61beccc270a744711963d1528c0b3839afcc5735","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0","v9.4.4"],"title":"Bump undici v6.x from 6.24.1 to 6.27.0","number":276165,"url":"https://github.com/elastic/kibana/pull/276165","mergeCommit":{"message":"Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)\n\n## Summary\n\nRe-locks the transitive `undici` v6.x dependency from `6.24.1` to\n`6.27.0` (latest in the 6.x line). No resolution override was needed —\nboth consumers already declare compatible ranges:\n\n- `@elastic/opamp-client-node@0.5.0` → `undici \"^6.21.2\"`\n- `@elastic/transport@8.9.6` → `undici \"^6.21.1\"`\n\n`6.27.0` satisfies both. The lock file entry was updated to point at the\ncorrect tarball and integrity hash.\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` completes cleanly\n- [ ] CI green (no runtime changes; only lock file updated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"61beccc270a744711963d1528c0b3839afcc5735"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276165","number":276165,"mergeCommit":{"message":"Bump undici v6.x from 6.24.1 to 6.27.0 (#276165)\n\n## Summary\n\nRe-locks the transitive `undici` v6.x dependency from `6.24.1` to\n`6.27.0` (latest in the 6.x line). No resolution override was needed —\nboth consumers already declare compatible ranges:\n\n- `@elastic/opamp-client-node@0.5.0` → `undici \"^6.21.2\"`\n- `@elastic/transport@8.9.6` → `undici \"^6.21.1\"`\n\n`6.27.0` satisfies both. The lock file entry was updated to point at the\ncorrect tarball and integrity hash.\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` completes cleanly\n- [ ] CI green (no runtime changes; only lock file updated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"61beccc270a744711963d1528c0b3839afcc5735"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276181","number":276181,"state":"MERGED","mergeCommit":{"sha":"6017ae4d9a1dcfb384388912bf6c3bf3eb16034a","message":"[9.4] Bump undici v6.x from 6.24.1 to 6.27.0 (#276165) (#276181)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Bump undici v6.x from 6.24.1 to 6.27.0\n(#276165)](https://github.com/elastic/kibana/pull/276165)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"}},{"url":"https://github.com/elastic/kibana/pull/276224","number":276224,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->