### PR TITLE
[9.4] [ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201) (#276321)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.test.ts
@@ -257,4 +257,32 @@ describe('requestOAuthToken', () => {
       refreshTokenExpiresIn: 86400,
     });
   });
+
+  test('accepts a 201 response as success, matching providers like CrowdStrike', async () => {
+    const configurationUtilities = actionsConfigMock.create();
+    axiosInstanceMock.mockReturnValueOnce({
+      status: 201,
+      data: {
+        token_type: 'bearer',
+        access_token: 'crowdstrike-token-123',
+        expires_in: 1799,
+      },
+    });
+
+    const result = await requestOAuthToken<TestOAuthRequestParams>(
+      'https://test',
+      'client_credentials',
+      configurationUtilities,
+      mockLogger,
+      { client_id: 'id', client_secret: 'secret' }
+    );
+
+    expect(result).toEqual({
+      tokenType: 'bearer',
+      accessToken: 'crowdstrike-token-123',
+      expiresIn: 1799,
+      refreshToken: undefined,
+      refreshTokenExpiresIn: undefined,
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/request_oauth_token.ts
@@ -72,7 +72,7 @@ export async function requestOAuthToken<T>(
     validateStatus: () => true,
   });
 
-  if (res.status === 200) {
+  if (res.status >= 200 && res.status < 300) {
     return {
       tokenType: res.data.token_type,
       accessToken: res.data.access_token,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201) (#276321)](https://github.com/elastic/kibana/pull/276321)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tal","email":"tal.borenstein@elastic.co"},"sourceCommit":{"committedDate":"2026-07-06T07:02:02Z","message":"[ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201) (#276321)\n\ntl;dr: CrowdStrike's `/oauth2/token` returns `201` on a successful token\nrequest, not `200`. We only treated `200` as success, so a valid token\nresponse got thrown away as an error — token was fetched but never used.\nWidened the check to any `2xx`. Added a regression test for the `201`\ncase.\n\nReported by a community user hitting this with a CrowdStrike-backed HTTP\nconnector.\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"c4d8172ff3a0a81fa8207f0da1799e5e73e9f006","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:version","v9.4.0","v9.5.0"],"title":"[ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201)","number":276321,"url":"https://github.com/elastic/kibana/pull/276321","mergeCommit":{"message":"[ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201) (#276321)\n\ntl;dr: CrowdStrike's `/oauth2/token` returns `201` on a successful token\nrequest, not `200`. We only treated `200` as success, so a valid token\nresponse got thrown away as an error — token was fetched but never used.\nWidened the check to any `2xx`. Added a regression test for the `201`\ncase.\n\nReported by a community user hitting this with a CrowdStrike-backed HTTP\nconnector.\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"c4d8172ff3a0a81fa8207f0da1799e5e73e9f006"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276321","number":276321,"mergeCommit":{"message":"[ResponseOps] Fix OAuth client credentials token parsing rejecting 2xx non-200 responses (e.g. CrowdStrike 201) (#276321)\n\ntl;dr: CrowdStrike's `/oauth2/token` returns `201` on a successful token\nrequest, not `200`. We only treated `200` as success, so a valid token\nresponse got thrown away as an error — token was fetched but never used.\nWidened the check to any `2xx`. Added a regression test for the `201`\ncase.\n\nReported by a community user hitting this with a CrowdStrike-backed HTTP\nconnector.\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"c4d8172ff3a0a81fa8207f0da1799e5e73e9f006"}}]}] BACKPORT-->