### PR TITLE
[One Workflow] Enable workflow visualization behind only the experimental flag

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/constants.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/constants.ts
@@ -17,7 +17,6 @@ export const WORKFLOWS_MANAGEMENT_FEATURE_ID = 'workflowsManagement';
  */
 export const WORKFLOWS_UI_SETTING_ID = 'workflows:ui:enabled';
 export const WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID = 'workflows:experimentalFeatures';
-export const WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID = 'workflows:ui:visualEditor:enabled';
 export const WORKFLOWS_UI_EXECUTION_GRAPH_SETTING_ID = 'workflows:ui:executionGraph:enabled';
 export const WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID = 'workflows:ui:showExecutor:enabled';
 export const WORKFLOWS_UI_SHOW_MANAGED_WORKFLOWS_SETTING_ID = 'workflows:ui:showManagedWorkflows';

--- a/src/platform/plugins/shared/workflows_management/README.md
+++ b/src/platform/plugins/shared/workflows_management/README.md
@@ -41,7 +41,6 @@ Experimental Workflows features are gated behind a separate Advanced Setting:
 ```yml
 uiSettings.overrides:
   workflows:experimentalFeatures: true
-  workflows:ui:visualEditor:enabled: true
   workflows:ui:executionGraph:enabled: true
   workflows:ui:showExecutor:enabled: true
 ```

--- a/src/platform/plugins/shared/workflows_management/public/hooks/use_workflows_experimental_ui_setting.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/hooks/use_workflows_experimental_ui_setting.test.ts
@@ -10,7 +10,7 @@
 import { renderHook } from '@testing-library/react';
 import {
   WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID,
-  WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID,
+  WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID,
 } from '@kbn/workflows/common/constants';
 import { useWorkflowsExperimentalUiSetting } from './use_workflows_experimental_ui_setting';
 
@@ -35,7 +35,7 @@ describe('useWorkflowsExperimentalUiSetting', () => {
     });
 
     const { result } = renderHook(() =>
-      useWorkflowsExperimentalUiSetting(WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID)
+      useWorkflowsExperimentalUiSetting(WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID)
     );
 
     expect(result.current).toBe(false);
@@ -50,7 +50,7 @@ describe('useWorkflowsExperimentalUiSetting', () => {
     });
 
     const { result } = renderHook(() =>
-      useWorkflowsExperimentalUiSetting(WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID)
+      useWorkflowsExperimentalUiSetting(WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID)
     );
 
     expect(result.current).toBe(false);
