### PR TITLE
[UIAM OAuth] UX alignment on the application connections page

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
@@ -43,9 +43,10 @@ export type {
   AgentBuilderAnnouncementModalProps,
   AgentBuilderAnnouncementVariant,
 } from './announcement_modal/agent_builder_announcement_modal';
-export { McpClientDetails, McpClientLogo } from './oauth_clients';
+export { McpClientDetails, McpClientDetailsContent, McpClientLogo } from './oauth_clients';
 export type {
   McpClientDetailsProps,
+  McpClientDetailsContentProps,
   McpClientDetailsData,
   McpClientDetailsPresentation,
   McpClientLogoProps,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/index.ts
@@ -7,7 +7,9 @@
 
 export { McpClientDetails } from './mcp_client_details';
 export type { McpClientDetailsProps } from './mcp_client_details';
+export { McpClientDetailsContent } from './mcp_client_details_content';
 export type {
+  McpClientDetailsContentProps,
   McpClientDetailsData,
   McpClientDetailsPresentation,
 } from './mcp_client_details_content';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
@@ -15,7 +15,7 @@ import useToggle from 'react-use/lib/useToggle';
 import { labels } from './translations';
 import { McpClientDetailsField } from './mcp_client_details_field';
 
-export type McpClientDetailsPresentation = 'modal' | 'flyout';
+export type McpClientDetailsPresentation = 'modal' | 'flyout' | 'popover';
 export type McpClientDetailsData = OAuthClient & { client_secret?: string };
 
 const hasClientSecret = (

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_field.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_field.tsx
@@ -30,38 +30,37 @@ export const McpClientDetailsField = ({
   children,
 }: PropsWithChildren<McpClientDetailsFieldProps>) => {
   return (
-    <EuiPanel color="subdued" hasBorder={false} hasShadow={false} paddingSize="m">
-      <EuiFlexGroup
-        gutterSize="s"
-        alignItems="center"
-        justifyContent="spaceBetween"
-        responsive={false}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs">
-            <strong>{label}</strong>
-          </EuiText>
-        </EuiFlexItem>
-        {actions && actions.length > 0 ? (
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-              {actions.map((action, index) => (
-                <EuiFlexItem key={index} grow={false}>
-                  {action}
-                </EuiFlexItem>
-              ))}
-            </EuiFlexGroup>
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiText size="xs">{label}</EuiText>
+      <EuiPanel color="subdued" hasBorder={false} hasShadow={false} paddingSize="m">
+        <EuiFlexGroup
+          gutterSize="s"
+          alignItems="center"
+          justifyContent="spaceBetween"
+          responsive={false}
+        >
+          <EuiFlexItem grow={true}>
+            <div css={fieldValueStyles}>{children}</div>
           </EuiFlexItem>
-        ) : null}
-      </EuiFlexGroup>
-      <EuiSpacer size="s" />
-      <div css={fieldValueStyles}>{children}</div>
-      {append && (
-        <>
-          <EuiSpacer size="s" />
-          {append}
-        </>
-      )}
-    </EuiPanel>
+          {actions && actions.length > 0 ? (
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                {actions.map((action, index) => (
+                  <EuiFlexItem key={index} grow={false}>
+                    {action}
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+        {append && (
+          <>
+            <EuiSpacer size="s" />
+            {append}
+          </>
+        )}
+      </EuiPanel>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients_table.tsx
@@ -147,7 +147,6 @@ export const McpClientsTable = memo(() => {
             )
           ) : null
         }
-        responsiveBreakpoint={false}
       />
     </>
   );

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
@@ -41,6 +41,7 @@ export const useConnectionTableColumns = ({
       field: 'connection.name',
       name: labels.connectionColumns.connectionName,
       sortable: ({ connection: { name, id } }) => name ?? id,
+      truncateText: true,
       render: (_, applicationConnection: ApplicationConnection) => {
         const { client, connection } = applicationConnection;
         const displayName = connection.name ?? connection.id;
@@ -63,6 +64,7 @@ export const useConnectionTableColumns = ({
       field: 'client.client_name',
       name: labels.connectionColumns.clientName,
       sortable: ({ client: { client_name, id } }) => client_name ?? id,
+      truncateText: true,
       render: (_, { client }: ApplicationConnection) => {
         const displayName = client.client_name ?? client.id;
         return (
@@ -83,6 +85,7 @@ export const useConnectionTableColumns = ({
     const authorizationDateColumn: EuiTableFieldDataColumnType<ApplicationConnection> = {
       field: 'connection.creation',
       name: labels.connectionColumns.authorizationDate,
+      width: '160px',
       sortable: ({ connection }) =>
         connection.creation ? new Date(connection.creation).getTime() : 0,
       render: (_value: string | undefined, { connection }: ApplicationConnection) =>
@@ -96,6 +99,7 @@ export const useConnectionTableColumns = ({
     const connectedByColumn: EuiTableComputedColumnType<ApplicationConnection> = {
       name: labels.connectionColumns.connectedBy,
       sortable: ({ connection }) => connection.user_id ?? '',
+      truncateText: true,
       render: ({ connection }: ApplicationConnection) => {
         const dataTestSubj = `applicationConnectionConnectedBy-${connection.id}`;
         if (!connection.user_id) {
@@ -119,10 +123,11 @@ export const useConnectionTableColumns = ({
 
     const statusColumn: EuiTableComputedColumnType<ApplicationConnection> = {
       name: labels.connectionColumns.status,
+      width: '120px',
       sortable: (applicationConnection) => (isConnectionActive(applicationConnection) ? 0 : 1),
       render: (applicationConnection) =>
         isConnectionActive(applicationConnection) ? (
-          <EuiToolTip content={labels.status.connectedTooltip} position="top">
+          <EuiToolTip content={labels.status.connectedTooltip} position="top" display="flex">
             <EuiHealth color="success">{labels.status.connected}</EuiHealth>
           </EuiToolTip>
         ) : (

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/revoke_application_connections_modal.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/revoke_application_connections_modal.tsx
@@ -33,6 +33,7 @@ import type {
   RevokedApplicationConnection,
 } from './constants/types';
 import { useRevokeConnections } from './hooks/use_revoke_connections';
+import { RevokeClientDetailsPopover } from './revoke_client_details_popover';
 import { useCurrentUser } from '../../components/use_current_user';
 
 export interface RevokeApplicationConnectionsModalProps {
@@ -104,7 +105,7 @@ export const RevokeApplicationConnectionsModal = ({
     {
       field: 'client.client_name',
       name: labels.revoke.clientNameColumn,
-      render: (_value, item) => item.client.client_name ?? item.client.id,
+      render: (_value, item) => <RevokeClientDetailsPopover client={item.client} />,
     },
     {
       field: 'userId',

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/revoke_client_details_popover.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/revoke_client_details_popover.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLink, EuiPopover } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+import useToggle from 'react-use/lib/useToggle';
+
+import { McpClientDetailsContent } from '@kbn/agent-builder-browser';
+
+import { labels } from './constants/i18n';
+import type { OAuthClient } from './service/application_connections_api_client';
+
+const popoverContentStyles = css`
+  inline-size: 460px;
+`;
+
+export interface RevokeClientDetailsPopoverProps {
+  client: OAuthClient;
+}
+
+export const RevokeClientDetailsPopover = ({ client }: RevokeClientDetailsPopoverProps) => {
+  const [isOpen, toggleOpen] = useToggle(false);
+  const displayName = client.client_name ?? client.id;
+
+  return (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => toggleOpen(false)}
+      anchorPosition="rightCenter"
+      panelPaddingSize="m"
+      aria-label={labels.viewClientDetails.linkAriaLabel(displayName)}
+      button={
+        <EuiLink
+          onClick={() => toggleOpen()}
+          aria-label={labels.viewClientDetails.linkAriaLabel(displayName)}
+          data-test-subj={`revokeClientDetailsPopoverButton-${client.id}`}
+        >
+          {displayName}
+        </EuiLink>
+      }
+    >
+      <div css={popoverContentStyles} data-test-subj={`revokeClientDetailsPopover-${client.id}`}>
+        <McpClientDetailsContent clientDetails={client} presentation="popover" />
+      </div>
+    </EuiPopover>
+  );
+};


### PR DESCRIPTION
## Summary

UX enhancements and alignment fixes for the application connections management views. Changes include:

- Client names in the revoke connections modal are now clickable and open a popover with the full client details, so admins can review what they're revoking without leaving the modal.
- Cleaned up the connections table layout with consistent column widths and text truncation, keeping rows readable and aligned regardless of content length.
- Fixed the connections table so columns collapse correctly at smaller viewport sizes.
- Fixed minor alignment issues in table rows and in the shared client details fields.

### Demo

__Client Details Popover in revoke modal__

<img width="1737" height="679" alt="Screenshot 2026-07-06 at 17 26 44" src="https://github.com/user-attachments/assets/ebef2597-3153-4260-b3ee-b027a459c4b7" />

__Application Connections table__

<img width="1506" height="767" alt="Screenshot 2026-07-06 at 17 28 44" src="https://github.com/user-attachments/assets/e1aefc47-c2d9-4d88-a0d9-27196b62b11e" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

