### PR TITLE
[8.19] [Console] Fix memoize ES|QL autocomplete sources (#275535)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts
@@ -12,3 +12,4 @@ export { useSetInitialValue } from './use_set_initial_value';
 export { useSetupAutocompletePolling } from './use_setup_autocomplete_polling';
 export { useSetupAutosave } from './use_setup_autosave';
 export { useKeyboardCommandsUtils } from './use_register_keyboard_commands';
+export { useConsoleEsqlCallbacks } from './use_console_esql_callbacks';

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import { getESQLSources } from '@kbn/esql-editor/src/helpers';
+import { getESQLQueryColumns } from '@kbn/esql-utils';
+import { serviceContextMock } from '../../../contexts/services_context.mock';
+import {
+  CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY,
+  useConsoleEsqlCallbacks,
+} from './use_console_esql_callbacks';
+
+jest.mock('@kbn/esql-editor/src/helpers', () => ({
+  getESQLSources: jest.fn(),
+}));
+
+jest.mock('@kbn/esql-utils', () => ({
+  getESQLQueryColumns: jest.fn(),
+}));
+
+const mockGetESQLSources = getESQLSources as jest.MockedFunction<typeof getESQLSources>;
+const mockGetESQLQueryColumns = getESQLQueryColumns as jest.MockedFunction<
+  typeof getESQLQueryColumns
+>;
+
+type SourcesResult = Awaited<ReturnType<typeof getESQLSources>>;
+
+const createParams = () => {
+  const {
+    services: { application, http, licensing, data, dataViews },
+  } = serviceContextMock.create();
+
+  return { application, http, licensing, data, dataViews };
+};
+
+describe('useConsoleEsqlCallbacks', () => {
+  const sources: SourcesResult = [{ name: 'logs', hidden: false, type: 'Index' }];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+    mockGetESQLSources.mockResolvedValue(sources);
+    mockGetESQLQueryColumns.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reuses the same sources request while the cache is fresh', async () => {
+    const params = createParams();
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(params));
+
+    const firstRequest = result.current.getSources!();
+    const secondRequest = result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+    expect(mockGetESQLSources).toHaveBeenCalledWith(
+      params.dataViews,
+      { application: params.application, http: params.http },
+      params.licensing.getLicense
+    );
+    await expect(firstRequest).resolves.toBe(sources);
+    await expect(secondRequest).resolves.toBe(sources);
+
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches sources again after the cache expires', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    await result.current.getSources!();
+    nowSpy.mockReturnValue(1000 + CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY + 1);
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache rejected sources requests', async () => {
+    const error = new Error('failed to fetch sources');
+    mockGetESQLSources.mockRejectedValueOnce(error).mockResolvedValueOnce(sources);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    await expect(result.current.getSources!()).rejects.toThrow(error);
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects concurrent callers sharing an in-flight request that fails and refetches afterwards', async () => {
+    const error = new Error('failed to fetch sources');
+    let rejectInFlight: (reason: Error) => void;
+    mockGetESQLSources
+      .mockImplementationOnce(
+        () =>
+          new Promise<SourcesResult>((_resolve, reject) => {
+            rejectInFlight = reject;
+          })
+      )
+      .mockResolvedValueOnce(sources);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    const firstRequest = result.current.getSources!();
+    const secondRequest = result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+
+    rejectInFlight!(error);
+
+    await expect(firstRequest).rejects.toThrow(error);
+    await expect(secondRequest).rejects.toThrow(error);
+
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a fresh cache when a stale request rejects after the cache was refreshed', async () => {
+    const staleError = new Error('stale sources request');
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    let rejectStale: (reason: Error) => void;
+    mockGetESQLSources
+      .mockImplementationOnce(
+        () =>
+          new Promise<SourcesResult>((_resolve, reject) => {
+            rejectStale = reject;
+          })
+      )
+      .mockResolvedValueOnce(sources);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    const staleRequest = Promise.resolve(result.current.getSources!());
+    staleRequest.catch(() => {});
+
+    nowSpy.mockReturnValue(1000 + CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY + 1);
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+
+    rejectStale!(staleError);
+    await expect(staleRequest).rejects.toThrow(staleError);
+
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts a fresh sources cache when dependencies change', async () => {
+    const { result, rerender } = renderHook((props) => useConsoleEsqlCallbacks(props), {
+      initialProps: createParams(),
+    });
+
+    await result.current.getSources!();
+    rerender(createParams());
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the cached sources and callback identity across rerenders when dependencies are unchanged', async () => {
+    const params = createParams();
+    const { result, rerender } = renderHook((props) => useConsoleEsqlCallbacks(props), {
+      initialProps: params,
+    });
+
+    const initialCallbacks = result.current;
+    await result.current.getSources!();
+    rerender(params);
+
+    expect(result.current).toBe(initialCallbacks);
+
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates column requests without caching them', async () => {
+    const params = createParams();
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(params));
+
+    await result.current.getColumnsFor!({ query: 'FROM logs' });
+    await result.current.getColumnsFor!({ query: 'FROM logs' });
+
+    expect(mockGetESQLQueryColumns).toHaveBeenCalledWith({
+      esqlQuery: 'FROM logs',
+      search: params.data.search.search,
+    });
+    expect(mockGetESQLQueryColumns).toHaveBeenCalledTimes(2);
+
+    const emptyResult = await result.current.getColumnsFor!();
+
+    expect(emptyResult).toEqual([]);
+    expect(mockGetESQLQueryColumns).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { ESQLCallbacks } from '@kbn/monaco';
+import { getESQLSources } from '@kbn/esql-editor/src/helpers';
+import { getESQLQueryColumns } from '@kbn/esql-utils';
+import { FieldType } from '@kbn/esql-validation-autocomplete/src/definitions/types';
+import { KBN_FIELD_TYPES } from '@kbn/field-types';
+import type { ContextValue } from '../../../contexts';
+
+export const CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
+
+interface CachedSources {
+  timestamp: number;
+  result: ReturnType<typeof getESQLSources>;
+}
+
+interface UseConsoleEsqlCallbacksParams {
+  application: ContextValue['services']['application'];
+  http: ContextValue['services']['http'];
+  licensing: ContextValue['services']['licensing'];
+  data: ContextValue['services']['data'];
+  dataViews: ContextValue['services']['dataViews'];
+}
+
+export const useConsoleEsqlCallbacks = ({
+  application,
+  http,
+  licensing,
+  data,
+  dataViews,
+}: UseConsoleEsqlCallbacksParams): ESQLCallbacks => {
+  const getSources = useMemo<Required<ESQLCallbacks>['getSources']>(() => {
+    let cachedSources: CachedSources | undefined;
+
+    return async () => {
+      // Re-fetch only when there is no cached result yet or the cached one has
+      // gone stale, so autocomplete does not hit the sources API on every keystroke.
+      // The staleness window mirrors the ES|QL editor's cache TTL for consistent behavior.
+      if (
+        !cachedSources ||
+        Date.now() - cachedSources.timestamp > CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY
+      ) {
+        const result = getESQLSources(dataViews, { application, http }, licensing?.getLicense);
+        // Evict the cached entry if this fetch rejects, but only if it is still the
+        // current one, so a later successful fetch is never overwritten by a stale failure.
+        void result.catch(() => {
+          if (cachedSources?.result === result) {
+            cachedSources = undefined;
+          }
+        });
+
+        cachedSources = {
+          timestamp: Date.now(),
+          result,
+        };
+      }
+
+      return cachedSources.result;
+    };
+  }, [application, http, licensing?.getLicense, dataViews]);
+
+  const getColumnsFor = useCallback(
+    async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
+      if (queryToExecute) {
+        try {
+          const columns = await getESQLQueryColumns({
+            esqlQuery: queryToExecute,
+            search: data.search.search,
+          });
+          return (
+            columns?.map((c) => {
+              return {
+                name: c.name,
+                type: c.meta.esType as FieldType,
+                hasConflict: c.meta.type === KBN_FIELD_TYPES.CONFLICT,
+              };
+            }) || []
+          );
+        } catch (error) {
+          // Handle error
+          return [];
+        }
+      }
+      return [];
+    },
+    [data.search.search]
+  );
+
+  return useMemo<ESQLCallbacks>(
+    () => ({
+      getSources,
+      getColumnsFor,
+    }),
+    [getSources, getColumnsFor]
+  );
+};

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
@@ -11,12 +11,8 @@ import React, { CSSProperties, useCallback, useMemo, useRef, useState, useEffect
 import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { CodeEditor } from '@kbn/code-editor';
-import { CONSOLE_LANG_ID, CONSOLE_THEME_ID, ConsoleLang, ESQLCallbacks, monaco } from '@kbn/monaco';
+import { CONSOLE_LANG_ID, CONSOLE_THEME_ID, ConsoleLang, monaco } from '@kbn/monaco';
 import { i18n } from '@kbn/i18n';
-import { getESQLSources } from '@kbn/esql-editor/src/helpers';
-import { getESQLQueryColumns } from '@kbn/esql-utils';
-import { FieldType } from '@kbn/esql-validation-autocomplete/src/definitions/types';
-import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { MonacoEditorActionsProvider } from './monaco_editor_actions_provider';
 import type { EditorRequest } from './types';
 import {
@@ -25,6 +21,7 @@ import {
   useSetupAutosave,
   useResizeCheckerUtils,
   useKeyboardCommandsUtils,
+  useConsoleEsqlCallbacks,
 } from './hooks';
 import {
   useServicesContext,
@@ -138,38 +135,7 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
     unregisterKeyboardCommands();
   }, [destroyResizeChecker, unregisterKeyboardCommands]);
 
-  const esqlCallbacks: ESQLCallbacks = useMemo(() => {
-    const callbacks: ESQLCallbacks = {
-      getSources: async () => {
-        const getLicense = licensing?.getLicense;
-        return await getESQLSources(dataViews, { application, http }, getLicense);
-      },
-      getColumnsFor: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
-        if (queryToExecute) {
-          try {
-            const columns = await getESQLQueryColumns({
-              esqlQuery: queryToExecute,
-              search: data.search.search,
-            });
-            return (
-              columns?.map((c) => {
-                return {
-                  name: c.name,
-                  type: c.meta.esType as FieldType,
-                  hasConflict: c.meta.type === KBN_FIELD_TYPES.CONFLICT,
-                };
-              }) || []
-            );
-          } catch (error) {
-            // Handle error
-            return [];
-          }
-        }
-        return [];
-      },
-    };
-    return callbacks;
-  }, [licensing, dataViews, application, http, data.search.search]);
+  const esqlCallbacks = useConsoleEsqlCallbacks({ application, http, licensing, data, dataViews });
 
   const suggestionProvider = useMemo(
     () => ConsoleLang.getSuggestionProvider?.(esqlCallbacks, actionsProvider),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix memoize ES|QL autocomplete sources (#275535)](https://github.com/elastic/kibana/pull/275535)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-07-03T15:52:11Z","message":"[Console] Fix memoize ES|QL autocomplete sources (#275535)\n\nCloses #271878\n\n## Summary\n\n- Memoizes Console's ES|QL source autocomplete callback so repeated\nsource completions reuse a fresh request instead of refetching the same\nsource list on every keystroke.\n- Keeps ES|QL column lookup uncached and refreshes the source cache when\nservice dependencies change, after the cache expires, or after a failed\nsource request.\n\n## Root Cause\n\n- Console wired ES|QL source autocomplete directly to `getESQLSources`,\nso every source-position completion invoked the sources lookup again.\n\n## Fix\n\n- Moves Console ES|QL callbacks into `useConsoleEsqlCallbacks`, caches\nthe in-flight/resolved sources request for 10 minutes, and clears the\ncache on rejection.\n- Adds hook coverage for fresh-cache reuse, cache expiry,\nrejected-request retry, dependency changes, rerender identity stability,\nand uncached column lookup.\n\n\nhttps://github.com/user-attachments/assets/5217ef88-9ee2-4163-937f-16320bbc30cb\n\n## Test Plan\n\n- In local Kibana, open Dev Tools > Console and enter:\n  ```\n  POST _query\n  {\n    \"query\": \"\"\"FROM \"\"\"\n  }\n  ```\nPlace the cursor after `FROM `, open browser DevTools > Network, and\ntype a few characters of an index name, such as `logs`. Expected result:\nafter the initial ES|QL sources and Fleet package requests, typing more\ncharacters does not issue a new sources request or `GET\n/api/fleet/epm/packages/installed` on every keystroke while the source\ncache is fresh.\n- `node scripts/jest\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts`\n— 8 tests passed\n- `node scripts/eslint\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx`\n— no errors\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — exited with 0\n\n## Release Note\n\n- Console ES|QL source autocomplete now reuses a fresh source list\ninstead of refetching it on every keystroke.\n\nAssisted with Copilot using GPT-5.5\n\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>","sha":"b41dce55a0d6eed0d27400708c91cab1822aacbd","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","Feature:Dev Tools","release_note:fix","Team:Kibana Management","backport:all-open","v9.5.0","v9.4.4","v9.3.8"],"title":"[Console] Fix memoize ES|QL autocomplete sources","number":275535,"url":"https://github.com/elastic/kibana/pull/275535","mergeCommit":{"message":"[Console] Fix memoize ES|QL autocomplete sources (#275535)\n\nCloses #271878\n\n## Summary\n\n- Memoizes Console's ES|QL source autocomplete callback so repeated\nsource completions reuse a fresh request instead of refetching the same\nsource list on every keystroke.\n- Keeps ES|QL column lookup uncached and refreshes the source cache when\nservice dependencies change, after the cache expires, or after a failed\nsource request.\n\n## Root Cause\n\n- Console wired ES|QL source autocomplete directly to `getESQLSources`,\nso every source-position completion invoked the sources lookup again.\n\n## Fix\n\n- Moves Console ES|QL callbacks into `useConsoleEsqlCallbacks`, caches\nthe in-flight/resolved sources request for 10 minutes, and clears the\ncache on rejection.\n- Adds hook coverage for fresh-cache reuse, cache expiry,\nrejected-request retry, dependency changes, rerender identity stability,\nand uncached column lookup.\n\n\nhttps://github.com/user-attachments/assets/5217ef88-9ee2-4163-937f-16320bbc30cb\n\n## Test Plan\n\n- In local Kibana, open Dev Tools > Console and enter:\n  ```\n  POST _query\n  {\n    \"query\": \"\"\"FROM \"\"\"\n  }\n  ```\nPlace the cursor after `FROM `, open browser DevTools > Network, and\ntype a few characters of an index name, such as `logs`. Expected result:\nafter the initial ES|QL sources and Fleet package requests, typing more\ncharacters does not issue a new sources request or `GET\n/api/fleet/epm/packages/installed` on every keystroke while the source\ncache is fresh.\n- `node scripts/jest\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts`\n— 8 tests passed\n- `node scripts/eslint\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx`\n— no errors\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — exited with 0\n\n## Release Note\n\n- Console ES|QL source autocomplete now reuses a fresh source list\ninstead of refetching it on every keystroke.\n\nAssisted with Copilot using GPT-5.5\n\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>","sha":"b41dce55a0d6eed0d27400708c91cab1822aacbd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275535","number":275535,"mergeCommit":{"message":"[Console] Fix memoize ES|QL autocomplete sources (#275535)\n\nCloses #271878\n\n## Summary\n\n- Memoizes Console's ES|QL source autocomplete callback so repeated\nsource completions reuse a fresh request instead of refetching the same\nsource list on every keystroke.\n- Keeps ES|QL column lookup uncached and refreshes the source cache when\nservice dependencies change, after the cache expires, or after a failed\nsource request.\n\n## Root Cause\n\n- Console wired ES|QL source autocomplete directly to `getESQLSources`,\nso every source-position completion invoked the sources lookup again.\n\n## Fix\n\n- Moves Console ES|QL callbacks into `useConsoleEsqlCallbacks`, caches\nthe in-flight/resolved sources request for 10 minutes, and clears the\ncache on rejection.\n- Adds hook coverage for fresh-cache reuse, cache expiry,\nrejected-request retry, dependency changes, rerender identity stability,\nand uncached column lookup.\n\n\nhttps://github.com/user-attachments/assets/5217ef88-9ee2-4163-937f-16320bbc30cb\n\n## Test Plan\n\n- In local Kibana, open Dev Tools > Console and enter:\n  ```\n  POST _query\n  {\n    \"query\": \"\"\"FROM \"\"\"\n  }\n  ```\nPlace the cursor after `FROM `, open browser DevTools > Network, and\ntype a few characters of an index name, such as `logs`. Expected result:\nafter the initial ES|QL sources and Fleet package requests, typing more\ncharacters does not issue a new sources request or `GET\n/api/fleet/epm/packages/installed` on every keystroke while the source\ncache is fresh.\n- `node scripts/jest\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts`\n— 8 tests passed\n- `node scripts/eslint\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx`\n— no errors\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — exited with 0\n\n## Release Note\n\n- Console ES|QL source autocomplete now reuses a fresh source list\ninstead of refetching it on every keystroke.\n\nAssisted with Copilot using GPT-5.5\n\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>","sha":"b41dce55a0d6eed0d27400708c91cab1822aacbd"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276277","number":276277,"state":"MERGED","mergeCommit":{"sha":"d768439982770f2cc77321342d05f7e958264a26","message":"[9.4] [Console] Fix memoize ES|QL autocomplete sources (#275535) (#276277)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Console] Fix memoize ES|QL autocomplete sources\n(#275535)](https://github.com/elastic/kibana/pull/275535)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276276","number":276276,"state":"MERGED","mergeCommit":{"sha":"b277170a14d8db2946b1a67429ca3c1478b2946b","message":"[9.3] [Console] Fix memoize ES|QL autocomplete sources (#275535) (#276276)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Console] Fix memoize ES|QL autocomplete sources\n(#275535)](https://github.com/elastic/kibana/pull/275535)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>"}}]}] BACKPORT-->