### PR TITLE
[ResponseOps][PerAlertSnooze] Add more severity values to snooze alert API and UI

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -6605,12 +6605,15 @@ paths:
                               - severity_equals
                             type: string
                           value:
-                            description: 'The target severity level: critical, high, medium, low, or info.'
+                            description: 'The target severity level: critical, major, high, medium, minor, low, warning, or info.'
                             enum:
                               - critical
+                              - major
                               - high
                               - medium
+                              - minor
                               - low
+                              - warning
                               - info
                             type: string
                         required:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -7041,12 +7041,15 @@ paths:
                               - severity_equals
                             type: string
                           value:
-                            description: 'The target severity level: critical, high, medium, low, or info.'
+                            description: 'The target severity level: critical, major, high, medium, minor, low, warning, or info.'
                             enum:
                               - critical
+                              - major
                               - high
                               - medium
+                              - minor
                               - low
+                              - warning
                               - info
                             type: string
                         required:

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/built_in_data_conditions.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/built_in_data_conditions.tsx
@@ -7,13 +7,7 @@
 
 import React from 'react';
 import { EuiBadge, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiSelect } from '@elastic/eui';
-import {
-  ALERT_SEVERITY_CRITICAL,
-  ALERT_SEVERITY_HIGH,
-  ALERT_SEVERITY_MEDIUM,
-  ALERT_SEVERITY_LOW,
-  ALERT_SEVERITY_INFO,
-} from '@kbn/rule-data-utils';
+import { ALERT_SEVERITY_VALUES } from '@kbn/rule-data-utils';
 import {
   DataConditionType,
   type AlertSeverityLevel,
@@ -25,29 +19,28 @@ import * as i18n from './translations';
 // Per-severity i18n labels and badge colors.
 const SEVERITY_LABELS: Record<AlertSeverityLevel, string> = {
   critical: i18n.SEVERITY_CRITICAL,
+  major: i18n.SEVERITY_MAJOR,
   high: i18n.SEVERITY_HIGH,
   medium: i18n.SEVERITY_MEDIUM,
+  minor: i18n.SEVERITY_MINOR,
   low: i18n.SEVERITY_LOW,
+  warning: i18n.SEVERITY_WARNING,
   info: i18n.SEVERITY_INFO,
 };
 
 // Mapped to EUI badge color tokens.
 const SEVERITY_COLORS: Record<AlertSeverityLevel, string> = {
   critical: 'danger',
+  major: 'danger',
   high: 'warning',
   medium: 'success',
+  minor: 'success',
   low: 'primary',
+  warning: 'default',
   info: 'default',
 };
 
-const SEVERITY_DROPDOWN_VALUES: readonly AlertSeverityLevel[] = [
-  ALERT_SEVERITY_CRITICAL,
-  ALERT_SEVERITY_HIGH,
-  ALERT_SEVERITY_MEDIUM,
-  ALERT_SEVERITY_LOW,
-  ALERT_SEVERITY_INFO,
-];
-const SEVERITY_OPTIONS = SEVERITY_DROPDOWN_VALUES.map((value) => ({
+const SEVERITY_OPTIONS = ALERT_SEVERITY_VALUES.map((value) => ({
   value,
   text: SEVERITY_LABELS[value],
 }));

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.test.tsx
@@ -10,9 +10,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import {
   ALERT_SEVERITY_CRITICAL,
+  ALERT_SEVERITY_MAJOR,
   ALERT_SEVERITY_HIGH,
   ALERT_SEVERITY_MEDIUM,
+  ALERT_SEVERITY_MINOR,
   ALERT_SEVERITY_LOW,
+  ALERT_SEVERITY_WARNING,
   ALERT_SEVERITY_INFO,
 } from '@kbn/rule-data-utils';
 import { EuiFieldText } from '@elastic/eui';
@@ -315,7 +318,7 @@ describe('DataConditionPanel', () => {
   });
 
   describe('severity_equals dropdown', () => {
-    it('lists only the five primary severity levels in highest → lowest order', () => {
+    it('lists the full severity superset in highest → lowest order', () => {
       render(
         <DataConditionPanel
           entry={createEntry({ type: DataConditionType.SEVERITY_EQUALS, value: undefined })}
@@ -332,9 +335,12 @@ describe('DataConditionPanel', () => {
 
       expect(offered).toEqual([
         ALERT_SEVERITY_CRITICAL,
+        ALERT_SEVERITY_MAJOR,
         ALERT_SEVERITY_HIGH,
         ALERT_SEVERITY_MEDIUM,
+        ALERT_SEVERITY_MINOR,
         ALERT_SEVERITY_LOW,
+        ALERT_SEVERITY_WARNING,
         ALERT_SEVERITY_INFO,
       ]);
     });

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/translations.ts
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/translations.ts
@@ -188,6 +188,10 @@ export const SEVERITY_CRITICAL = i18n.translate(
   'responseOpsAlertSnooze.conditionalSnoozePanel.severityCritical',
   { defaultMessage: 'Critical' }
 );
+export const SEVERITY_MAJOR = i18n.translate(
+  'responseOpsAlertSnooze.conditionalSnoozePanel.severityMajor',
+  { defaultMessage: 'Major' }
+);
 export const SEVERITY_HIGH = i18n.translate(
   'responseOpsAlertSnooze.conditionalSnoozePanel.severityHigh',
   { defaultMessage: 'High' }
@@ -196,9 +200,17 @@ export const SEVERITY_MEDIUM = i18n.translate(
   'responseOpsAlertSnooze.conditionalSnoozePanel.severityMedium',
   { defaultMessage: 'Medium' }
 );
+export const SEVERITY_MINOR = i18n.translate(
+  'responseOpsAlertSnooze.conditionalSnoozePanel.severityMinor',
+  { defaultMessage: 'Minor' }
+);
 export const SEVERITY_LOW = i18n.translate(
   'responseOpsAlertSnooze.conditionalSnoozePanel.severityLow',
   { defaultMessage: 'Low' }
+);
+export const SEVERITY_WARNING = i18n.translate(
+  'responseOpsAlertSnooze.conditionalSnoozePanel.severityWarning',
+  { defaultMessage: 'Warning' }
 );
 export const SEVERITY_INFO = i18n.translate(
   'responseOpsAlertSnooze.conditionalSnoozePanel.severityInfo',

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/types.ts
@@ -7,13 +7,7 @@
 
 import type { Moment } from 'moment';
 import type { ReactNode } from 'react';
-import type {
-  ALERT_SEVERITY_CRITICAL,
-  ALERT_SEVERITY_HIGH,
-  ALERT_SEVERITY_MEDIUM,
-  ALERT_SEVERITY_LOW,
-  ALERT_SEVERITY_INFO,
-} from '@kbn/rule-data-utils';
+import type { AlertSeverity } from '@kbn/rule-data-utils';
 
 export type SnoozeUnit = 'm' | 'h' | 'd' | 'w' | 'M';
 export type QuickDurationId = 'indefinitely' | '1h' | '8h' | '24h' | 'custom';
@@ -27,12 +21,7 @@ export interface CustomDurationState {
   dateTime: Moment | null;
 }
 
-export type AlertSeverityLevel =
-  | typeof ALERT_SEVERITY_CRITICAL
-  | typeof ALERT_SEVERITY_HIGH
-  | typeof ALERT_SEVERITY_MEDIUM
-  | typeof ALERT_SEVERITY_LOW
-  | typeof ALERT_SEVERITY_INFO;
+export type AlertSeverityLevel = AlertSeverity;
 
 /**
  * Built-in data condition type identifiers.

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/snooze_alert/schemas/v1.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/snooze_alert/schemas/v1.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { ALERT_SEVERITY_VALUES } from '@kbn/rule-data-utils';
 import { snoozeAlertParamsSchema, snoozeAlertBodySchema } from './v1';
 import {
   MAX_ID_LENGTH,
@@ -129,5 +130,78 @@ describe('snoozeAlertBodySchema', () => {
         ],
       })
     ).not.toThrow();
+  });
+
+  test.each([...ALERT_SEVERITY_VALUES])('accepts severity_equals with value "%s"', (severity) => {
+    expect(() =>
+      snoozeAlertBodySchema.validate({
+        conditions: [{ type: 'severity_equals', value: severity }],
+      })
+    ).not.toThrow();
+  });
+
+  test('rejects severity_equals with an unknown severity value', () => {
+    expect(() =>
+      snoozeAlertBodySchema.validate({
+        conditions: [{ type: 'severity_equals', value: 'catastrophic' }],
+      })
+    ).toThrow();
+  });
+
+  test('rejects severity_equals without a value', () => {
+    expect(() =>
+      snoozeAlertBodySchema.validate({
+        conditions: [{ type: 'severity_equals' }],
+      })
+    ).toThrow();
+  });
+
+  test('rejects a condition with an unknown type', () => {
+    expect(() =>
+      snoozeAlertBodySchema.validate({
+        conditions: [{ type: 'unknown_type' }],
+      })
+    ).toThrow();
+  });
+
+  test('accepts condition_operator "all"', () => {
+    expect(() =>
+      snoozeAlertBodySchema.validate({
+        conditions: [{ type: 'severity_change' }],
+        condition_operator: 'all',
+      })
+    ).not.toThrow();
+  });
+
+  test('rejects an unknown condition_operator', () => {
+    expect(() =>
+      snoozeAlertBodySchema.validate({
+        conditions: [{ type: 'severity_change' }],
+        condition_operator: 'none',
+      })
+    ).toThrow();
+  });
+
+  test('rejects a body with neither expires_at nor conditions', () => {
+    expect(() => snoozeAlertBodySchema.validate({})).toThrow(
+      'either [expires_at] or [conditions] must be provided'
+    );
+  });
+
+  test('rejects an empty conditions array', () => {
+    expect(() => snoozeAlertBodySchema.validate({ conditions: [] })).toThrow(
+      '[conditions] must contain at least one condition'
+    );
+  });
+
+  test('rejects an expires_at in the past', () => {
+    const pastDate = new Date(Date.now() - 86400000).toISOString(); // yesterday
+    expect(() => snoozeAlertBodySchema.validate({ expires_at: pastDate })).toThrow(
+      '[expires_at] must be in the future'
+    );
+  });
+
+  test('rejects a non-ISO expires_at', () => {
+    expect(() => snoozeAlertBodySchema.validate({ expires_at: 'not-a-date' })).toThrow();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/snooze_alert/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/snooze_alert/schemas/v1.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
+import type { Type } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
+import { ALERT_SEVERITY_VALUES, type AlertSeverity } from '@kbn/rule-data-utils';
 import { ISO_DATE_REGEX } from '../../../../schedule/constants';
 import {
   MAX_ID_LENGTH,
@@ -51,16 +53,11 @@ const snoozeConditionSchema = schema.oneOf([
     {
       type: schema.literal('severity_equals'),
       value: schema.oneOf(
-        [
-          schema.literal('critical'),
-          schema.literal('high'),
-          schema.literal('medium'),
-          schema.literal('low'),
-          schema.literal('info'),
-        ],
+        ALERT_SEVERITY_VALUES.map((severity) => schema.literal(severity)) as [Type<AlertSeverity>],
         {
           meta: {
-            description: 'The target severity level: critical, high, medium, low, or info.',
+            description:
+              'The target severity level: critical, major, high, medium, minor, low, warning, or info.',
           },
         }
       ),


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana-team/issues/3682

This PR adds `major | minor | warning` values to severity for snooze alert schema API. It also adds same values to UI.

https://github.com/user-attachments/assets/a178ff33-dee6-4505-8613-d523b12ad839


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

