### PR TITLE
[Alerting v2] Make rule executor ES|QL stream format configurable (JSON default)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/config.test.ts
@@ -58,6 +58,23 @@ describe('alerting_v2 config schema', () => {
     });
   });
 
+  describe('query.streamFormat', () => {
+    it('defaults to json', () => {
+      const config = configSchema.validate({});
+      expect(config.query.streamFormat).toBe('json');
+    });
+
+    it('accepts arrow', () => {
+      expect(configSchema.validate({ query: { streamFormat: 'arrow' } }).query.streamFormat).toBe(
+        'arrow'
+      );
+    });
+
+    it('rejects an unknown format', () => {
+      expect(() => configSchema.validate({ query: { streamFormat: 'csv' } })).toThrow();
+    });
+  });
+
   describe('rules.maxScheduledPerMinute', () => {
     it('defaults to 400', () => {
       const config = configSchema.validate({});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/config.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/config.ts
@@ -23,6 +23,27 @@ const MINIMUM_SCHEDULE_INTERVAL_FLOOR = MIN_SCHEDULE_INTERVAL;
 /** Highest value `xpack.alerting_v2.rules.minimumScheduleInterval` may be set to. */
 const MAX_MINIMUM_SCHEDULE_INTERVAL = '30d';
 
+/**
+ * Wire format used by the rule executor's streaming breach query
+ * (`QueryService.executeQueryStream`).
+ *
+ * - `json`: fetch the ES|QL result as JSON and re-emit it as row batches
+ *   through the streaming interface. Default. Buffers the full result in
+ *   memory but avoids the Arrow IPC dependency and its type constraints.
+ * - `arrow`: consume the ES|QL result as an Apache Arrow IPC stream, parsing
+ *   one record batch at a time. Lower memory footprint for large results.
+ *
+ * Both modes expose the same `AsyncIterable<T[]>` contract, so downstream
+ * pipeline steps always handle stream-like (batched) data.
+ */
+export type QueryStreamFormat = 'json' | 'arrow';
+
+const querySchema = schema.object({
+  streamFormat: schema.oneOf([schema.literal('json'), schema.literal('arrow')], {
+    defaultValue: 'json',
+  }),
+});
+
 const rulesSchema = schema.object({
   /**
    * Smallest `schedule.every` a rule is allowed to use. Rules created, updated
@@ -61,7 +82,9 @@ export const configSchema = schema.object({
     removalDelay: schema.string({ defaultValue: '1h', validate: validateDuration }),
   }),
   rules: rulesSchema,
+  query: querySchema,
 });
 
 export type PluginConfig = TypeOf<typeof configSchema>;
 export type RulesConfig = TypeOf<typeof rulesSchema>;
+export type QueryConfig = TypeOf<typeof querySchema>;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.mock.ts
@@ -6,18 +6,24 @@
  */
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { QueryStreamFormat } from '../../../config';
 import { createMockEsClient } from '../../test_utils';
 import { createLoggerService } from '../logger_service/logger_service.mock';
 import { QueryService } from './query_service';
 import type { DeeplyMockedApi } from '@kbn/core-elasticsearch-client-server-mocks';
 
-export function createQueryService(): {
+/**
+ * Defaults `streamFormat` to `arrow` so existing streaming tests that drive the
+ * Arrow reader mocks keep working. Pass `json` to exercise the JSON streaming
+ * path (the production default configured via `xpack.alerting_v2.query`).
+ */
+export function createQueryService(streamFormat: QueryStreamFormat = 'arrow'): {
   queryService: QueryService;
   mockEsClient: DeeplyMockedApi<ElasticsearchClient>;
   mockLogger: jest.Mocked<Logger>;
 } {
   const mockEsClient = createMockEsClient();
   const { loggerService, mockLogger } = createLoggerService();
-  const queryService = new QueryService(mockEsClient, loggerService);
+  const queryService = new QueryService(mockEsClient, loggerService, streamFormat);
   return { queryService, mockEsClient, mockLogger };
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.test.ts
@@ -440,4 +440,149 @@ describe('QueryService', () => {
       expect(reader.cancel).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('executeQueryStream (json format)', () => {
+    const mockQuery = 'FROM .alerting-* | LIMIT 10';
+
+    beforeEach(() => {
+      const mocks = createQueryService('json');
+      mockEsClient = mocks.mockEsClient;
+      mockLogger = mocks.mockLogger;
+      queryService = mocks.queryService;
+    });
+
+    it('yields rows from the JSON response as a single batch', async () => {
+      mockEsClient.esql.query.mockResolvedValue({
+        columns: [
+          { name: 'host', type: 'keyword' },
+          { name: 'count', type: 'integer' },
+        ],
+        values: [
+          ['host-a', 1],
+          ['host-b', 2],
+        ],
+      });
+
+      const batches: Array<Record<string, unknown>[]> = [];
+      for await (const batch of queryService.executeQueryStream({ query: mockQuery })) {
+        batches.push(batch);
+      }
+
+      expect(mockEsClient.esql.query).toHaveBeenCalledTimes(1);
+      expect(mockEsClient.helpers.esql).not.toHaveBeenCalled();
+      expect(batches).toEqual([
+        [
+          { host: 'host-a', count: 1 },
+          { host: 'host-b', count: 2 },
+        ],
+      ]);
+    });
+
+    it('chunks large results into batches', async () => {
+      const rowCount = 2500;
+      mockEsClient.esql.query.mockResolvedValue({
+        columns: [{ name: 'host', type: 'keyword' }],
+        values: Array.from({ length: rowCount }, (_, i) => [`host-${i}`]),
+      });
+
+      const batches: Array<Record<string, unknown>[]> = [];
+      for await (const batch of queryService.executeQueryStream({ query: mockQuery })) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(3);
+      expect(batches[0]).toHaveLength(1000);
+      expect(batches[1]).toHaveLength(1000);
+      expect(batches[2]).toHaveLength(500);
+      expect(batches.flat()).toHaveLength(rowCount);
+    });
+
+    it('yields no batches when the result is empty', async () => {
+      mockEsClient.esql.query.mockResolvedValue({
+        columns: [{ name: 'host', type: 'keyword' }],
+        values: [],
+      });
+
+      const batches: Array<Record<string, unknown>[]> = [];
+      for await (const batch of queryService.executeQueryStream({ query: mockQuery })) {
+        batches.push(batch);
+      }
+
+      expect(batches).toEqual([]);
+    });
+
+    it('coerces BigInt values to Number in streamed rows', async () => {
+      mockEsClient.esql.query.mockResolvedValue({
+        columns: [
+          { name: 'host', type: 'keyword' },
+          { name: 'cpu', type: 'long' },
+        ],
+        values: [['host-a', BigInt(80)]],
+      } as unknown as EsqlQueryResponse);
+
+      const batches: Array<Record<string, unknown>[]> = [];
+      for await (const batch of queryService.executeQueryStream({ query: mockQuery })) {
+        batches.push(batch);
+      }
+
+      expect(batches).toEqual([[{ host: 'host-a', cpu: 80 }]]);
+      expect(typeof batches[0][0].cpu).toBe('number');
+    });
+
+    it('passes the query and abort signal to the JSON ES|QL API', async () => {
+      mockEsClient.esql.query.mockResolvedValue({
+        columns: [{ name: 'host', type: 'keyword' }],
+        values: [['host-a']],
+      });
+
+      const abortController = new AbortController();
+      const filter = { bool: { filter: [] } };
+
+      for await (const _batch of queryService.executeQueryStream({
+        query: mockQuery,
+        filter,
+        abortSignal: abortController.signal,
+      })) {
+        // consume
+      }
+
+      expect(mockEsClient.esql.query).toHaveBeenCalledWith(
+        {
+          query: mockQuery,
+          drop_null_columns: false,
+          filter,
+          params: undefined,
+        },
+        { signal: abortController.signal }
+      );
+    });
+
+    it('throws and logs error when the JSON query rejects', async () => {
+      mockEsClient.esql.query.mockRejectedValue(new Error('ES query failed'));
+
+      await expect(async () => {
+        for await (const _batch of queryService.executeQueryStream({ query: mockQuery })) {
+          // consume
+        }
+      }).rejects.toThrow('ES query failed');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('logs debug instead of error when cancelled', async () => {
+      const { RuleExecutionCancellationError } = jest.requireActual('../../execution_context');
+      mockEsClient.esql.query.mockRejectedValue(
+        new RuleExecutionCancellationError('Streaming query aborted')
+      );
+
+      await expect(async () => {
+        for await (const _batch of queryService.executeQueryStream({ query: mockQuery })) {
+          // consume
+        }
+      }).rejects.toThrow(/aborted/i);
+
+      expect(mockLogger.debug).toHaveBeenCalled();
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts
@@ -9,10 +9,18 @@ import type { EsqlQueryRequest, EsqlQueryResponse } from '@elastic/elasticsearch
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { inject, injectable } from 'inversify';
 import type { AsyncRecordBatchStreamReader } from 'apache-arrow/Arrow.node';
+import type { QueryStreamFormat } from '../../../config';
 import type { LoggerServiceContract } from '../logger_service/logger_service';
 import { LoggerServiceToken } from '../logger_service/logger_service';
 import type { ExecutionContext } from '../../execution_context';
 import { createExecutionContext, isRuleExecutionCancellationError } from '../../execution_context';
+
+/**
+ * Number of rows emitted per batch when streaming an ES|QL result in `json`
+ * format. The JSON response is fetched in full and then chunked so downstream
+ * consumers still receive stream-like (batched) data, matching the Arrow path.
+ */
+const JSON_STREAM_BATCH_SIZE = 1000;
 
 export interface ExecuteQueryParams {
   query: EsqlQueryRequest['query'];
@@ -31,7 +39,8 @@ export interface QueryServiceContract {
 export class QueryService implements QueryServiceContract {
   constructor(
     private readonly esClient: ElasticsearchClient,
-    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract
+    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
+    private readonly streamFormat: QueryStreamFormat = 'json'
   ) {}
 
   async executeQuery({
@@ -76,7 +85,18 @@ export class QueryService implements QueryServiceContract {
     return this.toRows<T>(response);
   }
 
-  async *executeQueryStream<T = Record<string, unknown>>({
+  async *executeQueryStream<T = Record<string, unknown>>(
+    params: ExecuteQueryParams
+  ): AsyncIterable<T[]> {
+    if (this.streamFormat === 'json') {
+      yield* this.streamViaJson<T>(params);
+      return;
+    }
+
+    yield* this.streamViaArrow<T>(params);
+  }
+
+  private async *streamViaArrow<T>({
     query,
     filter,
     params,
@@ -85,7 +105,7 @@ export class QueryService implements QueryServiceContract {
     const context = createExecutionContext(abortSignal ?? new AbortController().signal);
 
     this.logger.debug({
-      message: () => `QueryService: Executing streaming query`,
+      message: () => `QueryService: Executing streaming query (arrow format)`,
     });
 
     let reader: AsyncRecordBatchStreamReader | undefined;
@@ -126,6 +146,60 @@ export class QueryService implements QueryServiceContract {
       throw error;
     } finally {
       await this.closeReader(reader);
+    }
+  }
+
+  private async *streamViaJson<T>({
+    query,
+    filter,
+    params,
+    abortSignal,
+  }: ExecuteQueryParams): AsyncIterable<T[]> {
+    const context = createExecutionContext(abortSignal ?? new AbortController().signal);
+
+    this.logger.debug({
+      message: () => `QueryService: Executing streaming query (json format)`,
+    });
+
+    try {
+      context.throwIfAborted();
+
+      const response = await this.esClient.esql.query(
+        {
+          query,
+          drop_null_columns: false,
+          filter,
+          params,
+        },
+        { signal: context.signal }
+      );
+
+      const rows = this.toRows<T>(response);
+
+      // The JSON response is materialized in full, then re-emitted as batches so
+      // downstream consumers keep handling stream-like data (as with Arrow).
+      for (let start = 0; start < rows.length; start += JSON_STREAM_BATCH_SIZE) {
+        context.throwIfAborted();
+        yield rows.slice(start, start + JSON_STREAM_BATCH_SIZE);
+      }
+
+      this.logger.debug({
+        message: `QueryService: Streaming query completed successfully`,
+      });
+    } catch (error) {
+      if (isRuleExecutionCancellationError(error)) {
+        this.logger.debug({
+          message: 'QueryService: Streaming query aborted',
+        });
+      } else {
+        this.logger.error({
+          error,
+          code: 'ESQL_QUERY_ERROR',
+          type: 'QueryServiceError',
+        });
+      }
+
+      throw error;
     }
   }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -6,9 +6,16 @@
  */
 
 import { PluginSetup, PluginStart } from '@kbn/core-di';
-import { CoreStart, Request, SavedObjectsClientFactory } from '@kbn/core-di-server';
+import {
+  CoreStart,
+  PluginInitializer,
+  Request,
+  SavedObjectsClientFactory,
+} from '@kbn/core-di-server';
+import type { PluginInitializerContext } from '@kbn/core/server';
 import type { ContainerModuleLoadOptions } from 'inversify';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/maintenance-windows-plugin/common';
+import type { PluginConfig } from '../config';
 import { AlertActionsClient } from '../lib/alert_actions_client';
 import { DirectorService } from '../lib/director/director';
 import { BasicTransitionStrategy } from '../lib/director/strategies/basic_strategy';
@@ -249,7 +256,10 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
     .toDynamicValue(({ get }) => {
       const loggerService = get(LoggerServiceToken);
       const esClient = get(EsServiceScopedToken);
-      return new QueryService(esClient, loggerService);
+      const { streamFormat } = get<PluginInitializerContext<PluginConfig>['config']>(
+        PluginInitializer('config')
+      ).get<PluginConfig>().query;
+      return new QueryService(esClient, loggerService, streamFormat);
     })
     .inRequestScope();
 
@@ -258,7 +268,10 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
       const loggerService = get(LoggerServiceToken);
       // Rule-execution queries run against user data and must respect the space project routing.
       const esClient = get(EsServiceScopedSpaceRoutingToken);
-      return new QueryService(esClient, loggerService);
+      const { streamFormat } = get<PluginInitializerContext<PluginConfig>['config']>(
+        PluginInitializer('config')
+      ).get<PluginConfig>().query;
+      return new QueryService(esClient, loggerService, streamFormat);
     })
     .inRequestScope();
 
@@ -266,7 +279,10 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
     .toDynamicValue(({ get }) => {
       const loggerService = get(LoggerServiceToken);
       const esClient = get(EsServiceInternalToken);
-      return new QueryService(esClient, loggerService);
+      const { streamFormat } = get<PluginInitializerContext<PluginConfig>['config']>(
+        PluginInitializer('config')
+      ).get<PluginConfig>().query;
+      return new QueryService(esClient, loggerService, streamFormat);
     })
     .inSingletonScope();
 


### PR DESCRIPTION
## Summary

Makes the Alerting v2 rule executor's ES|QL streaming format configurable and defaults it to **JSON**, while preserving the stream-like processing the pipeline relies on.

Previously `QueryService.executeQueryStream` (the breach-query hot path) always consumed ES|QL results as an Apache Arrow IPC record-batch stream. This adds a new config option so operators can choose the wire format:

- `xpack.alerting_v2.query.streamFormat`: `'json' | 'arrow'`, default `'json'`.

Both modes expose the same `AsyncIterable<T[]>` contract, so downstream pipeline steps (`ExecuteRuleQueryStep` → `CreateAlertEvents` → …) always handle batched, stream-like data and require no changes.

- **JSON mode (default):** fetches the ES|QL result via `esql.query` and re-emits rows in batches (chunked) through the streaming interface. Reuses the existing `toRows`/`coerceBigInts` normalization.
- **Arrow mode (opt-in):** unchanged behavior — parses one Arrow `RecordBatch` at a time.

The selected format is read from config and wired into all three `QueryService` DI bindings.

### Trade-offs

- JSON mode buffers the full ES|QL response in memory before re-emitting batches (no true backpressure like Arrow). This is the accepted trade-off for defaulting to JSON; the streaming interface is preserved so the executor still processes data in batches.

### Testing

- Unit tests: added a full JSON-format `executeQueryStream` suite (batching/chunking, empty results, BigInt coercion, abort/error/cancel parity) and config tests for the new key. Existing Arrow tests unchanged (mock factory defaults to `arrow`).
- Type check + lint pass for the plugin.
- Verified end-to-end against a local Kibana in both modes: a breach rule produced identical `.rule-events` (correct grouping, `count` coerced to number) under JSON (default) and Arrow (`--xpack.alerting_v2.query.streamFormat=arrow`). Arrow startup also confirms the config key is accepted.

### Follow-ups

- Since Arrow is no longer the default, consider a Scout config set that runs the existing `rule_executor.spec.ts` with `streamFormat: arrow` to keep the Arrow path covered in CI.
- New config key: evaluate whether it needs cloud allowlisting / docker list inclusion (see checklist).

### Checklist

- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the docker list
- [x] Unit tests were updated or added to match the most common scenarios

### Identify risks

- Behavior change: the default streaming format switches from Arrow to JSON. JSON buffers the full result in memory, which could increase memory usage for very large breach-query results relative to Arrow. Mitigation: batched emission preserved; operators can opt back into Arrow via config.

Made with [Cursor](https://cursor.com)