### PR TITLE
[One Workflow] Instruct workflow authoring skill to use ai.prompt over deprecated inference.* / bedrock.* / gen-ai.* / gemini.*

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.test.ts
@@ -63,8 +63,12 @@ describe('workflowAuthoringSkill', () => {
       expect(workflowAuthoringSkill.content).not.toMatch(/type: slack_api/);
     });
 
-    it('instructs to use ai.prompt/ai.agent and avoid deprecated model-connector step types', () => {
-      expect(workflowAuthoringSkill.content).toContain('ONLY use `ai.prompt` or `ai.agent`');
+    it('instructs to use the ai.* step family and avoid deprecated model-connector step types', () => {
+      expect(workflowAuthoringSkill.content).toContain('ONLY use the `ai.*` step family');
+      expect(workflowAuthoringSkill.content).toContain('`ai.prompt`');
+      expect(workflowAuthoringSkill.content).toContain('`ai.summarize`');
+      expect(workflowAuthoringSkill.content).toContain('`ai.classify`');
+      expect(workflowAuthoringSkill.content).toContain('`ai.agent`');
       expect(workflowAuthoringSkill.content).toContain('type: ai.prompt');
       expect(workflowAuthoringSkill.content).not.toMatch(/type: inference\./);
       expect(workflowAuthoringSkill.content).not.toMatch(/type: bedrock\./);

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.test.ts
@@ -63,6 +63,15 @@ describe('workflowAuthoringSkill', () => {
       expect(workflowAuthoringSkill.content).not.toMatch(/type: slack_api/);
     });
 
+    it('instructs to use ai.prompt/ai.agent and avoid deprecated model-connector step types', () => {
+      expect(workflowAuthoringSkill.content).toContain('ONLY use `ai.prompt` or `ai.agent`');
+      expect(workflowAuthoringSkill.content).toContain('type: ai.prompt');
+      expect(workflowAuthoringSkill.content).not.toMatch(/type: inference\./);
+      expect(workflowAuthoringSkill.content).not.toMatch(/type: bedrock\./);
+      expect(workflowAuthoringSkill.content).not.toMatch(/type: gen-ai\./);
+      expect(workflowAuthoringSkill.content).not.toMatch(/type: gemini\./);
+    });
+
     it('does not document the deleted low-level edit tools', () => {
       expect(workflowAuthoringSkill.content).not.toContain('workflow_insert_step');
       expect(workflowAuthoringSkill.content).not.toContain('workflow_modify_step');

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.ts
@@ -130,20 +130,25 @@ Every step (regardless of type) supports these properties. They are NOT repeated
 - **elasticsearch.search**: Query Elasticsearch indices
 - **elasticsearch.bulk**: Bulk index documents
 - **ai.prompt**: One-shot LLM call (prompt in, structured output out)
+- **ai.summarize**: Purpose-built summarization step (text in, summary out)
+- **ai.classify**: Purpose-built classification step (text + labels in, label out)
 - **ai.agent**: Invoke an AI agent (multi-turn, tool-using)
 
-**AI steps: ONLY use \`ai.prompt\` or \`ai.agent\`.** Discovery may also surface
+**AI steps: ONLY use the \`ai.*\` step family.** Discovery may also surface
 direct model-connector step types (\`inference.*\`, \`bedrock.*\`, \`gen-ai.*\`,
-\`gemini.*\`); these are deprecated and must NOT be used for new steps. Route all
-LLM calls through \`ai.prompt\` (for one-shot inference/analysis) or \`ai.agent\`
-(when tool use or multi-turn reasoning is needed).
+\`gemini.*\`); these are deprecated and must NOT be used for new steps. Pick the
+narrowest \`ai.*\` step that fits the use case:
+- summarization → \`ai.summarize\`
+- classification / routing / labeling → \`ai.classify\`
+- multi-turn or tool-using flows → \`ai.agent\`
+- everything else (generic one-shot inference / analysis / extraction) → \`ai.prompt\`
 
 **AI step example (PREFERRED):**
 \`\`\`yaml
 - name: triage_analysis
   type: ai.prompt
   with:
-    prompt: "Summarize the alert: {{ steps.fetch_alert.output }}"
+    prompt: "Analyze the alert: {{ steps.fetch_alert.output }}"
 \`\`\`
 
 #### Connector-Based Step Types (PREFERRED for integrations!)

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.ts
@@ -129,7 +129,22 @@ Every step (regardless of type) supports these properties. They are NOT repeated
 - **console**: Log messages to execution output
 - **elasticsearch.search**: Query Elasticsearch indices
 - **elasticsearch.bulk**: Bulk index documents
-- **ai.agent**: Invoke an AI agent
+- **ai.prompt**: One-shot LLM call (prompt in, structured output out)
+- **ai.agent**: Invoke an AI agent (multi-turn, tool-using)
+
+**AI steps: ONLY use \`ai.prompt\` or \`ai.agent\`.** Discovery may also surface
+direct model-connector step types (\`inference.*\`, \`bedrock.*\`, \`gen-ai.*\`,
+\`gemini.*\`); these are deprecated and must NOT be used for new steps. Route all
+LLM calls through \`ai.prompt\` (for one-shot inference/analysis) or \`ai.agent\`
+(when tool use or multi-turn reasoning is needed).
+
+**AI step example (PREFERRED):**
+\`\`\`yaml
+- name: triage_analysis
+  type: ai.prompt
+  with:
+    prompt: "Summarize the alert: {{ steps.fetch_alert.output }}"
+\`\`\`
 
 #### Connector-Based Step Types (PREFERRED for integrations!)
 

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.ts
@@ -129,19 +129,17 @@ Every step (regardless of type) supports these properties. They are NOT repeated
 - **console**: Log messages to execution output
 - **elasticsearch.search**: Query Elasticsearch indices
 - **elasticsearch.bulk**: Bulk index documents
-- **ai.prompt**: One-shot LLM call (prompt in, structured output out)
-- **ai.summarize**: Purpose-built summarization step (text in, summary out)
-- **ai.classify**: Purpose-built classification step (text + labels in, label out)
+- **ai.prompt**: One-shot LLM call
+- **ai.summarize**: Summarize text
+- **ai.classify**: Classify text into one of a set of labels
 - **ai.agent**: Invoke an AI agent (multi-turn, tool-using)
 
 **AI steps: ONLY use the \`ai.*\` step family.** Discovery may also surface
 direct model-connector step types (\`inference.*\`, \`bedrock.*\`, \`gen-ai.*\`,
 \`gemini.*\`); these are deprecated and must NOT be used for new steps. Pick the
-narrowest \`ai.*\` step that fits the use case:
-- summarization → \`ai.summarize\`
-- classification / routing / labeling → \`ai.classify\`
-- multi-turn or tool-using flows → \`ai.agent\`
-- everything else (generic one-shot inference / analysis / extraction) → \`ai.prompt\`
+narrowest \`ai.*\` step for the task: \`ai.summarize\` for summarization,
+\`ai.classify\` for classification/routing, \`ai.agent\` for tool-using flows,
+\`ai.prompt\` for everything else.
 
 **AI step example (PREFERRED):**
 \`\`\`yaml


### PR DESCRIPTION
Closes an ergonomic gap that surfaces as the `deprecated-step-validation` warning in the YAML editor:

> Step type "inference.completion" is deprecated. Use "ai.prompt" instead.

Follow-up to #273140 (same nudge, applied to the `ai.*` family).

## Summary

`DEPRECATED_STEP_PREFIX_METADATA` marks `inference.*`, `bedrock.*`, `gen-ai.*`, and `gemini.*` deprecated in favor of `ai.prompt`, but the workflow authoring skill only mentioned `ai.agent`, so the LLM still reaches for `inference.completion` when asked to add an analysis step.

Add explicit guidance + `ai.prompt` example, and steer each use-case to its narrowest `ai.*` step:

- `ai.summarize` — summarization
- `ai.classify` — classification / routing
- `ai.agent` — multi-turn / tool-using
- `ai.prompt` — everything else

Test asserts the four step types are named and no deprecated model-connector example survives.

## Testing

- `node scripts/jest x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/workflow_authoring_skill.test.ts` — passes.