### PR TITLE
Fix ESO ci_checks snapshot after alerting_v2 enabled by default

### DIFF
--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
@@ -20,7 +20,7 @@ import type { EncryptedSavedObjectsService } from '../../server/crypto';
 import * as EncryptedSavedObjectsModule from '../../server/saved_objects';
 
 // This will only change if new ESOs are introduced. This number should never get smaller.
-export const ESO_TYPES_COUNT = 24 as const;
+export const ESO_TYPES_COUNT = 25 as const;
 
 describe('checking changes on all registered encrypted SO types', () => {
   let esServer: TestElasticsearchUtils;
@@ -68,6 +68,7 @@ describe('checking changes on all registered encrypted SO types', () => {
         "action_task_params": "06aa563283bdcd5c07ec433a7d0b8425019ad11d75595ee1431691667ecd2cec",
         "ad_hoc_run_params": "6539367aa4ae8340c62f123c3457c6b8d7873c92de68651c70d41028dfe7ed32",
         "alert": "878a3b83179bbf2ad9d3862fcba539b7066429869b14c120a1dc7a8d39f4a7fa",
+        "alerting_action_policy": "539c465f3bf4d062e394acbbb9184f995f48127f701e40ba6f601dc5a20300fd",
         "anonymization-salt": "1e5ff6ba241b27bbfc6901898b0ece9327ba63fdaea1f2f6cba6344d4a425b43",
         "api_key_pending_invalidation": "4dafadadaaca2f2f3f6038ee8363b71b2d101371ca98c34d2b6aa2a96f7e71c5",
         "api_key_to_invalidate": "d7a3423a74032bb5ecce9a0975e8ea1d5d5171348f99173df54b2fa0dfd3de43",
@@ -135,6 +136,7 @@ describe('checking changes on all registered encrypted SO types', () => {
         "alert|11",
         "alert|10",
         "alert|1",
+        "alerting_action_policy|1",
         "anonymization-salt|1",
         "api_key_pending_invalidation|2",
         "api_key_pending_invalidation|1",


### PR DESCRIPTION
alerting_v2 was enabled by default in #276217, which registers the new alerting_action_policy encrypted saved object type. The kibana-pull-request pipeline's selective test filtering didn't run this integration test since the PR touched no encrypted_saved_objects files, so the snapshot went stale and started failing on every kibana-on-merge build.

Fixes: https://github.com/elastic/kibana/issues/240718
Fixes: https://github.com/elastic/kibana/issues/240719
See: https://github.com/elastic/kibana/commit/a17d6bb8afee38c1b52280397ef599e513ef00c5 (#276217)