### PR TITLE
[Agent Builder] Chat: Add ErrorBoundary to attachments

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
+
+const ThrowingContent = () => {
+  throw new Error('boom');
+};
+
+describe('AttachmentRenderErrorBoundary', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders children when nothing throws', () => {
+    render(
+      <AttachmentRenderErrorBoundary>
+        {() => <div>Attachment content</div>}
+      </AttachmentRenderErrorBoundary>
+    );
+
+    expect(screen.getByText('Attachment content')).toBeInTheDocument();
+  });
+
+  it('renders a fallback callout instead of crashing when a child throws', () => {
+    render(
+      <AttachmentRenderErrorBoundary>{() => <ThrowingContent />}</AttachmentRenderErrorBoundary>
+    );
+
+    expect(screen.getByText("Couldn't render this attachment")).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const fallbackTitle = i18n.translate('xpack.agentBuilder.attachments.renderErrorBoundary.title', {
+  defaultMessage: "Couldn't render this attachment",
+});
+
+interface AttachmentRenderErrorBoundaryProps {
+  children: () => ReactNode;
+}
+
+interface AttachmentRenderErrorBoundaryState {
+  hasError: boolean;
+}
+
+const RenderContent: React.FC<{ children: () => ReactNode }> = ({ children }) => <>{children()}</>;
+
+export class AttachmentRenderErrorBoundary extends Component<
+  AttachmentRenderErrorBoundaryProps,
+  AttachmentRenderErrorBoundaryState
+> {
+  state: AttachmentRenderErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Attachment renderer threw an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          title={fallbackTitle}
+          color="warning"
+          iconType="warning"
+          size="s"
+        />
+      );
+    }
+
+    return <RenderContent>{this.props.children}</RenderContent>;
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
@@ -64,6 +64,25 @@ describe('CanvasFlyout', () => {
     mockCanvasState = null;
   });
 
+  it('shows a fallback instead of crashing when renderCanvasContent throws', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockAttachmentsService.getAttachmentUiDefinition.mockReturnValue({
+      getLabel: () => 'Test attachment',
+      renderCanvasContent: () => {
+        throw new Error('boom');
+      },
+    });
+    mockCanvasState = {
+      attachment: { id: 'attachment-1', type: 'test', data: {} },
+      isSidebar: false,
+    };
+
+    render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(screen.getByText("Couldn't render this attachment")).not.toBeNull();
+  });
+
   it('closes canvas when conversation ID changes', () => {
     const { rerender } = render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -16,6 +16,7 @@ import { useConversationContext } from '../../../../../context/conversation/conv
 import { useAgentId } from '../../../../../hooks/use_conversation';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
 import { useCanvasContext } from './canvas_context';
 
 const DEFAULT_CANVAS_WIDTH = '50vw';
@@ -117,6 +118,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   }
 
   const { attachment, isSidebar } = canvasState;
+  const { renderCanvasContent } = uiDefinition;
   const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
   const header = uiDefinition?.getHeader?.({ attachment });
 
@@ -160,20 +162,22 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         previewBadgeState="preview_available"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
-        <React.Fragment key={`${attachment.id}:${attachment.version ?? 'latest'}`}>
-          {uiDefinition.renderCanvasContent(
-            {
-              attachment,
-              isSidebar,
-              openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
-            },
-            {
-              registerActionButtons,
-              updateOrigin,
-              closeCanvas,
-            }
-          )}
-        </React.Fragment>
+        <AttachmentRenderErrorBoundary key={`${attachment.id}:${attachment.version ?? 'latest'}`}>
+          {() =>
+            renderCanvasContent(
+              {
+                attachment,
+                isSidebar,
+                openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
+              },
+              {
+                registerActionButtons,
+                updateOrigin,
+                closeCanvas,
+              }
+            )
+          }
+        </AttachmentRenderErrorBoundary>
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.test.tsx
@@ -88,6 +88,32 @@ describe('InlineAttachmentWithActions', () => {
     jest.clearAllMocks();
   });
 
+  it('shows a fallback instead of crashing when renderInlineContent throws', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const attachment: UnknownAttachment = { id: 'attachment-1', type: 'test', data: {} };
+    const attachmentsService = {
+      getAttachmentUiDefinition: jest.fn().mockReturnValue({
+        getLabel: () => 'Test attachment',
+        renderInlineContent: () => {
+          throw new Error('boom');
+        },
+      }),
+      updateOrigin: jest.fn(),
+    };
+
+    render(
+      <InlineAttachmentWithActions
+        attachment={attachment}
+        attachmentsService={attachmentsService as unknown as AttachmentsService}
+        conversationId="conversation-1"
+        isSidebar={false}
+      />
+    );
+
+    expect(screen.getByText("Couldn't render this attachment")).not.toBeNull();
+  });
+
   it('renders action buttons registered by inline content', async () => {
     const attachment: UnknownAttachment = { id: 'attachment-1', type: 'test', data: {} };
     const attachmentsService = {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -18,6 +18,7 @@ import { useConversationContext } from '../../../../../context/conversation/conv
 import { useAgentId } from '../../../../../hooks/use_conversation';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
 import { getAttachmentPreviewKey, useCanvasContext } from './canvas_context';
 
 interface InlineAttachmentWithActionsProps {
@@ -170,17 +171,21 @@ const InlineAttachmentWithActionsComponent: React.FC<InlineAttachmentWithActions
         onClosePreview={closeCanvas}
       />
       <EuiSplitPanel.Inner grow={false} paddingSize="none">
-        {uiDefinition?.renderInlineContent?.(
-          {
-            attachment,
-            isSidebar,
-            screenContext,
-            openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
-          },
-          {
-            registerActionButtons,
+        <AttachmentRenderErrorBoundary key={attachmentPreviewKey}>
+          {() =>
+            uiDefinition?.renderInlineContent?.(
+              {
+                attachment,
+                isSidebar,
+                screenContext,
+                openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
+              },
+              {
+                registerActionButtons,
+              }
+            )
           }
-        )}
+        </AttachmentRenderErrorBoundary>
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
   );


### PR DESCRIPTION
## Summary
- Wrap both attachment render call sites (canvas flyout, inline card) in a new `AttachmentRenderErrorBoundary`
- A throwing renderer now shows a "Couldn't render this attachment" callout instead of crashing the whole chat/sidebar

## For code review

This PR is split into 2 commits, one per call site — review commit-by-commit for an easier pass:

| # | Commit | Description |
| --- | --- | --- |
| 1 | [Contain attachment renderer errors to the Canvas Flyout](https://github.com/elastic/kibana/pull/276381/commits/7c3b309eabb66df431aa3f2f99dcb52aa895b355) | Adds the shared `AttachmentRenderErrorBoundary` and wires it into the canvas flyout's `renderCanvasContent` |
| 2 | [Contain attachment renderer errors to the inline attachment card](https://github.com/elastic/kibana/pull/276381/commits/37ecb31971118a1056042c17f8d6e7f42de2d890) | Wires the same boundary into `renderInlineContent` for the inline card |

## Before/after

**Agent Builder routed app**

| Before | After |
|---|---|
| ![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/a4ip8y2m-before_routed_app.png) | ![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/zkrcrhzt-after_routed_app.png) |

**AI Agents chat (sidebar)**

| Before | After |
|---|---|
| ![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/mrgau0so-sidebar_conversation.png) | ![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/3pfoavme-after_sidebar.png) |

## Test plan
- [x] Unit tests: throwing-renderer cases in `inline_attachment_with_actions.test.tsx`, `canvas_flyout.test.tsx`, `attachment_render_error_boundary.test.tsx`
- [x] Manual: verified both surfaces with a temporary throw in `text_attachment.tsx`

Closes elastic/search-team#15135

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->