### PR TITLE
[Onboarding] Fix flaky Kubernetes redirect test with a cold-boot timeout

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/kubernetes_flow.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/kubernetes_flow.spec.ts
@@ -9,6 +9,10 @@ import { expect } from '@kbn/scout-oblt/ui';
 import { tags } from '@kbn/scout-oblt';
 import { test } from '../fixtures';
 
+// Cold mount after a full-page `gotoApp` reload can exceed the default 10s
+// `expect` timeout under CI load, so post-reload render waits get a larger budget.
+const APP_BOOT_TIMEOUT = 30_000;
+
 test.describe.serial(
   'Kubernetes Onboarding',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
@@ -35,13 +39,19 @@ test.describe.serial(
     }) => {
       await pageObjects.kubernetes.gotoPath('otel-kubernetes?ingestion=wired&foo=bar');
 
+      // Wait for the redirected page to render first (absorbs SPA cold-boot latency),
+      // then assert the URL, which has already settled by then.
+      await expect(pageObjects.kubernetes.layout('otel')).toBeVisible({
+        timeout: APP_BOOT_TIMEOUT,
+      });
       await expect(page).toHaveURL(/\/kubernetes\?foo=bar/);
-      await expect(pageObjects.kubernetes.layout('otel')).toBeVisible();
     });
 
     test('Kubernetes step controls expose expected branch UI', async ({ pageObjects }) => {
       await pageObjects.kubernetes.gotoPath('/kubernetes');
-      await expect(pageObjects.kubernetes.layout('otel')).toBeVisible();
+      await expect(pageObjects.kubernetes.layout('otel')).toBeVisible({
+        timeout: APP_BOOT_TIMEOUT,
+      });
 
       await test.step('select existing collector tab', async () => {
         await pageObjects.kubernetes.collectorTab('existing').click();


### PR DESCRIPTION
closes: #275114

## Summary

The `kubernetes_flow.spec.ts` Scout test navigates to `/otel-kubernetes?ingestion=wired&foo=bar` and asserts it redirects to `/kubernetes?foo=bar`. It flaked intermittently in CI.

The redirect is a client-side React Router `<Redirect>` that only runs once the onboarding SPA has mounted. `gotoPath` uses `page.gotoApp` -> `page.goto()`, which returns on the `load` event, but the SPA mounts asynchronously afterwards. Under CI load that mount occasionally takes longer than the default 10s `expect` timeout, so the assertion times out before the redirect and render complete (the failure screenshot shows a blank body with a spinner). The Scout per-test budget is 60s, but individual `expect` assertions default to 10s, which is the limit being hit.

## Changes

- Added an `APP_BOOT_TIMEOUT` (30s) constant for waits that follow a full-page `gotoApp` reload.
- Redirect test: wait for the redirected page to render (`layout('otel')`) with the boot timeout, then assert the settled URL.
- Applied the same boot timeout to the sibling `Kubernetes step controls` test, which shares the exact pattern (full reload then immediate `layout('otel')` wait) and had the same latent flake, hidden only because `describe.serial` skips it once the redirect test fails.

## Why the AI automated attempt (#276427) won't work

That PR only reversed the two assertions. `toHaveURL` is already a retrying assertion with its own 10s budget, so reordering did not add boot time. The flaky verifier on that PR reproduced the failure on the reordered `toBeVisible` assertion, confirming the ordering was not the cause.
