### PR TITLE
[Agent Builder] Fix SML _search route dropping requested permissions field

### DIFF
--- a/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
@@ -62,27 +62,20 @@ export interface SmlSearchHttpResponse {
 }
 
 /**
- * Per-hit shape returned by `POST /sml/_search`.
- * Baseline always includes id, type, title, origin, description. Optional fields
- * (content, tags, references, spaces, permissions) are included only when
- * explicitly requested via the `fields[]` parameter.
+ * Permissions required to access the underlying element. Always present
+ * on `SmlHttpItem`; inner arrays may be empty.
  */
-export interface SmlSearchHttpResultItem {
-  id: string;
-  type: string;
-  origin: { uri: string };
-  title: string;
-  description?: string;
-  content?: string;
-  references?: Array<{ uri: string }>;
-  tags?: string[];
-  permissions?: SmlHttpItem['permissions'];
+export interface SmlPermissionsHttp {
+  kibana: { privileges: Array<{ name: string }> };
+  elasticsearch: { indices: Array<{ name: string }> };
 }
 
 /**
  * Wire representation of a single SML object.
  *
  * Mirrors the server-side `SmlDocument` shape used by the storage layer.
+ * Every field is always present — GET/list/PUT have no `fields[]` opt-in
+ * mechanism, unlike `_search` (see `SmlSearchHttpResultItem`).
  */
 export interface SmlHttpItem {
   id: string;
@@ -90,21 +83,36 @@ export interface SmlHttpItem {
   title: string;
   origin: { uri: string };
   content: string;
+  description: string;
+  references: Array<{ uri: string }>;
   created_at: string;
   updated_at: string;
   spaces: string[];
   tags: string[];
-  /**
-   * Permissions required to access the underlying element. Always
-   * present; inner arrays may be empty.
-   */
-  permissions: {
-    kibana: { privileges: Array<{ name: string }> };
-    elasticsearch: { indices: Array<{ name: string }> };
-  };
+  permissions: SmlPermissionsHttp;
   /** How this chunk was produced. */
   ingestion_method: 'manual' | 'crawled';
 }
+
+/**
+ * `T`, but every key in `K` is made optional rather than required.
+ */
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/**
+ * Per-hit shape returned by `POST /sml/_search`.
+ *
+ * Structurally `SmlHttpItem` with every field except the baseline identity
+ * fields (`id`, `type`, `title`, `origin`) made optional — those are the
+ * only fields not gated by the `fields[]` request parameter. This
+ * derivation keeps `_search`'s per-hit shape from drifting out of sync with
+ * `SmlHttpItem`: a field added, renamed, or reshaped on one is reflected on
+ * the other automatically, at compile time.
+ */
+export type SmlSearchHttpResultItem = WithOptional<
+  SmlHttpItem,
+  Exclude<keyof SmlHttpItem, 'id' | 'type' | 'title' | 'origin'>
+>;
 
 /**
  * Response body for `GET /internal/agent_context_layer/sml/{originId}`.

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
@@ -76,6 +76,7 @@ export interface SmlSearchHttpResultItem {
   content?: string;
   references?: Array<{ uri: string }>;
   tags?: string[];
+  permissions?: SmlHttpItem['permissions'];
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
@@ -100,14 +100,10 @@ export interface SmlHttpItem {
 type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 /**
- * Per-hit shape returned by `POST /sml/_search`.
- *
- * Structurally `SmlHttpItem` with every field except the baseline identity
- * fields (`id`, `type`, `title`, `origin`) made optional — those are the
- * only fields not gated by the `fields[]` request parameter. This
- * derivation keeps `_search`'s per-hit shape from drifting out of sync with
- * `SmlHttpItem`: a field added, renamed, or reshaped on one is reflected on
- * the other automatically, at compile time.
+ * Per-hit shape returned by `POST /sml/_search`: `SmlHttpItem` with every
+ * field except the baseline identity fields (`id`, `type`, `title`,
+ * `origin`) made optional, since those are the only fields not gated by the
+ * `fields[]` request parameter.
  */
 export type SmlSearchHttpResultItem = WithOptional<
   SmlHttpItem,

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.test.ts
@@ -9,7 +9,7 @@ import { toSmlHttpItem } from './common';
 import { sampleDocument } from './test_helpers';
 
 describe('toSmlHttpItem', () => {
-  it('maps every SmlDocument field onto the HTTP wire shape, including description and references', () => {
+  it('maps every SmlDocument field onto the HTTP wire shape', () => {
     expect(toSmlHttpItem(sampleDocument)).toEqual({
       id: sampleDocument.id,
       type: sampleDocument.type,
@@ -17,20 +17,21 @@ describe('toSmlHttpItem', () => {
       origin: sampleDocument.origin,
       content: sampleDocument.content,
       description: sampleDocument.description,
+      tags: sampleDocument.tags,
       references: sampleDocument.references,
       created_at: sampleDocument.created_at,
       updated_at: sampleDocument.updated_at,
       spaces: sampleDocument.spaces,
-      tags: [],
       permissions: sampleDocument.permissions,
       ingestion_method: sampleDocument.ingestion_method,
     });
   });
 
-  it('defaults description to an empty string and references to an empty array when absent', () => {
-    const { description, references, ...docWithoutOptionalFields } = sampleDocument;
+  it('defaults description, tags, and references when absent from the document', () => {
+    const { description, tags, references, ...docWithoutOptionalFields } = sampleDocument;
     const item = toSmlHttpItem(docWithoutOptionalFields);
     expect(item.description).toBe('');
+    expect(item.tags).toEqual([]);
     expect(item.references).toEqual([]);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { toSmlHttpItem } from './common';
+import { sampleDocument } from './test_helpers';
+
+describe('toSmlHttpItem', () => {
+  it('maps every SmlDocument field onto the HTTP wire shape, including description and references', () => {
+    expect(toSmlHttpItem(sampleDocument)).toEqual({
+      id: sampleDocument.id,
+      type: sampleDocument.type,
+      title: sampleDocument.title,
+      origin: sampleDocument.origin,
+      content: sampleDocument.content,
+      description: sampleDocument.description,
+      references: sampleDocument.references,
+      created_at: sampleDocument.created_at,
+      updated_at: sampleDocument.updated_at,
+      spaces: sampleDocument.spaces,
+      tags: [],
+      permissions: sampleDocument.permissions,
+      ingestion_method: sampleDocument.ingestion_method,
+    });
+  });
+
+  it('defaults description to an empty string and references to an empty array when absent', () => {
+    const { description, references, ...docWithoutOptionalFields } = sampleDocument;
+    const item = toSmlHttpItem(docWithoutOptionalFields);
+    expect(item.description).toBe('');
+    expect(item.references).toEqual([]);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.ts
@@ -18,6 +18,8 @@ export const toSmlHttpItem = (doc: SmlDocument): SmlHttpItem => ({
   title: doc.title,
   origin: doc.origin,
   content: doc.content,
+  description: doc.description ?? '',
+  references: doc.references ?? [],
   created_at: doc.created_at,
   updated_at: doc.updated_at,
   spaces: doc.spaces,

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
@@ -164,6 +164,61 @@ describe('registerSearchRoute', () => {
     expect(results[0]).not.toHaveProperty('permissions');
   });
 
+  it('includes spaces, created_at, updated_at, and ingestion_method when requested via fields', async () => {
+    const mockResults: SmlSearchResult[] = [
+      {
+        id: 'chunk-1',
+        type: 'dashboard',
+        title: 'Test Dashboard',
+        origin: { uri: 'dashboard-1' },
+        spaces: ['default'],
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-02T00:00:00.000Z',
+        ingestion_method: 'crawled',
+      },
+    ];
+    mockSmlService.search.mockResolvedValue({ results: mockResults });
+
+    const response = await callHandler({
+      query: 'test',
+      size: 10,
+      fields: ['spaces', 'created_at', 'updated_at', 'ingestion_method'],
+    });
+    expect(mockSmlService.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: ['spaces', 'created_at', 'updated_at', 'ingestion_method'],
+      })
+    );
+    const body = response.ok.mock.calls[0][0]?.body as Record<string, unknown>;
+    const results = (body as any).results;
+    expect(results[0]).toMatchObject({
+      spaces: ['default'],
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-02T00:00:00.000Z',
+      ingestion_method: 'crawled',
+    });
+  });
+
+  it('omits spaces, created_at, updated_at, and ingestion_method from the response when the service result has none', async () => {
+    const mockResults: SmlSearchResult[] = [
+      {
+        id: 'chunk-1',
+        type: 'dashboard',
+        title: 'Test Dashboard',
+        origin: { uri: 'dashboard-1' },
+      },
+    ];
+    mockSmlService.search.mockResolvedValue({ results: mockResults });
+
+    const response = await callHandler({ query: 'test', size: 10 });
+    const body = response.ok.mock.calls[0][0]?.body as Record<string, unknown>;
+    const results = (body as any).results;
+    expect(results[0]).not.toHaveProperty('spaces');
+    expect(results[0]).not.toHaveProperty('created_at');
+    expect(results[0]).not.toHaveProperty('updated_at');
+    expect(results[0]).not.toHaveProperty('ingestion_method');
+  });
+
   it('passes constraints and agent-supplied filters through to sml.search', async () => {
     mockSmlService.search.mockResolvedValue({ results: [] });
     await callHandler({

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
@@ -113,6 +113,57 @@ describe('registerSearchRoute', () => {
     expect(results[0]).not.toHaveProperty('content');
   });
 
+  it('includes permissions in the response when requested via fields', async () => {
+    const permissions = {
+      kibana: { privileges: [{ name: 'saved_object:dashboard/get' }] },
+      elasticsearch: { indices: [{ name: 'metrics-*' }] },
+    };
+    const mockResults: SmlSearchResult[] = [
+      {
+        id: 'chunk-1',
+        type: 'dashboard',
+        title: 'Test Dashboard',
+        origin: { uri: 'dashboard-1' },
+        permissions,
+      },
+    ];
+    mockSmlService.search.mockResolvedValue({ results: mockResults });
+
+    const response = await callHandler({
+      query: 'test',
+      size: 10,
+      fields: ['permissions'],
+    });
+    expect(mockSmlService.search).toHaveBeenCalledWith(
+      expect.objectContaining({ fields: ['permissions'] })
+    );
+    const body = response.ok.mock.calls[0][0]?.body as Record<string, unknown>;
+    const results = (body as any).results;
+    expect(results[0].permissions).toEqual(permissions);
+  });
+
+  it('omits permissions from the response when the service result has no permissions', async () => {
+    // Mirrors what the real service returns when `fields` doesn't include
+    // 'permissions': the `permissions` property is absent from the hit
+    // entirely (see includePermissions gating in sml_service.ts), not merely
+    // undefined. This asserts the route's mapping doesn't add it out of
+    // thin air.
+    const mockResults: SmlSearchResult[] = [
+      {
+        id: 'chunk-1',
+        type: 'dashboard',
+        title: 'Test Dashboard',
+        origin: { uri: 'dashboard-1' },
+      },
+    ];
+    mockSmlService.search.mockResolvedValue({ results: mockResults });
+
+    const response = await callHandler({ query: 'test', size: 10 });
+    const body = response.ok.mock.calls[0][0]?.body as Record<string, unknown>;
+    const results = (body as any).results;
+    expect(results[0]).not.toHaveProperty('permissions');
+  });
+
   it('passes constraints and agent-supplied filters through to sml.search', async () => {
     mockSmlService.search.mockResolvedValue({ results: [] });
     await callHandler({

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
@@ -121,6 +121,7 @@ export const registerSearchRoute = ({
             if (hit.description !== undefined) item.description = hit.description;
             if (hit.references !== undefined) item.references = hit.references;
             if (hit.tags !== undefined) item.tags = hit.tags;
+            if (hit.permissions !== undefined) item.permissions = hit.permissions;
             return item;
           }),
         };

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
@@ -10,7 +10,7 @@ import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { SmlSearchHttpResponse, SmlSearchHttpResultItem } from '../../common/http_api/sml';
 import { SML_HTTP_SEARCH_QUERY_MAX_LENGTH, SmlSearchFilterType } from '../../common/http_api/sml';
 import { smlSearchPath } from '../../common/constants';
-import type { SmlService } from '../services/sml/types';
+import type { SmlSearchResult, SmlService } from '../services/sml/types';
 import type { AgentContextLayerStartDependencies, AgentContextLayerPluginStart } from '../types';
 import {
   SmlAuthzEnumerationIncompleteError,
@@ -20,6 +20,42 @@ import { READ_SECURITY, withSmlFeatureFlag } from './common';
 
 const SML_SEARCH_SIZE_MAX = 1000;
 const SML_SEARCH_FILTER_ARRAY_MAX = 100;
+// Count of `fields[]` literals in the request schema below — keep in sync
+// with the `schema.oneOf` list; `maxSize` bounds the array length below.
+const SML_SEARCH_FIELDS_MAX = 9;
+
+/**
+ * Builds the `SmlSearchHttpResultItem` for one service-layer hit.
+ *
+ * Deliberately a hand-written, one-line-per-field mapping rather than a
+ * generic loop over `SmlSearchResult`'s keys: `SmlSearchResult` is an
+ * internal service-layer type describing what the storage/query layer can
+ * produce, while `SmlSearchHttpResultItem` is the public wire contract. This
+ * function is the seam where those two are deliberately decoupled — a
+ * generic key-driven copy would silently couple the API response shape to
+ * internal storage schema changes. Keep it explicit; when adding a new
+ * `fields[]`-requestable field, add both the schema literal above and a line
+ * here (this pairing is exactly what search-team#15114 tracked, so this
+ * comment doubles as the reminder to update both).
+ */
+const toSmlSearchHttpResultItem = (hit: SmlSearchResult): SmlSearchHttpResultItem => {
+  const item: SmlSearchHttpResultItem = {
+    id: hit.id,
+    type: hit.type,
+    origin: hit.origin,
+    title: hit.title,
+  };
+  if (hit.content !== undefined) item.content = hit.content;
+  if (hit.description !== undefined) item.description = hit.description;
+  if (hit.references !== undefined) item.references = hit.references;
+  if (hit.tags !== undefined) item.tags = hit.tags;
+  if (hit.spaces !== undefined) item.spaces = hit.spaces;
+  if (hit.permissions !== undefined) item.permissions = hit.permissions;
+  if (hit.created_at !== undefined) item.created_at = hit.created_at;
+  if (hit.updated_at !== undefined) item.updated_at = hit.updated_at;
+  if (hit.ingestion_method !== undefined) item.ingestion_method = hit.ingestion_method;
+  return item;
+};
 
 export const registerSearchRoute = ({
   router,
@@ -79,8 +115,11 @@ export const registerSearchRoute = ({
                 schema.literal('references'),
                 schema.literal('spaces'),
                 schema.literal('permissions'),
+                schema.literal('created_at'),
+                schema.literal('updated_at'),
+                schema.literal('ingestion_method'),
               ]),
-              { maxSize: 6 }
+              { maxSize: SML_SEARCH_FIELDS_MAX }
             )
           ),
         }),
@@ -110,20 +149,7 @@ export const registerSearchRoute = ({
         });
 
         const body: SmlSearchHttpResponse = {
-          results: results.map((hit) => {
-            const item: SmlSearchHttpResultItem = {
-              id: hit.id,
-              type: hit.type,
-              origin: hit.origin,
-              title: hit.title,
-            };
-            if (hit.content !== undefined) item.content = hit.content;
-            if (hit.description !== undefined) item.description = hit.description;
-            if (hit.references !== undefined) item.references = hit.references;
-            if (hit.tags !== undefined) item.tags = hit.tags;
-            if (hit.permissions !== undefined) item.permissions = hit.permissions;
-            return item;
-          }),
+          results: results.map(toSmlSearchHttpResultItem),
         };
 
         return response.ok({ body });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
@@ -20,23 +20,14 @@ import { READ_SECURITY, withSmlFeatureFlag } from './common';
 
 const SML_SEARCH_SIZE_MAX = 1000;
 const SML_SEARCH_FILTER_ARRAY_MAX = 100;
-// Count of `fields[]` literals in the request schema below — keep in sync
-// with the `schema.oneOf` list; `maxSize` bounds the array length below.
+// Count of `fields[]` literals in the schema below; keep in sync.
 const SML_SEARCH_FIELDS_MAX = 9;
 
 /**
- * Builds the `SmlSearchHttpResultItem` for one service-layer hit.
- *
- * Deliberately a hand-written, one-line-per-field mapping rather than a
- * generic loop over `SmlSearchResult`'s keys: `SmlSearchResult` is an
- * internal service-layer type describing what the storage/query layer can
- * produce, while `SmlSearchHttpResultItem` is the public wire contract. This
- * function is the seam where those two are deliberately decoupled — a
- * generic key-driven copy would silently couple the API response shape to
- * internal storage schema changes. Keep it explicit; when adding a new
- * `fields[]`-requestable field, add both the schema literal above and a line
- * here (this pairing is exactly what search-team#15114 tracked, so this
- * comment doubles as the reminder to update both).
+ * Hand-written rather than a generic loop over `SmlSearchResult`'s keys, so
+ * the wire contract doesn't silently couple to internal storage schema
+ * changes. When adding a new `fields[]`-requestable field, update both the
+ * schema literals above and this mapping.
  */
 const toSmlSearchHttpResultItem = (hit: SmlSearchResult): SmlSearchHttpResultItem => {
   const item: SmlSearchHttpResultItem = {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/test_helpers.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/test_helpers.ts
@@ -66,6 +66,7 @@ export const sampleDocument: SmlDocument = {
   origin: { uri: 'visualization://viz-1' },
   content: 'some content',
   description: 'A test viz for CPU usage',
+  tags: ['demo'],
   references: [{ uri: 'dashboard://abc' }],
   created_at: '2024-01-01',
   updated_at: '2024-01-02',

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/test_helpers.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/test_helpers.ts
@@ -65,6 +65,8 @@ export const sampleDocument: SmlDocument = {
   origin_id: 'viz-1',
   origin: { uri: 'visualization://viz-1' },
   content: 'some content',
+  description: 'A test viz for CPU usage',
+  references: [{ uri: 'dashboard://abc' }],
   created_at: '2024-01-01',
   updated_at: '2024-01-02',
   spaces: ['test-space'],

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -564,6 +564,39 @@ describe('SmlService', () => {
       expect(result.results[0]).not.toHaveProperty('permissions');
     });
 
+    it('attaches permissions when fields includes permissions (includePermissions branch)', async () => {
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      esqlQueryMock.mockResolvedValue({
+        columns: makeEsqlColumns(false),
+        values: [
+          makeEsqlRow('chunk-1', 'lens', 'My Viz', 'ref-1', ['saved_object:lens/get'], {
+            esIndices: ['metrics-*'],
+            includeContent: false,
+          }),
+        ],
+      } as any);
+
+      const result = await smlService.search({
+        query: 'viz',
+        size: 10,
+        spaceId: 'default',
+        esClient: scopedClient,
+        request,
+        fields: ['permissions'],
+      });
+
+      expect(result.results[0]).toEqual({
+        id: 'chunk-1',
+        type: 'lens',
+        title: 'My Viz',
+        origin: { uri: 'ref-1' },
+        permissions: makePermissions(['saved_object:lens/get'], ['metrics-*']),
+      });
+    });
+
     it('returns only the requested fields when fields param is provided', async () => {
       const service = createSmlService();
       service.setup({ logger });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -58,7 +58,11 @@ const buildTermsEnumMock = (universe: { kibana?: string[]; esIndices?: string[] 
 // Column order produced by buildSmlEsqlQuery. The permission name fields
 // (perm_kibana, perm_es_indices) are always present; spaces and other optional
 // fields appear only when explicitly requested.
-const makeEsqlColumns = (includeContent = true, includeSpaces = false) => [
+const makeEsqlColumns = (
+  includeContent = true,
+  includeSpaces = false,
+  includeBookkeeping = false
+) => [
   { name: 'id', type: 'keyword' },
   { name: 'type', type: 'keyword' },
   { name: 'title', type: 'text' },
@@ -70,6 +74,13 @@ const makeEsqlColumns = (includeContent = true, includeSpaces = false) => [
   { name: 'perm_kibana', type: 'keyword' },
   { name: 'perm_es_indices', type: 'keyword' },
   ...(includeContent ? [{ name: 'content', type: 'text' }] : []),
+  ...(includeBookkeeping
+    ? [
+        { name: 'created_at', type: 'date' },
+        { name: 'updated_at', type: 'date' },
+        { name: 'ingestion_method', type: 'keyword' },
+      ]
+    : []),
 ];
 
 // Build a single ES|QL row value array matching makeEsqlColumns order. The
@@ -90,6 +101,10 @@ const makeEsqlRow = (
     esIndices,
     includeContent = true,
     includeSpaces = false,
+    createdAt,
+    updatedAt,
+    ingestionMethod,
+    includeBookkeeping = false,
   }: {
     spaces?: string | string[];
     description?: string;
@@ -99,6 +114,10 @@ const makeEsqlRow = (
     esIndices?: string | string[] | null;
     includeContent?: boolean;
     includeSpaces?: boolean;
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    ingestionMethod?: string | null;
+    includeBookkeeping?: boolean;
   } = {}
 ): unknown[] => [
   id,
@@ -112,6 +131,7 @@ const makeEsqlRow = (
   permissions,
   esIndices ?? null,
   ...(includeContent ? [content ?? null] : []),
+  ...(includeBookkeeping ? [createdAt ?? null, updatedAt ?? null, ingestionMethod ?? null] : []),
 ];
 
 const createMockScopedClient = (
@@ -594,6 +614,47 @@ describe('SmlService', () => {
         title: 'My Viz',
         origin: { uri: 'ref-1' },
         permissions: makePermissions(['saved_object:lens/get'], ['metrics-*']),
+      });
+    });
+
+    it('attaches spaces, created_at, updated_at, and ingestion_method when requested via fields', async () => {
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      esqlQueryMock.mockResolvedValue({
+        columns: makeEsqlColumns(false, true, true),
+        values: [
+          makeEsqlRow('chunk-1', 'lens', 'My Viz', 'ref-1', ['saved_object:lens/get'], {
+            includeContent: false,
+            includeSpaces: true,
+            spaces: ['default'],
+            includeBookkeeping: true,
+            createdAt: '2024-01-01T00:00:00.000Z',
+            updatedAt: '2024-01-02T00:00:00.000Z',
+            ingestionMethod: 'manual',
+          }),
+        ],
+      } as any);
+
+      const result = await smlService.search({
+        query: 'viz',
+        size: 10,
+        spaceId: 'default',
+        esClient: scopedClient,
+        request,
+        fields: ['spaces', 'created_at', 'updated_at', 'ingestion_method'],
+      });
+
+      expect(result.results[0]).toEqual({
+        id: 'chunk-1',
+        type: 'lens',
+        title: 'My Viz',
+        origin: { uri: 'ref-1' },
+        spaces: ['default'],
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-02T00:00:00.000Z',
+        ingestion_method: 'manual',
       });
     });
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -21,6 +21,7 @@ import type {
   SmlSearchConstraints,
   MatchedDiscoveryLabel,
   SmlPermissions,
+  SmlIngestionMethod,
 } from './types';
 import { createSmlTypeRegistry, type SmlTypeRegistry } from './sml_type_registry';
 import { createSmlIndexer, type SmlIndexer } from './sml_indexer';
@@ -836,7 +837,7 @@ const buildSmlEsqlQuery = ({
   lines.push('| EVAL perm_kibana = permissions.kibana.privileges.name');
   lines.push('| EVAL perm_es_indices = permissions.elasticsearch.indices.name');
 
-  // spaces is purely opt-in.
+  // spaces, created_at, updated_at, ingestion_method are purely opt-in.
   const keepCols = [
     'id',
     'type',
@@ -849,6 +850,9 @@ const buildSmlEsqlQuery = ({
     'perm_kibana',
     'perm_es_indices',
     ...(shouldKeep('content') ? ['content'] : []),
+    ...(shouldKeep('created_at') ? ['created_at'] : []),
+    ...(shouldKeep('updated_at') ? ['updated_at'] : []),
+    ...(shouldKeep('ingestion_method') ? ['ingestion_method'] : []),
   ];
   lines.push(`| KEEP ${keepCols.join(', ')}`);
 
@@ -1097,6 +1101,24 @@ const searchSml = async ({
     if (refUrisIdx !== undefined) {
       const refUris = toStringArray(row[refUrisIdx]);
       if (refUris.length > 0) result.references = refUris.map((uri) => ({ uri }));
+    }
+
+    const createdAtIdx = colIndex.get('created_at');
+    if (createdAtIdx !== undefined) {
+      const createdAt = row[createdAtIdx];
+      if (createdAt != null) result.created_at = String(createdAt);
+    }
+
+    const updatedAtIdx = colIndex.get('updated_at');
+    if (updatedAtIdx !== undefined) {
+      const updatedAt = row[updatedAtIdx];
+      if (updatedAt != null) result.updated_at = String(updatedAt);
+    }
+
+    const ingestionMethodIdx = colIndex.get('ingestion_method');
+    if (ingestionMethodIdx !== undefined) {
+      const ingestionMethod = row[ingestionMethodIdx];
+      if (ingestionMethod != null) result.ingestion_method = ingestionMethod as SmlIngestionMethod;
     }
 
     return result;

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -269,18 +269,13 @@ export interface SmlDocument {
 }
 
 /**
- * Compact SML search result — LLM-shaped by default. Baseline (`id`, `type`,
- * `title`, `origin`) is always present; every other field is opt-in via the
- * caller's `fields` array, including the full `content` blob and bookkeeping
- * fields (`created_at`, `updated_at`, `ingestion_method`) that are excluded
- * unless explicitly requested — callers fetch full content via the lookup
- * tool (`sml_read`) when they don't need it inline. `extended_attrs` and
- * `discovery_labels` are never surfaced through search at all; there is no
- * `fields` value for them.
+ * Compact SML search result. Baseline (`id`, `type`, `title`, `origin`) is
+ * always present; every other field is opt-in via the caller's `fields`
+ * array. `extended_attrs` and `discovery_labels` are never surfaced through
+ * search — there is no `fields` value for them.
  *
- * `permissions` is retained here so callers (route / tool wrapper) can apply
- * post-hoc authorization filtering. Callers should not expose it
- * unconditionally or by default — the `sml_search` LLM tool wrapper never
+ * `permissions` is retained so callers (route / tool wrapper) can apply
+ * post-hoc authorization filtering; the `sml_search` LLM tool wrapper never
  * forwards it, by construction (it whitelists an explicit output shape).
  */
 export interface SmlSearchResult {
@@ -527,7 +522,8 @@ export interface SmlService {
     /**
      * Optional fields to include beyond the baseline (`id`, `type`, `title`,
      * `description`). Valid opt-in values: `'content'`, `'tags'`,
-     * `'references'`, `'spaces'`, `'permissions'`.
+     * `'references'`, `'spaces'`, `'permissions'`, `'created_at'`,
+     * `'updated_at'`, `'ingestion_method'`.
      */
     fields?: string[];
     /** Runtime-imposed per-type id-allowlist constraints. See {@link SmlSearchConstraints}. */

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -274,12 +274,16 @@ export interface SmlDocument {
  * lookup tool (`sml_read`) when they need it.
  *
  * `permissions` is retained here so callers (route / tool wrapper) can apply
- * post-hoc authorization filtering; downstream consumers should not expose it
- * in their response shape.
+ * post-hoc authorization filtering. Callers should not expose it
+ * unconditionally or by default — the `sml_search` LLM tool wrapper never
+ * forwards it, by construction (it whitelists an explicit output shape).
  *
- * Optional fields (`content`, `description`, `tags`, `references`) are omitted
- * when the caller passes a `fields` array that excludes them. `spaces` and
- * `permissions` are internal pipeline details — not present in results.
+ * Optional fields (`content`, `description`, `tags`, `references`,
+ * `spaces`, `permissions`) are omitted unless the caller passes a `fields`
+ * array that includes them. The `_search` HTTP route currently only wires
+ * `permissions` through to callers that request it; `spaces` is computed
+ * here but not yet forwarded by that route (TODO: wire `spaces` through
+ * `SmlSearchHttpResultItem` the same way, see search-team#15114).
  */
 export interface SmlSearchResult {
   id: string;

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -269,21 +269,19 @@ export interface SmlDocument {
 }
 
 /**
- * Compact SML search result — LLM-shaped. Drops the full `content` blob, the
- * full `extended_attrs`, and bookkeeping fields. Callers fetch full content via the
- * lookup tool (`sml_read`) when they need it.
+ * Compact SML search result — LLM-shaped by default. Baseline (`id`, `type`,
+ * `title`, `origin`) is always present; every other field is opt-in via the
+ * caller's `fields` array, including the full `content` blob and bookkeeping
+ * fields (`created_at`, `updated_at`, `ingestion_method`) that are excluded
+ * unless explicitly requested — callers fetch full content via the lookup
+ * tool (`sml_read`) when they don't need it inline. `extended_attrs` and
+ * `discovery_labels` are never surfaced through search at all; there is no
+ * `fields` value for them.
  *
  * `permissions` is retained here so callers (route / tool wrapper) can apply
  * post-hoc authorization filtering. Callers should not expose it
  * unconditionally or by default — the `sml_search` LLM tool wrapper never
  * forwards it, by construction (it whitelists an explicit output shape).
- *
- * Optional fields (`content`, `description`, `tags`, `references`,
- * `spaces`, `permissions`) are omitted unless the caller passes a `fields`
- * array that includes them. The `_search` HTTP route currently only wires
- * `permissions` through to callers that request it; `spaces` is computed
- * here but not yet forwarded by that route (TODO: wire `spaces` through
- * `SmlSearchHttpResultItem` the same way, see search-team#15114).
  */
 export interface SmlSearchResult {
   id: string;
@@ -296,6 +294,9 @@ export interface SmlSearchResult {
   tags?: string[];
   spaces?: string[];
   permissions?: SmlPermissions;
+  created_at?: string;
+  updated_at?: string;
+  ingestion_method?: SmlIngestionMethod;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Commit 1 — bugfix (search-team#15114):**
- `POST /internal/agent_context_layer/sml/_search` accepted `fields: ["permissions"]` in its request schema, and the service layer (`sml_service.ts`) already computed `permissions` on results when requested — but the route's response mapping never copied it onto the HTTP response item, so it was silently dropped. GET routes (`list`, `get`) already return `permissions` unconditionally via `toSmlHttpItem`, so this was a wiring gap specific to the POST `_search` route.
- Adds `permissions` to `SmlSearchHttpResultItem` and wires it through in `search.ts`'s response mapping, following the same `if (hit.x !== undefined) item.x = hit.x` pattern already used for `content`/`description`/`references`/`tags`.
- Corrects a stale doc comment on `SmlSearchResult` (`server/services/sml/types.ts`) that claimed `permissions`/`spaces` were "internal pipeline details — not present in results," which contradicted the `includePermissions` behavior already implemented in the service layer.

**Commit 2 — type unification + fields[] extension (follow-up from PR discussion):**
- `SmlSearchHttpResultItem` and `SmlHttpItem` had drifted into two independently hand-maintained interfaces describing largely the same per-record shape — which is exactly how the `permissions` bug above happened. `SmlSearchHttpResultItem` is now derived from `SmlHttpItem` via a `WithOptional<T, K>` utility type ("`SmlHttpItem`, but every field except the baseline identity fields is optional"), so the two can no longer structurally drift apart for fields they share.
- **Behavior change:** deriving the type honestly required `SmlHttpItem` to include every field the stored document actually has. `description` and `references` were missing from `SmlHttpItem` despite being present on `SmlDocument` — so **GET `/sml/{type}/{originId}` and GET `/sml` (list) now return `description` and `references` in every response item**, where previously those fields were silently absent from the wire response entirely. This mirrors the existing `content`/`tags` fallback pattern (`doc.description ?? ''`, `doc.references ?? []`) already used for other optional-on-storage, always-present-on-wire fields. Verified no consumer (searched `agent_builder` and elsewhere) assumes these fields are absent.
- Extends `_search`'s `fields[]` parameter to also accept `created_at`, `updated_at`, and `ingestion_method` (previously only `content`, `description`, `tags`, `references`, `spaces`, `permissions`), and wires `spaces` through to the response (previously computed by the service but never forwarded by the route — a pre-existing gap noted in a TODO from commit 1, now closed).
- The service-layer-to-wire-contract mapping in `search.ts` (now named `toSmlSearchHttpResultItem`) stays a hand-written, one-line-per-field function rather than a generic loop — deliberately, to avoid coupling the public API response shape to internal storage-schema changes. Commented accordingly so a future refactor doesn't reintroduce that coupling.

This is a purely additive, opt-in change for `_search`: no existing caller passes the newly-accepted `fields[]` values today. `permissions`/`spaces`/bookkeeping fields are ACL/metadata already exposed unconditionally by GET; POST `_search` requires the same `READ_SECURITY` authz as GET, so there's no new information disclosure.

**Security note:** verified the `sml_search` LLM tool wrapper (`agent_builder/server/services/tools/builtin/sml/sml_search.ts`) is unaffected by either commit — it calls the service directly without a `fields` param, and its handler builds an explicit output whitelist rather than forwarding raw hits, so none of these fields have a path to reach the LLM.

## Test plan

- [x] Route-level tests for `permissions`, `spaces`, `created_at`, `updated_at`, `ingestion_method` — both "included when requested" and "omitted when absent from the service result" cases
- [x] Service-level tests covering the `includePermissions` branch and the new bookkeeping-fields branch, end-to-end against real ES|QL row shapes
- [x] New `common.test.ts` covering `toSmlHttpItem`'s full field mapping, including the new `description`/`references` wiring and their empty-string/empty-array fallback defaults
- [x] `node scripts/jest --config x-pack/platform/plugins/shared/agent_context_layer/jest.config.js server/routes/ server/services/sml/` — 252/252 passing
- [x] Type-checked `agent_context_layer` and `agent_builder` (the latter re-exports/imports `SmlSearchHttpResultItem`/`SmlHttpItem`) — no errors introduced
- [x] `node scripts/eslint --fix` on all changed files — clean

## References

Closes elastic/search-team#15114
