### PR TITLE
[Streams, Index Management] Update DLM frozen phase enterprise gating links

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/constants.ts
@@ -6,7 +6,22 @@
  */
 
 /**
- * Link to the Elastic Cloud subscription features page. Used by the enterprise
- * gating UX (badges/modals) to point users at the available subscription tiers.
+ * Link to the Elastic subscription features page. Used by the enterprise
+ * gating UX (badges/modals) to point self-managed users at the available
+ * subscription tiers.
  */
-export const SUBSCRIPTION_FEATURES_URL = 'https://www.elastic.co/subscriptions/cloud';
+export const SUBSCRIPTION_FEATURES_URL = 'https://www.elastic.co/subscriptions';
+
+/**
+ * Link to the Elastic Cloud subscription features page. Used by the enterprise
+ * gating UX (badges/modals) to point Cloud-hosted stateful users at the
+ * available subscription tiers.
+ */
+export const CLOUD_SUBSCRIPTION_FEATURES_URL = 'https://www.elastic.co/subscriptions/cloud';
+
+/**
+ * Link to the Elastic "Contact us" page. Used by the enterprise gating UX
+ * (badges/modals) as the primary action for self-managed users, who cannot
+ * start a trial or upgrade in-product.
+ */
+export const CONTACT_US_URL = 'https://www.elastic.co/contact';

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/steps/step_logistics.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/steps/step_logistics.tsx
@@ -19,6 +19,11 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import {
+  CLOUD_SUBSCRIPTION_FEATURES_URL,
+  CONTACT_US_URL,
+  SUBSCRIPTION_FEATURES_URL,
+} from '@kbn/data-lifecycle-phases';
 import { DlmPhasesSelector } from '../../../../data_lifecycle';
 import type { DlmPhasesSelectorProps, SerializedDlmPhases } from '../../../../data_lifecycle';
 import { resolveLogisticsLifecycle } from '../../../../../../../common/lib';
@@ -40,8 +45,6 @@ import { logisticsFormSchema } from './step_logistics_schema';
 
 const UseField = getUseField({ component: Field });
 const FormRow = getFormRow({ titleTag: 'h3' });
-
-const SUBSCRIPTION_FEATURES_URL = 'https://www.elastic.co/subscriptions/cloud';
 
 interface Props {
   defaultValue: { [key: string]: any; lifecycle?: DataRetention; _meta?: Record<string, unknown> };
@@ -104,7 +107,12 @@ const useDlmEnterpriseConfig = (): DlmPhasesSelectorProps['enterprise'] => {
     isCloudEnabled: Boolean(cloud?.isCloudEnabled),
     canManageLicense: Boolean(application?.capabilities?.management?.stack?.license_management),
     trialDaysLeft: cloud?.trialDaysLeft?.(),
-    subscriptionFeaturesUrl: SUBSCRIPTION_FEATURES_URL,
+    subscriptionFeaturesUrl: cloud?.isCloudEnabled
+      ? CLOUD_SUBSCRIPTION_FEATURES_URL
+      : SUBSCRIPTION_FEATURES_URL,
+    onUpgrade: cloud?.isCloudEnabled
+      ? undefined
+      : () => window.open(CONTACT_US_URL, '_blank', 'noopener'),
   };
 };
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/steps/step_logistics.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/steps/step_logistics.tsx
@@ -20,7 +20,11 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { SUBSCRIPTION_FEATURES_URL } from '@kbn/data-lifecycle-phases';
+import {
+  CLOUD_SUBSCRIPTION_FEATURES_URL,
+  CONTACT_US_URL,
+  SUBSCRIPTION_FEATURES_URL,
+} from '@kbn/data-lifecycle-phases';
 
 import { DlmPhasesSelector } from '../../data_lifecycle';
 import type { DlmPhasesSelectorProps, SerializedDlmPhases } from '../../data_lifecycle';
@@ -110,7 +114,12 @@ const useDlmEnterpriseConfig = (): DlmPhasesSelectorProps['enterprise'] => {
     isCloudEnabled: Boolean(cloud?.isCloudEnabled),
     canManageLicense: Boolean(application?.capabilities?.management?.stack?.license_management),
     trialDaysLeft: cloud?.trialDaysLeft?.(),
-    subscriptionFeaturesUrl: SUBSCRIPTION_FEATURES_URL,
+    subscriptionFeaturesUrl: cloud?.isCloudEnabled
+      ? CLOUD_SUBSCRIPTION_FEATURES_URL
+      : SUBSCRIPTION_FEATURES_URL,
+    onUpgrade: cloud?.isCloudEnabled
+      ? undefined
+      : () => window.open(CONTACT_US_URL, '_blank', 'noopener'),
   };
 };
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/lifecycle/use_edit_data_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/lifecycle/use_edit_data_lifecycle.ts
@@ -16,6 +16,11 @@ import {
   isInheritFailureStore,
   isEnabledFailureStore,
 } from '@kbn/streams-schema';
