### PR TITLE
[Agent Builder] Fix @ mention autocomplete regressions in chat command menu

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/attributes.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/attributes.ts
@@ -10,3 +10,4 @@ export const COMMAND_BADGE_ATTRIBUTE = 'data-command-badge';
 export const COMMAND_BADGE_LABEL_ATTRIBUTE = 'data-command-badge-label';
 export const COMMAND_ID_ATTRIBUTE = 'data-command-id';
 export const COMMAND_METADATA_ATTRIBUTE = 'data-command-metadata';
+export const COMMAND_BADGE_MATCHED_ATTRIBUTE = 'data-command-badge-matched';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/command_badge_serializer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/command_badge_serializer.test.ts
@@ -126,6 +126,22 @@ describe('serializeEditorContent', () => {
 
     expect(serializeEditorContent(div)).toBe('[@visualization/Pacific Sales](sml://chunk-1)');
   });
+
+  it('serializes an unmatched badge as plain text, not a badge link', () => {
+    // There's no resolved entity to reference, so it should read exactly as
+    // if the user had typed this text without the mention system involved.
+    const div = document.createElement('div');
+    const badge = createCommandBadgeElement({
+      commandId: CommandId.Sml,
+      label: 'connector/nosuchthing',
+      id: '',
+      metadata: {},
+      matched: false,
+    });
+    div.appendChild(badge);
+
+    expect(serializeEditorContent(div)).toBe('@connector/nosuchthing');
+  });
 });
 
 describe('deserializeBadgeContent', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/command_badge_serializer.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/command_badge_serializer.ts
@@ -7,7 +7,11 @@
 
 import type { CommandBadgeData } from './types';
 import { getCommandDefinition } from '../command_menu';
-import { COMMAND_ID_ATTRIBUTE, COMMAND_METADATA_ATTRIBUTE } from './attributes';
+import {
+  COMMAND_BADGE_MATCHED_ATTRIBUTE,
+  COMMAND_ID_ATTRIBUTE,
+  COMMAND_METADATA_ATTRIBUTE,
+} from './attributes';
 import { getCommandDefinitionByScheme } from '../command_menu/command_definitions';
 
 interface TextSegment {
@@ -35,6 +39,12 @@ export const serializeCommandBadge = (element: HTMLElement): string => {
   }
   const { scheme } = commandDefinition;
   const displayText = element.textContent ?? '';
+
+  // No resolved entity to reference — send the plain typed text, as if the
+  // mention system had never gotten involved.
+  if (element.getAttribute(COMMAND_BADGE_MATCHED_ATTRIBUTE) === 'false') {
+    return displayText;
+  }
 
   const metadataRaw = element.getAttribute(COMMAND_METADATA_ATTRIBUTE);
   let id = '';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/create_badge_element.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/create_badge_element.test.ts
@@ -9,6 +9,7 @@ import { CommandId } from '../command_menu/types';
 import {
   COMMAND_BADGE_ATTRIBUTE,
   COMMAND_BADGE_LABEL_ATTRIBUTE,
+  COMMAND_BADGE_MATCHED_ATTRIBUTE,
   COMMAND_ID_ATTRIBUTE,
   COMMAND_METADATA_ATTRIBUTE,
 } from './attributes';
@@ -121,5 +122,33 @@ describe('createBadgeElement', () => {
     expect(badge.firstElementChild?.textContent).toBe('@dashboard/My chart');
     expect(badge.getAttribute('aria-label')).toBe('@dashboard/My chart');
     expect(badge.title).toBe('@dashboard/My chart');
+  });
+
+  describe('unmatched badges', () => {
+    it('sets data-command-badge-matched to false when matched is false', () => {
+      const badge = createCommandBadgeElement({
+        commandId: CommandId.Sml,
+        label: 'connector/nosuchthing',
+        id: '',
+        metadata: {},
+        matched: false,
+      });
+
+      expect(badge.getAttribute(COMMAND_BADGE_MATCHED_ATTRIBUTE)).toBe('false');
+      expect(badge.getAttribute(COMMAND_BADGE_ATTRIBUTE)).toBe('true');
+      expect(badge.contentEditable).toBe('false');
+      expect(badge.textContent).toBe('@connector/nosuchthing');
+    });
+
+    it('omits data-command-badge-matched for a normal (matched) badge', () => {
+      const badge = createCommandBadgeElement({
+        commandId: CommandId.Sml,
+        label: 'connector/s3',
+        id: 'chunk-1',
+        metadata: {},
+      });
+
+      expect(badge.hasAttribute(COMMAND_BADGE_MATCHED_ATTRIBUTE)).toBe(false);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/create_badge_element.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/create_badge_element.ts
@@ -8,6 +8,7 @@
 import {
   COMMAND_BADGE_ATTRIBUTE,
   COMMAND_BADGE_LABEL_ATTRIBUTE,
+  COMMAND_BADGE_MATCHED_ATTRIBUTE,
   COMMAND_ID_ATTRIBUTE,
   COMMAND_METADATA_ATTRIBUTE,
 } from './attributes';
@@ -23,6 +24,9 @@ export const createCommandBadgeElement = (data: CommandBadgeData): HTMLSpanEleme
   span.setAttribute(COMMAND_BADGE_ATTRIBUTE, 'true');
   span.setAttribute(COMMAND_ID_ATTRIBUTE, data.commandId);
   span.setAttribute(COMMAND_METADATA_ATTRIBUTE, JSON.stringify({ id: data.id, ...data.metadata }));
+  if (data.matched === false) {
+    span.setAttribute(COMMAND_BADGE_MATCHED_ATTRIBUTE, 'false');
+  }
 
   const sequence = getCommandDefinition(data.commandId)?.sequence ?? '';
   const displayText = `${sequence}${data.label}`;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/index.ts
@@ -11,6 +11,7 @@ export { COMMAND_BADGE_MAX_WIDTH_CH } from './constants';
 export {
   COMMAND_BADGE_ATTRIBUTE,
   COMMAND_BADGE_LABEL_ATTRIBUTE,
+  COMMAND_BADGE_MATCHED_ATTRIBUTE,
   COMMAND_ID_ATTRIBUTE,
 } from './attributes';
 export { createCommandBadgeElement, isElementCommandBadge } from './create_badge_element';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/types.ts
@@ -13,4 +13,8 @@ export interface CommandBadgeData {
   readonly id: string;
   // Metadata must not include `id` property
   readonly metadata: Record<string, string> & { id?: never };
+  /** False for a badge committed with no resolved match (e.g. a typo'd connector name). Defaults to true. */
+  readonly matched?: boolean;
+  /** Only consume this many chars of the active query into the badge, leaving the rest as plain text. Defaults to the full query. */
+  readonly consumedLength?: number;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/command_matcher.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/command_matcher.test.ts
@@ -108,6 +108,35 @@ describe('matchCommand', () => {
     });
   });
 
+  describe('active command stickiness', () => {
+    it('keeps the active "@" command active even when "/" appears closer to the cursor', () => {
+      const result = matchCommand('@foo /bar', allCommands, CommandId.Sml);
+      expect(result.isActive).toBe(true);
+      expect(result.activeCommand?.command.id).toBe(CommandId.Sml);
+      expect(result.activeCommand?.query).toBe('foo /bar');
+    });
+
+    it('keeps the active "/" command active even when "@" appears closer to the cursor', () => {
+      const result = matchCommand('/foo @bar', allCommands, CommandId.Skill);
+      expect(result.isActive).toBe(true);
+      expect(result.activeCommand?.command.id).toBe(CommandId.Skill);
+      expect(result.activeCommand?.query).toBe('foo @bar');
+    });
+
+    it('falls back to the closest sequence once the active command is no longer present', () => {
+      const result = matchCommand('@bar', allCommands, CommandId.Skill);
+      expect(result.isActive).toBe(true);
+      expect(result.activeCommand?.command.id).toBe(CommandId.Sml);
+      expect(result.activeCommand?.query).toBe('bar');
+    });
+
+    it('has no effect when no command is currently active', () => {
+      const result = matchCommand('@foo /bar', allCommands);
+      expect(result.activeCommand?.command.id).toBe(CommandId.Skill);
+      expect(result.activeCommand?.query).toBe('bar');
+    });
+  });
+
   describe('edge cases', () => {
     it('returns inactive for empty input', () => {
       const result = matchCommand('', allCommands);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/command_matcher.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/command_matcher.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CommandMatchResult, ActiveCommand, CommandDefinition } from './types';
+import type { CommandMatchResult, ActiveCommand, CommandDefinition, CommandId } from './types';
 
 /**
  * Determines if the character at the given position is at a word boundary.
@@ -25,17 +25,24 @@ const INACTIVE_RESULT: CommandMatchResult = {
 };
 
 /**
- * Given the text preceding the cursor, checks if any registered command
- * is active. Returns the command whose sequence appears closest to the cursor.
+ * Given the text preceding the cursor, checks if any registered command is
+ * active.
  *
- * The algorithm checks every registered command, finds the last word-boundary
- * occurrence of each sequence, and picks the one nearest to the cursor position.
+ * Every registered command is checked for its last word-boundary occurrence.
+ * If a command is already active (`activeCommandId`) and it still has a
+ * match, that command is kept active, even if another command's sequence
+ * appears closer to the cursor — otherwise a trigger character typed as
+ * plain text inside an in-progress command's query (e.g. "/" typed while
+ * writing an "@" mention) would hijack the active command. Absent an active
+ * command, the sequence closest to the cursor starts a new one.
  */
 export const matchCommand = (
   textBeforeCursor: string,
-  definitions: readonly CommandDefinition[]
+  definitions: readonly CommandDefinition[],
+  activeCommandId?: CommandId
 ): CommandMatchResult => {
   let best: ActiveCommand | null = null;
+  let active: ActiveCommand | null = null;
 
   for (const command of definitions) {
     const { sequence } = command;
@@ -49,17 +56,25 @@ export const matchCommand = (
       continue;
     }
 
+    const candidate: ActiveCommand = {
+      command,
+      commandStartOffset: lastIndex,
+      query: textBeforeCursor.substring(lastIndex + sequence.length),
+    };
+
+    if (command.id === activeCommandId) {
+      active = candidate;
+    }
+
     if (best === null || lastIndex > best.commandStartOffset) {
-      best = {
-        command,
-        commandStartOffset: lastIndex,
-        query: textBeforeCursor.substring(lastIndex + sequence.length),
-      };
+      best = candidate;
     }
   }
 
-  if (best) {
-    return { isActive: true, activeCommand: best };
+  const result = active ?? best;
+
+  if (result) {
+    return { isActive: true, activeCommand: result };
   }
 
   return INACTIVE_RESULT;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
@@ -420,5 +420,44 @@ describe('CommandMenuList', () => {
         expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
       });
     });
+
+    describe('onEscapeNoMatch', () => {
+      it('does not treat Escape as handled by default', () => {
+        const ref = createRef<CommandMenuHandle>();
+        renderWithProvider(
+          <CommandMenuList ref={ref} options={mockOptions} isLoading={false} onSelect={jest.fn()} />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: 'Escape' } as React.KeyboardEvent)).toBe(
+          false
+        );
+      });
+
+      it('claims Escape and calls onEscapeNoMatch when provided', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        const onEscapeNoMatch = jest.fn();
+        renderWithProvider(
+          <CommandMenuList
+            ref={ref}
+            options={[]}
+            isLoading={false}
+            onSelect={onSelect}
+            onEscapeNoMatch={onEscapeNoMatch}
+          />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: 'Escape' } as React.KeyboardEvent)).toBe(
+          true
+        );
+
+        act(() => {
+          ref.current!.handleKeyDown({ key: 'Escape' } as React.KeyboardEvent);
+        });
+
+        expect(onEscapeNoMatch).toHaveBeenCalledTimes(1);
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
@@ -362,5 +362,63 @@ describe('CommandMenuList', () => {
         expect(onSelect).not.toHaveBeenCalled();
       });
     });
+
+    describe('onSpaceNoMatch', () => {
+      it('claims Space and calls onSpaceNoMatch instead of onSelect when there is no spaceSelection', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        const onSpaceNoMatch = jest.fn();
+        renderWithProvider(
+          <CommandMenuList
+            ref={ref}
+            options={[]}
+            isLoading={false}
+            onSelect={onSelect}
+            onSpaceNoMatch={onSpaceNoMatch}
+          />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(true);
+
+        act(() => {
+          ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+        });
+
+        expect(onSpaceNoMatch).toHaveBeenCalledTimes(1);
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+
+      it('prefers spaceSelection over onSpaceNoMatch when both are provided and a match exists', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        const onSpaceNoMatch = jest.fn();
+        renderWithProvider(
+          <CommandMenuList
+            ref={ref}
+            options={mockOptions}
+            isLoading={false}
+            onSelect={onSelect}
+            spaceSelection
+            onSpaceNoMatch={onSpaceNoMatch}
+          />
+        );
+
+        act(() => {
+          ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+        });
+
+        expect(onSelect).toHaveBeenCalledWith({ key: '1', label: 'Alpha' });
+        expect(onSpaceNoMatch).not.toHaveBeenCalled();
+      });
+
+      it('does not claim Space when neither spaceSelection nor onSpaceNoMatch is provided', () => {
+        const ref = createRef<CommandMenuHandle>();
+        renderWithProvider(
+          <CommandMenuList ref={ref} options={mockOptions} isLoading={false} onSelect={jest.fn()} />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
@@ -238,5 +238,84 @@ describe('CommandMenuList', () => {
 
       expect(ref.current!.isKeyDownEventHandled({ key: 'a' } as React.KeyboardEvent)).toBe(false);
     });
+
+    describe('spaceSelection', () => {
+      it('does not treat Space as handled by default', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        renderWithProvider(
+          <CommandMenuList ref={ref} options={mockOptions} isLoading={false} onSelect={onSelect} />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
+        act(() => {
+          ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+        });
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+
+      it('selects the highlighted option on Space when enabled and options exist', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        renderWithProvider(
+          <CommandMenuList
+            ref={ref}
+            options={mockOptions}
+            isLoading={false}
+            onSelect={onSelect}
+            spaceSelection
+          />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(true);
+        act(() => {
+          ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+        });
+        expect(onSelect).toHaveBeenCalledWith({ key: '1', label: 'Alpha' });
+      });
+
+      it('selects the arrow-navigated option on Space, not just the first', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        renderWithProvider(
+          <CommandMenuList
+            ref={ref}
+            options={mockOptions}
+            isLoading={false}
+            onSelect={onSelect}
+            spaceSelection
+          />
+        );
+
+        act(() => {
+          ref.current!.handleKeyDown({ key: 'ArrowDown' } as React.KeyboardEvent);
+        });
+        act(() => {
+          ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+        });
+        expect(onSelect).toHaveBeenCalledWith({ key: '2', label: 'Beta' });
+      });
+
+      it('still claims Space with zero options, so it never leaks through as a literal character', () => {
+        const ref = createRef<CommandMenuHandle>();
+        const onSelect = jest.fn();
+        renderWithProvider(
+          <CommandMenuList
+            ref={ref}
+            options={[]}
+            isLoading={false}
+            onSelect={onSelect}
+            spaceSelection
+          />
+        );
+
+        expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(true);
+
+        act(() => {
+          ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+        });
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.test.tsx
@@ -141,6 +141,51 @@ describe('CommandMenuList', () => {
       expect(onSelect).toHaveBeenCalledWith({ key: '2', label: 'Beta' });
     });
 
+    it('resets the highlight when options reorder, even at the same length', () => {
+      // Without this, navigating to index 1 and then having a same-length
+      // reorder land underneath it (e.g. an exact match moving to the
+      // front) would silently select whatever is now at index 1 instead of
+      // the item the user actually navigated to.
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      const { rerender } = renderWithProvider(
+        <CommandMenuList
+          ref={ref}
+          options={[
+            { key: 'bob', label: 'Bob' },
+            { key: 'alice', label: 'Alice' },
+          ]}
+          isLoading={false}
+          onSelect={onSelect}
+        />
+      );
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: 'ArrowDown' } as React.KeyboardEvent);
+      });
+
+      // Same length (2), but Alice moved to the front.
+      rerender(
+        <EuiProvider>
+          <CommandMenuList
+            ref={ref}
+            options={[
+              { key: 'alice', label: 'Alice' },
+              { key: 'bob', label: 'Bob' },
+            ]}
+            isLoading={false}
+            onSelect={onSelect}
+          />
+        </EuiProvider>
+      );
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: 'Enter' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({ key: 'alice', label: 'Alice' });
+    });
+
     it('navigates up from second item', () => {
       const ref = createRef<CommandMenuHandle>();
       const onSelect = jest.fn();

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
@@ -62,6 +62,8 @@ interface CommandMenuListProps {
   readonly spaceSelection?: boolean;
   /** Called instead of selecting when Space is pressed with no `spaceSelection`. */
   readonly onSpaceNoMatch?: () => void;
+  /** Called when Escape is pressed with no candidates, instead of just dismissing. */
+  readonly onEscapeNoMatch?: () => void;
 }
 
 export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProps>(
@@ -74,6 +76,7 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
       'data-test-subj': dataTestSubj = 'commandMenuList',
       spaceSelection,
       onSpaceNoMatch,
+      onEscapeNoMatch,
     },
     ref
   ) => {
@@ -132,6 +135,9 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
         if (event.key === keys.SPACE && (spaceSelection || onSpaceNoMatch)) {
           return true;
         }
+        if (event.key === keys.ESCAPE && onEscapeNoMatch) {
+          return true;
+        }
         return handledKeys.includes(event.key);
       },
       handleKeyDown: (event: React.KeyboardEvent): void => {
@@ -147,6 +153,8 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
           } else if (onSpaceNoMatch) {
             onSpaceNoMatch();
           }
+        } else if (event.key === keys.ESCAPE) {
+          onEscapeNoMatch?.();
         }
       },
     }));

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
@@ -58,6 +58,8 @@ interface CommandMenuListProps {
   readonly onSelect: (option: CommandMenuListOption) => void;
   readonly width?: number;
   readonly 'data-test-subj'?: string;
+  /** When true, Space also selects the highlighted option, like Enter. */
+  readonly spaceSelection?: boolean;
 }
 
 export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProps>(
@@ -68,6 +70,7 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
       onSelect,
       width: menuWidth = MENU_WIDTH,
       'data-test-subj': dataTestSubj = 'commandMenuList',
+      spaceSelection,
     },
     ref
   ) => {
@@ -120,6 +123,11 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
           keys.ENTER,
           keys.TAB,
         ];
+        // Always claim Space, even with zero options: results can lag a
+        // keystroke behind, and a leaked space would type as plain text.
+        if (spaceSelection && event.key === keys.SPACE) {
+          return true;
+        }
         return handledKeys.includes(event.key);
       },
       handleKeyDown: (event: React.KeyboardEvent): void => {
@@ -127,7 +135,11 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
           handleSetActive((prev) => Math.min(prev + 1, options.length - 1));
         } else if (event.key === keys.ARROW_UP || (event.ctrlKey && event.key === 'p')) {
           handleSetActive((prev) => Math.max(prev - 1, 0));
-        } else if (event.key === keys.ENTER || event.key === keys.TAB) {
+        } else if (
+          event.key === keys.ENTER ||
+          event.key === keys.TAB ||
+          (spaceSelection && event.key === keys.SPACE)
+        ) {
           handleSelectOption();
         }
       },

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
@@ -81,9 +81,10 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
 
     const containerRef = useRef<HTMLDivElement>(null);
 
+    const optionKeysSignature = JSON.stringify(options.map((option) => option.key));
     useEffect(() => {
       setActiveIndex(0);
-    }, [options.length]);
+    }, [optionKeysSignature]);
 
     const scrollIndexIntoView = (index: number) => {
       const items = containerRef.current?.querySelectorAll('.euiSelectableListItem');

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/components/command_menu_list.tsx
@@ -60,6 +60,8 @@ interface CommandMenuListProps {
   readonly 'data-test-subj'?: string;
   /** When true, Space also selects the highlighted option, like Enter. */
   readonly spaceSelection?: boolean;
+  /** Called instead of selecting when Space is pressed with no `spaceSelection`. */
+  readonly onSpaceNoMatch?: () => void;
 }
 
 export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProps>(
@@ -71,6 +73,7 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
       width: menuWidth = MENU_WIDTH,
       'data-test-subj': dataTestSubj = 'commandMenuList',
       spaceSelection,
+      onSpaceNoMatch,
     },
     ref
   ) => {
@@ -126,7 +129,7 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
         ];
         // Always claim Space, even with zero options: results can lag a
         // keystroke behind, and a leaked space would type as plain text.
-        if (spaceSelection && event.key === keys.SPACE) {
+        if (event.key === keys.SPACE && (spaceSelection || onSpaceNoMatch)) {
           return true;
         }
         return handledKeys.includes(event.key);
@@ -136,12 +139,14 @@ export const CommandMenuList = forwardRef<CommandMenuHandle, CommandMenuListProp
           handleSetActive((prev) => Math.min(prev + 1, options.length - 1));
         } else if (event.key === keys.ARROW_UP || (event.ctrlKey && event.key === 'p')) {
           handleSetActive((prev) => Math.max(prev - 1, 0));
-        } else if (
-          event.key === keys.ENTER ||
-          event.key === keys.TAB ||
-          (spaceSelection && event.key === keys.SPACE)
-        ) {
+        } else if (event.key === keys.ENTER || event.key === keys.TAB) {
           handleSelectOption();
+        } else if (event.key === keys.SPACE) {
+          if (spaceSelection) {
+            handleSelectOption();
+          } else if (onSpaceNoMatch) {
+            onSpaceNoMatch();
+          }
         }
       },
     }));

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/skills/skills.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/skills/skills.test.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import React, { createRef } from 'react';
+import { render, screen, act } from '@testing-library/react';
 import { EuiProvider } from '@elastic/eui';
 import { Skills } from './skills';
