### PR TITLE
[kbn-evals] Local execution model fix for Agent Builder client

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/chat_client.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/chat_client.ts
@@ -95,6 +95,9 @@ export class AgentBuilderEvaluationChatClient {
           connector_id: this.connectorId,
           conversation_id: conversationId,
           input: messages[messages.length - 1].message,
+          // Local execution mode runs inside this HTTP request, so the eval worker's W3C `traceparent`
+          // propagates and all server-side gen_ai spans nest under the eval's trace.
+          _execution_mode: 'local',
         }),
       });
 

--- a/x-pack/platform/packages/shared/kbn-evals-suite-smoke-tests/evals/test.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-smoke-tests/evals/test.spec.ts
@@ -7,6 +7,7 @@
 
 import { expect } from '@playwright/test';
 import { MessageRole } from '@kbn/inference-common';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import type { Evaluator } from '@kbn/evals';
 import { evaluate, tags } from '@kbn/evals';
 import { replaySnapshot, createGcsRepository } from '@kbn/es-snapshot-loader';
@@ -99,7 +100,7 @@ evaluate.describe('kbn-evals framework smoke tests', { tag: tags.stateful.classi
 
   evaluate(
     'smoke tests: trace-retrieval',
-    async ({ executorClient, inferenceClient, evaluators }) => {
+    async ({ executorClient, agentBuilderClient, evaluators }) => {
       const { inputTokens, outputTokens } = evaluators.traceBasedEvaluators;
 
       const result = await executorClient.runExperiment(
@@ -113,11 +114,11 @@ evaluate.describe('kbn-evals framework smoke tests', { tag: tags.stateful.classi
           ],
           task: async (example) => {
             const { prompt } = example.input! as { prompt: string };
-            const response = await inferenceClient.chatComplete({
-              stream: false,
-              messages: [{ role: MessageRole.User, content: prompt }],
+            const response = await agentBuilderClient.converse({
+              agentId: agentBuilderDefaultAgentId,
+              input: prompt,
             });
-            return { response: response.content };
+            return { response: response.message };
           },
         },
         [inputTokens, outputTokens]

--- a/x-pack/platform/packages/shared/kbn-evals-suite-smoke-tests/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-smoke-tests/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/evals'
   - '@kbn/inference-common'
   - '@kbn/es-snapshot-loader'
+  - '@kbn/agent-builder-common'
 tags:
   - functional-tests
   - package

--- a/x-pack/platform/packages/shared/kbn-evals-suite-smoke-tests/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-smoke-tests/tsconfig.json
@@ -6,5 +6,10 @@
   },
   "include": ["**/*.ts"],
   "exclude": ["target/**/*"],
-  "kbn_references": ["@kbn/evals", "@kbn/inference-common", "@kbn/es-snapshot-loader"]
+  "kbn_references": [
+    "@kbn/evals",
+    "@kbn/inference-common",
+    "@kbn/es-snapshot-loader",
+    "@kbn/agent-builder-common"
+  ]
 }


### PR DESCRIPTION
## Summary

- Agent Builder's default execution mode (`task_manager`) prevents trace propagation from the evaluation framework, resulting in failure to capture trace-based metrics. This change adds `_execution_mode: local` param to the Agent Builder client in Agent Builder's eval suite.
- Smoke testing trace based evaluators using built-in `agentBuilderClient` fixture rather than the inference API. 

### Testing

```bash
node scripts/evals start --profile local --suite smoke-tests
```


