### PR TITLE
[9.4] [Agent Builder] Chat: Add ErrorBoundary to attachments (#276381)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
+
+const ThrowingContent = () => {
+  throw new Error('boom');
+};
+
+describe('AttachmentRenderErrorBoundary', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders children when nothing throws', () => {
+    render(
+      <AttachmentRenderErrorBoundary>
+        {() => <div>Attachment content</div>}
+      </AttachmentRenderErrorBoundary>
+    );
+
+    expect(screen.getByText('Attachment content')).toBeInTheDocument();
+  });
+
+  it('renders a fallback callout instead of crashing when a child throws', () => {
+    render(
+      <AttachmentRenderErrorBoundary>{() => <ThrowingContent />}</AttachmentRenderErrorBoundary>
+    );
+
+    expect(screen.getByText("Couldn't render this attachment")).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_render_error_boundary.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const fallbackTitle = i18n.translate('xpack.agentBuilder.attachments.renderErrorBoundary.title', {
+  defaultMessage: "Couldn't render this attachment",
+});
+
+interface AttachmentRenderErrorBoundaryProps {
+  children: () => ReactNode;
+}
+
+interface AttachmentRenderErrorBoundaryState {
+  hasError: boolean;
+}
+
+const RenderContent: React.FC<{ children: () => ReactNode }> = ({ children }) => <>{children()}</>;
+
+export class AttachmentRenderErrorBoundary extends Component<
+  AttachmentRenderErrorBoundaryProps,
+  AttachmentRenderErrorBoundaryState
+> {
+  state: AttachmentRenderErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Attachment renderer threw an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          title={fallbackTitle}
+          color="warning"
+          iconType="warning"
+          size="s"
+        />
+      );
+    }
+
+    return <RenderContent>{this.props.children}</RenderContent>;
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
@@ -63,6 +63,25 @@ describe('CanvasFlyout', () => {
     mockCanvasState = null;
   });
 
+  it('shows a fallback instead of crashing when renderCanvasContent throws', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockAttachmentsService.getAttachmentUiDefinition.mockReturnValue({
+      getLabel: () => 'Test attachment',
+      renderCanvasContent: () => {
+        throw new Error('boom');
+      },
+    });
+    mockCanvasState = {
+      attachment: { id: 'attachment-1', type: 'test', data: {} },
+      isSidebar: false,
+    };
+
+    render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(screen.getByText("Couldn't render this attachment")).not.toBeNull();
+  });
+
   it('closes canvas when conversation ID changes', () => {
     const { rerender } = render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -15,6 +15,7 @@ import { useConversationId } from '../../../../../context/conversation/use_conve
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
 import { useCanvasContext } from './canvas_context';
 
 const DEFAULT_CANVAS_WIDTH = '50vw';
@@ -114,6 +115,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   }
 
   const { attachment, isSidebar } = canvasState;
+  const { renderCanvasContent } = uiDefinition;
   const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
 
   const flyoutType = isSidebar || isNarrowViewport ? 'overlay' : 'push';
@@ -153,20 +155,22 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         previewBadgeState="preview_available"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
-        <React.Fragment key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>
-          {uiDefinition.renderCanvasContent(
-            {
-              attachment,
-              isSidebar,
-              openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
-            },
-            {
-              registerActionButtons,
-              updateOrigin,
-              closeCanvas,
-            }
-          )}
-        </React.Fragment>
+        <AttachmentRenderErrorBoundary key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>
+          {() =>
+            renderCanvasContent(
+              {
+                attachment,
+                isSidebar,
+                openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
+              },
+              {
+                registerActionButtons,
+                updateOrigin,
+                closeCanvas,
+              }
+            )
+          }
+        </AttachmentRenderErrorBoundary>
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -17,6 +17,7 @@ import type { AttachmentsService } from '../../../../../../services/attachments/
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
 import { getAttachmentPreviewKey, useCanvasContext } from './canvas_context';
 
 interface InlineAttachmentWithActionsProps {
@@ -126,12 +127,16 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
         previewBadgeState={resolvedPreviewBadgeState}
       />
       <EuiSplitPanel.Inner grow={false} paddingSize="none">
-        {uiDefinition?.renderInlineContent?.({
-          attachment,
-          isSidebar,
-          screenContext,
-          openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
-        })}
+        <AttachmentRenderErrorBoundary key={attachmentPreviewKey}>
+          {() =>
+            uiDefinition?.renderInlineContent?.({
+              attachment,
+              isSidebar,
+              screenContext,
+              openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
+            })
+          }
+        </AttachmentRenderErrorBoundary>
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Chat: Add ErrorBoundary to attachments (#276381)](https://github.com/elastic/kibana/pull/276381)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Petr Krejcik","email":"petr.krejcik@elastic.co"},"sourceCommit":{"committedDate":"2026-07-06T15:24:20Z","message":"[Agent Builder] Chat: Add ErrorBoundary to attachments (#276381)\n\n## Summary\n- Wrap both attachment render call sites (canvas flyout, inline card) in\na new `AttachmentRenderErrorBoundary`\n- A throwing renderer now shows a \"Couldn't render this attachment\"\ncallout instead of crashing the whole chat/sidebar\n\n## For code review\n\nThis PR is split into 2 commits, one per call site — review\ncommit-by-commit for an easier pass:\n\n| # | Commit | Description |\n| --- | --- | --- |\n| 1 | [Contain attachment renderer errors to the Canvas\nFlyout](https://github.com/elastic/kibana/pull/276381/commits/7c3b309eabb66df431aa3f2f99dcb52aa895b355)\n| Adds the shared `AttachmentRenderErrorBoundary` and wires it into the\ncanvas flyout's `renderCanvasContent` |\n| 2 | [Contain attachment renderer errors to the inline attachment\ncard](https://github.com/elastic/kibana/pull/276381/commits/37ecb31971118a1056042c17f8d6e7f42de2d890)\n| Wires the same boundary into `renderInlineContent` for the inline card\n|\n\n## Before/after\n\n**Agent Builder routed app**\n\n| Before | After |\n|---|---|\n|\n![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/a4ip8y2m-before_routed_app.png)\n|\n![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/zkrcrhzt-after_routed_app.png)\n|\n\n**AI Agents chat (sidebar)**\n\n| Before | After |\n|---|---|\n|\n![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/mrgau0so-sidebar_conversation.png)\n|\n![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/3pfoavme-after_sidebar.png)\n|\n\n## Test plan\n- [x] Unit tests: throwing-renderer cases in\n`inline_attachment_with_actions.test.tsx`, `canvas_flyout.test.tsx`,\n`attachment_render_error_boundary.test.tsx`\n- [x] Manual: verified both surfaces with a temporary throw in\n`text_attachment.tsx`\n\nCloses elastic/search-team#15135","sha":"05aaa331589eb83fd3adaddf0a52d9ef7722ba64","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","Team:agent-builder","feature:agent-builder","v9.5.0"],"title":"[Agent Builder] Chat: Add ErrorBoundary to attachments","number":276381,"url":"https://github.com/elastic/kibana/pull/276381","mergeCommit":{"message":"[Agent Builder] Chat: Add ErrorBoundary to attachments (#276381)\n\n## Summary\n- Wrap both attachment render call sites (canvas flyout, inline card) in\na new `AttachmentRenderErrorBoundary`\n- A throwing renderer now shows a \"Couldn't render this attachment\"\ncallout instead of crashing the whole chat/sidebar\n\n## For code review\n\nThis PR is split into 2 commits, one per call site — review\ncommit-by-commit for an easier pass:\n\n| # | Commit | Description |\n| --- | --- | --- |\n| 1 | [Contain attachment renderer errors to the Canvas\nFlyout](https://github.com/elastic/kibana/pull/276381/commits/7c3b309eabb66df431aa3f2f99dcb52aa895b355)\n| Adds the shared `AttachmentRenderErrorBoundary` and wires it into the\ncanvas flyout's `renderCanvasContent` |\n| 2 | [Contain attachment renderer errors to the inline attachment\ncard](https://github.com/elastic/kibana/pull/276381/commits/37ecb31971118a1056042c17f8d6e7f42de2d890)\n| Wires the same boundary into `renderInlineContent` for the inline card\n|\n\n## Before/after\n\n**Agent Builder routed app**\n\n| Before | After |\n|---|---|\n|\n![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/a4ip8y2m-before_routed_app.png)\n|\n![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/zkrcrhzt-after_routed_app.png)\n|\n\n**AI Agents chat (sidebar)**\n\n| Before | After |\n|---|---|\n|\n![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/mrgau0so-sidebar_conversation.png)\n|\n![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/3pfoavme-after_sidebar.png)\n|\n\n## Test plan\n- [x] Unit tests: throwing-renderer cases in\n`inline_attachment_with_actions.test.tsx`, `canvas_flyout.test.tsx`,\n`attachment_render_error_boundary.test.tsx`\n- [x] Manual: verified both surfaces with a temporary throw in\n`text_attachment.tsx`\n\nCloses elastic/search-team#15135","sha":"05aaa331589eb83fd3adaddf0a52d9ef7722ba64"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276381","number":276381,"mergeCommit":{"message":"[Agent Builder] Chat: Add ErrorBoundary to attachments (#276381)\n\n## Summary\n- Wrap both attachment render call sites (canvas flyout, inline card) in\na new `AttachmentRenderErrorBoundary`\n- A throwing renderer now shows a \"Couldn't render this attachment\"\ncallout instead of crashing the whole chat/sidebar\n\n## For code review\n\nThis PR is split into 2 commits, one per call site — review\ncommit-by-commit for an easier pass:\n\n| # | Commit | Description |\n| --- | --- | --- |\n| 1 | [Contain attachment renderer errors to the Canvas\nFlyout](https://github.com/elastic/kibana/pull/276381/commits/7c3b309eabb66df431aa3f2f99dcb52aa895b355)\n| Adds the shared `AttachmentRenderErrorBoundary` and wires it into the\ncanvas flyout's `renderCanvasContent` |\n| 2 | [Contain attachment renderer errors to the inline attachment\ncard](https://github.com/elastic/kibana/pull/276381/commits/37ecb31971118a1056042c17f8d6e7f42de2d890)\n| Wires the same boundary into `renderInlineContent` for the inline card\n|\n\n## Before/after\n\n**Agent Builder routed app**\n\n| Before | After |\n|---|---|\n|\n![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/a4ip8y2m-before_routed_app.png)\n|\n![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/zkrcrhzt-after_routed_app.png)\n|\n\n**AI Agents chat (sidebar)**\n\n| Before | After |\n|---|---|\n|\n![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/mrgau0so-sidebar_conversation.png)\n|\n![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260706/3pfoavme-after_sidebar.png)\n|\n\n## Test plan\n- [x] Unit tests: throwing-renderer cases in\n`inline_attachment_with_actions.test.tsx`, `canvas_flyout.test.tsx`,\n`attachment_render_error_boundary.test.tsx`\n- [x] Manual: verified both surfaces with a temporary throw in\n`text_attachment.tsx`\n\nCloses elastic/search-team#15135","sha":"05aaa331589eb83fd3adaddf0a52d9ef7722ba64"}}]}] BACKPORT-->