### PR TITLE
[Data Federation] Make S3 region field always visible and required 

### DIFF
--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.test.tsx
@@ -75,4 +75,41 @@ describe('CreateDataSourceFlyout', () => {
       expect(getByTestId('createDataSourceFlyoutSubmit')).not.toBeDisabled();
     });
   });
+
+  it('shows the S3 region field without expanding connection settings, and requires it on create', async () => {
+    const toasts = createToastsMock();
+    const client = createClientMock();
+    const onSave = jest.fn().mockResolvedValue(null);
+
+    const { getByTestId, queryByText } = render(
+      <EuiProvider>
+        <CreateDataSourceFlyout
+          dataSourcesClient={client}
+          toasts={toasts}
+          onClose={jest.fn()}
+          onSave={onSave}
+          existingDataSourceNames={[]}
+        />
+      </EuiProvider>
+    );
+
+    // Region is visible up front, without expanding "Show connection settings".
+    expect(getByTestId('createDataSourceFlyoutS3Region')).toBeInTheDocument();
+
+    fireEvent.change(getByTestId('createDataSourceFlyoutName'), { target: { value: 'my-ds' } });
+    fireEvent.click(getByTestId('createDataSourceFlyoutSubmit'));
+
+    await waitFor(() => {
+      expect(queryByText('Region is required.')).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.change(getByTestId('createDataSourceFlyoutS3Region'), {
+      target: { value: 'us-east-1' },
+    });
+
+    await waitFor(() => {
+      expect(queryByText('Region is required.')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.tsx
@@ -45,6 +45,7 @@ import {
 import { CreateDataSourceFlyoutAuthenticationFields } from './create_data_source_flyout_authentication_fields';
 import { CreateDataSourceFlyoutAuthenticationSelect } from './create_data_source_flyout_authentication_select';
 import { CreateDataSourceFlyoutTypeSettingsBlock } from './create_data_source_flyout_type_settings';
+import { CreateDataSourceFlyoutTypeSettingsS3Region } from './create_data_source_flyout_type_settings_s3';
 import {
   authenticationModeFromDataSource,
   dataSourceToFlyoutFormValues,
@@ -301,6 +302,13 @@ export const CreateDataSourceFlyout: FunctionComponent<CreateDataSourceFlyoutPro
               inputRef={descriptionField.ref}
             />
           </EuiFormRow>
+          {dataSourceType === 's3' && (
+            <CreateDataSourceFlyoutTypeSettingsS3Region
+              control={control}
+              unregister={unregister}
+              isRequired={!isEditMode}
+            />
+          )}
           <CreateDataSourceFlyoutTypeSettingsBlock
             control={control}
             dataSourceType={dataSourceType}

--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout_type_settings_s3.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout_type_settings_s3.tsx
@@ -22,6 +22,59 @@ import type { CreateDataSourceFlyoutFormValues } from './create_data_source_flyo
 import type { FederatedIdentityClusterInfo } from './federated_identity_cluster_info';
 import { FederatedIdentityClusterInfoFields } from './federated_identity_cluster_info_fields';
 
+export function CreateDataSourceFlyoutTypeSettingsS3Region({
+  control,
+  unregister,
+  isRequired,
+}: {
+  control: Control<CreateDataSourceFlyoutFormValues, any>;
+  unregister: UseFormUnregister<CreateDataSourceFlyoutFormValues>;
+  isRequired: boolean;
+}) {
+  const { field: regionField, fieldState: regionState } = useController({
+    name: 'settings.region',
+    control,
+    rules: isRequired
+      ? {
+          validate: (value?: string) =>
+            value?.trim()
+              ? true
+              : i18n.translate('xpack.dataFederation.createFlyout.s3.fields.regionRequired', {
+                  defaultMessage: 'Region is required.',
+                }),
+        }
+      : undefined,
+  });
+
+  useEffect(() => {
+    return () => {
+      unregister('settings.region');
+    };
+  }, [unregister]);
+
+  return (
+    <EuiFormRow
+      label={i18n.translate('xpack.dataFederation.createFlyout.s3.fields.region', {
+        defaultMessage: 'Region',
+      })}
+      fullWidth
+      isInvalid={Boolean(regionState.error)}
+      error={regionState.error?.message}
+    >
+      <EuiFieldText
+        data-test-subj="createDataSourceFlyoutS3Region"
+        fullWidth
+        autoComplete="off"
+        isInvalid={Boolean(regionState.error)}
+        value={regionField.value}
+        onChange={(e) => regionField.onChange(e.target.value)}
+        name={regionField.name}
+        inputRef={regionField.ref}
+      />
+    </EuiFormRow>
+  );
+}
+
 export function CreateDataSourceFlyoutTypeSettingsS3({
   control,
   unregister,
@@ -29,10 +82,6 @@ export function CreateDataSourceFlyoutTypeSettingsS3({
   control: Control<CreateDataSourceFlyoutFormValues, any>;
   unregister: UseFormUnregister<CreateDataSourceFlyoutFormValues>;
 }) {
-  const { field: regionField } = useController({
-    name: 'settings.region',
-    control,
-  });
   const { field: endpointField } = useController({
     name: 'settings.endpoint',
     control,
@@ -40,46 +89,27 @@ export function CreateDataSourceFlyoutTypeSettingsS3({
 
   useEffect(() => {
     return () => {
-      unregister('settings.region');
       unregister('settings.endpoint');
     };
   }, [unregister]);
 
   return (
-    <>
-      <EuiFormRow
-        label={i18n.translate('xpack.dataFederation.createFlyout.s3.fields.region', {
-          defaultMessage: 'Region',
-        })}
+    <EuiFormRow
+      label={i18n.translate('xpack.dataFederation.createFlyout.s3.fields.endpoint', {
+        defaultMessage: 'Endpoint',
+      })}
+      fullWidth
+    >
+      <EuiFieldText
+        data-test-subj="createDataSourceFlyoutS3Endpoint"
         fullWidth
-      >
-        <EuiFieldText
-          data-test-subj="createDataSourceFlyoutS3Region"
-          fullWidth
-          autoComplete="off"
-          value={regionField.value}
-          onChange={(e) => regionField.onChange(e.target.value)}
-          name={regionField.name}
-          inputRef={regionField.ref}
-        />
-      </EuiFormRow>
-      <EuiFormRow
-        label={i18n.translate('xpack.dataFederation.createFlyout.s3.fields.endpoint', {
-          defaultMessage: 'Endpoint',
-        })}
-        fullWidth
-      >
-        <EuiFieldText
-          data-test-subj="createDataSourceFlyoutS3Endpoint"
-          fullWidth
-          autoComplete="off"
-          value={endpointField.value}
-          onChange={(e) => endpointField.onChange(e.target.value)}
-          name={endpointField.name}
-          inputRef={endpointField.ref}
-        />
-      </EuiFormRow>
-    </>
+        autoComplete="off"
+        value={endpointField.value}
+        onChange={(e) => endpointField.onChange(e.target.value)}
+        name={endpointField.name}
+        inputRef={endpointField.ref}
+      />
+    </EuiFormRow>
   );
 }
 


### PR DESCRIPTION
## Summary

Description: Region is required for S3 data sources to work correctly, but it was buried in a collapsed "connection settings" section and optional; this surfaces it as a top-level field and requires it on create.