### PR TITLE
Disallow the removal of all spaces from a job or trained model

### DIFF
--- a/x-pack/platform/plugins/shared/ml/server/saved_objects/service.ts
+++ b/x-pack/platform/plugins/shared/ml/server/saved_objects/service.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import { memoize } from 'lodash';
 import type {
   KibanaRequest,
@@ -367,6 +368,23 @@ export function mlSavedObjectServiceFactory(
     const type = jobType;
     if (jobIds.length === 0 || (spacesToAdd.length === 0 && spacesToRemove.length === 0)) {
       return {};
+    }
+
+    if (spacesToAdd.length === 0) {
+      const allJobObjects = await getAllJobObjectsForAllSpaces(
+        jobType,
+        jobIds.length === 1 ? jobIds[0] : undefined
+      );
+      for (const jobId of jobIds) {
+        const currentSpaces =
+          allJobObjects.find((j) => j.attributes.job_id === jobId)?.namespaces ?? [];
+        if (
+          currentSpaces.length > 0 &&
+          currentSpaces.every((space) => spacesToRemove.includes(space))
+        ) {
+          throw Boom.badRequest(`Cannot remove job '${jobId}' from all spaces`);
+        }
+      }
     }
 
     const results: SavedObjectResult = Object.create(null);
@@ -749,6 +767,23 @@ export function mlSavedObjectServiceFactory(
     if (modelIds.length === 0 || (spacesToAdd.length === 0 && spacesToRemove.length === 0)) {
       return {};
     }
+
+    if (spacesToAdd.length === 0) {
+      const allModelObjects = await getAllTrainedModelObjectsForAllSpaces(
+        modelIds.length === 1 ? [modelIds[0]] : undefined
+      );
+      for (const modelId of modelIds) {
+        const currentSpaces =
+          allModelObjects.find((m) => m.attributes.model_id === modelId)?.namespaces ?? [];
+        if (
+          currentSpaces.length > 0 &&
+          currentSpaces.every((space) => spacesToRemove.includes(space))
+        ) {
+          throw Boom.badRequest(`Cannot remove trained model '${modelId}' from all spaces`);
+        }
+      }
+    }
+
     const results: SavedObjectResult = Object.create(null);
     const models = await _getTrainedModelObjects();
     const trainedModelObjectIdMap = new Map<string, string>();

--- a/x-pack/platform/test/api_integration/apis/ml/saved_objects/update_jobs_spaces.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/saved_objects/update_jobs_spaces.ts
@@ -87,6 +87,25 @@ export default ({ getService }: FtrProviderContext) => {
       await ml.api.assertJobSpaces(adJobId, jobType, [idSpace1]);
     });
 
+    it('should fail when attempting to remove all spaces from an AD job', async () => {
+      const jobType = 'anomaly-detector';
+      await ml.api.assertJobSpaces(adJobId, jobType, [defaultSpaceId]);
+      const body = await runRequest(
+        {
+          jobType,
+          jobIds: [adJobId],
+          spacesToAdd: [],
+          spacesToRemove: [defaultSpaceId],
+        },
+        400,
+        USER.ML_POWERUSER
+      );
+
+      expect(body.error).to.eql('Bad Request');
+      expect(body.message).to.eql(`Cannot remove job '${adJobId}' from all spaces`);
+      await ml.api.assertJobSpaces(adJobId, jobType, [defaultSpaceId]);
+    });
+
     it('should assign DFA job to space for user with access to that space', async () => {
       const jobType = 'data-frame-analytics';
       await ml.api.assertJobSpaces(dfaJobId, jobType, [defaultSpaceId]);

--- a/x-pack/platform/test/api_integration/apis/ml/saved_objects/update_trained_model_spaces.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/saved_objects/update_trained_model_spaces.ts
@@ -79,6 +79,25 @@ export default ({ getService }: FtrProviderContext) => {
       await ml.api.assertTrainedModelSpaces(trainedModelId, [idSpace1]);
     });
 
+    it('should fail when attempting to remove all spaces from a trained model', async () => {
+      await ml.api.assertTrainedModelSpaces(trainedModelId, [defaultSpaceId]);
+      const body = await runRequest(
+        {
+          modelIds: [trainedModelId],
+          spacesToAdd: [],
+          spacesToRemove: [defaultSpaceId],
+        },
+        400,
+        USER.ML_POWERUSER
+      );
+
+      expect(body.error).to.eql('Bad Request');
+      expect(body.message).to.eql(
+        `Cannot remove trained model '${trainedModelId}' from all spaces`
+      );
+      await ml.api.assertTrainedModelSpaces(trainedModelId, [defaultSpaceId]);
+    });
+
     it('should fail to update trained model spaces for space the user has no access to', async () => {
       await ml.api.assertTrainedModelSpaces(trainedModelId, [defaultSpaceId]);
       const body = await runRequest(


### PR DESCRIPTION
Adds a check to the APIs `/api/ml/saved_objects/update_jobs_spaces` and `/api/ml/saved_objects/update_trained_models_spaces` to ensure a job or trained model cannot have all of its spaces removed.
An error will be thrown if the user attempts this.

Fixes https://github.com/elastic/kibana/issues/276473

Note, it's not possible to attempt this via the UI. This fix only addresses an issue caused by calling the API manually.

<!--ONMERGE {"backportTargets":["8.18","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->