### PR TITLE
[Console] Fix autocomplete matching incorrect endpoint for competing URL patterns

### DIFF
--- a/src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts
@@ -13,6 +13,7 @@ import type {
   AutocompleteComponent,
   AutocompleteTermDefinition,
 } from './components/autocomplete_component';
+import { ConstantComponent } from './components/constant_component';
 import type { AutoCompleteContext, ResultTerm } from './types';
 import { asArray } from '../utils/array_utils';
 
@@ -70,19 +71,26 @@ export class WalkingState {
   contextExtensionList: Array<Record<string, unknown>>;
   depth: number;
   priority: number | undefined;
+  // Number of path segments matched literally (via a ConstantComponent). Used to
+  // prefer the most specific endpoint when several patterns match the same path,
+  // e.g. `_connector/_sync_job` should match the literal `_sync_job` endpoint
+  // rather than the `_connector/{connector_id}` parameter endpoint.
+  specificity: number;
 
   constructor(
     parentName: string | undefined,
     components: AutocompleteComponent[],
     contextExtensionList: Array<Record<string, unknown>>,
     depth?: number,
-    priority?: number
+    priority?: number,
+    specificity?: number
   ) {
     this.parentName = parentName;
     this.components = components;
     this.contextExtensionList = contextExtensionList;
     this.depth = depth || 0;
     this.priority = priority;
+    this.specificity = specificity || 0;
   }
 }
 
@@ -129,8 +137,10 @@ export function walkTokenPath(
           }
         }
 
+        const specificity = ws.specificity + (component instanceof ConstantComponent ? 1 : 0);
+
         nextWalkingStates.push(
-          new WalkingState(component.name, next, extensionList, ws.depth + 1, priority)
+          new WalkingState(component.name, next, extensionList, ws.depth + 1, priority, specificity)
         );
       }
     });
@@ -184,9 +194,13 @@ export function populateContext(
   // apply what values were set so far to context, selecting the deepest on which sets the context
   if (walkStates.length !== 0) {
     let wsToUse;
-    walkStates = _.sortBy(walkStates, function (ws) {
-      return _.isNumber(ws.priority) ? ws.priority : Number.MAX_VALUE;
-    });
+    // Sort by explicit priority first (lower wins), then prefer the most specific
+    // path (more literally-matched segments) so a concrete endpoint is chosen over
+    // a competing parameter pattern regardless of endpoint registration order.
+    walkStates = _.sortBy(walkStates, [
+      (ws: WalkingState) => (_.isNumber(ws.priority) ? ws.priority : Number.MAX_VALUE),
+      (ws: WalkingState) => -ws.specificity,
+    ]);
     wsToUse = _.find(walkStates, function (ws) {
       return _.isEmpty(ws.components);
     });

--- a/src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts
@@ -25,6 +25,12 @@ declare global {
 
 type AutocompleteContext = AutoCompleteContext;
 
+interface WalkingStateOptions {
+  depth?: number;
+  priority?: number;
+  specificity?: number;
+}
+
 export function wrapComponentWithDefaults<T extends AutocompleteComponent>(
   component: T,
   defaults: Record<string, unknown>
@@ -81,16 +87,14 @@ export class WalkingState {
     parentName: string | undefined,
     components: AutocompleteComponent[],
     contextExtensionList: Array<Record<string, unknown>>,
-    depth?: number,
-    priority?: number,
-    specificity?: number
+    { depth = 0, priority, specificity = 0 }: WalkingStateOptions = {}
   ) {
     this.parentName = parentName;
     this.components = components;
     this.contextExtensionList = contextExtensionList;
-    this.depth = depth || 0;
+    this.depth = depth;
     this.priority = priority;
-    this.specificity = specificity || 0;
+    this.specificity = specificity;
   }
 }
 
@@ -140,7 +144,11 @@ export function walkTokenPath(
         const specificity = ws.specificity + (component instanceof ConstantComponent ? 1 : 0);
 
         nextWalkingStates.push(
-          new WalkingState(component.name, next, extensionList, ws.depth + 1, priority, specificity)
+          new WalkingState(component.name, next, extensionList, {
+            depth: ws.depth + 1,
+            priority,
+            specificity,
+          })
         );
       }
     });
@@ -191,7 +199,7 @@ export function populateContext(
     context.autoCompleteSet = Array.from(autoCompleteSet.values());
   }
 
-  // apply what values were set so far to context, selecting the deepest on which sets the context
+  // Apply accumulated context from the best matching state.
   if (walkStates.length !== 0) {
     let wsToUse;
     // Sort by explicit priority first (lower wins), then prefer the most specific

--- a/src/platform/plugins/shared/console/public/lib/autocomplete/url_autocomplete.test.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/url_autocomplete.test.ts
@@ -466,4 +466,72 @@ describe('Url autocomplete', () => {
       method: 'PUT',
     });
   })();
