### PR TITLE
[Workflows] Apply callKibanaApi structured-error contract to attack assign/tags steps

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/assign_attack_step/assign_attack_step.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/assign_attack_step/assign_attack_step.test.ts
@@ -8,6 +8,7 @@
 import { assignAttackStepDefinition } from './assign_attack_step';
 import { assignAttackInputSchema } from '../../../../common/workflows/step_types/assign_attack_step/assign_attack_step_common';
 import { ExecutionError } from '@kbn/workflows/server';
+import { KibanaApiCallError } from '@kbn/workflows-extensions/server';
 import { DETECTION_ENGINE_ATTACKS_ASSIGNEES_URL } from '../../../../common/constants';
 import type { StepHandlerContext } from '@kbn/workflows-extensions/server';
 
@@ -108,18 +109,32 @@ describe('assignAttackStepDefinition', () => {
       });
     });
 
-    it('should throw ExecutionError if API returns >= 400', async () => {
+    it('persists only status (not the raw body/headers) when callKibanaApi throws on a non-2xx', async () => {
       const mockContext = createMockContext({
         ids: 'attack-1',
         assignees_to_add: ['user1'],
         assignees_to_remove: [],
       });
-      (mockContext.contextManager.callKibanaApi as jest.Mock).mockResolvedValue({
-        status: 404,
-        body: { error: 'Not found' },
-      });
+      (mockContext.contextManager.callKibanaApi as jest.Mock).mockRejectedValue(
+        new KibanaApiCallError({
+          status: 500,
+          headers: { 'x-leaky-header': 'header-value' },
+          body: { sensitive: 'partial-success-payload', items: [{ id: 'attack-1' }] },
+          message: 'HTTP 500: bulk action partially failed',
+        })
+      );
 
-      await expect(assignAttackStepDefinition.handler(mockContext)).rejects.toThrow(ExecutionError);
+      const error = await assignAttackStepDefinition
+        .handler(mockContext)
+        .then(() => undefined)
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(ExecutionError);
+      const serialized = (error as ExecutionError).toSerializableObject();
+      expect(serialized.type).toBe('ApiError');
+      expect(serialized.details).toEqual({ status: 500 });
+      expect(JSON.stringify(serialized.details)).not.toContain('partial-success-payload');
+      expect(JSON.stringify(serialized.details)).not.toContain('x-leaky-header');
     });
 
     it('should throw ExecutionError if API call throws an error', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/assign_attack_step/assign_attack_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/assign_attack_step/assign_attack_step.ts
@@ -6,9 +6,9 @@
  */
 
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
-import { ExecutionError } from '@kbn/workflows/server';
 import { DETECTION_ENGINE_ATTACKS_ASSIGNEES_URL } from '../../../../common/constants';
 import { assignAttackStepCommonDefinition } from '../../../../common/workflows/step_types/assign_attack_step/assign_attack_step_common';
+import { toAlertApiExecutionError } from '../to_alert_api_execution_error';
 
 export const assignAttackStepDefinition = createServerStepDefinition({
   ...assignAttackStepCommonDefinition,
@@ -23,7 +23,7 @@ export const assignAttackStepDefinition = createServerStepDefinition({
     const attackIds = Array.isArray(ids) ? ids : [ids];
 
     try {
-      const { status: responseStatus, body } = await context.contextManager.callKibanaApi<{
+      await context.contextManager.callKibanaApi<{
         took?: number;
         errors?: boolean;
         items?: unknown[];
@@ -40,14 +40,6 @@ export const assignAttackStepDefinition = createServerStepDefinition({
         },
       });
 
-      if (responseStatus >= 400) {
-        throw new ExecutionError({
-          type: 'ApiError',
-          message: `Failed to assign attack: HTTP ${responseStatus}`,
-          details: { body },
-        });
-      }
-
       return {
         output: {
           success: true,
@@ -55,14 +47,7 @@ export const assignAttackStepDefinition = createServerStepDefinition({
         },
       };
     } catch (error) {
-      if (error instanceof ExecutionError) {
-        throw error;
-      }
-      throw new ExecutionError({
-        type: 'ApiError',
-        message: error instanceof Error ? error.message : 'Unknown error occurred',
-        details: { error },
-      });
+      throw toAlertApiExecutionError(error, 'assign attack');
     }
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_attack_tags_step/set_attack_tags_step.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_attack_tags_step/set_attack_tags_step.test.ts
@@ -7,6 +7,7 @@
 
 import { ExecutionError } from '@kbn/workflows/server';
 import type { StepHandlerContext } from '@kbn/workflows-extensions/server';
+import { KibanaApiCallError } from '@kbn/workflows-extensions/server';
 import { setAttackTagsStepDefinition } from './set_attack_tags_step';
 import { DETECTION_ENGINE_ATTACKS_TAGS_URL } from '../../../../common/constants';
 
@@ -111,21 +112,31 @@ describe('setAttackTagsStepDefinition', () => {
     });
   });
 
-  it('throws ExecutionError on API failure', async () => {
+  it('persists only status (not the raw body/headers) when callKibanaApi throws on a non-2xx', async () => {
     const mockContext = createMockContext({
       ids: 'attack-1',
       tags_to_add: ['tag1'],
     });
-    (mockContext.contextManager.callKibanaApi as jest.Mock).mockResolvedValue({
-      status: 400,
-      body: { error: 'Bad Request' },
-    });
+    (mockContext.contextManager.callKibanaApi as jest.Mock).mockRejectedValue(
+      new KibanaApiCallError({
+        status: 500,
+        headers: { 'x-leaky-header': 'header-value' },
+        body: { sensitive: 'partial-success-payload', items: [{ id: 'attack-1' }] },
+        message: 'HTTP 500: bulk action partially failed',
+      })
+    );
 
-    await expect(
-      setAttackTagsStepDefinition.handler(
-        mockContext as unknown as Parameters<typeof setAttackTagsStepDefinition.handler>[0]
-      )
-    ).rejects.toThrow(ExecutionError);
+    const error = await setAttackTagsStepDefinition
+      .handler(mockContext as unknown as Parameters<typeof setAttackTagsStepDefinition.handler>[0])
+      .then(() => undefined)
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(ExecutionError);
+    const serialized = (error as ExecutionError).toSerializableObject();
+    expect(serialized.type).toBe('ApiError');
+    expect(serialized.details).toEqual({ status: 500 });
+    expect(JSON.stringify(serialized.details)).not.toContain('partial-success-payload');
+    expect(JSON.stringify(serialized.details)).not.toContain('x-leaky-header');
   });
 
   it('throws ExecutionError on network failure', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_attack_tags_step/set_attack_tags_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_attack_tags_step/set_attack_tags_step.ts
@@ -6,9 +6,9 @@
  */
 
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
-import { ExecutionError } from '@kbn/workflows/server';
 import { DETECTION_ENGINE_ATTACKS_TAGS_URL } from '../../../../common/constants';
 import { setAttackTagsStepCommonDefinition } from '../../../../common/workflows/step_types/set_attack_tags_step/set_attack_tags_step_common';
+import { toAlertApiExecutionError } from '../to_alert_api_execution_error';
 
 export const setAttackTagsStepDefinition = createServerStepDefinition({
   ...setAttackTagsStepCommonDefinition,
@@ -22,9 +22,7 @@ export const setAttackTagsStepDefinition = createServerStepDefinition({
     const ids = Array.isArray(attackIds) ? attackIds : [attackIds];
 
     try {
-      const { status: responseStatus, body } = await context.contextManager.callKibanaApi<
-        Record<string, unknown>
-      >({
+      await context.contextManager.callKibanaApi<Record<string, unknown>>({
         method: 'POST',
         path: DETECTION_ENGINE_ATTACKS_TAGS_URL,
         body: {
@@ -36,14 +34,6 @@ export const setAttackTagsStepDefinition = createServerStepDefinition({
           update_related_alerts: updateRelatedAlerts,
         },
       });
-
-      if (responseStatus >= 400) {
-        throw new ExecutionError({
-          type: 'ApiError',
-          message: `Failed to set attack tags: HTTP ${responseStatus}`,
-          details: { body },
-        });
-      }
 
       const addedCount = tagsToAdd.length;
       const removedCount = tagsToRemove.length;
@@ -58,14 +48,7 @@ export const setAttackTagsStepDefinition = createServerStepDefinition({
         },
       };
     } catch (error) {
-      if (error instanceof ExecutionError) {
-        throw error;
-      }
-      throw new ExecutionError({
-        type: 'ApiError',
-        message: error instanceof Error ? error.message : 'Unknown error occurred',
-        details: { error },
-      });
+      throw toAlertApiExecutionError(error, 'set attack tags');
     }
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #275297. In that PR I moved `callKibanaApi` to throw a typed `KibanaApiCallError` on non-2xx and updated the alert steps + one attack step (`set_attack_status`) to the new contract via the shared `toAlertApiExecutionError` helper. As @PhilippeOberti noted in [review](https://github.com/elastic/kibana/pull/275297#pullrequestreview), two more attack steps — **assign** and **tags** — were merged around the same time and still use the old pattern.

This PR brings `assign_attack_step` and `set_attack_tags_step` in line with the other six steps.

## Problem (before)

Both steps still had:

```ts
const { status: responseStatus, body } = await context.contextManager.callKibanaApi(...);
if (responseStatus >= 400) {
  throw new ExecutionError({ type: 'ApiError', message: `... HTTP ${responseStatus}`, details: { body } });
}
// ...
} catch (error) {
  if (error instanceof ExecutionError) throw error;
  throw new ExecutionError({ type: 'ApiError', message: ..., details: { error } });
}
```

Two issues, both consequences of the #275297 contract change:
1. **Dead code** — `callKibanaApi` now *throws* `KibanaApiCallError` on non-2xx, so the `responseStatus >= 400` branch is never reached.
2. **ES leak** — a real failure falls through to the generic catch, which nests the whole `KibanaApiCallError` (including `body` + `headers`) into `details: { error }`, and `toSerializableObject()` writes it to Elasticsearch — the exact regression #275297 removed elsewhere.

## Fix

Route both steps' `catch` through the shared `toAlertApiExecutionError(error, action)` helper (added in #275297), and drop the dead branch. An uncaught `callKibanaApi` failure now persists only `details: { status }`; the potentially large/sensitive `body`/`headers` stay on the in-process error instance for `instanceof KibanaApiCallError` recovery and are never serialized to ES.

## Test plan

- [x] `node scripts/jest .../step_types/assign_attack_step .../step_types/set_attack_tags_step` — 8/8 pass
- [x] Tests rewritten to drive the real `KibanaApiCallError` throw contract and assert the ES guard (`details` is exactly `{ status }`, no body/headers leak)
- [x] ESLint clean on changed files

Refs #275297

Made with [Cursor](https://cursor.com)