### PR TITLE
[Security Solution] Alert analysis workflow review follow-ups

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/alert_analysis_workflow.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/alert_analysis_workflow.ts
@@ -57,19 +57,19 @@ export type AlertAnalysisWorkflowRuleAttachmentListRequestQuery = z.infer<
   typeof AlertAnalysisWorkflowRuleAttachmentListRequestQuery
 >;
 
-export const AlertAnalysisWorkflowRuleAttachmentStatsRequestBody = z.object({
+export const AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery = z.object({
   search: z.string().optional().default(''),
 });
 
-export type AlertAnalysisWorkflowRuleAttachmentStatsRequestBody = z.infer<
-  typeof AlertAnalysisWorkflowRuleAttachmentStatsRequestBody
+export type AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery = z.infer<
+  typeof AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery
 >;
 
-export const AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody =
-  AlertAnalysisWorkflowRuleAttachmentStatsRequestBody;
+export const AlertAnalysisWorkflowRuleAttachmentSelectionRequestQuery =
+  AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery;
 
-export type AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody = z.infer<
-  typeof AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody
+export type AlertAnalysisWorkflowRuleAttachmentSelectionRequestQuery = z.infer<
+  typeof AlertAnalysisWorkflowRuleAttachmentSelectionRequestQuery
 >;
 
 export const AlertAnalysisWorkflowRuleAttachmentUpdateRequestBody = z

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/api.ts
@@ -13,8 +13,6 @@ import {
   ALERT_ANALYSIS_WORKFLOW_RULE_UPDATE_ROUTE,
   ALERT_ANALYSIS_WORKFLOW_RULES_ROUTE,
   ALERT_ANALYSIS_WORKFLOW_SETTINGS_ROUTE,
-  type AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody,
-  type AlertAnalysisWorkflowRuleAttachmentStatsRequestBody,
   type AlertAnalysisWorkflowRuleAttachmentUpdateRequestBody,
   type AlertAnalysisWorkflowSettings,
   type RuleAttachmentPage,
@@ -113,12 +111,10 @@ export const fetchAlertAnalysisWorkflowRuleAttachmentStats = ({
   http: HttpStart;
   search: string;
 }): Promise<RuleAttachmentStats> => {
-  const body: AlertAnalysisWorkflowRuleAttachmentStatsRequestBody = { search };
-
   return http.fetch<RuleAttachmentStats>(ALERT_ANALYSIS_WORKFLOW_RULE_STATS_ROUTE, {
-    method: 'POST',
+    method: 'GET',
     version: ALERT_ANALYSIS_WORKFLOW_API_VERSION,
-    body: JSON.stringify(body),
+    query: { search },
   });
 };
 
@@ -129,12 +125,10 @@ export const fetchAlertAnalysisWorkflowRuleAttachmentSelection = ({
   http: HttpStart;
   search: string;
 }): Promise<RuleAttachmentSelection> => {
-  const body: AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody = { search };
-
   return http.fetch<RuleAttachmentSelection>(ALERT_ANALYSIS_WORKFLOW_RULE_SELECTION_ROUTE, {
-    method: 'POST',
+    method: 'GET',
     version: ALERT_ANALYSIS_WORKFLOW_API_VERSION,
-    body: JSON.stringify(body),
+    query: { search },
   });
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.test.tsx
@@ -10,9 +10,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { focusManager } from '@kbn/react-query';
 import { coreMock } from '@kbn/core/public/mocks';
-import { RULES_FEATURE_ID } from '../../../../../common/constants';
 import { TestProviders } from '../../../../common/mock';
 import { createStartServicesMock } from '../../../../common/lib/kibana/kibana_react.mock';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { ALERT_ANALYSIS_WORKFLOW_API_VERSION, ALERT_ANALYSIS_WORKFLOW_SETTINGS_ROUTE } from './api';
 import { AlertAnalysisWorkflowPage } from '.';
 
@@ -24,6 +24,9 @@ jest.mock('../../../../common/containers/use_full_screen', () => ({
 }));
 
 jest.mock('../../../../common/hooks/use_license');
+jest.mock('../../../../common/components/user_privileges');
+
+const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 
 describe('AlertAnalysisWorkflowPage', () => {
   const coreStart = coreMock.createStart();
@@ -44,9 +47,12 @@ describe('AlertAnalysisWorkflowPage', () => {
       ...coreStart.application.capabilities,
       advancedSettings: { show: true, save: true },
       securitySolution: { show: true, crud: true },
-      [RULES_FEATURE_ID]: { read_rules: true, edit_rules: true },
       workflowsManagement: { updateWorkflow: true },
     };
+    // The page reads rules-edit via useUserPrivileges (not raw capabilities).
+    useUserPrivilegesMock.mockReturnValue({
+      rulesPrivileges: { rules: { read: true, edit: true } },
+    });
     coreStart.application.getUrlForApp.mockImplementation(
       (appId, options) => `/app/${appId}${options?.path ?? ''}`
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import type { Capabilities } from '@kbn/core/types';
+import { isEqual } from 'lodash';
 import { useMutation, useQuery, useQueryClient } from '@kbn/react-query';
 import { ConnectorSelector } from '@kbn/security-solution-connectors';
 import { AiIcon } from '@kbn/shared-ux-ai-components';
@@ -35,7 +35,7 @@ import { SecurityPageName } from '../../../../app/types';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { useAIConnectors } from '../../../../common/hooks/use_ai_connectors';
-import { extractRulesCapabilities } from '../../../../common/utils/rules_capabilities';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import {
   fetchAlertAnalysisWorkflowSettings,
   saveAlertAnalysisWorkflowSettings,
@@ -51,47 +51,19 @@ const ALERT_ANALYSIS_WORKFLOW_SETTINGS_QUERY_KEY = [
 
 type AlertAnalysisWorkflowSettingsError = Error & { body?: { message?: string } };
 
-const areSettingsEqual = (
-  left: AlertAnalysisWorkflowSettingsWithConnector | undefined,
-  right: AlertAnalysisWorkflowSettingsWithConnector | undefined
-): boolean => {
-  return (
-    left?.workflowEnabled === right?.workflowEnabled &&
-    left?.autoCloseEnabled === right?.autoCloseEnabled &&
-    left?.autoCloseConfidenceScoreMinThreshold === right?.autoCloseConfidenceScoreMinThreshold &&
-    left?.autoCloseConfidenceScoreMaxThreshold === right?.autoCloseConfidenceScoreMaxThreshold &&
-    left?.connectorId === right?.connectorId &&
-    left?.createConversation === right?.createConversation
-  );
-};
-
-const getAlertAnalysisWorkflowAccess = (
-  capabilities: Capabilities,
-  isEnterprise: boolean
-): { canAccessPage: boolean; canEditAdvancedSettings: boolean } => {
-  const rulesCapabilities = extractRulesCapabilities(capabilities);
-  const canEditWorkflow =
-    capabilities.workflowsManagement?.[WorkflowsManagementUiActions.update] === true;
-  const canEditAdvancedSettings = Boolean(
-    capabilities.advancedSettings?.save && rulesCapabilities.rules.edit && canEditWorkflow
-  );
-
-  return {
-    canEditAdvancedSettings,
-    canAccessPage: isEnterprise && canEditAdvancedSettings,
-  };
-};
-
 export const AlertAnalysisWorkflowPage: React.FC = () => {
   const {
     services: { application, http, notifications, settings },
   } = useKibana();
   const queryClient = useQueryClient();
   const isEnterprise = useLicense().isEnterprise();
-  const { canAccessPage, canEditAdvancedSettings } = getAlertAnalysisWorkflowAccess(
-    application.capabilities,
-    isEnterprise
+  const { edit: canEditRules } = useUserPrivileges().rulesPrivileges.rules;
+  const canEditWorkflow =
+    application.capabilities.workflowsManagement?.[WorkflowsManagementUiActions.update] === true;
+  const canEditAdvancedSettings = Boolean(
+    application.capabilities.advancedSettings?.save && canEditRules && canEditWorkflow
   );
+  const canAccessPage = isEnterprise && canEditAdvancedSettings;
   const { aiConnectors, isLoading: isLoadingConnectors } = useAIConnectors();
   const { data: savedSettingsResponse, isLoading } = useQuery({
     queryKey: ALERT_ANALYSIS_WORKFLOW_SETTINGS_QUERY_KEY,
@@ -107,7 +79,7 @@ export const AlertAnalysisWorkflowPage: React.FC = () => {
   const [pageSettings, setPageSettings] = useState<
     AlertAnalysisWorkflowSettingsWithConnector | undefined
   >();
-  const isDirty = !areSettingsEqual(pageSettings, savedSettings);
+  const isDirty = !isEqual(pageSettings, savedSettings);
   const isWorkflowEnabled = pageSettings?.workflowEnabled ?? true;
   const isThresholdRangeInvalid =
     pageSettings !== undefined &&

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/rule_attachment_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/rule_attachment_section.test.tsx
@@ -331,8 +331,7 @@ describe('AlertAnalysisWorkflowRuleAttachmentSection', () => {
       }
 
       if (path === ALERT_ANALYSIS_WORKFLOW_RULE_STATS_ROUTE) {
-        const body = options?.body ? JSON.parse(options.body) : {};
-        return body.search === 'malware'
+        return options?.query?.search === 'malware'
           ? { total: 1, attached: 0 }
           : { total: TOTAL_RULES, attached: ATTACHED_RULES };
       }

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachment_routes.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachment_routes.test.ts
@@ -182,15 +182,15 @@ describe('registerAlertAnalysisWorkflowRuleAttachmentRoutes', () => {
       createRule({ id: 'rule-1', actions: [createWorkflowAction()] }),
       createRule({ id: 'rule-2' }),
     ]);
-    const handler = router.versioned.getRoute('post', ALERT_ANALYSIS_WORKFLOW_RULE_STATS_ROUTE)
+    const handler = router.versioned.getRoute('get', ALERT_ANALYSIS_WORKFLOW_RULE_STATS_ROUTE)
       .versions['1'].handler;
 
     await handler(
       context,
       createRequest({
-        method: 'post',
+        method: 'get',
         path: ALERT_ANALYSIS_WORKFLOW_RULE_STATS_ROUTE,
-        body: { search: '' },
+        query: { search: '' },
       }),
       mockResponse
     );
@@ -208,15 +208,15 @@ describe('registerAlertAnalysisWorkflowRuleAttachmentRoutes', () => {
       createRule({ id: 'rule-1', actions: [createWorkflowAction()] }),
       createRule({ id: 'rule-2' }),
     ]);
-    const handler = router.versioned.getRoute('post', ALERT_ANALYSIS_WORKFLOW_RULE_SELECTION_ROUTE)
+    const handler = router.versioned.getRoute('get', ALERT_ANALYSIS_WORKFLOW_RULE_SELECTION_ROUTE)
       .versions['1'].handler;
 
     await handler(
       context,
       createRequest({
-        method: 'post',
+        method: 'get',
         path: ALERT_ANALYSIS_WORKFLOW_RULE_SELECTION_ROUTE,
-        body: { search: '' },
+        query: { search: '' },
       }),
       mockResponse
     );

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachment_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachment_routes.ts
@@ -17,12 +17,12 @@ import {
   ALERT_ANALYSIS_WORKFLOW_RULE_UPDATE_ROUTE,
   ALERT_ANALYSIS_WORKFLOW_RULES_ROUTE,
   AlertAnalysisWorkflowRuleAttachmentListRequestQuery,
-  AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody,
-  AlertAnalysisWorkflowRuleAttachmentStatsRequestBody,
+  AlertAnalysisWorkflowRuleAttachmentSelectionRequestQuery,
+  AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery,
   AlertAnalysisWorkflowRuleAttachmentUpdateRequestBody,
   type AlertAnalysisWorkflowRuleAttachmentListRequestQuery as AlertAnalysisWorkflowRuleAttachmentListRequestQueryType,
-  type AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody as AlertAnalysisWorkflowRuleAttachmentSelectionRequestBodyType,
-  type AlertAnalysisWorkflowRuleAttachmentStatsRequestBody as AlertAnalysisWorkflowRuleAttachmentStatsRequestBodyType,
+  type AlertAnalysisWorkflowRuleAttachmentSelectionRequestQuery as AlertAnalysisWorkflowRuleAttachmentSelectionRequestQueryType,
+  type AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery as AlertAnalysisWorkflowRuleAttachmentStatsRequestQueryType,
   type AlertAnalysisWorkflowRuleAttachmentUpdateRequestBody as AlertAnalysisWorkflowRuleAttachmentUpdateRequestBodyType,
 } from '../../../common/workflows/alert_analysis_workflow';
 import type {
@@ -133,7 +133,7 @@ export const registerAlertAnalysisWorkflowRuleAttachmentRoutes = (
     );
 
   router.versioned
-    .post({
+    .get({
       path: ALERT_ANALYSIS_WORKFLOW_RULE_STATS_ROUTE,
       access: 'internal',
       security: {
@@ -147,7 +147,9 @@ export const registerAlertAnalysisWorkflowRuleAttachmentRoutes = (
         version: ALERT_ANALYSIS_WORKFLOW_API_VERSION,
         validate: {
           request: {
-            body: buildRouteValidationWithZod(AlertAnalysisWorkflowRuleAttachmentStatsRequestBody),
+            query: buildRouteValidationWithZod(
+              AlertAnalysisWorkflowRuleAttachmentStatsRequestQuery
+            ),
           },
         },
       },
@@ -160,7 +162,7 @@ export const registerAlertAnalysisWorkflowRuleAttachmentRoutes = (
           }
 
           const { search } =
-            request.body as AlertAnalysisWorkflowRuleAttachmentStatsRequestBodyType;
+            request.query as AlertAnalysisWorkflowRuleAttachmentStatsRequestQueryType;
           const service = await createReadService(context);
           const body = await service.getRuleAttachmentStats({ search });
 
@@ -176,7 +178,7 @@ export const registerAlertAnalysisWorkflowRuleAttachmentRoutes = (
     );
 
   router.versioned
-    .post({
+    .get({
       path: ALERT_ANALYSIS_WORKFLOW_RULE_SELECTION_ROUTE,
       access: 'internal',
       security: {
@@ -190,8 +192,8 @@ export const registerAlertAnalysisWorkflowRuleAttachmentRoutes = (
         version: ALERT_ANALYSIS_WORKFLOW_API_VERSION,
         validate: {
           request: {
-            body: buildRouteValidationWithZod(
-              AlertAnalysisWorkflowRuleAttachmentSelectionRequestBody
+            query: buildRouteValidationWithZod(
+              AlertAnalysisWorkflowRuleAttachmentSelectionRequestQuery
             ),
           },
         },
@@ -205,7 +207,7 @@ export const registerAlertAnalysisWorkflowRuleAttachmentRoutes = (
           }
 
           const { search } =
-            request.body as AlertAnalysisWorkflowRuleAttachmentSelectionRequestBodyType;
+            request.query as AlertAnalysisWorkflowRuleAttachmentSelectionRequestQueryType;
           const service = await createReadService(context);
           const body = await service.getRuleAttachmentSelection({ search });
 


### PR DESCRIPTION
## Summary

Follow-up to #269743 applying @dplumlee's review nits (he approved on that PR; it auto-merged before these landed):

- Replace the hand-written `areSettingsEqual` field comparison with lodash `isEqual` on the alert analysis settings page.
- Read rules-edit via `useUserPrivileges().rulesPrivileges.rules.edit` and inline the access check, instead of `extractRulesCapabilities` in a pure helper, for consistency with the rest of the app's RBAC.
- Switch the rule-attachment stats and selection routes from `POST` to `GET`. They only take a `search` string (matching the already-`GET` list route), so the read-only browse operations use `GET`.

## Testing

- `node scripts/jest` on the settings page, rule-attachment section, and rule-attachment routes suites (all green).
- `node scripts/type_check --project x-pack/solutions/security/plugins/security_solution/tsconfig.json` (0 errors).
- `node scripts/eslint` on the changed files.

_PR developed with Claude Code + Opus 4.8_