### PR TITLE
[core] Track app ownership + report undeclared cross-plugin navigation

### DIFF
--- a/src/core/packages/application/browser-internal/src/application_service.tsx
+++ b/src/core/packages/application/browser-internal/src/application_service.tsx
@@ -106,6 +106,7 @@ interface AppInternalState {
  */
 export class ApplicationService {
   private readonly apps = new Map<string, App<any>>();
+  private readonly appOwners = new Map<string, PluginOpaqueId>();
   private readonly mounters = new Map<string, Mounter>();
   private readonly capabilities = new CapabilitiesService();
   private readonly appInternalStates = new Map<string, AppInternalState>();
@@ -219,6 +220,7 @@ export class ApplicationService {
           status: app.status ?? AppStatus.accessible,
           deepLinks: populateDeepLinkDefaults(appProps.deepLinks),
         });
+        this.appOwners.set(app.id, plugin);
         if (updater$) {
           registerStatusUpdater(app.id, updater$);
         }
@@ -338,6 +340,7 @@ export class ApplicationService {
       isAppRegistered: (appId: string): boolean => {
         return applications$.value.get(appId) !== undefined;
       },
+      getAppOwner: (appId: string) => this.appOwners.get(appId),
       getUrlForApp: (
         appId,
         {

--- a/src/core/packages/application/browser-internal/src/types.ts
+++ b/src/core/packages/application/browser-internal/src/types.ts
@@ -52,6 +52,15 @@ export interface InternalApplicationStart extends ApplicationStart {
   getComponent(): JSX.Element | null;
 
   /**
+   * Returns the opaque id of the plugin that registered the given application, or
+   * `undefined` if the application is unknown or was not registered by a plugin.
+   * Used by Core to attribute cross-plugin navigation to an owning plugin.
+   *
+   * @internal
+   */
+  getAppOwner(appId: string): PluginOpaqueId | undefined;
+
+  /**
    * The potential action menu set by the currently mounted app.
    * Consumed by the chrome header.
    *

--- a/src/core/packages/application/browser-mocks/src/application_service.mock.ts
+++ b/src/core/packages/application/browser-mocks/src/application_service.mock.ts
@@ -95,6 +95,7 @@ const createInternalStartContractMock = (
     currentLocation$: currentLocation$.asObservable(),
     currentActionMenu$: new BehaviorSubject<MountPoint | undefined>(undefined),
     getComponent: jest.fn(),
+    getAppOwner: jest.fn(),
     getUrlForApp: jest.fn(),
     isAppRegistered: jest.fn(),
     navigateToApp: jest.fn().mockImplementation((appId) => currentAppId$.next(appId)),

--- a/src/core/packages/plugins/browser-internal/src/nav_dependency_check.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/nav_dependency_check.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { PluginName, PluginOpaqueId } from '@kbn/core-base-common';
+import { createNavDependencyReporter } from './nav_dependency_check';
+
+describe('createNavDependencyReporter', () => {
+  // Opaque ids for the plugins that own apps in these tests.
+  const discoverOwner = Symbol('discover');
+  const transformOwner = Symbol('transform');
+  const callerOwner = Symbol('securitySolution');
+
+  const appOwners: Record<string, PluginOpaqueId> = {
+    discover: discoverOwner,
+    transform: transformOwner,
+    myOwnApp: callerOwner,
+  };
+
+  const opaqueIdToPluginId = new Map<PluginOpaqueId, PluginName>([
+    [discoverOwner, 'discover'],
+    [transformOwner, 'transform'],
+    [callerOwner, 'securitySolution'],
+  ]);
+
+  let logger: jest.Mocked<Pick<Logger, 'warn'>>;
+
+  const createReporter = () =>
+    createNavDependencyReporter({
+      getAppOwner: (appId) => appOwners[appId],
+      opaqueIdToPluginId,
+      logger: logger as unknown as Logger,
+    });
+
+  beforeEach(() => {
+    logger = { warn: jest.fn() };
+  });
+
+  it('warns when a plugin navigates to another plugin app it does not declare', () => {
+    const report = createReporter();
+
+    report('securitySolution', new Set(), 'discover');
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toContain('securitySolution');
+    expect(logger.warn.mock.calls[0][0]).toContain('discover');
+  });
+
+  it('does not warn when the owning plugin is a declared dependency', () => {
+    const report = createReporter();
+
+    report('securitySolution', new Set(['discover']), 'discover');
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when a plugin navigates within its own app', () => {
+    const report = createReporter();
+
+    report('securitySolution', new Set(), 'myOwnApp');
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('resolves the owner from a deep-link target of the form "appId:deepLinkId"', () => {
+    const report = createReporter();
+
+    report('securitySolution', new Set(), 'transform:my_deep_link');
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toContain('transform');
+  });
+
+  it('does not warn when the target app has no known owner (e.g. a Core app)', () => {
+    const report = createReporter();
+
+    report('securitySolution', new Set(), 'unknownApp');
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('reports each undeclared caller -> owner edge only once', () => {
+    const report = createReporter();
+
+    report('securitySolution', new Set(), 'discover');
+    report('securitySolution', new Set(), 'discover');
+    report('securitySolution', new Set(), 'discover:some_deep_link');
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/packages/plugins/browser-internal/src/nav_dependency_check.ts
+++ b/src/core/packages/plugins/browser-internal/src/nav_dependency_check.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { PluginName, PluginOpaqueId } from '@kbn/core-base-common';
+
+/** @internal */
+export interface NavDependencyReporterDeps {
+  /** Resolves an appId to the opaque id of the plugin that registered it. */
+  getAppOwner: (appId: string) => PluginOpaqueId | undefined;
+  /** Reverse lookup from a plugin's opaque id to its plugin id. */
+  opaqueIdToPluginId: ReadonlyMap<PluginOpaqueId, PluginName>;
+  logger: Logger;
+}
+
+/**
+ * Reports (in log form) a cross-plugin navigation to an application whose owning
+ * plugin is not declared as a dependency of the caller. This is the "report" mode
+ * of the navigation-dependency cross-check: it never throws, and each undeclared
+ * `caller -> owner` edge is logged at most once.
+ *
+ * @internal
+ */
+export type NavDependencyReporter = (
+  callerPluginId: PluginName,
+  callerDependencies: ReadonlySet<PluginName>,
+  /** Either an appId (`"discover"`) or a deep-link id (`"management:transform"`). */
+  target: string
+) => void;
+
+const NOOP_REPORTER: NavDependencyReporter = () => {};
+
+/** @internal */
+export const createNavDependencyReporter = ({
+  getAppOwner,
+  opaqueIdToPluginId,
+  logger,
+}: NavDependencyReporterDeps): NavDependencyReporter => {
+  const alreadyReported = new Set<string>();
+
+  return (callerPluginId, callerDependencies, target) => {
+    // Deep-link ids take the shape `appId:deepLinkId`; only the app id owns a plugin.
+    const appId = target.split(':')[0];
+    if (!appId) {
+      return;
+    }
+
+    const ownerOpaqueId = getAppOwner(appId);
+    if (!ownerOpaqueId) {
+      // App not registered (yet), or registered by Core rather than a plugin — nothing to attribute.
+      return;
+    }
+
+    const ownerPluginId = opaqueIdToPluginId.get(ownerOpaqueId);
+    if (!ownerPluginId || ownerPluginId === callerPluginId) {
+      // Owner is not a plugin, or the caller is navigating within its own app.
+      return;
+    }
+
+    if (callerDependencies.has(ownerPluginId)) {
+      // Dependency is declared — this is exactly what we want.
+      return;
+    }
+
+    const edge = `${callerPluginId} -> ${ownerPluginId} (${appId})`;
+    if (alreadyReported.has(edge)) {
+      return;
+    }
+    alreadyReported.add(edge);
+
+    logger.warn(
+      `Plugin "${callerPluginId}" navigates to application "${appId}" owned by plugin "${ownerPluginId}", ` +
+        `but does not declare a dependency on it. Add "${ownerPluginId}" to "runtimePluginDependencies" ` +
+        `(or "requiredPlugins"/"optionalPlugins") in the kibana.jsonc manifest of "${callerPluginId}" so this ` +
+        `navigation dependency is explicit. See https://github.com/elastic/kibana/issues/66682`
+    );
+  };
+};
+
+/** @internal */
+export const createNoopNavDependencyReporter = (): NavDependencyReporter => NOOP_REPORTER;

--- a/src/core/packages/plugins/browser-internal/src/plugin_context.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin_context.ts
@@ -15,6 +15,7 @@ import type { PluginInitializerContext } from '@kbn/core-plugins-browser';
 import type { PluginWrapper } from './plugin';
 import type { PluginsServiceSetupDeps, PluginsServiceStartDeps } from './plugins_service';
 import type { IRuntimePluginContractResolver } from './plugin_contract_resolver';
+import type { NavDependencyReporter } from './nav_dependency_check';
 
 /**
  * Provides a plugin-specific context passed to the plugin's constructor. This is currently
@@ -134,20 +135,43 @@ export function createPluginStartContext<
   deps,
   plugin,
   runtimeResolver,
+  reportNavDependency,
 }: {
   deps: PluginsServiceStartDeps;
   plugin: PluginWrapper<TSetup, TStart, TPluginsSetup, TPluginsStart>;
   runtimeResolver: IRuntimePluginContractResolver;
+  reportNavDependency?: NavDependencyReporter;
 }): CoreStart {
+  // Dependencies this plugin declares in its manifest (any channel), used to decide
+  // whether a cross-plugin navigation is explicitly declared.
+  const declaredDependencies = new Set<string>([
+    ...plugin.requiredPlugins,
+    ...plugin.optionalPlugins,
+    ...plugin.runtimePluginDependencies,
+  ]);
+  const reportNav = reportNavDependency
+    ? (target: string) => reportNavDependency(plugin.name, declaredDependencies, target)
+    : undefined;
+
   return {
     analytics: deps.analytics,
     application: {
       applications$: deps.application.applications$,
       currentAppId$: deps.application.currentAppId$,
       capabilities: deps.application.capabilities,
-      navigateToApp: deps.application.navigateToApp,
+      navigateToApp: reportNav
+        ? (appId, options) => {
+            reportNav(options?.deepLinkId ? `${appId}:${options.deepLinkId}` : appId);
+            return deps.application.navigateToApp(appId, options);
+          }
+        : deps.application.navigateToApp,
       navigateToUrl: deps.application.navigateToUrl,
-      getUrlForApp: deps.application.getUrlForApp,
+      getUrlForApp: reportNav
+        ? (appId, options) => {
+            reportNav(options?.deepLinkId ? `${appId}:${options.deepLinkId}` : appId);
+            return deps.application.getUrlForApp(appId, options);
+          }
+        : deps.application.getUrlForApp,
       isAppRegistered: deps.application.isAppRegistered,
       currentLocation$: deps.application.currentLocation$,
     },

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -18,6 +18,7 @@ import {
   createPluginStartContext,
 } from './plugin_context';
 import { RuntimePluginContractResolver } from './plugin_contract_resolver';
+import { createNavDependencyReporter } from './nav_dependency_check';
 
 /** @internal */
 export type PluginsServiceSetupDeps = InternalCoreSetup;
@@ -124,6 +125,19 @@ export class PluginsService
   }
 
   public async start(deps: PluginsServiceStartDeps): Promise<InternalPluginsServiceStart> {
+    // Cross-check (report mode): warn when a plugin navigates to another plugin's app
+    // without declaring the dependency. Gated to dev builds so we don't surface warnings
+    // in end-user browser consoles. See https://github.com/elastic/kibana/issues/66682
+    const reportNavDependency = this.coreContext.env.mode.dev
+      ? createNavDependencyReporter({
+          getAppOwner: (appId) => deps.application.getAppOwner(appId),
+          opaqueIdToPluginId: new Map<PluginOpaqueId, PluginName>(
+            [...this.plugins].map(([pluginName, plugin]) => [plugin.opaqueId, pluginName])
+          ),
+          logger: this.coreContext.logger.get('plugins', 'navigation-dependencies'),
+        })
+      : undefined;
+
     // Setup each plugin with required and optional plugin contracts
     const contracts = new Map<string, unknown>();
     for (const [pluginName, plugin] of this.plugins.entries()) {
@@ -145,6 +159,7 @@ export class PluginsService
           deps,
           plugin,
           runtimeResolver: this.runtimeResolver,
+          reportNavDependency,
         }),
         pluginDepContracts
       );


### PR DESCRIPTION
## Summary

Part of the **Stack B** initiative to make cross-plugin navigation/app references explicit (elastic/kibana-team#3675, addresses [elastic/kibana#66682](https://github.com/elastic/kibana/issues/66682)).

This is the **base PR** of a stack. It adds the ownership backbone and a *report-mode* cross-check for the programmatic navigation path:

- `ApplicationService` (browser) now records the registering plugin for each app and exposes it via the internal `getAppOwner(appId)`.
- Each plugin's `navigateToApp` / `getUrlForApp` is wrapped so that navigating to an app owned by a plugin the caller does **not** declare as a dependency (`requiredPlugins` ∪ `optionalPlugins` ∪ `runtimePluginDependencies`) logs a deduped warning.
- Gated to **dev builds** — no warnings in end-user browser consoles. Nothing throws; this is report-only.

No public API surface changes (everything is `@internal`).

## Stack
1. 👉 **this PR** — app ownership + programmatic report-mode check
2. solution side-nav `link:` cross-check
3. ESLint rule for literal `navigateToApp`/`getUrlForApp`/`link:` call sites
4. one-time migration seeding `runtimePluginDependencies`
5. flip report → hard-fail in dev/CI

## Test plan
- [x] Unit tests for the reporter (own app / declared / undeclared / deep-link / unknown-owner / dedupe)
- [x] `plugins/browser-internal` + `application/browser-internal` suites, typecheck, eslint green

Made with [Cursor](https://cursor.com)