+import { CommandId } from '../../types';
+import type { CommandMenuHandle } from '../../types';
 
 const mockSkills = [
   { id: 'skill-1', name: 'Summarize', description: 'Summarize text' },
@@ -76,5 +78,69 @@ describe('Skills', () => {
     expect(screen.getByTestId('skillsMenu-loading')).toBeInTheDocument();
 
     useAgentSkillsMock.useAgentSkills = originalImpl;
+  });
+
+  describe('mark as invalid on Escape for no-match queries', () => {
+    it('does not claim Escape while there are still matching skills', () => {
+      const ref = createRef<CommandMenuHandle>();
+      renderWithProvider(<Skills ref={ref} query="sum" onSelect={jest.fn()} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: 'Escape' } as React.KeyboardEvent)).toBe(
+        false
+      );
+    });
+
+    it('commits an invalid badge on Escape when nothing matches the query', () => {
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(<Skills ref={ref} query="nosuchskill" onSelect={onSelect} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: 'Escape' } as React.KeyboardEvent)).toBe(
+        true
+      );
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: 'Escape' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Skill,
+        label: 'nosuchskill',
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: 'nosuchskill'.length,
+      });
+    });
+
+    it('caps the invalid badge at the first space, since a skill name can legitimately contain one', () => {
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(
+        <Skills ref={ref} query="nosuchskill and then more text" onSelect={onSelect} />
+      );
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: 'Escape' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Skill,
+        label: 'nosuchskill',
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: 'nosuchskill'.length,
+      });
+    });
+
+    it('does not claim Escape for an empty query', () => {
+      const ref = createRef<CommandMenuHandle>();
+      renderWithProvider(<Skills ref={ref} query="" onSelect={jest.fn()} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: 'Escape' } as React.KeyboardEvent)).toBe(
+        false
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/skills/skills.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/skills/skills.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { forwardRef, useMemo } from 'react';
+import React, { forwardRef, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { EuiText, useEuiTheme } from '@elastic/eui';
 import { useAgentSkills } from '../../../../../../../hooks/skills/use_agent_skills';
@@ -64,19 +64,45 @@ export const Skills = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
         });
     }, [skills, query, skillRowStyles]);
 
