### PR TITLE
[kbn-evals] Factuality: don't near-zero grounded answers absent from a thin reference

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  calculateFactualScore,
+  calculateRelevanceScore,
+  calculateProceduralFidelityScore,
+} from './scoring';
+import type { CorrectnessAnalysis } from './types';
+
+type Claim = CorrectnessAnalysis['analysis'][number];
+
+const claim = (overrides: Partial<Claim>): Claim => ({
+  claim: 'c',
+  centrality: 'central',
+  centrality_reason: '',
+  verdict: 'FULLY_SUPPORTED',
+  sequence_match: 'NOT_APPLICABLE',
+  justification_snippet: undefined,
+  explanation: '',
+  ...overrides,
+});
+
+const analysisOf = (claims: Array<Partial<Claim>>): CorrectnessAnalysis => ({
+  summary: {
+    factual_accuracy_summary: 'ACCURATE',
+    relevance_summary: 'RELEVANT',
+    sequence_accuracy_summary: 'NOT_APPLICABLE',
+  },
+  analysis: claims.map(claim),
+});
+
+describe('calculateFactualScore', () => {
+  it('returns 0 for empty / missing analysis', () => {
+    expect(calculateFactualScore(analysisOf([]))).toBe(0);
+    expect(calculateFactualScore({ ...analysisOf([]), analysis: [] })).toBe(0);
+  });
+
+  it('returns 1.0 when every claim is fully supported', () => {
+    expect(
+      calculateFactualScore(
+        analysisOf([{ verdict: 'FULLY_SUPPORTED' }, { verdict: 'FULLY_SUPPORTED' }])
+      )
+    ).toBeCloseTo(1.0, 5);
+  });
+
+  it('keeps CONTRADICTED central as a hard fail (single wrong claim collapses to 0)', () => {
+    // This is the property we must NOT regress: a verified-wrong central claim
+    // still zeroes the geometric mean regardless of the other claims.
+    expect(
+      calculateFactualScore(
+        analysisOf([
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'CONTRADICTED', centrality: 'central' },
+        ])
+      )
+    ).toBe(0);
+  });
+
+  it('does NOT near-zero a grounded answer whose central claims are merely absent from a thin reference', () => {
+    // The artifact fix: NOT_IN_GROUND_TRUTH central was 0.1 (→ geometric mean ~0.1
+    // = "MAJOR_INACCURACIES"); it is now 0.8 so an unverifiable-but-not-contradicted
+    // answer is not treated as a factual error.
+    const score = calculateFactualScore(
+      analysisOf([
+        { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+        { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+        { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      ])
+    );
+    expect(score).toBeCloseTo(0.8, 5);
+    expect(score).toBeGreaterThan(0.5);
+  });
+
+  it('scores a mostly-supported answer with one extra grounded central claim highly', () => {
+    const score = calculateFactualScore(
+      analysisOf([
+        { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+        { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+        { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      ])
+    );
+    expect(score).toBeGreaterThan(0.9);
+  });
+});
+
+describe('calculateRelevanceScore', () => {
+  it('is the proportion of central claims', () => {
+    expect(
+      calculateRelevanceScore(
+        analysisOf([{ centrality: 'central' }, { centrality: 'peripheral' }])
+      )
+    ).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe('calculateProceduralFidelityScore', () => {
+  it('is 1.0 when sequence is not applicable', () => {
+    const a = analysisOf([{ centrality: 'central', sequence_match: 'MATCH' }]);
+    a.summary.sequence_accuracy_summary = 'NOT_APPLICABLE';
+    expect(calculateProceduralFidelityScore(a)).toBe(1.0);
+  });
+
+  it('is the fraction of central claims in the correct sequence', () => {
+    const a = analysisOf([
+      { centrality: 'central', sequence_match: 'MATCH' },
+      { centrality: 'central', sequence_match: 'MISMATCH' },
+    ]);
+    a.summary.sequence_accuracy_summary = 'MISMATCH';
+    expect(calculateProceduralFidelityScore(a)).toBeCloseTo(0.5, 5);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.test.ts
@@ -91,9 +91,7 @@ describe('calculateFactualScore', () => {
 describe('calculateRelevanceScore', () => {
   it('is the proportion of central claims', () => {
     expect(
-      calculateRelevanceScore(
-        analysisOf([{ centrality: 'central' }, { centrality: 'peripheral' }])
-      )
+      calculateRelevanceScore(analysisOf([{ centrality: 'central' }, { centrality: 'peripheral' }]))
     ).toBeCloseTo(0.5, 5);
   });
 });

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.ts
@@ -7,7 +7,28 @@
 
 import type { CorrectnessAnalysis } from './types';
 
-// Scoring weights based on the severity of each error type
+// Scoring weights based on the severity of each error type.
+//
+// `CONTRADICTED` is a *verified* factual error — the ground truth says otherwise
+// — and stays a hard fail (central 0.0) so a single wrong central claim still
+// collapses the geometric mean to 0.
+//
+// `NOT_IN_GROUND_TRUTH` is NOT a verified error: it means the claim could not be
+// confirmed against the ground truth. When the dataset's ground-truth reference
+// is deliberately thin / data-agnostic (as in several agent-builder + alerts-rag
+// suites), a rich, correct, retrieval-grounded answer NECESSARILY contains
+// central claims absent from the reference. The previous central=0.1 weight,
+// combined with the geometric mean, forced such answers to ~0 Factuality
+// ("MAJOR_INACCURACIES") even though they passed Groundedness — a scoring
+// artifact, not a model failure. Whether an answer invents unsupported facts is
+// what the Groundedness evaluator (answer vs retrieved context) measures; it is
+// not Factuality's job to punish "richer than a thin reference". So an
+// unverifiable claim scores high-but-not-perfect rather than near-zero.
+//
+// NOTE: these two weights are the fix for that artifact; the exact values are
+// pending calibration against a real eval run (see the validation plan on the
+// tracking issue) — a run with/without this change should show Factuality track
+// Groundedness on grounded answers while genuine CONTRADICTED cases stay at 0.
 const CLAIM_FACTUAL_SCORE_MAP = {
   FULLY_SUPPORTED: 1.0,
   PARTIALLY_SUPPORTED: {
@@ -19,8 +40,8 @@ const CLAIM_FACTUAL_SCORE_MAP = {
     peripheral: 0.1,
   },
   NOT_IN_GROUND_TRUTH: {
-    central: 0.1,
-    peripheral: 0.5,
+    central: 0.8,
+    peripheral: 0.9,
   },
 } as const;
 


### PR DESCRIPTION
## Summary

**Draft — proposal pending eval-gate validation (see "Validation" below). Do not merge yet.**

The shared correctness **Factuality** evaluator (`x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.ts`) computes a **geometric mean** of per-claim scores. The `NOT_IN_GROUND_TRUTH` verdict — a claim that could *not be confirmed* against the ground truth, as distinct from `CONTRADICTED` (verified wrong) — was weighted `central = 0.1`.

When a dataset's ground-truth reference is deliberately thin / data-agnostic (several agent-builder and alerts-rag suites are), a **correct, retrieval-grounded** answer necessarily makes central claims that aren't in the reference. Every such claim scores 0.1, and the geometric mean collapses the whole Factuality score to ~0 (`MAJOR_INACCURACIES`) — even when the *same answer passes Groundedness*.

### Evidence

A per-example failing-score analysis of a recent golden-cluster weekly run (`security-alerts-rag-regression`, subject = Claude Opus) showed **Factuality failing 90 examples** (all `MAJOR_INACCURACIES`, score 0) while **Groundedness failed only 10** on the *same* answers. The split — grounded but "factually inaccurate" — is the fingerprint of a scoring artifact, not model behavior, and it appears across subject models and across suites that share this evaluator.

### Change

- `NOT_IN_GROUND_TRUTH`: `central 0.1 → 0.8`, `peripheral 0.5 → 0.9`.
- `CONTRADICTED` stays `central 0.0` — a single **verified-wrong** central claim still zeroes the geometric mean (invariant preserved and unit-tested).

Rationale: whether an answer invents unsupported facts is what **Groundedness** (answer vs retrieved context) measures. Factuality should penalize *contradictions*, not *richness beyond a thin reference*.

Adds unit coverage for `calculateFactualScore` (including the `CONTRADICTED` hard-fail invariant and the not-in-ground-truth case) plus basic relevance/sequence tests — this scorer previously had no direct test.

## Validation

- Verified the scoring math locally: the artifact case (3 `NOT_IN_GROUND_TRUTH` central claims) moves 0.1 → 0.8; `CONTRADICTED` central stays 0.0; all-supported stays 1.0.
- **Not yet run behind the full eval gate.** Before this merges, an eval run of alerts-rag + one agent-builder suite (Opus/Sonnet) **with and without** this change should confirm Factuality rises to track Groundedness on grounded answers while genuine `CONTRADICTED` cases still score 0. The exact weights (0.8 / 0.9) are the calibration lever for that run.

Tracking + full analysis: `elastic/security-team#18060`.

## Risk

Touches every suite's Factuality (shared evaluator). Scores will rise on suites with thin references; that is the intended correction. Genuine-contradiction hard-fails are unchanged.