### PR TITLE
[Fleet] Fix 403 when setting a new default fleet server host over a preconfigured default

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server_host.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server_host.test.ts
@@ -274,6 +274,86 @@ describe('create', () => {
       )
     ).rejects.toThrow('id is not valid');
   });
+
+  it('should undefault an existing preconfigured default host when creating a new default via API', async () => {
+    const esClientMock = elasticsearchServiceMock.createInternalClient();
+    const soClientMock = getMockedSoClient();
+    const esoClientMock = getMockedEncryptedSoClient();
+
+    (isSecretStorageEnabled as jest.Mock).mockResolvedValue(false);
+
+    // getDefaultFleetServerHost() uses soClient.find — return a preconfigured default.
+    soClientMock.find.mockImplementation(async ({ type }: any) => {
+      if (type === FLEET_SERVER_HOST_SAVED_OBJECT_TYPE) {
+        return {
+          saved_objects: [
+            {
+              id: 'preconfigured-default',
+              attributes: {
+                name: 'Preconfigured Default',
+                host_urls: [],
+                is_default: true,
+                is_preconfigured: true,
+              },
+            },
+          ],
+        } as any;
+      }
+      return { saved_objects: [] } as any;
+    });
+
+    // First call: this.get('preconfigured-default') inside the internal update().
+    // Second call: post-create re-fetch of the newly created host.
+    esoClientMock.getDecryptedAsInternalUser
+      .mockResolvedValueOnce({
+        id: 'preconfigured-default',
+        type: FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+        references: [],
+        attributes: {
+          name: 'Preconfigured Default',
+          host_urls: [],
+          is_default: true,
+          is_preconfigured: true,
+          allow_edit: [],
+        },
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'new-host',
+        type: FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+        references: [],
+        attributes: {
+          name: 'New Default',
+          host_urls: ['https://fleet.example.com:8220'],
+          is_default: true,
+          is_preconfigured: false,
+        },
+      } as any);
+
+    soClientMock.update.mockResolvedValue({ id: 'preconfigured-default', attributes: {} } as any);
+
+    // Creating a host via the API (fromPreconfiguration is undefined) must not be rejected
+    // by the preconfiguration guard when unsetting is_default on the preconfigured host.
+    await expect(
+      fleetServerHostService.create(
+        soClientMock,
+        esClientMock,
+        {
+          name: 'New Default',
+          host_urls: ['https://fleet.example.com:8220'],
+          is_default: true,
+          is_preconfigured: false,
+        },
+        { id: 'new-host' }
+      )
+    ).resolves.toBeDefined();
+
+    // The preconfigured host was undefaulted even though it was not edited from preconfiguration.
+    expect(soClientMock.update).toHaveBeenCalledWith(
+      FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+      'preconfigured-default',
+      expect.objectContaining({ is_default: false })
+    );
+  });
 });
 
 describe('delete fleetServerHost', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server_host.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server_host.test.ts
@@ -522,6 +522,76 @@ describe('update', () => {
     await expect(result).resolves.toBeDefined();
   });
 
+  it('should undefault an existing preconfigured default host when setting a new default via API', async () => {
+    const soClient = getMockedSoClient();
+    const esoClient = getMockedEncryptedSoClient();
+
+    // The host being updated is a regular (non-preconfigured) host; the current default is a
+    // preconfigured host that does not allow editing is_default.
+    esoClient.getDecryptedAsInternalUser.mockImplementation(async (type: string, id: string) => {
+      if (id === 'private-fleet-server') {
+        return {
+          id: 'private-fleet-server',
+          type: FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+          references: [],
+          attributes: {
+            name: 'Private Fleet Server',
+            host_urls: ['https://private.fleet.aws.elastic.cloud:443'],
+            is_default: true,
+            is_preconfigured: true,
+            allow_edit: [],
+          },
+        } as any;
+      }
+      return {
+        id: 'regular-host',
+        type: FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+        references: [],
+        attributes: {
+          name: 'Regular Host',
+          host_urls: ['https://fleet.example.com:8220'],
+          is_default: false,
+          is_preconfigured: false,
+        },
+      } as any;
+    });
+
+    // getDefaultFleetServerHost() resolves to the preconfigured default host.
+    soClient.find.mockImplementation(async ({ type }: any) => {
+      if (type === FLEET_SERVER_HOST_SAVED_OBJECT_TYPE) {
+        return {
+          saved_objects: [
+            {
+              id: 'private-fleet-server',
+              attributes: {
+                name: 'Private Fleet Server',
+                host_urls: [],
+                is_default: true,
+                is_preconfigured: true,
+              },
+            },
+          ],
+        } as any;
+      }
+      return { saved_objects: [] } as any;
+    });
+
+    soClient.update.mockResolvedValue({ id: 'regular-host', attributes: {} } as any);
+
+    // Setting a new default via an API call (fromPreconfiguration is undefined) must not be
+    // rejected by the preconfiguration guard when unsetting is_default on the preconfigured host.
+    await expect(
+      fleetServerHostService.update(soClient, esClientMock, 'regular-host', { is_default: true })
+    ).resolves.toBeDefined();
+
+    // The preconfigured host was undefaulted even though it was not edited from preconfiguration.
+    expect(soClient.update).toHaveBeenCalledWith(
+      FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+      'private-fleet-server',
+      expect.objectContaining({ is_default: false })
+    );
+  });
+
   it('should not call extractAndUpdateFleetServerHostsSecrets or deleteSecrets when updating a non-secret field on a host with stored secrets', async () => {
     const soClient = getMockedSoClient();
     const esoClient = getMockedEncryptedSoClient();

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server_host.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server_host.ts
@@ -101,7 +101,11 @@ class FleetServerHostService {
           esClient,
           defaultItem.id,
           { is_default: false },
-          { fromPreconfiguration: options?.fromPreconfiguration }
+          // fromPreconfiguration: true so the internal unsetting of is_default on the
+          // existing default host bypasses the preconfiguration edit restriction. This is a
+          // system-level side effect of setting a new default, not a user edit, so it must be
+          // allowed even when the current default is a preconfigured host.
+          { fromPreconfiguration: true }
         );
       }
     }
@@ -378,7 +382,11 @@ class FleetServerHostService {
           {
             is_default: false,
           },
-          { fromPreconfiguration: options?.fromPreconfiguration }
+          // fromPreconfiguration: true so the internal unsetting of is_default on the
+          // existing default host bypasses the preconfiguration edit restriction. This is a
+          // system-level side effect of setting a new default, not a user edit, so it must be
+          // allowed even when the current default is a preconfigured host.
+          { fromPreconfiguration: true }
         );
       }
     }


