### PR TITLE
SIEM Readiness - Users now able to use Platform in their prompt to check for siem readiness

### DIFF
--- a/x-pack/solutions/security/packages/siem-readiness/index.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/index.ts
@@ -14,6 +14,11 @@ export { filterPipelinesByCategories } from './src/filter_pipelines_by_categorie
 export { filterRetentionItemsByCategories } from './src/filter_retention_items_by_categories';
 export { enrichFinding, enrichFindings } from './src/enrich_finding';
 export type { EnrichmentContext, Dimension } from './src/enrich_finding';
+export { buildPlatformReadiness, matchPlatforms } from './src/build_platform_readiness';
+export type {
+  BuildPlatformReadinessParams,
+  PlatformFindingInput,
+} from './src/build_platform_readiness';
 export {
   recommendedActionsRegistry,
   getDefaultActions,

--- a/x-pack/solutions/security/packages/siem-readiness/src/build_platform_readiness.test.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/build_platform_readiness.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildPlatformReadiness, matchPlatforms } from './build_platform_readiness';
+import type { ActionableFinding } from './types';
+import type { RuleIndexEntry } from './reverse_map_types';
+
+const createRule = (overrides: Partial<RuleIndexEntry> = {}): RuleIndexEntry => ({
+  id: 'rule-1',
+  name: 'Test Rule',
+  tactics: [{ id: 'TA0001', name: 'Initial Access' }],
+  enabled: true,
+  ...overrides,
+});
+
+const createFinding = (overrides: Partial<ActionableFinding> = {}): ActionableFinding => ({
+  severity: 'WARNING',
+  message: 'Test finding',
+  resource: 'logs-aws.cloudtrail-default',
+  ...overrides,
+});
+
+describe('buildPlatformReadiness', () => {
+  const categoriesResult = {
+    rawCategoriesMap: [],
+    mainCategoriesMap: [
+      {
+        category: 'Cloud',
+        indices: [{ indexName: 'logs-aws.cloudtrail-default', docs: 1000 }],
+      },
+    ],
+  };
+
+  it('returns a healthy platform with stream and rule counts', () => {
+    const indexToPlatform = new Map([
+      ['logs-aws.cloudtrail-default', 'AWS account 123456789012'],
+      ['logs-aws.s3-default', 'AWS account 123456789012'],
+    ]);
+    const indexToRules = new Map([
+      [
+        'logs-aws.cloudtrail-default',
+        [
+          createRule({ id: 'rule-1' }),
+          createRule({ id: 'rule-2', tactics: [{ id: 'TA0002', name: 'Execution' }] }),
+        ],
+      ],
+    ]);
+
+    const result = buildPlatformReadiness({
+      indexToPlatform,
+      indexToRules,
+      pipelineToIndices: new Map(),
+      categoryToIndices: new Map(),
+      categoriesResult,
+      findings: [],
+    });
+
+    expect(result.status).toBe('healthy');
+    expect(result.platforms).toHaveLength(1);
+    expect(result.platforms[0]).toMatchObject({
+      platform: 'AWS account 123456789012',
+      primaryCategory: 'Cloud',
+      activeStreams: 2,
+      enabledRules: 2,
+      mitreTactics: 2,
+      status: 'healthy',
+    });
+  });
+
+  it('attributes continuity findings via affectedPlatform and sets topFinding', () => {
+    const indexToPlatform = new Map([['logs-aws.cloudtrail-default', 'AWS account 123456789012']]);
+
+    const result = buildPlatformReadiness({
+      indexToPlatform,
+      indexToRules: new Map(),
+      pipelineToIndices: new Map([['cloudtrail-pipeline', ['logs-aws.cloudtrail-default']]]),
+      categoryToIndices: new Map(),
+      categoriesResult,
+      findings: [
+        {
+          dimension: 'continuity',
+          finding: createFinding({
+            severity: 'CRITICAL',
+            message: 'Data stream serving pipeline cloudtrail-pipeline has gone silent',
+            resource: 'cloudtrail-pipeline',
+            affectedPlatform: 'AWS account 123456789012',
+            type: 'silence',
+          }),
+        },
+      ],
+    });
+
+    expect(result.status).toBe('actionsRequired');
+    expect(result.platforms[0].status).toBe('actionsRequired');
+    expect(result.platforms[0].topFinding).toContain('gone silent');
+    expect(result.platforms[0].findings).toHaveLength(1);
+  });
+
+  it('filters platforms by partial name match', () => {
+    const indexToPlatform = new Map([
+      ['logs-aws.cloudtrail-default', 'AWS account 123456789012'],
+      ['logs-endpoint-default', 'windows Endpoints'],
+    ]);
+
+    const result = buildPlatformReadiness({
+      indexToPlatform,
+      indexToRules: new Map(),
+      pipelineToIndices: new Map(),
+      categoryToIndices: new Map(),
+      categoriesResult,
+      findings: [],
+      platformFilter: 'aws account',
+    });
+
+    expect(result.platforms).toHaveLength(1);
+    expect(result.platforms[0].platform).toBe('AWS account 123456789012');
+  });
+
+  it('summarizes when no platform matches the filter', () => {
+    const indexToPlatform = new Map([['logs-aws.cloudtrail-default', 'AWS account 123456789012']]);
+
+    const result = buildPlatformReadiness({
+      indexToPlatform,
+      indexToRules: new Map(),
+      pipelineToIndices: new Map(),
+      categoryToIndices: new Map(),
+      categoriesResult,
+      findings: [],
+      platformFilter: 'gcp',
+    });
+
+    expect(result.platforms).toHaveLength(0);
+    expect(result.summary).toContain('No platform matched "gcp"');
+    expect(result.summary).toContain('AWS account 123456789012');
+  });
+});
+
+describe('matchPlatforms', () => {
+  it('returns exact and partial matches', () => {
+    const platforms = ['AWS account 123456789012', 'windows Endpoints'];
+
+    expect(matchPlatforms('AWS account 123456789012', platforms).matches).toEqual([
+      'AWS account 123456789012',
+    ]);
+    expect(matchPlatforms('windows', platforms).matches).toEqual(['windows Endpoints']);
+  });
+});

