### PR TITLE
[Data Federation] Add tooltip explaining why delete is disabled for data sources with datasets

### DIFF
--- a/x-pack/platform/plugins/private/data_federation/public/main.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.test.tsx
@@ -119,4 +119,49 @@ describe('Main', () => {
     expect(editButtons[0]).toBeEnabled();
     expect(editButtons[1]).toBeDisabled();
   });
+
+  it('disables the delete action for a data source with connected datasets', async () => {
+    const http = createHttpMock();
+    (http.get as jest.Mock).mockImplementation(async (path: string) => {
+      if (path === DATA_SOURCES_LIST_ROUTE_PATH) {
+        return {
+          data_sources: [
+            { name: 'connected', type: 's3', description: '', settings: {} },
+            { name: 'unconnected', type: 's3', description: '', settings: {} },
+          ],
+        };
+      }
+      if (path === DATA_SETS_LIST_ROUTE_PATH) {
+        return {
+          data_sets: [{ name: 'my-dataset', data_source: 'connected', resource: 'bucket/*' }],
+        };
+      }
+      throw new Error(`Unexpected GET: ${path}`);
+    });
+
+    const { getByRole, getByTestId, getAllByTestId, findByText } = render(
+      <EuiProvider>
+        <Main httpClient={http as unknown as HttpSetup} toasts={createToastsMock()} />
+      </EuiProvider>
+    );
+
+    fireEvent.click(getByRole('tab', { name: mainTranslations.tabs.sources }));
+
+    let deleteButtons: HTMLElement[] = [];
+    await waitFor(() => {
+      deleteButtons = getAllByTestId('dataSetsDeleteIconButton');
+      expect(deleteButtons).toHaveLength(2);
+    });
+
+    expect(deleteButtons[0]).toBeDisabled();
+    expect(deleteButtons[1]).toBeEnabled();
+
+    fireEvent.mouseOver(deleteButtons[0]);
+    await findByText(mainTranslations.columns.dataSources.deleteActionHasDataSetsDescription);
+
+    const connectedCheckbox = getByTestId('checkboxSelectRow-connected');
+    expect(connectedCheckbox).toBeDisabled();
+    fireEvent.mouseOver(connectedCheckbox);
+    await findByText(mainTranslations.columns.dataSources.deleteActionHasDataSetsDescription);
+  });
 });

--- a/x-pack/platform/plugins/private/data_federation/public/main.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.tsx
@@ -477,16 +477,32 @@ export const Main: FunctionComponent<MainProps> = ({
             ),
           },
           {
-            name: mainTranslations.columns.dataSources.deleteAction,
-            description: mainTranslations.columns.dataSources.deleteActionDescription,
-            icon: 'trash',
-            color: 'danger',
-            type: 'icon',
-            enabled: (item) => (dataSetsCountByDataSource.get(item.name) ?? 0) === 0,
-            onClick: (item) => {
-              handleDeleteDataSource(item);
+            // Same limitation as the edit action above: EUI can't show a tooltip on a
+            // disabled default action icon, so this renders the button manually to explain
+            // why deleting is disabled.
+            render: (item: DataSource) => {
+              const hasDataSets = (dataSetsCountByDataSource.get(item.name) ?? 0) > 0;
+              return (
+                <EuiToolTip
+                  content={
+                    hasDataSets
+                      ? mainTranslations.columns.dataSources.deleteActionHasDataSetsDescription
+                      : mainTranslations.columns.dataSources.deleteActionDescription
+                  }
+                >
+                  <span>
+                    <EuiButtonIcon
+                      aria-label={mainTranslations.columns.dataSources.deleteAction}
+                      iconType="trash"
+                      color="danger"
+                      isDisabled={hasDataSets}
+                      onClick={() => handleDeleteDataSource(item)}
+                      data-test-subj="dataSetsDeleteIconButton"
+                    />
+                  </span>
+                </EuiToolTip>
+              );
             },
-            'data-test-subj': 'dataSetsDeleteIconButton',
           },
         ],
       },
@@ -706,6 +722,10 @@ export const Main: FunctionComponent<MainProps> = ({
                 selected: selectedItems,
                 onSelectionChange: setSelectedItems,
                 selectable: (row) => (dataSetsCountByDataSource.get(row.name) ?? 0) === 0,
+                selectableMessage: (selectable) =>
+                  selectable
+                    ? ''
+                    : mainTranslations.columns.dataSources.deleteActionHasDataSetsDescription,
               }}
               sorting
               pagination={{

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -67,7 +67,7 @@ export const mainTranslations = {
         'xpack.dataFederation.table.deleteActionHasDataSetsDescription',
         {
           defaultMessage:
-            "To delete a data source, you must first delete all datasets that read from it.",
+            'To delete a data source, you must first delete all datasets that read from it.',
         }
       ),
       caption: i18n.translate('xpack.dataFederation.table.caption', {

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -67,7 +67,7 @@ export const mainTranslations = {
         'xpack.dataFederation.table.deleteActionHasDataSetsDescription',
         {
           defaultMessage:
-            "You can't delete a data source while datasets read from it. Delete those datasets first.",
+            "To delete a data source, you must first delete all datasets that read from it.",
         }
       ),
       caption: i18n.translate('xpack.dataFederation.table.caption', {

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -63,6 +63,13 @@ export const mainTranslations = {
           defaultMessage: 'Delete data source',
         }
       ),
+      deleteActionHasDataSetsDescription: i18n.translate(
+        'xpack.dataFederation.table.deleteActionHasDataSetsDescription',
+        {
+          defaultMessage:
+            "You can't delete a data source while datasets read from it. Delete those datasets first.",
+        }
+      ),
       caption: i18n.translate('xpack.dataFederation.table.caption', {
         defaultMessage: 'Data sources',
       }),


### PR DESCRIPTION
## Summary

Data sources with connected datasets already block deletion, but gave no explanation why. This PR adds a tooltip on the disabled row delete action and on the disabled selection checkbox explaining that connected datasets must be deleted first.


<img width="898" height="264" alt="Screenshot 2026-07-06 at 09 46 32" src="https://github.com/user-attachments/assets/00b03b22-de64-4a93-bb3c-352a82c5070d" />