+
+  (function () {
+    // https://github.com/elastic/kibana/issues/182360
+    // When a concrete path segment (e.g. `_sync_job`) also matches a sibling
+    // parameter pattern (e.g. `{connector_id}`), the endpoint whose pattern
+    // matches literally must win, regardless of endpoint registration order.
+    const paramFirst: EndpointsById = {
+      'connector.get': {
+        patterns: ['_connector/{connector_id}'],
+        methods: ['GET'],
+      },
+      'connector.sync_job_list': {
+        patterns: ['_connector/_sync_job'],
+        methods: ['GET'],
+      },
+    };
+    patternsTest(
+      'Competing endpoints - literal wins over param (param registered first)',
+      paramFirst,
+      '_connector/_sync_job$',
+      { method: 'GET', endpoint: 'connector.sync_job_list' }
+    );
+
+    const literalFirst: EndpointsById = {
+      'connector.sync_job_list': {
+        patterns: ['_connector/_sync_job'],
+        methods: ['GET'],
+      },
+      'connector.get': {
+        patterns: ['_connector/{connector_id}'],
+        methods: ['GET'],
+      },
+    };
+    patternsTest(
+      'Competing endpoints - literal wins over param (literal registered first)',
+      literalFirst,
+      '_connector/_sync_job$',
+      { method: 'GET', endpoint: 'connector.sync_job_list' }
+    );
+
+    // A genuine parameter value must still resolve to the param endpoint.
+    patternsTest(
+      'Competing endpoints - param still matches non-literal value',
+      paramFirst,
+      '_connector/some_id$',
+      { method: 'GET', endpoint: 'connector.get', connector_id: 'some_id' }
+    );
+
+    // Explicit priority remains the primary key: it wins even when the
+    // literal-segment specificity would favor the other endpoint.
+    const paramWithPriority: EndpointsById = {
+      'connector.get': {
+        patterns: ['_connector/{connector_id}'],
+        methods: ['GET'],
+        priority: 0,
+      },
+      'connector.sync_job_list': {
+        patterns: ['_connector/_sync_job'],
+        methods: ['GET'],
+      },
+    };
+    patternsTest(
+      'Competing endpoints - explicit priority beats specificity',
+      paramWithPriority,
+      '_connector/_sync_job$',
+      { method: 'GET', endpoint: 'connector.get', connector_id: '_sync_job' }
+    );
+  })();
 });


### PR DESCRIPTION
## Summary

Closes #182360

In Dev Tools Console, the autocomplete engine could match the **wrong** API endpoint when a typed URL matched both a literal endpoint and a sibling parameterized one. For example, typing `GET _connector/_sync_job` resolved to `connector.get` (pattern `_connector/{connector_id}`, treating `_sync_job` as a `{connector_id}` value) instead of `connector.sync_job_list` (pattern `_connector/_sync_job`).

### Reproduction

1. Open Dev Tools Console.
2. Type `GET _connector/_sync_job?`.
3. Trigger URL-param autocomplete.
4. On `main`, Console suggests params from `connector.get`, including `include_deleted`, because `_sync_job` is treated as `{connector_id}`.
5. On this branch, Console suggests params from `connector.sync_job_list`, including `status`, `job_type`, `from`, `size`, and `connector_id`.
### Root cause

In `populateContext` (`src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts`), when several endpoint patterns match the same path, candidates were sorted only by explicit endpoint `priority`. With no priorities set, the winner was decided by endpoint **registration order** (endpoints load lexicographically, so `connector.get` registers before `connector.sync_job_list`), making the parameter pattern win over the literal one.

### Fix

Track how many path segments each candidate matched **literally** (via `ConstantComponent`) as a `specificity` score, and use it as a tie-breaker **after** explicit `priority`. A concrete endpoint now wins over a competing parameter pattern regardless of registration order. Explicit `priority` remains the primary key, so existing priority-based behavior is unchanged.

| Before  | After |
| ------------- | ------------- |
| <img width="600" height="320" alt="console_base_bug" src="https://github.com/user-attachments/assets/bf65fac4-2f09-47ef-adb7-d50b66bad02e" /> | <img width="600" height="360" alt="console_head_fixed" src="https://github.com/user-attachments/assets/30edf112-129d-4e6b-a91b-d54c8a29c7e8" /> |

### Testing

Added regression tests in `url_autocomplete.test.ts` covering both registration orders and confirming a genuine parameter value still resolves to the parameter endpoint. `jest`, `eslint`, and `type_check` (console project) all pass.

**Live verification** (Dev Tools Console, query-param autocomplete for `GET _connector/_sync_job?`), base vs. this branch:

| | Before (base) | After (this PR) |
|---|---|---|
| Suggested URL params | `error_trace, filter_path, format, human, include_deleted, pretty` | `connector_id, error_trace, filter_path, format, from, human, job_type, pretty, size, status` |
| `include_deleted` (only on `connector.get`) | present ❌ | absent ✅ |
| `status` / `job_type` / `from` / `size` / `connector_id` (`connector.sync_job_list`) | absent ❌ | present ✅ |
| Matched endpoint | `connector.get` (wrong) | `connector.sync_job_list` (correct) |

### Release Notes

Fixed a bug in Dev Tools Console where autocomplete could match an incorrect API endpoint when a URL matched both a literal endpoint and a parameterized one (for example `GET _connector/_sync_job`).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->