### PR TITLE
[Alerting V2] Refactor ComposeDiscoverFlyout: resolveSteps prop

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -24,6 +24,7 @@ import { createTestQueryClient } from '../../test_utils';
 import { ComposeDiscoverFlyout } from './compose_discover_flyout';
 import type { ComposeDiscoverFlyoutProps } from './compose_discover_flyout';
 import type { ComposeDiscoverForm } from './compose_discover_form';
+import { ComposeDiscoverBuilderStateHost } from './rule_builder';
 
 type FormProps = React.ComponentProps<typeof ComposeDiscoverForm>;
 
@@ -223,9 +224,33 @@ const createMockServices = (): RuleFormServices => ({
 
 const testQueryClient = createTestQueryClient();
 
-const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+/*
+ * Wraps children with the real ComposeDiscoverBuilderStateHost (not a mock) so tests
+ * exercise the actual builder-state resolution + Provider wiring the production callers
+ * use — builderType/initialQuery/esqlVariables here drive what gets resolved, exactly as
+ * they would from a real caller.
+ */
+const TestWrapper = ({
+  builderType,
+  initialQuery,
+  esqlVariables,
+  children,
+}: {
+  builderType?: string;
+  initialQuery?: string;
+  esqlVariables?: ESQLControlVariable[];
+  children: (builderParsedFromDiscover: boolean) => React.ReactNode;
+}) => (
   <IntlProvider locale="en">
-    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={testQueryClient}>
+      <ComposeDiscoverBuilderStateHost
+        builderType={builderType}
+        initialQuery={initialQuery}
+        esqlVariables={esqlVariables}
+      >
+        {children}
+      </ComposeDiscoverBuilderStateHost>
+    </QueryClientProvider>
   </IntlProvider>
 );
 
@@ -237,12 +262,20 @@ const defaultProps: ComposeDiscoverFlyoutProps = {
   onCreateRule: jest.fn(),
 };
 
-const renderFlyout = (overrides: Partial<ComposeDiscoverFlyoutProps> = {}) =>
-  render(
-    <TestWrapper>
-      <ComposeDiscoverFlyout {...defaultProps} {...overrides} />
+const renderFlyout = (overrides: Partial<ComposeDiscoverFlyoutProps> = {}) => {
+  const props = { ...defaultProps, ...overrides };
+  return render(
+    <TestWrapper
+      builderType={props.builderType}
+      initialQuery={props.initialQuery}
+      esqlVariables={props.esqlVariables}
+    >
+      {(builderParsedFromDiscover) => (
+        <ComposeDiscoverFlyout {...props} builderParsedFromDiscover={builderParsedFromDiscover} />
+      )}
     </TestWrapper>
   );
+};
 
 const getEditModeButton = (mode: 'form' | 'yaml') => {
   const buttons = screen.getByTestId('composeDiscoverEditModeToggle').querySelectorAll('button');
@@ -576,19 +609,19 @@ describe('ComposeDiscoverFlyout', () => {
         esqlVariables: [] as ESQLControlVariable[],
       };
       const { rerender } = render(
-        <TestWrapper>
-          <ComposeDiscoverFlyout {...props} />
-        </TestWrapper>
+        <TestWrapper>{() => <ComposeDiscoverFlyout {...props} />}</TestWrapper>
       );
 
       expect(screen.queryByTestId('ruleV2FlyoutValidationErrors')).not.toBeInTheDocument();
 
       rerender(
         <TestWrapper>
-          <ComposeDiscoverFlyout
-            {...props}
-            initialQuery="FROM logs-* | WHERE host == ?host | LIMIT 5"
-          />
+          {() => (
+            <ComposeDiscoverFlyout
+              {...props}
+              initialQuery="FROM logs-* | WHERE host == ?host | LIMIT 5"
+            />
+          )}
         </TestWrapper>
       );
 
@@ -602,16 +635,14 @@ describe('ComposeDiscoverFlyout', () => {
         esqlVariables: [] as ESQLControlVariable[],
       };
       const { rerender } = render(
-        <TestWrapper>
-          <ComposeDiscoverFlyout {...props} />
-        </TestWrapper>
+        <TestWrapper>{() => <ComposeDiscoverFlyout {...props} />}</TestWrapper>
       );
 
       fireEvent.click(screen.getByTestId('mockMakeDirty'));
 
       rerender(
         <TestWrapper>
-          <ComposeDiscoverFlyout {...props} initialQuery="FROM metrics-* | LIMIT 5" />
+          {() => <ComposeDiscoverFlyout {...props} initialQuery="FROM metrics-* | LIMIT 5" />}
         </TestWrapper>
       );
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -44,6 +44,36 @@ jest.mock('./compose_discover_form', () => {
     'react-hook-form'
   ) as typeof import('react-hook-form');
   const actual = jest.requireActual('./use_compose_discover_state');
+  /*
+   * Mirrors STEP_REGISTRY's real getSandboxConfig for 'alertCondition'/'recoveryCondition' —
+   * kept in sync manually since this mock replaces the real STEP_REGISTRY entirely (to avoid
+   * rendering the real, heavy step components). Anything wrong here shows up as a real
+   * behavioral test failure (autoSplitOnApply not running, tabs not appearing), not a silent gap.
+   */
+  const getSandboxConfigForId = (
+    id: string,
+    state: { mode: string; manualSplitEnabled: boolean; recoveryType: string }
+  ) => {
+    if (id === 'alertCondition') {
+      const usesUnifiedEditorByDefault =
+        state.mode === 'create' || state.mode === 'edit' || state.mode === 'clone';
+      return {
+        tabs: usesUnifiedEditorByDefault
+          ? state.manualSplitEnabled
+            ? ['base', 'alert']
+            : undefined
+          : ['base', 'alert'],
+        autoSplitOnApply: !state.manualSplitEnabled,
+      };
+    }
+    if (id === 'recoveryCondition') {
+      return {
+        tabs: state.recoveryType === 'custom' ? ['recovery'] : undefined,
+        autoSplitOnApply: false,
+      };
+    }
+    return { tabs: undefined, autoSplitOnApply: false };
+  };
   return {
     getSteps: (isAlert: boolean) => ({
       steps: actual.getStepIds(isAlert).map((id: string) => {
@@ -52,7 +82,16 @@ jest.mock('./compose_discover_form', () => {
           recoveryCondition: 'Recovery Condition',
           details: 'Details & Artifacts',
         };
-        return { id, title: titles[id], render: () => <div /> };
+        return {
+          id,
+          title: titles[id],
+          render: () => <div />,
+          getSandboxConfig: (state: {
+            mode: string;
+            manualSplitEnabled: boolean;
+            recoveryType: string;
+          }) => getSandboxConfigForId(id, state),
+        };
       }),
     }),
     ComposeDiscoverForm: (props: FormProps) => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -55,7 +55,13 @@ import {
   parseDiscoverQueryForBuilder,
   type BuilderState,
 } from './rule_builder';
-import type { ComposeDiscoverAction, ComposeDiscoverMode, QueryTab, RecoveryType } from './types';
+import type {
+  ComposeDiscoverAction,
+  ComposeDiscoverMode,
+  QueryTab,
+  RecoveryType,
+  SandboxConfig,
+} from './types';
 import { isBuilderConditionStepId } from './types';
 import { getSandboxTabs, useComposeDiscoverState } from './use_compose_discover_state';
 import { useEsqlAutocomplete } from './use_esql_providers';
@@ -234,6 +240,12 @@ export function ComposeDiscoverFlyout({
   resolveSteps,
 }: ComposeDiscoverFlyoutProps): React.ReactElement | null {
   const isBuilderMode = Boolean(builderType);
+  /*
+   * Whether the sandbox owns an independent, losable draft right now (feeds
+   * sandboxConfig.isEditable below). In builder mode the sandbox read-only-mirrors
+   * external state instead.
+   */
+  const isEditable = !isBuilderMode;
   /*
    * ── UI state (step navigation, sandbox open/close, tab selection, etc.) ──
    * In edit mode, seed the sandbox draft with the rule's existing query so the
@@ -601,14 +613,75 @@ export function ComposeDiscoverFlyout({
     [methods, dispatch]
   );
 
+  const { steps, renderCustomRecovery } = resolveSteps ? resolveSteps(isAlert) : getSteps(isAlert);
+  const currentStep = steps[uiState.step];
+  const isLastStep = uiState.step === steps.length - 1;
+
+  /*
+   * TODO: recoveryType drives whether the recovery tab appears in YAML mode.
+   * Follow schema decisions in #268984 — if recoveryType is superseded by a
+   * field on RuleQuery itself, gate this on query shape instead.
+   */
+  const sandboxTabs = useMemo<QueryTab[] | undefined>(() => {
+    if (!uiState.yamlMode) {
+      return getSandboxTabs(isAlert, {
+        step: uiState.step,
+        recoveryType: uiState.recoveryType,
+        mode: uiState.mode,
+        manualSplitEnabled: uiState.manualSplitEnabled,
+      });
+    }
+    /*
+     * In YAML mode the sandbox stays open (and is forced open for non-representable
+     * rules). A standalone query can't be represented as base/alert tabs, so it uses
+     * the single unified editor; composed queries keep the split tabs.
+     */
+    if (sandboxQuery.format === 'standalone') return undefined;
+    return uiState.recoveryType === 'custom' ? ['base', 'alert', 'recovery'] : ['base', 'alert'];
+  }, [
+    uiState.yamlMode,
+    uiState.recoveryType,
+    uiState.step,
+    uiState.mode,
+    uiState.manualSplitEnabled,
+    sandboxQuery.format,
+    isAlert,
+  ]);
+
+  /*
+   * Create/edit/clone default to a single unified editor on the Alert Condition step — no
+   * base/alert tabs. On Apply, derive the base query and alert condition from that unified
+   * text via the heuristic split. When the user has opted in to manual split, Apply commits
+   * the already-separated base/alert verbatim without running the heuristic.
+   */
+  const autoSplitOnApply =
+    currentStep?.id === 'alertCondition' &&
+    !uiState.yamlMode &&
+    isAlert &&
+    !uiState.manualSplitEnabled;
+
+  /*
+   * One derived fact for "how should the sandbox behave right now," replacing the scattered
+   * isBuilderMode/currentStep.id checks this used to require at each consumer. tabs and
+   * autoSplitOnApply are still computed the same way as before this commit (via
+   * getSandboxTabs()/the inline check above) — only isEditable is genuinely new here. The
+   * next commit replaces how tabs/autoSplitOnApply are computed without touching any of
+   * their consumers, since they already read from this object.
+   */
+  const sandboxConfig: SandboxConfig = {
+    tabs: sandboxTabs,
+    autoSplitOnApply,
+    isEditable,
+  };
+
   useEffect(() => {
-    if (!isBuilderMode) return;
+    if (sandboxConfig.isEditable) return;
     const sub = methods.watch((values) => {
       if (values.query) setSandboxQuery(values.query as RuleQuery);
       if (values.timeField) setSandboxTimeField(values.timeField);
     });
     return () => sub.unsubscribe();
-  }, [isBuilderMode, methods]);
+  }, [sandboxConfig.isEditable, methods]);
 
   const handleRecoveryTypeChange = useCallback(
     (type: RecoveryType) => {
@@ -670,12 +743,17 @@ export function ComposeDiscoverFlyout({
           dispatch({ type: 'CLOSE_CHILD' });
         }
       }
-      dispatch({ type: 'SET_RECOVERY_TYPE', recoveryType: type, isBuilderMode });
+      dispatch({
+        type: 'SET_RECOVERY_TYPE',
+        recoveryType: type,
+        isEditable: sandboxConfig.isEditable,
+      });
     },
     [
       dispatch,
       methods,
       isBuilderMode,
+      sandboxConfig.isEditable,
       builderState,
       uiState.queryCommitted,
       uiState.childOpen,
@@ -688,12 +766,6 @@ export function ComposeDiscoverFlyout({
   /** Create, edit, and clone share the unified ↔ split-tab sandbox toggle. */
   const supportsUnifiedEditorToggle = isCreate || isEditing;
   const title = getFlyoutTitle(mode);
-
-  const { steps, renderCustomRecovery } = resolveSteps
-    ? resolveSteps(isAlert)
-    : getSteps(isAlert);
-  const currentStep = steps[uiState.step];
-  const isLastStep = uiState.step === steps.length - 1;
 
   // ── YAML mode state ──────────────────────────────────────────────────────
   const [yamlText, setYamlText] = useState(() => {
@@ -777,21 +849,8 @@ export function ComposeDiscoverFlyout({
   );
 
   const handleSandboxApply = useCallback(() => {
-    /*
-     * Create/edit/clone default to a single unified editor on the Alert Condition
-     * step — no base/alert tabs. On Apply, derive the base query and alert condition
-     * from that unified text via the heuristic split.
-     * When the user has opted in to manual split, Apply commits the already-separated
-     * base/alert verbatim without running the heuristic.
-     */
-    const shouldRunHeuristicSplit =
-      currentStep?.id === 'alertCondition' &&
-      !uiState.yamlMode &&
-      isAlert &&
-      !uiState.manualSplitEnabled;
-
     let queryToCommit: RuleQuery = sandboxQuery;
-    if (shouldRunHeuristicSplit) {
+    if (sandboxConfig.autoSplitOnApply) {
       const split = splitResultToRuleQuery(getBreachQuery(sandboxQuery)).query;
       queryToCommit = resolveUnifiedAlertApplyQuery(sandboxQuery, split);
     }
@@ -814,10 +873,8 @@ export function ComposeDiscoverFlyout({
   }, [
     sandboxQuery,
     sandboxTimeField,
-    currentStep?.id,
+    sandboxConfig.autoSplitOnApply,
     uiState.yamlMode,
-    uiState.manualSplitEnabled,
-    isAlert,
     methods,
     dispatch,
     cancelYamlParse,
@@ -877,14 +934,14 @@ export function ComposeDiscoverFlyout({
       const valid = await currentStep.validate(methods, uiState, baseServices, builderState);
       if (!valid) return;
     }
-    dispatch({ type: 'GO_NEXT', isAlert, isBuilderMode });
+    dispatch({ type: 'GO_NEXT', stepCount: steps.length, isEditable: sandboxConfig.isEditable });
   }, [
     hasValidationErrors,
     currentStep,
     methods,
     uiState,
-    isAlert,
-    isBuilderMode,
+    steps.length,
+    sandboxConfig.isEditable,
     dispatch,
     baseServices,
     builderState,
@@ -939,37 +996,6 @@ export function ComposeDiscoverFlyout({
     </>
   ) : null;
 
-  /*
-   * TODO: recoveryType drives whether the recovery tab appears in YAML mode.
-   * Follow schema decisions in #268984 — if recoveryType is superseded by a
-   * field on RuleQuery itself, gate this on query shape instead.
-   */
-  const sandboxTabs = useMemo<QueryTab[] | undefined>(() => {
-    if (!uiState.yamlMode) {
-      return getSandboxTabs(isAlert, {
-        step: uiState.step,
-        recoveryType: uiState.recoveryType,
-        mode: uiState.mode,
-        manualSplitEnabled: uiState.manualSplitEnabled,
-      });
-    }
-    /*
-     * In YAML mode the sandbox stays open (and is forced open for non-representable
-     * rules). A standalone query can't be represented as base/alert tabs, so it uses
-     * the single unified editor; composed queries keep the split tabs.
-     */
-    if (sandboxQuery.format === 'standalone') return undefined;
-    return uiState.recoveryType === 'custom' ? ['base', 'alert', 'recovery'] : ['base', 'alert'];
-  }, [
-    uiState.yamlMode,
-    uiState.recoveryType,
-    uiState.step,
-    uiState.mode,
-    uiState.manualSplitEnabled,
-    sandboxQuery.format,
-    isAlert,
-  ]);
-
   const isAlertConditionStep = currentStep?.id === 'alertCondition';
 
   /*
@@ -980,7 +1006,7 @@ export function ComposeDiscoverFlyout({
    */
   const sandboxHelpText =
     isAlert &&
-    !isBuilderMode &&
+    sandboxConfig.isEditable &&
     !uiState.yamlMode &&
     supportsUnifiedEditorToggle &&
     isAlertConditionStep ? (
@@ -1003,7 +1029,7 @@ export function ComposeDiscoverFlyout({
 
   const handleSandboxTabChange = useCallback(
     (tab: QueryTab) => {
-      const tabs = sandboxTabs ?? [];
+      const tabs = sandboxConfig.tabs ?? [];
 
       if (tab === 'alert' && isAlertTabDisabled(tabs, sandboxQuery)) {
         return;
@@ -1011,7 +1037,7 @@ export function ComposeDiscoverFlyout({
 
       dispatch({ type: 'SET_TAB', tab });
     },
-    [dispatch, sandboxQuery, sandboxTabs]
+    [dispatch, sandboxQuery, sandboxConfig.tabs]
   );
 
   /*
@@ -1066,7 +1092,7 @@ export function ComposeDiscoverFlyout({
    */
   const sandboxHeaderActions = useMemo(() => {
     if (
-      isBuilderMode ||
+      !sandboxConfig.isEditable ||
       uiState.yamlMode ||
       !supportsUnifiedEditorToggle ||
       !isAlert ||
@@ -1119,7 +1145,7 @@ export function ComposeDiscoverFlyout({
       </EuiToolTip>
     );
   }, [
-    isBuilderMode,
+    sandboxConfig.isEditable,
     uiState.yamlMode,
     supportsUnifiedEditorToggle,
     uiState.manualSplitEnabled,
@@ -1270,7 +1296,7 @@ export function ComposeDiscoverFlyout({
               isCreate={isCreate}
               hasValidationErrors={hasValidationErrors}
               yamlHasErrors={yamlHasErrors}
-              isBuilderMode={isBuilderMode}
+              isEditable={sandboxConfig.isEditable}
               isBuilderStepValid={isBuilderStepValid}
               isSaving={isSaving}
               onNext={handleNext}
@@ -1281,10 +1307,10 @@ export function ComposeDiscoverFlyout({
             {uiState.childOpen && (
               <QuerySandboxFlyout
                 query={sandboxQuery}
-                onQueryChange={isBuilderMode ? undefined : setSandboxQuery}
-                tabs={sandboxTabs}
+                onQueryChange={sandboxConfig.isEditable ? setSandboxQuery : undefined}
+                tabs={sandboxConfig.tabs}
                 timeField={sandboxTimeField || '@timestamp'}
-                onTimeFieldChange={isBuilderMode ? undefined : setSandboxTimeField}
+                onTimeFieldChange={sandboxConfig.isEditable ? setSandboxTimeField : undefined}
                 timeFieldOptions={timeFieldOptions}
                 isTimeFieldResolved={sandboxIsTimeFieldResolved}
                 dateRange={dateRange}
@@ -1296,7 +1322,7 @@ export function ComposeDiscoverFlyout({
                 onClose={handleSandboxClose}
                 helpText={sandboxHelpText}
                 headerActions={sandboxHeaderActions}
-                onApply={isBuilderMode ? undefined : handleSandboxApply}
+                onApply={sandboxConfig.isEditable ? handleSandboxApply : undefined}
               />
             )}
           </EuiFlyout>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -58,12 +58,14 @@ import {
 import type {
   ComposeDiscoverAction,
   ComposeDiscoverMode,
+  ComposeDiscoverState,
   QueryTab,
   RecoveryType,
   SandboxConfig,
+  StepSandboxConfig,
 } from './types';
 import { isBuilderConditionStepId } from './types';
-import { getSandboxTabs, useComposeDiscoverState } from './use_compose_discover_state';
+import { useComposeDiscoverState } from './use_compose_discover_state';
 import { useEsqlAutocomplete } from './use_esql_providers';
 import {
   guessRecoveryBlock,
@@ -618,59 +620,50 @@ export function ComposeDiscoverFlyout({
   const isLastStep = uiState.step === steps.length - 1;
 
   /*
-   * TODO: recoveryType drives whether the recovery tab appears in YAML mode.
-   * Follow schema decisions in #268984 — if recoveryType is superseded by a
-   * field on RuleQuery itself, gate this on query shape instead.
+   * YAML isn't a step, so it can't get its config from STEP_REGISTRY the same way — a
+   * standalone object with the same shape, selected by a plain ternary right below. Captures
+   * sandboxQuery.format via closure rather than adding it as a function param, keeping
+   * getSandboxConfig's (state) => StepSandboxConfig shape uniform between steps and this source.
    */
-  const sandboxTabs = useMemo<QueryTab[] | undefined>(() => {
-    if (!uiState.yamlMode) {
-      return getSandboxTabs(isAlert, {
-        step: uiState.step,
-        recoveryType: uiState.recoveryType,
-        mode: uiState.mode,
-        manualSplitEnabled: uiState.manualSplitEnabled,
-      });
-    }
-    /*
-     * In YAML mode the sandbox stays open (and is forced open for non-representable
-     * rules). A standalone query can't be represented as base/alert tabs, so it uses
-     * the single unified editor; composed queries keep the split tabs.
-     */
-    if (sandboxQuery.format === 'standalone') return undefined;
-    return uiState.recoveryType === 'custom' ? ['base', 'alert', 'recovery'] : ['base', 'alert'];
-  }, [
-    uiState.yamlMode,
-    uiState.recoveryType,
-    uiState.step,
-    uiState.mode,
-    uiState.manualSplitEnabled,
-    sandboxQuery.format,
-    isAlert,
-  ]);
+  const yamlSandboxConfig = useMemo<{
+    getSandboxConfig: (state: ComposeDiscoverState) => StepSandboxConfig;
+  }>(
+    () => ({
+      getSandboxConfig: (state) => {
+        /*
+         * In YAML mode the sandbox stays open (and is forced open for non-representable
+         * rules). A standalone query can't be represented as base/alert tabs, so it uses
+         * the single unified editor; composed queries keep the split tabs.
+         * TODO: recoveryType drives whether the recovery tab appears here. Follow schema
+         * decisions in #268984 — if recoveryType is superseded by a field on RuleQuery
+         * itself, gate this on query shape instead.
+         */
+        if (sandboxQuery.format === 'standalone') {
+          return { tabs: undefined, autoSplitOnApply: false };
+        }
+        return {
+          tabs: state.recoveryType === 'custom' ? ['base', 'alert', 'recovery'] : ['base', 'alert'],
+          autoSplitOnApply: false,
+        };
+      },
+    }),
+    [sandboxQuery.format]
+  );
+
+  const stepSandboxConfig: StepSandboxConfig = uiState.yamlMode
+    ? yamlSandboxConfig.getSandboxConfig(uiState)
+    : currentStep?.getSandboxConfig?.(uiState) ?? { tabs: undefined, autoSplitOnApply: false };
 
   /*
-   * Create/edit/clone default to a single unified editor on the Alert Condition step — no
-   * base/alert tabs. On Apply, derive the base query and alert condition from that unified
-   * text via the heuristic split. When the user has opted in to manual split, Apply commits
-   * the already-separated base/alert verbatim without running the heuristic.
-   */
-  const autoSplitOnApply =
-    currentStep?.id === 'alertCondition' &&
-    !uiState.yamlMode &&
-    isAlert &&
-    !uiState.manualSplitEnabled;
-
-  /*
-   * One derived fact for "how should the sandbox behave right now," replacing the scattered
-   * isBuilderMode/currentStep.id checks this used to require at each consumer. tabs and
-   * autoSplitOnApply are still computed the same way as before this commit (via
-   * getSandboxTabs()/the inline check above) — only isEditable is genuinely new here. The
-   * next commit replaces how tabs/autoSplitOnApply are computed without touching any of
-   * their consumers, since they already read from this object.
+   * tabs/autoSplitOnApply only apply to alert-condition-shaped editing (isAlert, or YAML
+   * mode, which represents either kind) — a signal rule's alertCondition step never has an
+   * independent base/alert split to show or auto-split on Apply. isEditable is uniform
+   * across every builder step (confirmed with Jason), so it's computed once here rather
+   * than per-step.
    */
   const sandboxConfig: SandboxConfig = {
-    tabs: sandboxTabs,
-    autoSplitOnApply,
+    tabs: uiState.yamlMode || isAlert ? stepSandboxConfig.tabs : undefined,
+    autoSplitOnApply: uiState.yamlMode || isAlert ? stepSandboxConfig.autoSplitOnApply : false,
     isEditable,
   };
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -49,12 +49,7 @@ import {
 import { HorizontalMinimalStepper, type MinimalStep } from './horizontal_minimal_stepper';
 import { QuerySandboxFlyout } from './query_sandbox_flyout';
 import { isAlertTabDisabled } from './compose_discover_tabs';
-import {
-  RULE_BUILDER_REGISTRY,
-  BuilderStateProvider,
-  parseDiscoverQueryForBuilder,
-  type BuilderState,
-} from './rule_builder';
+import { RULE_BUILDER_REGISTRY, useBuilderState, type BuilderState } from './rule_builder';
 import type {
   ComposeDiscoverAction,
   ComposeDiscoverMode,
@@ -170,8 +165,19 @@ export interface ComposeDiscoverFlyoutProps {
   onUpdateRule?: (id: string, payload: ReturnType<typeof composeFormToUpdateRequest>) => void;
   /** True while a create/update mutation is in flight. */
   isSaving?: boolean;
+  /**
+   * Still needed here for payload construction (compose_mappers.ts) and RULE_BUILDER_REGISTRY
+   * lookups (submit-time validation) — unrelated to builder *state* ownership, which now lives
+   * entirely with the caller (see ComposeDiscoverBuilderStateHost).
+   */
   builderType?: string;
-  initialBuilderState?: BuilderState;
+  /**
+   * Whether builderType's initial state was successfully derived from a Discover-seeded query.
+   * Resolved by the caller (via resolveInitialBuilderState/ComposeDiscoverBuilderStateHost) —
+   * the flyout needs only this one fact, not the parsing logic itself, to decide whether the
+   * raw ES|QL query should also seed the RHF form. Ignored outside create mode.
+   */
+  builderParsedFromDiscover?: boolean;
   /** Pre-populated ES|QL query (e.g. from Discover). Seeds the base query in create mode. */
   initialQuery?: string;
   /** ES|QL control variables from Discover — inlined into initialQuery when provided. */
@@ -236,7 +242,7 @@ export function ComposeDiscoverFlyout({
   onUpdateRule,
   isSaving = false,
   builderType,
-  initialBuilderState,
+  builderParsedFromDiscover = false,
   initialQuery,
   esqlVariables,
   resolveSteps,
@@ -313,20 +319,12 @@ export function ComposeDiscoverFlyout({
   // Registered once here so providers persist across Sandbox open/close cycles.
   useEsqlAutocomplete(baseServices);
 
-  const [initialParsedState] = useState<BuilderState | null>(() => {
-    if (!builderType || initialBuilderState !== undefined || !inlineResult.query) return null;
-    return parseDiscoverQueryForBuilder(inlineResult.query);
-  });
-
-  const builderParsedFromDiscover = initialParsedState !== null;
-
-  const [builderState, setBuilderState] = useState<BuilderState>(() => {
-    if (!builderType) return undefined;
-    if (initialBuilderState !== undefined) return initialBuilderState;
-    if (initialParsedState) return initialParsedState;
-    const definition = RULE_BUILDER_REGISTRY[builderType];
-    return definition ? definition.createDefaultState() : undefined;
-  });
+  /*
+   * builderState's initial value and its "was it Discover-seeded" fact (builderParsedFromDiscover,
+   * a prop above) are both resolved by the caller now — see ComposeDiscoverBuilderStateHost. This
+   * only reads the live value from the context the caller wraps this component in.
+   */
+  const { state: builderState, setState: setBuilderState } = useBuilderState<BuilderState>();
 
   const validationErrors = inlineResult.unresolved;
   const hasValidationErrors = validationErrors.length > 0;
@@ -748,6 +746,7 @@ export function ComposeDiscoverFlyout({
       isBuilderMode,
       sandboxConfig.isEditable,
       builderState,
+      setBuilderState,
       uiState.queryCommitted,
       uiState.childOpen,
       uiState.yamlMode,
@@ -1257,26 +1256,21 @@ export function ComposeDiscoverFlyout({
               ) : (
                 <>
                   {validationCallout}
-                  <BuilderStateProvider
-                    builderState={builderState}
-                    setBuilderState={setBuilderState}
-                  >
-                    <ComposeDiscoverForm
-                      state={uiState}
-                      dispatch={dispatch}
-                      services={baseServices}
-                      onRecoveryTypeChange={handleRecoveryTypeChange}
-                      onKindChange={handleKindChange}
-                      isEditing={isEditing}
-                      ruleId={ruleId}
-                      builderType={builderType}
-                      currentStep={currentStep}
-                      renderCustomRecovery={renderCustomRecovery}
-                      onManualSplit={
-                        supportsUnifiedEditorToggle ? handleManualSplitFromForm : undefined
-                      }
-                    />
-                  </BuilderStateProvider>
+                  <ComposeDiscoverForm
+                    state={uiState}
+                    dispatch={dispatch}
+                    services={baseServices}
+                    onRecoveryTypeChange={handleRecoveryTypeChange}
+                    onKindChange={handleKindChange}
+                    isEditing={isEditing}
+                    ruleId={ruleId}
+                    builderType={builderType}
+                    currentStep={currentStep}
+                    renderCustomRecovery={renderCustomRecovery}
+                    onManualSplit={
+                      supportsUnifiedEditorToggle ? handleManualSplitFromForm : undefined
+                    }
+                  />
                 </>
               )}
             </EuiFlyoutBody>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -39,6 +39,7 @@ import { parseYamlToFormValues, serializeFormToYaml } from '../../form/utils/yam
 import { isNonRepresentableRule } from '../../form/utils/is_non_representable';
 import { ComposeDiscoverFooter } from './compose_discover_footer';
 import { ComposeDiscoverForm, getSteps } from './compose_discover_form';
+import type { ResolvedSteps } from './compose_discover_form';
 import {
   composeFormToCreateRequest,
   composeFormToUpdateRequest,
@@ -167,6 +168,13 @@ export interface ComposeDiscoverFlyoutProps {
   initialQuery?: string;
   /** ES|QL control variables from Discover — inlined into initialQuery when provided. */
   esqlVariables?: ESQLControlVariable[];
+  /**
+   * Resolves the step sequence for the current `isAlert` value. The caller owns this
+   * decision (e.g. a Builder wrapper supplies `(isAlert) => getSteps(isAlert, builderType)`)
+   * so the flyout itself never needs to know whether it's rendering a builder flow.
+   * Defaults to the plain (non-builder) step sequence when omitted.
+   */
+  resolveSteps?: (isAlert: boolean) => ResolvedSteps;
 }
 
 const FLYOUT_TITLE_ID = 'composeDiscoverFlyoutTitle';
@@ -223,6 +231,7 @@ export function ComposeDiscoverFlyout({
   initialBuilderState,
   initialQuery,
   esqlVariables,
+  resolveSteps,
 }: ComposeDiscoverFlyoutProps): React.ReactElement | null {
   const isBuilderMode = Boolean(builderType);
   /*
@@ -680,7 +689,9 @@ export function ComposeDiscoverFlyout({
   const supportsUnifiedEditorToggle = isCreate || isEditing;
   const title = getFlyoutTitle(mode);
 
-  const { steps } = getSteps(isAlert, builderType);
+  const { steps, renderCustomRecovery } = resolveSteps
+    ? resolveSteps(isAlert)
+    : getSteps(isAlert);
   const currentStep = steps[uiState.step];
   const isLastStep = uiState.step === steps.length - 1;
 
@@ -1240,6 +1251,8 @@ export function ComposeDiscoverFlyout({
                       isEditing={isEditing}
                       ruleId={ruleId}
                       builderType={builderType}
+                      currentStep={currentStep}
+                      renderCustomRecovery={renderCustomRecovery}
                       onManualSplit={
                         supportsUnifiedEditorToggle ? handleManualSplitFromForm : undefined
                       }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.test.tsx
@@ -84,7 +84,7 @@ const renderFooter = ({
     isCreate: true,
     hasValidationErrors: false,
     yamlHasErrors: false,
-    isBuilderMode: false,
+    isEditable: true,
     isBuilderStepValid: true,
     isSaving: false,
     onNext,
@@ -162,7 +162,7 @@ describe('ComposeDiscoverFooter', () => {
     it('dispatches GO_BACK when Back is clicked', () => {
       const { dispatch } = renderFooter({ stateOverrides: { step: 1 } });
       fireEvent.click(screen.getByTestId('composeDiscoverBack'));
-      expect(dispatch).toHaveBeenCalledWith({ type: 'GO_BACK', isBuilderMode: false });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'GO_BACK', isEditable: true });
     });
   });
 
@@ -352,10 +352,10 @@ describe('ComposeDiscoverFooter', () => {
       expect(screen.getByTestId('composeDiscoverBack')).toBeDisabled();
     });
 
-    it('does not disable Back when child flyout is open in builder mode', () => {
+    it('does not disable Back when child flyout is open and not editable (builder mode)', () => {
       renderFooter({
         stateOverrides: { step: 1, childOpen: true },
-        propsOverrides: { isBuilderMode: true },
+        propsOverrides: { isEditable: false },
       });
       expect(screen.getByTestId('composeDiscoverBack')).not.toBeDisabled();
     });
@@ -366,7 +366,7 @@ describe('ComposeDiscoverFooter', () => {
       renderFooter({
         propsOverrides: {
           currentStep: BUILDER_CONDITION_STEP,
-          isBuilderMode: true,
+          isEditable: false,
           isBuilderStepValid: false,
         },
       });
@@ -377,19 +377,19 @@ describe('ComposeDiscoverFooter', () => {
       renderFooter({
         propsOverrides: {
           currentStep: BUILDER_CONDITION_STEP,
-          isBuilderMode: true,
+          isEditable: false,
           isBuilderStepValid: true,
         },
       });
       expect(screen.getByTestId('composeDiscoverNext')).not.toBeDisabled();
     });
 
-    it('does not block Next due to childOpen in builder mode', () => {
+    it('does not block Next due to childOpen and not editable (builder mode)', () => {
       renderFooter({
         stateOverrides: { childOpen: true },
         propsOverrides: {
           currentStep: BUILDER_CONDITION_STEP,
-          isBuilderMode: true,
+          isEditable: false,
           isBuilderStepValid: true,
         },
       });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.tsx
@@ -66,7 +66,8 @@ export interface ComposeDiscoverFooterProps {
   isCreate: boolean;
   hasValidationErrors: boolean;
   yamlHasErrors: boolean;
-  isBuilderMode: boolean;
+  /** Mirrors sandboxConfig.isEditable — whether the sandbox owns an independent, losable draft right now. */
+  isEditable: boolean;
   isBuilderStepValid: boolean;
   isSaving: boolean;
   onNext: () => void;
@@ -82,7 +83,7 @@ export const ComposeDiscoverFooter = ({
   isCreate,
   hasValidationErrors,
   yamlHasErrors,
-  isBuilderMode,
+  isEditable,
   isBuilderStepValid,
   isSaving,
   onNext,
@@ -115,7 +116,7 @@ export const ComposeDiscoverFooter = ({
     alertConditionState !== undefined && alertConditionState !== 'success';
 
   const nextDisabled =
-    (!isBuilderMode && uiState.childOpen) ||
+    (isEditable && uiState.childOpen) ||
     hasValidationErrors ||
     (isConditionStep && !isBuilderStep && !uiState.queryCommitted) ||
     (isBuilderStep && !isBuilderStepValid) ||
@@ -185,8 +186,8 @@ export const ComposeDiscoverFooter = ({
             <EuiButton
               color="text"
               iconType="arrowLeft"
-              isDisabled={!isBuilderMode && uiState.childOpen}
-              onClick={() => dispatch({ type: 'GO_BACK', isBuilderMode })}
+              isDisabled={isEditable && uiState.childOpen}
+              onClick={() => dispatch({ type: 'GO_BACK', isEditable })}
               data-test-subj="composeDiscoverBack"
             >
               {BACK_BUTTON_LABEL}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -354,6 +354,53 @@ describe('step validation', () => {
       'notifications',
     ]);
   });
+
+  describe('getSandboxConfig', () => {
+    const alertStep = getSteps(true).steps.find((s) => s.id === 'alertCondition')!;
+    // getStepIds (no builderType) never includes 'builderCondition' — use the builder step list.
+    const builderStep = getSteps(true, 'threshold').steps.find((s) => s.id === 'builderCondition')!;
+    const recoveryStep = getSteps(true).steps.find((s) => s.id === 'recoveryCondition')!;
+    const detailsStep = getSteps(true).steps.find((s) => s.id === 'details')!;
+
+    it('alertCondition: single editor by default, auto-splits on Apply', () => {
+      const state = createState({ manualSplitEnabled: false });
+      expect(alertStep.getSandboxConfig!(state)).toEqual({
+        tabs: undefined,
+        autoSplitOnApply: true,
+      });
+    });
+
+    it('alertCondition: split tabs and no auto-split once manual split is enabled', () => {
+      const state = createState({ manualSplitEnabled: true });
+      expect(alertStep.getSandboxConfig!(state)).toEqual({
+        tabs: ['base', 'alert'],
+        autoSplitOnApply: false,
+      });
+    });
+
+    it('builderCondition: never has tabs or auto-split — every builder sandbox is read-only', () => {
+      const state = createState({ manualSplitEnabled: false });
+      expect(builderStep.getSandboxConfig!(state)).toEqual({
+        tabs: undefined,
+        autoSplitOnApply: false,
+      });
+    });
+
+    it('recoveryCondition: shows the recovery tab only when recoveryType is custom', () => {
+      expect(recoveryStep.getSandboxConfig!(createState({ recoveryType: 'custom' }))).toEqual({
+        tabs: ['recovery'],
+        autoSplitOnApply: false,
+      });
+      expect(recoveryStep.getSandboxConfig!(createState({ recoveryType: 'default' }))).toEqual({
+        tabs: undefined,
+        autoSplitOnApply: false,
+      });
+    });
+
+    it('details: no getSandboxConfig defined — caller defaults to a single editor, no auto-split', () => {
+      expect(detailsStep.getSandboxConfig).toBeUndefined();
+    });
+  });
 });
 
 describe('shell shared fields', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -99,8 +99,9 @@ const createComposeFormWrapper = (
   };
 };
 
-const renderComposeDiscoverDetailsStep = (defaultValues: FormValues = BASE_COMPOSE_VALUES) =>
-  render(
+const renderComposeDiscoverDetailsStep = (defaultValues: FormValues = BASE_COMPOSE_VALUES) => {
+  const { steps, renderCustomRecovery } = getSteps(defaultValues.kind === 'alert');
+  return render(
     <ComposeDiscoverForm
       state={createState({ step: 2 })}
       dispatch={jest.fn()}
@@ -108,9 +109,12 @@ const renderComposeDiscoverDetailsStep = (defaultValues: FormValues = BASE_COMPO
       onRecoveryTypeChange={jest.fn()}
       onKindChange={jest.fn()}
       isEditing={false}
+      currentStep={steps[2]}
+      renderCustomRecovery={renderCustomRecovery}
     />,
     { wrapper: createComposeFormWrapper(defaultValues) }
   );
+};
 
 describe('step validation', () => {
   beforeEach(() => {
@@ -358,14 +362,19 @@ describe('shell shared fields', () => {
     formOverrides: Partial<FormValues> = {}
   ) => {
     const services = { ...createMockServices(), dashboard: mockDashboard };
+    const state = createState({ queryCommitted: true, ...stateOverrides });
+    const isAlert = (formOverrides.kind ?? BASE_COMPOSE_VALUES.kind) === 'alert';
+    const { steps, renderCustomRecovery } = getSteps(isAlert);
     return render(
       <ComposeDiscoverForm
-        state={createState({ queryCommitted: true, ...stateOverrides })}
+        state={state}
         dispatch={jest.fn()}
         services={services}
         onRecoveryTypeChange={jest.fn()}
         onKindChange={jest.fn()}
         isEditing={false}
+        currentStep={steps[state.step]}
+        renderCustomRecovery={renderCustomRecovery}
       />,
       { wrapper: createComposeFormWrapper({ ...BASE_COMPOSE_VALUES, ...formOverrides }, services) }
     );
@@ -410,6 +419,7 @@ describe('shell shared fields', () => {
 
   it('disables ModeSelect in edit mode', () => {
     const services = { ...createMockServices(), dashboard: mockDashboard };
+    const { steps, renderCustomRecovery } = getSteps(true);
     render(
       <ComposeDiscoverForm
         state={createState({ queryCommitted: true, step: 0 })}
@@ -418,6 +428,8 @@ describe('shell shared fields', () => {
         onRecoveryTypeChange={jest.fn()}
         onKindChange={jest.fn()}
         isEditing={true}
+        currentStep={steps[0]}
+        renderCustomRecovery={renderCustomRecovery}
       />,
       { wrapper: createComposeFormWrapper({ ...BASE_COMPOSE_VALUES }, services) }
     );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -81,6 +81,24 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
       }
       return getBreachQuery(query).trim().length > 0;
     },
+    getSandboxConfig: (state) => {
+      /*
+       * create/edit/clone default to a single unified editor — no base/alert tabs — and
+       * derive the split heuristically on Apply. Manual split opts out of both: separate
+       * tabs, verbatim commit. (state.mode is remapped 'clone' -> 'edit' before it reaches
+       * state, so this is always true today; kept explicit to match the pre-refactor check.)
+       */
+      const usesUnifiedEditorByDefault =
+        state.mode === 'create' || state.mode === 'edit' || state.mode === 'clone';
+      return {
+        tabs: usesUnifiedEditorByDefault
+          ? state.manualSplitEnabled
+            ? ['base', 'alert']
+            : undefined
+          : ['base', 'alert'],
+        autoSplitOnApply: !state.manualSplitEnabled,
+      };
+    },
   },
   builderCondition: {
     id: 'builderCondition',
@@ -89,6 +107,9 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
     }),
     render: () => null,
     validate: (_methods, s) => s.queryCommitted,
+    // Every builder sandbox is read-only (isEditable: false, computed by the caller) — no
+    // tabs or auto-split concept applies since there's no independent draft to split.
+    getSandboxConfig: () => ({ tabs: undefined, autoSplitOnApply: false }),
   },
   recoveryCondition: {
     id: 'recoveryCondition',
@@ -103,6 +124,10 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
         renderCustomRecovery={props.renderCustomRecovery}
       />
     ),
+    getSandboxConfig: (state) => ({
+      tabs: state.recoveryType === 'custom' ? ['recovery'] : undefined,
+      autoSplitOnApply: false,
+    }),
   },
   details: {
     id: 'details',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { useWatch } from 'react-hook-form';
 import { EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
@@ -44,8 +44,11 @@ interface Props {
   onKindChange: (kind: 'signal' | 'alert') => void;
   isEditing: boolean;
   ruleId?: string;
+  /** Only used for the ModeSelect disable condition below — not step resolution (see `currentStep`). */
   builderType?: string;
   onManualSplit?: () => void;
+  currentStep: StepDefinition;
+  renderCustomRecovery: StepRenderProps['renderCustomRecovery'];
 }
 
 const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
@@ -135,7 +138,7 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
   },
 };
 
-interface ResolvedSteps {
+export interface ResolvedSteps {
   steps: StepDefinition[];
   renderCustomRecovery?: StepRenderProps['renderCustomRecovery'];
 }
@@ -180,13 +183,10 @@ export const ComposeDiscoverForm = ({
   ruleId,
   builderType,
   onManualSplit,
+  currentStep,
+  renderCustomRecovery,
 }: Props) => {
   const isAlert = useWatch<FormValues, 'kind'>({ name: 'kind' }) === 'alert';
-  const { steps, renderCustomRecovery } = useMemo(
-    () => getSteps(isAlert, builderType),
-    [isAlert, builderType]
-  );
-  const currentStep = steps[state.step];
   const isAlertConditionStep = isAlertConditionStepId(currentStep.id);
 
   const stepContent = currentStep.render({

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { ComposeDiscoverForm, getSteps } from './compose_discover_form';
+export type { ResolvedSteps } from './compose_discover_form';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/index.ts
@@ -8,6 +8,9 @@
 export { ComposeDiscoverFlyout } from './compose_discover_flyout';
 export type { ComposeDiscoverFlyoutProps } from './compose_discover_flyout';
 
+export { getSteps } from './compose_discover_form';
+export type { ResolvedSteps } from './compose_discover_form';
+
 export { QuerySandboxFlyout } from './query_sandbox_flyout';
 export type { QuerySandboxFlyoutProps } from './query_sandbox_flyout';
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/builder_state_host.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/builder_state_host.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import type { ESQLControlVariable } from '@kbn/esql-types';
+import { BuilderStateProvider } from './builder_state_context';
+import { resolveInitialBuilderState } from './resolve_initial_state';
+import type { BuilderState } from './types';
+
+export interface ComposeDiscoverBuilderStateHostProps {
+  builderType?: string;
+  initialBuilderState?: BuilderState;
+  initialQuery?: string;
+  esqlVariables?: ESQLControlVariable[];
+  children: (parsedFromDiscover: boolean) => React.ReactNode;
+}
+
+/**
+ * Resolves what builderState should start as, owns it for the lifetime of one
+ * ComposeDiscoverFlyout session, and wraps children in the BuilderStateProvider the
+ * flyout reads from — replacing the useState/Provider the flyout used to own internally.
+ * Mount this fresh each time a flyout session starts (e.g. inside the same conditional
+ * that mounts ComposeDiscoverFlyout) so builder state resets between sessions the same
+ * way the flyout's own local state used to when it fully unmounted/remounted.
+ */
+export const ComposeDiscoverBuilderStateHost = ({
+  builderType,
+  initialBuilderState,
+  initialQuery,
+  esqlVariables,
+  children,
+}: ComposeDiscoverBuilderStateHostProps): React.ReactElement => {
+  const [{ builderState: initial, parsedFromDiscover }] = useState(() =>
+    resolveInitialBuilderState(builderType, { initialBuilderState, initialQuery, esqlVariables })
+  );
+  const [builderState, setBuilderState] = useState<BuilderState>(initial);
+
+  return (
+    <BuilderStateProvider builderState={builderState} setBuilderState={setBuilderState}>
+      {children(parsedFromDiscover)}
+    </BuilderStateProvider>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/index.ts
@@ -8,6 +8,13 @@
 export type { RuleBuilderDefinition, RuleBuilderStepProps, BuilderState } from './types';
 export { RULE_BUILDER_REGISTRY } from './registry';
 export { BuilderStateProvider, useBuilderState } from './builder_state_context';
+export { resolveInitialBuilderState } from './resolve_initial_state';
+export type {
+  ResolvedBuilderState,
+  ResolveInitialBuilderStateParams,
+} from './resolve_initial_state';
+export { ComposeDiscoverBuilderStateHost } from './builder_state_host';
+export type { ComposeDiscoverBuilderStateHostProps } from './builder_state_host';
 export { RuleBuilderAlertConditionStep } from './threshold/alert_condition_step';
 export { buildThresholdEsql } from './threshold/build_esql';
 export { parseThresholdEsql, parseDiscoverQueryForBuilder } from './threshold/parse_esql';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/resolve_initial_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/resolve_initial_state.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ESQLControlVariable } from '@kbn/esql-types';
+import { inlineEsqlVariables } from '../../../utils/esql_rule_utils';
+import { RULE_BUILDER_REGISTRY } from './registry';
+import { parseDiscoverQueryForBuilder } from './threshold/parse_esql';
+import type { BuilderState } from './types';
+
+export interface ResolvedBuilderState {
+  builderState: BuilderState;
+  /**
+   * True when builderState was derived by successfully parsing a Discover-seeded query —
+   * false when it came from a caller-provided value or a fresh default. Callers that also
+   * seed the underlying RHF form from the same Discover query need this fact: a raw ES|QL
+   * string shouldn't be pushed into the form when the builder couldn't represent it.
+   */
+  parsedFromDiscover: boolean;
+}
+
+export interface ResolveInitialBuilderStateParams {
+  /** An already-known builder state (e.g. parsed from a persisted rule being edited). */
+  initialBuilderState?: BuilderState;
+  /** A Discover-seeded ES|QL query to attempt parsing into builder state, when initialBuilderState isn't provided. */
+  initialQuery?: string;
+  esqlVariables?: ESQLControlVariable[];
+}
+
+/**
+ * Resolves what a builder's state should start as, given everything a caller might supply.
+ * Mirrors resolveSteps' role for step sequencing: the caller (not ComposeDiscoverFlyout)
+ * decides this once, up front, so the flyout never needs its own "am I in builder mode"
+ * initial-state logic.
+ */
+export const resolveInitialBuilderState = (
+  builderType: string | undefined,
+  { initialBuilderState, initialQuery, esqlVariables }: ResolveInitialBuilderStateParams
+): ResolvedBuilderState => {
+  if (!builderType) {
+    return { builderState: undefined, parsedFromDiscover: false };
+  }
+  if (initialBuilderState !== undefined) {
+    return { builderState: initialBuilderState, parsedFromDiscover: false };
+  }
+  const inlinedQuery =
+    initialQuery !== undefined ? inlineEsqlVariables(initialQuery, esqlVariables).query : '';
+  const parsed = inlinedQuery ? parseDiscoverQueryForBuilder(inlinedQuery) : null;
+  if (parsed) {
+    return { builderState: parsed, parsedFromDiscover: true };
+  }
+  const definition = RULE_BUILDER_REGISTRY[builderType];
+  return { builderState: definition?.createDefaultState(), parsedFromDiscover: false };
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
@@ -59,6 +59,23 @@ export interface StepDefinition {
 }
 
 /**
+ * Three independent, intrinsically-named facts about the active sandbox editing surface —
+ * replaces checking a mode's name (currentStep.id, isBuilderMode, manualSplitEnabled, ...)
+ * at each use site. See the design thread for the full reasoning; the short version: the
+ * original bug this refactor responds to was one flag (manualSplitEnabled) doing two
+ * unrelated jobs (tab shape *and* apply behavior) — these three fields can't cross-multiply
+ * that way because each is a single, orthogonal fact.
+ */
+export interface SandboxConfig {
+  /** Which editors to show. undefined/[] = one unified editor. */
+  tabs: QueryTab[] | undefined;
+  /** Whether Apply should derive a split from free text (true) or commit the draft as-is. */
+  autoSplitOnApply: boolean;
+  /** Whether the sandbox owns an independent, losable draft, or mirrors an external source of truth. */
+  isEditable: boolean;
+}
+
+/**
  * UI-only state for the ComposeDiscover flyout.
  *
  * Query content lives in RHF (committed state) and local useState in the parent flyout (editing buffer).
@@ -86,12 +103,17 @@ export interface ComposeDiscoverState {
 }
 
 export type ComposeDiscoverAction =
-  | { type: 'SET_RECOVERY_TYPE'; recoveryType: RecoveryType; isBuilderMode?: boolean }
+  /**
+   * isEditable mirrors sandboxConfig.isEditable — whether the sandbox owns an independent,
+   * losable draft right now. Required (not optional) so a caller can't silently fall back
+   * to the wrong default.
+   */
+  | { type: 'SET_RECOVERY_TYPE'; recoveryType: RecoveryType; isEditable: boolean }
   | { type: 'KIND_CHANGE'; kind: 'signal' | 'alert' }
   | { type: 'SET_TAB'; tab: QueryTab }
   | { type: 'SET_STEP'; step: number }
-  | { type: 'GO_NEXT'; isAlert: boolean; isBuilderMode?: boolean }
-  | { type: 'GO_BACK'; isBuilderMode?: boolean }
+  | { type: 'GO_NEXT'; stepCount: number; isEditable: boolean }
+  | { type: 'GO_BACK'; isEditable: boolean }
   | { type: 'OPEN_CHILD'; isAlert: boolean }
   | { type: 'OPEN_CHILD_FOR_STEP'; step: number; isAlert: boolean }
   | { type: 'CLOSE_CHILD' }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
@@ -46,18 +46,6 @@ export interface StepRenderProps {
   onManualSplit?: () => void;
 }
 
-export interface StepDefinition {
-  id: StepId;
-  title: string;
-  render: (props: StepRenderProps) => React.ReactNode;
-  validate?: (
-    methods: UseFormReturn<FormValues>,
-    state: ComposeDiscoverState,
-    services?: RuleFormServices,
-    builderState?: BuilderState
-  ) => Promise<boolean> | boolean;
-}
-
 /**
  * Three independent, intrinsically-named facts about the active sandbox editing surface —
  * replaces checking a mode's name (currentStep.id, isBuilderMode, manualSplitEnabled, ...)
@@ -73,6 +61,27 @@ export interface SandboxConfig {
   autoSplitOnApply: boolean;
   /** Whether the sandbox owns an independent, losable draft, or mirrors an external source of truth. */
   isEditable: boolean;
+}
+
+/**
+ * The two SandboxConfig fields a step/source genuinely varies by identity — isEditable is
+ * deliberately excluded: it's uniform across every builder step (confirmed with Jason), so
+ * it's computed once by the caller assembling the final SandboxConfig, not per-step.
+ */
+export type StepSandboxConfig = Pick<SandboxConfig, 'tabs' | 'autoSplitOnApply'>;
+
+export interface StepDefinition {
+  id: StepId;
+  title: string;
+  render: (props: StepRenderProps) => React.ReactNode;
+  validate?: (
+    methods: UseFormReturn<FormValues>,
+    state: ComposeDiscoverState,
+    services?: RuleFormServices,
+    builderState?: BuilderState
+  ) => Promise<boolean> | boolean;
+  /** Omitted steps default to `{ tabs: undefined, autoSplitOnApply: false }` (single unified editor, no auto-split). */
+  getSandboxConfig?: (state: ComposeDiscoverState) => StepSandboxConfig;
 }
 
 /**

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
@@ -151,19 +151,23 @@ describe('reducer', () => {
   describe('SET_RECOVERY_TYPE', () => {
     it('opens child to recovery tab when switching to custom', () => {
       const state = createState({ recoveryType: 'default' });
-      const next = reducer(state, { type: 'SET_RECOVERY_TYPE', recoveryType: 'custom' });
+      const next = reducer(state, {
+        type: 'SET_RECOVERY_TYPE',
+        recoveryType: 'custom',
+        isEditable: true,
+      });
 
       expect(next.recoveryType).toBe('custom');
       expect(next.childOpen).toBe(true);
       expect(next.activeTab).toBe('recovery');
     });
 
-    it('does not open child when switching to custom in builder mode', () => {
+    it('does not open child when switching to custom and not editable (builder mode)', () => {
       const state = createState({ recoveryType: 'default', childOpen: false });
       const next = reducer(state, {
         type: 'SET_RECOVERY_TYPE',
         recoveryType: 'custom',
-        isBuilderMode: true,
+        isEditable: false,
       });
 
       expect(next.recoveryType).toBe('custom');
@@ -172,7 +176,11 @@ describe('reducer', () => {
 
     it('does not open child when switching to default', () => {
       const state = createState({ recoveryType: 'custom', childOpen: false });
-      const next = reducer(state, { type: 'SET_RECOVERY_TYPE', recoveryType: 'default' });
+      const next = reducer(state, {
+        type: 'SET_RECOVERY_TYPE',
+        recoveryType: 'default',
+        isEditable: true,
+      });
 
       expect(next.recoveryType).toBe('default');
       expect(next.childOpen).toBe(false);
@@ -198,43 +206,50 @@ describe('reducer', () => {
   });
 
   describe('GO_NEXT', () => {
-    it('closes preview when advancing in non-builder mode', () => {
+    it('closes preview when advancing and editable (non-builder mode)', () => {
       const state = createState({ step: 0, childOpen: true });
-      const next = reducer(state, { type: 'GO_NEXT', isAlert: true });
+      const next = reducer(state, { type: 'GO_NEXT', stepCount: 4, isEditable: true });
 
       expect(next.step).toBe(1);
       expect(next.childOpen).toBe(false);
     });
 
-    it('preserves preview state when advancing in builder mode', () => {
+    it('preserves preview state when advancing and not editable (builder mode)', () => {
       const state = createState({ step: 0, childOpen: true });
-      const next = reducer(state, { type: 'GO_NEXT', isAlert: true, isBuilderMode: true });
+      const next = reducer(state, { type: 'GO_NEXT', stepCount: 4, isEditable: false });
 
       expect(next.step).toBe(1);
       expect(next.childOpen).toBe(true);
     });
 
-    it('keeps preview closed if user closed it in builder mode', () => {
+    it('keeps preview closed if user closed it and not editable (builder mode)', () => {
       const state = createState({ step: 0, childOpen: false });
-      const next = reducer(state, { type: 'GO_NEXT', isAlert: true, isBuilderMode: true });
+      const next = reducer(state, { type: 'GO_NEXT', stepCount: 4, isEditable: false });
 
       expect(next.step).toBe(1);
       expect(next.childOpen).toBe(false);
+    });
+
+    it('clamps at stepCount - 1', () => {
+      const state = createState({ step: 3, childOpen: false });
+      const next = reducer(state, { type: 'GO_NEXT', stepCount: 4, isEditable: true });
+
+      expect(next.step).toBe(3);
     });
   });
 
   describe('GO_BACK', () => {
-    it('closes preview when going back in non-builder mode', () => {
+    it('closes preview when going back and editable (non-builder mode)', () => {
       const state = createState({ step: 2, childOpen: true });
-      const next = reducer(state, { type: 'GO_BACK' });
+      const next = reducer(state, { type: 'GO_BACK', isEditable: true });
 
       expect(next.step).toBe(1);
       expect(next.childOpen).toBe(false);
     });
 
-    it('preserves preview state when going back in builder mode', () => {
+    it('preserves preview state when going back and not editable (builder mode)', () => {
       const state = createState({ step: 2, childOpen: true });
-      const next = reducer(state, { type: 'GO_BACK', isBuilderMode: true });
+      const next = reducer(state, { type: 'GO_BACK', isEditable: false });
 
       expect(next.step).toBe(1);
       expect(next.childOpen).toBe(true);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
@@ -110,7 +110,7 @@ export function reducer(
       return {
         ...state,
         recoveryType: action.recoveryType,
-        ...(action.recoveryType === 'custom' && !action.isBuilderMode
+        ...(action.recoveryType === 'custom' && action.isEditable
           ? { childOpen: true, activeTab: 'recovery' as const }
           : {}),
       };
@@ -130,14 +130,11 @@ export function reducer(
     case 'SET_STEP':
       return { ...state, step: action.step };
     case 'GO_NEXT': {
-      const stepCount = (
-        action.isBuilderMode ? getBuilderStepIds(action.isAlert) : getStepIds(action.isAlert)
-      ).length;
-      const nextStep = Math.min(state.step + 1, stepCount - 1);
+      const nextStep = Math.min(state.step + 1, action.stepCount - 1);
       return {
         ...state,
         step: nextStep,
-        childOpen: action.isBuilderMode ? state.childOpen : false,
+        childOpen: action.isEditable ? false : state.childOpen,
       };
     }
     case 'GO_BACK': {
@@ -145,7 +142,7 @@ export function reducer(
       return {
         ...state,
         step: prevStep,
-        childOpen: action.isBuilderMode ? state.childOpen : false,
+        childOpen: action.isEditable ? false : state.childOpen,
       };
     }
     case 'OPEN_CHILD':

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -10,6 +10,10 @@ export { ComposeDiscoverFlyout } from './flyout/compose_discover';
 export type { ComposeDiscoverFlyoutProps } from './flyout/compose_discover';
 export type { ComposeDiscoverMode } from './flyout/compose_discover/types';
 
+// Step resolution — callers construct their own `resolveSteps` for ComposeDiscoverFlyoutProps
+export { getSteps } from './flyout/compose_discover';
+export type { ResolvedSteps } from './flyout/compose_discover';
+
 // Rule Builder registry
 export { RULE_BUILDER_REGISTRY } from './flyout/compose_discover/rule_builder';
 export type { BuilderState } from './flyout/compose_discover/rule_builder';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -18,6 +18,17 @@ export type { ResolvedSteps } from './flyout/compose_discover';
 export { RULE_BUILDER_REGISTRY } from './flyout/compose_discover/rule_builder';
 export type { BuilderState } from './flyout/compose_discover/rule_builder';
 
+// Builder state — callers own this via ComposeDiscoverBuilderStateHost, wrapping
+// ComposeDiscoverFlyout from the outside, instead of the flyout owning it internally.
+export {
+  ComposeDiscoverBuilderStateHost,
+  resolveInitialBuilderState,
+} from './flyout/compose_discover/rule_builder';
+export type {
+  ComposeDiscoverBuilderStateHostProps,
+  ResolvedBuilderState,
+} from './flyout/compose_discover/rule_builder';
+
 // Compose Discover sandbox — embeddable ES|QL editor + results panel (props-only)
 export { QuerySandboxFlyout } from './flyout/compose_discover';
 export type { QuerySandboxFlyoutProps, QueryTab } from './flyout/compose_discover';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
@@ -75,6 +75,13 @@ jest.mock('@kbn/alerting-v2-rule-form', () => ({
     capturedComposeProps = props;
     return <div data-test-subj="mockComposeDiscoverFlyout" />;
   },
+  // Pass-through: this test only asserts on props ComposeDiscoverFlyout receives, not
+  // on real builder-state resolution (that's covered in the package's own tests).
+  ComposeDiscoverBuilderStateHost: ({
+    children,
+  }: {
+    children: (parsedFromDiscover: boolean) => React.ReactNode;
+  }) => children(false),
 }));
 
 // Collects all pending resolvers from untilPluginStartServicesReady calls so the test

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
@@ -21,7 +21,11 @@ import type { History } from 'history';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
 import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
-import type { ComposeDiscoverFlyoutProps, ResolvedSteps } from '@kbn/alerting-v2-rule-form';
+import type {
+  ComposeDiscoverBuilderStateHostProps,
+  ComposeDiscoverFlyoutProps,
+  ResolvedSteps,
+} from '@kbn/alerting-v2-rule-form';
 import { Context } from '@kbn/core-di-browser';
 import { untilPluginStartServicesReady, type AlertingV2KibanaServices } from './kibana_services';
 import { RuleCreateOptionsFlyout } from './components/rule_create_options/rule_create_options_flyout';
@@ -64,6 +68,7 @@ interface LoadedModules {
   services: AlertingV2KibanaServices;
   ComposeDiscoverFlyout: React.ComponentType<ComposeDiscoverFlyoutProps>;
   getSteps: (isAlert: boolean, builderType?: string) => ResolvedSteps;
+  ComposeDiscoverBuilderStateHost: React.ComponentType<ComposeDiscoverBuilderStateHostProps>;
 }
 
 const noopSubscribe = () => () => {};
@@ -124,6 +129,7 @@ const CreateRuleOptionsFlyoutInner = ({
       services,
       ComposeDiscoverFlyout: mod.ComposeDiscoverFlyout,
       getSteps: mod.getSteps,
+      ComposeDiscoverBuilderStateHost: mod.ComposeDiscoverBuilderStateHost,
     };
   }, []);
 
@@ -238,7 +244,7 @@ const CreateRuleOptionsFlyoutInner = ({
     );
   }
 
-  const { services, ComposeDiscoverFlyout, getSteps } = value;
+  const { services, ComposeDiscoverFlyout, getSteps, ComposeDiscoverBuilderStateHost } = value;
 
   const isRuleManagementABSkillAvailable = getIsRuleManagementABSkillAvailable(
     services.application,
@@ -248,17 +254,21 @@ const CreateRuleOptionsFlyoutInner = ({
   if (step.type === 'esql') {
     return (
       <Context.Provider value={services.container}>
-        <ComposeDiscoverFlyout
-          historyKey={historyKey}
-          mode="create"
-          onClose={onClose}
-          services={services}
-          onCreateRule={handleCreateRule}
-          isSaving={isSaving}
-          initialQuery={query}
-          esqlVariables={esqlVariables}
-          resolveSteps={(isAlert) => getSteps(isAlert)}
-        />
+        <ComposeDiscoverBuilderStateHost>
+          {() => (
+            <ComposeDiscoverFlyout
+              historyKey={historyKey}
+              mode="create"
+              onClose={onClose}
+              services={services}
+              onCreateRule={handleCreateRule}
+              isSaving={isSaving}
+              initialQuery={query}
+              esqlVariables={esqlVariables}
+              resolveSteps={(isAlert) => getSteps(isAlert)}
+            />
+          )}
+        </ComposeDiscoverBuilderStateHost>
       </Context.Provider>
     );
   }
@@ -266,18 +276,27 @@ const CreateRuleOptionsFlyoutInner = ({
   if (step.type === 'threshold') {
     return (
       <Context.Provider value={services.container}>
-        <ComposeDiscoverFlyout
-          historyKey={historyKey}
-          mode="create"
-          onClose={onClose}
-          services={services}
+        <ComposeDiscoverBuilderStateHost
           builderType="threshold"
-          onCreateRule={handleCreateRule}
-          isSaving={isSaving}
           initialQuery={query}
           esqlVariables={esqlVariables}
-          resolveSteps={(isAlert) => getSteps(isAlert, 'threshold')}
-        />
+        >
+          {(builderParsedFromDiscover) => (
+            <ComposeDiscoverFlyout
+              historyKey={historyKey}
+              mode="create"
+              onClose={onClose}
+              services={services}
+              builderType="threshold"
+              builderParsedFromDiscover={builderParsedFromDiscover}
+              onCreateRule={handleCreateRule}
+              isSaving={isSaving}
+              initialQuery={query}
+              esqlVariables={esqlVariables}
+              resolveSteps={(isAlert) => getSteps(isAlert, 'threshold')}
+            />
+          )}
+        </ComposeDiscoverBuilderStateHost>
       </Context.Provider>
     );
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
@@ -21,7 +21,7 @@ import type { History } from 'history';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
 import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
-import type { ComposeDiscoverFlyoutProps } from '@kbn/alerting-v2-rule-form';
+import type { ComposeDiscoverFlyoutProps, ResolvedSteps } from '@kbn/alerting-v2-rule-form';
 import { Context } from '@kbn/core-di-browser';
 import { untilPluginStartServicesReady, type AlertingV2KibanaServices } from './kibana_services';
 import { RuleCreateOptionsFlyout } from './components/rule_create_options/rule_create_options_flyout';
@@ -63,6 +63,7 @@ type Step =
 interface LoadedModules {
   services: AlertingV2KibanaServices;
   ComposeDiscoverFlyout: React.ComponentType<ComposeDiscoverFlyoutProps>;
+  getSteps: (isAlert: boolean, builderType?: string) => ResolvedSteps;
 }
 
 const noopSubscribe = () => () => {};
@@ -122,6 +123,7 @@ const CreateRuleOptionsFlyoutInner = ({
     return {
       services,
       ComposeDiscoverFlyout: mod.ComposeDiscoverFlyout,
+      getSteps: mod.getSteps,
     };
   }, []);
 
@@ -236,7 +238,7 @@ const CreateRuleOptionsFlyoutInner = ({
     );
   }
 
-  const { services, ComposeDiscoverFlyout } = value;
+  const { services, ComposeDiscoverFlyout, getSteps } = value;
 
   const isRuleManagementABSkillAvailable = getIsRuleManagementABSkillAvailable(
     services.application,
@@ -255,6 +257,7 @@ const CreateRuleOptionsFlyoutInner = ({
           isSaving={isSaving}
           initialQuery={query}
           esqlVariables={esqlVariables}
+          resolveSteps={(isAlert) => getSteps(isAlert)}
         />
       </Context.Provider>
     );
@@ -273,6 +276,7 @@ const CreateRuleOptionsFlyoutInner = ({
           isSaving={isSaving}
           initialQuery={query}
           esqlVariables={esqlVariables}
+          resolveSteps={(isAlert) => getSteps(isAlert, 'threshold')}
         />
       </Context.Provider>
     );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_compose_discover_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_compose_discover_flyout.tsx
@@ -10,7 +10,12 @@ import type {
   ComposeDiscoverMode,
   RuleFormServices,
 } from '@kbn/alerting-v2-rule-form';
-import { ComposeDiscoverFlyout, getSteps, RULE_BUILDER_REGISTRY } from '@kbn/alerting-v2-rule-form';
+import {
+  ComposeDiscoverBuilderStateHost,
+  ComposeDiscoverFlyout,
+  getSteps,
+  RULE_BUILDER_REGISTRY,
+} from '@kbn/alerting-v2-rule-form';
 import { getBreachEsqlQuery, getRecoverEsqlQuery } from '@kbn/alerting-v2-schemas';
 import { PluginStart } from '@kbn/core-di';
 import { CoreStart, useService } from '@kbn/core-di-browser';
@@ -186,45 +191,52 @@ export const useComposeDiscoverFlyout = ({
   );
 
   const flyout = flyoutOpen ? (
-    <ComposeDiscoverFlyout
-      historyKey={historyKey}
-      mode={flyoutMode}
-      rule={targetRule ?? undefined}
-      ruleId={flyoutMode === 'edit' ? targetRule?.id : undefined}
-      onClose={closeFlyout}
-      services={ruleFormServices}
+    <ComposeDiscoverBuilderStateHost
       builderType={builderType ?? undefined}
       initialBuilderState={initialBuilderState}
-      resolveSteps={resolveSteps}
-      onCreateRule={(payload, ruleNotifications) =>
-        createRuleMutation.mutate(payload, {
-          onSuccess: (rule) => {
-            const actions = ruleNotifications?.workflows ?? [];
-            if (actions.length > 0) {
-              setupNotificationsMutation.mutate(
-                { rule, actions },
-                { onSuccess: closeAndRedirect, onError: closeAndRedirect }
-              );
-            } else {
-              closeAndRedirect();
-            }
-          },
-        })
-      }
-      onUpdateRule={(id, payload) =>
-        updateRuleMutation.mutate(
-          { id, payload },
-          {
-            onSuccess: closeFlyout,
+    >
+      {(builderParsedFromDiscover) => (
+        <ComposeDiscoverFlyout
+          historyKey={historyKey}
+          mode={flyoutMode}
+          rule={targetRule ?? undefined}
+          ruleId={flyoutMode === 'edit' ? targetRule?.id : undefined}
+          onClose={closeFlyout}
+          services={ruleFormServices}
+          builderType={builderType ?? undefined}
+          builderParsedFromDiscover={builderParsedFromDiscover}
+          resolveSteps={resolveSteps}
+          onCreateRule={(payload, ruleNotifications) =>
+            createRuleMutation.mutate(payload, {
+              onSuccess: (rule) => {
+                const actions = ruleNotifications?.workflows ?? [];
+                if (actions.length > 0) {
+                  setupNotificationsMutation.mutate(
+                    { rule, actions },
+                    { onSuccess: closeAndRedirect, onError: closeAndRedirect }
+                  );
+                } else {
+                  closeAndRedirect();
+                }
+              },
+            })
           }
-        )
-      }
-      isSaving={
-        createRuleMutation.isLoading ||
-        setupNotificationsMutation.isLoading ||
-        updateRuleMutation.isLoading
-      }
-    />
+          onUpdateRule={(id, payload) =>
+            updateRuleMutation.mutate(
+              { id, payload },
+              {
+                onSuccess: closeFlyout,
+              }
+            )
+          }
+          isSaving={
+            createRuleMutation.isLoading ||
+            setupNotificationsMutation.isLoading ||
+            updateRuleMutation.isLoading
+          }
+        />
+      )}
+    </ComposeDiscoverBuilderStateHost>
   ) : null;
 
   return {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_compose_discover_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_compose_discover_flyout.tsx
@@ -10,7 +10,7 @@ import type {
   ComposeDiscoverMode,
   RuleFormServices,
 } from '@kbn/alerting-v2-rule-form';
-import { ComposeDiscoverFlyout, RULE_BUILDER_REGISTRY } from '@kbn/alerting-v2-rule-form';
+import { ComposeDiscoverFlyout, getSteps, RULE_BUILDER_REGISTRY } from '@kbn/alerting-v2-rule-form';
 import { getBreachEsqlQuery, getRecoverEsqlQuery } from '@kbn/alerting-v2-schemas';
 import { PluginStart } from '@kbn/core-di';
 import { CoreStart, useService } from '@kbn/core-di-browser';
@@ -180,6 +180,11 @@ export const useComposeDiscoverFlyout = ({
     [openRuleFlyout]
   );
 
+  const resolveSteps = useCallback(
+    (isAlert: boolean) => getSteps(isAlert, builderType ?? undefined),
+    [builderType]
+  );
+
   const flyout = flyoutOpen ? (
     <ComposeDiscoverFlyout
       historyKey={historyKey}
@@ -190,6 +195,7 @@ export const useComposeDiscoverFlyout = ({
       services={ruleFormServices}
       builderType={builderType ?? undefined}
       initialBuilderState={initialBuilderState}
+      resolveSteps={resolveSteps}
       onCreateRule={(payload, ruleNotifications) =>
         createRuleMutation.mutate(payload, {
           onSuccess: (rule) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
@@ -85,6 +85,12 @@ jest.mock('@kbn/alerting-v2-rule-form', () => ({
       Compose Discover flyout
     </button>
   ),
+  // Pass-through: this test doesn't exercise real builder-state resolution.
+  ComposeDiscoverBuilderStateHost: ({
+    children,
+  }: {
+    children: (parsedFromDiscover: boolean) => React.ReactNode;
+  }) => children(false),
 }));
 
 const mockUseFetchRules = jest.fn();


### PR DESCRIPTION
Closes #276279.

Draft PR to track progress on the `resolveSteps`/`SandboxConfig`/builder-state refactor described in #276279. Opened early for visibility into the diff as it develops — not ready for review yet.

## The problem

`ComposeDiscoverFlyout` decides internal behavior by checking a mode's *name* at scattered call sites (`currentStep.id === 'alertCondition'`, `isBuilderMode`, `manualSplitEnabled`) instead of by intrinsic facts. The bug that started this refactor (see #276279) was one flag doing two unrelated jobs — a symptom of that pattern.

## Commits, each a self-contained step toward the fix

1. **Let callers resolve their own step sequence (`resolveSteps`)** — the flyout no longer computes `isBuilderMode` to decide which steps exist; the wrapping caller supplies its own step sequence.
2. **Introduce `SandboxConfig`: one derived fact, not scattered `isBuilderMode` checks** — replaces ~10 separate `isBuilderMode` reads (navigation blocking, footer disable logic, sandbox wiring, help text, header actions) with one object's `isEditable` field. No bare `isEditable` variable is left over — `sandboxConfig.isEditable` is the only source.
3. **Source `SandboxConfig.tabs`/`.autoSplitOnApply` per-step instead of ad hoc** — completes the model: these two fields move from ad hoc `currentStep.id` checks to a real per-step `getSandboxConfig` function, fixing a latent non-builder-aware bug along the way (builder mode was borrowing `alertCondition`'s tab logic via array-index coincidence).
4. **Move `builderState` ownership out of `ComposeDiscoverFlyout`** — the last remaining piece. The flyout no longer owns builder state via its own `useState`/`BuilderStateProvider`; a new `ComposeDiscoverBuilderStateHost` (mirroring how `resolveSteps` works) resolves and owns it in the caller instead, and the flyout reads it from context.

After this PR, `ComposeDiscoverFlyout` no longer computes `isBuilderMode` internally or checks a step's name to decide behavior anywhere except a small set of intentionally-parked exceptions (documented in the design thread) — every caller-facing decision is either handed in explicitly (`resolveSteps`, `builderType` for payload construction) or derived once into `SandboxConfig`/`useBuilderState()`.
