### PR TITLE
[Security Solution] Fix agent builder Add-to-chat button stuck disabled on license race

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/license/license.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/license/license.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Observable, Subscription } from 'rxjs';
+import { map, of } from 'rxjs';
 import type { ILicense, LicenseType } from '@kbn/licensing-types';
 
 // Generic license service class that works with the license observable
@@ -61,6 +62,18 @@ export class LicenseService {
   }
   public isEnterprise(): boolean {
     return this.isAtLeast('enterprise');
+  }
+
+  /**
+   * Emits whenever the enterprise-license check changes, so consumers that need to
+   * react to a license resolving asynchronously (e.g. right after `start()`) can
+   * update instead of reading a snapshot that goes stale once mutated internally.
+   */
+  public isEnterprise$(): Observable<boolean> {
+    if (!this.observable) {
+      return of(this.isEnterprise());
+    }
+    return this.observable.pipe(map((license) => isAtLeast(license, 'enterprise')));
   }
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/common/license/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/license/mocks.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { of } from 'rxjs';
 import type { LicenseService } from './license';
 
 export const createLicenseServiceMock = (): jest.Mocked<LicenseService> => {
@@ -17,5 +18,6 @@ export const createLicenseServiceMock = (): jest.Mocked<LicenseService> => {
     isGoldPlus: jest.fn().mockReturnValue(true),
     isPlatinumPlus: jest.fn().mockReturnValue(true),
     isEnterprise: jest.fn().mockReturnValue(true),
+    isEnterprise$: jest.fn().mockReturnValue(of(true)),
   } as unknown as jest.Mocked<LicenseService>;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/hooks/use_agent_builder_availability.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/hooks/use_agent_builder_availability.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import { of } from 'rxjs';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { useAgentBuilderAvailability } from './use_agent_builder_availability';
 import { useKibana } from '../../common/lib/kibana';
@@ -25,6 +26,7 @@ describe('useAgentBuilderAvailability', () => {
     jest.clearAllMocks();
     mockUseLicense.mockReturnValue({
       isEnterprise: jest.fn(() => true),
+      isEnterprise$: jest.fn(() => of(true)),
     });
   });
 
@@ -207,6 +209,7 @@ describe('useAgentBuilderAvailability', () => {
     mockUseUiSetting$.mockReturnValue([AIChatExperience.Agent]);
     mockUseLicense.mockReturnValue({
       isEnterprise: jest.fn(() => false),
+      isEnterprise$: jest.fn(() => of(false)),
     });
 
     const { result } = renderHook(() => useAgentBuilderAvailability());

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/hooks/use_agent_builder_availability.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/hooks/use_agent_builder_availability.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
@@ -35,6 +36,11 @@ export const useAgentBuilderAvailability = (): UseAgentBuilderAvailability => {
     },
   } = useKibana();
   const licenseService = useLicense();
+  // Subscribed via the observable (rather than reading `licenseService.isEnterprise()`
+  // directly) so the button reacts when the license resolves asynchronously after
+  // mount instead of staying stuck on the pre-resolution snapshot.
+  const isEnterprise$ = useMemo(() => licenseService.isEnterprise$(), [licenseService]);
+  const hasValidAgentBuilderLicense = useObservable(isEnterprise$, licenseService.isEnterprise());
 
   return useMemo(() => {
     const agentBuilderCapabilities = capabilities[AGENTBUILDER_FEATURE_ID];
@@ -45,7 +51,7 @@ export const useAgentBuilderAvailability = (): UseAgentBuilderAvailability => {
       isAgentBuilderEnabled: hasAgentBuilderPrivilege && isAgentChatExperienceEnabled,
       hasAgentBuilderPrivilege,
       isAgentChatExperienceEnabled,
-      hasValidAgentBuilderLicense: licenseService.isEnterprise(),
+      hasValidAgentBuilderLicense,
     };
-  }, [capabilities, chatExperience, licenseService]);
+  }, [capabilities, chatExperience, hasValidAgentBuilderLicense]);
 };


### PR DESCRIPTION
## Summary

This is a regression from #248027, which correctly added a license check to disable the agent builder "Add to chat" button for non-Enterprise licenses. That check reads `licenseService.isEnterprise()` as a one-time snapshot inside a `useMemo`, so if the license resolves *after* the component's first render, nothing tells React to re-render — the button stays disabled forever.

Under CI's slower/loaded ES + Fleet startup, the license reliably resolves after first render, so the button is now consistently stuck disabled. This is what's failing `add_rule_attachment_to_chat.cy.ts` (elastic/kibana#260436, elastic/kibana#260437, elastic/kibana#260438) on unrelated PRs — not flakiness, a real race exposed by CI timing.

## Fix

Added `LicenseService.isEnterprise$()`, an observable that emits whenever the license updates, and switched `useAgentBuilderAvailability` to subscribe to it via `useObservable` instead of reading a stale snapshot.

## Test plan
- [x] Updated/passing unit tests for `useAgentBuilderAvailability` and `LicenseService`
- [x] `node scripts/type_check --project x-pack/solutions/security/plugins/security_solution/tsconfig.json` passes
- [ ] Confirm `add_rule_attachment_to_chat.cy.ts` passes in CI