### PR TITLE
[UIAM OAuth] Add Agent Builder EBT for MCP Clients page

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/moon.yml
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: x-pack/platform/packages/shared/agent-builder/agent-builder-browser
 dependsOn:
   - '@kbn/agent-builder-common'
+  - '@kbn/ebt-click'
   - '@kbn/zod'
   - '@kbn/i18n'
   - '@kbn/i18n-react'

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
@@ -8,7 +8,8 @@
 import React, { useCallback } from 'react';
 import { EuiButtonIcon, EuiCallOut, EuiCopy, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import type { OAuthClient } from '@kbn/agent-builder-common';
-import { OAuthClientType } from '@kbn/agent-builder-common';
+import { AGENT_BUILDER_UI_EBT, OAuthClientType } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import fileSaver from 'file-saver';
 import { isEmpty } from 'lodash';
 import useToggle from 'react-use/lib/useToggle';
@@ -121,6 +122,11 @@ export const McpClientDetailsContent = ({
                     color="text"
                     aria-label={labels.details.modal.copySecret}
                     onClick={copy}
+                    {...getEbtProps({
+                      element: AGENT_BUILDER_UI_EBT.element.flyout,
+                      action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_COPY_SECRET,
+                      detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+                    })}
                   />
                 </EuiToolTip>
               )}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
@@ -123,7 +123,7 @@ export const McpClientDetailsContent = ({
                     aria-label={labels.details.modal.copySecret}
                     onClick={copy}
                     {...getEbtProps({
-                      element: AGENT_BUILDER_UI_EBT.element.flyout,
+                      element: AGENT_BUILDER_UI_EBT.element.pageContent,
                       action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_COPY_SECRET,
                       detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
                     })}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tsconfig.json
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tsconfig.json
@@ -18,6 +18,7 @@
   ],
   "kbn_references": [
     "@kbn/agent-builder-common",
+    "@kbn/ebt-click",
     "@kbn/zod",
     "@kbn/i18n",
     "@kbn/i18n-react",

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
@@ -1170,7 +1170,7 @@ const MANAGE_ENTITY_LIST_VIEW_EVENT: AgentBuilderTelemetryEvent = {
     entity_type: {
       type: 'keyword',
       _meta: {
-        description: 'Type of entity on the list page (tool|plugin|skill)',
+        description: 'Type of entity on the list page (tool|plugin|skill|mcp_client)',
         optional: false,
       },
     },

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_ui_ebt.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_ui_ebt.ts
@@ -64,6 +64,14 @@ const ebtAction = {
     COPY_MCP_URL: 'copy_mcp_url',
     BULK_IMPORT_MCP: 'bulk_import_mcp',
     MANAGE_MCP_CLIENTS: 'manage_mcp_clients',
+    MCP_CLIENT_CREATE_OPEN: 'mcp_client_create_open',
+    MCP_CLIENT_CREATE_SUBMIT: 'mcp_client_create_submit',
+    MCP_CLIENT_CREATE_CANCEL: 'mcp_client_create_cancel',
+    MCP_CLIENT_VIEW_DETAILS: 'mcp_client_view_details',
+    MCP_CLIENT_COPY_SECRET: 'mcp_client_copy_secret',
+    MCP_CLIENT_REVOKE_OPEN: 'mcp_client_revoke_open',
+    MCP_CLIENT_REVOKE_CONFIRM: 'mcp_client_revoke_confirm',
+    MANAGE_APPLICATION_CONNECTIONS_LINK: 'manage_application_connections_link',
     MCP_DOCS: 'mcp_docs',
     ADD_REFERENCED_FILE: 'add_referenced_file',
     REMOVE_REFERENCED_FILE: 'remove_referenced_file',
@@ -222,6 +230,7 @@ const ebtEntity = {
   PLUGIN: 'plugin',
   SKILL: 'skill',
   AGENT: 'agent',
+  MCP_CLIENT: 'mcp_client',
 } as const;
 const ebtFormat = {} as const;
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/create/mcp_client_create.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/create/mcp_client_create.tsx
@@ -16,6 +16,8 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
+import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { useUnsavedChangesPrompt } from '@kbn/unsaved-changes-prompt';
 import { defer } from 'lodash';
@@ -109,7 +111,16 @@ export const McpClientCreate = () => {
           <EuiSpacer size="xl" />
           <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty size="m" color="text" onClick={handleCancel}>
+              <EuiButtonEmpty
+                size="m"
+                color="text"
+                onClick={handleCancel}
+                {...getEbtProps({
+                  element: AGENT_BUILDER_UI_EBT.element.pageContent,
+                  action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_CREATE_CANCEL,
+                  detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+                })}
+              >
                 {labels.tools.mcpClients.form.cancelButton}
               </EuiButtonEmpty>
             </EuiFlexItem>
@@ -121,6 +132,11 @@ export const McpClientCreate = () => {
                 isLoading={isCreating}
                 disabled={hasErrors || isCreating}
                 data-test-subj="mcpClientCreateButton"
+                {...getEbtProps({
+                  element: AGENT_BUILDER_UI_EBT.element.pageContent,
+                  action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_CREATE_SUBMIT,
+                  detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+                })}
               >
                 {labels.tools.mcpClients.form.createButton}
               </EuiButton>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_client_actions_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_client_actions_button.tsx
@@ -14,6 +14,8 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import useToggle from 'react-use/lib/useToggle';
+import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import { useMcpClientsActions } from '../../context/mcp_clients_provider';
 import { labels } from '../../utils/i18n';
 
@@ -47,6 +49,11 @@ export const McpClientActionsMenu = ({
       color="danger"
       onClick={handleRevoke}
       data-test-subj={`mcpClientRevokeAction-${clientId}`}
+      {...getEbtProps({
+        element: AGENT_BUILDER_UI_EBT.element.pageContent,
+        action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_REVOKE_OPEN,
+        detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+      })}
     >
       {labels.tools.mcpClients.actions.revoke}
     </EuiContextMenuItem>,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients.tsx
@@ -12,6 +12,8 @@ import type { UseEuiTheme } from '@elastic/eui';
 import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { MANAGEMENT_APP_ID } from '@kbn/management-plugin/public';
+import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import { McpClientsTable } from './mcp_clients_table';
 import { labels } from '../../utils/i18n';
 import { useMcpClientsActions } from '../../context/mcp_clients_provider';
@@ -56,12 +58,27 @@ export const AgentBuilderMcpClients = () => {
         pageTitle={labels.tools.mcpClients.title}
         description={labels.tools.mcpClients.description}
         rightSideItems={[
-          <EuiButton fill onClick={createMcpClient} data-test-subj="mcpClientsAddButton">
+          <EuiButton
+            fill
+            onClick={createMcpClient}
+            data-test-subj="mcpClientsAddButton"
+            {...getEbtProps({
+              element: AGENT_BUILDER_UI_EBT.element.pageContent,
+              action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_CREATE_OPEN,
+              detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+            })}
+          >
             {labels.tools.mcpClients.addMcpClientButtonLabel}
           </EuiButton>,
           <EuiButtonEmpty
             href={applicationConnectionsUrl}
             data-test-subj="mcpClientsManageApplicationConnectionsButton"
+            {...getEbtProps({
+              element: AGENT_BUILDER_UI_EBT.element.pageContent,
+              action:
+                AGENT_BUILDER_UI_EBT.action.globalManagement.MANAGE_APPLICATION_CONNECTIONS_LINK,
+              detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+            })}
           >
             {labels.tools.mcpClients.manageApplicationConnectionsButtonLabel}
           </EuiButtonEmpty>,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table.tsx
@@ -18,9 +18,12 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { OAuthClient } from '@kbn/agent-builder-common';
+import { AGENT_BUILDER_EVENT_TYPES, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import { i18n } from '@kbn/i18n';
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import { useOAuthClients } from '../../hooks/oauth_clients/use_oauth_clients';
+import { useKibana } from '../../hooks/use_kibana';
 import { useMcpClientsActions } from '../../context/mcp_clients_provider';
 import { labels } from '../../utils/i18n';
 import illustrationGenai from './assets/illustration_genai.svg';
@@ -56,14 +59,28 @@ const emptyPromptStyles = ({ euiTheme }: UseEuiTheme) => css`
 `;
 
 export const McpClientsTable = memo(() => {
+  const {
+    services: { analytics },
+  } = useKibana();
   const { clients, isLoading, error } = useOAuthClients();
   const { createMcpClient } = useMcpClientsActions();
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const columns = useMcpClientsTableColumns();
   const { searchConfig, results: tableClients } = useMcpClientsTableSearch({ clients });
+  const hasFiredListViewRef = useRef(false);
 
   const hasClients = clients.length > 0;
+
+  useEffect(() => {
+    if (!isLoading && !hasFiredListViewRef.current) {
+      hasFiredListViewRef.current = true;
+      analytics.reportEvent(AGENT_BUILDER_EVENT_TYPES.ManageEntityListView, {
+        entity_type: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+        entity_count: clients.length,
+      });
+    }
+  }, [isLoading, clients.length, analytics]);
 
   useEffect(() => {
     setPageIndex(0);
@@ -135,6 +152,11 @@ export const McpClientsTable = memo(() => {
                   <EuiButton
                     onClick={createMcpClient}
                     data-test-subj="mcpClientsEmptyStateAddButton"
+                    {...getEbtProps({
+                      element: AGENT_BUILDER_UI_EBT.element.pageContent,
+                      action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_CREATE_OPEN,
+                      detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+                    })}
                   >
                     {labels.tools.mcpClients.addMcpClientOAuthButtonLabel}
                   </EuiButton>,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table_columns.tsx
@@ -15,6 +15,8 @@ import {
   type EuiTableFieldDataColumnType,
 } from '@elastic/eui';
 import type { OAuthClient } from '@kbn/agent-builder-common';
+import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import React, { useMemo } from 'react';
 import { isEmpty } from 'lodash';
 import { McpClientLogo } from '@kbn/agent-builder-browser';
@@ -51,6 +53,11 @@ export const useMcpClientsTableColumns = (): Array<EuiBasicTableColumn<OAuthClie
             <EuiLink
               onClick={() => viewClientDetails(client, 'flyout')}
               data-test-subj={`mcpClientsListNameLink-${client.id}`}
+              {...getEbtProps({
+                element: AGENT_BUILDER_UI_EBT.element.pageContent,
+                action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_VIEW_DETAILS,
+                detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+              })}
             >
               {name}
             </EuiLink>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/revoke_mcp_client_modal.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/revoke_mcp_client_modal.tsx
@@ -22,6 +22,8 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
+import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { getEbtProps } from '@kbn/ebt-click';
 import { useRevokeOAuthClient } from '../../hooks/oauth_clients/use_revoke_oauth_client';
 import { useToasts } from '../../hooks/use_toasts';
 import { labels } from '../../utils/i18n';
@@ -110,6 +112,11 @@ export const RevokeMcpClientModal = ({
           isLoading={isRevoking}
           disabled={!isConfirmed || isRevoking}
           data-test-subj="mcpClientRevokeConfirmButton"
+          {...getEbtProps({
+            element: AGENT_BUILDER_UI_EBT.element.pageContent,
+            action: AGENT_BUILDER_UI_EBT.action.globalManagement.MCP_CLIENT_REVOKE_CONFIRM,
+            detail: AGENT_BUILDER_UI_EBT.entity.MCP_CLIENT,
+          })}
         >
           {labels.tools.mcpClients.revoke.revokeButton}
         </EuiButton>


### PR DESCRIPTION
## Summary

Instruments the Agent Builder MCP Clients page with Event-Based Telemetry (EBT) to capture user interactions across the list, create, details, and revoke flows.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
