### PR TITLE
fix(kbn-evals): exclude NOT_IN_GROUND_TRUTH claims from Factuality geometric mean

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  calculateFactualScore,
+  calculateRelevanceScore,
+  calculateProceduralFidelityScore,
+} from './scoring';
+import type { CorrectnessAnalysis } from './types';
+
+type Claim = CorrectnessAnalysis['analysis'][number];
+
+const buildAnalysis = (
+  claims: Array<Pick<Claim, 'verdict' | 'centrality'> & Partial<Pick<Claim, 'sequence_match'>>>,
+  summary?: Partial<CorrectnessAnalysis['summary']>
+): CorrectnessAnalysis => ({
+  summary: {
+    factual_accuracy_summary: 'ACCURATE',
+    relevance_summary: 'RELEVANT',
+    sequence_accuracy_summary: 'NOT_APPLICABLE',
+    ...summary,
+  },
+  analysis: claims.map((c) => ({
+    claim: 'test claim',
+    centrality: c.centrality,
+    centrality_reason: '',
+    verdict: c.verdict,
+    sequence_match: c.sequence_match ?? 'NOT_APPLICABLE',
+    justification_snippet: undefined,
+    explanation: '',
+  })),
+});
+
+describe('calculateFactualScore', () => {
+  it('returns 0 when analysis is empty', () => {
+    expect(calculateFactualScore(buildAnalysis([]))).toBe(0);
+  });
+
+  it('returns 1 when all claims are FULLY_SUPPORTED', () => {
+    expect(
+      calculateFactualScore(
+        buildAnalysis([
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'FULLY_SUPPORTED', centrality: 'peripheral' },
+        ])
+      )
+    ).toBe(1);
+  });
+
+  it('tanks to 0 for a contradicted central claim (geometric-mean intent preserved)', () => {
+    expect(
+      calculateFactualScore(
+        buildAnalysis([
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'CONTRADICTED', centrality: 'central' },
+        ])
+      )
+    ).toBe(0);
+  });
+
+  it('a contradicted central claim still tanks the score even when extra unverifiable claims are present', () => {
+    expect(
+      calculateFactualScore(
+        buildAnalysis([
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'CONTRADICTED', centrality: 'central' },
+          { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+          { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'peripheral' },
+        ])
+      )
+    ).toBe(0);
+  });
+
+  // Core artifact fix: a grounded, accurate answer that is richer than a thin
+  // reference must not be crushed by the extra (NOT_IN_GROUND_TRUTH) claims.
+  it('does not penalize extra NOT_IN_GROUND_TRUTH claims when verifiable claims are accurate', () => {
+    const analysis = buildAnalysis([
+      { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+      { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+    ]);
+    // Only the two FULLY_SUPPORTED claims are scored -> perfect factuality.
+    expect(calculateFactualScore(analysis)).toBe(1);
+  });
+
+  it('reflects verifiable-claim accuracy without dilution from extra claims', () => {
+    const analysis = buildAnalysis([
+      { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+      { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+      { verdict: 'PARTIALLY_SUPPORTED', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+    ]);
+    // geometric mean of [1, 1, 0.9] ~= 0.965, NOT the ~0.31 the old product-of-all produced.
+    expect(calculateFactualScore(analysis)).toBeCloseTo(Math.pow(0.9, 1 / 3), 5);
+  });
+
+  it('falls back to scoring unverifiable claims when no claim can be checked (avoids rewarding an off-reference answer)', () => {
+    const analysis = buildAnalysis([
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+      { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'central' },
+    ]);
+    // All central NOT_IN_GROUND_TRUTH -> 0.1 each -> geometric mean 0.1 (NOT a perfect 1.0).
+    expect(calculateFactualScore(analysis)).toBeCloseTo(0.1, 5);
+  });
+});
+
+describe('calculateRelevanceScore', () => {
+  it('returns 0 for empty analysis', () => {
+    expect(calculateRelevanceScore(buildAnalysis([]))).toBe(0);
+  });
+
+  it('is the proportion of central claims', () => {
+    expect(
+      calculateRelevanceScore(
+        buildAnalysis([
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'FULLY_SUPPORTED', centrality: 'central' },
+          { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'peripheral' },
+          { verdict: 'NOT_IN_GROUND_TRUTH', centrality: 'peripheral' },
+        ])
+      )
+    ).toBe(0.5);
+  });
+});
+
+describe('calculateProceduralFidelityScore', () => {
+  it('returns 1 when sequence is not applicable', () => {
+    expect(
+      calculateProceduralFidelityScore(
+        buildAnalysis([{ verdict: 'FULLY_SUPPORTED', centrality: 'central' }], {
+          sequence_accuracy_summary: 'NOT_APPLICABLE',
+        })
+      )
+    ).toBe(1);
+  });
+
+  it('is the proportion of central claims whose sequence matches', () => {
+    expect(
+      calculateProceduralFidelityScore(
+        buildAnalysis(
+          [
+            { verdict: 'FULLY_SUPPORTED', centrality: 'central', sequence_match: 'MATCH' },
+            { verdict: 'FULLY_SUPPORTED', centrality: 'central', sequence_match: 'MISMATCH' },
+            { verdict: 'FULLY_SUPPORTED', centrality: 'peripheral', sequence_match: 'MATCH' },
+          ],
+          { sequence_accuracy_summary: 'PARTIAL' }
+        )
+      )
+    ).toBe(0.5);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.ts
@@ -30,6 +30,18 @@ const CLAIM_FACTUAL_SCORE_MAP = {
  * This function computes the geometric mean of the scores assigned to each claim,
  * ensuring that a single critically incorrect claim (such as a contradicted central claim
  * with a score of 0.0) will result in an overall factual score of 0.0.
+ *
+ * `NOT_IN_GROUND_TRUTH` claims are excluded from the geometric mean when at least one
+ * claim CAN be checked against the reference. Such claims are, by definition, statements
+ * that the reference neither supports nor contradicts — they are extra information, not
+ * factual errors. Including them in the geometric product conflates "the answer is richer
+ * than the (often thin) reference" with "the answer is wrong": a low fixed weight (0.1 for
+ * central) multiplicatively crushes an otherwise-accurate answer, producing a uniform low
+ * score that is a scoring artifact rather than a measure of accuracy (see security-team#18060).
+ * Coverage of the reference is already measured separately by the Relevance score. When every
+ * claim is unverifiable, there is no reference overlap to score against, so the original
+ * behaviour is retained (the unverifiable claims are scored) to avoid rewarding a fully
+ * off-reference answer with a perfect score.
  */
 export function calculateFactualScore(correctnessEvaluation: CorrectnessAnalysis): number {
   const analysis = correctnessEvaluation?.analysis;
@@ -37,8 +49,13 @@ export function calculateFactualScore(correctnessEvaluation: CorrectnessAnalysis
     return 0.0;
   }
 
+  const verifiableClaims = analysis.filter(
+    (claim) => (claim.verdict || 'NOT_IN_GROUND_TRUTH') !== 'NOT_IN_GROUND_TRUTH'
+  );
+  const scoredClaims = verifiableClaims.length > 0 ? verifiableClaims : analysis;
+
   let productOfScores = 1.0;
-  for (const claim of analysis) {
+  for (const claim of scoredClaims) {
     const verdict = claim.verdict || 'NOT_IN_GROUND_TRUTH';
     const centrality = claim.centrality || 'peripheral';
 
@@ -55,7 +72,7 @@ export function calculateFactualScore(correctnessEvaluation: CorrectnessAnalysis
   }
 
   // Geometric mean: n-th root of the product
-  const numClaims = analysis.length;
+  const numClaims = scoredClaims.length;
   const score = productOfScores > 0 ? Math.pow(productOfScores, 1 / numClaims) : 0.0;
 
   return score;


### PR DESCRIPTION
## Summary

The shared `Factuality` quantitative correctness evaluator computes a **geometric mean** of per-claim scores (`x-pack/platform/packages/shared/kbn-evals/src/evaluators/correctness/scoring.ts`). `NOT_IN_GROUND_TRUTH` claims — statements the reference neither supports nor contradicts — carry a low fixed weight (`0.1` central / `0.5` peripheral). Because the mean is a **product**, each such extra claim multiplicatively drags the whole score down.

The failure mode: a **fully accurate answer that is simply richer than a thin reference** accumulates several `NOT_IN_GROUND_TRUTH` claims and lands at a uniform `~0.1–0.3`, indistinguishable from a genuinely inaccurate answer. This is a **scoring artifact**, worst exactly where ground truth is sparsest (e.g. multi-turn), not a measure of accuracy. Tracked in `security-team#18060`.

Concretely, the geometric mean of `[FULLY_SUPPORTED=1, FULLY_SUPPORTED=1, PARTIALLY=0.9, NOT_IN_GROUND_TRUTH=0.1 ×3]` is `~0.31` today, even though every checkable claim is accurate.

## Change

Score factual accuracy **only over claims that can be checked against the reference** (`FULLY_SUPPORTED` / `PARTIALLY_SUPPORTED` / `CONTRADICTED`):

- Preserves the deliberate geometric-mean intent — a single **contradicted central** claim still tanks the score to `0` (with or without extra unverifiable claims present).
- No longer penalizes grounded-but-richer answers. Reference **coverage** is already measured separately by the `Relevance` score (central-vs-total proportion).
- **All-unverifiable fallback**: when *every* claim is `NOT_IN_GROUND_TRUTH` (no reference overlap at all), the original behaviour is retained so a fully off-reference answer is not rewarded with a perfect `1.0`.

Adds `scoring.test.ts` — the file had no unit coverage. Cases: the artifact, the fix, preserved contradiction-tanking (incl. with extra unverifiable claims), the all-unverifiable fallback, plus `Relevance` and `Sequence Accuracy`.

## Blast radius

This changes how **every** eval suite's `Factuality` sub-score is computed. Expected direction: grounded-but-rich answers score higher; contradicted-central answers are unaffected (still `0`); fully off-reference answers are unaffected (fallback). Suites with thresholds calibrated against the old crushing behaviour should be re-baselined.

## Validation

- [x] `scoring.test.ts` — 11/11 pass (`node scripts/jest --config x-pack/platform/packages/shared/kbn-evals/jest.config.js .../correctness/scoring.test.ts`)
- [x] Type-check clean for `kbn-evals` (pre-existing unrelated errors in other packages only)
- [ ] **Full eval-gate re-run required before merge** — a real converse + judge run on at least one content-quality suite (e.g. `security-alert-triage`, `security-multi-step`) to confirm the aggregate Factuality lift materializes on real traces and no suite regresses. This is the empirical confirmation of the C1/C5 lift; the unit tests only prove the scorer mechanism.

Draft pending owner design agreement + the eval-gate re-run above.

/cc @elastic/nightshift-context-and-research-team @elastic/security-genai-research-and-development