### PR TITLE
[ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.test.ts
@@ -260,6 +260,34 @@ describe('requestOAuthToken', () => {
     });
   });
 
+  test('accepts a 201 response as success, matching providers like CrowdStrike', async () => {
+    const configurationUtilities = actionsConfigMock.create();
+    axiosInstanceMock.mockReturnValueOnce({
+      status: 201,
+      data: {
+        token_type: 'bearer',
+        access_token: 'crowdstrike-token-123',
+        expires_in: 1799,
+      },
+    });
+
+    const result = await requestOAuthToken<TestOAuthRequestParams>(
+      'https://test',
+      'client_credentials',
+      configurationUtilities,
+      mockLogger,
+      { client_id: 'id', client_secret: 'secret' }
+    );
+
+    expect(result).toEqual({
+      tokenType: 'bearer',
+      accessToken: 'crowdstrike-token-123',
+      expiresIn: 1799,
+      refreshToken: undefined,
+      refreshTokenExpiresIn: undefined,
+    });
+  });
+
   test('throws when the token endpoint returns a non-JSON (string) response body', async () => {
     const configurationUtilities = actionsConfigMock.create();
     axiosInstanceMock.mockReturnValueOnce({

--- a/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.ts
@@ -98,7 +98,7 @@ export async function requestOAuthToken<T>(
     validateStatus: () => true,
   });
 
-  if (res.status === 200) {
+  if (res.status >= 200 && res.status < 300) {
     if (typeof res.data !== 'object' || res.data == null) {
       logger.warn(
         `OAuth token endpoint ${tokenUrl} returned a non-JSON response. Ensure the provider supports Accept: application/json.`


### PR DESCRIPTION
tl;dr: CrowdStrike's `/oauth2/token` returns `201` on a successful token request, not `200`. We only treated `200` as success, so a valid token response got thrown away as an error — token was fetched but never used. Widened the check to any `2xx`. Added a regression test for the `201` case.

Reported by a community user hitting this with a CrowdStrike-backed HTTP connector.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->