### PR TITLE
[Entity Analytics][Graph] Fix flaky alerts/network events FTR page objects (9.4 backport)

### DIFF
--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/alerts_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/alerts_page.ts
@@ -24,6 +24,7 @@ export class AlertsPageObject extends FtrService {
   private readonly retry = this.ctx.getService('retry');
   private readonly pageObjects = this.ctx.getPageObjects(['common', 'header']);
   private readonly testSubjects = this.ctx.getService('testSubjects');
+  private readonly queryBar = this.ctx.getService('queryBar');
   private readonly defaultTimeoutMs = this.ctx.getService('config').get('timeouts.waitFor');
 
   async navigateToAlertsPage(urlQueryParams: string = ''): Promise<void> {
@@ -47,11 +48,17 @@ export class AlertsPageObject extends FtrService {
   }
 
   /**
-   * Clicks the refresh button on the Alerts page and waits for it to complete
+   * Refreshes the Alerts page query and waits for it to complete.
+   *
+   * Submits via the query input + Enter rather than clicking the `querySubmitButton`
+   * directly. When the alert flyout is open its fixed-position header (e.g. the Share
+   * button) overlaps the refresh button at the top of the viewport and intercepts the
+   * click, causing flaky ElementClickInterceptedError failures. The query input sits on
+   * the opposite (left) side of the bar and is never covered by the flyout header.
    */
   async clickRefresh(): Promise<void> {
     await this.ensureOnAlertsPage();
-    await this.testSubjects.click('querySubmitButton');
+    await this.queryBar.submitQuery();
 
     // wait for refresh to complete
     await this.retry.waitFor(
@@ -65,10 +72,16 @@ export class AlertsPageObject extends FtrService {
   }
 
   async ensureOnAlertsPage(): Promise<void> {
-    await this.testSubjects.existOrFail('detectionsAlertsPage');
+    await this.testSubjects.existOrFail('alerts-page-content');
   }
 
   async waitForListToHaveAlerts(timeoutMs?: number): Promise<void> {
+    // Wait for the table container to be ready before checking for rows, so we
+    // don't enter the refresh loop while the initial data fetch is still in flight.
+    await this.testSubjects.existOrFail('alertsTableIsLoaded', {
+      timeout: timeoutMs ?? this.defaultTimeoutMs,
+    });
+
     const allEventRows = await this.testSubjects.findService.allByCssSelector(
       ALERT_TABLE_ROW_CSS_SELECTOR
     );

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/network_events_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/network_events_page.ts
@@ -65,7 +65,7 @@ export class NetworkEventsPageObject extends FtrService {
   }
 
   async ensureOnNetworkEventsPage(): Promise<void> {
-    await this.testSubjects.existOrFail('network-details-headline');
+    await this.testSubjects.existOrFail('header-page-title');
   }
 
   async waitForListToHaveEvents(timeoutMs?: number): Promise<void> {


### PR DESCRIPTION
## Summary

Manual partial backport to 9.4 of the flaky-test fixes from #272452.

The original PR was not backported wholesale because it also contains grouping/pinning feature work (`fetch_entity_relationships_graph.ts`, graph UI controls, entity flyout tests, etc.) that is not applicable/desired on 9.4. This PR cherry-picks only the flaky FTR page-object fixes:

- `alerts_page.ts`: submit refresh via `queryBar.submitQuery()` instead of clicking `querySubmitButton` directly (avoids `ElementClickInterceptedError` when the alert flyout's fixed header overlaps the button), wait for `alertsTableIsLoaded` before checking for rows, and fix `ensureOnAlertsPage`'s stale test subject (`detectionsAlertsPage` → `alerts-page-content`).
- `network_events_page.ts`: fix `ensureOnNetworkEventsPage`'s stale test subject (`network-details-headline` → `header-page-title`).

Both replacement test subjects (`alerts-page-content`, `alertsTableIsLoaded`, `header-page-title`) already exist in the 9.4 source, so this is a safe drop-in.

Related: #272452

## Test plan
- [ ] Flaky Test Runner on the affected FTR suites