### PR TITLE
[Fleet] Add agent count to reassign modal

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -108,7 +108,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
       <>
         {isReassignFlyoutOpen && (
           <EuiPortal>
-            <AgentReassignAgentPolicyModal agents={[agent]} onClose={onClose} />
+            <AgentReassignAgentPolicyModal agents={[agent]} agentCount={1} onClose={onClose} />
           </EuiPortal>
         )}
         {isUnenrollModalOpen && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -427,6 +427,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
         <EuiPortal>
           <AgentReassignAgentPolicyModal
             agents={agents}
+            agentCount={agentCount}
             onClose={() => {
               setIsReassignFlyoutOpen(false);
               refreshAgents();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -370,6 +370,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         <EuiPortal>
           <AgentReassignAgentPolicyModal
             agents={[agentToReassign]}
+            agentCount={1}
             onClose={() => {
               setAgentToReassign(undefined);
               refreshAgents();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.test.tsx
@@ -57,11 +57,15 @@ function mockPolicies(policies = [POLICY_A, POLICY_B]) {
   });
 }
 
-function render(props: { agents: any; onClose?: () => void }) {
+function render(props: { agents: any; agentCount?: number; onClose?: () => void }) {
   const renderer = createFleetTestRendererMock();
   const onClose = props.onClose ?? jest.fn();
   const utils = renderer.render(
-    <AgentReassignAgentPolicyModal onClose={onClose} agents={props.agents} />
+    <AgentReassignAgentPolicyModal
+      onClose={onClose}
+      agents={props.agents}
+      agentCount={props.agentCount ?? 1}
+    />
   );
   return { utils, onClose };
 }
@@ -88,6 +92,14 @@ describe('AgentReassignAgentPolicyModal', () => {
 
       // policy-a is pre-selected (matches agent's current policy) — button must be disabled
       expect(utils.getByTestId('confirmModalConfirmButton')).toBeDisabled();
+    });
+
+    it('shows the singular agent count in the description', () => {
+      const { utils } = render({ agents: singleAgent, agentCount: 1 });
+
+      expect(
+        utils.getByText('Choose a new agent policy to assign the selected agent to.')
+      ).toBeInTheDocument();
     });
 
     it('calls sendPostAgentReassign when a different policy is selected', async () => {
@@ -168,7 +180,7 @@ describe('AgentReassignAgentPolicyModal', () => {
 
     it('calls sendPostBulkAgentReassign with agent ids and selected policy', async () => {
       mockSendPostBulkAgentReassign.mockResolvedValue({});
-      const { utils, onClose } = render({ agents: bulkAgents });
+      const { utils, onClose } = render({ agents: bulkAgents, agentCount: bulkAgents.length });
 
       act(() => {
         fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
@@ -187,9 +199,17 @@ describe('AgentReassignAgentPolicyModal', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
+    it('shows the agent count in the description', () => {
+      const { utils } = render({ agents: bulkAgents, agentCount: bulkAgents.length });
+
+      expect(
+        utils.getByText('Choose a new agent policy to assign the selected 2 agents to.')
+      ).toBeInTheDocument();
+    });
+
     it('shows "in progress" success toast for bulk agent array', async () => {
       mockSendPostBulkAgentReassign.mockResolvedValue({});
-      const { utils } = render({ agents: bulkAgents });
+      const { utils } = render({ agents: bulkAgents, agentCount: bulkAgents.length });
 
       act(() => {
         fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
@@ -206,7 +226,7 @@ describe('AgentReassignAgentPolicyModal', () => {
 
     it('passes the kuery string directly to sendPostBulkAgentReassign', async () => {
       mockSendPostBulkAgentReassign.mockResolvedValue({});
-      const { utils } = render({ agents: kuery });
+      const { utils } = render({ agents: kuery, agentCount: 5 });
 
       act(() => {
         fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
@@ -222,9 +242,17 @@ describe('AgentReassignAgentPolicyModal', () => {
       });
     });
 
+    it('shows the query-based agent count in the description', () => {
+      const { utils } = render({ agents: kuery, agentCount: 5 });
+
+      expect(
+        utils.getByText('Choose a new agent policy to assign the selected 5 agents to.')
+      ).toBeInTheDocument();
+    });
+
     it('shows "in progress" success toast for kuery-based bulk reassignment', async () => {
       mockSendPostBulkAgentReassign.mockResolvedValue({});
-      const { utils } = render({ agents: kuery });
+      const { utils } = render({ agents: kuery, agentCount: 5 });
 
       act(() => {
         fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
@@ -237,7 +265,7 @@ describe('AgentReassignAgentPolicyModal', () => {
 
     it('does not use single-agent path for kuery string', async () => {
       mockSendPostBulkAgentReassign.mockResolvedValue({});
-      const { utils } = render({ agents: kuery });
+      const { utils } = render({ agents: kuery, agentCount: 5 });
 
       act(() => {
         fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
@@ -31,11 +31,13 @@ import { SO_SEARCH_LIMIT } from '../../../../constants';
 interface Props {
   onClose: () => void;
   agents: Agent[] | string;
+  agentCount: number;
 }
 
 export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
   onClose,
   agents,
+  agentCount,
 }) => {
   const modalTitleId = useGeneratedHtmlId();
 
@@ -143,9 +145,9 @@ export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
       <p>
         <FormattedMessage
           id="xpack.fleet.agentReassignPolicy.flyoutDescription"
-          defaultMessage="Choose a new agent policy to assign the selected {count, plural, one {agent} other {agents}} to."
+          defaultMessage="Choose a new agent policy to assign the selected {count, plural, one {agent} other {# agents}} to."
           values={{
-            count: isSingleAgent ? 1 : 0,
+            count: agentCount,
           }}
         />
       </p>


### PR DESCRIPTION
## Summary

Closes #276164

The bulk agent policy reassign modal didn't show how many agents would be affected, unlike other bulk actions (e.g. upgrade, unenroll) which already display a count. This made it easy to misjudge the blast radius of a reassignment, especially when agents are selected via a query across all pages rather than individually. This PR adds an `agentCount` prop to `AgentReassignAgentPolicyModal` and wires it into the confirmation copy ("...assign the selected N agents to."), reusing the `agentCount` value already computed for the other bulk-action modals in `AgentBulkActions`.

<img width="1707" height="1271" alt="image" src="https://github.com/user-attachments/assets/277a4f8f-d270-4a6d-829e-163660af161a" />


### Testing

1. Go to **Fleet > Agents**.
2. Select several agents individually (checkbox selection) and open **Actions > Assign to new policy**. Confirm the modal reads "assign the selected N agents to" with the correct count.
3. Select "all agents matching this query" instead (query-based selection across pages) and repeat — confirm the count reflects the total matching agent count, not just the current page.
4. Open a single agent's details page and use **Actions > Assign new policy**. Confirm the copy reads "assign the selected agent to" (singular, no number) for a single agent.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A


<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->