### PR TITLE
[Entity Store] [Fix]: Aggregate drop errors instead of logging errors per dropped document

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/entity_metadata/entity_metadata_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/entity_metadata/entity_metadata_client.test.ts
@@ -51,7 +51,9 @@ describe('EntityMetadataClient', () => {
 
   // Drains the helper `datasource` (so the mock counts docs) and invokes
   // `onDrop` once per simulated drop before resolving to bulk stats.
-  const mockHelpersBulk = (drops: Array<{ status: number; error?: { reason?: string } }> = []) => {
+  const mockHelpersBulk = (
+    drops: Array<{ status: number; error?: { type?: string; reason?: string } }> = []
+  ) => {
     const impl = jest.fn().mockImplementation(async (opts: any) => {
       let total = 0;
       for await (const _ of opts.datasource) total++;
@@ -68,7 +70,7 @@ describe('EntityMetadataClient', () => {
   describe('bulkAppendMetadata', () => {
     it('returns zero counts and skips helpers.bulk when no docs are passed', async () => {
       const result = await client.bulkAppendMetadata([]);
-      expect(result).toEqual({ successful: 0, failed: 0 });
+      expect(result).toEqual({ successful: 0, failed: 0, dropsByType: [] });
       expect(esClient.helpers.bulk).not.toHaveBeenCalled();
     });
 
@@ -100,14 +102,38 @@ describe('EntityMetadataClient', () => {
     it('returns the successful/failed counts reported by the helper', async () => {
       mockHelpersBulk();
       const result = await client.bulkAppendMetadata([makeDoc(), makeDoc()]);
-      expect(result).toEqual({ successful: 2, failed: 0 });
+      expect(result).toEqual({ successful: 2, failed: 0, dropsByType: [] });
     });
 
-    it('reports dropped docs in the failed count and logs each drop without throwing', async () => {
-      mockHelpersBulk([{ status: 503, error: { reason: 'index read-only' } }]);
+    it('reports dropped docs in the failed count and returns the drop reason without logging or throwing', async () => {
+      mockHelpersBulk([
+        { status: 503, error: { type: 'cluster_block_exception', reason: 'index read-only' } },
+      ]);
       const result = await client.bulkAppendMetadata([makeDoc(), makeDoc()]);
-      expect(result).toEqual({ successful: 1, failed: 1 });
-      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('index read-only'));
+      expect(result).toEqual({
+        successful: 1,
+        failed: 1,
+        dropsByType: [
+          {
+            type: 'cluster_block_exception',
+            count: 1,
+            status: 503,
+            sampleReason: 'index read-only',
+          },
+        ],
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('collapses multiple drops of the same error type into a single summary entry', async () => {
+      mockHelpersBulk([
+        { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+        { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+      ]);
+      const result = await client.bulkAppendMetadata([makeDoc(), makeDoc()]);
+      expect(result.dropsByType).toEqual([
+        { type: 'security_exception', count: 2, status: 403, sampleReason: 'unauthorized' },
+      ]);
     });
 
     it('does NOT throw on partial bulk failures', async () => {
@@ -115,6 +141,7 @@ describe('EntityMetadataClient', () => {
       await expect(client.bulkAppendMetadata([makeDoc()])).resolves.toEqual({
         successful: 0,
         failed: 1,
+        dropsByType: [{ type: 'unknown', count: 1, status: 400, sampleReason: 'bad field' }],
       });
     });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/entity_metadata/entity_metadata_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/entity_metadata/entity_metadata_client.ts
@@ -66,8 +66,11 @@ export class EntityMetadataClient {
    * Appends one or more documents to the entity metadata datastream.
    * Does not throw on partial bulk failure — the underlying helper retries
    * transient errors and reports unrecoverable per-doc drops via its `onDrop`
-   * hook (logged in the infra layer). Resolves to `{ successful, failed }`
-   * counts. Transport-level exceptions propagate to the caller's boundary.
+   * hook, aggregated by the infra layer into `dropsByType`. Resolves to
+   * `{ successful, failed, dropsByType }`. This client does not log drop
+   * reasons itself — callers own logging a single summary line with
+   * whatever domain context they have. Transport-level exceptions propagate
+   * to the caller's boundary.
    *
    * The caller owns the doc shape (must include `event.action` and any
    * domain-specific fields). The client does not validate the shape.
@@ -75,15 +78,14 @@ export class EntityMetadataClient {
   public async bulkAppendMetadata<TDoc extends object>(
     docs: TDoc[]
   ): Promise<BulkCreateEntityMetadataDocsResult> {
-    if (docs.length === 0) return { successful: 0, failed: 0 };
+    if (docs.length === 0) return { successful: 0, failed: 0, dropsByType: [] };
 
-    const { successful, failed } = await bulkCreateEntityMetadataDocs(this.esClient, {
+    const { successful, failed, dropsByType } = await bulkCreateEntityMetadataDocs(this.esClient, {
       index: getMetadataEntitiesDataStreamName(this.namespace),
       docs,
-      logger: this.logger,
     });
 
     this.logger.debug(`Appended ${successful} entity metadata docs, dropped ${failed}`);
-    return { successful, failed };
+    return { successful, failed, dropsByType };
   }
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/index.ts
@@ -16,6 +16,8 @@ export type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/
 export type { EntityUpdateClient, BulkObject, BulkObjectResponse } from './domain/crud';
 export type { EntityMetadataClient } from './domain/entity_metadata';
 export type { ResolutionClient } from './domain/resolution';
+export type { BulkDropTypeSummary } from './infra/elasticsearch/bulk_drop_aggregator';
+export { formatBulkDropSummary } from './infra/elasticsearch/bulk_drop_aggregator';
 export { getLatestEntitiesIndexName, getEntitiesAlias, ENTITY_LATEST } from '../common';
 export { getHistorySnapshotIndexPattern } from './domain/asset_manager/history_snapshot_index';
 export { ENGINE_METADATA_TYPE_FIELD } from './domain/logs_extraction/query_builder_commons';

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/bulk_drop_aggregator.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/bulk_drop_aggregator.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BulkDropAggregator, formatBulkDropSummary } from './bulk_drop_aggregator';
+import type { BulkDropTypeSummary } from './bulk_drop_aggregator';
+
+describe('BulkDropAggregator', () => {
+  it('starts empty', () => {
+    const aggregator = new BulkDropAggregator();
+    expect(aggregator.total).toBe(0);
+    expect(aggregator.summary()).toEqual([]);
+  });
+
+  it('groups drops by error.type', () => {
+    const aggregator = new BulkDropAggregator();
+    aggregator.record({
+      status: 403,
+      error: { type: 'security_exception', reason: 'unauthorized' },
+    });
+    aggregator.record({
+      status: 403,
+      error: { type: 'security_exception', reason: 'unauthorized' },
+    });
+    aggregator.record({
+      status: 400,
+      error: { type: 'mapper_parsing_exception', reason: 'bad field' },
+    });
+
+    const summary = aggregator.summary();
+    expect(summary).toHaveLength(2);
+    expect(summary).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'security_exception', count: 2 }),
+        expect.objectContaining({ type: 'mapper_parsing_exception', count: 1 }),
+      ])
+    );
+  });
+
+  it('falls back to "unknown" when error.type is absent', () => {
+    const aggregator = new BulkDropAggregator();
+    aggregator.record({ status: 500, error: null });
+    aggregator.record({ status: 500, error: {} });
+
+    const summary = aggregator.summary();
+    expect(summary).toHaveLength(1);
+    expect(summary[0]).toMatchObject({ type: 'unknown', count: 2, sampleReason: 'unknown error' });
+  });
+
+  it('retains the status and reason of the first drop seen for each type as a representative sample', () => {
+    const aggregator = new BulkDropAggregator();
+    aggregator.record({
+      status: 403,
+      error: { type: 'security_exception', reason: 'first reason' },
+    });
+    aggregator.record({
+      status: 403,
+      error: { type: 'security_exception', reason: 'second reason' },
+    });
+
+    const summary = aggregator.summary();
+    expect(summary[0]).toMatchObject({ status: 403, sampleReason: 'first reason', count: 2 });
+  });
+
+  it('counts total drops across all types', () => {
+    const aggregator = new BulkDropAggregator();
+    aggregator.record({ status: 403, error: { type: 'security_exception' } });
+    aggregator.record({ status: 400, error: { type: 'mapper_parsing_exception' } });
+    aggregator.record({ status: 400, error: { type: 'mapper_parsing_exception' } });
+
+    expect(aggregator.total).toBe(3);
+  });
+
+  it('sorts the summary by count descending', () => {
+    const aggregator = new BulkDropAggregator();
+    aggregator.record({ status: 400, error: { type: 'rare_exception' } });
+    aggregator.record({ status: 403, error: { type: 'common_exception' } });
+    aggregator.record({ status: 403, error: { type: 'common_exception' } });
+    aggregator.record({ status: 403, error: { type: 'common_exception' } });
+
+    expect(aggregator.summary().map((s) => s.type)).toEqual(['common_exception', 'rare_exception']);
+  });
+
+  describe('format', () => {
+    it('formats a single type with count, status, and sample reason', () => {
+      const aggregator = new BulkDropAggregator();
+      for (let i = 0; i < 5000; i++) {
+        aggregator.record({
+          status: 403,
+          error: { type: 'security_exception', reason: 'action unauthorized for service account' },
+        });
+      }
+
+      expect(aggregator.format()).toBe(
+        'security_exception (5000, status 403): action unauthorized for service account'
+      );
+    });
+
+    it('joins multiple types with " | "', () => {
+      const aggregator = new BulkDropAggregator();
+      aggregator.record({
+        status: 403,
+        error: { type: 'security_exception', reason: 'unauthorized' },
+      });
+      aggregator.record({
+        status: 403,
+        error: { type: 'security_exception', reason: 'unauthorized' },
+      });
+      aggregator.record({
+        status: 400,
+        error: { type: 'mapper_parsing_exception', reason: 'bad field' },
+      });
+
+      expect(aggregator.format()).toBe(
+        'security_exception (2, status 403): unauthorized | mapper_parsing_exception (1, status 400): bad field'
+      );
+    });
+  });
+});
+
+describe('formatBulkDropSummary', () => {
+  const makeSummary = (count: number, type = 'error'): BulkDropTypeSummary => ({
+    type,
+    count,
+    status: 400,
+    sampleReason: 'reason',
+  });
+
+  it('returns an empty string for an empty summary', () => {
+    expect(formatBulkDropSummary([])).toBe('');
+  });
+
+  it('caps the number of shown types and appends an overflow suffix', () => {
+    const summary = Array.from({ length: 7 }, (_, i) => makeSummary(7 - i, `type_${i}`));
+    const formatted = formatBulkDropSummary(summary, 5);
+    expect(formatted).toContain('(+2 more error types)');
+    expect(formatted).not.toContain('type_5');
+    expect(formatted).not.toContain('type_6');
+  });
+
+  it('does not append an overflow suffix when within the cap', () => {
+    const summary = [makeSummary(2, 'a'), makeSummary(1, 'b')];
+    expect(formatBulkDropSummary(summary, 5)).not.toContain('more error types');
+  });
+
+  it('respects a custom maxTypes', () => {
+    const summary = [makeSummary(3, 'a'), makeSummary(2, 'b'), makeSummary(1, 'c')];
+    const formatted = formatBulkDropSummary(summary, 1);
+    expect(formatted).toContain('a (3');
+    expect(formatted).not.toContain('b (2');
+    expect(formatted).toContain('(+2 more error types)');
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/bulk_drop_aggregator.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/bulk_drop_aggregator.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const DEFAULT_MAX_TYPES = 5;
+
+/**
+ * Minimal shape needed from `esClient.helpers.bulk`'s `onDrop` callback
+ * payload. Kept structural (rather than importing
+ * `@elastic/elasticsearch/lib/helpers`'s `OnDropDocument`) so callers can
+ * pass the hook payload straight through without an extra type import.
+ */
+export interface BulkDropRecord {
+  status: number;
+  error?: { type?: string | null; reason?: string | null } | null;
+}
+
+export interface BulkDropTypeSummary {
+  /** ES error type (e.g. `security_exception`, `mapper_parsing_exception`), or `unknown` when absent. */
+  type: string;
+  /** Number of dropped docs that shared this error type. */
+  count: number;
+  /** HTTP-like status of the first drop seen for this type. */
+  status: number;
+  /** Reason string from the first drop seen for this type, kept as a representative sample. */
+  sampleReason: string;
+}
+
+/**
+ * Formats a drop summary into a single bounded log line, sorted by
+ * frequency so the most impactful failure leads. Caps the number of error
+ * types shown so a run with many distinct failures still produces a
+ * readable (and boundedly-sized) log line.
+ */
+export const formatBulkDropSummary = (
+  summary: BulkDropTypeSummary[],
+  maxTypes: number = DEFAULT_MAX_TYPES
+): string => {
+  const sorted = [...summary].sort((a, b) => b.count - a.count);
+  const shown = sorted
+    .slice(0, maxTypes)
+    .map(
+      ({ type, count, status, sampleReason }) =>
+        `${type} (${count}, status ${status}): ${sampleReason}`
+    )
+    .join(' | ');
+  const overflowCount = sorted.length - maxTypes;
+  const overflow = overflowCount > 0 ? ` (+${overflowCount} more error types)` : '';
+  return `${shown}${overflow}`;
+};
+
+/**
+ * Accumulates per-document bulk drops (as reported by `esClient.helpers.bulk`'s
+ * `onDrop` hook, called once per rejected document) into a per-error-type
+ * summary. A systemic failure — missing privileges, a read-only index, a
+ * mapping conflict — rejects every document in the batch with the same
+ * error type, so grouping here turns thousands of identical `onDrop` calls
+ * into a handful of summary entries instead of one log line each.
+ */
+export class BulkDropAggregator {
+  private readonly byType = new Map<string, BulkDropTypeSummary>();
+
+  record(dropped: BulkDropRecord): void {
+    const type = dropped.error?.type ?? 'unknown';
+    const existing = this.byType.get(type);
+    if (existing) {
+      existing.count += 1;
+      return;
+    }
+    this.byType.set(type, {
+      type,
+      count: 1,
+      status: dropped.status,
+      sampleReason: dropped.error?.reason ?? 'unknown error',
+    });
+  }
+
+  public get total(): number {
+    let total = 0;
+    for (const { count } of this.byType.values()) total += count;
+    return total;
+  }
+
+  summary(): BulkDropTypeSummary[] {
+    return [...this.byType.values()].sort((a, b) => b.count - a.count);
+  }
+
+  format(maxTypes?: number): string {
+    return formatBulkDropSummary(this.summary(), maxTypes);
+  }
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/entity_metadata.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/entity_metadata.ts
@@ -6,13 +6,16 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { Logger } from '@kbn/logging';
+import { BulkDropAggregator } from './bulk_drop_aggregator';
+import type { BulkDropTypeSummary } from './bulk_drop_aggregator';
 
 export interface BulkCreateEntityMetadataDocsResult {
   /** Number of docs successfully appended. */
   successful: number;
   /** Number of docs dropped after exhausting the helper's retries. */
   failed: number;
+  /** Dropped docs grouped by ES error type, sorted by frequency. Empty when nothing was dropped. */
+  dropsByType: BulkDropTypeSummary[];
 }
 
 /**
@@ -26,8 +29,12 @@ export interface BulkCreateEntityMetadataDocsResult {
  * hand-rolled `esClient.bulk`: the helper streams from the datasource instead
  * of materializing the whole `operations` array, chunks by `flushBytes` so a
  * high-fan-out run can't exceed `http.max_content_length`, and retries 429s.
- * Per-doc drops are surfaced via `onDrop` and logged here; the call resolves
- * to `{ successful, failed }` counts.
+ * Per-doc drops are surfaced via `onDrop`; this function only aggregates them
+ * by error type — it does not log. A systemic failure (missing privileges, a
+ * read-only index) rejects every doc in the batch, so logging per drop here
+ * would flood the log with identical lines. The call resolves to
+ * `{ successful, failed, dropsByType }`; callers own logging a single
+ * summary line with whatever domain context they have.
  *
  */
 export const bulkCreateEntityMetadataDocs = async <TDoc extends object>(
@@ -35,22 +42,19 @@ export const bulkCreateEntityMetadataDocs = async <TDoc extends object>(
   params: {
     index: string;
     docs: TDoc[];
-    logger: Logger;
   }
 ): Promise<BulkCreateEntityMetadataDocsResult> => {
+  const dropAggregator = new BulkDropAggregator();
+
   const { successful, failed } = await esClient.helpers.bulk({
     datasource: params.docs,
     index: params.index,
     refresh: false,
     onDocument: () => ({ create: {} }),
     onDrop: (dropped) => {
-      params.logger.error(
-        `entity metadata doc dropped from bulk operation (reason: ${
-          dropped.error?.reason || 'unknown error'
-        })`
-      );
+      dropAggregator.record(dropped);
     },
   });
 
-  return { successful, failed };
+  return { successful, failed, dropsByType: dropAggregator.summary() };
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/ingest.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/ingest.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import type { ESQLSearchResponse } from '@kbn/es-types';
+import { ingestEntities } from './ingest';
+
+const TARGET_INDEX = '.entities.v2.latest.security_default';
+
+const makeEsqlResponse = (rowCount: number): ESQLSearchResponse => ({
+  columns: [{ name: 'entity.id', type: 'keyword' }],
+  values: Array.from({ length: rowCount }, (_, i) => [`entity-${i}`]),
+});
+
+describe('ingestEntities', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let logger: MockedLogger;
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    logger = loggerMock.create();
+  });
+
+  // Drains the helper `datasource` (so the mock counts docs) and invokes
+  // `onDrop` once per simulated drop before resolving.
+  const mockHelpersBulk = (
+    drops: Array<{ status: number; error?: { type?: string; reason?: string } }> = []
+  ) => {
+    const impl = jest.fn().mockImplementation(async (opts: any) => {
+      let total = 0;
+      for await (const _ of opts.datasource) total++;
+      for (const drop of drops) {
+        opts.onDrop({ ...drop, document: {}, operation: { create: {} }, retried: false });
+      }
+      const failed = drops.length;
+      return { total, failed, successful: total - failed };
+    });
+    esClient.helpers.bulk = impl as unknown as typeof esClient.helpers.bulk;
+    return impl;
+  };
+
+  it('does not log when nothing is dropped', async () => {
+    mockHelpersBulk();
+    await ingestEntities({
+      esClient,
+      esqlResponse: makeEsqlResponse(2),
+      targetIndex: TARGET_INDEX,
+      logger,
+      refresh: false,
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs a single aggregated error line instead of one per dropped doc', async () => {
+    mockHelpersBulk([
+      { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+      { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+      { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+    ]);
+    await ingestEntities({
+      esClient,
+      esqlResponse: makeEsqlResponse(3),
+      targetIndex: TARGET_INDEX,
+      logger,
+      refresh: false,
+    });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('security_exception (3, status 403): unauthorized')
+    );
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining(TARGET_INDEX));
+  });
+
+  it('still invokes onDropped once per dropped doc (metric callback unaffected by log aggregation)', async () => {
+    mockHelpersBulk([
+      { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+      { status: 400, error: { type: 'mapper_parsing_exception', reason: 'bad field' } },
+    ]);
+    const onDropped = jest.fn();
+    await ingestEntities({
+      esClient,
+      esqlResponse: makeEsqlResponse(2),
+      targetIndex: TARGET_INDEX,
+      logger,
+      refresh: false,
+      onDropped,
+    });
+    expect(onDropped).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call onDropped when nothing is dropped', async () => {
+    mockHelpersBulk();
+    const onDropped = jest.fn();
+    await ingestEntities({
+      esClient,
+      esqlResponse: makeEsqlResponse(2),
+      targetIndex: TARGET_INDEX,
+      logger,
+      refresh: false,
+      onDropped,
+    });
+    expect(onDropped).not.toHaveBeenCalled();
+  });
+
+  it('groups drops by error type, collapsing repeats but keeping distinct types separate', async () => {
+    mockHelpersBulk([
+      { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+      { status: 403, error: { type: 'security_exception', reason: 'unauthorized' } },
+      { status: 400, error: { type: 'mapper_parsing_exception', reason: 'bad field' } },
+    ]);
+    await ingestEntities({
+      esClient,
+      esqlResponse: makeEsqlResponse(3),
+      targetIndex: TARGET_INDEX,
+      logger,
+      refresh: false,
+    });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [message] = logger.error.mock.calls[0];
+    expect(message).toContain('security_exception (2, status 403): unauthorized');
+    expect(message).toContain('mapper_parsing_exception (1, status 400): bad field');
+  });
+
+  it('does nothing (no bulk call, no log) when the ESQL response has no rows', async () => {
+    mockHelpersBulk();
+    await ingestEntities({
+      esClient,
+      esqlResponse: makeEsqlResponse(0),
+      targetIndex: TARGET_INDEX,
+      logger,
+      refresh: false,
+    });
+    expect(esClient.helpers.bulk).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/ingest.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/ingest.ts
@@ -14,6 +14,7 @@ import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import { waitForTaskToComplete } from './wait_for_task';
 import type { WaitForTaskOptions } from './wait_for_task';
+import { BulkDropAggregator } from './bulk_drop_aggregator';
 
 const BATCH_SIZE = 5 * 1024 * 1024; // 5MB
 const RETRY_ON_CONFLICT = 3;
@@ -163,6 +164,8 @@ export async function ingestEntities({
     }
   }
 
+  const dropAggregator = new BulkDropAggregator();
+
   await esClient.helpers.bulk(
     {
       datasource: documentGenerator(),
@@ -189,11 +192,22 @@ export async function ingestEntities({
         return [{ create: {} }, doc];
       },
       onDrop: (dropped) => {
-        const errorReason = dropped.error?.reason || 'unknown error';
-        logger.error(`entity dropped from bulk operation (reason: ${errorReason})`);
+        // Aggregated below rather than logged per doc: a systemic failure
+        // (missing privileges, a read-only index) rejects every doc in the
+        // batch identically, which would otherwise flood the log with one
+        // line per document.
+        dropAggregator.record(dropped);
         onDropped?.();
       },
     },
     options
   );
+
+  if (dropAggregator.total > 0) {
+    logger.error(
+      `entity ingest dropped ${
+        dropAggregator.total
+      } doc(s) from bulk operation into ${targetIndex}. Failures by type: ${dropAggregator.format()}`
+    );
+  }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/write_relationship_metadatas.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/write_relationship_metadatas.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { loggerMock } from '@kbn/logging-mocks';
-import type { EntityMetadataClient } from '@kbn/entity-store/server';
+import type { EntityMetadataClient, BulkDropTypeSummary } from '@kbn/entity-store/server';
 import type { RelationshipMetadataDoc } from '@kbn/entity-store/common';
 
 import { writeRelationshipMetadatas } from './write_relationship_metadatas';
@@ -24,7 +24,8 @@ const baseContext = {
 };
 
 const makeEntityMetadataClient = (
-  failed: number = 0
+  failed: number = 0,
+  dropsByType: BulkDropTypeSummary[] = []
 ): {
   entityMetadataClient: EntityMetadataClient;
   bulkAppend: jest.Mock;
@@ -32,6 +33,7 @@ const makeEntityMetadataClient = (
   const bulkAppend = jest.fn().mockImplementation(async (docs: unknown[]) => ({
     successful: docs.length - failed,
     failed,
+    dropsByType,
   }));
   const entityMetadataClient = {
     bulkAppendMetadata: bulkAppend,
@@ -312,6 +314,47 @@ describe('writeRelationshipMetadatas', () => {
       ];
       await writeRelationshipMetadatas(entityMetadataClient, logger, records, baseContext);
       expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('logs a single aggregated error line including the failure-by-type breakdown, not one per dropped doc', async () => {
+      const logger = loggerMock.create();
+      const { entityMetadataClient } = makeEntityMetadataClient(1, [
+        {
+          type: 'security_exception',
+          count: 1,
+          status: 403,
+          sampleReason: 'action unauthorized for service account',
+        },
+      ]);
+      const records: EntityRelationshipRecord[] = [
+        {
+          entityId: 'user:alice@corp',
+          entityType: 'user',
+          relationships: { accesses_frequently: ['host:laptopA'] },
+        },
+      ];
+      await writeRelationshipMetadatas(entityMetadataClient, logger, records, baseContext);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'security_exception (1, status 403): action unauthorized for service account'
+        )
+      );
+    });
+
+    it('falls back to a plain failure count message when dropsByType is empty', async () => {
+      const logger = loggerMock.create();
+      const { entityMetadataClient } = makeEntityMetadataClient(1, []);
+      const records: EntityRelationshipRecord[] = [
+        {
+          entityId: 'user:alice@corp',
+          entityType: 'user',
+          relationships: { accesses_frequently: ['host:laptopA'] },
+        },
+      ];
+      await writeRelationshipMetadatas(entityMetadataClient, logger, records, baseContext);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith('Failed to append 1 of 1 relationship metadata.');
     });
 
     it('logs at info level (not error) when bulkAppend returns no failures', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/write_relationship_metadatas.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/write_relationship_metadatas.ts
@@ -7,6 +7,7 @@
 
 import type { Logger } from '@kbn/logging';
 import type { EntityMetadataClient } from '@kbn/entity-store/server';
+import { formatBulkDropSummary } from '@kbn/entity-store/server';
 import type { RelationshipKind, RelationshipMetadataDoc } from '@kbn/entity-store/common';
 
 import type { EntityRelationshipRecord } from './types';
@@ -97,11 +98,16 @@ export const writeRelationshipMetadatas = async (
 
   if (docs.length === 0) return { docsAttempted: 0, docsApplied: 0 };
 
-  const { successful, failed } = await entityMetadataClient.bulkAppendMetadata(docs);
+  const { successful, failed, dropsByType } = await entityMetadataClient.bulkAppendMetadata(docs);
 
   if (failed > 0) {
-    // Per-doc drop reasons are logged in the entity-store infra layer's onDrop hook.
-    logger.error(`Failed to append ${failed} of ${docs.length} relationship metadata`);
+    // Aggregated by error type in the entity-store infra layer (a systemic
+    // failure, e.g. missing privileges, rejects every doc identically) —
+    // logged once here rather than once per dropped doc.
+    const reasons = dropsByType?.length
+      ? ` Failures by type: ${formatBulkDropSummary(dropsByType)}`
+      : '';
+    logger.error(`Failed to append ${failed} of ${docs.length} relationship metadata.${reasons}`);
   } else {
     logger.info(`Appended ${docs.length} relationship metadata to metadata datastream`);
   }


### PR DESCRIPTION
## Summary

The Elasticsearch client's bulk helper logs each dropped document individually via its 'onDrop' hook. For systemic failures (e.g., missing permissions, read-only index), this leads to log flooding with thousands of identical lines.

This change introduces a 'BulkDropAggregator' to group these per-document drops by error type, count, status, and sample reason. The 'EntityMetadataClient' now returns this aggregated summary, and higher-level components like 'ingestEntities' and 'writeRelationshipMetadatas' log a single, comprehensive line detailing the failure types, making logs more concise and actionable.

