### PR TITLE
scripts/check: Bound Jest worker memory

### DIFF
--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -497,6 +497,39 @@ describe('run_check', () => {
     expect(output).toContain('node scripts/jest --config packages/foo/jest.config.js');
   });
 
+  it('surfaces an OOM note instead of treating a worker crash as a plain failure', async () => {
+    mockRunJestViaMoon.mockResolvedValue({
+      taskCount: 1,
+      cachedCount: 0,
+      totalTests: 0,
+      failed: [
+        {
+          project: '@kbn/foo',
+          configPath: 'packages/foo/jest.config.js',
+          cached: false,
+          passed: false,
+          testCount: 0,
+          failures: [
+            {
+              file: 'packages/foo/src/bar.test.ts',
+              name: 'Test suite failed to run',
+              message: 'Jest worker encountered 4 child process exceptions, exceeding retry limit',
+              oom: true,
+            },
+          ],
+        },
+      ],
+      exitCode: 1,
+    });
+
+    await handler(createArgs());
+
+    expect(process.exitCode).toBe(1);
+    const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
+    expect(output).toContain('This looks like a Jest worker ran out of memory');
+    expect(output).toContain('NODE_OPTIONS=--max-old-space-size=8192');
+  });
+
   it('uses the repo root tsconfig in the tsc rerun command when no nearer config exists', async () => {
     mockExistsSync.mockImplementation(
       (p: string) => p === '/repo/packages/foo/jest.config.js' || p === '/repo/tsconfig.json'

--- a/src/dev/run_check.ts
+++ b/src/dev/run_check.ts
@@ -510,6 +510,7 @@ run(
             errors.push(new Error('jest failed'));
           } else if (result.failed.length > 0) {
             const failCount = result.failed.length;
+            const oomDetected = result.failed.some((task) => task.failures.some((f) => f.oom));
             jestProgress.writeResult(
               line(
                 'jest',
@@ -519,6 +520,13 @@ run(
               )
             );
             writeln('');
+            if (oomDetected) {
+              writeln(
+                '    ⚠ This looks like a Jest worker ran out of memory, not a real test failure.'
+              );
+              writeln('      Try: NODE_OPTIONS=--max-old-space-size=8192 node scripts/check');
+              writeln('');
+            }
             for (const task of result.failed) {
               // Group failures by file
               const byFile = new Map<string, JestFailedTest[]>();

--- a/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts
@@ -13,7 +13,34 @@ jest.mock('@kbn/repo-info', () => ({
   REPO_ROOT: '/repo',
 }));
 
-import { parseMoonJestOutput, computeJestParallelism } from './run_jest_via_moon';
+import {
+  parseMoonJestOutput,
+  computeJestParallelism,
+  buildMoonJestWarnings,
+  buildJestNodeOptions,
+  JEST_WORKER_MAX_OLD_SPACE_MB,
+} from './run_jest_via_moon';
+
+describe('buildJestNodeOptions', () => {
+  it('sets the default heap cap when NODE_OPTIONS is unset', () => {
+    expect(buildJestNodeOptions(undefined)).toBe(
+      `--max-old-space-size=${JEST_WORKER_MAX_OLD_SPACE_MB}`
+    );
+  });
+
+  it('lets a user-supplied --max-old-space-size win over the default (last flag wins)', () => {
+    // This is the exact remediation run_check.ts prints on OOM: it must actually take effect.
+    const result = buildJestNodeOptions('--max-old-space-size=8192');
+    const values = [...result.matchAll(/--max-old-space-size=(\d+)/g)].map((m) => m[1]);
+    expect(values[values.length - 1]).toBe('8192');
+  });
+
+  it('preserves other user-supplied NODE_OPTIONS flags', () => {
+    expect(buildJestNodeOptions('--trace-warnings')).toBe(
+      `--max-old-space-size=${JEST_WORKER_MAX_OLD_SPACE_MB} --trace-warnings`
+    );
+  });
+});
 
 describe('parseMoonJestOutput', () => {
   it('parses successful Jest JSON output with project prefix', () => {
@@ -83,17 +110,100 @@ describe('parseMoonJestOutput', () => {
     expect(result.parseFailures).toHaveLength(1);
     expect(result.parseFailures[0]).toContain('Failed to parse Jest JSON from project @kbn/bad');
   });
+
+  it('flags a Jest worker OOM signature as failure with oom set', () => {
+    const output = [
+      'fail RunTask(@kbn/foo:jest) (2s, abc123)',
+      '@kbn/foo:jest | {"success":false,"numTotalTests":2,"numPassedTests":1,"numFailedTests":1,"testResults":[{"name":"/repo/packages/foo/src/bar.test.ts","assertionResults":[{"status":"failed","fullName":"bar should work","failureMessages":["Jest worker encountered 4 child process exceptions, exceeding retry limit"]}]}]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks[0].failures[0].oom).toBe(true);
+  });
+
+  it('flags a whole-suite crash with no assertion results as failure with oom set', () => {
+    // This is the literal message jest-worker's ChildProcessWorker/NodeThreadsWorker raise
+    // for a crashed/OOM-killed worker; Jest's formatTestResults flattens it into `message`.
+    // The raw V8 "heap out of memory" crash text never reaches this field.
+    const output = [
+      'fail RunTask(@kbn/foo:jest) (2s, abc123)',
+      '@kbn/foo:jest | {"success":false,"numTotalTests":0,"numPassedTests":0,"numFailedTests":0,"testResults":[{"name":"/repo/packages/foo/src/bar.test.ts","status":"failed","message":"Jest worker ran out of memory and crashed","assertionResults":[]}]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks[0].failures).toHaveLength(1);
+    expect(result.tasks[0].failures[0]).toMatchObject({
+      name: 'Test suite failed to run',
+      oom: true,
+    });
+  });
+
+  it('does not flag a normal assertion failure as oom', () => {
+    const output = [
+      'fail RunTask(@kbn/foo:jest) (2s, abc123)',
+      '@kbn/foo:jest | {"success":false,"numTotalTests":2,"numPassedTests":1,"numFailedTests":1,"testResults":[{"name":"/repo/packages/foo/src/bar.test.ts","assertionResults":[{"status":"failed","fullName":"bar should work","failureMessages":["Error: expected true"]}]}]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks[0].failures[0].oom).toBe(false);
+  });
+});
+
+describe('buildMoonJestWarnings', () => {
+  it('flags a raw V8 heap crash when no tasks parsed and exit code is non-zero', () => {
+    const output = [
+      '<--- Last few GCs --->',
+      'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory',
+    ].join('\n');
+
+    const warnings = buildMoonJestWarnings({
+      output,
+      exitCode: 134,
+      taskCount: 0,
+      parseFailures: [],
+    });
+
+    expect(warnings?.[0]).toContain('out-of-memory crash signature');
+  });
+
+  it('falls back to a generic message when no tasks parsed and no OOM signature present', () => {
+    const warnings = buildMoonJestWarnings({
+      output: 'some unrelated crash output',
+      exitCode: 1,
+      taskCount: 0,
+      parseFailures: [],
+    });
+
+    expect(warnings?.[0]).toContain('no Jest task output was parsed');
+  });
+
+  it('returns undefined when tasks parsed and there are no parse failures', () => {
+    const warnings = buildMoonJestWarnings({
+      output: '',
+      exitCode: 0,
+      taskCount: 1,
+      parseFailures: [],
+    });
+
+    expect(warnings).toBeUndefined();
+  });
 });
 
 describe('computeJestParallelism', () => {
   let cpusSpy: jest.SpyInstance;
+  let memSpy: jest.SpyInstance;
+
+  const GB = 1024 * 1024 * 1024;
 
   beforeEach(() => {
     cpusSpy = jest.spyOn(Os, 'cpus').mockReturnValue(new Array(8).fill({}) as any);
+    // Plenty of RAM by default so these tests exercise the CPU-bound path only.
+    memSpy = jest.spyOn(Os, 'totalmem').mockReturnValue(64 * GB);
   });
 
   afterEach(() => {
     cpusSpy.mockRestore();
+    memSpy.mockRestore();
   });
 
   it('caps Moon concurrency at 2', () => {
@@ -117,5 +227,14 @@ describe('computeJestParallelism', () => {
     cpusSpy.mockReturnValue(new Array(2).fill({}) as any);
     const { maxWorkers } = computeJestParallelism(10);
     expect(maxWorkers).toBe(2);
+  });
+
+  it('caps maxWorkers by available memory on high-core, low-RAM machines', () => {
+    cpusSpy.mockReturnValue(new Array(16).fill({}) as any);
+    memSpy.mockReturnValue(16 * GB);
+    const { concurrency, maxWorkers } = computeJestParallelism(1);
+    expect(concurrency).toBe(1);
+    // Without the memory bound this would be 16 (one worker per CPU).
+    expect(maxWorkers).toBe(3);
   });
 });

--- a/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.ts
@@ -34,6 +34,8 @@ export interface JestFailedTest {
   line?: number;
   name: string;
   message: string;
+  /** True when the failure message matches a known Jest worker OOM/crash signature. */
+  oom?: boolean;
 }
 
 export interface MoonJestTaskResult {
@@ -68,6 +70,40 @@ export interface MoonJestParseResult {
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+
+/** Mirrors CI's unit-test heap cap (`.buildkite/scripts/steps/test/jest_parallel.sh`). */
+export const JEST_WORKER_MAX_OLD_SPACE_MB = 4096;
+
+/** Leave headroom for the OS, IDE, browser, and Kibana dev server sharing the machine. */
+const AVAILABLE_MEMORY_FRACTION = 0.75;
+
+/**
+ * Node/V8 takes the last of duplicate `--max-old-space-size` flags in NODE_OPTIONS, so the
+ * default must come first: it acts as a floor when NODE_OPTIONS is unset, but a caller who
+ * already set their own `--max-old-space-size` (e.g. following the OOM remediation message
+ * run_check.ts prints) still wins.
+ */
+export const buildJestNodeOptions = (existingNodeOptions?: string): string =>
+  [`--max-old-space-size=${JEST_WORKER_MAX_OLD_SPACE_MB}`, existingNodeOptions]
+    .filter(Boolean)
+    .join(' ');
+
+/**
+ * Matches the literal errors jest-worker raises for a crashed/OOM-killed worker
+ * (see `_onExit`/`_detectOutOfMemoryCrash` in jest-worker's ChildProcessWorker and
+ * NodeThreadsWorker) once Jest has wrapped them into a suite's testExecError/message.
+ * These are the strings that actually show up in `--json` output; the raw V8
+ * "heap out of memory" crash text never reaches this field, see RAW_OOM_SIGNATURE_RE below.
+ */
+const WORKER_OOM_MESSAGE_RE =
+  /Jest worker encountered \d+ child process exceptions, exceeding retry limit|Jest worker ran out of memory and crashed/i;
+
+/**
+ * Mirrors jest-worker's own out-of-memory heuristic (`_detectOutOfMemoryCrash`, which
+ * scans a crashed child's raw stderr for these substrings). Used to recognize an OOM
+ * when the whole Jest process dies before producing any JSON for us to parse.
+ */
+const RAW_OOM_SIGNATURE_RE = /heap out of memory|allocation failure;|Last few GCs/i;
 
 /** Walk up from a test file to find the nearest jest config. */
 export const findJestConfig = (testFilePath: string): string | undefined => {
@@ -133,14 +169,26 @@ const resolveAffectedPackageInfo = async (files: string[]): Promise<AffectedPack
  * want the 1 uncached Jest process to keep most cores instead of reserving them
  * for Moon slots that finish immediately.
  *
+ * maxWorkers is also capped by available memory: on high-core, lower-RAM machines,
+ * sizing purely off `cpus` can schedule more concurrent Jest worker processes than
+ * the machine can actually hold (each capped at JEST_WORKER_MAX_OLD_SPACE_MB), which
+ * OOM-kills a worker without it looking any different from a real test failure.
+ *
  * - maxWorkers never drops below 2
  * - Moon concurrency caps at 2
  */
 export const computeJestParallelism = (estimatedTasks: number) => {
   const cpus = Os.cpus().length;
+  const availableMemMb = (Os.totalmem() / (1024 * 1024)) * AVAILABLE_MEMORY_FRACTION;
   const safeEstimatedTasks = Math.max(1, estimatedTasks);
   const concurrency = Math.min(safeEstimatedTasks, 2);
-  const maxWorkers = Math.max(2, Math.floor(cpus / concurrency));
+
+  const cpuBoundWorkers = Math.floor(cpus / concurrency);
+  const memoryBoundWorkers = Math.floor(
+    availableMemMb / JEST_WORKER_MAX_OLD_SPACE_MB / concurrency
+  );
+
+  const maxWorkers = Math.max(2, Math.min(cpuBoundWorkers, memoryBoundWorkers));
   return { concurrency, maxWorkers };
 };
 
@@ -173,7 +221,9 @@ export const parseMoonJestOutput = (output: string): MoonJestParseResult => {
 
         for (const suite of json.testResults ?? []) {
           const file = Path.relative(REPO_ROOT, suite.name);
-          for (const assertion of suite.assertionResults ?? []) {
+          const assertionResults = suite.assertionResults ?? [];
+
+          for (const assertion of assertionResults) {
             if (assertion.status === 'failed') {
               const message = (assertion.failureMessages ?? []).join('\n');
               const lineMatch = stripAnsi(message).match(
@@ -184,8 +234,22 @@ export const parseMoonJestOutput = (output: string): MoonJestParseResult => {
                 line: lineMatch ? parseInt(lineMatch[1], 10) : undefined,
                 name: assertion.fullName ?? assertion.title ?? 'unknown',
                 message,
+                oom: WORKER_OOM_MESSAGE_RE.test(message),
               });
             }
+          }
+
+          // A crashed worker can kill a suite before it runs any assertions; Jest's
+          // formatTestResults flattens that suite-level testExecError into `message`
+          // (there is no separate `testExecError` key in the --json output).
+          if (assertionResults.length === 0 && suite.status === 'failed') {
+            const message = suite.message ?? '';
+            failures.push({
+              file,
+              name: 'Test suite failed to run',
+              message,
+              oom: WORKER_OOM_MESSAGE_RE.test(message),
+            });
           }
         }
 
@@ -236,6 +300,37 @@ const extractMoonFailureExcerpt = (output: string) => {
     .filter(Boolean)
     .filter((lineText) => !lineText.startsWith('{'))
     .slice(-8);
+};
+
+/**
+ * When Moon exits non-zero and no Jest task JSON was parsed at all, the Jest process
+ * likely crashed before it could report anything. Check the raw output for the same
+ * V8 crash signature jest-worker itself looks for (RAW_OOM_SIGNATURE_RE) so we can tell
+ * the user "this was OOM" instead of a generic "no output parsed" message.
+ */
+export const buildMoonJestWarnings = ({
+  output,
+  exitCode,
+  taskCount,
+  parseFailures,
+}: {
+  output: string;
+  exitCode: number;
+  taskCount: number;
+  parseFailures: string[];
+}): string[] | undefined => {
+  if (taskCount === 0 && exitCode !== 0) {
+    const noOutputMessage = RAW_OOM_SIGNATURE_RE.test(output)
+      ? `Moon exited with code ${exitCode} and the output contains a Node/V8 out-of-memory ` +
+        `crash signature. The Jest process likely ran out of heap before producing any JSON ` +
+        `output; try freeing up memory or narrowing the affected files so fewer configs run ` +
+        `at once.`
+      : `Moon exited with code ${exitCode} but no Jest task output was parsed. ` +
+        `The Jest task may have failed before producing JSON output, run jest directly to verify.`;
+    return [noOutputMessage, ...parseFailures];
+  }
+
+  return parseFailures.length > 0 ? parseFailures : undefined;
 };
 
 const parseMoonJestProgressProject = (rawLine: string) => {
@@ -344,6 +439,10 @@ export const runJestViaMoon = async ({
         ...process.env,
         CI_STATS_DISABLED: 'true',
         FORCE_COLOR: '1',
+        // Cap each Jest worker's heap explicitly (mirrors CI) instead of relying on Node's
+        // per-machine default, which isn't sized for `concurrency * maxWorkers` processes
+        // running at once and can silently OOM a worker.
+        NODE_OPTIONS: buildJestNodeOptions(process.env.NODE_OPTIONS),
       },
     }
   );
@@ -387,16 +486,12 @@ export const runJestViaMoon = async ({
 
   const cachedCount = tasks.filter((t) => t.cached).length;
   const ranCount = tasks.length - cachedCount;
-  const warnings =
-    tasks.length === 0 && result.exitCode !== 0
-      ? [
-          `Moon exited with code ${result.exitCode} but no Jest task output was parsed. ` +
-            `The Jest task may have failed before producing JSON output — run jest directly to verify.`,
-          ...parseFailures,
-        ]
-      : parseFailures.length > 0
-      ? parseFailures
-      : undefined;
+  const warnings = buildMoonJestWarnings({
+    output,
+    exitCode: result.exitCode ?? 0,
+    taskCount: tasks.length,
+    parseFailures,
+  });
 
   return {
     taskCount: tasks.length,


### PR DESCRIPTION
`node scripts/check` runs affected Jest configs through Moon with worker parallelism sized only off CPU count, and never sets a heap limit for the spawned processes. CI avoids this by explicitly capping parallelism and setting `NODE_OPTIONS=--max-old-space-size` for `jest_parallel.sh`, but the local check path had no equivalent, so on high-core/lower-RAM machines a worker can get OOM-killed while running the full affected config (not just the changed file). When that happens, Jest's own retry logic reports it as a normal test failure with no indication it was actually a resourcing issue, which is confusing when the same tests pass when run directly and in CI.

- computeJestParallelism now also bounds maxWorkers by available memory, not just CPU count.
- Moon-spawned Jest processes get an explicit `NODE_OPTIONS=--max-old-space-size=4096`, mirroring CI.
- parseMoonJestOutput tags failures matching known Jest OOM/crash signatures (including whole-suite crashes with no assertion results) so `run_check.ts` can surface a clear "ran out of memory" note instead of treating it like a real test failure.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->