+    const noMatch = query.length > 0 && options.length === 0 && !isLoading;
+
+    const handleSelect = useCallback(
+      (option: CommandMenuListOption) => {
+        onSelect({
+          commandId: CommandId.Skill,
+          label: option.label,
+          id: option.key,
+          metadata: {},
+        });
+      },
+      [onSelect]
+    );
+
+    const handleCommitInvalid = useCallback(() => {
+      // Unlike a connector name, a skill name can legitimately contain
+      // spaces, so capping at the first space is a best-effort guess at
+      // what the user meant to reference, not a guarantee like it is for
+      // a single-token connector name. Escape (rather than Space) is the
+      // trigger here precisely because Space can't double as "done typing".
+      const spaceIndex = query.indexOf(' ');
+      const consumedQuery = spaceIndex === -1 ? query : query.slice(0, spaceIndex);
+      onSelect({
+        commandId: CommandId.Skill,
+        label: consumedQuery,
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: consumedQuery.length,
+      });
+    }, [onSelect, query]);
+
     return (
       <CommandMenuList
         ref={ref}
         options={options}
         isLoading={isLoading}
-        onSelect={(option: CommandMenuListOption) => {
-          onSelect({
-            commandId: CommandId.Skill,
-            label: option.label,
-            id: option.key,
-            metadata: {},
-          });
-        }}
+        onSelect={handleSelect}
+        onEscapeNoMatch={noMatch ? handleCommitInvalid : undefined}
         width={SKILLS_MENU_WIDTH}
         data-test-subj="skillsMenu"
       />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
@@ -146,10 +146,10 @@ describe('Sml', () => {
   });
 
   describe('select on space for "type/name" queries', () => {
-    it('selects the highlighted match on Space once a name follows the slash', () => {
+    it('selects the match on Space once the exact name is typed', () => {
       const ref = createRef<CommandMenuHandle>();
       const onSelect = jest.fn();
-      renderWithProvider(<Sml ref={ref} query="visualization/s" onSelect={onSelect} />);
+      renderWithProvider(<Sml ref={ref} query="visualization/Pacific Sales" onSelect={onSelect} />);
 
       expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(true);
 
@@ -163,6 +163,23 @@ describe('Sml', () => {
         label: 'visualization/Pacific Sales',
         metadata: {},
       });
+    });
+
+    it('does not claim Space for a partial name with no exact match yet, so it types through normally', () => {
+      // Otherwise every Space keystroke while still narrowing down a search
+      // (or after a typo that never resolves) would be silently swallowed
+      // instead of typed, joining the rest of the sentence into one word.
+      const ref = createRef<CommandMenuHandle>();
+      renderWithProvider(<Sml ref={ref} query="visualization/Pac" onSelect={jest.fn()} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
+    });
+
+    it('does not claim Space when there are no matches at all', () => {
+      const ref = createRef<CommandMenuHandle>();
+      renderWithProvider(<Sml ref={ref} query="visualization/nosuchthing" onSelect={jest.fn()} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
     });
 
     it('does not select on Space for a bare trailing slash with no name yet', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
@@ -175,7 +175,76 @@ describe('Sml', () => {
       expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
     });
 
-    it('does not claim Space when there are no matches at all', () => {
+    it('commits a no-match badge on Space when there are zero candidates at all', () => {
+      mockUseSmlAutocompleteReturn = {
+        results: [],
+        total: 0,
+        isLoading: false,
+        isError: false,
+        error: null,
+      };
+
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(<Sml ref={ref} query="visualization/nosuchthing" onSelect={onSelect} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(true);
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Sml,
+        label: 'visualization/nosuchthing',
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: 'visualization/nosuchthing'.length,
+      });
+    });
+
+    it('caps the no-match badge at the first space, leaving pasted sentence text alone', () => {
+      // e.g. pasting "look in @connector/workday is the best" — only
+      // "connector/workday" should become the badge; " is the best" must
+      // stay as plain, untouched text rather than getting swallowed too.
+      mockUseSmlAutocompleteReturn = {
+        results: [],
+        total: 0,
+        isLoading: false,
+        isError: false,
+        error: null,
+      };
+
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(
+        <Sml ref={ref} query="connector/workday is the best" onSelect={onSelect} />
+      );
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Sml,
+        label: 'connector/workday',
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: 'connector/workday'.length,
+      });
+    });
+
+    it('does not commit a no-match badge while the very first fetch is still loading', () => {
+      mockUseSmlAutocompleteReturn = {
+        results: [],
+        total: 0,
+        isLoading: true,
+        isError: false,
+        error: null,
+      };
+
       const ref = createRef<CommandMenuHandle>();
       renderWithProvider(<Sml ref={ref} query="visualization/nosuchthing" onSelect={jest.fn()} />);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import React, { createRef } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { EuiProvider } from '@elastic/eui';
 import { Sml } from './sml';
 import { CommandId } from '../../types';
+import type { CommandMenuHandle } from '../../types';
 
 const defaultMockResults = [
   {
@@ -142,5 +143,99 @@ describe('Sml', () => {
     renderWithProvider(<Sml query="git" onSelect={jest.fn()} />);
 
     expect(mockUseSmlAutocomplete).toHaveBeenCalledWith('git', { constraints: undefined });
+  });
+
+  describe('select on space for "type/name" queries', () => {
+    it('selects the highlighted match on Space once a name follows the slash', () => {
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(<Sml ref={ref} query="visualization/s" onSelect={onSelect} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(true);
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Sml,
+        id: 'chunk-1',
+        label: 'visualization/Pacific Sales',
+        metadata: {},
+      });
+    });
+
+    it('does not select on Space for a bare trailing slash with no name yet', () => {
+      const ref = createRef<CommandMenuHandle>();
+      renderWithProvider(<Sml ref={ref} query="visualization/" onSelect={jest.fn()} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
+    });
+
+    it('does not select on Space for a plain free-text query with no slash', () => {
+      const ref = createRef<CommandMenuHandle>();
+      renderWithProvider(<Sml ref={ref} query="Pacific Sales" onSelect={jest.fn()} />);
+
+      expect(ref.current!.isKeyDownEventHandled({ key: ' ' } as React.KeyboardEvent)).toBe(false);
+    });
+
+    it('selects the exact name match, not whichever result the API ranked first', () => {
+      mockUseSmlAutocompleteReturn = {
+        results: [
+          { id: 'connector-2', origin_id: 'att-2', type: 'connector', title: 'workday_2' },
+          { id: 'connector-1', origin_id: 'att-1', type: 'connector', title: 'workday' },
+        ],
+        total: 2,
+        isLoading: false,
+        isError: false,
+        error: null,
+      };
+
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(<Sml ref={ref} query="connector/workday" onSelect={onSelect} />);
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Sml,
+        id: 'connector-1',
+        label: 'connector/workday',
+        metadata: {},
+      });
+    });
+
+    it('respects explicit arrow-key navigation away from the exact match', () => {
+      mockUseSmlAutocompleteReturn = {
+        results: [
+          { id: 'connector-2', origin_id: 'att-2', type: 'connector', title: 'workday_2' },
+          { id: 'connector-1', origin_id: 'att-1', type: 'connector', title: 'workday' },
+        ],
+        total: 2,
+        isLoading: false,
+        isError: false,
+        error: null,
+      };
+
+      const ref = createRef<CommandMenuHandle>();
+      const onSelect = jest.fn();
+      renderWithProvider(<Sml ref={ref} query="connector/workday" onSelect={onSelect} />);
+
+      act(() => {
+        ref.current!.handleKeyDown({ key: 'ArrowDown' } as React.KeyboardEvent);
+      });
+      act(() => {
+        ref.current!.handleKeyDown({ key: ' ' } as React.KeyboardEvent);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        commandId: CommandId.Sml,
+        id: 'connector-2',
+        label: 'connector/workday_2',
+        metadata: {},
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
@@ -26,25 +26,31 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
     const { euiTheme } = useEuiTheme();
     const { results, isLoading } = useSmlAutocomplete(query, { constraints });
     const { type, title } = useMemo(() => getSmlMenuHighlightSearchStrings(query), [query]);
-    // A "type/name" query's name is a single token, so Space can safely commit it.
     const canSelectOnSpace = query.includes('/') && title.length > 0;
-    // Sort an exact name match to the front so it's the one Space (or Enter)
-    // commits, rather than whatever the API happened to rank first.
-    const orderedResults = useMemo(() => {
+    // Only commit on Space once there's a confirmed exact name match — not
+    // just "some results exist" or "more might arrive" — so Space is free to
+    // be typed normally the rest of the time instead of being swallowed.
+    const exactMatchIndex = useMemo(() => {
       if (!canSelectOnSpace) {
-        return results;
+        return -1;
       }
       const lowerName = title.toLowerCase();
-      const exactIndex = results.findIndex((item) => item.title.toLowerCase() === lowerName);
-      if (exactIndex <= 0) {
+      return results.findIndex((item) => item.title.toLowerCase() === lowerName);
+    }, [results, title, canSelectOnSpace]);
+    const spaceSelection = exactMatchIndex !== -1;
+
+    // Sort the exact match to the front so it's the one Space (or Enter)
+    // commits, rather than whatever the API happened to rank first.
+    const orderedResults = useMemo(() => {
+      if (exactMatchIndex <= 0) {
         return results;
       }
       return [
-        results[exactIndex],
-        ...results.slice(0, exactIndex),
-        ...results.slice(exactIndex + 1),
+        results[exactMatchIndex],
+        ...results.slice(0, exactMatchIndex),
+        ...results.slice(exactMatchIndex + 1),
       ];
-    }, [results, title, canSelectOnSpace]);
+    }, [results, exactMatchIndex]);
 
     const smlMenuLabelStyles = useMemo(
       () => ({
@@ -103,7 +109,7 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
         options={options}
         isLoading={isLoading}
         onSelect={handleSelect}
-        spaceSelection={canSelectOnSpace}
+        spaceSelection={spaceSelection}
         data-test-subj="smlMenu"
       />
     );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
@@ -38,6 +38,7 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
       return results.findIndex((item) => item.title.toLowerCase() === lowerName);
     }, [results, title, canSelectOnSpace]);
     const spaceSelection = exactMatchIndex !== -1;
+    const noMatch = canSelectOnSpace && results.length === 0 && !isLoading;
 
     // Sort the exact match to the front so it's the one Space (or Enter)
     // commits, rather than whatever the API happened to rank first.
@@ -103,6 +104,24 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
       [onSelect]
     );
 
+    const handleCommitNoMatch = useCallback(() => {
+      // Cap the badge at the first space after the "/" — a real name can't
+      // contain one, so anything past it (e.g. sentence text accidentally
+      // absorbed from a paste) is left untouched as plain text instead of
+      // getting swallowed into the badge too.
+      const slashIndex = query.indexOf('/');
+      const spaceIndex = query.indexOf(' ', slashIndex + 1);
+      const consumedQuery = spaceIndex === -1 ? query : query.slice(0, spaceIndex);
+      onSelect({
+        commandId: CommandId.Sml,
+        label: consumedQuery,
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: consumedQuery.length,
+      });
+    }, [onSelect, query]);
+
     return (
       <CommandMenuList
         ref={ref}
@@ -110,6 +129,7 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
         isLoading={isLoading}
         onSelect={handleSelect}
         spaceSelection={spaceSelection}
+        onSpaceNoMatch={noMatch ? handleCommitNoMatch : undefined}
         data-test-subj="smlMenu"
       />
     );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
@@ -26,6 +26,25 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
     const { euiTheme } = useEuiTheme();
     const { results, isLoading } = useSmlAutocomplete(query, { constraints });
     const { type, title } = useMemo(() => getSmlMenuHighlightSearchStrings(query), [query]);
+    // A "type/name" query's name is a single token, so Space can safely commit it.
+    const canSelectOnSpace = query.includes('/') && title.length > 0;
+    // Sort an exact name match to the front so it's the one Space (or Enter)
+    // commits, rather than whatever the API happened to rank first.
+    const orderedResults = useMemo(() => {
+      if (!canSelectOnSpace) {
+        return results;
+      }
+      const lowerName = title.toLowerCase();
+      const exactIndex = results.findIndex((item) => item.title.toLowerCase() === lowerName);
+      if (exactIndex <= 0) {
+        return results;
+      }
+      return [
+        results[exactIndex],
+        ...results.slice(0, exactIndex),
+        ...results.slice(exactIndex + 1),
+      ];
+    }, [results, title, canSelectOnSpace]);
 
     const smlMenuLabelStyles = useMemo(
       () => ({
@@ -41,7 +60,7 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
 
     const options: CommandMenuListOption[] = useMemo(
       () =>
-        results.map((item) => {
+        orderedResults.map((item) => {
           const typeLabel = item.type;
           const titlePlain = item.title;
 
@@ -63,7 +82,7 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
             ),
           };
         }),
-      [results, title, type, smlMenuLabelStyles]
+      [orderedResults, title, type, smlMenuLabelStyles]
     );
 
     const handleSelect = useCallback(
@@ -84,6 +103,7 @@ export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
         options={options}
         isLoading={isLoading}
         onSelect={handleSelect}
+        spaceSelection={canSelectOnSpace}
         data-test-subj="smlMenu"
       />
     );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/use_command_menu.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/use_command_menu.ts
@@ -49,8 +49,13 @@ export const useCommandMenu = (options: UseCommandMenuOptions = {}): CommandMenu
         return;
       }
       const textBeforeCursor = getTextBeforeCursor(element);
-      const nextMatch = matchCommand(textBeforeCursor, definitions);
-      setMatch(nextMatch);
+      setMatch((prev) =>
+        matchCommand(
+          textBeforeCursor,
+          definitions,
+          prev.isActive ? prev.activeCommand?.command.id : undefined
+        )
+      );
     },
     [enabled, definitions]
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
@@ -53,6 +53,20 @@ const ClickableMenuComponent = React.forwardRef<CommandMenuHandle, CommandMenuCo
   )
 );
 
+const EscapeClaimingMenuComponent = React.forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
+  ({ onSelect }, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      isKeyDownEventHandled: (event) => event.key === 'Escape',
+      handleKeyDown: (event) => {
+        if (event.key === 'Escape') {
+          onSelect(mockBadgeData);
+        }
+      },
+    }));
+    return <div />;
+  }
+);
+
 const mockOnSubmit = jest.fn();
 
 const createMockMessageEditor = (): {
@@ -395,6 +409,38 @@ describe('MessageEditor', () => {
     fireEvent.click(screen.getByTestId('menuOption'));
 
     expect(messageEditor.handleCommandSelect).toHaveBeenCalledWith(mockBadgeData);
+  });
+
+  it('lets the active menu claim Escape instead of just dismissing (e.g. to commit a no-match badge)', () => {
+    const { messageEditor } = createMockMessageEditor();
+    messageEditor.commandMatch = {
+      isActive: true,
+      activeCommand: {
+        command: {
+          id: CommandId.Skill,
+          sequence: '/',
+          name: 'Skill',
+          scheme: 'skill',
+          menuComponent: EscapeClaimingMenuComponent,
+        },
+        commandStartOffset: 0,
+        query: 'nosuchskill',
+      },
+    };
+
+    render(
+      <MessageEditor
+        messageEditor={messageEditor}
+        onSubmit={mockOnSubmit}
+        data-test-subj="messageEditor"
+      />
+    );
+
+    const editor = screen.getByTestId('messageEditor');
+    fireEvent.keyDown(editor, { key: 'Escape' });
+
+    expect(messageEditor.handleCommandSelect).toHaveBeenCalledWith(mockBadgeData);
+    expect(messageEditor.dismissActionMenu).not.toHaveBeenCalled();
   });
 
   it('unwraps a no-match badge into editable text when clicked', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
@@ -11,6 +11,7 @@ import { MessageEditor } from './message_editor';
 import { createTextFragment } from './utils';
 import type { MessageEditorController, MessageEditorInstance } from './use_message_editor';
 import { CommandId } from './command_menu';
+import { createCommandBadgeElement } from './command_badge';
 import type {
   CommandMenuComponentProps,
   CommandMenuHandle,
@@ -67,6 +68,7 @@ const createMockMessageEditor = (): {
       commandMatch: { isActive: false, activeCommand: null },
       dismissActionMenu: jest.fn(),
       handleCommandSelect: jest.fn(),
+      unwrapUnmatchedBadge: jest.fn(),
     },
     controller: {
       clear: jest.fn(),
@@ -393,5 +395,72 @@ describe('MessageEditor', () => {
     fireEvent.click(screen.getByTestId('menuOption'));
 
     expect(messageEditor.handleCommandSelect).toHaveBeenCalledWith(mockBadgeData);
+  });
+
+  it('unwraps a no-match badge into editable text when clicked', () => {
+    const { messageEditor } = createMockMessageEditor();
+    render(
+      <MessageEditor
+        messageEditor={messageEditor}
+        onSubmit={mockOnSubmit}
+        data-test-subj="messageEditor"
+      />
+    );
+
+    const editor = screen.getByTestId('messageEditor');
+    const badge = createCommandBadgeElement({
+      commandId: CommandId.Sml,
+      label: 'connector/nosuchthing',
+      id: '',
+      metadata: {},
+      matched: false,
+    });
+    editor.appendChild(badge);
+
+    fireEvent.click(badge);
+
+    expect(messageEditor.unwrapUnmatchedBadge).toHaveBeenCalledWith(badge);
+  });
+
+  it('does not unwrap a normal (matched) badge when clicked', () => {
+    const { messageEditor } = createMockMessageEditor();
+    render(
+      <MessageEditor
+        messageEditor={messageEditor}
+        onSubmit={mockOnSubmit}
+        data-test-subj="messageEditor"
+      />
+    );
+
+    const editor = screen.getByTestId('messageEditor');
+    const badge = createCommandBadgeElement({
+      commandId: CommandId.Sml,
+      label: 'connector/s3',
+      id: 'chunk-1',
+      metadata: {},
+    });
+    editor.appendChild(badge);
+
+    fireEvent.click(badge);
+
+    expect(messageEditor.unwrapUnmatchedBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not unwrap anything when clicking plain text', () => {
+    const { messageEditor } = createMockMessageEditor();
+    render(
+      <MessageEditor
+        messageEditor={messageEditor}
+        onSubmit={mockOnSubmit}
+        data-test-subj="messageEditor"
+      />
+    );
+
+    const editor = screen.getByTestId('messageEditor');
+    editor.appendChild(document.createTextNode('hello world'));
+
+    fireEvent.click(editor);
+
+    expect(messageEditor.unwrapUnmatchedBadge).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
@@ -166,9 +166,9 @@ export const MessageEditor: React.FC<MessageEditorProps> = ({
       ${euiTextTruncate('100%')}
     }
     [${COMMAND_BADGE_ATTRIBUTE}][${COMMAND_BADGE_MATCHED_ATTRIBUTE}='false'] {
-      color: ${euiTheme.colors.textDanger};
-      background-color: ${euiTheme.colors.backgroundLightDanger};
-      border: ${euiTheme.border.width.thin} dashed ${euiTheme.colors.textDanger};
+      color: inherit;
+      background-color: transparent;
+      padding: 0;
     }
   `;
   const editorStyles = [
@@ -267,14 +267,20 @@ export const MessageEditor: React.FC<MessageEditorProps> = ({
           // If no badges, let the browser handle cut natively
         }}
         onKeyDown={(event) => {
-          if (event.key === keys.ESCAPE) {
-            event.stopPropagation();
-            messageEditor.dismissActionMenu();
-            return;
-          }
+          // Let the active menu claim Escape first (e.g. to commit a
+          // no-match badge for a skill query); otherwise fall back to
+          // just dismissing the menu, as Escape always did before.
           if (commandMatch.isActive && commandMenuRef.current?.isKeyDownEventHandled(event)) {
             commandMenuRef.current.handleKeyDown(event);
             event.preventDefault();
+            if (event.key === keys.ESCAPE) {
+              event.stopPropagation();
+            }
+            return;
+          }
+          if (event.key === keys.ESCAPE) {
+            event.stopPropagation();
+            messageEditor.dismissActionMenu();
             return;
           }
           if (!event.shiftKey && event.key === keys.ENTER && !isComposing) {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
@@ -21,6 +21,7 @@ import type { CommandMenuHandle } from './command_menu';
 import {
   COMMAND_BADGE_ATTRIBUTE,
   COMMAND_BADGE_LABEL_ATTRIBUTE,
+  COMMAND_BADGE_MATCHED_ATTRIBUTE,
   COMMAND_BADGE_MAX_WIDTH_CH,
   isElementCommandBadge,
 } from './command_badge';
@@ -164,6 +165,11 @@ export const MessageEditor: React.FC<MessageEditorProps> = ({
       min-width: 0;
       ${euiTextTruncate('100%')}
     }
+    [${COMMAND_BADGE_ATTRIBUTE}][${COMMAND_BADGE_MATCHED_ATTRIBUTE}='false'] {
+      color: ${euiTheme.colors.textDanger};
+      background-color: ${euiTheme.colors.backgroundLightDanger};
+      border: ${euiTheme.border.width.thin} dashed ${euiTheme.colors.textDanger};
+    }
   `;
   const editorStyles = [
     heightStyles,
@@ -205,6 +211,15 @@ export const MessageEditor: React.FC<MessageEditorProps> = ({
         onBlur={messageEditor.dismissActionMenu}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
+        onClick={(event) => {
+          const badge = (event.target as HTMLElement).closest(
+            `[${COMMAND_BADGE_ATTRIBUTE}][${COMMAND_BADGE_MATCHED_ATTRIBUTE}='false']`
+          );
+          if (badge instanceof HTMLElement) {
+            event.preventDefault();
+            messageEditor.unwrapUnmatchedBadge(badge);
+          }
+        }}
         onPaste={(event) => {
           event.preventDefault();
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useMessageEditor } from './use_message_editor';
+import { CommandId } from './command_menu';
+import type { MessageEditorInstance } from './use_message_editor';
+import { stripZeroWidthSpaces } from './utils';
+
+jest.mock('../../../../hooks/use_context_engine_enabled', () => ({
+  useContextEngineEnabled: () => true,
+}));
+jest.mock('../../../../hooks/use_experimental_features', () => ({
+  useExperimentalFeatures: () => true,
+}));
+jest.mock('./command_menu/use_command_menu_prefetch', () => ({
+  useCommandMenuPrefetch: () => jest.fn(),
+}));
+
+const NBSP = ' ';
+
+const attachRef = (instance: MessageEditorInstance, element: HTMLDivElement) => {
+  (instance.ref as React.MutableRefObject<HTMLDivElement | null>).current = element;
+};
+
+const setCursorAtEnd = (element: HTMLElement) => {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  range.collapse(false);
+  const sel = window.getSelection()!;
+  sel.removeAllRanges();
+  sel.addRange(range);
+};
+
+describe('useMessageEditor handleCommandSelect', () => {
+  let div: HTMLDivElement;
+
+  beforeEach(() => {
+    div = document.createElement('div');
+    div.contentEditable = 'true';
+    document.body.appendChild(div);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(div);
+  });
+
+  it('with consumedLength, only replaces the matched prefix, leaving the rest of a pasted sentence untouched', () => {
+    const { result } = renderHook(() => useMessageEditor());
+    attachRef(result.current.messageEditor, div);
+
+    div.textContent = 'look in @connector/workday is the best';
+    setCursorAtEnd(div);
+
+    act(() => {
+      result.current.messageEditor.onChange();
+    });
+
+    const activeCommand = result.current.messageEditor.commandMatch.activeCommand;
+    expect(activeCommand?.command.id).toBe(CommandId.Sml);
+    expect(activeCommand?.query).toBe('connector/workday is the best');
+
+    act(() => {
+      result.current.messageEditor.handleCommandSelect({
+        commandId: CommandId.Sml,
+        label: 'connector/workday',
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: 'connector/workday'.length,
+      });
+    });
+
+    const badge = div.querySelector('[data-command-badge]');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe('@connector/workday');
+    expect(badge!.getAttribute('data-command-badge-matched')).toBe('false');
+    // The leftover text is untouched, not swallowed into the badge or
+    // duplicated with an extra inserted space.
+    expect(div.textContent).toBe('look in @connector/workday is the best');
+    expect(badge!.nextSibling?.textContent?.startsWith(' is the best')).toBe(true);
+  });
+
+  it('without consumedLength, consumes the full query and inserts a trailing space', () => {
+    const { result } = renderHook(() => useMessageEditor());
+    attachRef(result.current.messageEditor, div);
+
+    div.textContent = '@connector/workday';
+    setCursorAtEnd(div);
+
+    act(() => {
+      result.current.messageEditor.onChange();
+    });
+
+    expect(result.current.messageEditor.commandMatch.activeCommand?.query).toBe(
+      'connector/workday'
+    );
+
+    act(() => {
+      result.current.messageEditor.handleCommandSelect({
+        commandId: CommandId.Sml,
+        label: 'connector/workday',
+        id: 'chunk-1',
+        metadata: {},
+      });
+    });
+
+    const badge = div.querySelector('[data-command-badge]');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe('@connector/workday');
+    expect(badge!.hasAttribute('data-command-badge-matched')).toBe(false);
+    // Nothing left over: the full query was consumed, and a fresh
+    // non-breaking space is appended so typing can continue after the badge.
+    // (A leading zero-width caret target precedes it since the badge is the
+    // editor's first child — pre-existing, unrelated behavior.)
+    expect(stripZeroWidthSpaces(div.textContent ?? '')).toBe(`@connector/workday${NBSP}`);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.test.ts
@@ -85,6 +85,45 @@ describe('useMessageEditor handleCommandSelect', () => {
     expect(badge!.nextSibling?.textContent?.startsWith(' is the best')).toBe(true);
   });
 
+  it('with consumedLength, places the cursor at the end of the leftover text rather than jumping it backward', () => {
+    // e.g. typing "use the /no-match skill for" and hitting Escape: the
+    // invalid badge only covers "no-match", but the cursor should stay
+    // where the user was actually typing (end of "for"), not snap back to
+    // right after the badge (before "skill for").
+    const { result } = renderHook(() => useMessageEditor());
+    attachRef(result.current.messageEditor, div);
+
+    div.textContent = 'use the /no-match skill for';
+    setCursorAtEnd(div);
+
+    act(() => {
+      result.current.messageEditor.onChange();
+    });
+
+    const activeCommand = result.current.messageEditor.commandMatch.activeCommand;
+    expect(activeCommand?.command.id).toBe(CommandId.Skill);
+    expect(activeCommand?.query).toBe('no-match skill for');
+
+    act(() => {
+      result.current.messageEditor.handleCommandSelect({
+        commandId: CommandId.Skill,
+        label: 'no-match',
+        id: '',
+        metadata: {},
+        matched: false,
+        consumedLength: 'no-match'.length,
+      });
+    });
+
+    const badge = div.querySelector('[data-command-badge]');
+    expect(badge).not.toBeNull();
+    expect(badge!.nextSibling?.textContent).toBe(' skill for');
+
+    const range = window.getSelection()!.getRangeAt(0);
+    expect(range.startContainer).toBe(badge!.nextSibling);
+    expect(range.startOffset).toBe(' skill for'.length);
+  });
+
   it('without consumedLength, consumes the full query and inserts a trailing space', () => {
     const { result } = renderHook(() => useMessageEditor());
     attachRef(result.current.messageEditor, div);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
@@ -18,6 +18,7 @@ import {
   insertSpaceAfter,
   placeCursorAfter,
   placeCursorAtEnd,
+  placeCursorInText,
   stripZeroWidthSpaces,
   unwrapBadge,
 } from './utils';
@@ -120,9 +121,17 @@ const useMessageEditorInstance = ({
 
         if (selection.consumedLength != null) {
           // Only a prefix of the query was consumed — the rest is leftover
-          // text that already starts with the space we stopped at, so land
-          // the cursor right after the badge instead of adding another one.
-          placeCursorAfter(badge, sel);
+          // text already sitting right after the badge. Land the cursor at
+          // the end of that leftover (where it originally was) rather than
+          // snapping it back to right after the badge, which would jump the
+          // cursor backward past anything the user kept typing.
+          const leftoverLength = commandMatch.activeCommand.query.length - selection.consumedLength;
+          const leftover = badge.nextSibling;
+          if (leftoverLength > 0 && leftover instanceof Text) {
+            placeCursorInText(leftover, leftoverLength, sel);
+          } else {
+            placeCursorAfter(badge, sel);
+          }
         } else {
           const space = insertSpaceAfter(badge, ref.current);
           placeCursorAfter(space, sel);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
@@ -19,6 +19,7 @@ import {
   placeCursorAfter,
   placeCursorAtEnd,
   stripZeroWidthSpaces,
+  unwrapBadge,
 } from './utils';
 
 export interface MessageEditorInstance {
@@ -30,6 +31,8 @@ export interface MessageEditorInstance {
   dismissActionMenu: () => void;
   /** Handle selection of an item from the command menu */
   handleCommandSelect: (selection: CommandBadgeData) => void;
+  /** Replace a no-match badge with its plain text, editable and live-matched again */
+  unwrapUnmatchedBadge: (badge: HTMLElement) => void;
 }
 
 export interface MessageEditorController {
@@ -104,18 +107,37 @@ const useMessageEditorInstance = ({
           return;
         }
 
-        const commandRange = createCommandRange(ref.current, commandMatch.activeCommand);
+        const commandRange = createCommandRange(
+          ref.current,
+          commandMatch.activeCommand,
+          selection.consumedLength
+        );
         commandRange.deleteContents();
 
         const badge = createCommandBadgeElement(selection);
         commandRange.insertNode(badge);
         ensureCaretTargetBeforeFirstBadge(ref.current);
 
-        const space = insertSpaceAfter(badge, ref.current);
-        placeCursorAfter(space, sel);
+        if (selection.consumedLength != null) {
+          // Only a prefix of the query was consumed — the rest is leftover
+          // text that already starts with the space we stopped at, so land
+          // the cursor right after the badge instead of adding another one.
+          placeCursorAfter(badge, sel);
+        } else {
+          const space = insertSpaceAfter(badge, ref.current);
+          placeCursorAfter(space, sel);
+        }
 
         syncIsEmpty();
         dismissCommandMenu();
+      },
+      unwrapUnmatchedBadge: (badge: HTMLElement) => {
+        if (!ref.current) {
+          return;
+        }
+        unwrapBadge(badge);
+        syncIsEmpty();
+        checkInputForCommand(ref.current);
       },
     }),
     [

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { unwrapBadge } from './utils';
+import { createCommandBadgeElement } from './command_badge';
+import { CommandId } from './command_menu';
+
+describe('unwrapBadge', () => {
+  const createUnmatchedBadge = () =>
+    createCommandBadgeElement({
+      commandId: CommandId.Sml,
+      label: 'connector/nosuchthing',
+      id: '',
+      metadata: {},
+      matched: false,
+    });
+
+  it('replaces the badge with a single text node containing its display text', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const badge = createUnmatchedBadge();
+    container.appendChild(badge);
+
+    unwrapBadge(badge);
+
+    expect(container.contains(badge)).toBe(false);
+    expect(container.childNodes).toHaveLength(1);
+    expect(container.firstChild?.nodeType).toBe(Node.TEXT_NODE);
+    expect(container.textContent).toBe('@connector/nosuchthing');
+
+    document.body.removeChild(container);
+  });
+
+  it('places a collapsed cursor at the end of the restored text', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const badge = createUnmatchedBadge();
+    container.appendChild(badge);
+
+    unwrapBadge(badge);
+
+    const sel = window.getSelection();
+    expect(sel?.rangeCount).toBe(1);
+    const range = sel!.getRangeAt(0);
+    expect(range.collapsed).toBe(true);
+    expect(range.startContainer).toBe(container.firstChild);
+    expect(range.startOffset).toBe((container.firstChild as Text).length);
+
+    document.body.removeChild(container);
+  });
+
+  it('preserves surrounding text and other nodes', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.appendChild(document.createTextNode('Use '));
+    const badge = createUnmatchedBadge();
+    container.appendChild(badge);
+    container.appendChild(document.createTextNode(' please'));
+
+    unwrapBadge(badge);
+
+    expect(container.textContent).toBe('Use @connector/nosuchthing please');
+
+    document.body.removeChild(container);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.ts
@@ -87,6 +87,20 @@ export const placeCursorAfter = (node: Node, sel: Selection): void => {
 };
 
 /**
+ * Collapses the selection to a cursor position at `offset` within `node`,
+ * instead of always jumping to the node's end. Used when leftover text
+ * follows the caret's original position (e.g. text the user typed after
+ * a since-invalidated mention) that must stay past the cursor, not before it.
+ */
+export const placeCursorInText = (node: Text, offset: number, sel: Selection): void => {
+  const range = document.createRange();
+  range.setStart(node, Math.min(offset, node.length));
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+};
+
+/**
  * Replaces a badge element with a plain text node holding its display text,
  * and places the cursor at the end of the restored text. Used to let the
  * user click a no-match badge and correct it back into a live, editable

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.ts
@@ -34,16 +34,20 @@ export const createTextFragment = (text: string): DocumentFragment => {
 };
 
 /**
- * Creates a DOM Range spanning the full command text (sequence + query)
- * within the editor, e.g. the range covering "/summ" in "hello /summ".
+ * Creates a DOM Range spanning the command text (sequence + query) within
+ * the editor, e.g. the range covering "/summ" in "hello /summ". Pass
+ * `consumedLength` to only span a prefix of `query` (e.g. a no-match badge
+ * that only claims up to the first space), leaving the rest as plain text.
+ * Defaults to the full query.
  */
 export const createCommandRange = (
   messageEditorElement: HTMLElement,
-  activeCommand: ActiveCommand
+  activeCommand: ActiveCommand,
+  consumedLength?: number
 ): Range => {
   const { commandStartOffset, query, command } = activeCommand;
   const startPos = charOffsetToDomPosition(messageEditorElement, commandStartOffset);
-  const endOffset = commandStartOffset + command.sequence.length + query.length;
+  const endOffset = commandStartOffset + command.sequence.length + (consumedLength ?? query.length);
   const endPos = charOffsetToDomPosition(messageEditorElement, endOffset);
 
   const range = document.createRange();
@@ -80,6 +84,21 @@ export const placeCursorAfter = (node: Node, sel: Selection): void => {
   range.collapse(true);
   sel.removeAllRanges();
   sel.addRange(range);
+};
+
+/**
+ * Replaces a badge element with a plain text node holding its display text,
+ * and places the cursor at the end of the restored text. Used to let the
+ * user click a no-match badge and correct it back into a live, editable
+ * mention instead of retyping it from scratch.
+ */
+export const unwrapBadge = (badge: HTMLElement): void => {
+  const textNode = document.createTextNode(badge.textContent ?? '');
+  badge.replaceWith(textNode);
+  const sel = window.getSelection();
+  if (sel) {
+    placeCursorAfter(textNode, sel);
+  }
 };
 
 export const placeCursorAtEnd = (editorElement: HTMLDivElement) => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/sml/use_sml_autocomplete.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/sml/use_sml_autocomplete.test.tsx
@@ -71,6 +71,39 @@ describe('useSmlAutocomplete', () => {
     });
   });
 
+  it('keeps showing the previous results while a newer query is still loading', async () => {
+    const firstResults = [{ id: 'wd-1', type: 'connector', title: 'workday' }];
+    const secondResults = [{ id: 'wd-2', type: 'connector', title: 'workday_2' }];
+    let resolveSecond: (value: { results: typeof secondResults }) => void = () => {};
+    const secondPromise = new Promise<{ results: typeof secondResults }>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    mockAutocomplete
+      .mockResolvedValueOnce({ results: firstResults })
+      .mockImplementationOnce(() => secondPromise);
+
+    const { result, rerender } = renderHook(({ query }) => useSmlAutocomplete(query), {
+      wrapper: createWrapper(),
+      initialProps: { query: 'workda' },
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual(firstResults);
+    });
+
+    rerender({ query: 'workday' });
+
+    // Second query still in flight; results must not flash to `[]`.
+    expect(result.current.results).toEqual(firstResults);
+
+    resolveSecond({ results: secondResults });
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual(secondResults);
+    });
+  });
+
   it('surfaces failures via notifications.toasts.addError', async () => {
     const networkError = new Error('network');
     mockAutocomplete.mockRejectedValue(networkError);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/sml/use_sml_autocomplete.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/sml/use_sml_autocomplete.ts
@@ -63,6 +63,8 @@ export const useSmlAutocomplete = (query: string, options?: UseSmlAutocompleteOp
       }),
     staleTime: SML_AUTOCOMPLETE_STALE_TIME_MS,
     cacheTime: SML_AUTOCOMPLETE_CACHE_TIME_MS,
+    // Avoids `results` flashing empty on every debounce tick mid-keystroke.
+    keepPreviousData: true,
   });
 
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -960,6 +960,129 @@ describe('SmlService', () => {
       expect(call.query!.bool!.must).toEqual([{ match_all: {} }]);
     });
 
+    const nameNestedQuery = (name: string) => ({
+      nested: {
+        path: 'discovery_labels',
+        query: {
+          multi_match: {
+            query: name,
+            type: 'bool_prefix',
+            operator: 'and',
+            fields: [
+              'discovery_labels.value',
+              'discovery_labels.value._2gram',
+              'discovery_labels.value._3gram',
+            ],
+          },
+        },
+        inner_hits: {
+          _source: ['discovery_labels.value', 'discovery_labels.kind'],
+          size: 10,
+          highlight: {
+            type: 'unified',
+            number_of_fragments: 0,
+            pre_tags: ['<em>'],
+            post_tags: ['</em>'],
+            encoder: 'html',
+            fields: {
+              'discovery_labels.value': {},
+            },
+          },
+        },
+      },
+    });
+
+    describe('"type/name" query syntax', () => {
+      it('splits into two independent nested queries, ANDed at the parent level', async () => {
+        const service = createSmlService();
+        service.setup({ logger });
+        const smlService = service.start({ logger });
+
+        esClient.search.mockResolvedValue({ hits: { total: 0, hits: [] } } as any);
+
+        await smlService.autocomplete({
+          query: 'connector/s3',
+          size: 10,
+          spaceId: 'default',
+          esClient: scopedClient,
+          request,
+        });
+
+        const call = esClient.search.mock.calls[0]![0]!;
+        expect(call.query!.bool!.must).toEqual([
+          {
+            bool: {
+              must: [
+                {
+                  nested: {
+                    path: 'discovery_labels',
+                    query: {
+                      bool: {
+                        must: [
+                          {
+                            multi_match: {
+                              query: 'connector',
+                              type: 'bool_prefix',
+                              operator: 'and',
+                              fields: [
+                                'discovery_labels.value',
+                                'discovery_labels.value._2gram',
+                                'discovery_labels.value._3gram',
+                              ],
+                            },
+                          },
+                          { term: { 'discovery_labels.kind': 'type' } },
+                        ],
+                      },
+                    },
+                  },
+                },
+                nameNestedQuery('s3'),
+              ],
+            },
+          },
+        ]);
+      });
+
+      it('falls back to a single nested query for a bare trailing slash', async () => {
+        const service = createSmlService();
+        service.setup({ logger });
+        const smlService = service.start({ logger });
+
+        esClient.search.mockResolvedValue({ hits: { total: 0, hits: [] } } as any);
+
+        await smlService.autocomplete({
+          query: 'connector/',
+          size: 10,
+          spaceId: 'default',
+          esClient: scopedClient,
+          request,
+        });
+
+        const call = esClient.search.mock.calls[0]![0]!;
+        expect(call.query!.bool!.must).toEqual([nameNestedQuery('connector/')]);
+      });
+
+      it('searches only by name when the query starts with a slash', async () => {
+        const service = createSmlService();
+        service.setup({ logger });
+        const smlService = service.start({ logger });
+
+        esClient.search.mockResolvedValue({ hits: { total: 0, hits: [] } } as any);
+
+        await smlService.autocomplete({
+          query: '/s3',
+          size: 10,
+          spaceId: 'default',
+          esClient: scopedClient,
+          request,
+        });
+
+        const call = esClient.search.mock.calls[0]![0]!;
+        expect(call.query!.bool!.must).toEqual([nameNestedQuery('s3')]);
+      });
+    });
+
     it('threads per-type constraints through buildConstraintsFilter into the ES filter clauses', async () => {
       const service = createSmlService();
       service.setup({ logger });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -1133,7 +1133,7 @@ const SML_LABEL_FIELDS = [
   'discovery_labels.value',
   'discovery_labels.value._2gram',
   'discovery_labels.value._3gram',
-];
+] as const;
 
 const SML_LABEL_INNER_HITS = {
   _source: ['discovery_labels.value', 'discovery_labels.kind'],
@@ -1149,7 +1149,7 @@ const SML_LABEL_INNER_HITS = {
       'discovery_labels.value': {},
     },
   },
-};
+} as const;
 
 const buildLabelBoolPrefixClause = (text: string): Record<string, unknown> => ({
   multi_match: {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -1129,27 +1129,57 @@ const pickHighlightSnippet = (
   return undefined;
 };
 
+const SML_LABEL_FIELDS = [
+  'discovery_labels.value',
+  'discovery_labels.value._2gram',
+  'discovery_labels.value._3gram',
+];
+
+const SML_LABEL_INNER_HITS = {
+  _source: ['discovery_labels.value', 'discovery_labels.kind'],
+  size: 10,
+  highlight: {
+    type: 'unified',
+    number_of_fragments: 0,
+    pre_tags: ['<em>'],
+    post_tags: ['</em>'],
+    // No-op until elastic/elasticsearch#53744 is fixed; HTML-encodes source text.
+    encoder: 'html',
+    fields: {
+      'discovery_labels.value': {},
+    },
+  },
+};
+
+const buildLabelBoolPrefixClause = (text: string): Record<string, unknown> => ({
+  multi_match: {
+    query: text,
+    type: 'bool_prefix',
+    operator: 'and',
+    fields: SML_LABEL_FIELDS,
+  },
+});
+
+const buildNestedLabelQuery = (text: string): Record<string, unknown> => ({
+  nested: {
+    path: 'discovery_labels',
+    query: buildLabelBoolPrefixClause(text),
+    inner_hits: SML_LABEL_INNER_HITS,
+  },
+});
+
 /**
- * Build the autocomplete query: a single nested `multi_match bool_prefix` against
- * `discovery_labels.value` (SAYT) and its auto-generated `_2gram` / `_3gram`
- * subfields, with `inner_hits` to surface which entries matched (with their
- * `kind`). Title and type are reachable through this surface because the
- * indexer auto-prepends them to `discovery_labels`.
+ * Build the autocomplete query: nested `multi_match bool_prefix` against
+ * `discovery_labels.value` (SAYT), requiring every typed token to match
+ * (including the trailing partial, as a prefix).
  *
- * `bool_prefix` is SAYT's native query type: all-but-last analyzed tokens are
- * required to match as exact indexed terms (against the bigram/trigram shingle
- * subfields), and the last token is required to match as a prefix (against
- * `_index_prefix`). With `operator: and` every typed token must contribute —
- * including the trailing partial. This yields tight per-token semantics:
- * `"github c"` matches `"GitHub Connector"` but not `"Githubster Cup"`
- * (because `"github"` is not an indexed token of `"Githubster"`).
- *
- * Known limitation: ES does not produce useful highlight snippets for
- * SAYT + `bool_prefix` + nested + inner_hits (bug
- * elastic/elasticsearch#53744, open since 2020). The highlight config below
- * is retained so the route is forward-compatible once the bug is fixed; until
- * then, `matched_discovery_labels` entries are returned without `highlighted`
- * and the UI renders plain `value`.
+ * `type` and `title` are indexed as separate `discovery_labels` siblings, and
+ * a nested query can't match tokens across siblings. So a "type/name" query
+ * (e.g. "connector/s3", matching how results render) is split into two
+ * nested queries ANDed together instead of one, each free to match a
+ * different sibling — the type part is also constrained to `kind: 'type'`.
+ * A bare trailing slash ("connector/") falls back to a single query so the
+ * type value itself still matches.
  *
  * After trim: empty string or `*` → `match_all`.
  */
@@ -1158,40 +1188,36 @@ const buildSmlAutocompleteQuery = (query: string): Record<string, unknown> => {
   if (trimmed === '' || trimmed === '*') {
     return { match_all: {} };
   }
-  return {
+
+  const slashIdx = trimmed.indexOf('/');
+  const namePart = slashIdx === -1 ? '' : trimmed.slice(slashIdx + 1).trim();
+
+  if (slashIdx === -1 || namePart === '') {
+    return buildNestedLabelQuery(trimmed);
+  }
+
+  const typePart = trimmed.slice(0, slashIdx).trim();
+  const nameClause = buildNestedLabelQuery(namePart);
+
+  if (!typePart) {
+    return nameClause;
+  }
+
+  const typeClause = {
     nested: {
       path: 'discovery_labels',
       query: {
-        multi_match: {
-          query: trimmed,
-          type: 'bool_prefix',
-          operator: 'and',
-          fields: [
-            'discovery_labels.value',
-            'discovery_labels.value._2gram',
-            'discovery_labels.value._3gram',
+        bool: {
+          must: [
+            buildLabelBoolPrefixClause(typePart),
+            { term: { 'discovery_labels.kind': 'type' } },
           ],
-        },
-      },
-      inner_hits: {
-        _source: ['discovery_labels.value', 'discovery_labels.kind'],
-        size: 10,
-        highlight: {
-          type: 'unified',
-          number_of_fragments: 0,
-          pre_tags: ['<em>'],
-          post_tags: ['</em>'],
-          // HTML-encode the source text so literal `<`/`>`/`&` in user content
-          // don't collide with the `<em>` wrappers when rendered. No-op while
-          // #53744 keeps SAYT+nested highlight broken; correct once it lands.
-          encoder: 'html',
-          fields: {
-            'discovery_labels.value': {},
-          },
         },
       },
     },
   };
+
+  return { bool: { must: [typeClause, nameClause] } };
 };
 
 /**


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/15121

- Stop "/" from hijacking an in-progress "@" mention. `matchCommand` picked whichever trigger character was closest to the cursor, so typing a space then "/" anywhere after an active "@" mention (e.g. while typing free text) silently replaced it with the "/" Skill command. Matching is now sticky to the currently active command until it's genuinely invalidated.

- Fix zero results for "type/name" mention queries (e.g. "connector/s3"). `type` and `title` are indexed as separate `discovery_labels` nested siblings, so a single nested `bool_prefix` query could never match both at once once the query had more than one token. The autocomplete query builder now splits "type/name" into two independent nested queries ANDed together instead of one.

- Make Space reliably commit the highlighted connector match. `useSmlAutocomplete` didn't use `keepPreviousData`, so results flashed empty on every debounce tick; combined with gating Space interception on having options available, a stray space could leak through as literal text and get silently absorbed into an unrecoverable mention query. Space now always claims the keystroke in this mode, and an exact name match is sorted to the front so it's the one committed even when another result ranks higher.

Known limitation: pasting (or otherwise bulk-inserting) text that contains a trigger character followed by an unrelated sentence, e.g. "Use @connector/workday to retrieve my available balance", is not yet handled — the mention's query has no upper bound, so it silently absorbs the rest of the sentence and gets stuck showing "No matching results". Dismissing (Escape) doesn't clear the underlying trigger, so it can reactivate on the very next keystroke. To be addressed separately.




