### PR TITLE
Fix ESO ci_checks snapshot after alert v14 and selective testing gap

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts
@@ -22,6 +22,15 @@ describe('expandJestImplicitConsumers', () => {
     expect(expanded.has('@kbn/alerting-plugin')).toBe(true);
   });
 
+  it('adds encrypted_saved_objects when an upstream plugin changes SO registration', () => {
+    const affected = new Set(['@kbn/fleet-plugin']);
+    const changedFiles = ['x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts'];
+
+    const expanded = expandJestImplicitConsumers(affected, changedFiles);
+
+    expect(expanded.has('@kbn/encrypted-saved-objects-plugin')).toBe(true);
+  });
+
   it('does not add encrypted_saved_objects for unrelated changes', () => {
     const affected = new Set(['@kbn/alerting-plugin']);
     const changedFiles = ['x-pack/platform/plugins/shared/alerting/server/routes/foo.ts'];

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expandJestImplicitConsumers } from './jest_implicit_consumers';
+
+describe('expandJestImplicitConsumers', () => {
+  it('adds encrypted_saved_objects when an upstream plugin changes SO model versions', () => {
+    const affected = new Set(['@kbn/alerting-plugin']);
+    const changedFiles = [
+      'x-pack/platform/plugins/shared/alerting/server/saved_objects/model_versions/rule_model_versions.ts',
+    ];
+
+    const expanded = expandJestImplicitConsumers(affected, changedFiles);
+
+    expect(expanded.has('@kbn/encrypted-saved-objects-plugin')).toBe(true);
+    expect(expanded.has('@kbn/alerting-plugin')).toBe(true);
+  });
+
+  it('does not add encrypted_saved_objects for unrelated changes', () => {
+    const affected = new Set(['@kbn/alerting-plugin']);
+    const changedFiles = ['x-pack/platform/plugins/shared/alerting/server/routes/foo.ts'];
+
+    const expanded = expandJestImplicitConsumers(affected, changedFiles);
+
+    expect(expanded.has('@kbn/encrypted-saved-objects-plugin')).toBe(false);
+  });
+});

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.ts
@@ -28,10 +28,13 @@ const ENCRYPTED_SAVED_OBJECTS_PLUGIN = '@kbn/encrypted-saved-objects-plugin';
 
 const IMPLICIT_JEST_CONSUMERS: readonly ImplicitConsumerRule[] = [
   {
-    reason: 'Encrypted SO model-version/schema changes must refresh the ESO ci_checks snapshot.',
+    reason:
+      'Encrypted SO registration, model-version, or schema changes must refresh the ESO ci_checks snapshot.',
     patterns: [
+      '**/server/saved_objects/index.{ts,tsx}',
       '**/server/saved_objects/model_versions/**/*.{ts,tsx}',
       '**/server/saved_objects/schemas/**/*.{ts,tsx}',
+      '**/packages/**/server/saved_objects/index.{ts,tsx}',
       '**/packages/**/server/saved_objects/model_versions/**/*.{ts,tsx}',
       '**/packages/**/server/saved_objects/schemas/**/*.{ts,tsx}',
     ],

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Overlay for Jest selective testing.
+ *
+ * The encrypted_saved_objects integration ci_checks test validates every
+ * registered encrypted SO type at runtime, but lives in @kbn/encrypted-saved-objects-plugin
+ * while publishers (alerting, actions, fleet, …) sit upstream in the dependency graph.
+ * Publisher-only model-version changes therefore skip that config under includeDownstream.
+ */
+
+import minimatch from 'minimatch';
+
+interface ImplicitConsumerRule {
+  reason: string;
+  patterns: readonly string[];
+  consumers: readonly string[];
+}
+
+const ENCRYPTED_SAVED_OBJECTS_PLUGIN = '@kbn/encrypted-saved-objects-plugin';
+
+const IMPLICIT_JEST_CONSUMERS: readonly ImplicitConsumerRule[] = [
+  {
+    reason: 'Encrypted SO model-version/schema changes must refresh the ESO ci_checks snapshot.',
+    patterns: [
+      '**/server/saved_objects/model_versions/**/*.{ts,tsx}',
+      '**/server/saved_objects/schemas/**/*.{ts,tsx}',
+      '**/packages/**/server/saved_objects/model_versions/**/*.{ts,tsx}',
+      '**/packages/**/server/saved_objects/schemas/**/*.{ts,tsx}',
+    ],
+    consumers: [ENCRYPTED_SAVED_OBJECTS_PLUGIN],
+  },
+];
+
+export function expandJestImplicitConsumers(
+  affected: ReadonlySet<string>,
+  changedFiles: readonly string[]
+): Set<string> {
+  const expanded = new Set(affected);
+
+  for (const rule of IMPLICIT_JEST_CONSUMERS) {
+    const trigger = changedFiles.find((file) =>
+      rule.patterns.some((pattern) => minimatch(file, pattern, { dot: true }))
+    );
+    if (!trigger) continue;
+
+    for (const id of rule.consumers) {
+      if (!expanded.has(id)) {
+        expanded.add(id);
+        console.log(
+          `Implicit Jest consumer added: ${id} (triggered by '${trigger}' — ${rule.reason})`
+        );
+      }
+    }
+  }
+
+  return expanded;
+}

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
@@ -16,6 +16,8 @@ import {
   touchedCriticalFiles,
 } from '../../affected-packages';
 
+import { expandJestImplicitConsumers } from './jest_implicit_consumers';
+
 /**
  * The shared inputs both per-variant filters need: which packages the PR
  * affects and which files it changed. Returned as `null` when affected-packages
@@ -49,9 +51,13 @@ export async function resolveSelectiveTestingContext(
     return null;
   }
 
-  console.log('Filtering Jest unit/integration tests for affected packages:', affectedPackages);
   const prChangedFiles = listChangedFiles({ mergeBase, commit: 'HEAD' });
-  return { affectedPackages, prChangedFiles };
+  const expandedAffectedPackages = expandJestImplicitConsumers(affectedPackages, prChangedFiles);
+  console.log(
+    'Filtering Jest unit/integration tests for affected packages:',
+    expandedAffectedPackages
+  );
+  return { affectedPackages: expandedAffectedPackages, prChangedFiles };
 }
 
 /** Narrow Jest unit configs to those owned by affected packages, unless a critical file changed. */

--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
@@ -129,6 +129,7 @@ describe('checking changes on all registered encrypted SO types', () => {
         "alert|4",
         "alert|3",
         "alert|2",
+        "alert|14",
         "alert|13",
         "alert|12",
         "alert|11",


### PR DESCRIPTION
## Summary
- Update the encrypted_saved_objects ci_checks snapshot for `alert|14` introduced by #276204.
- Add a Jest selective-testing implicit consumer so upstream SO model-version/schema changes trigger `@kbn/encrypted-saved-objects-plugin` integration tests.

Fixes #240719
Closes https://github.com/elastic/kibana-operations/issues/575

## Test plan
- [x] `node scripts/jest .buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts`
- [x] CI: encrypted_saved_objects jest integration ci_checks passes
- [x] CI: PR selective testing includes ESO integration config when alerting SO schemas change


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->