### PR TITLE
[9.4] [Lens] Fix invisible field names in dark mode field picker (#275785)

### DIFF
--- a/src/platform/packages/shared/kbn-visualization-ui-components/components/field_picker/field_picker.tsx
+++ b/src/platform/packages/shared/kbn-visualization-ui-components/components/field_picker/field_picker.tsx
@@ -64,7 +64,7 @@ export function FieldPicker<T extends FieldOptionValue = FieldOptionValue>(
               />
             ) : null,
             css: {
-              color: !fieldOption.compatible ? euiTheme.colors.lightShade : undefined,
+              color: !fieldOption.compatible ? euiTheme.colors.textDisabled : undefined,
               backgroundColor: !fieldOptionExists ? euiTheme.colors.lightestShade : undefined,
             },
           };
@@ -78,7 +78,7 @@ export function FieldPicker<T extends FieldOptionValue = FieldOptionValue>(
         <FieldIcon type={otherAttr.value.dataType} fill="none" className="eui-alignMiddle" />
       ) : null,
       css: {
-        color: !compatible ? euiTheme.colors.lightShade : undefined,
+        color: !compatible ? euiTheme.colors.textDisabled : undefined,
         backgroundColor: !exists ? euiTheme.colors.lightestShade : undefined,
       },
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens] Fix invisible field names in dark mode field picker (#275785)](https://github.com/elastic/kibana/pull/275785)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"teresaalvarezsoler","email":"99645649+teresaalvarezsoler@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-01T20:02:45Z","message":"[Lens] Fix invisible field names in dark mode field picker (#275785)\n\n## Summary\n\nFixes #265469\n\nField names render **black and invisible** in the Lens field picker in\ndark mode (both the Lens editor and the inline editor). This is most\nvisible when clicking the **Formula** tab and coming back to **Quick\nfunction**, where the field-name list becomes unreadable.\n\n### Root cause\n\nThe `FieldPicker` component sets the text `color` of incompatible/dimmed\nfield options to `euiTheme.colors.lightShade`:\n\n```ts\ncss: {\n  color: !compatible ? euiTheme.colors.lightShade : undefined,\n  backgroundColor: !exists ? euiTheme.colors.lightestShade : undefined,\n},\n```\n\n`lightShade` is a background **\"shade\"** token, not a text token. Shade\ntokens invert between themes:\n\n| Token | Light mode | Dark mode |\n|-------|-----------|-----------|\n| `colors.lightShade` | `#CAD3E2` (light gray – dims text nicely) |\n`#243147` (near-black blue-gray – invisible on the dark popover) |\n\nSo it only ever worked in light mode. In dark mode the dimmed field\nnames collapse to near-black on the dark popover background.\n\n### Fix\n\nUse `euiTheme.colors.textDisabled` — the theme-aware semantic token for\nsubdued/disabled text — so dimmed field options stay readable-but-muted\nin **both** light and dark mode. No behavior change for compatible\nfields (they still use the default text color).\n\n### Testing\n\n1. Enable dark mode.\n2. Create any visualization (XY, metric, …) and open a metric dimension.\n3. Click **Formula**, then switch back to **Quick function**.\n4. Field names in the selector are now visible (previously\nblack/invisible).\n\n- `node scripts/type_check` for `kbn-visualization-ui-components` ✅\n- `field_picker.test.tsx` ✅\n- eslint ✅\n\n### Checklist\n\n- [x] Any UI touched in this PR is usable by keyboard only / meets WCAG\ncontrast requirements (fix improves contrast)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>","sha":"280ecf802d6e1b2ca7ea51b30491776646d0d1ef","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","backport:version","v9.5.0","v9.4.4"],"title":"[Lens] Fix invisible field names in dark mode field picker","number":275785,"url":"https://github.com/elastic/kibana/pull/275785","mergeCommit":{"message":"[Lens] Fix invisible field names in dark mode field picker (#275785)\n\n## Summary\n\nFixes #265469\n\nField names render **black and invisible** in the Lens field picker in\ndark mode (both the Lens editor and the inline editor). This is most\nvisible when clicking the **Formula** tab and coming back to **Quick\nfunction**, where the field-name list becomes unreadable.\n\n### Root cause\n\nThe `FieldPicker` component sets the text `color` of incompatible/dimmed\nfield options to `euiTheme.colors.lightShade`:\n\n```ts\ncss: {\n  color: !compatible ? euiTheme.colors.lightShade : undefined,\n  backgroundColor: !exists ? euiTheme.colors.lightestShade : undefined,\n},\n```\n\n`lightShade` is a background **\"shade\"** token, not a text token. Shade\ntokens invert between themes:\n\n| Token | Light mode | Dark mode |\n|-------|-----------|-----------|\n| `colors.lightShade` | `#CAD3E2` (light gray – dims text nicely) |\n`#243147` (near-black blue-gray – invisible on the dark popover) |\n\nSo it only ever worked in light mode. In dark mode the dimmed field\nnames collapse to near-black on the dark popover background.\n\n### Fix\n\nUse `euiTheme.colors.textDisabled` — the theme-aware semantic token for\nsubdued/disabled text — so dimmed field options stay readable-but-muted\nin **both** light and dark mode. No behavior change for compatible\nfields (they still use the default text color).\n\n### Testing\n\n1. Enable dark mode.\n2. Create any visualization (XY, metric, …) and open a metric dimension.\n3. Click **Formula**, then switch back to **Quick function**.\n4. Field names in the selector are now visible (previously\nblack/invisible).\n\n- `node scripts/type_check` for `kbn-visualization-ui-components` ✅\n- `field_picker.test.tsx` ✅\n- eslint ✅\n\n### Checklist\n\n- [x] Any UI touched in this PR is usable by keyboard only / meets WCAG\ncontrast requirements (fix improves contrast)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>","sha":"280ecf802d6e1b2ca7ea51b30491776646d0d1ef"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275785","number":275785,"mergeCommit":{"message":"[Lens] Fix invisible field names in dark mode field picker (#275785)\n\n## Summary\n\nFixes #265469\n\nField names render **black and invisible** in the Lens field picker in\ndark mode (both the Lens editor and the inline editor). This is most\nvisible when clicking the **Formula** tab and coming back to **Quick\nfunction**, where the field-name list becomes unreadable.\n\n### Root cause\n\nThe `FieldPicker` component sets the text `color` of incompatible/dimmed\nfield options to `euiTheme.colors.lightShade`:\n\n```ts\ncss: {\n  color: !compatible ? euiTheme.colors.lightShade : undefined,\n  backgroundColor: !exists ? euiTheme.colors.lightestShade : undefined,\n},\n```\n\n`lightShade` is a background **\"shade\"** token, not a text token. Shade\ntokens invert between themes:\n\n| Token | Light mode | Dark mode |\n|-------|-----------|-----------|\n| `colors.lightShade` | `#CAD3E2` (light gray – dims text nicely) |\n`#243147` (near-black blue-gray – invisible on the dark popover) |\n\nSo it only ever worked in light mode. In dark mode the dimmed field\nnames collapse to near-black on the dark popover background.\n\n### Fix\n\nUse `euiTheme.colors.textDisabled` — the theme-aware semantic token for\nsubdued/disabled text — so dimmed field options stay readable-but-muted\nin **both** light and dark mode. No behavior change for compatible\nfields (they still use the default text color).\n\n### Testing\n\n1. Enable dark mode.\n2. Create any visualization (XY, metric, …) and open a metric dimension.\n3. Click **Formula**, then switch back to **Quick function**.\n4. Field names in the selector are now visible (previously\nblack/invisible).\n\n- `node scripts/type_check` for `kbn-visualization-ui-components` ✅\n- `field_picker.test.tsx` ✅\n- eslint ✅\n\n### Checklist\n\n- [x] Any UI touched in this PR is usable by keyboard only / meets WCAG\ncontrast requirements (fix improves contrast)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>","sha":"280ecf802d6e1b2ca7ea51b30491776646d0d1ef"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->