### PR TITLE
[Security Solution][Flyout] new flyout system GA. Invert newSystemFlyoutEnabled feature flag

### DIFF
--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -148,6 +148,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'securitySolution:enableNewFlyout': {
+    type: 'boolean',
+    _meta: { description: 'Allows users to enable/disable the new flyout system.' },
+  },
   'securitySolution:enableAssetCriticality': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -83,6 +83,7 @@ export interface UsageStats {
   'securitySolution:defaultAnomalyScore': number;
   'securitySolution:refreshIntervalDefaults': string;
   'securitySolution:enableNewsFeed': boolean;
+  'securitySolution:enableNewFlyout': boolean;
   'securitySolution:enableAssetCriticality': boolean;
   'securitySolution:excludeColdAndFrozenTiersInAnalyzer': boolean;
   'securitySolution:excludeColdAndFrozenTiersInPrevalence': boolean;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11159,6 +11159,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:enableNewFlyout": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Allows users to enable/disable the new flyout system."
+          }
+        },
         "securitySolution:enableAssetCriticality": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -265,9 +265,12 @@ export const allowedExperimentalValues = Object.freeze({
   dexAiSkillRecommendPrebuiltRules: false,
 
   /**
-   * Enables the new flyout using the EUI flyout system
+   * Disables the new flyout using the EUI flyout system. When this flag is off (the default), the
+   * "Enable new flyout" advanced setting is registered and defaults to off, so users can opt in.
+   * Turning this flag on unregisters that advanced setting, forcing the
+   * legacy flyout and effectively removing the new flyout option.
    */
-  newFlyoutSystemEnabled: false,
+  newFlyoutSystemDisabled: false,
 
   /**
    * Uses entity store v2 for entity analytics skill

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
@@ -6,21 +6,30 @@
  */
 
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { TestProviders } from '../../../../../common/mock';
 import { FieldMarkdownRenderer } from '.';
 import { MarkdownFormatterContext } from '../context';
 import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
+}));
 
 describe('FieldMarkdownRenderer', () => {
   const mockOpenRightPanel = jest.fn();
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
   const mockUseExpandableFlyoutApi = useExpandableFlyoutApi as jest.MockedFunction<
     typeof useExpandableFlyoutApi
   >;
+  const mockUseFlyoutApi = useFlyoutApi as jest.MockedFunction<typeof useFlyoutApi>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,6 +38,9 @@ describe('FieldMarkdownRenderer', () => {
       ...createExpandableFlyoutApiMock(),
       openRightPanel: mockOpenRightPanel,
     });
+    flyoutApi = createFlyoutApiMock();
+    mockUseFlyoutApi.mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   it('renders the field value', () => {
@@ -67,6 +79,34 @@ describe('FieldMarkdownRenderer', () => {
     fireEvent.click(entityButton);
 
     expect(mockOpenRightPanel).toHaveBeenCalledTimes(1);
+    expect(flyoutApi.openUserFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openHostFlyout).not.toHaveBeenCalled();
+  });
+
+  it('opens the entity flyout API when the new flyout is enabled', async () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    const icon = 'user';
+    const name = 'user.name';
+    const value = 'some.user';
+
+    render(
+      <TestProviders>
+        <MarkdownFormatterContext.Provider value={{ disableActions: false }}>
+          <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        </MarkdownFormatterContext.Provider>
+      </TestProviders>
+    );
+
+    const entityButton = screen.getByTestId('entityButton');
+
+    fireEvent.click(entityButton);
+
+    await waitFor(() => {
+      expect(flyoutApi.openUserFlyout).toHaveBeenCalledTimes(1);
+      expect(flyoutApi.openHostFlyout).not.toHaveBeenCalled();
+      expect(mockOpenRightPanel).not.toHaveBeenCalled();
+    });
   });
 
   it('does NOT render the entity button when flyoutPanelProps is null', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiButtonEmpty, EuiToolTip, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
+import { EuiBadge, EuiButtonEmpty, EuiLoadingSpinner, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-
 import { DraggableBadge } from '../../../../../common/components/draggables';
-import { getFlyoutPanelProps, ENTITY_TYPE_BY_FIELD } from './helpers';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { ENTITY_TYPE_BY_FIELD, getFlyoutPanelProps } from './helpers';
 import { useEntityEuidFromAlerts } from './use_entity_euid_from_alerts';
 import { useMarkdownFormatterContext } from '../context';
 import type { ParsedField } from '../types';
@@ -26,7 +27,9 @@ const inlineFieldWrapperCss = css`
 export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
   const { disableActions, scopeId, alertIds } = useMarkdownFormatterContext();
   const { openRightPanel } = useExpandableFlyoutApi();
+  const { openHostFlyout, openUserFlyout } = useFlyoutApi();
   const { euiTheme } = useEuiTheme();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
 
   const isEntityField = name in ENTITY_TYPE_BY_FIELD && typeof value === 'string';
 
@@ -43,10 +46,30 @@ export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
   );
 
   const onEntityClick = useCallback(() => {
-    if (flyoutPanelProps != null) {
+    if (flyoutPanelProps == null) {
+      return;
+    }
+
+    if (enableNewFlyout) {
+      if (ENTITY_TYPE_BY_FIELD[name] === 'host') {
+        openHostFlyout({ hostName: value as string, entityId: euid, scopeId });
+      } else {
+        openUserFlyout({ userName: value as string, entityId: euid, scopeId });
+      }
+    } else {
       openRightPanel(flyoutPanelProps);
     }
-  }, [flyoutPanelProps, openRightPanel]);
+  }, [
+    flyoutPanelProps,
+    openRightPanel,
+    openHostFlyout,
+    openUserFlyout,
+    enableNewFlyout,
+    name,
+    value,
+    euid,
+    scopeId,
+  ]);
 
   const entityButton: React.ReactElement | null = useMemo(
     () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.test.tsx
@@ -15,9 +15,12 @@ import { TestProviders } from '../../../../../common/mock';
 import { mockAttackDiscovery } from '../../../mock/mock_attack_discovery';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { SECURITY_FEATURE_ID } from '../../../../../../common';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../flyout_v2/use_flyout_api');
 
 jest.mock(
   '../../attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts',
@@ -46,6 +49,7 @@ describe('ActionableSummary', () => {
       ...createExpandableFlyoutApiMock(),
       openRightPanel: mockOpenRightPanel,
     });
+    jest.mocked(useFlyoutApi).mockReturnValue(createFlyoutApiMock());
   });
 
   describe('when entities with replacements are provided', () => {
@@ -153,6 +157,9 @@ describe('ActionableSummary', () => {
                 configurations: true,
               },
             },
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
           },
         },
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.test.tsx
@@ -17,9 +17,12 @@ import { mockAttackDiscovery } from '../../../../mock/mock_attack_discovery';
 import { ATTACK_CHAIN, DETAILS, SUMMARY } from './translations';
 import { SECURITY_FEATURE_ID } from '../../../../../../../common';
 import { useKibana } from '../../../../../../common/lib/kibana';
+import { useFlyoutApi } from '../../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('../../../../../../common/lib/kibana');
 jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../../flyout_v2/use_flyout_api');
 
 jest.mock(
   '../../../attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts',
@@ -50,6 +53,7 @@ describe('AttackDiscoveryTab', () => {
       ...createExpandableFlyoutApiMock(),
       openRightPanel: mockOpenRightPanel,
     });
+    jest.mocked(useFlyoutApi).mockReturnValue(createFlyoutApiMock());
   });
 
   describe('when showAnonymized is false', () => {
@@ -242,6 +246,9 @@ The user Administrator opened a malicious Microsoft Word document (C:\\Program F
             search: {
               search: jest.fn().mockReturnValue({ toPromise: jest.fn().mockResolvedValue({}) }),
             },
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
           },
           application: {
             capabilities: {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.test.tsx
@@ -18,6 +18,8 @@ import { getMockAttackDiscoveryAlerts } from '../../mock/mock_attack_discovery_a
 import { useFindAttackDiscoveries } from '../../use_find_attack_discoveries';
 import { useGetAttackDiscoveryGenerations } from '../../use_get_attack_discovery_generations';
 import { useKibana as mockUseKibana } from '../../../../common/lib/kibana';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -69,6 +71,9 @@ jest.mock('../../../../common/lib/kibana', () => ({
       featureFlags: {
         getBooleanValue: jest.fn().mockResolvedValue(false),
       },
+      uiSettings: {
+        get: jest.fn().mockReturnValue(false),
+      },
       theme: {
         getTheme: jest.fn().mockReturnValue({ darkMode: false }),
       },
@@ -82,6 +87,7 @@ jest.mock('../../../../common/lib/kibana', () => ({
     remove: jest.fn(),
   })),
 }));
+jest.mock('../../../../flyout_v2/use_flyout_api');
 
 jest.mock(
   '../attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts',
@@ -128,6 +134,9 @@ jest.mock(
     },
     featureFlags: {
       getBooleanValue: jest.fn().mockResolvedValue(false),
+    },
+    uiSettings: {
+      get: jest.fn().mockReturnValue(false),
     },
     theme: {
       getTheme: jest.fn().mockReturnValue({ darkMode: false }),
@@ -209,6 +218,7 @@ const defaultProps = {
 describe('History', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useFlyoutApi).mockReturnValue(createFlyoutApiMock());
 
     // Reset mocks to their default state
     (useFindAttackDiscoveries as jest.Mock).mockReturnValue({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.test.ts
@@ -37,37 +37,37 @@ describe('useIsNewFlyoutEnabled', () => {
     jest.clearAllMocks();
   });
 
-  it('returns false when the flag is off, ignoring the (unregistered) advanced setting', () => {
+  it('returns true when the flag is off and the user opted in via the advanced setting', () => {
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-    // Even if a stale `true` is still stored for the setting, the flag gates it off.
     mockUiSettingsGet.mockReturnValue(true);
 
     const { result } = renderHook(() => useIsNewFlyoutEnabled());
 
-    expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemEnabled');
-    expect(mockUiSettingsGet).not.toHaveBeenCalled();
-    expect(result.current).toBe(false);
+    expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemDisabled');
+    expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, false);
+    expect(result.current).toBe(true);
   });
 
-  it('returns false when the flag is on but the user has not turned the advanced setting on', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+  it('returns false when the flag is off and the advanced setting is off (default)', () => {
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
     mockUiSettingsGet.mockReturnValue(false);
 
     const { result } = renderHook(() => useIsNewFlyoutEnabled());
 
-    expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemEnabled');
+    expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemDisabled');
     expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, false);
     expect(result.current).toBe(false);
   });
 
-  it('returns true when the flag is on and the user turned the advanced setting on', () => {
+  it('returns false when the flag is on, ignoring any value stored for the advanced setting', () => {
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    // Even if a stale `true` is still stored for the setting, the feature flag wins.
     mockUiSettingsGet.mockReturnValue(true);
 
     const { result } = renderHook(() => useIsNewFlyoutEnabled());
 
-    expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemEnabled');
-    expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, false);
-    expect(result.current).toBe(true);
+    expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemDisabled');
+    expect(mockUiSettingsGet).not.toHaveBeenCalled();
+    expect(result.current).toBe(false);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.ts
@@ -12,22 +12,24 @@ import { useIsExperimentalFeatureEnabled } from './use_experimental_features';
 /**
  * Returns whether the new (EUI-based) flyout system should be used.
  *
- * The `newFlyoutSystemEnabled` experimental feature flag controls whether the
+ * The `newFlyoutSystemDisabled` experimental feature flag controls whether the
  * "Enable new flyout" advanced setting is registered:
- * - when the flag is on, the setting is registered and users can opt in
- *   (it defaults to `false`, so the new flyout is used only once the user turns it on);
- * - when the flag is off (the default), the setting is not registered and the new flyout is
- *   always disabled — regardless of any value the user may have previously stored for it.
+ * - when the flag is off (the default), the setting is registered and defaults to `false`, so the
+ *   new flyout is disabled unless the user explicitly opts in;
+ * - when the flag is on, the setting is unregistered and the new flyout is always disabled —
+ *   regardless of any value the user may have previously stored for it.
  */
 export const useIsNewFlyoutEnabled = (): boolean => {
   const { uiSettings } = useKibana().services;
-  const isNewFlyoutSystemEnabled = useIsExperimentalFeatureEnabled('newFlyoutSystemEnabled');
+  const isNewFlyoutSystemDisabled = useIsExperimentalFeatureEnabled('newFlyoutSystemDisabled');
 
-  // The feature flag gates registration of the advanced setting: when it's off, the setting isn't
-  // registered, so fall back to the legacy flyout regardless of any stale stored value.
-  if (!isNewFlyoutSystemEnabled) {
+  // The feature flag takes precedence: when it disables the new flyout system, the advanced setting
+  // is unregistered, so always fall back to the legacy flyout.
+  if (isNewFlyoutSystemDisabled) {
     return false;
   }
 
+  // The advanced setting is registered (and defaults to `false`) whenever the flag is off, so it is
+  // the source of truth for whether the user has opted in to the new flyout.
   return uiSettings.get<boolean>(ENABLE_NEW_FLYOUT_SETTING, false);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -25,7 +25,7 @@ describe('initUiSettings', () => {
   const mockExperimentalFeatures = {
     enableAlertsAndAttacksAlignment: false,
     extendedRuleExecutionLoggingEnabled: false,
-    newFlyoutSystemEnabled: false,
+    newFlyoutSystemDisabled: false,
     ruleChangesHistoryEnabled: false,
   } as ExperimentalFeatures;
 
@@ -100,20 +100,8 @@ describe('initUiSettings', () => {
     );
   });
 
-  it('does NOT register ENABLE_NEW_FLYOUT_SETTING when newFlyoutSystemEnabled flag is disabled', () => {
+  it('registers ENABLE_NEW_FLYOUT_SETTING when newFlyoutSystemDisabled flag is disabled', () => {
     initUiSettings(mockUiSettings, mockExperimentalFeatures, false);
-
-    const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
-    expect(registeredSettings).not.toHaveProperty(ENABLE_NEW_FLYOUT_SETTING);
-  });
-
-  it('registers ENABLE_NEW_FLYOUT_SETTING when newFlyoutSystemEnabled flag is enabled', () => {
-    const enabledFeatures = {
-      ...mockExperimentalFeatures,
-      newFlyoutSystemEnabled: true,
-    };
-
-    initUiSettings(mockUiSettings, enabledFeatures, false);
 
     const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
     expect(registeredSettings).toHaveProperty(ENABLE_NEW_FLYOUT_SETTING);
@@ -125,5 +113,17 @@ describe('initUiSettings', () => {
         requiresPageReload: true,
       })
     );
+  });
+
+  it('does NOT register ENABLE_NEW_FLYOUT_SETTING when newFlyoutSystemDisabled flag is enabled', () => {
+    const disabledFeatures = {
+      ...mockExperimentalFeatures,
+      newFlyoutSystemDisabled: true,
+    };
+
+    initUiSettings(mockUiSettings, disabledFeatures, false);
+
+    const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
+    expect(registeredSettings).not.toHaveProperty(ENABLE_NEW_FLYOUT_SETTING);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -321,7 +321,7 @@ export const initUiSettings = (
         technicalPreview: true,
       },
     }),
-    ...(experimentalFeatures.newFlyoutSystemEnabled && {
+    ...(!experimentalFeatures.newFlyoutSystemDisabled && {
       [ENABLE_NEW_FLYOUT_SETTING]: {
         name: i18n.translate('xpack.securitySolution.uiSettings.enableNewFlyoutLabel', {
           defaultMessage: 'Enable new flyout',


### PR DESCRIPTION
## Summary

Flips the `newSystemFlyoutEnabled ` to `newSystemFlyoutDisabled`, which inherently shows the `securitySolution: enableNewFlyout ` advanced setting by default.

That `securitySolution: enableNewFlyout ` remains off by default though. We will turn it on during the last BC.

https://github.com/user-attachments/assets/cc342db7-698a-49eb-9a95-9fecaf847e39

Also, the PR makes a small change to a link that we had forgotten to update on the attack discovery page.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->