### PR TITLE
[Cloud Connect] Tighten up permissions

### DIFF
--- a/x-pack/platform/plugins/shared/cloud_connect/moon.yml
+++ b/x-pack/platform/plugins/shared/cloud_connect/moon.yml
@@ -30,6 +30,8 @@ dependsOn:
   - '@kbn/licensing-plugin'
   - '@kbn/licensing-types'
   - '@kbn/home-plugin'
+  - '@kbn/core-security-server'
+  - '@kbn/core-http-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/cloud_connect/server/features.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/features.ts
@@ -6,6 +6,7 @@
  */
 
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
+import { ApiPrivileges } from '@kbn/core-security-server';
 import type { KibanaFeatureConfig } from '@kbn/features-plugin/server';
 import { PLUGIN_NAME } from '../common';
 import { CLOUD_CONNECT_API_KEY_TYPE } from '../common/constants';
@@ -35,7 +36,10 @@ export const cloudConnectedFeature: KibanaFeatureConfig = {
         read: [CLOUD_CONNECT_API_KEY_TYPE],
       },
       ui: ['show', 'configure'],
-      api: [],
+      api: [
+        ApiPrivileges.manage(CLOUD_CONNECTED_FEATURE_ID),
+        ApiPrivileges.read(CLOUD_CONNECTED_FEATURE_ID),
+      ],
     },
     read: {
       app: [CLOUD_CONNECTED_APP_ID, 'kibana'],
@@ -48,7 +52,7 @@ export const cloudConnectedFeature: KibanaFeatureConfig = {
         read: [CLOUD_CONNECT_API_KEY_TYPE],
       },
       ui: ['show'],
-      api: [],
+      api: [ApiPrivileges.read(CLOUD_CONNECTED_FEATURE_ID)],
     },
   },
 };

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.test.ts
@@ -10,6 +10,7 @@ import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mo
 import { registerAuthenticateRoute } from './authenticate';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import type { CloudConnectApiKey } from '../types';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 jest.mock('../services/cloud_connect_client');
 jest.mock('../lib/create_storage_service');
@@ -94,6 +95,13 @@ describe('Authentication Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/config'
       );
       routeHandler = getCall![1];
