### PR TITLE
[Agent Builder] Remove date from system prompt

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/README.md
+++ b/x-pack/platform/plugins/shared/agent_builder/README.md
@@ -45,10 +45,12 @@ elastic.apm.contextPropagationOnly: false
 telemetry.enabled: true
 telemetry.tracing.enabled: true
 
-telemetry.tracing.exporters.phoenix.base_url: 'http://localhost:6006/'
-telemetry.tracing.exporters.phoenix.public_url: 'http://localhost:6006/'
+telemetry.tracing.exporters.phoenix.base_url: 'http://localhost:6006'
+telemetry.tracing.exporters.phoenix.public_url: 'http://localhost:6006'
 telemetry.tracing.exporters.phoenix.project_name: '1chat'
 ```
+
+You can then view traces in the Phoenix Web UI `http://localhost:6006`
 
 ## Overview
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createAttachmentStateManager } from '@kbn/agent-builder-server/attachments';
+import { getStructuredAnswerPrompt } from './answer_agent';
+import { convertPreviousRounds } from '../utils/to_langchain_messages';
+
+jest.mock('../utils/to_langchain_messages', () => ({
+  convertPreviousRounds: jest.fn().mockResolvedValue([['human', 'history']]),
+}));
+
+describe('getStructuredAnswerPrompt', () => {
+  const now = new Date().toISOString();
+
+  it('does not render the current date in the system message and forwards conversationTimestamp', async () => {
+    const params = {
+      conversationTimestamp: now,
+      processedConversation: {
+        previousRounds: [],
+        nextInput: { message: '', attachments: [] },
+        attachments: [],
+        attachmentTypes: [],
+        attachmentStateManager: createAttachmentStateManager([], {
+          getTypeDefinition: (type: string) =>
+            ({
+              id: type,
+              validate: (input: unknown) => ({ valid: true, data: input }),
+              format: () => ({ getRepresentation: () => ({ type: 'text', value: '' }) }),
+            } as any),
+        }),
+      },
+      configuration: {
+        research: { instructions: '' },
+        answer: { instructions: '' },
+      },
+      capabilities: { visualizations: false },
+      skills: [],
+      actions: [],
+      answerActions: [],
+      cycleLimit: 1,
+      experimentalFeatures: { bash: false, skills: false },
+      toolManager: {} as any,
+      resultTransformer: jest.fn(),
+    } as any;
+
+    const messages = await getStructuredAnswerPrompt(params);
+
+    expect((messages[0] as [string, string])[1]).not.toContain('Current date');
+    expect(convertPreviousRounds).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationTimestamp: now })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.test.ts
@@ -49,7 +49,8 @@ describe('getStructuredAnswerPrompt', () => {
 
     const messages = await getStructuredAnswerPrompt(params);
 
-    expect((messages[0] as [string, string])[1]).not.toContain('Current date');
+    const systemMessage = (messages[0] as ['system', string])[1];
+    expect(systemMessage).not.toContain('Current date');
     expect(convertPreviousRounds).toHaveBeenCalledWith(
       expect.objectContaining({ conversationTimestamp: now })
     );

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.ts
@@ -9,7 +9,6 @@ import type { BaseMessageLike } from '@langchain/core/messages';
 import { cleanPrompt } from '@kbn/agent-builder-genai-utils/prompts';
 import { getConversationAttachmentsSection } from '../utils/attachment_presentation';
 import { convertPreviousRounds } from '../utils/to_langchain_messages';
-import { formatDate } from './utils/helpers';
 import { customInstructionsBlock } from './utils/custom_instructions';
 import { formatResearcherActionHistory, formatAnswerActionHistory } from './utils/actions';
 import { renderVisualizationPrompt } from './utils/visualizations';
@@ -43,6 +42,7 @@ export const getStructuredAnswerPrompt = async (
     conversation: processedConversation,
     resultTransformer,
     compactionSummary: processedConversation.compactionSummary,
+    conversationTimestamp,
   });
 
   return [
@@ -86,9 +86,6 @@ ${getConversationAttachmentsSection(versionedAttachmentPresentation)}
 ## CUSTOM RENDERING
 
 ${visEnabled ? renderVisualizationPrompt() : 'No custom renderers available'}
-
-## ADDITIONAL INFO
-- Current date: ${formatDate(conversationTimestamp)}
 
 ## PRE-RESPONSE COMPLIANCE CHECK
 - [ ] I responded using the structured output format with all required fields filled

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.test.ts
@@ -48,7 +48,8 @@ describe('getResearchAgentPrompt', () => {
 
     const messages = await getResearchAgentPrompt(params);
 
-    expect((messages[0] as [string, string])[1]).not.toContain('Current date');
+    const systemMessage = (messages[0] as ['system', string])[1];
+    expect(systemMessage).not.toContain('Current date');
     expect(convertPreviousRounds).toHaveBeenCalledWith(
       expect.objectContaining({ conversationTimestamp: now })
     );

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createAttachmentStateManager } from '@kbn/agent-builder-server/attachments';
+import { getResearchAgentPrompt } from './research_agent';
+import { convertPreviousRounds } from '../utils/to_langchain_messages';
+
+jest.mock('../utils/to_langchain_messages', () => ({
+  convertPreviousRounds: jest.fn().mockResolvedValue([['human', 'history']]),
+}));
+
+describe('getResearchAgentPrompt', () => {
+  const now = new Date().toISOString();
+
+  it('does not render the current date in the system message and forwards conversationTimestamp', async () => {
+    const params = {
+      conversationTimestamp: now,
+      processedConversation: {
+        previousRounds: [],
+        nextInput: { message: '', attachments: [] },
+        attachments: [],
+        attachmentTypes: [],
+        attachmentStateManager: createAttachmentStateManager([], {
+          getTypeDefinition: (type: string) =>
+            ({
+              id: type,
+              validate: (input: unknown) => ({ valid: true, data: input }),
+              format: () => ({ getRepresentation: () => ({ type: 'text', value: '' }) }),
+            } as any),
+        }),
+      },
+      configuration: {
+        research: { instructions: '' },
+        answer: { instructions: '' },
+      },
+      capabilities: { visualizations: false },
+      skills: [],
+      actions: [],
+      cycleLimit: 1,
+      experimentalFeatures: { bash: false, skills: false },
+      toolManager: {} as any,
+      resultTransformer: jest.fn(),
+    } as any;
+
+    const messages = await getResearchAgentPrompt(params);
+
+    expect((messages[0] as [string, string])[1]).not.toContain('Current date');
+    expect(convertPreviousRounds).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationTimestamp: now })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.ts
@@ -13,7 +13,6 @@ import { convertPreviousRounds } from '../utils/to_langchain_messages';
 import { attachmentTypeInstructions, renderAttachmentPrompt } from './utils/attachments';
 import { structuredOutputDescription } from './utils/custom_instructions';
 import { formatResearcherActionHistory } from './utils/actions';
-import { formatDate } from './utils/helpers';
 import { getFileSystemInstructions } from './utils/filestore';
 import type { PromptFactoryParams, ResearchAgentPromptRuntimeParams } from './types';
 import { renderVisualizationPrompt } from './utils/visualizations';
@@ -24,7 +23,14 @@ type ResearchAgentPromptParams = PromptFactoryParams & ResearchAgentPromptRuntim
 export const getResearchAgentPrompt = async (
   params: ResearchAgentPromptParams
 ): Promise<BaseMessageLike[]> => {
-  const { actions, cycleLimit, processedConversation, resultTransformer, toolManager } = params;
+  const {
+    actions,
+    cycleLimit,
+    processedConversation,
+    resultTransformer,
+    toolManager,
+    conversationTimestamp,
+  } = params;
 
   // Generate messages from the conversation's rounds, optionally
   // injecting a compaction summary for older compacted rounds.
@@ -34,6 +40,7 @@ export const getResearchAgentPrompt = async (
     conversation: processedConversation,
     resultTransformer,
     compactionSummary: processedConversation.compactionSummary,
+    conversationTimestamp,
   });
 
   return [
@@ -52,7 +59,6 @@ const getAgentSystemMessage = async ({
   configuration: {
     research: { instructions: customInstructions },
   },
-  conversationTimestamp,
   processedConversation: { attachmentTypes, versionedAttachmentPresentation },
   outputSchema,
   skills,
@@ -142,8 +148,5 @@ ${visEnabled ? renderVisualizationPrompt() : 'No custom renderers available'}
 
 ${renderAttachmentPrompt()}
 
-${renderRenderersPrompt(renderers, { bashEnabled: experimentalFeatures.bash })}
-
-## ADDITIONAL INFO
-- Current date: ${formatDate(conversationTimestamp)}`);
+${renderRenderersPrompt(renderers, { bashEnabled: experimentalFeatures.bash })}`);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.test.ts
@@ -21,6 +21,7 @@ import {
 import type { BackgroundExecutionState } from '@kbn/agent-builder-common/chat';
 import { sanitizeToolId, wrapToolResultContent } from '@kbn/agent-builder-genai-utils/langchain';
 import { convertPreviousRounds, groupToolCallSteps } from './to_langchain_messages';
+import { formatDate } from '../prompts/utils/helpers';
 import type { ToolCallResultTransformer } from './tool_summarization';
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
@@ -129,6 +130,63 @@ describe('convertPreviousRounds', () => {
     expect(result[0].content).toBe('hello');
   });
 
+  it('prefixes the next-input user message when conversationTimestamp is provided', async () => {
+    const nextInput = makeRoundInput('hello');
+    const result = await convertPreviousRounds({
+      conversation: createConversation({ nextInput }),
+      conversationTimestamp: now,
+    });
+    expect(result).toHaveLength(1);
+    expect(isHumanMessage(result[0])).toBe(true);
+    expect(result[0].content).toBe(`[Sent: ${formatDate(now)}]\n\nhello`);
+  });
+
+  it('places the next-input date prefix above attachment XML', async () => {
+    const attachment = makeProcessedAttachment(
+      'att-1',
+      'text',
+      { content: 'test content' },
+      'This is the formatted text content'
+    );
+    const nextInput = makeRoundInput('hello with attachment', [attachment]);
+    const result = await convertPreviousRounds({
+      conversation: createConversation({ nextInput }),
+      conversationTimestamp: now,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(isHumanMessage(result[0])).toBe(true);
+
+    const content = result[0].content as string;
+    expect(content.startsWith(`[Sent: ${formatDate(now)}]\n\nhello with attachment`)).toBe(true);
+    expect(content.indexOf('[Sent: ')).toBeLessThan(content.indexOf('<attachments>'));
+  });
+
+  it('uses the pending round timestamp when an awaiting-prompt round is promoted to next input', async () => {
+    const pendingStartedAt = '2026-06-30T12:34:56.000Z';
+    const previousRounds = [
+      createRound({
+        id: 'round-1',
+        status: ConversationRoundStatus.awaitingPrompt,
+        input: makeRoundInput('original user request'),
+        started_at: pendingStartedAt,
+      }),
+    ];
+
+    const result = await convertPreviousRounds({
+      conversation: createConversation({
+        previousRounds,
+        nextInput: makeRoundInput('prompt answer'),
+      }),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(isHumanMessage(result[0])).toBe(true);
+    expect(result[0].content).toBe(
+      `[Sent: ${formatDate(pendingStartedAt)}]\n\noriginal user request`
+    );
+  });
+
   it('handles a round with only user and assistant messages', async () => {
     const previousRounds = [
       createRound({
@@ -150,7 +208,7 @@ describe('convertPreviousRounds', () => {
 
     const [firstHumanMessage, firstAssistantMessage, secondHumanMessage] = result;
     expect(isHumanMessage(firstHumanMessage)).toBe(true);
-    expect(firstHumanMessage.content).toBe('hi');
+    expect(firstHumanMessage.content).toBe(`[Sent: ${formatDate(now)}]\n\nhi`);
     expect(isAIMessage(firstAssistantMessage)).toBe(true);
     expect(firstAssistantMessage.content).toBe('hello!');
     expect(isHumanMessage(secondHumanMessage)).toBe(true);
@@ -192,7 +250,7 @@ describe('convertPreviousRounds', () => {
       nextHumanMessage,
     ] = result;
     expect(isHumanMessage(firstHumanMessage)).toBe(true);
-    expect(firstHumanMessage.content).toBe('find foo');
+    expect(firstHumanMessage.content).toBe(`[Sent: ${formatDate(now)}]\n\nfind foo`);
     expect(isAIMessage(toolCallAIMessage)).toBe(true);
     expect((toolCallAIMessage as AIMessage).tool_calls).toHaveLength(1);
     expect((toolCallAIMessage as AIMessage).tool_calls![0].id).toBe('call-1');
@@ -262,11 +320,11 @@ describe('convertPreviousRounds', () => {
       lastHumanMessage,
     ] = result;
     expect(isHumanMessage(firstHumanMessage)).toBe(true);
-    expect(firstHumanMessage.content).toBe('hi');
+    expect(firstHumanMessage.content).toBe(`[Sent: ${formatDate(now)}]\n\nhi`);
     expect(isAIMessage(firstAssistantMessage)).toBe(true);
     expect(firstAssistantMessage.content).toBe('hello!');
     expect(isHumanMessage(secondHumanMessage)).toBe(true);
-    expect(secondHumanMessage.content).toBe('search for bar');
+    expect(secondHumanMessage.content).toBe(`[Sent: ${formatDate(now)}]\n\nsearch for bar`);
     expect(isAIMessage(toolCallAIMessage)).toBe(true);
     expect((toolCallAIMessage as AIMessage).tool_calls).toHaveLength(1);
     expect((toolCallAIMessage as AIMessage).tool_calls![0].id).toBe('call-2');

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.test.ts
@@ -187,6 +187,29 @@ describe('convertPreviousRounds', () => {
     );
   });
 
+  it('ignores epoch started_at dates', async () => {
+    const epochStartedAt = new Date(0).toISOString();
+    const previousRounds = [
+      createRound({
+        id: 'round-1',
+        input: makeRoundInput('legacy user message'),
+        response: makeAssistantResponse('hello!'),
+        started_at: epochStartedAt,
+      }),
+    ];
+
+    const result = await convertPreviousRounds({
+      conversation: createConversation({
+        previousRounds,
+        nextInput: makeRoundInput('current message'),
+      }),
+    });
+
+    const [firstHumanMessage] = result;
+    expect(isHumanMessage(firstHumanMessage)).toBe(true);
+    expect(firstHumanMessage.content).toBe('legacy user message');
+  });
+
   it('handles a round with only user and assistant messages', async () => {
     const previousRounds = [
       createRound({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.ts
@@ -186,7 +186,7 @@ const formatRoundInput = ({
     content += `\n\n${attachmentsXml}\n`;
   }
 
-  if (timestamp) {
+  if (timestamp && timestamp !== new Date(0).toISOString()) {
     content = `[Sent: ${formatDate(timestamp)}]\n\n${content}`;
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.ts
@@ -35,6 +35,7 @@ import type { ProcessedConversation, ProcessedConversationRound } from './prepar
 import type { ToolCallResultTransformer } from './tool_summarization';
 import { serializeCompactionSummary } from './compaction_serialize';
 import { materializeAskUserQuestionToolCall } from './ask_user_question_tool_call';
+import { formatDate } from '../prompts/utils/helpers';
 
 export interface ConversationToLangchainOptions {
   conversation: ProcessedConversation;
@@ -54,6 +55,13 @@ export interface ConversationToLangchainOptions {
    * user/assistant message pair representing the compacted history.
    */
   compactionSummary?: CompactionSummary;
+  /**
+   * Timestamp of the current (in-progress) round. When provided, it is
+   * prefixed onto the next-input user message. Previous rounds always use
+   * their own `started_at`. Kept out of the system prompt so the system+tools
+   * prefix stays stable across rounds (prompt-cache friendly).
+   */
+  conversationTimestamp?: string;
 }
 
 /**
@@ -67,11 +75,13 @@ export const convertPreviousRounds = async ({
   resultTransformer,
   ignoreSteps = false,
   compactionSummary,
+  conversationTimestamp,
 }: ConversationToLangchainOptions): Promise<BaseMessage[]> => {
   const messages: BaseMessage[] = [];
 
   let rounds = conversation.previousRounds;
   let input = conversation.nextInput;
+  let inputTimestamp = conversationTimestamp;
 
   // need to ignore the last round if it's awaiting a prompt, the graph handles resuming the actions
   // we also uses the last message's input as the "next" input (given the actual input will be the prompt response)
@@ -79,6 +89,7 @@ export const convertPreviousRounds = async ({
   if (lastRound && lastRound.status === ConversationRoundStatus.awaitingPrompt) {
     rounds = rounds.slice(0, rounds.length - 1);
     input = lastRound.input;
+    inputTimestamp = lastRound.started_at;
   }
 
   // Inject compaction summary as a user/assistant exchange before remaining rounds
@@ -92,7 +103,7 @@ export const convertPreviousRounds = async ({
     messages.push(...(await roundToLangchain(round, { resultTransformer, ignoreSteps })));
   }
 
-  messages.push(formatRoundInput({ input }));
+  messages.push(formatRoundInput({ input, timestamp: inputTimestamp }));
 
   return messages;
 };
@@ -107,7 +118,7 @@ export const roundToLangchain = async (
   const messages: BaseMessage[] = [];
 
   // user message
-  messages.push(formatRoundInput({ input: round.input }));
+  messages.push(formatRoundInput({ input: round.input, timestamp: round.started_at }));
 
   // steps
   if (!ignoreSteps) {
@@ -152,7 +163,13 @@ export const roundToLangchain = async (
   return messages;
 };
 
-const formatRoundInput = ({ input }: { input: ProcessedRoundInput }): HumanMessage => {
+const formatRoundInput = ({
+  input,
+  timestamp,
+}: {
+  input: ProcessedRoundInput;
+  timestamp?: string;
+}): HumanMessage => {
   const { message, attachments } = input;
 
   let content = message;
@@ -167,6 +184,10 @@ const formatRoundInput = ({ input }: { input: ProcessedRoundInput }): HumanMessa
     );
 
     content += `\n\n${attachmentsXml}\n`;
+  }
+
+  if (timestamp) {
+    content = `[Sent: ${formatDate(timestamp)}]\n\n${content}`;
   }
 
   return createUserMessage(content);


### PR DESCRIPTION
## Summary

Adds the current date to the top of the user message in the format `[Sent <timestamp>]\n\n` and remove the current date from the system message "additional info" to improve cache performance.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


