### PR TITLE
[Agent Builder][Visualizations] Vega authoring & feature polishes

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/actions.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/actions.ts
@@ -48,6 +48,7 @@ export const isValidateSpecAction = (action: VegaAction): action is ValidateSpec
 
 // Node name constants
 export const GENERATE_ESQL_NODE = 'generate_esql_query';
+export const SELECT_EXAMPLES_NODE = 'select_reference_examples';
 export const AUTHOR_SPEC_NODE = 'author_spec';
 export const VALIDATE_SPEC_NODE = 'validate_spec';
 export const FINALIZE_NODE = 'finalize';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -52,14 +52,23 @@ describe('createVegaGraph', () => {
 
   let logger: Logger;
   let invoke: jest.Mock;
+  /** Structured-output selector used by the reference-example selection node. */
+  let selectInvoke: jest.Mock;
+  let withStructuredOutput: jest.Mock;
   let modelProvider: ModelProvider;
 
   beforeEach(() => {
     jest.clearAllMocks();
     logger = createMockLogger();
     invoke = jest.fn();
+    // Default: the model selects no reference example, so authoring proceeds
+    // without a REFERENCE EXAMPLES block. Individual tests override this.
+    selectInvoke = jest.fn().mockResolvedValue({ exampleIds: [] });
+    withStructuredOutput = jest.fn(() => ({ invoke: selectInvoke }));
     modelProvider = {
-      getDefaultModel: jest.fn().mockResolvedValue({ chatModel: { invoke } }),
+      getDefaultModel: jest.fn().mockResolvedValue({
+        chatModel: { invoke, withStructuredOutput },
+      }),
     } as unknown as ModelProvider;
     mockedGenerateEsql.mockResolvedValue({ query: GENERATED_ESQL } as Awaited<
       ReturnType<typeof generateEsql>
@@ -99,6 +108,52 @@ describe('createVegaGraph', () => {
     expect(spec.data).toEqual({ url: { '%type%': 'esql', query: GENERATED_ESQL } });
     expect(spec.mark).toBe('bar');
     expect(state.esqlQuery).toBe(GENERATED_ESQL);
+  });
+
+  it('injects the model-selected reference example into the authoring prompt', async () => {
+    // The selection node picks an example; its structural block must reach the
+    // author prompt (bodies loaded only for the selected id).
+    selectInvoke.mockResolvedValue({ exampleIds: ['scatter_bubble'] });
+    invoke.mockResolvedValue(asCodeBlock({ mark: 'point' }));
+
+    await run();
+
+    const authorPrompt = JSON.stringify(invoke.mock.calls[0][0]);
+    expect(authorPrompt).toContain('REFERENCE EXAMPLES');
+    expect(authorPrompt).toContain('Scatter / bubble plot (encoded size)');
+  });
+
+  it('selects reference examples once and reuses them across authoring retries', async () => {
+    selectInvoke.mockResolvedValue({ exampleIds: ['heatmap'] });
+    invoke
+      .mockResolvedValueOnce('not json at all')
+      .mockResolvedValueOnce(asCodeBlock({ mark: 'rect' }));
+
+    await run();
+
+    // Two authoring attempts, but selection ran exactly once before the loop.
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(selectInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not select reference examples when ES|QL resolution fails', async () => {
+    mockedGenerateEsql.mockResolvedValue({
+      query: 'FROM logs-*',
+      error: 'verification_exception: boom',
+    } as Awaited<ReturnType<typeof generateEsql>>);
+
+    await run();
+
+    expect(selectInvoke).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('authors without a reference block when selection returns none', async () => {
+    invoke.mockResolvedValue(asCodeBlock({ mark: 'bar' }));
+
+    await run();
+
+    expect(JSON.stringify(invoke.mock.calls[0][0])).not.toContain('REFERENCE EXAMPLES');
   });
 
   it('seeds ES|QL generation with the existing query as context when editing', async () => {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -18,6 +18,7 @@ import { generateVisualizationEsql } from '../shared/generate_visualization_esql
 import { normalizeVegaSpec } from './normalize_spec';
 import { validateVegaSpec } from './vega_validator';
 import { createAuthorVegaSpecPrompt, vegaEsqlAdditionalInstructions } from './prompts';
+import { formatReferenceExamples, loadReferenceExamples } from './reference_examples';
 import {
   GENERATE_ESQL_NODE,
   AUTHOR_SPEC_NODE,
@@ -222,12 +223,19 @@ export const createVegaGraph = async (
       .filter(Boolean)
       .join('\n');
 
+    // Load only the reference examples whose keywords match this request, so an
+    // unmatched example never materializes its spec body.
+    const referenceExamples = formatReferenceExamples(
+      await loadReferenceExamples(state.nlQuery, state.chartType)
+    );
+
     const prompt = createAuthorVegaSpecPrompt({
       nlQuery: state.nlQuery,
       esqlQuery: state.esqlQuery,
       columns: state.columns,
       existingSpec: state.existingSpec,
       chartType: state.chartType,
+      referenceExamples,
       additionalContext: previousContext
         ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object that fixes the issues above.`
         : undefined,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -18,9 +18,10 @@ import { generateVisualizationEsql } from '../shared/generate_visualization_esql
 import { normalizeVegaSpec } from './normalize_spec';
 import { validateVegaSpec } from './vega_validator';
 import { createAuthorVegaSpecPrompt, vegaEsqlAdditionalInstructions } from './prompts';
-import { formatReferenceExamples, loadReferenceExamples } from './reference_examples';
+import { buildReferenceExamplesBlock } from './reference_examples';
 import {
   GENERATE_ESQL_NODE,
+  SELECT_EXAMPLES_NODE,
   AUTHOR_SPEC_NODE,
   VALIDATE_SPEC_NODE,
   FINALIZE_NODE,
@@ -81,6 +82,7 @@ const VegaStateAnnotation = Annotation.Root({
   esqlQuery: Annotation<string>(),
   columns: Annotation<EsqlEsqlColumnInfo[] | undefined>(),
   currentAttempt: Annotation<number>({ reducer: (_, newValue) => newValue, default: () => 0 }),
+  referenceExamples: Annotation<string>({ reducer: (_, newValue) => newValue, default: () => '' }),
   actions: Annotation<VegaAction[]>({
     reducer: (a, b) => [...a, ...b],
     default: () => [],
@@ -202,6 +204,17 @@ export const createVegaGraph = async (
     };
   };
 
+  // Runs once before the authoring retry loop; the model picks which examples fit.
+  const selectExamplesNode = async (state: VegaState) => {
+    const referenceExamples = await buildReferenceExamplesBlock({
+      nlQuery: state.nlQuery,
+      chartType: state.chartType,
+      model: defaultModel,
+      logger,
+    });
+    return { referenceExamples };
+  };
+
   const authorSpecNode = async (state: VegaState) => {
     const attempt = state.currentAttempt + 1;
     logger.debug(`Authoring Vega-Lite spec (attempt ${attempt}/${MAX_RETRY_ATTEMPTS})`);
@@ -223,19 +236,13 @@ export const createVegaGraph = async (
       .filter(Boolean)
       .join('\n');
 
-    // Load only the reference examples whose keywords match this request, so an
-    // unmatched example never materializes its spec body.
-    const referenceExamples = formatReferenceExamples(
-      await loadReferenceExamples(state.nlQuery, state.chartType)
-    );
-
     const prompt = createAuthorVegaSpecPrompt({
       nlQuery: state.nlQuery,
       esqlQuery: state.esqlQuery,
       columns: state.columns,
       existingSpec: state.existingSpec,
       chartType: state.chartType,
-      referenceExamples,
+      referenceExamples: state.referenceExamples,
       additionalContext: previousContext
         ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object that fixes the issues above.`
         : undefined,
@@ -353,7 +360,7 @@ export const createVegaGraph = async (
       logger.warn('ES|QL resolution failed; finalizing without authoring a Vega spec');
       return FINALIZE_NODE;
     }
-    return AUTHOR_SPEC_NODE;
+    return SELECT_EXAMPLES_NODE;
   };
 
   const shouldRetryRouter = (state: VegaState): string => {
@@ -377,14 +384,16 @@ export const createVegaGraph = async (
 
   return new StateGraph(VegaStateAnnotation)
     .addNode(GENERATE_ESQL_NODE, generateESQLNode)
+    .addNode(SELECT_EXAMPLES_NODE, selectExamplesNode)
     .addNode(AUTHOR_SPEC_NODE, authorSpecNode)
     .addNode(VALIDATE_SPEC_NODE, validateSpecNode)
     .addNode(FINALIZE_NODE, finalizeNode)
     .addEdge('__start__', GENERATE_ESQL_NODE)
     .addConditionalEdges(GENERATE_ESQL_NODE, afterGenerateEsqlRouter, {
-      [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
+      [SELECT_EXAMPLES_NODE]: SELECT_EXAMPLES_NODE,
       [FINALIZE_NODE]: FINALIZE_NODE,
     })
+    .addEdge(SELECT_EXAMPLES_NODE, AUTHOR_SPEC_NODE)
     .addEdge(AUTHOR_SPEC_NODE, VALIDATE_SPEC_NODE)
     .addConditionalEdges(VALIDATE_SPEC_NODE, shouldRetryRouter, {
       [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
@@ -43,6 +43,14 @@ describe('createAuthorVegaSpecPrompt', () => {
     expect(text).toContain('set explicit "width" and "height" INSIDE the inner "spec"');
   });
 
+  it('defers colors to the Kibana theme instead of hardcoding them', () => {
+    const text = systemText('any chart');
+    expect(text).toContain('Do NOT hardcode colors');
+    expect(text).toContain('theme-aware Elastic palette');
+    // Categorical color should not set a scheme/range (that would override the theme).
+    expect(text).toContain('do NOT set a "scheme", "range"');
+  });
+
   it('includes the chart-type hint only when one is provided', () => {
     expect(systemText('any chart')).not.toContain('Suggested chart style');
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
@@ -51,6 +51,14 @@ describe('createAuthorVegaSpecPrompt', () => {
     expect(text).toContain('do NOT set a "scheme", "range"');
   });
 
+  it('includes axis-readability guidance (labelLimit, time-axis, title:null)', () => {
+    const text = systemText('any chart');
+    expect(text).toContain('"labelLimit": 150');
+    expect(text).toContain('"labelAngle": 0');
+    expect(text).toContain('"tickCount": 8');
+    expect(text).toContain('"title": null');
+  });
+
   it('includes the chart-type hint only when one is provided', () => {
     expect(systemText('any chart')).not.toContain('Suggested chart style');
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
@@ -81,4 +81,10 @@ describe('vegaEsqlAdditionalInstructions', () => {
       'Never filter or bucket on a field produced by'
     );
   });
+
+  it('asks to RENAME dotted columns to dotless aliases, except the time field', () => {
+    expect(vegaEsqlAdditionalInstructions).toContain('Field names for Vega');
+    expect(vegaEsqlAdditionalInstructions).toContain('RENAME host.name AS host');
+    expect(vegaEsqlAdditionalInstructions).toContain('Do NOT rename the time field');
+  });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
@@ -59,6 +59,22 @@ describe('createAuthorVegaSpecPrompt', () => {
     expect(text).toContain('"title": null');
   });
 
+  it('injects the caller-provided reference-examples block verbatim', () => {
+    const [system] = createAuthorVegaSpecPrompt({
+      nlQuery: 'scatter of latency vs throughput',
+      esqlQuery: 'FROM logs-*',
+      referenceExamples: '\nREFERENCE EXAMPLES:\n### Scatter / bubble plot (encoded size)\n',
+    });
+    const text = String((system as [string, string])[1]);
+
+    expect(text).toContain('REFERENCE EXAMPLES');
+    expect(text).toContain('Scatter / bubble plot (encoded size)');
+  });
+
+  it('omits the reference-examples section when none is provided', () => {
+    expect(systemText('a bar chart of counts by status')).not.toContain('REFERENCE EXAMPLES');
+  });
+
   it('includes the chart-type hint only when one is provided', () => {
     expect(systemText('any chart')).not.toContain('Suggested chart style');
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
@@ -19,6 +19,11 @@ import type { SupportedChartType } from '@kbn/agent-builder-common/tools/tool_re
  * the selected range (see issue #275519). So, unlike Lens (which applies the time
  * range for us), every time-based Vega query must filter its own rows and must do
  * so on the original source field — not a `RENAME`/`EVAL`-derived one.
+ *
+ * It also asks the model to `RENAME` dotted result columns (e.g. `host.name`) to
+ * dotless aliases at the source: Vega reads a dot as a nested-object path, so a
+ * flat dotted column would otherwise render as "undefined". `field_escaping`
+ * remains a deterministic fallback for provided/recovered queries.
  */
 export const vegaEsqlAdditionalInstructions = `
 ## Vega time-range filtering (required)
@@ -27,7 +32,13 @@ This query feeds a Vega chart, whose ES|QL data source only respects the time pi
 
 Therefore, for EVERY time-based chart — time series AND plain metrics/categorical:
 - Always add an explicit row filter on the raw source time field: \`WHERE <time field> >= ?_tstart AND <time field> < ?_tend\`.
-- Use the RAW source time field (e.g. \`@timestamp\`) directly in both that WHERE filter and any \`BUCKET(...)\`. Never filter or bucket on a field produced by \`RENAME\` or \`EVAL\`; the time filter must reference the original source field so Kibana can bind the range to it.`;
+- Use the RAW source time field (e.g. \`@timestamp\`) directly in both that WHERE filter and any \`BUCKET(...)\`. Never filter or bucket on a field produced by \`RENAME\` or \`EVAL\`; the time filter must reference the original source field so Kibana can bind the range to it.
+
+## Field names for Vega
+
+Vega interprets a dot in a field name as a nested-object path, but ES|QL result columns are flat, so a column whose name contains a dot (e.g. \`host.name\`) is misread and renders as "undefined".
+- RENAME every such column to a readable, dotless alias in the query, e.g. \`RENAME host.name AS host\` or \`RENAME geo.dest AS destination\`, and reference the alias in the spec. Prefer this over leaving dotted names for the renderer to escape.
+- This applies to dimension/metric columns only. Do NOT rename the time field this way — keep filtering and bucketing on the raw source time field exactly as required above.`;
 
 /**
  * Describe the result columns of the backing ES|QL query so the model binds

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
@@ -95,7 +95,10 @@ CHART CHOICE:
 - Keep the spec minimal: include only what is needed to render the requested chart. Do NOT add decorative text layers with a constant "value" (e.g. a center label that just repeats a word); a text layer must encode a real field.
 
 COLOR:
-- Use "color" only for a meaningful dimension, and do NOT hand-author a "domain"; let it derive from the data. For categorical fields prefer a built-in scheme; for quantitative fields a sequential "scheme" ("blues", "viridis") is fine.
+- Kibana applies a theme-aware Elastic palette and adapts chart colors to the active light/dark theme. Do NOT hardcode colors: no hex values, no "config" block setting mark/axis/text colors, and no "mark": { "color": … } — hardcoding overrides the theme and breaks dark mode.
+- Use the "color" ENCODING only to distinguish a meaningful categorical dimension, and leave its scale to the theme: do NOT set a "scheme", "range", or hand-authored "domain" for categorical color.
+- Only for a quantitative color encoding may you set a sequential "scheme" ("blues", "viridis"), since there is no themed default for continuous scales.
+- Single-series charts need no color at all — the theme supplies the default series color.
 
 LAYOUT & STYLE RULES:
 - DO NOT set top-level "width" or "height"; the system makes the chart fill its container. Do NOT set fixed mark sizes (e.g. arc "outerRadius") that prevent the chart from filling its panel.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
@@ -58,6 +58,7 @@ export const createAuthorVegaSpecPrompt = ({
   columns,
   existingSpec,
   chartType,
+  referenceExamples,
   additionalContext,
 }: {
   nlQuery: string;
@@ -65,6 +66,12 @@ export const createAuthorVegaSpecPrompt = ({
   columns?: EsqlEsqlColumnInfo[];
   existingSpec?: string;
   chartType?: SupportedChartType;
+  /**
+   * Pre-selected, pre-loaded reference-example block to inject (see
+   * `reference_examples`). Loaded by the caller so only matched examples are
+   * materialized; empty string when nothing matched.
+   */
+  referenceExamples?: string;
   additionalContext?: string;
 }): BaseMessageLike[] => {
   const esqlQueryJson = JSON.stringify(esqlQuery);
@@ -130,7 +137,7 @@ FACETING / SMALL MULTIPLES:
 
 DOTS IN FIELD NAMES:
 - Vega treats an unescaped dot in a field name as nested-object access, but ES|QL columns are flat. For a column whose name contains a dot (e.g. "geo.dest"), backslash-escape every dot in "field" strings ("geo\\.dest") and use bracket access in expressions (datum['geo.dest']).
-
+${referenceExamples ?? ''}
 Your task is to author the visualization specification for the following request:
 
 <user_query>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
@@ -94,6 +94,11 @@ CHART CHOICE:
 - PIE/DONUT: do NOT use "arc" marks. Prefer a sorted horizontal bar chart (it is easier to read and compare); pre-sort the categories in the ES|QL query (SORT … DESC).
 - Keep the spec minimal: include only what is needed to render the requested chart. Do NOT add decorative text layers with a constant "value" (e.g. a center label that just repeats a word); a text layer must encode a real field.
 
+AXES:
+- Long category labels (common on horizontal bar charts) truncate by default; set "axis": { "labelLimit": 150 } on that axis so the labels stay readable.
+- Temporal axes: set "axis": { "labelAngle": 0, "tickCount": 8 } and let Vega auto-format the dates — do NOT rotate or hand-format date labels.
+- When the "title" already conveys what an axis represents, set "title": null on that axis to drop the redundant axis title.
+
 COLOR:
 - Kibana applies a theme-aware Elastic palette and adapts chart colors to the active light/dark theme. Do NOT hardcode colors: no hex values, no "config" block setting mark/axis/text colors, and no "mark": { "color": … } — hardcoding overrides the theme and breaks dark mode.
 - Use the "color" ENCODING only to distinguish a meaningful categorical dimension, and leave its scale to the theme: do NOT set a "scheme", "range", or hand-authored "domain" for categorical color.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
@@ -9,22 +9,7 @@ import type { BaseMessageLike } from '@langchain/core/messages';
 import type { EsqlEsqlColumnInfo } from '@elastic/elasticsearch/lib/api/types';
 import type { SupportedChartType } from '@kbn/agent-builder-common/tools/tool_result';
 
-/**
- * Vega-specific ES|QL guidance appended to the shared instructions when
- * generating the query for a Vega chart.
- *
- * Kibana's Vega ES|QL renderer only *filters* rows by the time picker when the
- * query filters on the raw source time field itself; binding `?_tstart`/`?_tend`
- * inside `BUCKET(...)` only sets the bucket extent and does NOT drop rows outside
- * the selected range (see issue #275519). So, unlike Lens (which applies the time
- * range for us), every time-based Vega query must filter its own rows and must do
- * so on the original source field — not a `RENAME`/`EVAL`-derived one.
- *
- * It also asks the model to `RENAME` dotted result columns (e.g. `host.name`) to
- * dotless aliases at the source: Vega reads a dot as a nested-object path, so a
- * flat dotted column would otherwise render as "undefined". `field_escaping`
- * remains a deterministic fallback for provided/recovered queries.
- */
+// Vega-specific ES|QL guidance; see issue #275519 for the time-filtering quirk.
 export const vegaEsqlAdditionalInstructions = `
 ## Vega time-range filtering (required)
 
@@ -40,10 +25,6 @@ Vega interprets a dot in a field name as a nested-object path, but ES|QL result 
 - RENAME every such column to a readable, dotless alias in the query, e.g. \`RENAME host.name AS host\` or \`RENAME geo.dest AS destination\`, and reference the alias in the spec. Prefer this over leaving dotted names for the renderer to escape.
 - This applies to dimension/metric columns only. Do NOT rename the time field this way — keep filtering and bucketing on the raw source time field exactly as required above.`;
 
-/**
- * Describe the result columns of the backing ES|QL query so the model binds
- * encodings to real field names and types instead of guessing.
- */
 const formatColumns = (columns: EsqlEsqlColumnInfo[] | undefined): string => {
   if (!columns || columns.length === 0) {
     return 'No column information is available; infer fields from the ES|QL query.';
@@ -66,11 +47,7 @@ export const createAuthorVegaSpecPrompt = ({
   columns?: EsqlEsqlColumnInfo[];
   existingSpec?: string;
   chartType?: SupportedChartType;
-  /**
-   * Pre-selected, pre-loaded reference-example block to inject (see
-   * `reference_examples`). Loaded by the caller so only matched examples are
-   * materialized; empty string when nothing matched.
-   */
+  /** Pre-selected, pre-loaded reference-example block (see `reference_examples`). */
   referenceExamples?: string;
   additionalContext?: string;
 }): BaseMessageLike[] => {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  VEGA_REFERENCE_EXAMPLES,
+  formatReferenceExamples,
+  loadReferenceExamples,
+  selectReferenceExamples,
+} from './reference_examples';
+
+const idsFor = (nlQuery: string): string[] =>
+  selectReferenceExamples(nlQuery).map((example) => example.id);
+
+describe('selectReferenceExamples', () => {
+  it('selects the combination example for a bar + overlaid line request', () => {
+    expect(
+      idsFor('bars of daily request count with an overlaid line of average response time')
+    ).toContain('layered_combo_dual_axis');
+  });
+
+  it('selects the faceted example for a small-multiples request', () => {
+    expect(idsFor('small multiples of p95 latency over time, one panel per service')).toContain(
+      'faceted_small_multiples'
+    );
+  });
+
+  it('selects the scatter example for a scatter/bubble request', () => {
+    expect(
+      idsFor('scatter of latency vs throughput per host, bubble size = error count')
+    ).toContain('scatter_bubble');
+  });
+
+  it('selects the heatmap example for a heatmap request', () => {
+    expect(idsFor('a heatmap of activity by hour and day')).toContain('heatmap');
+  });
+
+  it('returns no example for a plain single-series chart (routes to Lens)', () => {
+    expect(selectReferenceExamples('top 10 services by error count as a bar chart')).toEqual([]);
+  });
+
+  it('is case-insensitive', () => {
+    expect(idsFor('SCATTER of X VS Y')).toContain('scatter_bubble');
+  });
+
+  it('ranks the higher-scoring example first', () => {
+    // Matches scatter strongly (scatter, vs, bubble size) and faceted weakly.
+    const [first] = idsFor('scatter plot of latency vs throughput, bubble size by errors');
+    expect(first).toBe('scatter_bubble');
+  });
+
+  it('never returns more than two examples', () => {
+    const many = selectReferenceExamples(
+      'a combination bar and line dual-axis scatter bubble heatmap small multiples facet chart'
+    );
+    expect(many.length).toBeLessThanOrEqual(2);
+  });
+
+  it('selection is stateless across repeated calls (no global-regex lastIndex drift)', () => {
+    const first = idsFor('scatter of latency vs throughput');
+    const second = idsFor('scatter of latency vs throughput');
+    expect(second).toEqual(first);
+  });
+});
+
+describe('loadReferenceExamples', () => {
+  it('materializes only the matched examples with their spec bodies', async () => {
+    const loaded = await loadReferenceExamples('scatter of latency vs throughput');
+
+    expect(loaded.map((example) => example.id)).toEqual(['scatter_bubble']);
+    expect(loaded[0].spec.$schema).toBe('https://vega.github.io/schema/vega-lite/v6.json');
+  });
+
+  it('loads nothing for a plain single-series chart', async () => {
+    expect(await loadReferenceExamples('top 10 services by error count')).toEqual([]);
+  });
+});
+
+describe('reference example specs (loaded on demand)', () => {
+  it.each(VEGA_REFERENCE_EXAMPLES.map((example) => [example.id, example] as const))(
+    '%s is a guideline-compliant Vega-Lite v6 skeleton',
+    async (_id, example) => {
+      const spec = await example.load();
+
+      expect(spec.$schema).toBe('https://vega.github.io/schema/vega-lite/v6.json');
+
+      // Declares a renderable view.
+      const hasView = ['mark', 'layer', 'facet', 'repeat', 'concat', 'hconcat', 'vconcat'].some(
+        (key) => key in spec
+      );
+      expect(hasView).toBe(true);
+
+      // Binds Kibana's inline ES|QL data source.
+      const url = (spec.data as { url?: Record<string, unknown> })?.url;
+      expect(url?.['%type%']).toBe('esql');
+      expect(typeof url?.query).toBe('string');
+    }
+  );
+
+  it('never sets a fixed size on a non-faceted top level (auto-sizes to the container)', async () => {
+    for (const example of VEGA_REFERENCE_EXAMPLES) {
+      const spec = await example.load();
+      if ('facet' in spec) {
+        // Faceting is the one case where per-cell width/height belong on the inner spec.
+        const inner = spec.spec as Record<string, unknown>;
+        expect(inner.width).toBeDefined();
+        expect(inner.height).toBeDefined();
+        expect(spec.columns).toBeDefined();
+      } else {
+        expect(spec.width).toBeUndefined();
+        expect(spec.height).toBeUndefined();
+        expect(spec.autosize).toEqual({ type: 'fit', contains: 'padding' });
+      }
+    }
+  });
+
+  it('escapes dotted field references and filters time on the raw source field', async () => {
+    for (const example of VEGA_REFERENCE_EXAMPLES) {
+      const spec = await example.load();
+      const serialized = JSON.stringify(spec);
+      // Any dotted field used in an encoding is backslash-escaped, never left raw.
+      expect(serialized).not.toMatch(/"field":\s*"[a-z_]+\.[a-z_]+"/i);
+
+      const url = (spec.data as { url?: Record<string, unknown> }).url ?? {};
+      const query = String(url.query ?? '');
+      if (query.includes('?_tstart')) {
+        expect(query).toMatch(/WHERE @timestamp >= \?_tstart AND @timestamp < \?_tend/);
+        expect(url['%timefield%']).toBe('@timestamp');
+      }
+    }
+  });
+});
+
+describe('formatReferenceExamples', () => {
+  it('returns an empty string when there are no examples', () => {
+    expect(formatReferenceExamples([])).toBe('');
+  });
+
+  it('renders a titled JSON block per example and warns against copying data', async () => {
+    const rendered = formatReferenceExamples(
+      await loadReferenceExamples('scatter of x vs y')
+    );
+    expect(rendered).toContain('REFERENCE EXAMPLES');
+    expect(rendered).toContain('Scatter / bubble plot (encoded size)');
+    expect(rendered).toContain('```json');
+    expect(rendered).toContain('Do NOT copy their data source');
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
@@ -38,6 +38,16 @@ describe('selectReferenceExamples', () => {
     expect(idsFor('a heatmap of activity by hour and day')).toContain('heatmap');
   });
 
+  it('selects the timeline/gantt example for a gantt/duration request', () => {
+    expect(idsFor('a gantt chart of deployment stage durations')).toContain('timeline_gantt');
+  });
+
+  it('selects the calendar-heatmap example for a calendar request', () => {
+    expect(idsFor('a calendar heatmap of logins by week and weekday')).toContain(
+      'calendar_heatmap'
+    );
+  });
+
   it('returns no example for a plain single-series chart (routes to Lens)', () => {
     expect(selectReferenceExamples('top 10 services by error count as a bar chart')).toEqual([]);
   });
@@ -140,9 +150,7 @@ describe('formatReferenceExamples', () => {
   });
 
   it('renders a titled JSON block per example and warns against copying data', async () => {
-    const rendered = formatReferenceExamples(
-      await loadReferenceExamples('scatter of x vs y')
-    );
+    const rendered = formatReferenceExamples(await loadReferenceExamples('scatter of x vs y'));
     expect(rendered).toContain('REFERENCE EXAMPLES');
     expect(rendered).toContain('Scatter / bubble plot (encoded size)');
     expect(rendered).toContain('```json');

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
@@ -5,87 +5,150 @@
  * 2.0.
  */
 
+import type { ScopedModel } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
 import {
   VEGA_REFERENCE_EXAMPLES,
+  buildReferenceExamplesBlock,
+  createExampleSelectorPrompt,
+  formatReferenceCatalog,
   formatReferenceExamples,
   loadReferenceExamples,
   selectReferenceExamples,
 } from './reference_examples';
 
-const idsFor = (nlQuery: string): string[] =>
-  selectReferenceExamples(nlQuery).map((example) => example.id);
+/**
+ * Build a mock ScopedModel whose structured-output selector returns `exampleIds`
+ * (or throws, to exercise the fail-open path).
+ */
+const mockModel = (
+  result: { exampleIds?: string[] } | (() => never)
+): { model: ScopedModel; invoke: jest.Mock; withStructuredOutput: jest.Mock } => {
+  const invoke = jest.fn(async () => {
+    if (typeof result === 'function') {
+      return result();
+    }
+    return result;
+  });
+  const withStructuredOutput = jest.fn(() => ({ invoke }));
+  return {
+    model: { chatModel: { withStructuredOutput } } as unknown as ScopedModel,
+    invoke,
+    withStructuredOutput,
+  };
+};
+
+const mockLogger = (): Logger => ({ warn: jest.fn() } as unknown as Logger);
+
+const idsFor = async (result: { exampleIds?: string[] }): Promise<string[]> => {
+  const { model } = mockModel(result);
+  const selected = await selectReferenceExamples({ nlQuery: 'any request', model });
+  return selected.map((example) => example.id);
+};
+
+describe('formatReferenceCatalog', () => {
+  it('lists every example id, title and description (no spec bodies)', () => {
+    const catalog = formatReferenceCatalog();
+    for (const example of VEGA_REFERENCE_EXAMPLES) {
+      expect(catalog).toContain(`id: "${example.id}"`);
+      expect(catalog).toContain(example.title);
+    }
+    // A selection catalog must not carry heavy spec bodies.
+    expect(catalog).not.toContain('$schema');
+  });
+});
+
+describe('createExampleSelectorPrompt', () => {
+  it('embeds the catalog, the request and the tool name', () => {
+    const [system, human] = createExampleSelectorPrompt({ nlQuery: 'a heatmap by hour and day' });
+    const systemText = String((system as [string, string])[1]);
+    const humanText = String((human as [string, string])[1]);
+
+    expect(systemText).toContain('select_reference_examples');
+    expect(systemText).toContain('id: "heatmap"');
+    expect(humanText).toContain('a heatmap by hour and day');
+  });
+
+  it('includes the chart-type hint only when provided', () => {
+    const [, humanNoHint] = createExampleSelectorPrompt({ nlQuery: 'x' });
+    expect(String((humanNoHint as [string, string])[1])).not.toContain('Suggested chart style');
+  });
+});
 
 describe('selectReferenceExamples', () => {
-  it('selects the combination example for a bar + overlaid line request', () => {
+  it('resolves the model-returned ids to catalog examples', async () => {
+    expect(await idsFor({ exampleIds: ['scatter_bubble'] })).toEqual(['scatter_bubble']);
+  });
+
+  it('ignores ids that are not in the catalog', async () => {
+    expect(await idsFor({ exampleIds: ['not_a_real_example', 'heatmap'] })).toEqual(['heatmap']);
+  });
+
+  it('dedupes repeated ids', async () => {
+    expect(await idsFor({ exampleIds: ['heatmap', 'heatmap'] })).toEqual(['heatmap']);
+  });
+
+  it('caps the selection at two examples, preserving order', async () => {
     expect(
-      idsFor('bars of daily request count with an overlaid line of average response time')
-    ).toContain('layered_combo_dual_axis');
+      await idsFor({
+        exampleIds: ['layered_combo_dual_axis', 'faceted_small_multiples', 'scatter_bubble'],
+      })
+    ).toEqual(['layered_combo_dual_axis', 'faceted_small_multiples']);
   });
 
-  it('selects the faceted example for a small-multiples request', () => {
-    expect(idsFor('small multiples of p95 latency over time, one panel per service')).toContain(
-      'faceted_small_multiples'
-    );
+  it('returns nothing when the model selects no example (plain chart)', async () => {
+    expect(await idsFor({ exampleIds: [] })).toEqual([]);
+    expect(await idsFor({})).toEqual([]);
   });
 
-  it('selects the scatter example for a scatter/bubble request', () => {
-    expect(
-      idsFor('scatter of latency vs throughput per host, bubble size = error count')
-    ).toContain('scatter_bubble');
+  it('fails open to no examples (and warns) when the model call throws', async () => {
+    const { model } = mockModel(() => {
+      throw new Error('model unavailable');
+    });
+    const logger = mockLogger();
+
+    const selected = await selectReferenceExamples({ nlQuery: 'x', model, logger });
+
+    expect(selected).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('model unavailable'));
   });
 
-  it('selects the heatmap example for a heatmap request', () => {
-    expect(idsFor('a heatmap of activity by hour and day')).toContain('heatmap');
-  });
-
-  it('selects the timeline/gantt example for a gantt/duration request', () => {
-    expect(idsFor('a gantt chart of deployment stage durations')).toContain('timeline_gantt');
-  });
-
-  it('selects the calendar-heatmap example for a calendar request', () => {
-    expect(idsFor('a calendar heatmap of logins by week and weekday')).toContain(
-      'calendar_heatmap'
-    );
-  });
-
-  it('returns no example for a plain single-series chart (routes to Lens)', () => {
-    expect(selectReferenceExamples('top 10 services by error count as a bar chart')).toEqual([]);
-  });
-
-  it('is case-insensitive', () => {
-    expect(idsFor('SCATTER of X VS Y')).toContain('scatter_bubble');
-  });
-
-  it('ranks the higher-scoring example first', () => {
-    // Matches scatter strongly (scatter, vs, bubble size) and faceted weakly.
-    const [first] = idsFor('scatter plot of latency vs throughput, bubble size by errors');
-    expect(first).toBe('scatter_bubble');
-  });
-
-  it('never returns more than two examples', () => {
-    const many = selectReferenceExamples(
-      'a combination bar and line dual-axis scatter bubble heatmap small multiples facet chart'
-    );
-    expect(many.length).toBeLessThanOrEqual(2);
-  });
-
-  it('selection is stateless across repeated calls (no global-regex lastIndex drift)', () => {
-    const first = idsFor('scatter of latency vs throughput');
-    const second = idsFor('scatter of latency vs throughput');
-    expect(second).toEqual(first);
+  it('requests structured output under the select_reference_examples tool name', async () => {
+    const { model, withStructuredOutput } = mockModel({ exampleIds: [] });
+    await selectReferenceExamples({ nlQuery: 'x', model });
+    expect(withStructuredOutput).toHaveBeenCalledWith(expect.anything(), {
+      name: 'select_reference_examples',
+    });
   });
 });
 
 describe('loadReferenceExamples', () => {
-  it('materializes only the matched examples with their spec bodies', async () => {
-    const loaded = await loadReferenceExamples('scatter of latency vs throughput');
+  it('materializes the spec body for each selected example', async () => {
+    const [scatter] = VEGA_REFERENCE_EXAMPLES.filter((e) => e.id === 'scatter_bubble');
+    const loaded = await loadReferenceExamples([scatter]);
 
     expect(loaded.map((example) => example.id)).toEqual(['scatter_bubble']);
     expect(loaded[0].spec.$schema).toBe('https://vega.github.io/schema/vega-lite/v6.json');
   });
 
-  it('loads nothing for a plain single-series chart', async () => {
-    expect(await loadReferenceExamples('top 10 services by error count')).toEqual([]);
+  it('loads nothing when no examples are selected', async () => {
+    expect(await loadReferenceExamples([])).toEqual([]);
+  });
+});
+
+describe('buildReferenceExamplesBlock', () => {
+  it('selects, loads and formats the matched examples into a prompt block', async () => {
+    const { model } = mockModel({ exampleIds: ['scatter_bubble'] });
+    const block = await buildReferenceExamplesBlock({ nlQuery: 'scatter of x vs y', model });
+
+    expect(block).toContain('REFERENCE EXAMPLES');
+    expect(block).toContain('Scatter / bubble plot (encoded size)');
+    expect(block).toContain('```json');
+  });
+
+  it('returns an empty string when the model selects nothing (no bodies loaded)', async () => {
+    const { model } = mockModel({ exampleIds: [] });
+    expect(await buildReferenceExamplesBlock({ nlQuery: 'top 10 services', model })).toBe('');
   });
 });
 
@@ -150,7 +213,8 @@ describe('formatReferenceExamples', () => {
   });
 
   it('renders a titled JSON block per example and warns against copying data', async () => {
-    const rendered = formatReferenceExamples(await loadReferenceExamples('scatter of x vs y'));
+    const [scatter] = VEGA_REFERENCE_EXAMPLES.filter((e) => e.id === 'scatter_bubble');
+    const rendered = formatReferenceExamples(await loadReferenceExamples([scatter]));
     expect(rendered).toContain('REFERENCE EXAMPLES');
     expect(rendered).toContain('Scatter / bubble plot (encoded size)');
     expect(rendered).toContain('```json');

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/calendar_heatmap.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/calendar_heatmap.ts
@@ -5,13 +5,6 @@
  * 2.0.
  */
 
-/**
- * Calendar heatmap: a GitHub-style grid of a `rect` mark with an ordinal `x` for
- * the week and an ordinal `y` for the weekday (explicitly sorted Mon→Sun), colored
- * by a sequential scheme. The week/weekday buckets are derived with `EVAL
- * DATE_FORMAT(...)`. Loaded on demand by the reference-example catalog only when
- * the request matches.
- */
 export const spec: Record<string, unknown> = {
   $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
   title: 'Activity by Week and Weekday',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/calendar_heatmap.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/calendar_heatmap.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Calendar heatmap: a GitHub-style grid of a `rect` mark with an ordinal `x` for
+ * the week and an ordinal `y` for the weekday (explicitly sorted Mon→Sun), colored
+ * by a sequential scheme. The week/weekday buckets are derived with `EVAL
+ * DATE_FORMAT(...)`. Loaded on demand by the reference-example catalog only when
+ * the request matches.
+ */
+export const spec: Record<string, unknown> = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  title: 'Activity by Week and Weekday',
+  autosize: { type: 'fit', contains: 'padding' },
+  data: {
+    url: {
+      '%type%': 'esql',
+      '%timefield%': '@timestamp',
+      query:
+        'FROM logs-* | WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend | EVAL week = DATE_FORMAT("YYYY-ww", @timestamp), weekday = DATE_FORMAT("EEE", @timestamp) | STATS count = COUNT(*) BY week, weekday | SORT week ASC',
+    },
+  },
+  mark: 'rect',
+  encoding: {
+    x: { field: 'week', type: 'ordinal', title: 'Week', axis: { labelAngle: 0, labelLimit: 150 } },
+    y: {
+      field: 'weekday',
+      type: 'ordinal',
+      title: null,
+      sort: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    },
+    color: {
+      field: 'count',
+      type: 'quantitative',
+      title: 'Events',
+      scale: { scheme: 'greens' },
+    },
+    tooltip: [
+      { field: 'week', type: 'ordinal', title: 'Week' },
+      { field: 'weekday', type: 'ordinal', title: 'Weekday' },
+      { field: 'count', type: 'quantitative', title: 'Events' },
+    ],
+  },
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/faceted_small_multiples.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/faceted_small_multiples.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Faceted small multiples: a top-level `facet` + per-cell `spec`, with `columns`
+ * as a sibling and explicit per-cell sizing (auto-size does not apply to facets).
+ * Loaded on demand by the reference-example catalog only when the request matches.
+ */
+export const spec: Record<string, unknown> = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  title: 'p95 Latency Over Time by Service',
+  data: {
+    url: {
+      '%type%': 'esql',
+      '%timefield%': '@timestamp',
+      query:
+        'FROM traces-* | WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend | STATS p95_latency = PERCENTILE(latency_ms, 95) BY service.name, time_bucket = BUCKET(@timestamp, 1 hour) | SORT time_bucket ASC',
+    },
+  },
+  facet: { field: 'service\\.name', type: 'nominal', header: { title: 'Service' } },
+  columns: 3,
+  spec: {
+    width: 200,
+    height: 120,
+    mark: { type: 'line', point: false },
+    encoding: {
+      x: { field: 'time_bucket', type: 'temporal', title: null, axis: { labelAngle: 0 } },
+      y: { field: 'p95_latency', type: 'quantitative', title: 'p95 (ms)' },
+    },
+  },
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/faceted_small_multiples.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/faceted_small_multiples.ts
@@ -5,11 +5,6 @@
  * 2.0.
  */
 
-/**
- * Faceted small multiples: a top-level `facet` + per-cell `spec`, with `columns`
- * as a sibling and explicit per-cell sizing (auto-size does not apply to facets).
- * Loaded on demand by the reference-example catalog only when the request matches.
- */
 export const spec: Record<string, unknown> = {
   $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
   title: 'p95 Latency Over Time by Service',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/heatmap.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/heatmap.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Heatmap: a `rect` mark spanning two categorical/ordinal axes with a sequential
+ * color scheme for the measure. Loaded on demand by the reference-example catalog
+ * only when the request matches.
+ */
+export const spec: Record<string, unknown> = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  title: 'Event Density by Hour and Day',
+  autosize: { type: 'fit', contains: 'padding' },
+  data: {
+    url: {
+      '%type%': 'esql',
+      '%timefield%': '@timestamp',
+      query:
+        'FROM logs-* | WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend | EVAL hour = DATE_EXTRACT("HOUR_OF_DAY", @timestamp), day = DATE_FORMAT("EEE", @timestamp) | STATS count = COUNT(*) BY hour, day | SORT hour ASC',
+    },
+  },
+  mark: 'rect',
+  encoding: {
+    x: { field: 'hour', type: 'ordinal', title: 'Hour of Day', axis: { labelAngle: 0 } },
+    y: { field: 'day', type: 'ordinal', title: 'Day' },
+    color: {
+      field: 'count',
+      type: 'quantitative',
+      title: 'Events',
+      scale: { scheme: 'blues' },
+    },
+    tooltip: [
+      { field: 'day', type: 'ordinal', title: 'Day' },
+      { field: 'hour', type: 'ordinal', title: 'Hour' },
+      { field: 'count', type: 'quantitative', title: 'Events' },
+    ],
+  },
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/heatmap.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/heatmap.ts
@@ -5,11 +5,6 @@
  * 2.0.
  */
 
-/**
- * Heatmap: a `rect` mark spanning two categorical/ordinal axes with a sequential
- * color scheme for the measure. Loaded on demand by the reference-example catalog
- * only when the request matches.
- */
 export const spec: Record<string, unknown> = {
   $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
   title: 'Event Density by Hour and Day',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SupportedChartType } from '@kbn/agent-builder-common/tools/tool_result';
+
+/**
+ * A curated Vega-Lite reference example the authoring model can adapt.
+ *
+ * The catalog only covers the *non-trivial* chart shapes that a standard Lens
+ * chart cannot express and that the model most often gets structurally wrong —
+ * combination (dual-axis) charts, faceted small multiples, scatter/bubble plots,
+ * and heatmaps. Simple single-series bar/line charts are deliberately omitted:
+ * they route to Lens and need no example here.
+ *
+ * Only lightweight metadata (`match`, `title`, `description`) lives here; the
+ * spec body is *referenced content* loaded on demand via {@link VegaReferenceExample.load}
+ * so a request only pays to materialize the examples it actually matches. Each
+ * spec is a guideline-compliant skeleton (auto-sizing, single legend per shared
+ * scale, `sort: null` on shared axes, escaped dotted fields, explicit time-range
+ * filtering on the raw source field), with colors left to the theme / built-in
+ * schemes rather than a hardcoded palette.
+ */
+export interface VegaReferenceExample {
+  /** Stable identifier (also used in tests). */
+  readonly id: string;
+  /** Short human-facing title shown above the spec. */
+  readonly title: string;
+  /** When to reach for this pattern. */
+  readonly description: string;
+  /**
+   * Patterns matched (case-insensitively, statelessly) against the request text.
+   * Defined without the global flag so repeated `test()` calls stay stateless.
+   */
+  readonly match: readonly RegExp[];
+  /** Lazily load the illustrative Vega-Lite (v6) spec for this example. */
+  readonly load: () => Promise<Record<string, unknown>>;
+}
+
+/** A reference example whose spec body has been materialized. */
+export interface LoadedVegaReferenceExample {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly spec: Record<string, unknown>;
+}
+
+/**
+ * Catalog metadata, in priority order for equal-score ties. Spec bodies are
+ * referenced (not imported) so they load only when their example is selected.
+ */
+export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
+  {
+    id: 'layered_combo_dual_axis',
+    title: 'Combination chart (bars + overlaid line, dual axis)',
+    description:
+      'Two metrics over a shared axis: bars for one, an overlaid line for the other, on independent y-scales. Share the x encoding at the top level, set `sort: null` on any shared categorical axis, give each layer its own y `axis.title`, and put `resolve.scale.y = "independent"` at the top level.',
+    match: [
+      /dual[-\s]?axis/,
+      /\bcombo\b|combination/,
+      /overla(y|id|ying)/,
+      /bar.*\bline\b|\bline\b.*bar/,
+      /(count|bars?).*(average|avg|line)/,
+      /two (metrics|measures|series|y[-\s]?axes)/,
+    ],
+    load: () => import('./layered_combo_dual_axis').then((module) => module.spec),
+  },
+  {
+    id: 'faceted_small_multiples',
+    title: 'Faceted small multiples (one panel per category)',
+    description:
+      'Split one chart into a grid of small multiples: a top-level `facet` (the splitting field) plus a per-cell `spec`, with `columns` as a SIBLING of `facet`/`spec` (never inside `facet`). Auto-sizing does not apply to facets, so set explicit `width`/`height` on the inner `spec`. Keep the facet field low-cardinality (pre-limit in ES|QL).',
+    match: [
+      /small multiples/,
+      /\bfacet(s|ed|ing)?\b/,
+      /one (panel|chart|plot|line|graph) per\b/,
+      /a (panel|chart|plot) (for|per) each/,
+      /grid of (charts|panels|plots)/,
+      /split (in)?to (panels|charts|plots)/,
+    ],
+    load: () => import('./faceted_small_multiples').then((module) => module.spec),
+  },
+  {
+    id: 'scatter_bubble',
+    title: 'Scatter / bubble plot (encoded size)',
+    description:
+      'Relate two measures per entity with a `point` mark: quantitative `x` and `y`, a third measure as `size` (bubble), and a category as `color`. Disable zero baselines (`scale.zero = false`) when comparing magnitudes. Still filter by the time picker even without a temporal axis.',
+    match: [
+      /scatter/,
+      /bubble/,
+      /correlat/,
+      /\bvs\.?\b|versus/,
+      /size\s*=|bubble size|sized? by/,
+      /relationship between/,
+    ],
+    load: () => import('./scatter_bubble').then((module) => module.spec),
+  },
+  {
+    id: 'heatmap',
+    title: 'Heatmap (two categories + color measure)',
+    description:
+      'Density across two dimensions with a `rect` mark: an ordinal/nominal `x` and `y`, and a sequential `color` scheme for the measure. Extract categorical buckets with `EVAL`, but keep the time-picker filter on the raw source field.',
+    match: [
+      /heat\s?map/,
+      /\bmatrix\b/,
+      /\bby hour\b.*\bday\b|\bday\b.*\bby hour\b/,
+      /density/,
+      /calendar/,
+    ],
+    load: () => import('./heatmap').then((module) => module.spec),
+  },
+];
+
+/** Never inject more than this many examples, to keep the prompt bounded. */
+const MAX_SELECTED_EXAMPLES = 2;
+
+/**
+ * Pick the reference examples whose keyword patterns best match the request,
+ * returning their metadata only (no spec content is loaded here). Returns the
+ * highest-scoring examples (at most {@link MAX_SELECTED_EXAMPLES}), or an empty
+ * array when nothing matches — a plain chart gets no example rather than a
+ * misleading one. Catalog order breaks ties so selection is deterministic.
+ */
+export const selectReferenceExamples = (
+  nlQuery: string,
+  chartType?: SupportedChartType
+): VegaReferenceExample[] => {
+  const haystack = `${nlQuery} ${chartType ?? ''}`.toLowerCase();
+
+  return VEGA_REFERENCE_EXAMPLES.map((example) => ({
+    example,
+    score: example.match.reduce((total, pattern) => total + (pattern.test(haystack) ? 1 : 0), 0),
+  }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_SELECTED_EXAMPLES)
+    .map(({ example }) => example);
+};
+
+/**
+ * Select the matching examples and load *only their* spec bodies. This is the
+ * single entry point that materializes referenced content, so unmatched examples
+ * are never loaded.
+ */
+export const loadReferenceExamples = async (
+  nlQuery: string,
+  chartType?: SupportedChartType
+): Promise<LoadedVegaReferenceExample[]> => {
+  const selected = selectReferenceExamples(nlQuery, chartType);
+
+  return Promise.all(
+    selected.map(async ({ id, title, description, load }) => ({
+      id,
+      title,
+      description,
+      spec: await load(),
+    }))
+  );
+};
+
+/**
+ * Render loaded examples as a prompt section. Returns an empty string when there
+ * are none so callers can inject it unconditionally.
+ */
+export const formatReferenceExamples = (examples: LoadedVegaReferenceExample[]): string => {
+  if (examples.length === 0) {
+    return '';
+  }
+
+  const blocks = examples
+    .map(
+      (example) =>
+        `### ${example.title}\n${example.description}\n\`\`\`json\n${JSON.stringify(
+          example.spec,
+          null,
+          2
+        )}\n\`\`\``
+    )
+    .join('\n\n');
+
+  return `
+REFERENCE EXAMPLES:
+Adapt the structural pattern(s) below to the request. Do NOT copy their data source, fields, or query — bind the columns listed above. They illustrate correct structure only.
+
+${blocks}`;
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
@@ -13,8 +13,10 @@ import type { SupportedChartType } from '@kbn/agent-builder-common/tools/tool_re
  * The catalog only covers the *non-trivial* chart shapes that a standard Lens
  * chart cannot express and that the model most often gets structurally wrong —
  * combination (dual-axis) charts, faceted small multiples, scatter/bubble plots,
- * and heatmaps. Simple single-series bar/line charts are deliberately omitted:
- * they route to Lens and need no example here.
+ * heatmaps, timeline/Gantt ranged bars, and calendar heatmaps. Simple single-series
+ * bar/line charts are deliberately omitted: they route to Lens and need no example
+ * here. Chart shapes that Vega-Lite cannot express (Sankey, radar, sunburst) are
+ * out of scope until raw-Vega support lands.
  *
  * Only lightweight metadata (`match`, `title`, `description`) lives here; the
  * spec body is *referenced content* loaded on demand via {@link VegaReferenceExample.load}
@@ -103,14 +105,37 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     title: 'Heatmap (two categories + color measure)',
     description:
       'Density across two dimensions with a `rect` mark: an ordinal/nominal `x` and `y`, and a sequential `color` scheme for the measure. Extract categorical buckets with `EVAL`, but keep the time-picker filter on the raw source field.',
-    match: [
-      /heat\s?map/,
-      /\bmatrix\b/,
-      /\bby hour\b.*\bday\b|\bday\b.*\bby hour\b/,
-      /density/,
-      /calendar/,
-    ],
+    match: [/heat\s?map/, /\bmatrix\b/, /\bby hour\b.*\bday\b|\bday\b.*\bby hour\b/, /density/],
     load: () => import('./heatmap').then((module) => module.spec),
+  },
+  {
+    id: 'timeline_gantt',
+    title: 'Timeline / Gantt (ranged bars)',
+    description:
+      'Show the start-to-end span of each item as a horizontal ranged bar: a `bar` mark with a temporal `x` (start) and `x2` (end) against a nominal `y` (the item). Produce the start/end columns in ES|QL (e.g. `MIN`/`MAX` of the time field per item), pre-sort by start and set `sort: null` on `y`. Keep the time-picker filter on the raw source field.',
+    match: [
+      /\bgantt\b/,
+      /timeline/,
+      /\bschedule\b/,
+      /duration(s)? (of|per|by|for)\b/,
+      /start (and|to) end|(start|end) (time|date)s?/,
+      /\bspans?\b/,
+    ],
+    load: () => import('./timeline_gantt').then((module) => module.spec),
+  },
+  {
+    id: 'calendar_heatmap',
+    title: 'Calendar heatmap (week × weekday grid)',
+    description:
+      'GitHub-style calendar heatmap: a `rect` mark with an ordinal `x` for the week and an ordinal `y` for the weekday (explicitly sorted Mon→Sun via `sort`), colored by a sequential `scheme`. Derive the week/weekday buckets with `EVAL DATE_FORMAT(...)` and keep the time-picker filter on the raw source field.',
+    match: [
+      /calendar/,
+      /contribution (graph|chart)/,
+      /github[-\s]?style/,
+      /by (week and )?weekday/,
+      /activity (heat\s?map|calendar)/,
+    ],
+    load: () => import('./calendar_heatmap').then((module) => module.spec),
   },
 ];
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
@@ -5,44 +5,20 @@
  * 2.0.
  */
 
+import { z } from '@kbn/zod/v4';
+import type { BaseMessageLike } from '@langchain/core/messages';
+import type { Logger } from '@kbn/logging';
+import type { ScopedModel } from '@kbn/agent-builder-server';
 import type { SupportedChartType } from '@kbn/agent-builder-common/tools/tool_result';
 
-/**
- * A curated Vega-Lite reference example the authoring model can adapt.
- *
- * The catalog only covers the *non-trivial* chart shapes that a standard Lens
- * chart cannot express and that the model most often gets structurally wrong —
- * combination (dual-axis) charts, faceted small multiples, scatter/bubble plots,
- * heatmaps, timeline/Gantt ranged bars, and calendar heatmaps. Simple single-series
- * bar/line charts are deliberately omitted: they route to Lens and need no example
- * here. Chart shapes that Vega-Lite cannot express (Sankey, radar, sunburst) are
- * out of scope until raw-Vega support lands.
- *
- * Only lightweight metadata (`match`, `title`, `description`) lives here; the
- * spec body is *referenced content* loaded on demand via {@link VegaReferenceExample.load}
- * so a request only pays to materialize the examples it actually matches. Each
- * spec is a guideline-compliant skeleton (auto-sizing, single legend per shared
- * scale, `sort: null` on shared axes, escaped dotted fields, explicit time-range
- * filtering on the raw source field), with colors left to the theme / built-in
- * schemes rather than a hardcoded palette.
- */
 export interface VegaReferenceExample {
-  /** Stable identifier (also used in tests). */
   readonly id: string;
-  /** Short human-facing title shown above the spec. */
   readonly title: string;
-  /** When to reach for this pattern. */
+  /** Shown to the model to guide selection. */
   readonly description: string;
-  /**
-   * Patterns matched (case-insensitively, statelessly) against the request text.
-   * Defined without the global flag so repeated `test()` calls stay stateless.
-   */
-  readonly match: readonly RegExp[];
-  /** Lazily load the illustrative Vega-Lite (v6) spec for this example. */
   readonly load: () => Promise<Record<string, unknown>>;
 }
 
-/** A reference example whose spec body has been materialized. */
 export interface LoadedVegaReferenceExample {
   readonly id: string;
   readonly title: string;
@@ -50,24 +26,13 @@ export interface LoadedVegaReferenceExample {
   readonly spec: Record<string, unknown>;
 }
 
-/**
- * Catalog metadata, in priority order for equal-score ties. Spec bodies are
- * referenced (not imported) so they load only when their example is selected.
- */
+// Spec bodies are referenced (not imported) so they load only when selected.
 export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
   {
     id: 'layered_combo_dual_axis',
     title: 'Combination chart (bars + overlaid line, dual axis)',
     description:
       'Two metrics over a shared axis: bars for one, an overlaid line for the other, on independent y-scales. Share the x encoding at the top level, set `sort: null` on any shared categorical axis, give each layer its own y `axis.title`, and put `resolve.scale.y = "independent"` at the top level.',
-    match: [
-      /dual[-\s]?axis/,
-      /\bcombo\b|combination/,
-      /overla(y|id|ying)/,
-      /bar.*\bline\b|\bline\b.*bar/,
-      /(count|bars?).*(average|avg|line)/,
-      /two (metrics|measures|series|y[-\s]?axes)/,
-    ],
     load: () => import('./layered_combo_dual_axis').then((module) => module.spec),
   },
   {
@@ -75,14 +40,6 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     title: 'Faceted small multiples (one panel per category)',
     description:
       'Split one chart into a grid of small multiples: a top-level `facet` (the splitting field) plus a per-cell `spec`, with `columns` as a SIBLING of `facet`/`spec` (never inside `facet`). Auto-sizing does not apply to facets, so set explicit `width`/`height` on the inner `spec`. Keep the facet field low-cardinality (pre-limit in ES|QL).',
-    match: [
-      /small multiples/,
-      /\bfacet(s|ed|ing)?\b/,
-      /one (panel|chart|plot|line|graph) per\b/,
-      /a (panel|chart|plot) (for|per) each/,
-      /grid of (charts|panels|plots)/,
-      /split (in)?to (panels|charts|plots)/,
-    ],
     load: () => import('./faceted_small_multiples').then((module) => module.spec),
   },
   {
@@ -90,14 +47,6 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     title: 'Scatter / bubble plot (encoded size)',
     description:
       'Relate two measures per entity with a `point` mark: quantitative `x` and `y`, a third measure as `size` (bubble), and a category as `color`. Disable zero baselines (`scale.zero = false`) when comparing magnitudes. Still filter by the time picker even without a temporal axis.',
-    match: [
-      /scatter/,
-      /bubble/,
-      /correlat/,
-      /\bvs\.?\b|versus/,
-      /size\s*=|bubble size|sized? by/,
-      /relationship between/,
-    ],
     load: () => import('./scatter_bubble').then((module) => module.spec),
   },
   {
@@ -105,7 +54,6 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     title: 'Heatmap (two categories + color measure)',
     description:
       'Density across two dimensions with a `rect` mark: an ordinal/nominal `x` and `y`, and a sequential `color` scheme for the measure. Extract categorical buckets with `EVAL`, but keep the time-picker filter on the raw source field.',
-    match: [/heat\s?map/, /\bmatrix\b/, /\bby hour\b.*\bday\b|\bday\b.*\bby hour\b/, /density/],
     load: () => import('./heatmap').then((module) => module.spec),
   },
   {
@@ -113,14 +61,6 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     title: 'Timeline / Gantt (ranged bars)',
     description:
       'Show the start-to-end span of each item as a horizontal ranged bar: a `bar` mark with a temporal `x` (start) and `x2` (end) against a nominal `y` (the item). Produce the start/end columns in ES|QL (e.g. `MIN`/`MAX` of the time field per item), pre-sort by start and set `sort: null` on `y`. Keep the time-picker filter on the raw source field.',
-    match: [
-      /\bgantt\b/,
-      /timeline/,
-      /\bschedule\b/,
-      /duration(s)? (of|per|by|for)\b/,
-      /start (and|to) end|(start|end) (time|date)s?/,
-      /\bspans?\b/,
-    ],
     load: () => import('./timeline_gantt').then((module) => module.spec),
   },
   {
@@ -128,68 +68,119 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     title: 'Calendar heatmap (week × weekday grid)',
     description:
       'GitHub-style calendar heatmap: a `rect` mark with an ordinal `x` for the week and an ordinal `y` for the weekday (explicitly sorted Mon→Sun via `sort`), colored by a sequential `scheme`. Derive the week/weekday buckets with `EVAL DATE_FORMAT(...)` and keep the time-picker filter on the raw source field.',
-    match: [
-      /calendar/,
-      /contribution (graph|chart)/,
-      /github[-\s]?style/,
-      /by (week and )?weekday/,
-      /activity (heat\s?map|calendar)/,
-    ],
     load: () => import('./calendar_heatmap').then((module) => module.spec),
   },
 ];
 
-/** Never inject more than this many examples, to keep the prompt bounded. */
 const MAX_SELECTED_EXAMPLES = 2;
 
-/**
- * Pick the reference examples whose keyword patterns best match the request,
- * returning their metadata only (no spec content is loaded here). Returns the
- * highest-scoring examples (at most {@link MAX_SELECTED_EXAMPLES}), or an empty
- * array when nothing matches — a plain chart gets no example rather than a
- * misleading one. Catalog order breaks ties so selection is deterministic.
- */
-export const selectReferenceExamples = (
-  nlQuery: string,
-  chartType?: SupportedChartType
-): VegaReferenceExample[] => {
-  const haystack = `${nlQuery} ${chartType ?? ''}`.toLowerCase();
+const exampleById = (id: string): VegaReferenceExample | undefined =>
+  VEGA_REFERENCE_EXAMPLES.find((example) => example.id === id);
 
-  return VEGA_REFERENCE_EXAMPLES.map((example) => ({
-    example,
-    score: example.match.reduce((total, pattern) => total + (pattern.test(haystack) ? 1 : 0), 0),
-  }))
-    .filter(({ score }) => score > 0)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, MAX_SELECTED_EXAMPLES)
-    .map(({ example }) => example);
+export const formatReferenceCatalog = (): string =>
+  VEGA_REFERENCE_EXAMPLES.map(
+    (example) => `- id: "${example.id}" — ${example.title}\n  ${example.description}`
+  ).join('\n');
+
+const referenceSelectionSchema = z.object({
+  exampleIds: z
+    .array(z.string())
+    .default([])
+    .describe(
+      'IDs (from the catalog) of the reference examples whose STRUCTURE matches the request. Order by relevance. Use an empty array when none apply — e.g. a plain single-series bar/line chart, which needs no example.'
+    ),
+});
+
+export const createExampleSelectorPrompt = ({
+  nlQuery,
+  chartType,
+}: {
+  nlQuery: string;
+  chartType?: SupportedChartType;
+}): BaseMessageLike[] => {
+  const chartTypeHint = chartType ? `\nSuggested chart style: "${chartType}".` : '';
+
+  return [
+    [
+      'system',
+      `You are a Vega-Lite visualization expert selecting reference examples for a chart-authoring model.
+
+You are given a catalog of curated Vega-Lite example shapes and a chart request. Decide which example(s), if any, illustrate the STRUCTURE the request needs, and return their ids by calling the 'select_reference_examples' tool.
+
+RULES:
+1. Match on the chart's SHAPE/structure (combination, facet, scatter/bubble, heatmap, timeline, calendar), NOT on the specific fields or data in the request.
+2. Select at most ${MAX_SELECTED_EXAMPLES}, ordered by relevance. Most requests need zero or one.
+3. Return an EMPTY array when no example fits — e.g. a plain single-series bar or line chart. Do NOT force an unrelated example.
+4. Only return ids that appear verbatim in the catalog.
+
+CATALOG:
+${formatReferenceCatalog()}`,
+    ],
+    [
+      'human',
+      `Chart request:
+<user_query>
+${nlQuery}
+</user_query>${chartTypeHint}
+
+Call 'select_reference_examples' with the ids of the matching example(s), or an empty array if none apply.`,
+    ],
+  ];
 };
 
-/**
- * Select the matching examples and load *only their* spec bodies. This is the
- * single entry point that materializes referenced content, so unmatched examples
- * are never loaded.
- */
-export const loadReferenceExamples = async (
-  nlQuery: string,
-  chartType?: SupportedChartType
-): Promise<LoadedVegaReferenceExample[]> => {
-  const selected = selectReferenceExamples(nlQuery, chartType);
+// Best-effort: any failure yields an empty selection so authoring is not blocked.
+export const selectReferenceExamples = async ({
+  nlQuery,
+  chartType,
+  model,
+  logger,
+}: {
+  nlQuery: string;
+  chartType?: SupportedChartType;
+  model: ScopedModel;
+  logger?: Logger;
+}): Promise<VegaReferenceExample[]> => {
+  try {
+    const selectorModel = model.chatModel.withStructuredOutput(referenceSelectionSchema, {
+      name: 'select_reference_examples',
+    });
 
-  return Promise.all(
-    selected.map(async ({ id, title, description, load }) => ({
+    const response = await selectorModel.invoke(
+      createExampleSelectorPrompt({ nlQuery, chartType })
+    );
+    const requestedIds = Array.isArray(response?.exampleIds) ? response.exampleIds : [];
+
+    const selected: VegaReferenceExample[] = [];
+    for (const id of requestedIds) {
+      const example = exampleById(id);
+      if (example && !selected.includes(example)) {
+        selected.push(example);
+      }
+      if (selected.length >= MAX_SELECTED_EXAMPLES) {
+        break;
+      }
+    }
+
+    return selected;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger?.warn(`Reference-example selection failed; authoring without examples: ${message}`);
+    return [];
+  }
+};
+
+export const loadReferenceExamples = async (
+  examples: readonly VegaReferenceExample[]
+): Promise<LoadedVegaReferenceExample[]> =>
+  Promise.all(
+    examples.map(async ({ id, title, description, load }) => ({
       id,
       title,
       description,
       spec: await load(),
     }))
   );
-};
 
-/**
- * Render loaded examples as a prompt section. Returns an empty string when there
- * are none so callers can inject it unconditionally.
- */
 export const formatReferenceExamples = (examples: LoadedVegaReferenceExample[]): string => {
   if (examples.length === 0) {
     return '';
@@ -211,4 +202,22 @@ REFERENCE EXAMPLES:
 Adapt the structural pattern(s) below to the request. Do NOT copy their data source, fields, or query — bind the columns listed above. They illustrate correct structure only.
 
 ${blocks}`;
+};
+
+export const buildReferenceExamplesBlock = async ({
+  nlQuery,
+  chartType,
+  model,
+  logger,
+}: {
+  nlQuery: string;
+  chartType?: SupportedChartType;
+  model: ScopedModel;
+  logger?: Logger;
+}): Promise<string> => {
+  const selected = await selectReferenceExamples({ nlQuery, chartType, model, logger });
+  if (selected.length === 0) {
+    return '';
+  }
+  return formatReferenceExamples(await loadReferenceExamples(selected));
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/layered_combo_dual_axis.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/layered_combo_dual_axis.ts
@@ -5,11 +5,6 @@
  * 2.0.
  */
 
-/**
- * Combination (dual-axis) chart: bars for one metric with an overlaid line for
- * another, on independent y-scales. Loaded on demand by the reference-example
- * catalog only when the request matches.
- */
 export const spec: Record<string, unknown> = {
   $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
   title: 'Daily Request Count with Average Latency',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/layered_combo_dual_axis.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/layered_combo_dual_axis.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Combination (dual-axis) chart: bars for one metric with an overlaid line for
+ * another, on independent y-scales. Loaded on demand by the reference-example
+ * catalog only when the request matches.
+ */
+export const spec: Record<string, unknown> = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  title: 'Daily Request Count with Average Latency',
+  autosize: { type: 'fit', contains: 'padding' },
+  data: {
+    url: {
+      '%type%': 'esql',
+      '%timefield%': '@timestamp',
+      query:
+        'FROM logs-* | WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend | STATS request_count = COUNT(*), avg_latency = AVG(latency_ms) BY day = BUCKET(@timestamp, 1 day) | SORT day ASC',
+    },
+  },
+  encoding: {
+    x: { field: 'day', type: 'temporal', title: null, axis: { labelAngle: 0 } },
+  },
+  layer: [
+    {
+      mark: { type: 'bar', opacity: 0.7 },
+      encoding: {
+        y: { field: 'request_count', type: 'quantitative', axis: { title: 'Requests' } },
+      },
+    },
+    {
+      mark: { type: 'line', strokeWidth: 2, point: true, color: '#e8843c' },
+      encoding: {
+        y: { field: 'avg_latency', type: 'quantitative', axis: { title: 'Avg Latency (ms)' } },
+      },
+    },
+  ],
+  resolve: { scale: { y: 'independent' } },
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/layered_combo_dual_axis.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/layered_combo_dual_axis.ts
@@ -33,7 +33,7 @@ export const spec: Record<string, unknown> = {
       },
     },
     {
-      mark: { type: 'line', strokeWidth: 2, point: true, color: '#e8843c' },
+      mark: { type: 'line', strokeWidth: 2, point: true },
       encoding: {
         y: { field: 'avg_latency', type: 'quantitative', axis: { title: 'Avg Latency (ms)' } },
       },

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/scatter_bubble.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/scatter_bubble.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Scatter / bubble plot: a `point` mark relating two measures per entity, with a
+ * third measure encoded as `size` and a category as `color`. Loaded on demand by
+ * the reference-example catalog only when the request matches.
+ */
+export const spec: Record<string, unknown> = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  title: 'Latency vs Throughput by Host (bubble = error count)',
+  autosize: { type: 'fit', contains: 'padding' },
+  data: {
+    url: {
+      '%type%': 'esql',
+      '%timefield%': '@timestamp',
+      query:
+        'FROM metrics-* | WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend | STATS avg_latency = AVG(latency_ms), throughput = COUNT(*), error_count = SUM(is_error) BY host.name | SORT throughput DESC | LIMIT 100',
+    },
+  },
+  mark: { type: 'point', filled: true, opacity: 0.7 },
+  encoding: {
+    x: {
+      field: 'avg_latency',
+      type: 'quantitative',
+      title: 'Avg Latency (ms)',
+      scale: { zero: false },
+    },
+    y: { field: 'throughput', type: 'quantitative', title: 'Throughput', scale: { zero: false } },
+    size: { field: 'error_count', type: 'quantitative', title: 'Errors' },
+    color: { field: 'host\\.name', type: 'nominal', title: 'Host' },
+    tooltip: [
+      { field: 'host\\.name', type: 'nominal', title: 'Host' },
+      { field: 'avg_latency', type: 'quantitative', title: 'Avg Latency', format: '.1f' },
+      { field: 'throughput', type: 'quantitative', title: 'Throughput' },
+      { field: 'error_count', type: 'quantitative', title: 'Errors' },
+    ],
+  },
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/scatter_bubble.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/scatter_bubble.ts
@@ -5,11 +5,6 @@
  * 2.0.
  */
 
-/**
- * Scatter / bubble plot: a `point` mark relating two measures per entity, with a
- * third measure encoded as `size` and a category as `color`. Loaded on demand by
- * the reference-example catalog only when the request matches.
- */
 export const spec: Record<string, unknown> = {
   $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
   title: 'Latency vs Throughput by Host (bubble = error count)',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/timeline_gantt.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/timeline_gantt.ts
@@ -5,12 +5,6 @@
  * 2.0.
  */
 
-/**
- * Timeline / Gantt: a `bar` mark drawn as a ranged bar via a temporal `x` (start)
- * and `x2` (end) against a nominal `y` (the item). Start/end columns come from the
- * ES|QL query (here `MIN`/`MAX` of the time field per item). Loaded on demand by
- * the reference-example catalog only when the request matches.
- */
 export const spec: Record<string, unknown> = {
   $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
   title: 'Pipeline Stage Timeline',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/timeline_gantt.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/timeline_gantt.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Timeline / Gantt: a `bar` mark drawn as a ranged bar via a temporal `x` (start)
+ * and `x2` (end) against a nominal `y` (the item). Start/end columns come from the
+ * ES|QL query (here `MIN`/`MAX` of the time field per item). Loaded on demand by
+ * the reference-example catalog only when the request matches.
+ */
+export const spec: Record<string, unknown> = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  title: 'Pipeline Stage Timeline',
+  autosize: { type: 'fit', contains: 'padding' },
+  data: {
+    url: {
+      '%type%': 'esql',
+      '%timefield%': '@timestamp',
+      query:
+        'FROM ci-pipelines-* | WHERE @timestamp >= ?_tstart AND @timestamp < ?_tend | STATS start_time = MIN(@timestamp), end_time = MAX(@timestamp) BY stage | SORT start_time ASC',
+    },
+  },
+  mark: { type: 'bar', cornerRadius: 2 },
+  encoding: {
+    y: { field: 'stage', type: 'nominal', sort: null, title: null },
+    x: {
+      field: 'start_time',
+      type: 'temporal',
+      title: 'Time',
+      axis: { labelAngle: 0, tickCount: 8 },
+    },
+    x2: { field: 'end_time' },
+    tooltip: [
+      { field: 'stage', type: 'nominal', title: 'Stage' },
+      { field: 'start_time', type: 'temporal', title: 'Start' },
+      { field: 'end_time', type: 'temporal', title: 'End' },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Incremental follow-ups to the Vega work landed in #275257, published one feature per commit so each is easy to review and revert. This PR will grow as the remaining Vega authoring-quality and feature improvements are cherry-picked in; the list below is updated per feature.

## Features

### 1. Theme-aware Vega colors

Kibana's Vega renderer already applies a theme-aware Elastic palette (categorical colors, default mark color, and axis/label/title colors that adapt to light/dark) — but only for values the spec omits, so any hardcoded color silently overrides the theme and breaks dark mode. This change rewrites the author prompt's `COLOR` guidance to defer all coloring to the theme: no hex values, no `config`/`mark` color blocks, and no categorical `scheme`/`range`/`domain` (a sequential `scheme` is still allowed for *quantitative* color, which has no themed default). The result is charts that render correctly in both light and dark mode without the model hand-authoring colors.

<details>
<summary>Example prompts to verify</summary>

Run in both light and dark theme; confirm the generated spec has no hardcoded colors and renders readably in dark mode.

**Multi-series (themed Elastic palette, no `scheme`/`range`):**
- Show average `system.cpu.total.pct` over time grouped by `host.name` as vega
- Vega line chart of daily request count per `service.name`

**Single series (no `color` encoding — theme supplies the default):**
- Vega bar chart of total `bytes` by `geo.dest`
- Vega line of average response time over time

**Quantitative color (sequential `scheme` allowed here):**
- Vega heatmap of request count by hour of day and `host.name`, color by count
- Vega scatter of latency vs throughput per host, color by error count

**Dark-mode regression (the bug this fixes):**
- Generate any of the above, switch Kibana to dark mode (or Save to dashboard on a dark dashboard), and confirm axis/label/mark colors adapt and stay readable.

What to check in each spec: no `config` color settings, no `mark.color`, no hex values, and no `scheme`/`range`/`domain` on a categorical `color` encoding.
</details>

### 2. Axis-readability guidance

Reconciles the Vega author prompt with the public kibana-vega skill so axes stay legible by default: set `axis.labelLimit` so long category labels stop truncating, use `labelAngle: 0` + `tickCount` on temporal axes (letting Vega auto-format dates instead of rotating/hand-formatting them), and set `title: null` on an axis when the chart title already conveys its meaning. This is prompt-only guidance; the deterministic `autosize: fit` handling in `normalize_spec` is unchanged.

<details>
<summary>Example prompts to verify</summary>

**Long category labels (should get `labelLimit`, no truncation):**
- Vega horizontal bar chart of request count by `url.original` (long URLs)
- Vega bar chart of average bytes by `user_agent.original`

**Temporal axis (should use `labelAngle: 0` + `tickCount`, auto-formatted dates, no rotated labels):**
- Vega line of average response time over time
- Vega area chart of request count over time

**Redundant axis title (should set `title: null` when the chart title says it):**
- Vega chart titled "Requests per day" — the time axis should not repeat "day"/"timestamp"

What to check in each spec: long-label axes carry `"labelLimit"`, temporal axes use `"labelAngle": 0` (not rotated) with a `"tickCount"`, and axes drop redundant titles via `"title": null`.
</details>

### 3. Rename dotted ES|QL fields for Vega

Vega reads a dot in a field name as a nested-object path, but ES|QL result columns are flat, so a column named `host.name` is misread and renders as `undefined`. This extends the Vega-only ES|QL guidance (`vegaEsqlAdditionalInstructions`, already threaded through `generateVisualizationEsql`) to `RENAME` dotted columns to dotless aliases at the source (e.g. `RENAME host.name AS host`), fixing the problem before it reaches the spec. The time field is explicitly excluded so time-range filtering keeps referencing the raw source field, `field_escaping` stays as the deterministic fallback for provided/recovered queries, and **Lens is intentionally unaffected** — it maps ES|QL columns natively and renaming would strip the field-format/type metadata Lens relies on.

<details>
<summary>Example prompts to verify</summary>

Generate, then inspect the ES|QL query (recovered from the spec / shown in the tool call) and the Vega spec.

**Dotted dimension fields (query should `RENAME ... AS <dotless>`, spec references the alias, chart renders — not "undefined"):**
- Vega bar chart of count by `host.name`
- Vega bar chart of total bytes by `geo.dest`
- Vega line of average `system.cpu.total.pct` over time by `service.name`

**Time field must stay raw (regression guard):**
- Any time-based prompt above — confirm the `WHERE`/`BUCKET` still filter on the raw `@timestamp` (the time field is NOT renamed), so the time picker still drives the chart.

What to check: dotted dimension columns are aliased via `RENAME` and the chart renders real values; the time field keeps its original name in `WHERE`/`BUCKET`.
</details>

### 4. Reference-example catalog for Vega authoring

Adds a curated, in-repo catalog of guideline-compliant Vega-Lite example specs and injects the one or two whose keywords match the request into the authoring prompt. It targets the non-trivial shapes the model most often gets structurally wrong — **dual-axis combo, faceted small multiples, scatter/bubble, heatmap**, plus **timeline/Gantt** (ranged `x`/`x2` bars) and a **calendar heatmap** (week × weekday grid). Spec bodies are *referenced content*, dynamically imported only for matched examples, so an unmatched example never loads and a plain single-series chart (which routes to Lens) gets no example — keeping the prompt bounded. Every example is theme-aware (no hardcoded colors), auto-sizes, escapes/aliases dotted fields, and filters time on the raw source field.

Scope note: chart shapes Vega-Lite cannot express — **Sankey, radar/spider, sunburst** — are intentionally out of scope here; they require raw-Vega support, tracked as a separate follow-up.

<details>
<summary>Example prompts to verify</summary>

Ask for each; confirm the generated spec follows the matching pattern (structure only — the data/fields should come from the request, not be copied from the example).

- Vega combination chart: bars of daily request count with an overlaid line of average response time (dual axis) → `resolve.scale.y = "independent"`
- Vega small multiples of p95 latency over time, one panel per `service.name` → top-level `facet` + `columns` sibling, per-cell `width`/`height`
- Vega scatter of latency vs throughput per host, bubble size by error count → `point` mark, `size` encoding, `scale.zero = false`
- Vega heatmap of request count by hour and day → `rect` mark, sequential `scheme`
- Vega gantt/timeline of deployment stage durations → `bar` with temporal `x`/`x2`, nominal `y`
- Vega calendar heatmap of logins by week and weekday → `rect` grid, weekday sorted Mon→Sun

Negative check: "top 10 services by error count as a bar chart" should inject **no** REFERENCE EXAMPLES block (plain chart → Lens).
</details>

## Test plan

- [ ] Jest green for the touched Vega packages: `node scripts/jest x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega`
- [ ] Manual: prompts below render correctly in light **and** dark mode, with readable axes, no hardcoded colors, and no `undefined` from dotted fields.

<details>
<summary>Manual test prompts (Agent Builder chat → inspect generated Vega spec / Save to dashboard → Edit)</summary>

Ask the agent for each chart, then open the generated Vega spec and check the noted properties. Because this is prompt guidance the model won't be 100% consistent — spot-check a few of each.

**Theme-aware colors** — no `config`/`mark` color, no hex, no categorical `scheme`/`range`/`domain`; verify dark mode:
- Show average `system.cpu.total.pct` over time grouped by `host.name` as vega
- Vega line chart of daily request count per `service.name`
- Vega bar chart of total `bytes` by `geo.dest` (single series → no `color`)
- Vega heatmap of request count by hour of day and `host.name`, color by count (quantitative `scheme` OK)
- Regenerate any of the above and switch Kibana to dark mode → colors must adapt and stay readable.

**Axis readability** — `labelLimit` on long labels, `labelAngle: 0` + `tickCount` on time axes, `title: null` when redundant:
- Vega horizontal bar chart of request count by `url.original` (long URLs) → `"labelLimit"`, no truncation
- Vega bar chart of average bytes by `user_agent.original` → `"labelLimit"`
- Vega line of average response time over time → `"labelAngle": 0` + `"tickCount"`, auto-formatted dates
- Vega area chart of request count over time → temporal axis not rotated
- Vega chart titled "Requests per day" of daily request count → time axis `"title": null`

**Dotted field rename** — query aliases dotted columns; chart shows real values, not `undefined`; time field stays raw:
- Vega bar chart of count by `host.name` → query has `RENAME host.name AS host`
- Vega bar chart of total bytes by `geo.dest` → `RENAME geo.dest AS destination` (or similar)
- Vega line of average `system.cpu.total.pct` over time by `service.name` → `service.name` aliased, `@timestamp` NOT renamed

**Reference examples** — matched requests inject a structural example; plain charts inject none:
- Vega combination bars + overlaid line, dual axis → combo example structure
- Vega small multiples, one panel per service → faceted example structure
- Vega scatter of latency vs throughput, bubble size by errors → scatter/bubble structure
- Vega gantt/timeline of stage durations → ranged `x`/`x2` bars
- Vega calendar heatmap by week and weekday → week × weekday rect grid
- "top 10 services by error count as a bar chart" → NO reference-examples block (routes to Lens)
</details>