+    });
+
+    it('should require the cloudConnect read privilege', () => {
+      const getCall = mockRouter.get.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/config'
+      );
+      expect(getCall![0].security).toEqual(CLOUD_CONNECT_READ_SECURITY);
     });
 
     it('should return config with license and cluster info on happy path', async () => {
@@ -191,6 +199,13 @@ describe('Authentication Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/authenticate'
       );
       routeHandler = postCall![1];
+    });
+
+    it('should require the cloudConnect manage privilege', () => {
+      const postCall = mockRouter.post.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/authenticate'
+      );
+      expect(postCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
     });
 
     it('should authenticate with cluster-scoped key (happy path)', async () => {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
@@ -15,6 +15,7 @@ import { CloudConnectClient } from '../services/cloud_connect_client';
 import type { OnboardClusterResponse } from '../types';
 import { getCurrentClusterData } from '../lib/cluster_info';
 import { createStorageService } from '../lib/create_storage_service';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 const bodySchema = schema.object({
   apiKey: schema.string({ minLength: 1 }),
@@ -42,12 +43,7 @@ export const registerAuthenticateRoute = ({
   router.get(
     {
       path: `${API_BASE_PATH}/config`,
-      security: {
-        authz: {
-          enabled: false,
-          reason: 'This route returns public configuration information.',
-        },
-      },
+      security: CLOUD_CONNECT_READ_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -94,13 +90,7 @@ export const registerAuthenticateRoute = ({
   router.post(
     {
       path: `${API_BASE_PATH}/authenticate`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates authentication to the Cloud Connect API and handles authorization there.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: {
         body: bodySchema,
       },

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.test.ts
@@ -10,6 +10,7 @@ import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mo
 import { registerClustersRoute } from './clusters';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import type { CloudConnectApiKey } from '../types';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 jest.mock('../services/cloud_connect_client');
 jest.mock('../lib/create_storage_service');
@@ -109,6 +110,13 @@ describe('Clusters Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/cluster_details'
       );
       routeHandler = getCall![1];
+    });
+
+    it('should require the cloudConnect read privilege', () => {
+      const getCall = mockRouter.get.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster_details'
+      );
+      expect(getCall![0].security).toEqual(CLOUD_CONNECT_READ_SECURITY);
     });
 
     it('should return cluster details with subscription state on happy path', async () => {
@@ -465,6 +473,13 @@ describe('Clusters Routes', () => {
       routeHandler = deleteCall![1];
     });
 
+    it('should require the cloudConnect manage privilege', () => {
+      const deleteCall = mockRouter.delete.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster'
+      );
+      expect(deleteCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
+    });
+
     it('should disconnect cluster on happy path', async () => {
       mockStorageService.getApiKey.mockResolvedValue({
         apiKey: 'test-api-key-123',
@@ -581,6 +596,13 @@ describe('Clusters Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/cluster_details'
       );
       routeHandler = putCall![1];
+    });
+
+    it('should require the cloudConnect manage privilege', () => {
+      const putCall = mockRouter.put.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster_details'
+      );
+      expect(putCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
     });
 
     it('should update services on happy path', async () => {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
@@ -14,6 +14,7 @@ import { API_BASE_PATH } from '../../common/constants';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import { createStorageService } from '../lib/create_storage_service';
 import { enableInferenceCCM, disableInferenceCCM } from '../services/inference_ccm';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 interface CloudConnectedStartDeps {
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
@@ -36,13 +37,7 @@ export const registerClustersRoute = ({
   router.get(
     {
       path: `${API_BASE_PATH}/cluster_details`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_READ_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -141,13 +136,7 @@ export const registerClustersRoute = ({
   router.delete(
     {
       path: `${API_BASE_PATH}/cluster`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -215,13 +204,7 @@ export const registerClustersRoute = ({
   router.put(
     {
       path: `${API_BASE_PATH}/cluster_details`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: {
         body: schema.object({
           services: schema.recordOf(

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.test.ts
@@ -9,6 +9,7 @@ import type { IRouter } from '@kbn/core/server';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { registerRotateApiKeyRoute } from './rotate_api_key';
 import { CloudConnectClient } from '../services/cloud_connect_client';
+import { CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 jest.mock('../services/cloud_connect_client');
 jest.mock('../lib/create_storage_service');
@@ -106,6 +107,13 @@ describe('Rotate API Key Routes', () => {
       routeHandler = rotateCall![1];
     });
 
+    it('should require the cloudConnect manage privilege', () => {
+      const rotateCall = mockRouter.post.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster/rotate_api_key'
+      );
+      expect(rotateCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
+    });
+
     it('should rotate cluster API key and save new key', async () => {
       mockCloudConnectInstance.rotateClusterApiKey.mockResolvedValue({
         key: 'new-rotated-api-key-789',
@@ -162,6 +170,13 @@ describe('Rotate API Key Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/cluster/{service_key}/rotate_api_key'
       );
       routeHandler = rotateCall![1];
+    });
+
+    it('should require the cloudConnect manage privilege', () => {
+      const rotateCall = mockRouter.post.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster/{service_key}/rotate_api_key'
+      );
+      expect(rotateCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
     });
 
     it('should rotate EIS service API key and update inference CCM', async () => {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.ts
@@ -12,6 +12,7 @@ import axios from 'axios';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import { getApiKeyData, ApiKeyNotFoundError } from '../lib/create_storage_service';
 import { enableInferenceCCM } from '../services/inference_ccm';
+import { CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 interface CloudConnectedStartDeps {
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
@@ -33,13 +34,7 @@ export const registerRotateApiKeyRoute = ({
   router.post(
     {
       path: '/internal/cloud_connect/cluster/rotate_api_key',
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -112,13 +107,7 @@ export const registerRotateApiKeyRoute = ({
   router.post(
     {
       path: '/internal/cloud_connect/cluster/{service_key}/rotate_api_key',
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: {
         params: schema.object({
           // Only EIS is currently supported

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/route_security.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/route_security.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteSecurity } from '@kbn/core-http-server';
+import { ApiPrivileges } from '@kbn/core-security-server';
+import { CLOUD_CONNECTED_FEATURE_ID } from '../features';
+
+/**
+ * Applied to routes that only need to view Cloud Connect state, e.g. reading
+ * cluster/service details. Satisfied by either the `read` or `all` Kibana privilege.
+ */
+export const CLOUD_CONNECT_READ_SECURITY: RouteSecurity = {
+  authz: {
+    requiredPrivileges: [ApiPrivileges.read(CLOUD_CONNECTED_FEATURE_ID)],
+  },
+};
+
+/**
+ * Applied to routes that configure or mutate Cloud Connect state, e.g. onboarding,
+ * updating services, rotating keys, or disconnecting the cluster. Only satisfied by
+ * the `all` Kibana privilege.
+ */
+export const CLOUD_CONNECT_MANAGE_SECURITY: RouteSecurity = {
+  authz: {
+    requiredPrivileges: [ApiPrivileges.manage(CLOUD_CONNECTED_FEATURE_ID)],
+  },
+};

--- a/x-pack/platform/plugins/shared/cloud_connect/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cloud_connect/tsconfig.json
@@ -25,6 +25,8 @@
     "@kbn/core-analytics-browser",
     "@kbn/licensing-plugin",
     "@kbn/licensing-types",
-    "@kbn/home-plugin"
+    "@kbn/home-plugin",
+    "@kbn/core-security-server",
+    "@kbn/core-http-server"
   ]
 }


### PR DESCRIPTION
## Summary

This PR tightens the permissions for the cloud connect routes so that a valid permission is always required for a given action.


### How to test

Easiest via Kibana's own UI: Stack Management -> Roles -> Create role, under kibana privileges pick the "Cloud Connect" feature and set it to Read or All (leave a third role with no kibana privileges at all). Then Stack Management -> Users -> Create user, assign one role each:
  - cc_none: no `cloudConnect privilege`
  - cc_read: `cloudConnect: read`
  - cc_all: `cloudConnect: all`


Open Dev Tools -> Console, log in as each of cc_none / cc_read / cc_all in separate sessions, and
run these one at a time (the response panel shows the HTTP status directly):

```
GET kbn:internal/cloud_connect/config

GET kbn:internal/cloud_connect/cluster_details

PUT kbn:internal/cloud_connect/cluster_details
{
  "services": {
    "auto_ops": { "enabled": true }
  }
}
```

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->