### PR TITLE
[Security Solution][Flyout] Document securitySolution:enableNewFlyout advanced setting

### DIFF
--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2248,6 +2248,20 @@ groups:
           stack: unavailable
           security: ga
 
+      - setting: "securitySolution:enableNewFlyout"
+        id: security-solution-enable-new-flyout
+        description: |
+          Enables the new flyout system for document details in Security Solution.
+        datatype: bool
+        default: false
+        applies_to:
+          stack: preview 9.5
+          ech: ga
+          ece: ga
+          eck: ga
+          self: ga
+          security: preview
+
   - group: Timelion
     id: kibana-timelion-settings
     settings:

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2253,7 +2253,7 @@ groups:
         description: |
           Enables the new flyout system for document details in Security Solution.
         datatype: bool
-        default: false
+        default: true
         applies_to:
           stack: preview 9.5
           ech: ga

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -2260,7 +2260,7 @@ groups:
           ece: ga
           eck: ga
           self: ga
-          security: preview
+          security: ga
 
   - group: Timelion
     id: kibana-timelion-settings


### PR DESCRIPTION
## Summary

Follow-up to #275044 — documents the new `securitySolution:enableNewFlyout` advanced setting in the Security solution settings reference (`docs/reference/advanced-settings-space.yml`), as requested in [review](https://github.com/elastic/kibana/pull/275044#pullrequestreview-4628312557).

No code changes — docs only.