### PR TITLE
[APM] Prevent crashes on missing/invalid route query params

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_dependencies_to_dependencies_inventory.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_dependencies_to_dependencies_inventory.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { RedirectDependenciesToDependenciesInventory } from './redirect_dependencies_to_dependencies_inventory';
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-test-subj="location">{location.pathname + location.search}</div>;
+}
+
+function renderAt(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <RedirectDependenciesToDependenciesInventory>
+        <div>child content</div>
+      </RedirectDependenciesToDependenciesInventory>
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+describe('RedirectDependenciesToDependenciesInventory', () => {
+  it.each([
+    '/dependencies',
+    '/dependencies/overview',
+    '/dependencies/operations',
+    '/dependencies/operation',
+  ])('redirects %s to the dependencies inventory when dependencyName is missing', (pathname) => {
+    renderAt(`${pathname}?comparisonEnabled=true&rangeFrom=now-15m&rangeTo=now`);
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/dependencies/inventory');
+    // the existing query params are preserved through the redirect
+    expect(screen.getByTestId('location')).toHaveTextContent('comparisonEnabled=true');
+    expect(screen.getByTestId('location')).toHaveTextContent('rangeFrom=now-15m');
+  });
+
+  it('does not redirect a dependencies detail route when dependencyName is present', () => {
+    renderAt('/dependencies/overview?dependencyName=postgres&comparisonEnabled=true');
+
+    expect(screen.getByText('child content')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/dependencies/overview');
+  });
+
+  it('does not redirect the dependencies inventory itself', () => {
+    renderAt('/dependencies/inventory?comparisonEnabled=true');
+
+    expect(screen.getByText('child content')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/dependencies/inventory');
+  });
+
+  it('does not redirect unrelated routes without dependencyName', () => {
+    renderAt('/services?comparisonEnabled=true');
+
+    expect(screen.getByText('child content')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/services');
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_dependencies_to_dependencies_inventory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_dependencies_to_dependencies_inventory.tsx
@@ -19,11 +19,20 @@ export function RedirectDependenciesToDependenciesInventory({
   const query = qs.parse(location.search);
 
   const normalizedPathname = location.pathname.replace(/\/$/, '');
-  if (normalizedPathname === '/dependencies' && !('dependencyName' in query)) {
+
+  // `/dependencies/*` detail routes require `dependencyName` (inherited from the
+  // `/dependencies` parent); without it they crash on params validation, so fall
+  // back to the inventory. The inventory itself does not require it.
+  const isDependencyDetailRoute =
+    normalizedPathname === '/dependencies' ||
+    (normalizedPathname.startsWith('/dependencies/') &&
+      normalizedPathname !== '/dependencies/inventory');
+
+  if (isDependencyDetailRoute && !('dependencyName' in query)) {
     return (
       <Redirect
         to={qs.stringifyUrl({
-          url: location.pathname + '/inventory',
+          url: '/dependencies/inventory',
           query,
         })}
       />

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_dependencies_to_dependencies_inventory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_dependencies_to_dependencies_inventory.tsx
@@ -28,7 +28,7 @@ export function RedirectDependenciesToDependenciesInventory({
     (normalizedPathname.startsWith('/dependencies/') &&
       normalizedPathname !== '/dependencies/inventory');
 
-  if (isDependencyDetailRoute && !('dependencyName' in query)) {
+  if (isDependencyDetailRoute && typeof query?.dependencyName !== 'string') {
     return (
       <Redirect
         to={qs.stringifyUrl({

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_offset/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_offset/index.test.tsx
@@ -89,6 +89,28 @@ describe('RedirectWithOffset', () => {
     expect(query.comparisonEnabled).toBe('false');
   });
 
+  it('redirects with a valid comparisonEnabled when the url value is a bare key', async () => {
+    // A bare `?comparisonEnabled` key parses to null, which is not a valid boolean.
+    renderUrl({ pathname: '/services', search: 'comparisonEnabled', hash: '' }, true);
+
+    const query = qs.parse(history.entries[0].search);
+    expect(query.comparisonEnabled).toBe('true');
+  });
+
+  it('redirects with the default comparisonEnabled when the url value is invalid', async () => {
+    renderUrl(
+      {
+        pathname: '/services',
+        search: qs.stringify({ comparisonEnabled: 'maybe' }),
+        hash: '',
+      },
+      false
+    );
+
+    const query = qs.parse(history.entries[0].search);
+    expect(query.comparisonEnabled).toBe('false');
+  });
+
   it('redirects with offset=1d when comparisonType=day is set in the query params', () => {
     renderUrl(
       {

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_offset/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_offset/index.tsx
@@ -24,14 +24,19 @@ export function RedirectWithOffset({ children }: { children: React.ReactElement 
   const matchesRoute = isRouteWithComparison({ apmRouter, location });
   const query = qs.parse(location.search);
 
-  // Redirect when 'comparisonType' is set as we now use offset instead
-  // or when 'comparisonEnabled' is not set as it's now required
-  if (matchesRoute && ('comparisonType' in query || !('comparisonEnabled' in query))) {
+  // 'comparisonEnabled' is a required boolean; it's invalid when absent or not
+  // 'true'/'false' (e.g. a bare `?comparisonEnabled` key parses as null).
+  const isComparisonEnabledValid =
+    query.comparisonEnabled === 'true' || query.comparisonEnabled === 'false';
+
+  // Redirect to use offset instead of 'comparisonType', or to set a valid 'comparisonEnabled'.
+  if (matchesRoute && ('comparisonType' in query || !isComparisonEnabledValid)) {
     const { comparisonType, comparisonEnabled: urlComparisonEnabled, ...queryRest } = query;
 
     const comparisonEnabled = getComparisonEnabled({
       core,
-      urlComparisonEnabled: urlComparisonEnabled
+      // Only honor a valid URL value; otherwise use the advanced setting default.
+      urlComparisonEnabled: isComparisonEnabledValid
         ? toBoolean(urlComparisonEnabled as string)
         : undefined,
     }).toString();

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/is_route_with_time_range.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/is_route_with_time_range.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Location } from 'history';
+import { apmRouter } from '../routing/apm_route_config';
+import { isRouteWithComparison, isRouteWithTimeRange } from './is_route_with_time_range';
+
+const createLocation = (pathname: string): Location =>
+  ({ pathname, search: '', hash: '', state: undefined, key: '' } as Location);
+
+describe('isRouteWithTimeRange', () => {
+  it.each([
+    '/services',
+    '/traces',
+    '/service-map',
+    '/dependencies',
+    '/dependencies/inventory',
+    '/storage-explorer',
+    '/service-groups',
+    '/diagnostics',
+    '/services/opbeans-java',
+    '/mobile-services/opbeans-android',
+  ])('returns true for the time-range route %s', (pathname) => {
+    expect(isRouteWithTimeRange({ apmRouter, location: createLocation(pathname) })).toBe(true);
+  });
+
+  // Legacy `/backends*` routes redirect to `/dependencies*` but still require a
+  // time range because they render under the home route. Because the check is
+  // derived from the route params codec, they are covered automatically. See #1318.
+  it.each([
+    '/backends',
+    '/backends/inventory',
+    '/backends/operations',
+    '/backends/operation',
+    '/backends/overview',
+    '/backends/some-dependency/overview',
+  ])('returns true for the legacy backends route %s', (pathname) => {
+    expect(isRouteWithTimeRange({ apmRouter, location: createLocation(pathname) })).toBe(true);
+  });
+
+  it('returns true for the root pathname', () => {
+    expect(isRouteWithTimeRange({ apmRouter, location: createLocation('/') })).toBe(true);
+  });
+
+  it('returns false for a settings route that does not require a time range', () => {
+    expect(
+      isRouteWithTimeRange({ apmRouter, location: createLocation('/settings/agent-configuration') })
+    ).toBe(false);
+  });
+});
+
+describe('isRouteWithComparison', () => {
+  it.each([
+    '/services',
+    '/service-map',
+    '/dependencies',
+    '/dependencies/inventory',
+    '/services/opbeans-java',
+    '/mobile-services/opbeans-android',
+    '/service-groups',
+    '/backends/inventory',
+  ])('returns true for the comparison-aware route %s', (pathname) => {
+    expect(isRouteWithComparison({ apmRouter, location: createLocation(pathname) })).toBe(true);
+  });
+
+  it('returns false for a route that does not require comparisonEnabled', () => {
+    expect(
+      isRouteWithComparison({
+        apmRouter,
+        location: createLocation('/settings/agent-configuration'),
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for diagnostics which does not declare comparisonEnabled', () => {
+    expect(isRouteWithComparison({ apmRouter, location: createLocation('/diagnostics') })).toBe(
+      false
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/is_route_with_time_range.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/is_route_with_time_range.ts
@@ -5,7 +5,98 @@
  * 2.0.
  */
 import type { Location } from 'history';
+import type * as t from 'io-ts';
 import type { ApmRouter } from '../routing/apm_route_config';
+
+// Structural view over the io-ts codecs we introspect (all codecs carry `_tag`).
+interface TaggedCodec {
+  _tag?: string;
+  props?: t.Props;
+  types?: t.Mixed[];
+  type?: t.Mixed;
+}
+
+// Collects the keys a codec declares as required (`t.partial`/unions are ignored).
+function collectRequiredKeys(codec: t.Mixed, keys: Set<string>): void {
+  const tagged = codec as TaggedCodec;
+  switch (tagged._tag) {
+    case 'InterfaceType':
+      Object.keys(tagged.props ?? {}).forEach((key) => keys.add(key));
+      break;
+    case 'IntersectionType':
+      (tagged.types ?? []).forEach((member) => collectRequiredKeys(member, keys));
+      break;
+    case 'ExactType':
+    case 'RefinementType':
+      if (tagged.type) {
+        collectRequiredKeys(tagged.type, keys);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+// Finds the codecs assigned to `query` in a required position (`t.partial` query
+// is optional and ignored).
+function collectRequiredQueryCodecs(codec: t.Mixed, out: t.Mixed[]): void {
+  const tagged = codec as TaggedCodec;
+  switch (tagged._tag) {
+    case 'InterfaceType':
+      if (tagged.props && 'query' in tagged.props) {
+        out.push(tagged.props.query);
+      }
+      break;
+    case 'IntersectionType':
+      (tagged.types ?? []).forEach((member) => collectRequiredQueryCodecs(member, out));
+      break;
+    case 'ExactType':
+    case 'RefinementType':
+      if (tagged.type) {
+        collectRequiredQueryCodecs(tagged.type, out);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+interface RouteWithParams {
+  params?: t.Mixed;
+}
+
+// Derives the query params required by any route matching the current location,
+// so redirect guards cover every such route without a hardcoded allowlist.
+function getRequiredQueryKeys({
+  apmRouter,
+  location,
+}: {
+  apmRouter: ApmRouter;
+  location: Location;
+}): Set<string> {
+  const keys = new Set<string>();
+
+  let matchingRoutes: RouteWithParams[];
+  try {
+    matchingRoutes = apmRouter.getRoutesToMatch(
+      location.pathname || '/'
+    ) as unknown as RouteWithParams[];
+  } catch {
+    // No matching route: nothing to guard.
+    return keys;
+  }
+
+  for (const route of matchingRoutes) {
+    if (!route.params) {
+      continue;
+    }
+    const queryCodecs: t.Mixed[] = [];
+    collectRequiredQueryCodecs(route.params, queryCodecs);
+    queryCodecs.forEach((queryCodec) => collectRequiredKeys(queryCodec, keys));
+  }
+
+  return keys;
+}
 
 export function isRouteWithTimeRange({
   apmRouter,
@@ -14,25 +105,8 @@ export function isRouteWithTimeRange({
   apmRouter: ApmRouter;
   location: Location;
 }) {
-  const matchingRoutes = apmRouter.getRoutesToMatch(location.pathname);
-  const matchesRoute = matchingRoutes.some((route) => {
-    return (
-      route.path === '/diagnostics' ||
-      route.path === '/services' ||
-      route.path === '/traces' ||
-      route.path === '/service-map' ||
-      route.path === '/dependencies' ||
-      route.path === '/dependencies/inventory' ||
-      route.path === '/services/{serviceName}' ||
-      route.path === '/mobile-services/{serviceName}' ||
-      route.path === '/service-groups' ||
-      route.path === '/storage-explorer' ||
-      location.pathname === '/' ||
-      location.pathname === ''
-    );
-  });
-
-  return matchesRoute;
+  const requiredKeys = getRequiredQueryKeys({ apmRouter, location });
+  return requiredKeys.has('rangeFrom') && requiredKeys.has('rangeTo');
 }
 
 export function isRouteWithComparison({
@@ -42,20 +116,6 @@ export function isRouteWithComparison({
   apmRouter: ApmRouter;
   location: Location;
 }) {
-  const matchingRoutes = apmRouter.getRoutesToMatch(location.pathname);
-  const matchesRoute = matchingRoutes.some((route) => {
-    return (
-      route.path === '/services' ||
-      route.path === '/service-map' ||
-      route.path === '/dependencies' ||
-      route.path === '/dependencies/inventory' ||
-      route.path === '/services/{serviceName}' ||
-      route.path === '/mobile-services/{serviceName}' ||
-      route.path === '/service-groups' ||
-      location.pathname === '/' ||
-      location.pathname === ''
-    );
-  });
-
-  return matchesRoute;
+  const requiredKeys = getRequiredQueryKeys({ apmRouter, location });
+  return requiredKeys.has('comparisonEnabled');
 }


### PR DESCRIPTION
## Summary

Fixes several React error-boundary crashes in the APM app caused by `InvalidRouteParamsException` when route query params are missing or malformed (e.g. `Invalid value undefined supplied to ... rangeFrom: string`). These surface as fatal error screens when a user opens/reloads a URL that lacks or corrupts required query params (old bookmarks, hand-edited URLs).

### What changed

- **Codec-driven redirect guards** (`is_route_with_time_range.ts`): `isRouteWithTimeRange` and `isRouteWithComparison` now derive which query params a route actually requires by inspecting each matched route's io-ts params codec, instead of a hardcoded route allowlist. This makes the `RedirectWithDefaultDateRange` (`rangeFrom`/`rangeTo`) and `RedirectWithOffset` (`comparisonEnabled`) guards cover **every** route that requires those params — including the legacy `/backends/*` routes and `/traces` / `/storage-explorer`, which the allowlists were missing — and stays correct automatically as routes change.
- **`dependencyName` on dependency detail routes**: `RedirectDependenciesToDependenciesInventory` now redirects all `/dependencies/*` detail routes (`overview`, `operations`, `operation`) — not just `/dependencies` — to the dependencies inventory when `dependencyName` is absent, instead of crashing on params validation.
- **Invalid `comparisonEnabled`**: `RedirectWithOffset` now treats a *present-but-invalid* `comparisonEnabled` (e.g. a bare `?comparisonEnabled` key that `query-string` parses as `null`) the same as a missing one, redirecting to a valid boolean rather than letting it reach a fatal error.

### Context

The `null`-valued query-param variant of this error (bare keys such as `?kuery&serviceGroup`) was already addressed for the routes with defaults by the router self-healing mechanism (#257245) and its APM wiring (#272304, in 8.19.17+). This PR closes the remaining gaps for required params that have **no** static default (`rangeFrom`/`rangeTo`, `comparisonEnabled`, `dependencyName`) and for routes that the previous allowlists didn't cover.

### Testing

- New `is_route_with_time_range.test.ts` — codec-driven time-range/comparison detection across routes incl. legacy `/backends/*`, with negative cases.
- New `redirect_dependencies_to_dependencies_inventory.test.tsx` — dependency detail routes redirect to inventory when `dependencyName` is missing; no redirect when present / on inventory / on unrelated routes.
- Extended `redirect_with_offset` tests — bare and invalid `comparisonEnabled` redirect to a valid boolean.
- ESLint clean; APM type check green.

## References

Closes elastic/observability-error-backlog#1318

### Checklist

- [x] Unit tests were updated or added to match the most common scenarios

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->