### PR TITLE
[9.3] [Security Solution] Fix orphaned migration on partial upload failure (#266359)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/service/dashboard_migrations_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/service/dashboard_migrations_service.test.ts
@@ -31,6 +31,7 @@ import { MigrationSource } from '../../common/types';
 
 jest.mock('../api', () => ({
   createDashboardMigration: jest.fn(),
+  deleteDashboardMigration: jest.fn(),
   upsertDashboardMigrationResources: jest.fn(),
   startDashboardMigration: jest.fn(),
   stopDashboardMigration: jest.fn(),
@@ -80,6 +81,7 @@ const mockStartDashboardMigration = api.startDashboardMigration as jest.Mock;
 const mockStopDashboardMigration = api.stopDashboardMigration as jest.Mock;
 const mockAddDashboardsToDashboardMigration = api.addDashboardsToDashboardMigration as jest.Mock;
 const mockCreateDashboardMigration = api.createDashboardMigration as jest.Mock;
+const mockDeleteDashboardMigration = api.deleteDashboardMigration as jest.Mock;
 const mockUpsertDashboardMigrationResources = api.upsertDashboardMigrationResources as jest.Mock;
 
 const defaultMigrationStats = {
@@ -215,6 +217,41 @@ describe('SiemDashboardMigrationsService', () => {
         body: body.slice(CREATE_MIGRATION_BODY_BATCH_SIZE),
       });
       expect(migrationId).toBe('mig-1');
+    });
+
+    it('should delete migration when a batch fails, after all parallel batches have settled', async () => {
+      const body = new Array(CREATE_MIGRATION_BODY_BATCH_SIZE * 3).fill({
+        dashboard: 'dashboard',
+      });
+      const batchError = new Error('Invalid dashboard data');
+      mockCreateDashboardMigration.mockResolvedValueOnce({ migration_id: 'mig-1' });
+      mockDeleteDashboardMigration.mockResolvedValue(undefined);
+
+      let resolveBatch2: () => void;
+      const batch2Promise = new Promise<void>((resolve) => {
+        resolveBatch2 = resolve;
+      });
+
+      let callCount = 0;
+      mockAddDashboardsToDashboardMigration.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.reject(batchError);
+        }
+        if (callCount === 2) {
+          return batch2Promise;
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const createPromise = service.createDashboardMigration(body, 'test', MigrationSource.SPLUNK);
+
+      // Batch 2 is still in-flight; resolve it now to let allSettled complete
+      resolveBatch2!();
+
+      await expect(createPromise).rejects.toThrow('Invalid dashboard data');
+      expect(mockDeleteDashboardMigration).toHaveBeenCalledWith({ migrationId: 'mig-1' });
+      expect(mockAddDashboardsToDashboardMigration).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/service/dashboard_migrations_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/service/dashboard_migrations_service.ts
@@ -87,7 +87,13 @@ export class SiemDashboardMigrationsService extends SiemMigrationsServiceBase<Da
       const dashboardsBatch = dashboards.slice(i, i + CREATE_MIGRATION_BODY_BATCH_SIZE);
       batches.push(api.addDashboardsToDashboardMigration({ migrationId, body: dashboardsBatch }));
     }
-    await Promise.all(batches);
+    const results = await Promise.allSettled(batches);
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    );
+    if (rejected) {
+      throw rejected.reason;
+    }
   }
 
   /** Creates a dashboard migration with a name and adds the dashboards to it, returning the migration ID */
@@ -107,11 +113,12 @@ export class SiemDashboardMigrationsService extends SiemMigrationsServiceBase<Da
       throw emptyDashboardError;
     }
 
+    let migrationId: string | undefined;
     try {
-      // create the migration
-      const { migration_id: migrationId } = await api.createDashboardMigration({
+      const { migration_id } = await api.createDashboardMigration({
         name: migrationName,
       });
+      migrationId = migration_id;
 
       await this.addDashboardsToMigration(migrationId, data);
 
@@ -122,8 +129,11 @@ export class SiemDashboardMigrationsService extends SiemMigrationsServiceBase<Da
       });
       return migrationId;
     } catch (error) {
+      if (migrationId) {
+        await api.deleteDashboardMigration({ migrationId }).catch(() => {});
+      }
       this.telemetry.reportSetupMigrationCreated({
-        migrationId: undefined,
+        migrationId,
         count: dashboardsCount,
         error,
         vendor,

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.test.ts
@@ -23,6 +23,8 @@ import {
   getRuleMigrationStats,
   getRuleMigrationsStatsAll,
   addRulesToMigration,
+  addRulesToQRadarMigration,
+  deleteMigration,
 } from '../api';
 import { createTelemetryServiceMock } from '../../../common/lib/telemetry/telemetry_service.mock';
 import {
@@ -32,11 +34,15 @@ import {
 import type { StartPluginsDependencies } from '../../../types';
 import * as i18n from './translations';
 import { SiemRulesMigrationsService } from './rule_migrations_service';
-import type { CreateRuleMigrationRulesRequestBody } from '../../../../common/siem_migrations/model/api/rules/rule_migration.gen';
+import type {
+  CreateRuleMigrationRulesRequestBody,
+  CreateQRadarRuleMigrationRulesRequestBody,
+} from '../../../../common/siem_migrations/model/api/rules/rule_migration.gen';
 import { TASK_STATS_POLLING_SLEEP_SECONDS } from '../../common/constants';
 import { getMissingCapabilitiesChecker } from '../../common/service';
 import { raiseSuccessToast } from './notification/success_notification';
 import { MigrationSource } from '../../common/types';
+import { SiemMigrationsRuleEventTypes } from '../../../common/lib/telemetry/events/siem_migrations/types';
 
 // --- Mocks for external modules ---
 
@@ -50,6 +56,8 @@ jest.mock('../api', () => ({
   getMissingResources: jest.fn(),
   getIntegrations: jest.fn(),
   addRulesToMigration: jest.fn(),
+  addRulesToQRadarMigration: jest.fn(),
+  deleteMigration: jest.fn(),
 }));
 
 jest.mock('../../common/service/capabilities', () => ({
@@ -86,6 +94,10 @@ const mockGetRuleMigrationsStatsAll = getRuleMigrationsStatsAll as jest.Mock;
 const mockStartRuleMigrationAPI = startRuleMigrationAPI as jest.Mock;
 const mockStopRuleMigrationAPI = stopRuleMigrationAPI as jest.Mock;
 const mockGetMissingCapabilitiesChecker = getMissingCapabilitiesChecker as jest.Mock;
+const mockCreateRuleMigration = createRuleMigration as jest.Mock;
+const mockAddRulesToMigration = addRulesToMigration as jest.Mock;
+const mockAddRulesToQRadarMigration = addRulesToQRadarMigration as jest.Mock;
+const mockDeleteMigration = deleteMigration as jest.Mock;
 
 // --- End of mocks ---
 
@@ -206,6 +218,50 @@ describe('SiemRulesMigrationsService', () => {
       });
 
       expect(migrationId).toBe('mig-1');
+    });
+
+    it('should delete the migration when Splunk rule upload fails', async () => {
+      const body = [{ id: 'rule1' }] as CreateRuleMigrationRulesRequestBody;
+      const uploadError = new Error('Invalid rule data');
+      mockCreateRuleMigration.mockResolvedValueOnce({ migration_id: 'mig-1' });
+      mockAddRulesToMigration.mockRejectedValueOnce(uploadError);
+      mockDeleteMigration.mockResolvedValue(undefined);
+
+      await expect(
+        service.createRuleMigration({
+          rules: body,
+          migrationName: 'test',
+          vendor: MigrationSource.SPLUNK,
+        })
+      ).rejects.toThrow('Invalid rule data');
+
+      expect(mockDeleteMigration).toHaveBeenCalledWith({ migrationId: 'mig-1' });
+      const eventTypes = (mockTelemetry.reportEvent as jest.Mock).mock.calls.map((c) => c[0]);
+      expect(eventTypes).toContain(SiemMigrationsRuleEventTypes.SetupMigrationCreated);
+      expect(eventTypes).not.toContain(SiemMigrationsRuleEventTypes.SetupMigrationDeleted);
+    });
+
+    it('should delete the migration when QRadar rule upload fails', async () => {
+      const rules = {
+        xml: ['<rule>...</rule>'],
+      } as unknown as CreateQRadarRuleMigrationRulesRequestBody;
+      const uploadError = new Error('Invalid QRadar rule data');
+      mockCreateRuleMigration.mockResolvedValueOnce({ migration_id: 'mig-1' });
+      mockAddRulesToQRadarMigration.mockRejectedValueOnce(uploadError);
+      mockDeleteMigration.mockResolvedValue(undefined);
+
+      await expect(
+        service.createRuleMigration({
+          rules,
+          migrationName: 'test',
+          vendor: MigrationSource.QRADAR,
+        })
+      ).rejects.toThrow('Invalid QRadar rule data');
+
+      expect(mockDeleteMigration).toHaveBeenCalledWith({ migrationId: 'mig-1' });
+      const eventTypes = (mockTelemetry.reportEvent as jest.Mock).mock.calls.map((c) => c[0]);
+      expect(eventTypes).toContain(SiemMigrationsRuleEventTypes.SetupMigrationCreated);
+      expect(eventTypes).not.toContain(SiemMigrationsRuleEventTypes.SetupMigrationDeleted);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.ts
@@ -41,15 +41,15 @@ const CREATE_MIGRATION_BODY_BATCH_SIZE = 50;
 
 export type CreateRuleMigrationParams =
   | {
-      rules: CreateRuleMigrationRulesRequestBody;
-      migrationName: string;
-      vendor: 'splunk';
-    }
+    rules: CreateRuleMigrationRulesRequestBody;
+    migrationName: string;
+    vendor: 'splunk';
+  }
   | {
-      rules: CreateQRadarRuleMigrationRulesRequestBody;
-      migrationName: string;
-      vendor: 'qradar';
-    };
+    rules: CreateQRadarRuleMigrationRulesRequestBody;
+    migrationName: string;
+    vendor: 'qradar';
+  };
 
 export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMigrationStats> {
   public telemetry: SiemRulesMigrationsTelemetry;
@@ -131,16 +131,17 @@ export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMi
       throw emptyRulesError;
     }
 
+    let migrationId: string | undefined;
     try {
       if (vendor === MigrationSource.QRADAR) {
         if (!rules.xml) {
           throw new Error(i18n.EMPTY_RULES_ERROR);
         }
 
-        // create the migration
-        const { migration_id: migrationId } = await api.createRuleMigration({
+        const { migration_id } = await api.createRuleMigration({
           name: migrationName,
         });
+        migrationId = migration_id;
         const { count } = await this.addQradarRulesToMigration(migrationId, rules);
         this.telemetry.reportSetupMigrationCreated({ migrationId, count, vendor });
 
@@ -150,10 +151,10 @@ export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMi
           throw new Error(i18n.EMPTY_RULES_ERROR);
         }
 
-        // create the migration
-        const { migration_id: migrationId } = await api.createRuleMigration({
+        const { migration_id } = await api.createRuleMigration({
           name: migrationName,
         });
+        migrationId = migration_id;
         await this.addRulesToMigration(migrationId, rules);
         this.telemetry.reportSetupMigrationCreated({
           migrationId,
@@ -164,6 +165,9 @@ export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMi
         return migrationId;
       }
     } catch (error) {
+      if (migrationId) {
+        await api.deleteMigration({ migrationId }).catch(() => { });
+      }
       this.telemetry.reportSetupMigrationCreated({ count: 0, error, vendor });
       throw error;
     }

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/rule_migrations_service.ts
@@ -41,15 +41,15 @@ const CREATE_MIGRATION_BODY_BATCH_SIZE = 50;
 
 export type CreateRuleMigrationParams =
   | {
-    rules: CreateRuleMigrationRulesRequestBody;
-    migrationName: string;
-    vendor: 'splunk';
-  }
+      rules: CreateRuleMigrationRulesRequestBody;
+      migrationName: string;
+      vendor: 'splunk';
+    }
   | {
-    rules: CreateQRadarRuleMigrationRulesRequestBody;
-    migrationName: string;
-    vendor: 'qradar';
-  };
+      rules: CreateQRadarRuleMigrationRulesRequestBody;
+      migrationName: string;
+      vendor: 'qradar';
+    };
 
 export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMigrationStats> {
   public telemetry: SiemRulesMigrationsTelemetry;
@@ -166,7 +166,7 @@ export class SiemRulesMigrationsService extends SiemMigrationsServiceBase<RuleMi
       }
     } catch (error) {
       if (migrationId) {
-        await api.deleteMigration({ migrationId }).catch(() => { });
+        await api.deleteMigration({ migrationId }).catch(() => {});
       }
       this.telemetry.reportSetupMigrationCreated({ count: 0, error, vendor });
       throw error;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution] Fix orphaned migration on partial upload failure (#266359)](https://github.com/elastic/kibana/pull/266359)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2026-07-03T16:24:13Z","message":"[Security Solution] Fix orphaned migration on partial upload failure (#266359)\n\n## Summary\n\n- Handles #253402\n\nFixes an issue where uploading a file with some invalid dashboards (or\nrules) would leave behind an orphaned migration record on the\n\"Translated Dashboards\" (or \"Translated Rules\") tab with status `ready`\nand a \"Start translation\" button.\n\nThen user could start the translation of some successfully uploaded\ndashboards. Ideally we should be rejecting the whole batch.\n\nThe root cause is a two-step creation pattern: \n\n- the migration record is created first, \n- then items are added in batches (POST). If any batch fails (e.g. due\nto malformed `eai:data` in a dashboard), the migration record and any\nitems from successful parallel batches are left behind with no cleanup.\n- This PR adds a deletes the created artifacts if there is an error\nwhile uploading rules.\n\nThe fix is applied consistently across both dashboard and rule migration\nservices, covering all vendors (Splunk and QRadar).\n\n\n|Before|After|\n|---|---|\n|<video\nsrc=\"https://github.com/user-attachments/assets/cea186fd-d713-4b44-b29a-a51b68283428\"/>|<video\nsrc=\"https://github.com/user-attachments/assets/58d21eb7-f94e-4218-8e86-c89092d4130a\"/>|\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [x] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- The delete call in the catch block could theoretically fail (e.g.\nnetwork issue). **Severity: low.** Mitigation: the delete is wrapped in\n`.catch(() => {})` so it never masks the original error, and the user\nstill sees the upload failure toast. The orphaned migration would remain\nin this edge case but is no worse than the current behavior.\n- No performance risk: the delete call only fires on the error path.\n\n### Release note\n\n> Fixes an issue where uploading invalid rules or dashboard migration\nfiles that could leave behind orphaned migration entries.","sha":"f0df17c0d5dc1e5c0ae9e3d77e8bf2824c638efe","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.3.0","Team:Automatic Migrations","v9.4.0","v9.5.0"],"title":"[Security Solution] Fix orphaned migration on partial upload failure","number":266359,"url":"https://github.com/elastic/kibana/pull/266359","mergeCommit":{"message":"[Security Solution] Fix orphaned migration on partial upload failure (#266359)\n\n## Summary\n\n- Handles #253402\n\nFixes an issue where uploading a file with some invalid dashboards (or\nrules) would leave behind an orphaned migration record on the\n\"Translated Dashboards\" (or \"Translated Rules\") tab with status `ready`\nand a \"Start translation\" button.\n\nThen user could start the translation of some successfully uploaded\ndashboards. Ideally we should be rejecting the whole batch.\n\nThe root cause is a two-step creation pattern: \n\n- the migration record is created first, \n- then items are added in batches (POST). If any batch fails (e.g. due\nto malformed `eai:data` in a dashboard), the migration record and any\nitems from successful parallel batches are left behind with no cleanup.\n- This PR adds a deletes the created artifacts if there is an error\nwhile uploading rules.\n\nThe fix is applied consistently across both dashboard and rule migration\nservices, covering all vendors (Splunk and QRadar).\n\n\n|Before|After|\n|---|---|\n|<video\nsrc=\"https://github.com/user-attachments/assets/cea186fd-d713-4b44-b29a-a51b68283428\"/>|<video\nsrc=\"https://github.com/user-attachments/assets/58d21eb7-f94e-4218-8e86-c89092d4130a\"/>|\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [x] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- The delete call in the catch block could theoretically fail (e.g.\nnetwork issue). **Severity: low.** Mitigation: the delete is wrapped in\n`.catch(() => {})` so it never masks the original error, and the user\nstill sees the upload failure toast. The orphaned migration would remain\nin this edge case but is no worse than the current behavior.\n- No performance risk: the delete call only fires on the error path.\n\n### Release note\n\n> Fixes an issue where uploading invalid rules or dashboard migration\nfiles that could leave behind orphaned migration entries.","sha":"f0df17c0d5dc1e5c0ae9e3d77e8bf2824c638efe"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266359","number":266359,"mergeCommit":{"message":"[Security Solution] Fix orphaned migration on partial upload failure (#266359)\n\n## Summary\n\n- Handles #253402\n\nFixes an issue where uploading a file with some invalid dashboards (or\nrules) would leave behind an orphaned migration record on the\n\"Translated Dashboards\" (or \"Translated Rules\") tab with status `ready`\nand a \"Start translation\" button.\n\nThen user could start the translation of some successfully uploaded\ndashboards. Ideally we should be rejecting the whole batch.\n\nThe root cause is a two-step creation pattern: \n\n- the migration record is created first, \n- then items are added in batches (POST). If any batch fails (e.g. due\nto malformed `eai:data` in a dashboard), the migration record and any\nitems from successful parallel batches are left behind with no cleanup.\n- This PR adds a deletes the created artifacts if there is an error\nwhile uploading rules.\n\nThe fix is applied consistently across both dashboard and rule migration\nservices, covering all vendors (Splunk and QRadar).\n\n\n|Before|After|\n|---|---|\n|<video\nsrc=\"https://github.com/user-attachments/assets/cea186fd-d713-4b44-b29a-a51b68283428\"/>|<video\nsrc=\"https://github.com/user-attachments/assets/58d21eb7-f94e-4218-8e86-c89092d4130a\"/>|\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [x] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- The delete call in the catch block could theoretically fail (e.g.\nnetwork issue). **Severity: low.** Mitigation: the delete is wrapped in\n`.catch(() => {})` so it never masks the original error, and the user\nstill sees the upload failure toast. The orphaned migration would remain\nin this edge case but is no worse than the current behavior.\n- No performance risk: the delete call only fires on the error path.\n\n### Release note\n\n> Fixes an issue where uploading invalid rules or dashboard migration\nfiles that could leave behind orphaned migration entries.","sha":"f0df17c0d5dc1e5c0ae9e3d77e8bf2824c638efe"}}]}] BACKPORT-->