@@ -60,7 +60,7 @@ describe('useWorkflowsExperimentalUiSetting', () => {
     mockUseUiSetting.mockReturnValue(true);
 
     const { result } = renderHook(() =>
-      useWorkflowsExperimentalUiSetting(WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID)
+      useWorkflowsExperimentalUiSetting(WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID)
     );
 
     expect(result.current).toBe(true);

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
@@ -176,7 +176,6 @@ describe('WorkflowDetailEditor', () => {
     });
 
     mockUseUiSetting$.mockImplementation((key: string, defaultValue: boolean) => {
-      if (key === 'workflows:ui:visualEditor:enabled') return [false];
       if (key === 'workflows:ui:executionGraph:enabled') return [false];
       return [defaultValue];
     });
@@ -307,7 +306,7 @@ describe('WorkflowDetailEditor', () => {
 
       // Enable the visual editor so handleEditorViewChange runs the graph-focus logic.
       (useWorkflowsExperimentalUiSetting as jest.Mock).mockImplementation(
-        (settingId: string) => settingId === 'workflows:ui:visualEditor:enabled'
+        (settingId: string) => settingId === 'workflows:experimentalFeatures'
       );
 
       const wrapper = ({ children }: { children: React.ReactNode }) => {

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
@@ -26,8 +26,8 @@ import { i18n } from '@kbn/i18n';
 import type { monaco } from '@kbn/monaco';
 import { isMac } from '@kbn/shared-ux-utility';
 import {
+  WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID,
   WORKFLOWS_UI_EXECUTION_GRAPH_SETTING_ID,
-  WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID,
 } from '@kbn/workflows';
 import {
   ReactFlowProvider,
@@ -175,7 +175,7 @@ export const WorkflowDetailEditor = React.memo<WorkflowDetailEditorProps>(({ hig
   );
 
   const isVisualEditorEnabled = useWorkflowsExperimentalUiSetting(
-    WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID
+    WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID
   );
   const isExecutionGraphEnabled = useWorkflowsExperimentalUiSetting(
     WORKFLOWS_UI_EXECUTION_GRAPH_SETTING_ID

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -30,7 +30,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID } from '@kbn/workflows';
+import { WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/workflows';
 import { useWorkflowsCapabilities } from '@kbn/workflows-ui';
 import { useRunWorkflowWithConfirmation } from './use_run_workflow_with_confirmation';
 import { WorkflowDetailActionsMenu } from './workflow_detail_actions_menu';
@@ -263,7 +263,7 @@ export const WorkflowDetailHeader = React.memo(
     });
 
     const isVisualEditorEnabled = useWorkflowsExperimentalUiSetting(
-      WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID
+      WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID
     );
 
     const runDisabled = isExecutionsTab || !canExecuteWorkflow || !isSyntaxValid || isSaving;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -25,7 +25,7 @@ import type YAML from 'yaml';
 import { monaco, YAML_LANG_ID } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { isTriggerType, WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID } from '@kbn/workflows';
+import { isTriggerType, WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/workflows';
 import { useWorkflowsMonacoTheme } from '@kbn/workflows-ui';
 import type { z } from '@kbn/zod/v4';
 import { ActionsMenuButton } from './actions_menu_button';
@@ -194,7 +194,7 @@ export const WorkflowYAMLEditor = ({
   hideEditorTools = false,
 }: WorkflowYAMLEditorProps) => {
   const isVisualEditorEnabled = useWorkflowsExperimentalUiSetting(
-    WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID,
+    WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID,
     false
   );
   const { notifications, http } = useKibana().services;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
@@ -87,7 +87,7 @@ export class WorkflowEditorPage {
   /**
    * Switch to the graph view by clicking the bottom bar toggle.
    * Waits for the graph canvas to become visible.
-   * Requires the `workflows:ui:visualEditor:enabled` UI setting to be true.
+   * Requires the `workflows:experimentalFeatures` UI setting to be true.
    */
   async switchToGraphView(): Promise<void> {
     await this.page.testSubj.click('workflowEditorViewToggle-graph');

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_graph/workflow_graph_recovery.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_graph/workflow_graph_recovery.spec.ts
@@ -17,7 +17,6 @@ import {
 } from '../../fixtures/workflows';
 
 const EXPERIMENTAL_FEATURES_SETTING = 'workflows:experimentalFeatures';
-const VISUAL_EDITOR_SETTING = 'workflows:ui:visualEditor:enabled';
 const WORKFLOW_NAME = 'Graph Recovery Test';
 
 test.describe(
@@ -33,7 +32,6 @@ test.describe(
     test.beforeAll(async ({ scoutSpace }) => {
       await scoutSpace.uiSettings.set({
         [EXPERIMENTAL_FEATURES_SETTING]: true,
-        [VISUAL_EDITOR_SETTING]: true,
       });
     });
 
@@ -43,7 +41,6 @@ test.describe(
 
     test.afterAll(async ({ scoutSpace, apiServices }) => {
       await scoutSpace.uiSettings.unset(EXPERIMENTAL_FEATURES_SETTING);
-      await scoutSpace.uiSettings.unset(VISUAL_EDITOR_SETTING);
       await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
     });
 


### PR DESCRIPTION
## Summary

## PR description

Drop the `workflows:ui:visualEditor:enabled` dev flag, which was only
settable via `uiSettings.overrides` in `kibana.yml` and therefore
invisible to users. The visual editor is now gated exclusively by the
**Elastic Workflows: Experimental Features** toggle in Advanced Settings.

## Release note

```release_notes
Added a read-only workflow graph visualization that renders visually the workflow as an interactive node graph, accessible from the workflow editor when Elastic Workflows experimental features are enabled.
```