### PR DESCRIPTION
## Summary

Setting a fleet server host as default (via API or UI) unsets `is_default` on the existing default host through a recursive `update()` call. That call forwarded the caller's `fromPreconfiguration` flag, which is `undefined` for non-preconfiguration requests. When the current default is a **preconfigured** host, the field-level preconfiguration guard added in #275601 then rejected the internal `is_default: false` update with:

```
Preconfigured Fleet Server host <id> is_default cannot be updated outside of the Kibana config file.
```

This broke Fleet Server setup — e.g. the `security_solution` endpoint dev/CI harness (`startFleetServerWithDocker` → `POST /api/fleet/fleet_server_hosts` with `is_default: true`) started failing with `403 Forbidden`, which surfaced as Defend Workflows Cypress failures (Fleet Server never becomes healthy → response actions fail with `Action [...] not found`).

### Root cause

The "undefault the existing default host" step is a **system-level side effect** of choosing a new default, not a user edit. But both `create()` and `update()` forwarded `options?.fromPreconfiguration` into that recursive call, so any non-preconfiguration path (API request, UI edit) that set a new default while a preconfigured default existed hit the guard.

Before #275601 this was harmless — nothing rejected field edits on preconfigured hosts. #275601 added a field-level guard that inspects every changed field, turning the long-standing forwarded flag into a 403.

### Fix

Pass `fromPreconfiguration: true` unconditionally on the internal undefault call in both `create()` and `update()`. User edits to preconfigured hosts remain guarded because they go through the primary write path, which keeps the caller's real flag.

`bulkCreateForPreconfiguration` is left untouched — its callers always pass `true`.

## Testing

- Added regression test *"should undefault an existing preconfigured default host when setting a new default via API"* in `fleet_server_host.test.ts`. It updates a regular host to `is_default: true` while the current default is a preconfigured host with empty `allow_edit`, and asserts the update resolves and the preconfigured host is undefaulted (`soClient.update` called with `is_default: false`).
- Confirmed the new test **fails without the fix** with the exact CI error, and passes with it. Full suite: 19/19 green.

## Release note

Fixes a `403 Forbidden` error ("Preconfigured Fleet Server host ... is_default cannot be updated outside of the Kibana config file") when setting a new default Fleet Server host while the current default is a preconfigured host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)