### PR TITLE
[Observability] Remove unused oneOfLiterals from custom_threshold utils

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/utils.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/utils.ts
@@ -6,7 +6,6 @@
  */
 
 import { isError } from 'lodash';
-import { schema } from '@kbn/config-schema';
 import type { Logger, LogMeta } from '@kbn/logging';
 import type { ElasticsearchClient, IBasePath } from '@kbn/core/server';
 import { addSpaceIdToPath } from '@kbn/core-spaces-common';
@@ -35,12 +34,6 @@ const SUPPORTED_ES_FIELD_TYPES = [
   ES_FIELD_TYPES.IP,
   ES_FIELD_TYPES.BOOLEAN,
 ];
-
-export const oneOfLiterals = (arrayOfLiterals: Readonly<string[]>) =>
-  schema.string({
-    validate: (value) =>
-      arrayOfLiterals.includes(value) ? undefined : `must be one of ${arrayOfLiterals.join(' | ')}`,
-  });
 
 export const createScopedLogger = (
   logger: Logger,


### PR DESCRIPTION
## Summary

Removes the unused `oneOfLiterals` export (and its now-unused `schema` import) from `x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/utils.ts`.

This function has no importers anywhere in the repo — the live `oneOfLiterals` used by the custom_threshold rule type (and other rule types) lives in `@kbn/response-ops-rule-params/common/utils` instead. This copy appears to be an orphaned leftover from before that package existed.

Resolves a CodeQL "unbounded string in schema validation" finding on this file (code-scanning alert [elastic/kibana#9724](https://github.com/elastic/kibana/security/code-scanning/9724), tracked in [elastic/kibana-team#3634](https://github.com/elastic/kibana-team/issues/3634)) — the flagged validation schema is unreachable dead code, not a live gap.

## Test plan

- [x] Confirmed zero remaining references to `oneOfLiterals` in this file, or importers of it, anywhere in the repo (`grep -rn "oneOfLiterals"` across `x-pack/`)
- [x] Confirmed the `schema` import has no other usage in the file after removal
- Pure subtraction of dead code — no behavior change, no tests needed