### PR TITLE
[Defend Workflows] Temporarily Pin endpoint test agent to 9.4.3 unskip tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
@@ -19,8 +19,7 @@ import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
 import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 
-// Failing: See https://github.com/elastic/kibana/issues/207773
-describe.skip(
+describe(
   'Automated Response Actions',
   {
     tags: ['@ess', '@serverless'],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_list/endpoints.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_list/endpoints.cy.ts
@@ -28,8 +28,7 @@ import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
 import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 
-// Failing: See https://github.com/elastic/kibana/issues/218441
-describe.skip('Endpoints page', { tags: ['@ess', '@serverless'] }, () => {
+describe('Endpoints page', { tags: ['@ess', '@serverless'] }, () => {
   let indexedPolicy: IndexedFleetEndpointPolicyResponse;
   let policy: PolicyData;
   let createdHost: CreateAndEnrollEndpointHostResponse;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/file_operations.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/file_operations.cy.ts
@@ -21,14 +21,12 @@ import { enableAllPolicyProtections } from '../../../tasks/endpoint_policy';
 import { createEndpointHost } from '../../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../../tasks/delete_all_endpoint_data';
 
-// Failing: See https://github.com/elastic/kibana/issues/209065
-describe.skip('Response console', { tags: ['@ess', '@serverless'] }, () => {
+describe('Response console', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     login();
   });
 
-  // Failing: See https://github.com/elastic/kibana/issues/276337
-  describe.skip('File operations:', () => {
+  describe('File operations:', () => {
     const homeFilePath = Cypress.env('IS_CI') ? '/home/vagrant' : '/home/ubuntu';
 
     const fileContent = 'This is a test file for the get-file command.';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/support/create_and_enroll_endpoint_host_ci.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/support/create_and_enroll_endpoint_host_ci.ts
@@ -13,6 +13,7 @@ import { kibanaPackageJson } from '@kbn/repo-info';
 import { isServerlessKibanaFlavor } from '../../../../common/endpoint/utils/kibana_status';
 import { fetchFleetLatestAvailableAgentVersion } from '../../../../common/endpoint/utils/fetch_fleet_version';
 import { isFleetServerRunning } from '../../../../scripts/endpoint/common/fleet_server/fleet_server_services';
+import { PINNED_AGENT_VERSION } from '../../../../scripts/endpoint/common/endpoint_host_services';
 import type { HostVm } from '../../../../scripts/endpoint/common/types';
 import type { BaseVmCreateOptions } from '../../../../scripts/endpoint/common/vm_services';
 import { createVm } from '../../../../scripts/endpoint/common/vm_services';
@@ -76,6 +77,10 @@ export const createAndEnrollEndpointHostCI = async ({
     const isServerless = await isServerlessKibanaFlavor(kbnClient);
     if (isServerless) {
       agentVersion = await fetchFleetLatestAvailableAgentVersion(kbnClient);
+    } else {
+      // Temporary: pin the stateful/ESS agent to a version unaffected by the broken Linux
+      // ransomware global artifact (see PINNED_AGENT_VERSION). Remove once fixed upstream.
+      agentVersion = PINNED_AGENT_VERSION;
     }
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/endpoint_host_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/endpoint_host_services.ts
@@ -45,6 +45,20 @@ export interface CreateAndEnrollEndpointHostResponse {
 /**
  * Creates a new virtual machine (host) and enrolls that with Fleet
  */
+/**
+ * Temporary pin for the Elastic Agent version used by real-endpoint tests (Cypress + CLI runner).
+ *
+ * The stack (`9.5.0-SNAPSHOT`) Elastic Defend build fails to load the Linux `production-ransomware-v1`
+ * global artifact shipped in the current daily manifest (`ransom-protect` v0.0.3), and treats that
+ * single bad artifact as fatal to the entire global manifest — leaving the endpoint with no
+ * protections configured and the agent permanently `DEGRADED`, so policy status never reaches
+ * "Success". `9.4.3` tolerates the same bad artifact (applies the rest), so it enrolls healthy.
+ *
+ * Remove this pin (let the version fall back to the stack version) once the upstream ransomware
+ * artifact is fixed/rolled back. See https://github.com/elastic/kibana/issues/218441
+ */
+export const PINNED_AGENT_VERSION = '9.4.3';
+
 export const createAndEnrollEndpointHost = async ({
   kbnClient,
   log: _log,
@@ -65,6 +79,10 @@ export const createAndEnrollEndpointHost = async ({
     const isServerless = await isServerlessKibanaFlavor(kbnClient);
     if (isServerless) {
       agentVersion = await fetchFleetLatestAvailableAgentVersion(kbnClient);
+    } else {
+      // Temporary: pin the stateful/ESS agent to a version unaffected by the broken Linux
+      // ransomware global artifact (see PINNED_AGENT_VERSION). Remove once fixed upstream.
+      agentVersion = PINNED_AGENT_VERSION;
     }
   }
   const activeSpaceId = (await fetchActiveSpace(kbnClient)).id;


### PR DESCRIPTION
## Summary

Real-endpoint Defend Workflows Cypress suites have been failing on `main` (agent enrolls but goes **unhealthy/`DEGRADED`**, policy status never reaches "Success"), which led to several suites being skipped.

Root cause is **upstream, not in Kibana**: the current daily global-artifacts manifest ships a Linux `production-ransomware-v1` artifact (`ransom-protect` v0.0.3) whose Lua script the stack (`9.5.0-SNAPSHOT`) Elastic Defend build **fails to load** (`LuaLib: Failed to load script` → `Unable to load ransomware script`). Defend then treats that single bad artifact as **fatal to the entire global manifest** ("No global artifacts available"), so **every protection is left unconfigured** and the agent is permanently `DEGRADED`.

Verified on a live env that a **`9.4.3`** agent tolerates the same bad artifact (applies the rest of the manifest) and enrolls **healthy** — so this pins the test agent to `9.4.3` as a temporary mitigation and unskips the suites that were disabled for this.

Tracking / upstream fix: elastic/kibana#218441 (upstream rollback/fix of the `ransom-protect` Linux ransomware artifact is owned by the Protections team).

## Changes

- **Pin agent version to `9.4.3`** for real-endpoint tests, in both host-enroll paths (single shared `PINNED_AGENT_VERSION` constant):
  - `scripts/endpoint/common/endpoint_host_services.ts` (local / multipass)
  - `public/management/cypress/support/create_and_enroll_endpoint_host_ci.ts` (CI / vagrant)
  - Applied only in the non-serverless branch (serverless already resolves the latest available agent), and only when `forceVersion` is not set — the explicit-version escape hatch is preserved.
- **Unskip** the suites that were skipped due to this failure:
  - `automated_response_actions.cy.ts` (#207773)
  - `response_console/file_operations.cy.ts` — `Response console` (#209065) and `File operations:` (#276337)

## Notes / follow-ups

- This is a **temporary mitigation**, not a fix. The pin and both call sites reference #218441 and should be removed once the upstream ransomware artifact is fixed/rolled back and the stack agent enrolls healthy again.
- Customer impact of the underlying artifact is limited (the Linux ransomware feature is diagnostic + agents fall back to the last-known-good artifacts); the sharp edge is fresh enrollments with no fallback, which is exactly what CI does.

## How to test

Run the Defend Workflows endpoint Cypress suites (ESS) and confirm the enrolled agent reaches a healthy state and the unskipped suites pass.
