### PR TITLE
skip failing uptime integration deprecation suite (#276248)

### DIFF
--- a/x-pack/solutions/observability/plugins/uptime/test/scout/api/tests/uptime/uptime_integration_deprecation.spec.ts
+++ b/x-pack/solutions/observability/plugins/uptime/test/scout/api/tests/uptime/uptime_integration_deprecation.spec.ts
@@ -61,7 +61,8 @@ const getBrowserZipInput = (zipUrl?: string) => ({
   ],
 });
 
-apiTest.describe('UptimeIntegrationDeprecation', { tag: '@local-stateful-classic' }, () => {
+// Failing: https://github.com/elastic/kibana/issues/276248
+apiTest.describe.skip('UptimeIntegrationDeprecation', { tag: '@local-stateful-classic' }, () => {
   let adminCredentials: RoleApiCredentials;
   let agentPolicyId: string;
 


### PR DESCRIPTION
## Summary
Manual skip, because the test is very flaky on PRs but didn't fail enough in the on-merge to create an issue.

I created an issue through AI: #276248