### PR TITLE
[Alerting][Data Views] Inject CPS project routing into dataViewsServiceFactory

### DIFF
--- a/src/platform/plugins/shared/data_views/server/data_views_service_factory.ts
+++ b/src/platform/plugins/shared/data_views/server/data_views_service_factory.ts
@@ -39,7 +39,8 @@ export const dataViewsServiceFactory = (deps: DataViewsServiceFactoryDeps) =>
     savedObjectsClient: SavedObjectsClientContract,
     elasticsearchClient: ElasticsearchClient,
     request?: KibanaRequest,
-    byPassCapabilities?: boolean
+    byPassCapabilities?: boolean,
+    projectRouting?: string
   ) {
     const { logger, uiSettings, fieldFormats, capabilities, rollupsEnabled } = deps;
     const uiSettingsClient = uiSettings.asScopedToClient(savedObjectsClient);
@@ -52,7 +53,8 @@ export const dataViewsServiceFactory = (deps: DataViewsServiceFactoryDeps) =>
         elasticsearchClient,
         savedObjectsClient,
         uiSettingsClient,
-        rollupsEnabled
+        rollupsEnabled,
+        projectRouting
       ),
       fieldFormats: formats,
       onError: (error) => {

--- a/src/platform/plugins/shared/data_views/server/index_patterns_api_client.test.ts
+++ b/src/platform/plugins/shared/data_views/server/index_patterns_api_client.test.ts
@@ -51,4 +51,45 @@ describe('IndexPatternsApiServer', () => {
       })
     );
   });
+
+  describe('projectRouting', () => {
+    const createServer = (defaultProjectRouting?: string) =>
+      new IndexPatternsApiServer(
+        coreRequestHandler.elasticsearch.client.asInternalUser,
+        coreRequestHandler.savedObjects.client,
+        coreRequestHandler.uiSettings.client,
+        false,
+        defaultProjectRouting
+      );
+
+    it('passes the constructor default projectRouting when no explicit value is provided', async () => {
+      const server = createServer('@kibana_space_default_default');
+
+      await server.getFieldsForWildcard({ pattern: '*' });
+
+      expect(getFieldsForWildcard).toHaveBeenCalledWith(
+        expect.objectContaining({ projectRouting: '@kibana_space_default_default' })
+      );
+    });
+
+    it('lets an explicit projectRouting option override the constructor default', async () => {
+      const server = createServer('@kibana_space_default_default');
+
+      await server.getFieldsForWildcard({ pattern: '*', projectRouting: 'explicit-routing' });
+
+      expect(getFieldsForWildcard).toHaveBeenCalledWith(
+        expect.objectContaining({ projectRouting: 'explicit-routing' })
+      );
+    });
+
+    it('passes undefined projectRouting when neither a default nor an explicit value is set', async () => {
+      const server = createServer();
+
+      await server.getFieldsForWildcard({ pattern: '*' });
+
+      expect(getFieldsForWildcard).toHaveBeenCalledWith(
+        expect.objectContaining({ projectRouting: undefined })
+      );
+    });
+  });
 });