--- a/x-pack/solutions/security/packages/siem-readiness/src/build_platform_readiness.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/build_platform_readiness.ts
@@ -1,0 +1,318 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Dimension } from './enrich_finding';
+import type {
+  ActionableFinding,
+  CategoriesResponse,
+  FindingSeverity,
+  MainCategories,
+  PlatformReadinessItem,
+  PlatformReadinessPayload,
+  VisibilityStatus,
+} from './types';
+import type {
+  CategoryToIndicesMap,
+  IndexToRulesMap,
+  PipelineToIndicesMap,
+  RuleIndexEntry,
+} from './reverse_map_types';
+
+export interface PlatformFindingInput {
+  dimension: Dimension;
+  finding: ActionableFinding;
+}
+
+export interface BuildPlatformReadinessParams {
+  indexToPlatform: Map<string, string>;
+  indexToRules: IndexToRulesMap;
+  pipelineToIndices: PipelineToIndicesMap;
+  categoryToIndices: CategoryToIndicesMap;
+  categoriesResult: CategoriesResponse;
+  findings: PlatformFindingInput[];
+  platformFilter?: string;
+}
+
+const SEVERITY_RANK: Record<FindingSeverity, number> = {
+  CRITICAL: 3,
+  WARNING: 2,
+  INFORMATIONAL: 1,
+};
+
+const extractDataStreamName = (resource: string): string | undefined => {
+  const match = resource.match(/^\.ds-(.+)-\d{4}\.\d{2}\.\d{2}-\d+$/);
+  return match?.[1];
+};
+
+const toDataStreamName = (index: string): string => extractDataStreamName(index) ?? index;
+
+const dedupeRulesById = (rules: RuleIndexEntry[]): RuleIndexEntry[] => {
+  const seen = new Set<string>();
+  return rules.filter((rule) => {
+    if (seen.has(rule.id)) {
+      return false;
+    }
+    seen.add(rule.id);
+    return true;
+  });
+};
+
+const getRulesForIndices = (
+  indices: Iterable<string>,
+  indexToRules: IndexToRulesMap
+): RuleIndexEntry[] => {
+  const rules = [...indices].flatMap((index) => indexToRules.get(index) ?? []);
+  return dedupeRulesById(rules);
+};
+
+const resolvePlatformForFinding = (
+  input: PlatformFindingInput,
+  indexToPlatform: Map<string, string>,
+  pipelineToIndices: PipelineToIndicesMap,
+  categoryToIndices: CategoryToIndicesMap
+): string | undefined => {
+  const { dimension, finding } = input;
+
+  if (finding.affectedPlatform) {
+    return finding.affectedPlatform;
+  }
+
+  let platformLookupIndex = finding.resource;
+  if (dimension === 'continuity') {
+    platformLookupIndex = pipelineToIndices.get(finding.resource)?.[0] ?? finding.resource;
+  } else if (dimension === 'coverage') {
+    platformLookupIndex = categoryToIndices.get(finding.resource)?.[0] ?? finding.resource;
+  }
+
+  return (
+    indexToPlatform.get(platformLookupIndex) ??
+    indexToPlatform.get(extractDataStreamName(platformLookupIndex) ?? '')
+  );
+};
+
+const invertPlatformMap = (indexToPlatform: Map<string, string>): Map<string, Set<string>> => {
+  const platformToStreams = new Map<string, Set<string>>();
+
+  for (const [indexName, platform] of indexToPlatform.entries()) {
+    const streamName = toDataStreamName(indexName);
+    const streams = platformToStreams.get(platform) ?? new Set<string>();
+    streams.add(streamName);
+    platformToStreams.set(platform, streams);
+  }
+
+  return platformToStreams;
+};
+
+const getPrimaryCategory = (
+  streamNames: Set<string>,
+  categoriesResult: CategoriesResponse
+): MainCategories | undefined => {
+  const categoryDocCounts = new Map<string, number>();
+
+  for (const group of categoriesResult.mainCategoriesMap ?? []) {
+    for (const indexInfo of group.indices) {
+      const streamName = toDataStreamName(indexInfo.indexName);
+      if (streamNames.has(streamName) || streamNames.has(indexInfo.indexName)) {
+        const current = categoryDocCounts.get(group.category) ?? 0;
+        categoryDocCounts.set(group.category, current + indexInfo.docs);
+      }
+    }
+  }
+
+  let primaryCategory: MainCategories | undefined;
+  let maxDocs = -1;
+  for (const [category, docs] of categoryDocCounts.entries()) {
+    if (docs > maxDocs) {
+      maxDocs = docs;
+      primaryCategory = category as MainCategories;
+    }
+  }
+
+  return primaryCategory;
+};
+
+const getPlatformStatus = (
+  activeStreams: number,
+  enabledRules: number,
+  findings: ActionableFinding[]
+): VisibilityStatus => {
+  const hasActionableFinding = findings.some(
+    (finding) => finding.severity === 'CRITICAL' || finding.severity === 'WARNING'
+  );
+  if (hasActionableFinding) {
+    return 'actionsRequired';
+  }
+  if (activeStreams === 0 && enabledRules === 0) {
+    return 'noData';
+  }
+  return 'healthy';
+};
+
+const getTopFinding = (findings: ActionableFinding[]): string | undefined => {
+  const sorted = [...findings].sort(
+    (a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity]
+  );
+  return sorted[0]?.message;
+};
+
+const worstStatus = (statuses: VisibilityStatus[]): VisibilityStatus => {
+  if (statuses.some((status) => status === 'actionsRequired')) {
+    return 'actionsRequired';
+  }
+  if (statuses.some((status) => status === 'noData')) {
+    return 'noData';
+  }
+  return 'healthy';
+};
+
+export const matchPlatforms = (
+  query: string,
+  platforms: string[]
+): { matches: string[]; ambiguous: boolean } => {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return { matches: platforms, ambiguous: false };
+  }
+
+  const exactMatches = platforms.filter((platform) => platform.toLowerCase() === normalizedQuery);
+  if (exactMatches.length > 0) {
+    return { matches: exactMatches, ambiguous: exactMatches.length > 1 };
+  }
+
+  const partialMatches = platforms.filter((platform) =>
+    platform.toLowerCase().includes(normalizedQuery)
+  );
+  return { matches: partialMatches, ambiguous: partialMatches.length > 1 };
+};
+
+const buildPlatformSummary = (
+  platforms: PlatformReadinessItem[],
+  platformFilter: string | undefined,
+  matchResult: { matches: string[]; ambiguous: boolean },
+  allPlatformNames: string[]
+): string => {
+  if (platformFilter && matchResult.matches.length === 0) {
+    const knownPlatforms = allPlatformNames.join(', ');
+    return knownPlatforms
+      ? `No platform matched "${platformFilter}". Known platforms: ${knownPlatforms}.`
+      : `No platform matched "${platformFilter}" and no platforms were discovered.`;
+  }
+
+  if (platformFilter && matchResult.ambiguous) {
+    return `Multiple platforms matched "${platformFilter}": ${matchResult.matches.join(', ')}.`;
+  }
+
+  if (platformFilter && platforms.length === 1) {
+    const platform = platforms[0];
+    const issue = platform.topFinding ? ` ${platform.topFinding}` : '';
+    return `${platform.platform}: ${platform.activeStreams} active stream(s), ${platform.enabledRules} enabled rule(s), ${platform.mitreTactics} MITRE tactic(s).${issue}`;
+  }
+
+  const needingAction = platforms.filter((platform) => platform.status === 'actionsRequired');
+  if (needingAction.length === 0) {
+    return `All ${platforms.length} discovered platform(s) are healthy.`;
+  }
+
+  const leastReady = needingAction
+    .map((platform) => platform.platform)
+    .slice(0, 3)
+    .join(', ');
+  return `Coverage is uneven across platforms. Platforms needing attention: ${leastReady}.`;
+};
+
+export const buildPlatformReadiness = ({
+  indexToPlatform,
+  indexToRules,
+  pipelineToIndices,
+  categoryToIndices,
+  categoriesResult,
+  findings,
+  platformFilter,
+}: BuildPlatformReadinessParams): PlatformReadinessPayload => {
+  const platformToStreams = invertPlatformMap(indexToPlatform);
+  const findingsByPlatform = new Map<string, ActionableFinding[]>();
+
+  for (const input of findings) {
+    const platform = resolvePlatformForFinding(
+      input,
+      indexToPlatform,
+      pipelineToIndices,
+      categoryToIndices
+    );
+    if (platform) {
+      const existing = findingsByPlatform.get(platform) ?? [];
+      existing.push(input.finding);
+      findingsByPlatform.set(platform, existing);
+    }
+  }
+
+  const allPlatformNames = new Set<string>([
+    ...platformToStreams.keys(),
+    ...findingsByPlatform.keys(),
+  ]);
+
+  let platforms: PlatformReadinessItem[] = [...allPlatformNames].map((platform) => {
+    const streamNames = platformToStreams.get(platform) ?? new Set<string>();
+    const platformIndices = new Set<string>();
+    for (const [indexName, label] of indexToPlatform.entries()) {
+      if (label === platform) {
+        platformIndices.add(indexName);
+        platformIndices.add(toDataStreamName(indexName));
+      }
+    }
+
+    const platformFindings = findingsByPlatform.get(platform) ?? [];
+    const rules = getRulesForIndices(platformIndices, indexToRules);
+    const tacticIds = new Set<string>();
+    for (const rule of rules) {
+      for (const tactic of rule.tactics) {
+        tacticIds.add(tactic.id);
+      }
+    }
+
+    const item: PlatformReadinessItem = {
+      platform,
+      primaryCategory: getPrimaryCategory(streamNames, categoriesResult),
+      activeStreams: streamNames.size,
+      enabledRules: rules.length,
+      mitreTactics: tacticIds.size,
+      status: getPlatformStatus(streamNames.size, rules.length, platformFindings),
+      topFinding: getTopFinding(platformFindings),
+      findings: platformFindings,
+    };
+    return item;
+  });
+
+  platforms.sort((a, b) => {
+    if (a.status === 'actionsRequired' && b.status !== 'actionsRequired') {
+      return -1;
+    }
+    if (b.status === 'actionsRequired' && a.status !== 'actionsRequired') {
+      return 1;
+    }
+    return a.platform.localeCompare(b.platform);
+  });
+
+  const allNames = platforms.map((platform) => platform.platform);
+  const matchResult = platformFilter
+    ? matchPlatforms(platformFilter, allNames)
+    : { matches: allNames, ambiguous: false };
+
+  if (platformFilter) {
+    platforms = platforms.filter((platform) => matchResult.matches.includes(platform.platform));
+  }
+
+  const status =
+    platforms.length > 0 ? worstStatus(platforms.map((platform) => platform.status)) : 'noData';
+  const summary = buildPlatformSummary(platforms, platformFilter, matchResult, allNames);
+
+  return {
+    status,
+    summary,
+    platforms,
+  };
+};

