### PR TITLE
[Security Solution] Show managed workflows in the alert run workflow panel

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/run_workflow_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/run_workflow_panel.test.tsx
@@ -48,9 +48,13 @@ const requiredInputsWorkflow: WorkflowListItemDto = {
 
 let mockWorkflowsData: WorkflowListItemDto[] = [noInputsWorkflow];
 
+const mockUseWorkflows = jest.fn((_params: unknown) => ({ data: { results: mockWorkflowsData } }));
+const mockUseWorkflowsCapabilities = jest.fn(() => ({ canReadManagedWorkflow: true }));
+
 jest.mock('@kbn/workflows-ui', () => ({
   useRunWorkflow: () => ({ mutate: mockMutate }),
-  useWorkflows: () => ({ data: { results: mockWorkflowsData } }),
+  useWorkflows: (params: unknown) => mockUseWorkflows(params),
+  useWorkflowsCapabilities: () => mockUseWorkflowsCapabilities(),
   WorkflowSelector: ({ onWorkflowChange }: { onWorkflowChange: (id: string) => void }) => (
     <div data-test-subj="workflow-selector-mock">
       <button
@@ -124,6 +128,7 @@ describe('RunWorkflowPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockWorkflowsData = [noInputsWorkflow];
+    mockUseWorkflowsCapabilities.mockReturnValue({ canReadManagedWorkflow: true });
   });
 
   it('should render the workflow selector', () => {
@@ -249,6 +254,37 @@ describe('RunWorkflowPanel', () => {
 
     expect(mockAddError).toHaveBeenCalledWith(error, {
       title: i18n.WORKFLOW_START_FAILED_TOAST,
+    });
+  });
+
+  describe('managed workflow visibility', () => {
+    it('requests only unmanaged workflows when no visibility is provided', () => {
+      renderComponent();
+
+      expect(mockUseWorkflows).toHaveBeenCalledWith(
+        expect.not.objectContaining({ managed: expect.anything() })
+      );
+    });
+
+    it('opts into managed workflows matching the visibility context when readable', () => {
+      renderComponent({ visibility: { selectors: ['rule_action'] } });
+
+      expect(mockUseWorkflows).toHaveBeenCalledWith(
+        expect.objectContaining({
+          managed: 'all',
+          visibilityContext: ['selector:rule_action'],
+        })
+      );
+    });
+
+    it('does not opt into managed workflows without the read-managed capability', () => {
+      mockUseWorkflowsCapabilities.mockReturnValue({ canReadManagedWorkflow: false });
+
+      renderComponent({ visibility: { selectors: ['rule_action'] } });
+
+      expect(mockUseWorkflows).toHaveBeenCalledWith(
+        expect.not.objectContaining({ managed: expect.anything() })
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/run_workflow_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/run_workflow_panel.tsx
@@ -8,10 +8,20 @@
 import React, { useCallback, useMemo } from 'react';
 
 import { EuiButton, EuiFlexGroup, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
-import { useRunWorkflow, useWorkflows, WorkflowSelector } from '@kbn/workflows-ui';
+import {
+  useRunWorkflow,
+  useWorkflows,
+  useWorkflowsCapabilities,
+  WorkflowSelector,
+} from '@kbn/workflows-ui';
+import type { WorkflowSelectorVisibility } from '@kbn/workflows-ui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { RunWorkflowResponseDto } from '@kbn/workflows';
+import {
+  getManagedWorkflowSelectorVisibilityContext,
+  getManagedWorkflowSolutionVisibilityContext,
+} from '@kbn/workflows';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { WORKFLOWS_APP_ID } from '@kbn/deeplinks-workflows';
 import type { RenderingService } from '@kbn/core-rendering-browser';
@@ -28,6 +38,12 @@ export interface RunWorkflowPanelProps {
   sortTriggerType: string;
   /** data-test-subj prefix for the execute button. */
   executeButtonTestSubj: string;
+  /**
+   * Managed workflows are excluded from the list unless the caller opts in with a matching
+   * visibility. Pass the selector(s)/solution(s) the surfacing context maps to (e.g.
+   * `{ selectors: ['rule_action'] }`) to include managed workflows tagged with that context.
+   */
+  visibility?: WorkflowSelectorVisibility;
   onClose: () => void;
   /** Optional callback invoked when workflow execution is triggered. */
   onExecute?: () => void;
@@ -38,6 +54,7 @@ export const RunWorkflowPanel = ({
   inputs,
   sortTriggerType,
   executeButtonTestSubj,
+  visibility,
   onClose,
   onExecute,
 }: RunWorkflowPanelProps) => {
@@ -52,8 +69,27 @@ export const RunWorkflowPanel = ({
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [isInputsModalOpen, setIsInputsModalOpen] = React.useState<boolean>(false);
 
+  const { canReadManagedWorkflow } = useWorkflowsCapabilities();
+  // Mirror the visibility-context derivation WorkflowSelector runs internally so both queries share
+  // a react-query cache key (one fetch) and the selected managed workflow resolves below.
+  const visibilityContext = useMemo(() => {
+    if (!visibility) return undefined;
+    const contexts = [
+      ...(visibility.selectors ?? []).map(getManagedWorkflowSelectorVisibilityContext),
+      ...(visibility.solutions ?? []).map(getManagedWorkflowSolutionVisibilityContext),
+    ];
+    return contexts.length > 0 ? contexts : undefined;
+  }, [visibility]);
+
   // Share the query key with WorkflowSelector so this is a cache hit — no extra fetch.
-  const { data: workflowsData } = useWorkflows({ size: 1000, page: 1, query: '' });
+  const { data: workflowsData } = useWorkflows({
+    size: 1000,
+    page: 1,
+    query: '',
+    ...(visibilityContext && canReadManagedWorkflow
+      ? { managed: 'all' as const, visibilityContext }
+      : {}),
+  });
   const selectedWorkflow = useMemo(
     () => workflowsData?.results.find((w) => w.id === selectedId),
     [workflowsData, selectedId]
@@ -140,6 +176,7 @@ export const RunWorkflowPanel = ({
     () => (
       <WorkflowSelector
         config={{
+          visibility,
           filterFunction: (workflows) => workflows.filter((w) => w.enabled),
           sortFunction: (workflows) =>
             workflows.sort((a, b) => {
@@ -159,7 +196,7 @@ export const RunWorkflowPanel = ({
         onWorkflowChange={setSelectedId}
       />
     ),
-    [selectedId, sortTriggerType]
+    [selectedId, sortTriggerType, visibility]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.test.tsx
@@ -27,6 +27,7 @@ const mockUseRunWorkflow = jest.fn(() => ({ mutate: mockMutate }));
 const mockUseWorkflowsCapabilities = jest.fn(() => ({
   canCreateWorkflow: true,
   canReadWorkflow: true,
+  canReadManagedWorkflow: true,
   canUpdateWorkflow: true,
   canDeleteWorkflow: true,
   canExecuteWorkflow: true,
@@ -34,7 +35,7 @@ const mockUseWorkflowsCapabilities = jest.fn(() => ({
   canCancelWorkflowExecution: true,
 }));
 const mockUseWorkflowsUIEnabledSetting = jest.fn(() => true);
-const mockUseWorkflows = jest.fn(() => ({ data: { results: [] } }));
+const mockUseWorkflows = jest.fn((_params: unknown) => ({ data: { results: [] } }));
 jest.mock('@kbn/kibana-react-plugin/public', () => {
   const actual = jest.requireActual('@kbn/kibana-react-plugin/public');
   return {
@@ -47,7 +48,7 @@ jest.mock('@kbn/workflows-ui', () => ({
   useRunWorkflow: () => mockUseRunWorkflow(),
   useWorkflowsCapabilities: () => mockUseWorkflowsCapabilities(),
   useWorkflowsUIEnabledSetting: () => mockUseWorkflowsUIEnabledSetting(),
-  useWorkflows: () => mockUseWorkflows(),
+  useWorkflows: (params: unknown) => mockUseWorkflows(params),
   WorkflowSelector: ({ onWorkflowChange }: { onWorkflowChange: (id: string) => void }) => (
     <div data-test-subj="workflow-selector-mock">
       {'Workflow selector'}
@@ -127,6 +128,7 @@ describe('useRunAlertWorkflowPanel', () => {
     mockUseWorkflowsCapabilities.mockReturnValue({
       canCreateWorkflow: true,
       canReadWorkflow: true,
+      canReadManagedWorkflow: true,
       canUpdateWorkflow: true,
       canDeleteWorkflow: true,
       canExecuteWorkflow: true,
@@ -177,6 +179,7 @@ describe('useRunAlertWorkflowPanel', () => {
       mockUseWorkflowsCapabilities.mockReturnValue({
         canCreateWorkflow: true,
         canReadWorkflow: true,
+        canReadManagedWorkflow: true,
         canUpdateWorkflow: true,
         canDeleteWorkflow: true,
         canExecuteWorkflow: false,
@@ -246,6 +249,21 @@ describe('AlertWorkflowsPanel', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('requests managed workflows tagged with the rule_action visibility context', () => {
+    const { result } = renderHook(() => useRunAlertWorkflowPanel(defaultProps), {
+      wrapper: TestProviders,
+    });
+    const panels = result.current.runAlertWorkflowPanel;
+    render(<TestProviders>{panels[0].content}</TestProviders>);
+
+    expect(mockUseWorkflows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        managed: 'all',
+        visibilityContext: ['selector:rule_action'],
+      })
+    );
   });
 
   it('execute button is disabled when no workflow is selected', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.tsx
@@ -10,10 +10,16 @@ import React, { useMemo } from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { useWorkflowsCapabilities, useWorkflowsUIEnabledSetting } from '@kbn/workflows-ui';
+import type { WorkflowSelectorVisibility } from '@kbn/workflows-ui';
 import type { AlertTableContextMenuItem } from '../types';
 import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 import * as i18n from '../translations';
 import { RunWorkflowPanel } from './run_workflow_panel';
+
+// Managed workflows surfaced as rule actions (e.g. the alert analysis workflow) carry the
+// `rule_action` selector visibility context; requesting it here includes them in the list alongside
+// user-created workflows. Module-scoped so the reference stays stable across renders.
+const ALERT_WORKFLOW_VISIBILITY: WorkflowSelectorVisibility = { selectors: ['rule_action'] };
 
 export interface AlertWorkflowsPanelProps {
   /** Array of alert ids and their respective indices */
@@ -42,6 +48,7 @@ export const AlertWorkflowsPanel = ({ alertIds, onClose, onExecute }: AlertWorkf
     <RunWorkflowPanel
       inputs={inputs}
       sortTriggerType="alert"
+      visibility={ALERT_WORKFLOW_VISIBILITY}
       executeButtonTestSubj="execute-alert-workflow-button"
       onClose={onClose}
       onExecute={onExecute}


### PR DESCRIPTION
Adds managed workflows (like the alert analysis workflow) to the alerts "Run workflow" panel. Before this, the panel only requested unmanaged workflows, so the alert analysis workflow never appeared and the panel showed "You don't have any workflows yet."

## Summary

The workflow list query defaults to `managed: 'unmanaged'`, which excludes every managed workflow. `WorkflowSelector` only opts into managed workflows when it's given a `visibility` (which becomes `managed: 'all'` plus a `visibilityContext`) and the user has the `canReadManagedWorkflow` capability. The alerts panel wasn't passing any visibility.

`RunWorkflowPanel` now takes an optional `visibility` and forwards it to both the `WorkflowSelector` and the sibling `useWorkflows` call, so the query shares one cache key and the selected managed workflow still resolves for the inputs modal. `AlertWorkflowsPanel` passes `{ selectors: ['rule_action'] }`, matching the `rule_action` selector already declared on the alert analysis workflow definition. This covers both the single alert take action and the bulk action, since both render `AlertWorkflowsPanel`.

## To test

1. Run Kibana and ES locally with the workflows feature enabled and the alert analysis managed workflow installed.
2. On the alerts page, select an alert and open Take action > Run workflow. Also try the bulk action with multiple alerts selected.
3. Before: the panel shows "You don't have any workflows yet."
   <img width="976" height="388" alt="Screenshot 2026-07-06 at 3 25 46 PM" src="https://github.com/user-attachments/assets/fe0a61b8-9157-4370-bd39-a9479fcd162e" />
4. After: the alert analysis workflow appears in the list and can be run.
   <img width="782" height="363" alt="Screenshot 2026-07-06 at 4 49 52 PM" src="https://github.com/user-attachments/assets/99f9bc24-dbc1-458a-a076-6d7aea16ff34" />


_PR developed with Claude Code + Opus 4.8_