--- a/src/platform/plugins/shared/data_views/server/index_patterns_api_client.ts
+++ b/src/platform/plugins/shared/data_views/server/index_patterns_api_client.ts
@@ -22,7 +22,8 @@ export class IndexPatternsApiServer implements IDataViewsApiClient {
     private readonly esClient: ElasticsearchClient,
     private readonly savedObjectsClient: SavedObjectsClientContract,
     private readonly uiSettingsClient: IUiSettingsClient,
-    private readonly rollupsEnabled: boolean
+    private readonly rollupsEnabled: boolean,
+    private readonly defaultProjectRouting?: string
   ) {}
   async getFieldsForWildcard({
     pattern,
@@ -55,7 +56,7 @@ export class IndexPatternsApiServer implements IDataViewsApiClient {
         abortSignal,
         runtimeMappings,
         allowHidden,
-        projectRouting,
+        projectRouting: projectRouting ?? this.defaultProjectRouting,
       })
       .catch((err) => {
         if (

--- a/src/platform/plugins/shared/data_views/server/types.ts
+++ b/src/platform/plugins/shared/data_views/server/types.ts
@@ -38,7 +38,14 @@ type ServiceFactory = (
   /**
    * Ignore capabilities
    */
-  byPassCapabilities?: boolean
+  byPassCapabilities?: boolean,
+  /**
+   * Cross-Project Search (CPS) `project_routing` expression to inject into every
+   * `fieldCaps` request made by the service. Required when the service is created with an
+   * internal-user Elasticsearch client (which is always origin-only routed) but the field
+   * lookups must fan out across CPS-connected projects (e.g. alerting rule execution).
+   */
+  projectRouting?: string
 ) => Promise<DataViewsService>;
 
 /**

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.test.ts
@@ -17,6 +17,8 @@ import { ruleMonitoringServiceMock } from '../monitoring/rule_monitoring_service
 import { ruleResultServiceMock } from '../monitoring/rule_result_service.mock';
 import type { AsScopedOptions } from '@kbn/core-elasticsearch-server';
 import { ESQL_ASYNC_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
+import { getSpaceNPRE } from '@kbn/cps-server-utils';
+import { asSpaceId } from '@kbn/core-spaces-common';
 
 jest.mock('../lib/wrap_scoped_cluster_client', () => ({
   createWrappedScopedClusterClientFactory: jest.fn().mockReturnValue({}),
@@ -148,6 +150,52 @@ describe('getExecutorServices', () => {
 
       expect(dataSearchAsScoped).toHaveBeenCalledTimes(1);
       expect(dataSearchAsScoped).toHaveBeenCalledWith(fakeRequest, projectRouting);
+    });
+
+    it('creates the data views service with the space NPRE as explicit projectRouting', async () => {
+      const context = createMockContext();
+      const fakeRequest = createFakeRequest();
+      const dataViewsServiceFactory = context.dataViews.dataViewsServiceFactory as jest.Mock;
+
+      const executorServices = getExecutorServices({
+        context,
+        fakeRequest,
+        abortController,
+        logger,
+        ruleMonitoringService,
+        ruleResultService,
+        ruleData,
+      });
+
+      await executorServices.getDataViews();
+
+      expect(dataViewsServiceFactory).toHaveBeenCalledTimes(1);
+      // request and byPassCapabilities are intentionally left undefined so the internal-user
+      // auth principal is preserved; only the explicit projectRouting is added.
+      const call = dataViewsServiceFactory.mock.calls[0];
+      expect(call[2]).toBeUndefined();
+      expect(call[3]).toBeUndefined();
+      expect(call[4]).toBe(getSpaceNPRE(asSpaceId('default')));
+    });
+
+    it('threads the rule spaceId into the resolved data views projectRouting', async () => {
+      const context = createMockContext();
+      const fakeRequest = createFakeRequest();
+      const dataViewsServiceFactory = context.dataViews.dataViewsServiceFactory as jest.Mock;
+
+      const executorServices = getExecutorServices({
+        context,
+        fakeRequest,
+        abortController,
+        logger,
+        ruleMonitoringService,
+        ruleResultService,
+        ruleData: { ...ruleData, spaceId: 'my-space' },
+      });
+
+      await executorServices.getDataViews();
+
+      expect(dataViewsServiceFactory.mock.calls[0][4]).toBe(getSpaceNPRE(asSpaceId('my-space')));
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.ts
@@ -12,6 +12,8 @@ import type {
 } from '@kbn/core/server';
 import type { DataViewsContract } from '@kbn/data-views-plugin/common';
 import type { AsScopedOptions } from '@kbn/core-elasticsearch-server';
+import { getSpaceNPRE } from '@kbn/cps-server-utils';
+import { asSpaceId } from '@kbn/core-spaces-common';
 import { RULE_SAVED_OBJECT_TYPE } from '..';
 import { getEsRequestTimeout } from '../lib';
 import type { CpsData } from '../types';
@@ -67,6 +69,11 @@ const projectRouting: AsScopedOptions = {
 export const getExecutorServices = (opts: GetExecutorServicesOpts): ExecutorServices => {
   const { context, abortController, fakeRequest, logger, ruleData, ruleTaskTimeout } = opts;
 
+  // The data views service is created with an internal-user ES client, which is always
+  // origin-only routed. To match the space routing used by the search/search-source clients,
+  // resolve the space NPRE expression and inject it explicitly into the data views field caps calls.
+  const dataViewsProjectRouting = getSpaceNPRE(asSpaceId(ruleData.spaceId));
+
   const wrappedClientOptions = {
     rule: ruleData,
     logger,
@@ -98,7 +105,10 @@ export const getExecutorServices = (opts: GetExecutorServicesOpts): ExecutorServ
       const dataViews = await withAlertingSpan('alerting:get-data-views-factory', () =>
         context.dataViews.dataViewsServiceFactory(
           savedObjectsClient,
-          scopedClusterClient.asInternalUser
+          scopedClusterClient.asInternalUser,
+          undefined,
+          undefined,
+          dataViewsProjectRouting
         )
       );
       return dataViews;


### PR DESCRIPTION
## Summary

When a rule executes, the alerting task runner builds the data views service from an **internal-user** Elasticsearch client (`scopedClusterClient.asInternalUser`). Per the core CPS contract, that client is always **origin-only** routed, so `fieldCaps` requests made by the data views service — directly or indirectly via `DataViewLazy` — never fan out across the space's CPS-connected projects, even though the rule's search/search-source clients are space-routed.

This PR threads an explicit `project_routing` expression through the data views `ServiceFactory` so it is applied to every `fieldCaps` call, while preserving the internal-user auth principal used to read index metadata.

## What changed

- **`@kbn/data-views-plugin` (server)**
  - `ServiceFactory` gains an optional `projectRouting?: string` argument.
  - `dataViewsServiceFactory` forwards it to `IndexPatternsApiServer`.
  - `IndexPatternsApiServer` stores it as a default and applies `projectRouting ?? this.defaultProjectRouting` on every `getFieldsForWildcard` call.
- **`@kbn/alerting-plugin` (task runner)**
  - `get_executor_services` resolves the rule's space NPRE (`getSpaceNPRE(asSpaceId(ruleData.spaceId))`) and passes it as the explicit `projectRouting` value. `request`/`byPassCapabilities` are left `undefined` so the internal-user principal is unchanged.

Because `DataViewsService` builds every `DataViewLazy` with its own `apiClient`, this single injection point covers direct callers (e.g. infra metric threshold) **and** `DataViewLazy`/`queryToFields` callers (e.g. security_solution detection rules and rule preview) without touching those call sites.

## Why the explicit-string path (not `asCurrentUser`)

`asInternalUser` can't carry project routing, and switching to `asCurrentUser` would change the auth principal (and apply FLS/DLS) for index-metadata reads. Injecting the resolved expression keeps internal-user auth while enabling CPS fan-out. The core CPS request handler treats an already-set `body.project_routing` as explicit (won't overwrite) and strips it when CPS is disabled, so stateful/non-CPS ES is unaffected.

## Out of scope

- `entity_store` builds its data views service on `asInternalUser` with the same gap.
- `rule_registry` constructs `IndexPatternsFetcher` directly, but only on the **read/UI path** — `AlertsClient.getBrowserFields`/`getAlertFields` (the alerts-table field browser, served via HTTP routes in a request context) and the unused `RuleDataClient` reader `getDynamicIndexPattern`. These are **not** part of rule-type execution, and they target project-local `.alerts-*` indices where CPS fan-out isn't meaningful, so no routing is threaded here.

## Test plan

- [x] Unit: `IndexPatternsApiServer` applies the constructor default, lets an explicit option override it, and passes `undefined` when neither is set.
- [x] Unit: `getExecutorServices` creates the data views service with the resolved space NPRE (and threads the rule `spaceId`), leaving `request`/`byPassCapabilities` undefined.
- [ ] Manual verification in a CPS-enabled Serverless environment: rule execution `fieldCaps` requests carry `project_routing` set to the space NPRE.

## To verify

Spin up a local CPS-enabled Serverless stack (Kibana + origin cluster + one linked project) with Scout, seed a field that exists **only** in the linked project, and confirm that rule execution routes its `fieldCaps` request with the space NPRE.

Ports/creds for the `cps_local` security harness:

- Kibana: `http://localhost:5620`
- Origin ES: `https://localhost:9220`
- Linked-project ES: `https://localhost:9230` (origin port + 10 offset)
- ES creds: `elastic_serverless` / `changeme` (self-signed cert → `curl -k`)

1. **Start the CPS stack** (prereqs: `yarn kbn bootstrap`, Docker running, ports free):

   ```bash
   node scripts/scout start-server \
     --arch serverless \
     --domain security_complete \
     --serverConfigSet cps_local
   ```

   Wait until Kibana is ready, then open `http://localhost:5620` and log in with the credentials printed in the terminal.

2. **Enable ES query logging** so the executor's `_field_caps` request is logged — add to `config/kibana.dev.yml`:

   ```yaml
   logging.loggers:
     - name: elasticsearch.query
       level: debug
   ```

3. **Seed a linked-only field.** In Kibana **Dev Tools → Console** (talks to the origin cluster):

   ```
   PUT cps-manual-test
   {
     "mappings": { "properties": {
       "@timestamp": { "type": "date" },
       "origin_marker": { "type": "keyword" }
     }}
   }

   POST cps-manual-test/_doc?refresh=wait_for
   { "@timestamp": "2026-07-07T10:00:00.000Z", "origin_marker": "present" }
   ```

   The linked cluster is not reachable from Dev Tools, so `curl` it directly on `:9230`:

   ```bash
   curl -k -u elastic_serverless:changeme -X PUT "https://localhost:9230/cps-manual-test" \
     -H 'content-type: application/json' -d '{
       "mappings": { "properties": {
         "@timestamp": { "type": "date" },
         "linked_marker": { "type": "keyword" }
       }}
     }'

   curl -k -u elastic_serverless:changeme -X POST "https://localhost:9230/cps-manual-test/_doc?refresh=wait_for" \
     -H 'content-type: application/json' -d '{
       "@timestamp": "2026-07-07T10:00:00.000Z", "linked_marker": "present"
     }'
   ```

4. **Create two spaces with different routing:**

   ```bash
   # fan-out to all projects
   curl -k -u elastic_serverless:changeme -X POST "http://localhost:5620/api/spaces/space" \
     -H 'content-type: application/json' -H 'kbn-xsrf: true' -d '{
       "id": "cps-all", "name": "CPS All", "disabledFeatures": [], "projectRouting": "_alias:*"
     }'

   # origin-only (negative control)
   curl -k -u elastic_serverless:changeme -X POST "http://localhost:5620/api/spaces/space" \
     -H 'content-type: application/json' -H 'kbn-xsrf: true' -d '{
       "id": "cps-origin", "name": "CPS Origin", "disabledFeatures": [], "projectRouting": "_alias:_origin"
     }'
   ```

5. **Create the detection rule in the `cps-all` space** (`http://localhost:5620/s/cps-all`) → **Security → Rules → Detection rules → Create new rule → Custom query**:

   - Index patterns: `cps-manual-test*`
   - Custom query (KQL): `linked_marker : "present"` (matches data that lives **only** in the linked project)
   - Name: `CPS All rule`; Schedule → Runs every `1 minute`, look-back `5 minutes`
   - Save & enable.

6. **Trigger a background execution and check the log.** Use the rule's **Manual run** (rule details → ⋯ → Manual run) or wait for the interval — not Preview, which runs in the request context. In the `start-server` terminal find the `elasticsearch.query` debug line for `POST /_field_caps` and confirm it carries the space NPRE:

   ```json
   {
     "path": "/cps-manual-test*/_field_caps",
     "body": { "project_routing": "@kibana_space_cps-all_default" }
   }
   ```

   Functional confirmation: the rule generates an alert (it matched `linked_marker` from the linked project).

7. **Negative control in `cps-origin`** (`/s/cps-origin`): create the same rule. On execution the `_field_caps` body shows `project_routing: "@kibana_space_cps-origin_default"` and the rule does **not** alert, since `linked_marker` isn't in the origin cluster. (Sanity: a rule on `origin_marker : "present"` alerts in both spaces.)

On `main` (without this PR) the executor's `_field_caps` goes out origin-only regardless of space routing, so the `cps-all` rule never sees `linked_marker`. With the change it carries the space NPRE and matches.

