### PR TITLE
Rename GitHub team: search-inference-team → inference-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1068,7 +1068,7 @@ x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-manageme
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
 x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/obs-onboarding-team
 x-pack/platform/packages/shared/kbn-inbox-common @elastic/security-genai-research-and-development
-x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/search-inference-team
+x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/inference-team
 x-pack/platform/packages/shared/kbn-inference-connectors @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-inference-prompt-utils @elastic/appex-ai-infra

--- a/x-pack/platform/packages/shared/kbn-inference-cli/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/kibana.jsonc
@@ -3,7 +3,7 @@
   "id": "@kbn/inference-cli",
   "owner": [
     "@elastic/appex-ai-infra",
-    "@elastic/search-inference-team"
+    "@elastic/inference-team"
   ],
   "group": "platform",
   "visibility": "shared",


### PR DESCRIPTION
## Summary

The `search-inference-team` GitHub team is being renamed to `inference-team`. This PR updates all references in this repo.

A placeholder `inference-team` team has been created at https://github.com/orgs/elastic/teams/inference-team. The existing team will be renamed in due course — **do not merge this PR until the team rename has happened**, otherwise CODEOWNERS/access rules will point to the wrong team.

## Changes

All occurrences of `search-inference-team` replaced with `inference-team` (including `@elastic/search-inference-team` → `@elastic/inference-team` in CODEOWNERS).

---
🤖 Raised automatically as part of the team rename. Contact @seanhandley with questions.