--- a/x-pack/solutions/security/packages/siem-readiness/src/types.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/types.ts
@@ -218,3 +218,20 @@ export interface RetentionPayload {
   items: RetentionInfo[];
   actionableFindings: ActionableFinding[];
 }
+
+export interface PlatformReadinessItem {
+  platform: string;
+  primaryCategory?: MainCategories;
+  activeStreams: number;
+  enabledRules: number;
+  mitreTactics: number;
+  status: VisibilityStatus;
+  topFinding?: string;
+  findings: ActionableFinding[];
+}
+
+export interface PlatformReadinessPayload {
+  status: VisibilityStatus;
+  summary: string;
+  platforms: PlatformReadinessItem[];
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/siem_readiness.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/siem_readiness.test.ts
@@ -95,6 +95,32 @@ const retentionData = {
   ],
 };
 
+const platformData = {
+  dimension: 'platform' as const,
+  status: 'actionsRequired' as const,
+  summary: 'AWS account needs attention.',
+  platforms: [
+    {
+      platform: 'AWS account 123456789012',
+      primaryCategory: 'Cloud',
+      activeStreams: 2,
+      enabledRules: 5,
+      mitreTactics: 3,
+      status: 'actionsRequired' as const,
+      topFinding: 'Data stream serving pipeline cloudtrail-pipeline has gone silent',
+      findings: [
+        {
+          category: 'Cloud',
+          severity: 'CRITICAL' as const,
+          message: 'Data stream serving pipeline cloudtrail-pipeline has gone silent',
+          resource: 'cloudtrail-pipeline',
+          affectedPlatform: 'AWS account 123456789012',
+        },
+      ],
+    },
+  ],
+};
+
 // ---- tests ----
 
 describe('siemReadinessAttachmentDataSchema', () => {
@@ -112,6 +138,10 @@ describe('siemReadinessAttachmentDataSchema', () => {
 
   it('validates retention data', () => {
     expect(siemReadinessAttachmentDataSchema.safeParse(retentionData).success).toBe(true);
+  });
+
+  it('validates platform data', () => {
+    expect(siemReadinessAttachmentDataSchema.safeParse(platformData).success).toBe(true);
   });
 
   it('rejects data with an unknown dimension', () => {
@@ -192,6 +222,16 @@ describe('createSiemReadinessAttachmentType', () => {
       expect(rep?.type).toBe('text');
       expect(rep?.value).toContain('Actions Required'); // not 'actionsRequired'
       expect(rep?.value).toContain('logs-cloud-default');
+    });
+
+    it('formats platform as text containing platform rollup details', async () => {
+      const formatted = await Promise.resolve(
+        attachmentType.format(makeAttachment(platformData), mockFormatContext)
+      );
+      const rep = await Promise.resolve(formatted.getRepresentation?.());
+      expect(rep?.type).toBe('text');
+      expect(rep?.value).toContain('AWS account 123456789012');
+      expect(rep?.value).toContain('Streams 2 active');
     });
 
     it('throws when data does not match any dimension schema', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/siem_readiness.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/siem_readiness.ts
@@ -14,6 +14,7 @@ import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import type {
   ContinuityPayload,
   CoveragePayload,
+  PlatformReadinessPayload,
   QualityPayload,
   RetentionInfo,
   RetentionPayload,
@@ -126,6 +127,26 @@ export const siemReadinessRetentionDataSchema = securityAttachmentDataSchema.ext
   actionableFindings: z.array(actionableFindingSchema),
 });
 
+// ---- Platform ----
+
+export const siemReadinessPlatformDataSchema = securityAttachmentDataSchema.extend({
+  dimension: z.literal('platform'),
+  status: z.enum(['healthy', 'actionsRequired', 'noData']),
+  summary: z.string().max(8000),
+  platforms: z.array(
+    z.object({
+      platform: z.string().max(200),
+      primaryCategory: z.string().max(100).optional(),
+      activeStreams: z.number(),
+      enabledRules: z.number(),
+      mitreTactics: z.number(),
+      status: z.enum(['healthy', 'actionsRequired', 'noData']),
+      topFinding: z.string().max(5000).optional(),
+      findings: z.array(actionableFindingSchema),
+    })
+  ),
+});
+
 // ---- Union schema ----
 
 export const siemReadinessAttachmentDataSchema = z.discriminatedUnion('dimension', [
@@ -133,6 +154,7 @@ export const siemReadinessAttachmentDataSchema = z.discriminatedUnion('dimension
   siemReadinessQualityDataSchema,
   siemReadinessContinuityDataSchema,
   siemReadinessRetentionDataSchema,
+  siemReadinessPlatformDataSchema,
 ]);
 
 export type SiemReadinessAttachmentData = z.infer<typeof siemReadinessAttachmentDataSchema>;
@@ -303,6 +325,31 @@ const formatRetentionForAgent = (data: RetentionPayload & { dimension: 'retentio
   return lines.join('\n');
 };
 
+const formatPlatformForAgent = (
+  data: PlatformReadinessPayload & { dimension: 'platform' }
+): string => {
+  const lines = [`SIEM Platform Readiness — ${formatStatus(data.status)}`, data.summary];
+
+  data.platforms.forEach((platform) => {
+    const issue = platform.topFinding ? ` (${platform.topFinding})` : '';
+    lines.push(
+      `- ${platform.platform}: Streams ${platform.activeStreams} active. Enabled rules: ${
+        platform.enabledRules
+      }. MITRE tactics: ${platform.mitreTactics}. Status: ${formatStatus(platform.status)}${issue}.`
+    );
+    if (platform.findings.length > 0) {
+      lines.push('  Findings:');
+      platform.findings.forEach((finding) => {
+        lines.push(
+          ...formatFindingWithBlastRadius(finding as z.infer<typeof actionableFindingSchema>)
+        );
+      });
+    }
+  });
+
+  return lines.join('\n');
+};
+
 const getAgentDescription = (): string => `
 You have access to SIEM readiness data for one dimension (coverage, quality, continuity, or retention).
 The attachment contains:
@@ -338,6 +385,8 @@ Field mapping (tool output camelCase → attachment snake_case):
 - policy name: policyName → policy_name
 
 Use the blast radius information to prioritize findings by impact. Always structure your response using the four-section format: Status → Summary → Findings by dimension then by category → Suggested Actions.
+
+Platform rollup attachments group readiness by ECS-derived platform labels (for example "AWS account 123456789012", "windows Endpoints") and include per-platform stream, rule, and tactic counts plus nested findings.
 `;
 
 // ---- Attachment type definition ----
@@ -374,6 +423,11 @@ export const createSiemReadinessAttachmentType = (): AttachmentTypeDefinition =>
             break;
           case 'retention':
             text = formatRetentionForAgent(data as RetentionPayload & { dimension: 'retention' });
+            break;
+          case 'platform':
+            text = formatPlatformForAgent(
+              data as PlatformReadinessPayload & { dimension: 'platform' }
+            );
             break;
         }
         return { type: 'text', value: text };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/siem_readiness/siem_readiness_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/siem_readiness/siem_readiness_skill.ts
@@ -11,6 +11,7 @@ import {
   SIEM_READINESS_QUALITY_TOOL_ID,
   SIEM_READINESS_CONTINUITY_TOOL_ID,
   SIEM_READINESS_RETENTION_TOOL_ID,
+  SIEM_READINESS_PLATFORM_TOOL_ID,
 } from '../../tools/siem_readiness';
 
 export const siemReadinessSkill = defineSkillType({
@@ -38,6 +39,7 @@ Use this skill when the user asks about:
 - \`security.siem_readiness.get_quality\` — ECS field compatibility results per index
 - \`security.siem_readiness.get_continuity\` — ingest pipeline stats (docs processed, failure rate, serving indices)
 - \`security.siem_readiness.get_retention\` — retention policy per data stream / index, days, and compliance status
+- \`security.siem_readiness.get_platform_readiness\` — readiness rolled up by ECS-derived platform label (streams, rules, MITRE tactics, nested findings across all dimensions)
 
 ## Response Structure
 
@@ -200,6 +202,19 @@ Playbook guidance:
 1. Call the relevant tools
 2. In the Findings section, focus on the Endpoint category but still show other categories if they have findings
 
+### For platform-specific questions (e.g., "How is AWS account 123456789012 readiness?"):
+1. Call \`get_platform_readiness\` with the \`platform\` parameter set to the user's platform label (case-insensitive partial match is supported)
+2. For comparison questions like "Which platform is least ready?" or "Compare windows Endpoints vs AWS", call \`get_platform_readiness\` without a filter
+3. Structure the response around each platform in \`platforms[]\`:
+   - Platform name
+   - Streams: \`activeStreams\`
+   - Enabled rules: \`enabledRules\`
+   - MITRE tactics: \`mitreTactics\`
+   - Status: \`status\` plus \`topFinding\` when present
+   - Nested \`findings\` with full blast radius sub-bullets
+4. Platform labels come from ECS fields in the actual data (for example "AWS account 123456789012", "windows Endpoints", "okta") — not environment nicknames like "AWS Prod"
+5. If the user's label does not match any platform, list the known platforms from the tool response and ask them to pick one
+
 ### For silence and volume-drop questions:
 - "Which data streams have gone silent?" → Call \`get_continuity\`, filter \`actionableFindings\` where \`type === 'silence'\`, report resource name, \`silenceMs\` converted to human-readable duration, and blast radius.
 - "Are any streams showing an unusual volume drop vs last week?" → Call \`get_continuity\`, filter \`actionableFindings\` where \`type\` is \`volume_drop_warning\` or \`volume_drop_critical\`, report \`volumeDropPct\`, \`lastFullDayDocs\`, \`baseline7dAvg\`, and blast radius.
@@ -250,6 +265,16 @@ Playbook guidance:
 - Threshold: 365 days (FedRAMP). \`retentionDays: null\` means no explicit retention — data kept forever — which is compliant.
 - When reporting retention findings: group by category using the \`categories\` field. Example: "1 index in Cloud has retention below threshold: logs-cloud_security_posture.findings-default (180d)".
 
+### Platform (\`get_platform_readiness\`)
+- \`status\`: \`healthy | actionsRequired | noData\`
+- \`summary\`: pre-computed summary string
+- \`platforms\`: array of \`{ platform, primaryCategory, activeStreams, enabledRules, mitreTactics, status, topFinding, findings }\`
+- \`platform\` parameter (optional): filter to one platform label; omit to compare all discovered platforms
+- Example prompts:
+  - "How is AWS account 123456789012 readiness?"
+  - "Which platform is least ready?"
+  - "Compare windows Endpoints vs AWS"
+
 ## Best Practices
 - Always call \`actionableFindings\` arrays first to build the Suggested Actions section — they are pre-computed from the data.
 - When \`statsAvailable\` is false (serverless), note this in the Continuity findings rather than reporting zero failures.
@@ -262,5 +287,6 @@ Playbook guidance:
     SIEM_READINESS_QUALITY_TOOL_ID,
     SIEM_READINESS_CONTINUITY_TOOL_ID,
     SIEM_READINESS_RETENTION_TOOL_ID,
+    SIEM_READINESS_PLATFORM_TOOL_ID,
   ],
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/get_platform_readiness_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/get_platform_readiness_tool.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType, type OtherResult } from '@kbn/agent-builder-common';
+import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
+import type { PlatformReadinessPayload } from '@kbn/siem-readiness';
+import {
+  createToolTestMocks,
+  createToolHandlerContext,
+  setupMockCoreStartServices,
+} from '../../__mocks__/test_helpers';
+import { getPlatformReadinessTool } from './get_platform_readiness_tool';
+import {
+  getContinuity,
+  getCoverage,
+  getQuality,
+  getRetention,
+} from '../../../lib/siem_readiness/dimensions';
+import { getSiemReadinessSharedContext } from '../../../lib/siem_readiness/fetchers';
+
+jest.mock('../../../lib/siem_readiness/dimensions', () => ({
+  getCoverage: jest.fn(),
+  getQuality: jest.fn(),
+  getContinuity: jest.fn(),
+  getRetention: jest.fn(),
+}));
+jest.mock('../../../lib/siem_readiness/fetchers', () => ({
+  getSiemReadinessSharedContext: jest.fn(),
+  fetchSiemReadinessSharedContext: jest.fn(),
+}));
+
+const mockGetCoverage = getCoverage as jest.Mock;
+const mockGetQuality = getQuality as jest.Mock;
+const mockGetContinuity = getContinuity as jest.Mock;
+const mockGetRetention = getRetention as jest.Mock;
+const mockGetSharedContext = getSiemReadinessSharedContext as jest.Mock;
+
+const mockSharedContext = {
+  reverseMapResult: {
+    indexToRules: new Map([
+      [
+        'logs-aws.cloudtrail-default',
+        [
+          {
+            id: 'rule-1',
+            name: 'AWS Rule',
+            tactics: [{ id: 'TA0001', name: 'Initial Access' }],
+            enabled: true,
+          },
+        ],
+      ],
+    ]),
+    pipelineToIndices: new Map(),
+    categoryToIndices: new Map([['Cloud', ['logs-aws.cloudtrail-default']]]),
+    tacticTotals: new Map(),
+    mlRules: [],
+    errors: { pipelineMap: false, categoryMap: false, rulesPartial: false },
+  },
+  categoriesResult: {
+    rawCategoriesMap: [],
+    mainCategoriesMap: [
+      {
+        category: 'Cloud',
+        indices: [{ indexName: 'logs-aws.cloudtrail-default', docs: 100 }],
+      },
+    ],
+  },
+  indexToPlatform: new Map([['logs-aws.cloudtrail-default', 'AWS account 123456789012']]),
+};
+
+describe('getPlatformReadinessTool', () => {
+  const { mockCore, mockLogger, mockEsClient, mockRequest } = createToolTestMocks();
+  const tool = getPlatformReadinessTool(mockCore, mockLogger, false);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMockCoreStartServices(mockCore, mockEsClient);
+    mockGetSharedContext.mockResolvedValue(mockSharedContext);
+    mockGetCoverage.mockResolvedValue({
+      status: 'healthy',
+      summary: 'Coverage healthy',
+      items: [],
+      actionableFindings: [],
+    });
+    mockGetQuality.mockResolvedValue({
+      status: 'healthy',
+      summary: 'Quality healthy',
+      items: [],
+      actionableFindings: [],
+    });
+    mockGetContinuity.mockResolvedValue({
+      status: 'actionsRequired',
+      summary: 'Continuity issues',
+      items: [],
+      actionableFindings: [
+        {
+          severity: 'CRITICAL',
+          message: 'Data stream serving pipeline cloudtrail-pipeline has gone silent',
+          resource: 'cloudtrail-pipeline',
+          type: 'silence',
+        },
+      ],
+    });
+    mockGetRetention.mockResolvedValue({
+      status: 'healthy',
+      summary: 'Retention healthy',
+      items: [],
+      actionableFindings: [],
+    });
+  });
+
+  it('returns ToolResultType.other with platform rollup data', async () => {
+    const result = (await tool.handler(
+      {},
+      createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+    )) as ToolHandlerStandardReturn;
+
+    expect(result.results[0].type).toBe(ToolResultType.other);
+    const data = (result.results[0] as OtherResult<PlatformReadinessPayload>).data;
+    expect(data.platforms.length).toBeGreaterThan(0);
+    expect(data.platforms[0].platform).toBe('AWS account 123456789012');
+    expect(data.platforms[0].enabledRules).toBe(1);
+  });
+
+  it('filters by platform when platform param is provided', async () => {
+    const result = (await tool.handler(
+      { platform: 'AWS account 123456789012' },
+      createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+    )) as ToolHandlerStandardReturn;
+
+    const data = (result.results[0] as OtherResult<PlatformReadinessPayload>).data;
+    expect(data.platforms).toHaveLength(1);
+    expect(data.platforms[0].platform).toBe('AWS account 123456789012');
+  });
+
+  it('returns ToolResultType.error when a dimension fetch throws', async () => {
+    mockGetQuality.mockRejectedValueOnce(new Error('ES failure'));
+    const result = (await tool.handler(
+      {},
+      createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+    )) as ToolHandlerStandardReturn;
+
+    expect(result.results[0].type).toBe(ToolResultType.error);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/get_platform_readiness_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/get_platform_readiness_tool.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import { getToolResultId } from '@kbn/agent-builder-server/tools';
+import type { Logger } from '@kbn/logging';
+import type { MainCategories, PlatformFindingInput } from '@kbn/siem-readiness';
+import {
+  buildPlatformReadiness,
+  enrichFindings,
+  filterPipelinesByCategories,
+  filterRetentionItemsByCategories,
+  getIndexCategoryMap,
+} from '@kbn/siem-readiness';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import {
+  getContinuity,
+  getCoverage,
+  getQuality,
+  getRetention,
+} from '../../../lib/siem_readiness/dimensions';
+import {
+  fetchSiemReadinessSharedContext,
+  getSiemReadinessSharedContext,
+} from '../../../lib/siem_readiness/fetchers';
+import { SIEM_READINESS_PLATFORM_TOOL_ID } from './tool_ids';
+
+const schema = z.object({
+  platform: z.string().max(200).optional(),
+});
+
+export const getPlatformReadinessTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  isServerless: boolean
+): BuiltinToolDefinition<typeof schema> => ({
+  id: SIEM_READINESS_PLATFORM_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'Retrieves SIEM readiness rolled up by platform label derived from ECS fields in the actual data (e.g. "AWS account 123456789012", "windows Endpoints", "okta"). Returns per-platform active stream counts, enabled rule counts, MITRE tactic counts, status, top finding, and nested actionable findings across coverage, quality, continuity, and retention. Pass an optional platform filter for questions like "How is AWS account 123456789012 readiness?" or omit it to compare all discovered platforms. When presenting platform findings, always show Affected Platform, Affected Rules, and Affected Tactics for each nested finding.',
+  schema,
+  tags: ['security', 'siem-readiness', 'platform'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async (params, { esClient, logger: handlerLogger, request }) => {
+    try {
+      const [coreStart, startPlugins] = await core.getStartServices();
+
+      const { reverseMapResult, categoriesResult, indexToPlatform } =
+        await getSiemReadinessSharedContext(request, async () => {
+          const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+          const dataViewsService = await startPlugins.dataViews.dataViewsServiceFactory(
+            coreStart.savedObjects.getScopedClient(request),
+            esClient.asCurrentUser
+          );
+          return fetchSiemReadinessSharedContext({
+            rulesClient,
+            esClient: esClient.asCurrentUser,
+            dataViewsService,
+            logger: handlerLogger,
+          });
+        });
+
+      const hasDetectionRules =
+        reverseMapResult.indexToRules.size > 0 ||
+        reverseMapResult.tacticTotals.size > 0 ||
+        reverseMapResult.mlRules.length > 0;
+
+      const [coveragePayload, qualityPayload, continuityPayload, retentionPayload] =
+        await Promise.all([
+          getCoverage({
+            logger: handlerLogger,
+            categoriesData: categoriesResult,
+            hasDetectionRules,
+          }),
+          getQuality({
+            esClient: esClient.asCurrentUser,
+            logger: handlerLogger,
+          }),
+          getContinuity({
+            esClient: esClient.asCurrentUser,
+            isServerless,
+            logger: handlerLogger,
+            categoriesData: categoriesResult,
+          }),
+          getRetention({
+            esClient: esClient.asCurrentUser,
+            isServerless,
+            logger: handlerLogger,
+          }),
+        ]);
+
+      const indexToCategoryMap = getIndexCategoryMap(categoriesResult);
+      const categorizedPipelines = filterPipelinesByCategories(
+        continuityPayload.items,
+        categoriesResult
+      );
+      const categorizedRetentionItems = filterRetentionItemsByCategories(
+        retentionPayload.items,
+        categoriesResult
+      );
+
+      const resourceToRetentionCategory = new Map<string, MainCategories>();
+      for (const group of categoriesResult.mainCategoriesMap ?? []) {
+        for (const item of categorizedRetentionItems) {
+          if (group.indices.some((idx) => idx.indexName.includes(item.indexName))) {
+            resourceToRetentionCategory.set(item.indexName, group.category as MainCategories);
+          }
+        }
+      }
+
+      const coverageFindings = enrichFindings(coveragePayload.actionableFindings ?? [], {
+        ...reverseMapResult,
+        indexToPlatform,
+        dimension: 'coverage',
+      });
+
+      const qualityFindings = enrichFindings(qualityPayload.actionableFindings ?? [], {
+        ...reverseMapResult,
+        indexToPlatform,
+        dimension: 'quality',
+      })
+        .filter((finding) => indexToCategoryMap.has(finding.resource))
+        .map((finding) => {
+          const category = indexToCategoryMap.get(finding.resource) as MainCategories | undefined;
+          return category ? { ...finding, category } : finding;
+        });
+
+      const continuityFindings = enrichFindings(continuityPayload.actionableFindings ?? [], {
+        ...reverseMapResult,
+        indexToPlatform,
+        dimension: 'continuity',
+      })
+        .filter((finding) =>
+          categorizedPipelines.some((pipeline) => pipeline.name === finding.resource)
+        )
+        .map((finding) => {
+          const pipeline = categorizedPipelines.find((item) => item.name === finding.resource);
+          const category = pipeline?.indices
+            .map((idx) => indexToCategoryMap.get(idx))
+            .find(Boolean) as MainCategories | undefined;
+          return category ? { ...finding, category } : finding;
+        });
+
+      const retentionFindings = enrichFindings(retentionPayload.actionableFindings ?? [], {
+        ...reverseMapResult,
+        indexToPlatform,
+        dimension: 'retention',
+      })
+        .filter((finding) => resourceToRetentionCategory.has(finding.resource))
+        .map((finding) => {
+          const category = resourceToRetentionCategory.get(finding.resource);
+          return category !== undefined ? { ...finding, category } : finding;
+        });
+
+      const findings: PlatformFindingInput[] = [
+        ...coverageFindings.map((finding) => ({ dimension: 'coverage' as const, finding })),
+        ...qualityFindings.map((finding) => ({ dimension: 'quality' as const, finding })),
+        ...continuityFindings.map((finding) => ({ dimension: 'continuity' as const, finding })),
+        ...retentionFindings.map((finding) => ({ dimension: 'retention' as const, finding })),
+      ];
+
+      const payload = buildPlatformReadiness({
+        indexToPlatform,
+        indexToRules: reverseMapResult.indexToRules,
+        pipelineToIndices: reverseMapResult.pipelineToIndices,
+        categoryToIndices: reverseMapResult.categoryToIndices,
+        categoriesResult,
+        findings,
+        platformFilter: params.platform,
+      });
+
+      return {
+        results: [
+          {
+            tool_result_id: getToolResultId(),
+            type: ToolResultType.other,
+            data: payload,
+          },
+        ],
+      };
+    } catch (error: unknown) {
+      const e = error as { message?: string };
+      return {
+        results: [
+          {
+            tool_result_id: getToolResultId(),
+            type: ToolResultType.error,
+            data: {
+              message: `Error fetching SIEM platform readiness: ${e.message ?? 'unknown error'}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/index.ts
@@ -10,5 +10,6 @@ export {
   SIEM_READINESS_QUALITY_TOOL_ID,
   SIEM_READINESS_CONTINUITY_TOOL_ID,
   SIEM_READINESS_RETENTION_TOOL_ID,
+  SIEM_READINESS_PLATFORM_TOOL_ID,
 } from './tool_ids';
 export { registerSiemReadinessTools } from './register_siem_readiness_tools';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/register_siem_readiness_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/register_siem_readiness_tools.ts
@@ -12,6 +12,7 @@ import { getCoverageTool } from './get_coverage_tool';
 import { getQualityTool } from './get_quality_tool';
 import { getContinuityTool } from './get_continuity_tool';
 import { getRetentionTool } from './get_retention_tool';
+import { getPlatformReadinessTool } from './get_platform_readiness_tool';
 
 export const registerSiemReadinessTools = (
   agentBuilder: AgentBuilderPluginSetup,
@@ -23,4 +24,5 @@ export const registerSiemReadinessTools = (
   agentBuilder.tools.register(getQualityTool(core, logger));
   agentBuilder.tools.register(getContinuityTool(core, logger, isServerless));
   agentBuilder.tools.register(getRetentionTool(core, logger, isServerless));
+  agentBuilder.tools.register(getPlatformReadinessTool(core, logger, isServerless));
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/tool_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/siem_readiness/tool_ids.ts
@@ -11,3 +11,6 @@ export const SIEM_READINESS_COVERAGE_TOOL_ID = securityTool('siem_readiness.get_
 export const SIEM_READINESS_QUALITY_TOOL_ID = securityTool('siem_readiness.get_quality');
 export const SIEM_READINESS_CONTINUITY_TOOL_ID = securityTool('siem_readiness.get_continuity');
 export const SIEM_READINESS_RETENTION_TOOL_ID = securityTool('siem_readiness.get_retention');
+export const SIEM_READINESS_PLATFORM_TOOL_ID = securityTool(
+  'siem_readiness.get_platform_readiness'
+);


### PR DESCRIPTION
## Summary

Previously we added Platform as field on Siem readiness blast radius but user werent able to use that as part of the prompt, This PR addresses that and User will now be able to use certain prompt like "How is PlatformNameHere doing"






