### PR TITLE
Stabilize saved search embeddable Scout test

### DIFF
--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
@@ -29,6 +29,20 @@ const createSavedSearch = async (
         searchSourceJSON:
           '{"highlightAll":true,"version":true,"query":{"language":"lucene","query":""},"filter":[],"indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index"}',
       },
+      tabs: [
+        {
+          id: 'my_tab',
+          label: 'My Tab',
+          attributes: {
+            columns: ['agent', 'bytes', 'clientip'],
+            sort: [['@timestamp', 'desc']],
+            kibanaSavedObjectMeta: {
+              searchSourceJSON:
+                '{"highlightAll":true,"version":true,"query":{"language":"lucene","query":""},"filter":[],"indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index"}',
+            },
+          },
+        },
+      ],
     },
     references: [
       {
@@ -74,7 +88,7 @@ test.describe('Discover app - saved search embeddable', { tag: tags.deploymentAg
       SAVED_SEARCH_TITLE,
       testData.DATA_VIEW_ID.LOGSTASH
     );
-    await pageObjects.dashboard.addPanelFromLibrary(SAVED_SEARCH_TITLE);
+    await pageObjects.dashboard.addSavedSearch(SAVED_SEARCH_TITLE);
     await page.testSubj.locator('savedSearchTotalDocuments').waitFor({
       state: 'visible',
     });


### PR DESCRIPTION
## Summary

This stabilizes the Discover saved search embeddable Scout test that has been flaky in RSPack runs when adding an API-created saved search from the Dashboard library flyout.

The failing runs searched for `TempSearch` in the Dashboard "Add to dashboard" flyout, but the expected saved search row never became clickable before the 10s timeout. The screenshot showed the flyout still open with unrelated library results, which points at a saved object finder/search readiness issue rather than a failed Dashboard assertion.

## Evidence

- Latest investigated Scout failure artifact: [saved search embeddable failure report](https://web.buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/019df498-83c7-41cf-ab8a-722570e4e92e/019f2810-a538-4bf0-945e-a2de50514fcb/019f2817-352b-4f05-a5fe-1ae6cf00f862/.scout/reports/scout-playwright-test-failures-6f0838260f5084f2/9028134cd73b3d5-8dadab4458b6f58.html)
- Failing selector: `[data-test-subj="savedObjectTitleTempSearch"]`
- Failure mode: `page.click` timed out while the library flyout search was still settling after typing `TempSearch`
- 40x RSPack flaky-runner comparison for this PR: [build 12954](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12954)
- 40x RSPack flaky-runner comparison for `main`: [build 12955](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12955)

## Fix

- create the test saved search with the current `tabs` attribute shape so it matches modern saved search content
- use the Dashboard Scout page object's `addSavedSearch()` helper instead of the legacy generic library helper, so the finder filters to saved searches and waits for its loading indicator before clicking the result

## Model used

- Codex, GPT-5-based coding agent

## Verification

- `node scripts/eslint --fix x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts`
- `node scripts/type_check --project x-pack/platform/plugins/private/discover_enhanced/tsconfig.json`
- `git diff --check`

No existing issue.