+import {
+  CLOUD_SUBSCRIPTION_FEATURES_URL,
+  CONTACT_US_URL,
+  SUBSCRIPTION_FEATURES_URL,
+} from '@kbn/data-lifecycle-phases';
 import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
 import type { IndexManagementLocatorParams } from '@kbn/index-management-shared-types';
 
@@ -97,7 +102,7 @@ export const useEditDataLifecycle = ({
   resolvedLifecycle,
   onClose,
 }: UseEditDataLifecycleArgs) => {
-  const { config, core, docLinks, plugins, services, url } = useAppContext();
+  const { config, core, plugins, services, url } = useAppContext();
   const locator = url.locators.get<IndexManagementLocatorParams>(INDEX_MANAGEMENT_LOCATOR_ID);
 
   const [isEditingDataLifecycle, setIsEditingDataLifecycle] = useState(false);
@@ -814,7 +819,12 @@ export const useEditDataLifecycle = ({
           canManageLicense:
             core.application.capabilities.management?.stack?.license_management === true,
           trialDaysLeft: plugins.cloud?.trialDaysLeft?.(),
-          subscriptionFeaturesUrl: docLinks.links.subscriptions,
+          subscriptionFeaturesUrl: plugins.cloud?.isCloudEnabled
+            ? CLOUD_SUBSCRIPTION_FEATURES_URL
+            : SUBSCRIPTION_FEATURES_URL,
+          onUpgrade: plugins.cloud?.isCloudEnabled
+            ? undefined
+            : () => window.open(CONTACT_US_URL, '_blank', 'noopener'),
         },
         onRefreshDefaultSnapshotRepository: loadDefaultSnapshotRepository,
       },
@@ -833,7 +843,6 @@ export const useEditDataLifecycle = ({
       config.isServerless,
       core,
       defaultSnapshotRepository,
-      docLinks.links.subscriptions,
       handleInheritSuccessfulLifecycleChange,
       hasEnterpriseLicense,
       ilmPolicies,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_dlm_frozen_phase_gating.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_dlm_frozen_phase_gating.tsx
@@ -9,6 +9,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import type { Streams } from '@kbn/streams-schema';
 import {
+  CLOUD_SUBSCRIPTION_FEATURES_URL,
+  CONTACT_US_URL,
   DefaultSnapshotRepositoryRequiredModal,
   EnterpriseGatingModal,
   SUBSCRIPTION_FEATURES_URL,
@@ -162,8 +164,14 @@ export const useDlmFrozenPhaseGating = ({
               : Boolean(application.capabilities?.management?.stack?.license_management)
           }
           trialStatus={cloud?.trialDaysLeft?.() === 0 ? 'expired' : 'notStarted'}
-          subscriptionFeaturesUrl={SUBSCRIPTION_FEATURES_URL}
-          onPrimaryAction={() => window.open(SUBSCRIPTION_FEATURES_URL, '_blank', 'noopener')}
+          subscriptionFeaturesUrl={
+            cloud?.isCloudEnabled ? CLOUD_SUBSCRIPTION_FEATURES_URL : SUBSCRIPTION_FEATURES_URL
+          }
+          onPrimaryAction={
+            cloud?.isCloudEnabled
+              ? undefined
+              : () => window.open(CONTACT_US_URL, '_blank', 'noopener')
+          }
           onCancel={closeModal}
           data-test-subj="streamsDlmFrozenEnterpriseGatingModal"
         />


### PR DESCRIPTION
## Summary

This PR:

- Added a dedicated self-managed subscriptions URL and a "Contact us" URL for the enterprise gating UX, keeping the existing Cloud subscriptions URL as a separate constant for Cloud-hosted stateful deployments.
- Fixed the frozen-phase enterprise gating modal in Streams and Index Management (index templates, component templates, data streams) to link self-managed users to the correct subscriptions page and wire up a working "Contact us" primary action.
- Updated the primary action button to be hidden entirely for Cloud-hosted stateful deployments, since trial/upgrade flows are handled by the Cloud UI rather than this modal.

### How to test

1. **Self-managed (default)** — run Kibana locally without `xpack.cloud.id` set, on a non-Enterprise license.
   - **Streams**: go to a stream's data lifecycle tab, try to add the Frozen phase → the "Enterprise license required" callout appears → click **Upgrade to enterprise** to open the modal.
   - **Index Management**: repeat the same Frozen-phase gating flow in each of: Data Streams detail panel → Edit lifecycle, Index Templates → create/edit → Logistics step, Component Templates → create/edit → Logistics step.
   - In each modal, confirm:
     - "Review subscription features" link → `https://www.elastic.co/subscriptions`
     - "Contact us" button is shown and opens `https://www.elastic.co/contact`

2. **Cloud-hosted stateful** — add `xpack.cloud.id: "fake_local_cloud_id"` to `config/kibana.dev.yml` and restart, keeping the license below Enterprise.
   - Repeat the same 4 gating flows (Streams + 3 Index Management entry points).
   - Confirm:
     - "Review subscription features" link → `https://www.elastic.co/subscriptions/cloud`
     - No primary CTA button is rendered (trial/upgrade is handled by the Cloud UI, not this modal)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.