### PR TITLE
[SigEvents] Cap alerting_v2 breach queries at MAX_ALERTS_PER_EXECUTION to prevent Arrow OOM

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/rules/v2_rules_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/rules/v2_rules_adapter.test.ts
@@ -82,7 +82,7 @@ describe('RulesAdapterV2', () => {
         grouping: { fields: ['_id'] },
         query: {
           format: 'standalone',
-          breach: { query: 'FROM logs-* METADATA _id | WHERE level == "error"' },
+          breach: { query: 'FROM logs-* METADATA _id | WHERE level == "error" | LIMIT 1000' },
         },
       });
       expect(lastCreateCall(mock).options).toEqual({ id: 'rule-1' });
@@ -142,7 +142,7 @@ describe('RulesAdapterV2', () => {
           grouping: { fields: ['_id'] },
           query: {
             format: 'standalone',
-            breach: { query: 'FROM logs-* METADATA _id | WHERE level == "error"' },
+            breach: { query: 'FROM logs-* METADATA _id | WHERE level == "error" | LIMIT 1000' },
           },
         },
       });
@@ -210,7 +210,7 @@ describe('RulesAdapterV2', () => {
         query: { format: 'standalone'; breach: { query: string } };
       };
       expect(data.query.breach.query).toBe(
-        'FROM logs.child, logs.child.* METADATA _id | WHERE KQL("message: error")'
+        'FROM logs.child, logs.child.* METADATA _id | WHERE KQL("message: error") | LIMIT 1000'
       );
     });
 
@@ -229,7 +229,31 @@ describe('RulesAdapterV2', () => {
       const data = lastUpdateCall(mock).data as {
         query: { format: 'standalone'; breach: { query: string } };
       };
-      expect(data.query.breach.query).toBe('FROM logs-* METADATA _id | WHERE level == "error"');
+      expect(data.query.breach.query).toBe(
+        'FROM logs-* METADATA _id | WHERE level == "error" | LIMIT 1000'
+      );
+    });
+
+    it('appends MAX_ALERTS_PER_EXECUTION unconditionally — ES|QL min-semantics clamp larger author limits', async () => {
+      // | LIMIT 500 | LIMIT 1000 → 500 (author wins, smaller limit)
+      // | LIMIT 50000 | LIMIT 1000 → 1000 (capped)
+      const mock = makeRulesClientMock();
+      mock.createRule.mockResolvedValue({} as never);
+      const adapter = makeAdapter(mock);
+      await adapter.createRule('rule-1', {
+        ...createBody,
+        params: {
+          timestampField: '@timestamp',
+          query: 'FROM logs-* METADATA _id, _source | WHERE level == "error" | LIMIT 500',
+        },
+      });
+
+      const data = lastCreateCall(mock).data as {
+        query: { format: 'standalone'; breach: { query: string } };
+      };
+      expect(data.query.breach.query).toBe(
+        'FROM logs-* METADATA _id | WHERE level == "error" | LIMIT 500 | LIMIT 1000'
+      );
     });
 
     it('leaves queries without METADATA unchanged', async () => {
@@ -247,7 +271,7 @@ describe('RulesAdapterV2', () => {
       const data = lastCreateCall(mock).data as {
         query: { format: 'standalone'; breach: { query: string } };
       };
-      expect(data.query.breach.query).toBe('FROM logs-* | WHERE level == "error"');
+      expect(data.query.breach.query).toBe('FROM logs-* | WHERE level == "error" | LIMIT 1000');
     });
   });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/rules/v2_rules_adapter.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/rules/v2_rules_adapter.ts
@@ -12,7 +12,10 @@ import type { Logger } from '@kbn/core/server';
 import type { RulesClientApi } from '@kbn/alerting-v2-plugin/server';
 import { stripMetadata, deriveQueryType } from '@kbn/streams-schema';
 import { QUERY_TYPE_STATS } from '@kbn/significant-events-schema';
-import { MATCH_LOOKBACK_MINUTES } from '../../../../significant_events/rules/esql/common';
+import {
+  MATCH_LOOKBACK_MINUTES,
+  MAX_ALERTS_PER_EXECUTION,
+} from '../../../../significant_events/rules/esql/common';
 import {
   STREAMS_RULE_CONSUMER,
   STREAMS_ESQL_RULE_TYPE_ID,
@@ -144,7 +147,8 @@ function assertMatchQuery(esqlQuery: string): void {
 
 function toV2BreachQuery(esqlQuery: string): string {
   assertMatchQuery(esqlQuery);
-  return stripMetadata(esqlQuery, V2_QUERY_METADATA_TO_STRIP);
+  const stripped = stripMetadata(esqlQuery, V2_QUERY_METADATA_TO_STRIP);
+  return `${stripped.trimEnd()} | LIMIT ${MAX_ALERTS_PER_EXECUTION}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes elastic/nightshift-program#553.

SigEvents MATCH rules installed via alerting_v2 were crashing with:
```
Failed to parse ES|QL response. Error: The value of "size" is out of range. It must be <= 1GiB.
```
The Arrow IPC reader materialises the full response body before yielding batches. A broad rule like `WHERE log.level == "error"` can match hundreds of rows per minute and exceed Node's ~1 GiB Buffer ceiling.

**Root cause (tracked separately in elastic/kibana#276603):** `execute_rule_query_step.ts` runs stored breach queries verbatim through `toArrowReader()` with no row cap — every alerting_v2 consumer is exposed.

**This PR** is a targeted mitigation for the SigEvents adapter path: `toV2BreachQuery` in `v2_rules_adapter.ts` now appends `| LIMIT MAX_ALERTS_PER_EXECUTION` **unconditionally**, mirroring `build_esql_search_request.ts:47` in the v1 executor. ES|QL min-semantics mean a smaller author-supplied limit still wins; a larger one gets clamped.

## Changes

- **`v2_rules_adapter.ts`** — `toV2BreachQuery` appends `| LIMIT ${MAX_ALERTS_PER_EXECUTION}` unconditionally; `MAX_ALERTS_PER_EXECUTION` imported from the existing `esql/common.ts` (no new constants introduced).
- **`v2_rules_adapter.test.ts`** — updated expectations; new test documents ES|QL min-semantics behaviour for queries that already carry a `LIMIT`.

## Test plan

**Unit:**
```
node scripts/jest x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/rules/v2_rules_adapter.test.ts
```
23 tests pass.

**E2E (manual, local server with alerting_v2 and SigEvents v2 adapter enabled):**

1. Installed a query without a `LIMIT` via:
   ```
   PUT /api/streams/logs.otel/queries/<id>
   {"esql":{"query":"FROM logs.otel, logs.otel.* METADATA _id, _source | WHERE log.level == \"error\""}}
   ```
2. Fetched the resulting alerting_v2 rule via `GET /api/alerting/v2/rules/<rule_id>` and confirmed the breach query is:
   ```
   FROM logs.otel, logs.otel.* METADATA _id | WHERE log.level == "error" | LIMIT 1000
   ```
3. All 8 pre-existing SigEvents rules in the test environment also show `| LIMIT 1000` appended, confirming the adapter applies the cap on every create/update regardless of whether the stored query has its own `LIMIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)