### PR TITLE
[9.4] [Entity Store] Use ES|QL SAMPLE for the logs-extraction pagination probe (#276211)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
@@ -1,13 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildLogPaginationCursorProbeEsql sorts ASC, limits, then aggregates MAX(timestamp) and COUNT(*) 1`] = `
+exports[`buildLogPaginationCursorProbeEsql samples, sorts ASC, limits to the scaled sample size, then aggregates MAX(timestamp) and COUNT(*) 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2024-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2024-01-02T00:00:00.000Z\\")
       AND ((TO_STRING(event.outcome) IS NULL OR TO_STRING(event.outcome) != \\"failure\\") AND (TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\" OR TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\" OR TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\"))
+  | SAMPLE 0.1
   | SORT @timestamp ASC
-  | LIMIT 100
+  | LIMIT 10
   | STATS @timestamp = MAX(@timestamp), total_logs = COUNT(*)"
 `;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
@@ -52,7 +52,16 @@ const emptyProbeResponse: ESQLSearchResponse = { columns: [], values: [] };
 const FIXED_NOW = new Date('2026-01-01T12:00:00.000Z');
 // '3h' lookbackPeriod → fresh fromDateISO = FIXED_NOW - 10 800 000 ms
 const EXPECTED_FROM_DATE_ISO = '2026-01-01T09:00:00.000Z';
+// '1m' delay → effectiveWindowEnd = FIXED_NOW - 60 000 ms. This is the `toDateISO` the outer
+// loop sweeps `sliceEnd` to whenever a slice resolves as the last page (see
+// `runLogsPaginationOuterLoop` in remote_logs_extraction_client.ts) — sampling means the last
+// page's real boundary is no longer trustworthy, so the sweep always goes to the window top
+// instead of the probe's own (possibly undershooting) MAX(@timestamp).
+const EXPECTED_WINDOW_END = '2026-01-01T11:59:00.000Z';
 
+// pickSampleProbability(10000) = min(1, max(0.1, 2500/10000)) = 0.25 (escalated above the 0.1
+// target since 10000 < LOG_EXTRACTION_SAMPLE_MIN_RETAINED's implied threshold of 25000).
+// scaledProbeLimit(DEFAULT_MAX_LOGS_PER_PAGE, 0.25) = round(10000 * 0.25) = 2500
 const DEFAULT_MAX_LOGS_PER_PAGE = 10000;
 
 describe('CcsLogsExtractionClient', () => {
@@ -126,7 +135,8 @@ describe('CcsLogsExtractionClient', () => {
     const result = await client.extractToUpdates(defaultExtractParams);
 
     expect(result).toEqual({ count: 2, pages: 1 });
-    // probe + entity page; total_logs=2 < maxLogsPerPage=10000 → isLastLogsPage=true, no second probe
+    // probe + entity page; total_logs=2 < scaledProbeLimit(10000)=2500 → isLastLogsPage=true,
+    // sweep extraction runs once (over the swept window) and no second probe is needed
     expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
     expect(mockIngestEntities).toHaveBeenCalledTimes(1);
     expect(mockIngestEntities).toHaveBeenCalledWith({
@@ -217,7 +227,8 @@ describe('CcsLogsExtractionClient', () => {
     const result = await client.extractToUpdates({ ...defaultExtractParams, docsLimit });
 
     expect(result).toEqual({ count: 3, pages: 2 });
-    // probe + 2 entity pages; total_logs=3 < maxLogsPerPage=10000 → isLastLogsPage=true, no second probe
+    // probe + 2 entity pages; total_logs=3 < scaledProbeLimit(10000)=2500 → isLastLogsPage=true,
+    // no second probe
     expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
     expect(mockIngestEntities).toHaveBeenCalledTimes(2);
     expect(mockIngestEntities).toHaveBeenNthCalledWith(
@@ -233,9 +244,10 @@ describe('CcsLogsExtractionClient', () => {
       checkpointTimestamp: '2024-06-15T10:00:00.000Z',
       paginationRecoveryId: 'host:h2',
     });
-    // Outer loop advance after slice completes
+    // Outer loop advance after slice completes: last-page slices are swept all the way to the
+    // window top (EXPECTED_WINDOW_END), not the probe's own (sampled) MAX(@timestamp).
     expect(mockCcsStateClient.update).toHaveBeenCalledWith('host', {
-      checkpointTimestamp: '2024-06-15T11:00:00.000Z',
+      checkpointTimestamp: EXPECTED_WINDOW_END,
       paginationRecoveryId: null,
     });
     // count > 0 → no clearRecoveryId
@@ -244,7 +256,11 @@ describe('CcsLogsExtractionClient', () => {
 
   it('should paginate across outer (log-slice) loop when probe signals more slices', async () => {
     const docsLimit = 5;
-    const maxLogsPerPage = 2;
+    // pickSampleProbability(20) = min(1, max(0.1, 2500/20)) = 1: below LOG_EXTRACTION_SAMPLE_MIN_RETAINED
+    // (2500), maxLogsPerPage=20 is too small for sampling to be accurate, so it escalates to an
+    // exact, unsampled probe (p=1). scaledProbeLimit(20, 1) = 20, same as the original
+    // pre-sampling LIMIT — total_logs below is compared directly against 20.
+    const maxLogsPerPage = 20;
 
     const slice1EntityPage: ESQLSearchResponse = {
       columns: [
@@ -265,12 +281,13 @@ describe('CcsLogsExtractionClient', () => {
       ],
     };
 
-    // Probe 1: total_logs=2 = maxLogsPerPage=2 → full page, isLastLogsPage=false → not last
-    // Probe 2: total_logs=1 < maxLogsPerPage=2 → partial page, isLastLogsPage=true → last slice
+    // Probe 1: total_logs=20 = scaledProbeLimit(20)=20 → saturated, isLastLogsPage=false → not last
+    // Probe 2: total_logs=5 < scaledProbeLimit(20)=20 → not saturated, isLastLogsPage=true → last
+    //   slice; sliceEnd is swept to EXPECTED_WINDOW_END rather than the probe's own timestamp.
     mockExecuteEsqlQuery
-      .mockResolvedValueOnce(makeProbeResponse('2024-06-15T10:00:00.000Z', 2))
+      .mockResolvedValueOnce(makeProbeResponse('2024-06-15T10:00:00.000Z', 20))
       .mockResolvedValueOnce(slice1EntityPage)
-      .mockResolvedValueOnce(makeProbeResponse('2024-06-15T11:00:00.000Z', 1))
+      .mockResolvedValueOnce(makeProbeResponse('2024-06-15T11:00:00.000Z', 5))
       .mockResolvedValueOnce(slice2EntityPage);
 
     const result = await client.extractToUpdates({
@@ -280,7 +297,8 @@ describe('CcsLogsExtractionClient', () => {
     });
 
     expect(result).toEqual({ count: 4, pages: 2 });
-    // 2 probes + 2 entity pages
+    // 2 probes + 2 entity pages; the last slice resolves from a present (non-empty) probe row,
+    // so no extra sweep probe/call is needed beyond the extraction that already ran for it.
     expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
     expect(mockIngestEntities).toHaveBeenCalledTimes(2);
 
@@ -289,8 +307,9 @@ describe('CcsLogsExtractionClient', () => {
       checkpointTimestamp: '2024-06-15T10:00:00.000Z',
       paginationRecoveryId: null,
     });
+    // Last slice: swept to the window top, not the probe's own MAX(@timestamp).
     expect(mockCcsStateClient.update).toHaveBeenCalledWith('host', {
-      checkpointTimestamp: '2024-06-15T11:00:00.000Z',
+      checkpointTimestamp: EXPECTED_WINDOW_END,
       paginationRecoveryId: null,
     });
     // count > 0 → no clearRecoveryId
@@ -334,19 +353,71 @@ describe('CcsLogsExtractionClient', () => {
       checkpointTimestamp: '2024-06-15T10:00:00.000Z',
       paginationRecoveryId: null,
     });
-    mockExecuteEsqlQuery.mockResolvedValueOnce(emptyProbeResponse);
+    // An empty (zero-row) probe no longer short-circuits the loop: it is treated like a
+    // non-saturated last page and triggers a follow-up sweep extraction over the full
+    // remaining window, so a second (empty) response is needed here.
+    mockExecuteEsqlQuery
+      .mockResolvedValueOnce(emptyProbeResponse)
+      .mockResolvedValueOnce({ columns: [], values: [] });
 
     const result = await client.extractToUpdates(defaultExtractParams);
 
     expect(result).toEqual({ count: 0, pages: 0 });
-    expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+    expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
     expect(mockIngestEntities).not.toHaveBeenCalled();
-    // clearRecoveryId called to clean up any stale recovery id; checkpoint unchanged
+    // clearRecoveryId called to clean up any stale recovery id (totalCount stayed 0)
     expect(mockCcsStateClient.clearRecoveryId).toHaveBeenCalledWith('host');
-    expect(mockCcsStateClient.update).not.toHaveBeenCalledWith(
-      'host',
-      expect.objectContaining({ checkpointTimestamp: null })
+    // The sweep still persists the swept slice end (window top), even though nothing was found
+    expect(mockCcsStateClient.update).toHaveBeenCalledWith('host', {
+      checkpointTimestamp: EXPECTED_WINDOW_END,
+      paginationRecoveryId: null,
+    });
+  });
+
+  it('does not drop real docs when the sampled probe finds nothing (follow-up sweep extraction still ingests them)', async () => {
+    // Core correctness guarantee of the SAMPLE-based probe: a probe reporting zero sampled rows
+    // does NOT prove the real window is empty (e.g. 1-2 real docs left, ~90% chance none get
+    // sampled at p=0.1). `hasLogsToProcess: false` must still trigger a follow-up sweep
+    // extraction over the full [fromDateISO, toDateISO] window so those real docs are ingested
+    // instead of being silently skipped.
+    mockCcsStateClient.findOrInit.mockResolvedValue({
+      checkpointTimestamp: '2024-06-15T10:00:00.000Z',
+      paginationRecoveryId: null,
+    });
+
+    const sweepExtractionResponse: ESQLSearchResponse = {
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD, type: 'date' },
+        { name: 'entity.id', type: 'keyword' },
+      ],
+      values: [['2024-06-15T10:30:00.000Z', '2024-06-15T10:30:00.000Z', 'host:h-tail']],
+    };
+
+    mockExecuteEsqlQuery
+      .mockResolvedValueOnce(emptyProbeResponse) // probe samples 0 rows despite real docs existing
+      .mockResolvedValueOnce(sweepExtractionResponse); // sweep extraction still finds the real doc
+
+    const result = await client.extractToUpdates(defaultExtractParams);
+
+    expect(result).toEqual({ count: 1, pages: 1 });
+    expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
+    expect(mockIngestEntities).toHaveBeenCalledTimes(1);
+    expect(mockIngestEntities).toHaveBeenCalledWith(
+      expect.objectContaining({ esqlResponse: sweepExtractionResponse })
     );
+
+    // The sweep extraction covers the whole remaining window — swept to the window top rather
+    // than being bounded by the (undershooting/empty) sampled probe boundary.
+    const sweepQuery = mockExecuteEsqlQuery.mock.calls[1][0].query as string;
+    expect(sweepQuery).toContain(EXPECTED_WINDOW_END);
+
+    // count > 0 → no clearRecoveryId, and the swept slice-end is persisted as usual.
+    expect(mockCcsStateClient.clearRecoveryId).not.toHaveBeenCalled();
+    expect(mockCcsStateClient.update).toHaveBeenCalledWith('host', {
+      checkpointTimestamp: EXPECTED_WINDOW_END,
+      paginationRecoveryId: null,
+    });
   });
 
   it('should resume from mid entity-page recovery state (paginationRecoveryId set)', async () => {
@@ -417,7 +488,10 @@ describe('CcsLogsExtractionClient', () => {
       checkpointTimestamp: null,
       paginationRecoveryId: null,
     });
-    mockExecuteEsqlQuery.mockResolvedValueOnce(emptyProbeResponse);
+    // Empty probe now runs a follow-up sweep extraction instead of short-circuiting the loop.
+    mockExecuteEsqlQuery
+      .mockResolvedValueOnce(emptyProbeResponse)
+      .mockResolvedValueOnce({ columns: [], values: [] });
 
     await client.extractToUpdates(defaultExtractParams);
 
@@ -433,7 +507,10 @@ describe('CcsLogsExtractionClient', () => {
       checkpointTimestamp: checkpoint,
       paginationRecoveryId: null,
     });
-    mockExecuteEsqlQuery.mockResolvedValueOnce(emptyProbeResponse);
+    // Empty probe now runs a follow-up sweep extraction instead of short-circuiting the loop.
+    mockExecuteEsqlQuery
+      .mockResolvedValueOnce(emptyProbeResponse)
+      .mockResolvedValueOnce({ columns: [], values: [] });
 
     await client.extractToUpdates(defaultExtractParams);
 
@@ -495,8 +572,10 @@ describe('CcsLogsExtractionClient', () => {
         checkpointTimestamp: checkpoint,
         paginationRecoveryId: null,
       });
-      // Each sub-window probe returns empty (no logs), so the inner outer-loop terminates
-      // immediately and never persists per-slice checkpoints. No state updates occur.
+      // Each sub-window probe returns empty (no logs). Under the new sweep semantics this no
+      // longer breaks the inner outer-loop immediately — each sub-window still runs one
+      // follow-up sweep extraction (also empty here) over its full span, and persists that
+      // swept slice-end as the sub-window's checkpoint.
       mockExecuteEsqlQuery.mockResolvedValue(emptyProbeResponse);
 
       const result = await client.extractToUpdates({
@@ -505,11 +584,14 @@ describe('CcsLogsExtractionClient', () => {
       });
 
       expect(result).toEqual({ count: 0, pages: 0 });
-      // 6 sub-windows × 1 probe each.
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(6);
-      // No per-sub-window checkpoint persistence — inner per-slice persistence is the only
-      // mechanism, and it didn't fire because every probe was empty.
-      expect(mockCcsStateClient.update).not.toHaveBeenCalled();
+      // 6 sub-windows × (1 probe + 1 follow-up sweep extraction).
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(12);
+      // Each sub-window's empty probe still sweeps to (and persists) its own window end.
+      expect(mockCcsStateClient.update).toHaveBeenCalledTimes(6);
+      expect(mockCcsStateClient.update).toHaveBeenLastCalledWith('host', {
+        checkpointTimestamp: EXPECTED_WINDOW_END,
+        paginationRecoveryId: null,
+      });
       // count=0 across all sub-windows → clearRecoveryId
       expect(mockCcsStateClient.clearRecoveryId).toHaveBeenCalledWith('host');
     });
@@ -521,23 +603,34 @@ describe('CcsLogsExtractionClient', () => {
         checkpointTimestamp: checkpoint,
         paginationRecoveryId: null,
       });
-      mockExecuteEsqlQuery.mockResolvedValueOnce(emptyProbeResponse);
+      // Empty probe now triggers one follow-up sweep extraction (also empty) instead of ending
+      // the loop immediately.
+      mockExecuteEsqlQuery
+        .mockResolvedValueOnce(emptyProbeResponse)
+        .mockResolvedValueOnce({ columns: [], values: [] });
 
       await client.extractToUpdates({
         ...defaultExtractParams,
         maxTimeWindowSize: '5m',
       });
 
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
-      // Empty probe → no per-slice state updates either.
-      expect(mockCcsStateClient.update).not.toHaveBeenCalled();
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
+      // The sweep still persists the swept (empty) slice-end as the checkpoint.
+      expect(mockCcsStateClient.update).toHaveBeenCalledWith('host', {
+        checkpointTimestamp: EXPECTED_WINDOW_END,
+        paginationRecoveryId: null,
+      });
     });
 
     it('bypasses the sub-window cap when windowOverride is provided', async () => {
       const overrideFrom = '2024-01-01T00:00:00.000Z';
       const overrideTo = '2024-12-31T23:59:00.000Z'; // ~1y, exceeds the 5m cap
 
-      mockExecuteEsqlQuery.mockResolvedValueOnce(emptyProbeResponse);
+      // Empty probe now triggers one follow-up sweep extraction (also empty). Override runs
+      // skip state updates regardless.
+      mockExecuteEsqlQuery
+        .mockResolvedValueOnce(emptyProbeResponse)
+        .mockResolvedValueOnce({ columns: [], values: [] });
 
       await client.extractToUpdates({
         ...defaultExtractParams,
@@ -545,8 +638,9 @@ describe('CcsLogsExtractionClient', () => {
         windowOverride: { fromDateISO: overrideFrom, toDateISO: overrideTo },
       });
 
-      // Single probe over the full user-supplied window — no sub-window splitting.
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+      // Single probe + sweep extraction over the full user-supplied window — no sub-window
+      // splitting.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
       const probeQuery = mockExecuteEsqlQuery.mock.calls[0][0].query as string;
       expect(probeQuery).toContain(overrideFrom);
       expect(probeQuery).toContain(overrideTo);
@@ -568,17 +662,19 @@ describe('CcsLogsExtractionClient', () => {
         maxTimeWindowSize: '5m',
       });
 
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
+      // 3 sub-windows × (1 probe + 1 follow-up sweep extraction, since every probe is empty).
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(6);
 
+      // Calls interleave probe/sweep per sub-window: [probe1, sweep1, probe2, sweep2, probe3, sweep3].
       const subWindow1 = mockExecuteEsqlQuery.mock.calls[0][0].query as string;
       expect(subWindow1).toContain('2026-01-01T11:44:00.000Z');
       expect(subWindow1).toContain('2026-01-01T11:49:00.000Z');
 
-      const subWindow2 = mockExecuteEsqlQuery.mock.calls[1][0].query as string;
+      const subWindow2 = mockExecuteEsqlQuery.mock.calls[2][0].query as string;
       expect(subWindow2).toContain('2026-01-01T11:49:00.000Z');
       expect(subWindow2).toContain('2026-01-01T11:54:00.000Z');
 
-      const subWindow3 = mockExecuteEsqlQuery.mock.calls[2][0].query as string;
+      const subWindow3 = mockExecuteEsqlQuery.mock.calls[4][0].query as string;
       expect(subWindow3).toContain('2026-01-01T11:54:00.000Z');
       expect(subWindow3).toContain('2026-01-01T11:59:00.000Z');
     });
@@ -587,7 +683,9 @@ describe('CcsLogsExtractionClient', () => {
   describe('stall detection', () => {
     // `sliceStart` starts undefined; it is only set after the first slice completes (line ~332).
     // Stall detection (`!!sliceStart && ...`) therefore requires at least two slice iterations.
-    // After the stall, a terminal empty probe ends the loop (full-page count no longer signals last page).
+    // After the stall, a terminal empty probe resolves as the last page and runs one follow-up
+    // sweep extraction over the remaining window before the loop ends (it no longer breaks
+    // immediately) — every "terminal empty probe" sequence below mocks one extra response for it.
 
     it('logs warn and bumps checkpointTimestamp by 1ms when timestamp unchanged and page is full', async () => {
       const stalledTs = '2024-06-15T10:00:00.000Z';
@@ -598,21 +696,28 @@ describe('CcsLogsExtractionClient', () => {
         paginationRecoveryId: null,
       });
 
-      // Slice 1: ends at stalledTs (full page → not last, loop continues).
-      // Slice 2: same stalledTs + full page → stall fires, extraction skipped, cursor bumped.
-      // Probe 3 (with bumpedTs): empty → loop ends.
+      // Slice 1: ends at stalledTs (saturated → not last, loop continues).
+      // Slice 2: same stalledTs + saturated page → stall fires, extraction skipped, cursor bumped.
+      // Probe 3 (with bumpedTs): empty → resolves as last page, runs one follow-up sweep
+      // extraction over the remaining window, then the loop ends.
       mockExecuteEsqlQuery
         .mockResolvedValueOnce(makeProbeResponse(stalledTs, DEFAULT_MAX_LOGS_PER_PAGE)) // slice 1, not last
         .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 1
         .mockResolvedValueOnce(makeProbeResponse(stalledTs, DEFAULT_MAX_LOGS_PER_PAGE)) // slice 2: stall fires, extraction skipped
-        .mockResolvedValueOnce(emptyProbeResponse); // probe 3 with bumpedTs → loop ends
+        .mockResolvedValueOnce(emptyProbeResponse) // probe 3 with bumpedTs → last page
+        .mockResolvedValueOnce({ columns: [], values: [] }); // follow-up sweep extraction → loop ends
 
       const result = await client.extractToUpdates(defaultExtractParams);
 
       expect(result.error).toBeUndefined();
       expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      // The stall message no longer includes a doc count — it now describes a "saturated page"
+      // rather than "a full page (${n} docs)", since a saturated sampled page no longer maps to
+      // an exact doc count.
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining(`CCS log-slice probe stalled at ${stalledTs}`)
+        expect.stringContaining(
+          `CCS log-slice probe stalled at ${stalledTs} with a saturated page; advancing cursor by 1ms. Docs sharing this timestamp beyond the configured per-page limit (${DEFAULT_MAX_LOGS_PER_PAGE}) will be dropped.`
+        )
       );
       // The outer loop persists the bumped value as checkpointTimestamp after the stalled slice.
       expect(mockCcsStateClient.update).toHaveBeenCalledWith('host', {
@@ -631,13 +736,15 @@ describe('CcsLogsExtractionClient', () => {
       });
 
       // Slice 1: sliceStart becomes ts1. Slice 2: advances to ts2 (different) → no stall.
-      // Full page (total=max) → isLastLogsPage=false → loop continues; terminal empty probe ends it.
+      // Saturated page (total >= scaledProbeLimit) → isLastLogsPage=false → loop continues;
+      // a terminal empty probe then resolves last and runs one follow-up sweep extraction.
       mockExecuteEsqlQuery
         .mockResolvedValueOnce(makeProbeResponse(ts1, DEFAULT_MAX_LOGS_PER_PAGE)) // slice 1, not last
         .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 1
-        .mockResolvedValueOnce(makeProbeResponse(ts2, DEFAULT_MAX_LOGS_PER_PAGE)) // full page, different ts → not last
+        .mockResolvedValueOnce(makeProbeResponse(ts2, DEFAULT_MAX_LOGS_PER_PAGE)) // saturated, different ts → not last
         .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 2
-        .mockResolvedValueOnce(emptyProbeResponse); // terminal probe → loop ends
+        .mockResolvedValueOnce(emptyProbeResponse) // terminal probe → last page
+        .mockResolvedValueOnce({ columns: [], values: [] }); // follow-up sweep extraction → loop ends
 
       const result = await client.extractToUpdates(defaultExtractParams);
 
@@ -653,12 +760,15 @@ describe('CcsLogsExtractionClient', () => {
         paginationRecoveryId: null,
       });
 
-      // Slice 1: sliceStart becomes ts1 (full page, not last). Slice 2: same ts but only 5 docs (partial) → no stall.
+      // Slice 1: sliceStart becomes ts1 (saturated, not last). Slice 2: same ts but only 5
+      // sampled docs (well below scaledProbeLimit=2500) → isLastLogsPage=true, so sliceEnd is
+      // swept to EXPECTED_WINDOW_END (not ts1) before reaching the stall check — no stall
+      // regardless, since the swept sliceEnd never equals sliceStart's ts1.
       mockExecuteEsqlQuery
         .mockResolvedValueOnce(makeProbeResponse(ts1, DEFAULT_MAX_LOGS_PER_PAGE)) // slice 1, not last
         .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 1
         .mockResolvedValueOnce(makeProbeResponse(ts1, 5)) // same ts, partial page → no stall, isLastLogsPage=true
-        .mockResolvedValueOnce({ columns: [], values: [] }); // entity extraction 2
+        .mockResolvedValueOnce({ columns: [], values: [] }); // entity extraction 2 (sliceEnd = EXPECTED_WINDOW_END)
 
       const result = await client.extractToUpdates(defaultExtractParams);
 
@@ -674,16 +784,63 @@ describe('CcsLogsExtractionClient', () => {
       });
 
       const someTs = '2024-06-15T10:00:00.000Z';
-      // Full page (total=max → isLastLogsPage=false): loop continues; terminal empty probe ends it.
+      // Saturated page (isLastLogsPage=false): loop continues; a terminal empty probe then
+      // resolves last and runs one follow-up sweep extraction before the loop ends.
       mockExecuteEsqlQuery
         .mockResolvedValueOnce(makeProbeResponse(someTs, DEFAULT_MAX_LOGS_PER_PAGE)) // slice 1, not last
         .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction
-        .mockResolvedValueOnce(emptyProbeResponse); // terminal probe → loop ends
+        .mockResolvedValueOnce(emptyProbeResponse) // terminal probe → last page
+        .mockResolvedValueOnce({ columns: [], values: [] }); // follow-up sweep extraction → loop ends
 
       const result = await client.extractToUpdates(defaultExtractParams);
 
       expect(result.error).toBeUndefined();
       expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('adaptive sampleProbability', () => {
+    it('escalates above the 0.1 target and emits a SAMPLE stage when maxLogsPerPage=10000', async () => {
+      mockExecuteEsqlQuery
+        .mockResolvedValueOnce(makeProbeResponse('2024-06-15T23:59:59.000Z', 2))
+        .mockResolvedValueOnce({ columns: [], values: [] });
+
+      await client.extractToUpdates({ ...defaultExtractParams, maxLogsPerPage: 10000 });
+
+      const probeQuery = mockExecuteEsqlQuery.mock.calls[0][0].query as string;
+      // pickSampleProbability(10000) = min(1, max(0.1, 2500/10000)) = 0.25
+      expect(probeQuery).toContain('| SAMPLE 0.25');
+    });
+
+    it('falls back to an exact, unsampled probe (no SAMPLE stage) when maxLogsPerPage is too small to sample accurately', async () => {
+      mockExecuteEsqlQuery
+        .mockResolvedValueOnce(makeProbeResponse('2024-06-15T23:59:59.000Z', 2))
+        .mockResolvedValueOnce({ columns: [], values: [] });
+
+      await client.extractToUpdates({ ...defaultExtractParams, maxLogsPerPage: 20 });
+
+      const probeQuery = mockExecuteEsqlQuery.mock.calls[0][0].query as string;
+      // pickSampleProbability(20) = 1 (20 <= LOG_EXTRACTION_SAMPLE_MIN_RETAINED / 1 threshold)
+      expect(probeQuery).not.toContain('SAMPLE');
+      expect(probeQuery).toContain('| LIMIT 20');
+    });
+
+    it('does not run a sweep extraction when an exact (unsampled) probe finds nothing', async () => {
+      // maxLogsPerPage=20 → pickSampleProbability(20)=1: too small for sampling to help, so
+      // the probe is exact. An empty result from an exact probe is definitive (no real docs can
+      // be missed the way a sampled probe can miss them), so the loop should stop immediately
+      // instead of running a redundant sweep extraction.
+      mockExecuteEsqlQuery.mockResolvedValueOnce(emptyProbeResponse);
+
+      const result = await client.extractToUpdates({ ...defaultExtractParams, maxLogsPerPage: 20 });
+
+      expect(result).toEqual({ count: 0, pages: 0 });
+      // Only the single (empty) probe call — no follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+      expect(mockIngestEntities).not.toHaveBeenCalled();
+      expect(mockCcsStateClient.clearRecoveryId).toHaveBeenCalledWith('host');
+      // No slice-end was ever swept/persisted, unlike the sampled-probe case.
+      expect(mockCcsStateClient.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
@@ -588,9 +588,7 @@ export class CcsLogsExtractionClient {
     if (sliceStart && sliceStart.timestampCursor === sliceEnd.timestampCursor && isFullPage) {
       const bumpedTs = moment(sliceEnd.timestampCursor).add(1, 'ms').toISOString();
       this.logger.warn(
-        `CCS log-slice probe stalled at ${
-          sliceEnd.timestampCursor
-        } with a saturated page; advancing cursor by 1ms. Docs sharing this timestamp beyond the configured per-page limit (${effectiveMaxLogsPerPage}) will be dropped.`
+        `CCS log-slice probe stalled at ${sliceEnd.timestampCursor} with a saturated page; advancing cursor by 1ms. Docs sharing this timestamp beyond the configured per-page limit (${effectiveMaxLogsPerPage}) will be dropped.`
       );
       return { timestampCursor: bumpedTs };
     }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
@@ -41,7 +41,7 @@ import {
   capExtractionWindowEnd,
   resolveCcsExtractionWindow,
 } from './extraction_window';
-import { capAtMaxLogsPerWindow } from './effective_page_limits';
+import { capAtMaxLogsPerWindow, pickSampleProbability } from './effective_page_limits';
 
 interface CcsExtractToUpdatesParams {
   type: EntityType;
@@ -287,6 +287,11 @@ export class CcsLogsExtractionClient {
   }): Promise<CcsExtractToUpdatesResult> {
     const effectiveMaxLogsPerPage = capAtMaxLogsPerWindow(maxLogsPerPage, maxLogsPerWindow);
     const effectiveDocsLimit = capAtMaxLogsPerWindow(docsLimit, maxLogsPerWindow);
+    // Escalates above the target probability (up to an exact, unsampled probe) once
+    // maxLogsPerPage is too small for the sampling estimator to be accurate — see
+    // pickSampleProbability. Computed once per loop invocation: effectiveMaxLogsPerPage is
+    // fixed for the whole loop.
+    const effectiveSampleProbability = pickSampleProbability(effectiveMaxLogsPerPage);
     let totalCount = 0;
     let totalPages = 0;
     let totalLogs = 0;
@@ -312,20 +317,34 @@ export class CcsLogsExtractionClient {
         toDateISO,
         sliceStart,
         maxLogsPerPage: effectiveMaxLogsPerPage,
+        sampleProbability: effectiveSampleProbability,
         abortController,
       });
 
-      if (!logPaginationCursor.hasLogsToProcess) {
+      if (!logPaginationCursor.hasLogsToProcess && effectiveSampleProbability >= 1) {
+        // Sampling wasn't active for this probe (maxLogsPerPage was too small — see
+        // pickSampleProbability), so an empty, exact result is definitive: no real docs
+        // remain. Stop immediately rather than running a redundant sweep extraction.
         break;
       }
 
-      let { logsPaginationCursor: sliceEnd } = logPaginationCursor;
+      // A saturated probe (the scaled LIMIT was filled) means ~maxLogsPerPage+ real docs likely
+      // remain: more pages follow, bounded by the sampled boundary. Otherwise — the sample fell
+      // short of the limit, or retained zero rows at all (hasLogsToProcess: false) — fewer real
+      // docs remain than maxLogsPerPage, so this is the last page. It is swept all the way to
+      // the window top (not the undershooting/absent sampled boundary) so nothing past it is
+      // silently dropped: a probe with zero sampled rows does not prove zero real docs remain
+      // (e.g. a couple of docs, ~90% chance neither gets sampled at the default p=0.1).
       isLastLogsPage = logPaginationCursor.isLastLogsPage;
+      let sliceEnd: LogSlicePaginationParams =
+        logPaginationCursor.hasLogsToProcess && !logPaginationCursor.isLastLogsPage
+          ? logPaginationCursor.logsPaginationCursor
+          : { timestampCursor: toDateISO };
 
       const bumpedSliceEnd = this.detectLogSliceStall(
         sliceStart,
         sliceEnd,
-        logPaginationCursor.sliceLogCount,
+        !isLastLogsPage,
         effectiveMaxLogsPerPage
       );
       if (bumpedSliceEnd) {
@@ -402,6 +421,7 @@ export class CcsLogsExtractionClient {
     toDateISO,
     sliceStart,
     maxLogsPerPage,
+    sampleProbability,
     abortController,
   }: {
     remoteIndexPatterns: string[];
@@ -410,6 +430,7 @@ export class CcsLogsExtractionClient {
     toDateISO: string;
     sliceStart: LogSlicePaginationParams | undefined;
     maxLogsPerPage: number;
+    sampleProbability: number;
     abortController?: AbortController;
   }): Promise<LogPaginationCursor> {
     const probeQuery = buildLogPaginationCursorProbeEsql({
@@ -419,6 +440,7 @@ export class CcsLogsExtractionClient {
       toDateISO,
       logsPageCursorStart: sliceStart,
       maxLogsPerPage,
+      sampleProbability,
     });
 
     this.logger.info(
@@ -431,11 +453,17 @@ export class CcsLogsExtractionClient {
       esClient: this.esClient,
       query: probeQuery,
       abortController,
+      telemetry: {
+        name: 'remote_probe_query',
+        namespace: this.namespace,
+        type,
+      },
     });
 
     return interpretLogPaginationCursorRows(
       parseLogPaginationCursorRow(probeResponse),
-      maxLogsPerPage
+      maxLogsPerPage,
+      sampleProbability
     );
   }
 
@@ -512,6 +540,11 @@ export class CcsLogsExtractionClient {
         esClient: this.esClient,
         query,
         abortController,
+        telemetry: {
+          name: 'remote_extraction_query',
+          namespace: this.namespace,
+          type,
+        },
       });
 
       count += esqlResponse.values.length;
@@ -541,21 +574,23 @@ export class CcsLogsExtractionClient {
     return { count, pages };
   }
 
-  /** Returns the bumped slice-end cursor when a stall is detected, null otherwise. Logs a warning on stall. */
+  /**
+   * Returns the bumped slice-end cursor when a stall is detected, null otherwise. Logs a
+   * warning on stall. `isFullPage` is `true` when the (possibly sampled) probe saturated its
+   * limit — i.e. this iteration was not resolved as the last page.
+   */
   private detectLogSliceStall(
     sliceStart: LogSlicePaginationParams | undefined,
     sliceEnd: LogSlicePaginationParams,
-    sliceLogCount: number,
-    maxLogsPerPage: number
+    isFullPage: boolean,
+    effectiveMaxLogsPerPage: number
   ): LogSlicePaginationParams | null {
-    if (
-      sliceStart &&
-      sliceStart.timestampCursor === sliceEnd.timestampCursor &&
-      sliceLogCount >= maxLogsPerPage
-    ) {
+    if (sliceStart && sliceStart.timestampCursor === sliceEnd.timestampCursor && isFullPage) {
       const bumpedTs = moment(sliceEnd.timestampCursor).add(1, 'ms').toISOString();
       this.logger.warn(
-        `CCS log-slice probe stalled at ${sliceEnd.timestampCursor} with a full page (${sliceLogCount} docs); advancing cursor by 1ms. Docs sharing this timestamp beyond maxLogsPerPage will be dropped.`
+        `CCS log-slice probe stalled at ${
+          sliceEnd.timestampCursor
+        } with a saturated page; advancing cursor by 1ms. Docs sharing this timestamp beyond the configured per-page limit (${effectiveMaxLogsPerPage}) will be dropped.`
       );
       return { timestampCursor: bumpedTs };
     }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/effective_page_limits.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/effective_page_limits.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  capAtMaxLogsPerWindow,
+  LOG_EXTRACTION_SAMPLE_MIN_RETAINED,
+  pickSampleProbability,
+} from './effective_page_limits';
+
+describe('capAtMaxLogsPerWindow', () => {
+  it('caps value to maxLogsPerWindow when the window cap is active', () => {
+    expect(capAtMaxLogsPerWindow(50000, 1000)).toBe(1000);
+  });
+
+  it('leaves value unchanged when value is already below maxLogsPerWindow', () => {
+    expect(capAtMaxLogsPerWindow(500, 1000)).toBe(500);
+  });
+
+  it('leaves value unchanged when maxLogsPerWindow is 0 (disabled)', () => {
+    expect(capAtMaxLogsPerWindow(50000, 0)).toBe(50000);
+  });
+});
+
+describe('pickSampleProbability', () => {
+  it('uses the target probability (0.1) at the default page size, where minRetained/M is small', () => {
+    expect(pickSampleProbability(50000)).toBeCloseTo(0.1);
+  });
+
+  it('escalates p above the target as maxLogsPerPage shrinks', () => {
+    expect(pickSampleProbability(10000)).toBeCloseTo(0.25); // 2500/10000
+    expect(pickSampleProbability(5000)).toBeCloseTo(0.5); // 2500/5000
+  });
+
+  it('floors at p=1 (an exact, unsampled probe) once maxLogsPerPage <= minRetained', () => {
+    expect(pickSampleProbability(2500)).toBe(1);
+    expect(pickSampleProbability(1000)).toBe(1);
+    expect(pickSampleProbability(20)).toBe(1);
+    expect(pickSampleProbability(1)).toBe(1);
+  });
+
+  it('never goes below targetProbability, even for very large maxLogsPerPage', () => {
+    expect(pickSampleProbability(10_000_000)).toBeCloseTo(0.1);
+  });
+
+  it('respects a custom targetProbability and minRetained', () => {
+    expect(pickSampleProbability(10000, 0.2, 1000)).toBeCloseTo(0.2); // 1000/10000=0.1 < target 0.2
+    expect(pickSampleProbability(2000, 0.2, 1000)).toBeCloseTo(0.5); // 1000/2000=0.5 > target 0.2
+  });
+
+  it('exposes LOG_EXTRACTION_SAMPLE_MIN_RETAINED as the documented threshold', () => {
+    expect(LOG_EXTRACTION_SAMPLE_MIN_RETAINED).toBe(2500);
+    expect(pickSampleProbability(LOG_EXTRACTION_SAMPLE_MIN_RETAINED)).toBe(1);
+    expect(pickSampleProbability(LOG_EXTRACTION_SAMPLE_MIN_RETAINED + 1)).toBeLessThan(1);
+  });
+
+  it('rounds the result to 4 decimal places instead of returning a long floating-point literal', () => {
+    // 2500 / 3000 = 0.8333333333333334 unrounded — embedding that raw value in an ES|QL SAMPLE
+    // clause would be unstable/unreadable, so pickSampleProbability bounds it up front.
+    expect(pickSampleProbability(3000)).toBe(0.8333);
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/effective_page_limits.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/effective_page_limits.ts
@@ -5,6 +5,11 @@
  * 2.0.
  */
 
+import {
+  LOG_EXTRACTION_SAMPLE_PROBABILITY,
+  roundSampleProbability,
+} from './log_pagination_probe_query_builder';
+
 /**
  * Returns the effective per-page log limit: when `maxLogsPerWindow` is active (> 0),
  * the page size is capped so a single probe never requests more logs than the remaining
@@ -12,3 +17,24 @@
  */
 export const capAtMaxLogsPerWindow = (value: number, maxLogsPerWindow: number): number =>
   maxLogsPerWindow > 0 ? Math.min(value, maxLogsPerWindow) : value;
+
+/**
+ * Minimum number of retained (sampled) rows needed for the probe's accuracy guarantee to hold —
+ * relative boundary error ≈ 1/√k. See `probe_benchmark/report.html` ("Choosing the sampling
+ * probability p") for the validation behind this value.
+ */
+export const LOG_EXTRACTION_SAMPLE_MIN_RETAINED = 2500;
+
+/**
+ * Adaptive sampling probability for the log-pagination probe: keeps the expected number of
+ * retained rows (`k = p · maxLogsPerPage`) at or above `minRetained` by raising `p` above
+ * `targetProbability` as `maxLogsPerPage` shrinks — up to `p = 1` (an exact, unsampled probe)
+ * once `maxLogsPerPage` is small enough that sampling can't reliably help. Never goes below
+ * `targetProbability`, so large pages keep the full validated speedup.
+ */
+export const pickSampleProbability = (
+  maxLogsPerPage: number,
+  targetProbability: number = LOG_EXTRACTION_SAMPLE_PROBABILITY,
+  minRetained: number = LOG_EXTRACTION_SAMPLE_MIN_RETAINED
+): number =>
+  roundSampleProbability(Math.min(1, Math.max(targetProbability, minRetained / maxLogsPerPage)));

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
@@ -8,14 +8,41 @@
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import { TIMESTAMP_FIELD } from './query_builder_commons';
 import {
+  LOG_EXTRACTION_SAMPLE_PROBABILITY,
   LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD,
   buildLogPaginationCursorProbeEsql,
   interpretLogPaginationCursorRows,
   parseLogPaginationCursorRow,
+  roundSampleProbability,
+  scaledProbeLimit,
 } from './log_pagination_probe_query_builder';
 
+describe('roundSampleProbability', () => {
+  it('bounds a long floating-point value to 4 decimal places', () => {
+    expect(roundSampleProbability(2500 / 3000)).toBe(0.8333);
+  });
+
+  it('leaves already-clean values unchanged', () => {
+    expect(roundSampleProbability(0.1)).toBe(0.1);
+    expect(roundSampleProbability(1)).toBe(1);
+  });
+});
+
+describe('scaledProbeLimit', () => {
+  it('scales maxLogsPerPage by the sample probability, rounding to the nearest integer', () => {
+    expect(scaledProbeLimit(100, 0.1)).toBe(10);
+    expect(scaledProbeLimit(100, 0.25)).toBe(25);
+    expect(scaledProbeLimit(100)).toBe(10); // defaults to LOG_EXTRACTION_SAMPLE_PROBABILITY
+  });
+
+  it('floors at 1 row so a tiny maxLogsPerPage never yields LIMIT 0', () => {
+    expect(scaledProbeLimit(1, 0.1)).toBe(1);
+    expect(scaledProbeLimit(4, 0.1)).toBe(1);
+  });
+});
+
 describe('buildLogPaginationCursorProbeEsql', () => {
-  it('sorts ASC, limits, then aggregates MAX(timestamp) and COUNT(*)', () => {
+  it('samples, sorts ASC, limits to the scaled sample size, then aggregates MAX(timestamp) and COUNT(*)', () => {
     const q = buildLogPaginationCursorProbeEsql({
       indexPatterns: ['logs-*'],
       type: 'user',
@@ -25,17 +52,113 @@ describe('buildLogPaginationCursorProbeEsql', () => {
     });
     expect(q).toMatchSnapshot();
   });
+
+  it('emits a SAMPLE stage and a LIMIT scaled to a custom sample probability', () => {
+    const q = buildLogPaginationCursorProbeEsql({
+      indexPatterns: ['logs-*'],
+      type: 'user',
+      fromDateISO: '2024-01-01T00:00:00.000Z',
+      toDateISO: '2024-01-02T00:00:00.000Z',
+      maxLogsPerPage: 100,
+      sampleProbability: 0.25,
+    });
+    expect(q).toContain('| SAMPLE 0.25');
+    expect(q).toContain(`| LIMIT ${scaledProbeLimit(100, 0.25)}`);
+    expect(q).not.toContain('| LIMIT 100');
+  });
+
+  it('defaults sampleProbability to LOG_EXTRACTION_SAMPLE_PROBABILITY when omitted', () => {
+    const q = buildLogPaginationCursorProbeEsql({
+      indexPatterns: ['logs-*'],
+      type: 'user',
+      fromDateISO: '2024-01-01T00:00:00.000Z',
+      toDateISO: '2024-01-02T00:00:00.000Z',
+      maxLogsPerPage: 100,
+    });
+    expect(q).toContain(`| SAMPLE ${LOG_EXTRACTION_SAMPLE_PROBABILITY}`);
+    expect(q).toContain(`| LIMIT ${scaledProbeLimit(100)}`);
+  });
+
+  it('omits the SAMPLE stage entirely at sampleProbability=1 (exact, unsampled probe)', () => {
+    const q = buildLogPaginationCursorProbeEsql({
+      indexPatterns: ['logs-*'],
+      type: 'user',
+      fromDateISO: '2024-01-01T00:00:00.000Z',
+      toDateISO: '2024-01-02T00:00:00.000Z',
+      maxLogsPerPage: 100,
+      sampleProbability: 1,
+    });
+    expect(q).not.toContain('SAMPLE');
+    // scaledProbeLimit(100, 1) === 100: identical to the original pre-sampling LIMIT.
+    expect(q).toContain('| LIMIT 100');
+  });
+
+  it('rounds a long floating-point sampleProbability before embedding it in the query', () => {
+    const q = buildLogPaginationCursorProbeEsql({
+      indexPatterns: ['logs-*'],
+      type: 'user',
+      fromDateISO: '2024-01-01T00:00:00.000Z',
+      toDateISO: '2024-01-02T00:00:00.000Z',
+      maxLogsPerPage: 3000,
+      sampleProbability: 2500 / 3000, // 0.8333333333333334 unrounded
+    });
+    expect(q).toContain('| SAMPLE 0.8333');
+    expect(q).not.toContain('0.8333333333333334');
+  });
 });
 
 describe('interpretLogPaginationCursorRows', () => {
   it('treats undefined row as hasLogsToProcess false', () => {
-    expect(interpretLogPaginationCursorRows(undefined, 100)).toEqual({ hasLogsToProcess: false });
+    expect(interpretLogPaginationCursorRows(undefined, 100)).toEqual({
+      hasLogsToProcess: false,
+      isLastLogsPage: true,
+      sliceLogCount: 0,
+    });
   });
 
-  it('returns isLastLogsPage false when sliceDocCount equals maxLogsPerPage (full page, more may follow)', () => {
+  it('returns isLastLogsPage false when the sampled count saturates the scaled limit (more pages may follow)', () => {
     const row = {
       logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
-      sliceDocCount: 100,
+      sliceDocCount: 10, // === scaledProbeLimit(100, 0.1)
+    };
+    expect(interpretLogPaginationCursorRows(row, 100, 0.1)).toEqual({
+      hasLogsToProcess: true,
+      logsPaginationCursor: row.logsPaginationCursor,
+      isLastLogsPage: false,
+      sliceLogCount: 100, // estimate: round(10 / 0.1)
+    });
+  });
+
+  it('returns isLastLogsPage true when the sampled count falls short of the scaled limit (last page)', () => {
+    const row = {
+      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
+      sliceDocCount: 9,
+    };
+    expect(interpretLogPaginationCursorRows(row, 100, 0.1)).toEqual({
+      hasLogsToProcess: true,
+      logsPaginationCursor: row.logsPaginationCursor,
+      isLastLogsPage: true,
+      sliceLogCount: 90, // estimate: round(9 / 0.1)
+    });
+  });
+
+  it('returns isLastLogsPage true when very few real logs likely remain', () => {
+    const row = {
+      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
+      sliceDocCount: 1,
+    };
+    expect(interpretLogPaginationCursorRows(row, 100, 0.1)).toEqual({
+      hasLogsToProcess: true,
+      logsPaginationCursor: row.logsPaginationCursor,
+      isLastLogsPage: true,
+      sliceLogCount: 10, // estimate: round(1 / 0.1)
+    });
+  });
+
+  it('defaults sampleProbability to LOG_EXTRACTION_SAMPLE_PROBABILITY when omitted', () => {
+    const row = {
+      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
+      sliceDocCount: 10,
     };
     expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
       hasLogsToProcess: true,
@@ -45,29 +168,16 @@ describe('interpretLogPaginationCursorRows', () => {
     });
   });
 
-  it('returns isLastLogsPage true when sliceDocCount is less than maxLogsPerPage (partial page = last)', () => {
+  it('respects a custom sample probability for both the saturation check and the estimate', () => {
     const row = {
       logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
-      sliceDocCount: 99,
+      sliceDocCount: 25, // === scaledProbeLimit(100, 0.25)
     };
-    expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
+    expect(interpretLogPaginationCursorRows(row, 100, 0.25)).toEqual({
       hasLogsToProcess: true,
       logsPaginationCursor: row.logsPaginationCursor,
-      isLastLogsPage: true,
-      sliceLogCount: 99,
-    });
-  });
-
-  it('returns isLastLogsPage true when fewer than maxLogsPerPage logs remain', () => {
-    const row = {
-      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
-      sliceDocCount: 3,
-    };
-    expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
-      hasLogsToProcess: true,
-      logsPaginationCursor: row.logsPaginationCursor,
-      isLastLogsPage: true,
-      sliceLogCount: 3,
+      isLastLogsPage: false,
+      sliceLogCount: 100, // estimate: round(25 / 0.25)
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
@@ -14,32 +14,49 @@ import {
   type LogSlicePaginationParams,
 } from './query_builder_commons';
 
-/** Column produced by {@link buildLogPaginationCursorProbeEsql} via `STATS COUNT(*)` after `LIMIT` (docs in this slice, at most `maxLogsPerPage`). */
 export const LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD = 'total_logs';
 
+export const LOG_EXTRACTION_SAMPLE_PROBABILITY = 0.1;
+
+export const roundSampleProbability = (sampleProbability: number): number =>
+  Math.round(sampleProbability * 10000) / 10000;
+
+export const scaledProbeLimit = (
+  maxLogsPerPage: number,
+  sampleProbability: number = LOG_EXTRACTION_SAMPLE_PROBABILITY
+): number => Math.max(1, Math.round(maxLogsPerPage * sampleProbability));
+
 /**
- * Returns at most one row: the inclusive slice end (`MAX(@timestamp)` of the capped page)
- * and the count of docs in this slice (`COUNT(*)`).
- * If `total_logs < maxLogsPerPage`, this slice exhausts the window (last page).
- * If `total_logs >= maxLogsPerPage`, more slices remain.
+ * Returns at most one row: the inclusive slice end (`MAX(@timestamp)` of the capped, sampled
+ * page) and the count of sampled docs in this slice (`COUNT(*)`).
+ * If `total_logs` is below the scaled sample limit, no more pages to process.
+ * If the scaled limit was saturated, more slices remain.
+ *
+ * `sampleProbability >= 1` omits the `SAMPLE` stage entirely rather than emitting a no-op
  */
 export function buildLogPaginationCursorProbeEsql(
-  params: LogPageProbeSourceClauseParams & { maxLogsPerPage: number }
+  params: LogPageProbeSourceClauseParams & { maxLogsPerPage: number; sampleProbability?: number }
 ): string {
-  const { maxLogsPerPage, ...sourceParams } = params;
+  const {
+    maxLogsPerPage,
+    sampleProbability: rawSampleProbability = LOG_EXTRACTION_SAMPLE_PROBABILITY,
+    ...sourceParams
+  } = params;
+  const sampleProbability = roundSampleProbability(rawSampleProbability);
+  const sampleStage = sampleProbability < 1 ? `\n  | SAMPLE ${sampleProbability}` : '';
   return (
     `${NULLIFY_UNMAPPED_FIELDS_SETTING}\n` +
     buildLogPageProbeSourceClause(sourceParams) +
-    `
+    `${sampleStage}
   | SORT ${TIMESTAMP_FIELD} ASC
-  | LIMIT ${maxLogsPerPage}
+  | LIMIT ${scaledProbeLimit(maxLogsPerPage, sampleProbability)}
   | STATS ${TIMESTAMP_FIELD} = MAX(${TIMESTAMP_FIELD}), ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} = COUNT(*)`
   );
 }
 
 export interface LogPaginationCursorParsedRow {
   logsPaginationCursor: LogSlicePaginationParams;
-  /** Number of docs in this slice (at most `maxLogsPerPage` due to `LIMIT`). */
+  /** Number of sampled docs in this slice (at most the scaled sample limit due to `LIMIT`). */
   sliceDocCount: number;
 }
 
@@ -76,29 +93,41 @@ export function parseLogPaginationCursorRow(
 }
 
 export type LogPaginationCursor =
-  | { hasLogsToProcess: false }
+  | {
+      hasLogsToProcess: false;
+      /** No docs were sampled at all, so this cannot be the start of another page. */
+      isLastLogsPage: true;
+      /** No sampled rows to extrapolate from — always 0. */
+      sliceLogCount: 0;
+    }
   | {
       hasLogsToProcess: true;
       logsPaginationCursor: LogSlicePaginationParams;
       isLastLogsPage: boolean;
-      /** Raw log count in this slice: `min(total_logs, maxLogsPerPage)`. Used for volume-cap accounting. */
+      /**
+       * Estimated real log count in this slice: `round(total_logs / sampleProbability)`.
+       * No longer an exact count now that the probe samples — used for volume-cap accounting,
+       * where the ~1-3% estimation error is within the existing cap tolerance.
+       */
       sliceLogCount: number;
     };
 
 export function interpretLogPaginationCursorRows(
   row: LogPaginationCursorParsedRow | undefined,
-  maxLogsPerPage: number
+  maxLogsPerPage: number,
+  rawSampleProbability: number = LOG_EXTRACTION_SAMPLE_PROBABILITY
 ): LogPaginationCursor {
   if (row === undefined) {
-    return { hasLogsToProcess: false };
+    return { hasLogsToProcess: false, isLastLogsPage: true, sliceLogCount: 0 };
   }
+  const sampleProbability = roundSampleProbability(rawSampleProbability);
   const { logsPaginationCursor, sliceDocCount } = row;
-  // total_logs is COUNT(*) after LIMIT — at most maxLogsPerPage. If fewer docs were returned
-  // than the limit, the window is exhausted. An exact full page means more slices may follow.
+  const scaledLimit = scaledProbeLimit(maxLogsPerPage, sampleProbability);
   return {
     hasLogsToProcess: true,
     logsPaginationCursor,
-    isLastLogsPage: sliceDocCount < maxLogsPerPage,
-    sliceLogCount: sliceDocCount,
+    isLastLogsPage: sliceDocCount < scaledLimit,
+    // Estimated slice log count, based on sampled count we extrapolate to the real count.
+    sliceLogCount: Math.round(sliceDocCount / sampleProbability),
   };
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -27,7 +27,12 @@ const LOG_PAGINATION_CURSOR_PROBE_COLUMNS: ESQLSearchResponse['columns'] = [
   { name: LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD, type: 'long' },
 ];
 
-/** Default total_logs = maxLogsPerPage so interpret marks a non-final slice (full page → more may follow). */
+/**
+ * Default total_logs = maxLogsPerPage, which is always >= the scaled sample limit
+ * (`scaledProbeLimit(maxLogsPerPage) = round(maxLogsPerPage * 0.1)`), so by default this mocks a
+ * saturated (non-final) slice — more pages may follow. Pass a smaller `totalLogsInSlice` below
+ * the effective page's scaled limit to mock a last/partial page instead.
+ */
 function mockLogPaginationCursorProbeRow(
   timestamp: string,
   totalLogsInSlice: number = LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT
@@ -45,7 +50,14 @@ function mockLogPaginationCursorProbeEmpty(): ESQLSearchResponse {
   };
 }
 
-/** First slice + extraction + terminal empty log pagination cursor probe (end of window). */
+/**
+ * First slice + extraction + terminal empty log pagination cursor probe (end of window) +
+ * the follow-up sweep extraction that the terminal empty probe now unconditionally triggers.
+ * A sampled probe returning zero rows does not prove the real remainder is empty, so the loop
+ * always re-scans `[logsPageCursorStart, toDateISO]` for real docs before exiting — see
+ * `runMainExtractionLoop`'s unification of the `hasLogsToProcess: false` and `isLastLogsPage`
+ * branches. That sweep is a 4th ESQL call (an extraction, here mocked empty).
+ */
 function mockExtractSuccessSequence(
   mainExtractionResponse: ESQLSearchResponse,
   totalLogsInSlice?: number
@@ -58,7 +70,8 @@ function mockExtractSuccessSequence(
       )
     )
     .mockResolvedValueOnce(mainExtractionResponse)
-    .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty());
+    .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty())
+    .mockResolvedValueOnce({ columns: [], values: [] });
 }
 import {
   LogExtractionConfig,
@@ -229,13 +242,18 @@ describe('LogsExtractionClient', () => {
       );
 
       expect(mockEngineDescriptorClient.findOrThrow).toHaveBeenCalledWith('user');
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.any(String),
-      });
+      // probe, extraction, terminal empty probe, and the follow-up sweep extraction it triggers.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.any(String),
+        })
+      );
 
-      expect(mockIngestEntities).toHaveBeenCalledTimes(1);
+      // The sweep extraction after the terminal empty probe ingests 0 rows but still calls
+      // ingestEntities unconditionally (see ingestEntityPagesWithinCurrentLogPage).
+      expect(mockIngestEntities).toHaveBeenCalledTimes(2);
       expect(mockIngestEntities).toHaveBeenCalledWith({
         esClient: mockEsClient,
         esqlResponse: mockEsqlResponse,
@@ -309,8 +327,11 @@ describe('LogsExtractionClient', () => {
       expect(result.success).toBe(true);
       expect(result.success && result.count).toBe(0);
 
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
-      expect(mockIngestEntities).toHaveBeenCalledTimes(0);
+      // A terminal empty probe no longer breaks immediately: it is unified with the last-page
+      // path and still runs a follow-up sweep extraction over the window before the loop exits,
+      // since a sampled probe returning zero rows does not prove the real remainder is empty.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
+      expect(mockIngestEntities).toHaveBeenCalledTimes(1);
       expect(mockEngineDescriptorClient.update).toHaveBeenCalledWith(
         'user',
         expect.objectContaining({
@@ -321,6 +342,88 @@ describe('LogsExtractionClient', () => {
           }),
         })
       );
+    });
+
+    it('sweeps and ingests real docs when the sampled probe returns zero rows (does not silently drop them)', async () => {
+      // Core correctness guarantee of the SAMPLE-based probe: sampling can return zero rows
+      // (hasLogsToProcess: false) even though real, unsampled docs still exist in the window
+      // (e.g. a couple of docs, ~90% chance neither gets sampled at the default p=0.1). The
+      // follow-up sweep extraction always re-scans the real [logsPageCursorStart, toDateISO]
+      // window and ingests idempotently, so nothing the sample missed is silently dropped.
+      const realDocsResponse: ESQLSearchResponse = {
+        columns: [
+          { name: '@timestamp', type: 'date' },
+          { name: HASHED_ID_FIELD, type: 'keyword' },
+        ],
+        values: [
+          ['2024-01-02T10:00:00.000Z', 'hash1'],
+          ['2024-01-02T10:00:01.000Z', 'hash2'],
+        ],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      // Probe samples zero rows, but the follow-up sweep extraction still finds real docs.
+      mockExecuteEsqlQuery
+        .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty())
+        .mockResolvedValueOnce(realDocsResponse);
+      mockIngestEntities.mockResolvedValue(undefined);
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(true);
+      // Nothing is silently dropped: the sweep extraction's real docs are still ingested.
+      expect(result.success && result.count).toBe(2);
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
+      expect(mockIngestEntities).toHaveBeenCalledTimes(1);
+      expect(mockIngestEntities).toHaveBeenCalledWith(
+        expect.objectContaining({ esqlResponse: realDocsResponse })
+      );
+    });
+
+    it('does not run a sweep extraction when an exact (unsampled) probe finds nothing', async () => {
+      // effectiveMaxLogsPerPage=1 (via maxLogsPerWindow=1) → pickSampleProbability(1)=1: too
+      // small for sampling to help, so the probe is exact. An empty result from an exact probe
+      // is definitive (no real docs can be missed the way a sampled probe can miss them), so
+      // the loop should stop immediately instead of running a redundant sweep extraction.
+      mockGlobalStateClient = createMockGlobalStateClient({ maxLogsPerWindow: 1 });
+      client = new LogsExtractionClient({
+        logger: mockLogger,
+        namespace: 'default',
+        esClient: mockEsClient,
+        dataViewsService: mockDataViewsService,
+        engineDescriptorClient: mockEngineDescriptorClient as unknown as EngineDescriptorClient,
+        globalStateClient: mockGlobalStateClient as unknown as EntityStoreGlobalStateClient,
+        ccsLogsExtractionClient: mockCcsLogsExtractionClient as unknown as CcsLogsExtractionClient,
+      });
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue({
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      } as any);
+      mockExecuteEsqlQuery.mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty());
+
+      const result = await client.extractLogs('user');
+
+      expect(result.success).toBe(true);
+      expect(result.success && result.count).toBe(0);
+      expect(result.success && result.logsProcessed).toBe(0);
+      expect(result.success && result.logsCapApplied).toBe(false);
+      // Only the single (empty) probe call — no follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+      expect(mockIngestEntities).not.toHaveBeenCalled();
     });
 
     it('should compute extraction window from lookbackPeriod and delay when no custom range', async () => {
@@ -354,14 +457,18 @@ describe('LogsExtractionClient', () => {
       const expectedFrom = moment.utc(fixedNow).subtract(3, 'hours').toISOString();
       const expectedTo = moment.utc(fixedNow).subtract(5, 'seconds').toISOString();
 
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.stringContaining(expectedFrom),
-      });
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.stringContaining(expectedTo),
-      });
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.stringContaining(expectedFrom),
+        })
+      );
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.stringContaining(expectedTo),
+        })
+      );
 
       jest.useRealTimers();
     });
@@ -463,14 +570,18 @@ describe('LogsExtractionClient', () => {
 
       const expectedTo = moment.utc(fixedNow).subtract(1, 'minute').toISOString();
 
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.stringContaining(checkpointTimestamp),
-      });
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.stringContaining(expectedTo),
-      });
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.stringContaining(checkpointTimestamp),
+        })
+      );
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.stringContaining(expectedTo),
+        })
+      );
 
       jest.useRealTimers();
     });
@@ -539,7 +650,8 @@ describe('LogsExtractionClient', () => {
       const result = await client.extractLogs('user');
 
       expect(result.success).toBe(true);
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
+      // probe, extraction, terminal empty probe, and its follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
       const firstProbeQuery = mockExecuteEsqlQuery.mock.calls[0][0].query;
       expect(firstProbeQuery).toContain(checkpointTimestamp);
       jest.useRealTimers();
@@ -631,14 +743,18 @@ describe('LogsExtractionClient', () => {
         specificWindow: { fromDateISO: fromDate, toDateISO: toDate },
       });
 
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.stringContaining(fromDate),
-      });
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
-        esClient: mockEsClient,
-        query: expect.stringContaining(toDate),
-      });
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.stringContaining(fromDate),
+        })
+      );
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+          query: expect.stringContaining(toDate),
+        })
+      );
       expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
     });
 
@@ -676,8 +792,9 @@ describe('LogsExtractionClient', () => {
 
       expect(result.success).toBe(true);
       expect(result.success && result.count).toBe(2);
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
-      expect(mockIngestEntities).toHaveBeenCalledTimes(1);
+      // probe, extraction, terminal empty probe, and its follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
+      expect(mockIngestEntities).toHaveBeenCalledTimes(2);
       expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
     });
 
@@ -772,7 +889,8 @@ describe('LogsExtractionClient', () => {
       expect(result.success && result.scannedIndices).toContain('metrics-*');
       expect(result.success && result.scannedIndices).toContain('remote_cluster:logs-*');
       expect(result.success && result.scannedIndices).toContain('other:filebeat-*');
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
+      // probe, extraction, terminal empty probe, and its follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
       expect(mockCcsLogsExtractionClient.extractToUpdates).toHaveBeenCalledTimes(1);
       expect(mockCcsLogsExtractionClient.extractToUpdates).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -817,8 +935,9 @@ describe('LogsExtractionClient', () => {
       expect(result.success && result.count).toBe(1);
       expect(result.success && result.scannedIndices).toContain('logs-*');
       expect(result.success && result.scannedIndices).toContain('remote_cluster:logs-*');
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
-      expect(mockIngestEntities).toHaveBeenCalledTimes(1);
+      // probe, extraction, terminal empty probe, and its follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
+      expect(mockIngestEntities).toHaveBeenCalledTimes(2);
 
       // CCS error is stored in the saved object alongside the cleared log extraction state.
       expect(mockEngineDescriptorClient.update).toHaveBeenCalledWith(
@@ -899,7 +1018,8 @@ describe('LogsExtractionClient', () => {
       await client.extractLogs('host');
 
       expect(mockEngineDescriptorClient.findOrThrow).toHaveBeenCalledWith('host');
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
+      // probe, extraction, terminal empty probe, and its follow-up sweep extraction.
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
       expect(mockIngestEntities).toHaveBeenCalledWith(
         expect.objectContaining({
           targetIndex: expect.stringContaining('.entities.v2.latest.security_default'),
@@ -993,6 +1113,10 @@ describe('LogsExtractionClient', () => {
         if (!result.success) return;
         expect(result.count).toBe(2);
         expect(result.logsCapApplied).toBe(true);
+        // effectiveMaxLogsPerPage=1 → pickSampleProbability(1)=1 (too small for sampling to help,
+        // falls back to an exact probe) → scaledProbeLimit(1, 1)=1 → LIMIT 1 → total_logs=1
+        // (saturated, not last) → sliceLogCount=round(1 / 1)=1 (exact, no estimation). This
+        // already meets maxLogsPerWindow=1, so the cap fires after slice 1.
         expect(result.logsProcessed).toBe(1);
 
         // Final engineDescriptorClient.update must NOT include logExtractionState —
@@ -1029,6 +1153,9 @@ describe('LogsExtractionClient', () => {
         if (!result.success) return;
         expect(result.count).toBe(2);
         expect(result.logsCapApplied).toBe(true);
+        // effectiveMaxLogsPerPage=1 → pickSampleProbability(1)=1 (exact probe) →
+        // scaledProbeLimit(1, 1)=1 → total_logs=1 (saturated) → sliceLogCount=round(1 / 1)=1,
+        // which already meets maxLogsPerWindow=1.
         expect(result.logsProcessed).toBe(1);
         expect(result.lastSearchTimestamp).toBe(effectiveWindowEnd);
 
@@ -1096,7 +1223,11 @@ describe('LogsExtractionClient', () => {
           ],
         };
         setupVolCapTest({ maxLogsPerWindow: 1, maxLogsPerWindowCapBehavior: 'defer' });
-        // effectiveMaxLogsPerPage=1 → LIMIT 1 → total_logs=1 → sliceLogCount=1
+        // effectiveMaxLogsPerPage=1 → pickSampleProbability(1)=1 (exact probe) →
+        // scaledProbeLimit(1, 1)=1 → LIMIT 1 → total_logs=1 (saturates the scaled limit, so not
+        // the last page) → sliceLogCount=round(1 / 1)=1, which already meets
+        // maxLogsPerWindow=1, so the cap fires after the first slice — the terminal empty probe
+        // below is never reached.
         mockExecuteEsqlQuery
           .mockResolvedValueOnce(mockLogPaginationCursorProbeRow(lastPageTimestamp, 1))
           .mockResolvedValueOnce(mainExtractionResponse)
@@ -1143,6 +1274,9 @@ describe('LogsExtractionClient', () => {
         expect(result.success).toBe(true);
         if (!result.success) return;
         expect(result.logsCapApplied).toBe(true);
+        // effectiveMaxLogsPerPage=1 → pickSampleProbability(1)=1 (exact probe) →
+        // scaledProbeLimit(1, 1)=1 → total_logs=1 (saturated) → sliceLogCount=round(1 / 1)=1,
+        // which already meets maxLogsPerWindow=1.
         expect(result.logsProcessed).toBe(1);
         // drop: lastSearchTimestamp is advanced to the window end
         expect(result.lastSearchTimestamp).toBe(toDateISO);
@@ -1156,7 +1290,9 @@ describe('LogsExtractionClient', () => {
       // Stall can only fire from iteration 2 onward (once `isFirstRunInThisCycle` is cleared).
       // Tests therefore use two slice iterations: slice 1 advances `checkpointTimestamp`
       // via `advanceEngineStateAfterLogPageCompletes`, and slice 2 is the stall candidate.
-      // After the stall, a terminal empty probe ends the loop (full-page count no longer signals last page).
+      // After the stall, a terminal empty probe is reached (full-page count no longer signals
+      // last page); a terminal empty probe is unified with the last-page path, so it still
+      // triggers one more (swept) extraction call before the loop actually ends.
 
       const setupStallTest = () => {
         mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
@@ -1177,21 +1313,27 @@ describe('LogsExtractionClient', () => {
 
         // Slice 1: ends at stalledTs (full page → not last, loop continues).
         // Slice 2: same stalledTs + full page → stall fires, extraction skipped, cursor bumped.
-        // Probe 3 (with bumpedTs): empty → loop ends.
+        // Probe 3 (with bumpedTs): empty → unified with the last-page path, so the loop still
+        // runs one more (swept) extraction over [bumpedTs, toDateISO] before ending.
         mockExecuteEsqlQuery
           .mockResolvedValueOnce(mockLogPaginationCursorProbeRow(stalledTs)) // slice 1, not last
           .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 1
           .mockResolvedValueOnce(
             mockLogPaginationCursorProbeRow(stalledTs, LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT) // slice 2: stall fires, extraction skipped
           )
-          .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty()); // probe 3 with bumpedTs → loop ends
+          .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty()) // probe 3 with bumpedTs → last page
+          .mockResolvedValueOnce({ columns: [], values: [] }); // follow-up sweep extraction → loop ends
 
         const result = await client.extractLogs('user');
 
         expect(result.success).toBe(true);
         expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+        // The message names the concrete effective per-page limit, not the (unavailable in this
+        // scope) raw config variable name.
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          expect.stringContaining(`Log-slice probe stalled at ${stalledTs}`)
+          expect.stringContaining(
+            `Log-slice probe stalled at ${stalledTs} with a saturated page; advancing cursor by 1ms. Docs sharing this timestamp beyond the configured per-page limit (${LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT}) will be dropped.`
+          )
         );
         // After the stall bump, a later update persists checkpointTimestamp = bumpedTs.
         const updateCalls = (mockEngineDescriptorClient.update as jest.Mock).mock.calls;
@@ -1207,7 +1349,8 @@ describe('LogsExtractionClient', () => {
         setupStallTest();
 
         // Slice 1 ends at ts1; slice 2 ends at ts2 (advances) → no stall.
-        // Full page (total=max) → isLastLogsPage=false → loop continues; terminal empty probe ends it.
+        // Full page (total=max) → isLastLogsPage=false → loop continues; terminal empty probe
+        // still triggers one more (swept) extraction before the loop ends.
         mockExecuteEsqlQuery
           .mockResolvedValueOnce(mockLogPaginationCursorProbeRow(ts1)) // slice 1, not last
           .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 1
@@ -1215,7 +1358,8 @@ describe('LogsExtractionClient', () => {
             mockLogPaginationCursorProbeRow(ts2, LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT) // full page, different ts → not last
           )
           .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction 2
-          .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty()); // terminal probe → loop ends
+          .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty()) // terminal probe → last page
+          .mockResolvedValueOnce({ columns: [], values: [] }); // follow-up sweep extraction → loop ends
 
         const result = await client.extractLogs('user');
 
@@ -1246,13 +1390,15 @@ describe('LogsExtractionClient', () => {
         setupStallTest();
 
         const someTs = '2024-01-02T10:00:00.000Z';
-        // Full page (total=max → isLastLogsPage=false): loop continues; terminal empty probe ends it.
+        // Full page (total=max → isLastLogsPage=false): loop continues; terminal empty probe
+        // still triggers one more (swept) extraction before the loop ends.
         mockExecuteEsqlQuery
           .mockResolvedValueOnce(
             mockLogPaginationCursorProbeRow(someTs, LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT)
           )
           .mockResolvedValueOnce({ columns: [], values: [] }) // entity extraction
-          .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty()); // terminal probe → loop ends
+          .mockResolvedValueOnce(mockLogPaginationCursorProbeEmpty()) // terminal probe → last page
+          .mockResolvedValueOnce({ columns: [], values: [] }); // follow-up sweep extraction → loop ends
 
         const result = await client.extractLogs('user');
 
@@ -1306,12 +1452,15 @@ describe('LogsExtractionClient', () => {
         const result = await client.extractLogs('user');
 
         expect(result.success).toBe(true);
-        // 6 sub-windows × 1 probe each. Each probe returns empty so the inner outer-loop never
-        // runs `advanceEngineStateAfterLogPageCompletes` — no per-slice persistence either.
-        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(6);
+        // 6 sub-windows × (1 probe + 1 follow-up sweep extraction) each. A terminal empty probe
+        // is unified with the last-page path: it still runs `advanceEngineStateAfterLogPageCompletes`
+        // and a swept extraction before that sub-window's inner loop ends, since a sampled probe
+        // returning zero rows does not prove the real remainder is empty.
+        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(12);
 
-        // Single update call: the final cleanup at the end of extractLogs.
-        expect(mockEngineDescriptorClient.update).toHaveBeenCalledTimes(1);
+        // 6 per-slice persistence calls (one per sub-window's inner loop) + 1 final cleanup call
+        // at the end of extractLogs.
+        expect(mockEngineDescriptorClient.update).toHaveBeenCalledTimes(7);
         expect(mockEngineDescriptorClient.update).toHaveBeenCalledWith(
           'user',
           expect.objectContaining({
@@ -1333,8 +1482,10 @@ describe('LogsExtractionClient', () => {
 
         await client.extractLogs('user');
 
-        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
-        expect(mockEngineDescriptorClient.update).toHaveBeenCalledTimes(1);
+        // 1 probe + 1 follow-up sweep extraction (terminal empty probe unified with last-page path).
+        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
+        // 1 per-slice persistence call (inner loop) + 1 final cleanup call.
+        expect(mockEngineDescriptorClient.update).toHaveBeenCalledTimes(2);
         expect(mockEngineDescriptorClient.update).toHaveBeenCalledWith(
           'user',
           expect.objectContaining({
@@ -1372,8 +1523,9 @@ describe('LogsExtractionClient', () => {
           specificWindow: { fromDateISO: fromDate, toDateISO: toDate },
         });
 
-        // A single probe over the full user-supplied window — no sub-window splitting.
-        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+        // A single probe over the full user-supplied window (no sub-window splitting), plus its
+        // follow-up sweep extraction; specificWindow mode never persists to the engine descriptor.
+        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
         const probeQuery = mockExecuteEsqlQuery.mock.calls[0][0].query;
         expect(probeQuery).toContain(fromDate);
         expect(probeQuery).toContain(toDate);
@@ -1390,17 +1542,20 @@ describe('LogsExtractionClient', () => {
 
         await client.extractLogs('user');
 
-        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(3);
+        // Each sub-window's terminal empty probe now also triggers a follow-up sweep extraction
+        // (same bounds as the probe), so calls interleave as [probe, sweep] per sub-window —
+        // index 0/2/4 are the probes, index 1/3/5 the sweeps.
+        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(6);
 
         const subWindow1 = mockExecuteEsqlQuery.mock.calls[0][0].query;
         expect(subWindow1).toContain('2025-01-15T11:44:00.000Z');
         expect(subWindow1).toContain('2025-01-15T11:49:00.000Z');
 
-        const subWindow2 = mockExecuteEsqlQuery.mock.calls[1][0].query;
+        const subWindow2 = mockExecuteEsqlQuery.mock.calls[2][0].query;
         expect(subWindow2).toContain('2025-01-15T11:49:00.000Z');
         expect(subWindow2).toContain('2025-01-15T11:54:00.000Z');
 
-        const subWindow3 = mockExecuteEsqlQuery.mock.calls[2][0].query;
+        const subWindow3 = mockExecuteEsqlQuery.mock.calls[4][0].query;
         expect(subWindow3).toContain('2025-01-15T11:54:00.000Z');
         expect(subWindow3).toContain(effectiveWindowEnd);
       });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -38,7 +38,7 @@ import {
   resolveMainExtractionWindow,
   validateExtractionWindow,
 } from './extraction_window';
-import { capAtMaxLogsPerWindow } from './effective_page_limits';
+import { capAtMaxLogsPerWindow, pickSampleProbability } from './effective_page_limits';
 import { getLatestEntitiesIndexName } from '../../../common/domain/entity_index';
 import { getUpdatesEntitiesDataStreamName } from '../asset_manager/updates_data_stream';
 import { executeEsqlQuery } from '../../infra/elasticsearch/esql';
@@ -523,6 +523,11 @@ export class LogsExtractionClient {
   }) {
     const effectiveMaxLogsPerPage = capAtMaxLogsPerWindow(maxLogsPerPage, maxLogsPerWindow);
     const effectiveDocsLimit = capAtMaxLogsPerWindow(docsLimit, maxLogsPerWindow);
+    // Escalates above the target probability (up to an exact, unsampled probe) once
+    // maxLogsPerPage is too small for the sampling estimator to be accurate — see
+    // pickSampleProbability. Computed once per loop invocation: effectiveMaxLogsPerPage is
+    // fixed for the whole loop.
+    const effectiveSampleProbability = pickSampleProbability(effectiveMaxLogsPerPage);
     let totalCount = 0;
     let totalLogs = 0;
     let pages = 0;
@@ -564,20 +569,36 @@ export class LogsExtractionClient {
           toDateISO,
           logsPageCursorStart,
           maxLogsPerPage: effectiveMaxLogsPerPage,
+          sampleProbability: effectiveSampleProbability,
           opts,
         });
 
-        if (!probe.hasLogsToProcess) {
+        if (!probe.hasLogsToProcess && effectiveSampleProbability >= 1) {
+          // Sampling wasn't active for this probe (maxLogsPerPage was too small — see
+          // pickSampleProbability), so an empty, exact result is definitive: no real docs
+          // remain. Stop immediately rather than running a redundant sweep extraction.
           break;
         }
 
-        let logsPageCursorEnd = probe.logsPaginationCursor;
         lastLogsPages = probe.isLastLogsPage;
+
+        let logsPageCursorEnd: LogSlicePaginationParams;
+        if (probe.hasLogsToProcess && !probe.isLastLogsPage) {
+          logsPageCursorEnd = probe.logsPaginationCursor;
+        } else {
+          // if the probe doesn't have more pages to process
+          // we keep the natural end of the window as the end cursor
+          // This is important because on low document count
+          // a sampled probe may return 0 documents. We need to still
+          // do a final extraction with the effective end of the window
+          // to ensure we don't miss any documents that may have been missed by the probe.
+          logsPageCursorEnd = { timestampCursor: toDateISO };
+        }
 
         const bumpedCursorEnd = this.detectLogSliceStall(
           logsPageCursorStart,
           logsPageCursorEnd,
-          probe.sliceLogCount,
+          !lastLogsPages,
           effectiveMaxLogsPerPage
         );
         if (bumpedCursorEnd) {
@@ -646,6 +667,7 @@ export class LogsExtractionClient {
     toDateISO,
     logsPageCursorStart,
     maxLogsPerPage,
+    sampleProbability,
     opts,
   }: {
     indexPatterns: string[];
@@ -654,6 +676,7 @@ export class LogsExtractionClient {
     toDateISO: string;
     logsPageCursorStart: LogSlicePaginationParams | undefined;
     maxLogsPerPage: number;
+    sampleProbability: number;
     opts?: LogsExtractionOptions;
   }): Promise<LogPaginationCursor> {
     const logPaginationCursorProbeQuery = buildLogPaginationCursorProbeEsql({
@@ -663,19 +686,26 @@ export class LogsExtractionClient {
       toDateISO,
       logsPageCursorStart,
       maxLogsPerPage,
+      sampleProbability,
     });
 
     const logPaginationCursorProbeResponse = await executeEsqlQuery({
       esClient: this.esClient,
       query: logPaginationCursorProbeQuery,
       abortController: opts?.abortController,
+      telemetry: {
+        name: 'probe_query',
+        namespace: this.namespace,
+        type,
+      },
     });
 
     const parsedLogPaginationCursor = parseLogPaginationCursorRow(logPaginationCursorProbeResponse);
 
     const interpretedLogPaginationCursor = interpretLogPaginationCursorRows(
       parsedLogPaginationCursor,
-      maxLogsPerPage
+      maxLogsPerPage,
+      sampleProbability
     );
 
     if (parsedLogPaginationCursor) {
@@ -684,16 +714,7 @@ export class LogsExtractionClient {
       );
     }
 
-    if (!interpretedLogPaginationCursor.hasLogsToProcess) {
-      return { hasLogsToProcess: false };
-    }
-
-    return {
-      hasLogsToProcess: true,
-      logsPaginationCursor: interpretedLogPaginationCursor.logsPaginationCursor,
-      isLastLogsPage: interpretedLogPaginationCursor.isLastLogsPage,
-      sliceLogCount: interpretedLogPaginationCursor.sliceLogCount,
-    };
+    return interpretedLogPaginationCursor;
   }
 
   /**
@@ -767,6 +788,11 @@ export class LogsExtractionClient {
         esClient: this.esClient,
         query,
         abortController: opts?.abortController,
+        telemetry: {
+          name: 'extraction_query',
+          namespace: this.namespace,
+          type,
+        },
       });
 
       addedToTotalCount += esqlResponse.values.length;
@@ -813,21 +839,21 @@ export class LogsExtractionClient {
     };
   }
 
-  /** Returns the bumped slice-end cursor when a stall is detected, null otherwise. Logs a warning on stall. */
+  /**
+   * Returns the bumped slice-end cursor when a stall is detected, null otherwise. Logs a
+   * warning on stall. `isFullPage` is `true` when the (possibly sampled) probe saturated its
+   * limit — i.e. this iteration was not resolved as the last page.
+   */
   private detectLogSliceStall(
     sliceStart: LogSlicePaginationParams | undefined,
     sliceEnd: LogSlicePaginationParams,
-    sliceLogCount: number,
-    maxLogsPerPage: number
+    isFullPage: boolean,
+    effectiveMaxLogsPerPage: number
   ): LogSlicePaginationParams | null {
-    if (
-      sliceStart &&
-      sliceStart.timestampCursor === sliceEnd.timestampCursor &&
-      sliceLogCount >= maxLogsPerPage
-    ) {
+    if (sliceStart && sliceStart.timestampCursor === sliceEnd.timestampCursor && isFullPage) {
       const bumpedTs = moment(sliceEnd.timestampCursor).add(1, 'ms').toISOString();
       this.logger.warn(
-        `Log-slice probe stalled at ${sliceEnd.timestampCursor} with a full page (${sliceLogCount} docs); advancing cursor by 1ms. Docs sharing this timestamp beyond maxLogsPerPage will be dropped.`
+        `Log-slice probe stalled at ${sliceEnd.timestampCursor} with a saturated page; advancing cursor by 1ms. Docs sharing this timestamp beyond the configured per-page limit (${effectiveMaxLogsPerPage}) will be dropped.`
       );
       return { timestampCursor: bumpedTs };
     }

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/esql.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/esql.test.ts
@@ -6,7 +6,53 @@
  */
 
 import type { ESQLSearchResponse } from '@kbn/es-types';
-import { esqlResponseToBulkObjects } from './esql';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { esqlResponseToBulkObjects, executeEsqlQuery } from './esql';
+
+function createMockEsClient(response: ESQLSearchResponse) {
+  return {
+    esql: {
+      query: jest.fn().mockResolvedValue(response),
+    },
+  } as unknown as jest.Mocked<ElasticsearchClient>;
+}
+
+describe('executeEsqlQuery', () => {
+  const response: ESQLSearchResponse = {
+    columns: [{ name: 'entity.id', type: 'keyword' }],
+    values: [['host:h1']],
+  };
+
+  it('runs the query directly and returns the response when telemetry is omitted', async () => {
+    const esClient = createMockEsClient(response);
+
+    const result = await executeEsqlQuery({ esClient, query: 'FROM logs-*' });
+
+    expect(result).toEqual(response);
+    expect(esClient.esql.query).toHaveBeenCalledTimes(1);
+    expect(esClient.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM logs-*' }),
+      expect.any(Object)
+    );
+  });
+
+  it('still runs the query and returns the response when telemetry is provided', async () => {
+    const esClient = createMockEsClient(response);
+
+    const result = await executeEsqlQuery({
+      esClient,
+      query: 'FROM logs-*',
+      telemetry: {
+        name: 'probe_query',
+        namespace: 'default',
+        type: 'host',
+      },
+    });
+
+    expect(result).toEqual(response);
+    expect(esClient.esql.query).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('esqlResponseToBulkObjects', () => {
   it('converts columnar ESQL response to bulk objects with type and doc', () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/esql.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/esql.ts
@@ -11,15 +11,28 @@ import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { EntityType } from '../../../common/domain/definitions/entity_schema';
 import type { Entity } from '../../../common/domain/definitions/entity.gen';
+import { runWithSpan } from '../../telemetry/traces';
+
+/**
+ * When provided, the query execution is wrapped in an APM/OTel span via `runWithSpan`. `name`
+ * is the short operation identifier (e.g. `probe_query`, `extraction_query`) — callers on the
+ * remote/CCS path distinguish themselves with a `remote_` prefix (e.g. `remote_probe_query`).
+ */
+export interface ExecuteEsqlQueryTelemetry {
+  name: string;
+  namespace: string;
+  type: EntityType;
+}
 
 interface ExecuteEsqlQueryParams {
   esClient: ElasticsearchClient;
   query: string;
   abortController?: AbortController;
   excludeColdFrozenTiers?: boolean;
+  telemetry?: ExecuteEsqlQueryTelemetry;
 }
 
-export const executeEsqlQuery = async ({
+const doExecuteEsqlQuery = async ({
   esClient,
   query,
   abortController,
@@ -41,6 +54,25 @@ export const executeEsqlQuery = async ({
   )) as unknown as ESQLSearchResponse;
 
   return response;
+};
+
+export const executeEsqlQuery = async ({
+  telemetry,
+  ...params
+}: ExecuteEsqlQueryParams): Promise<ESQLSearchResponse> => {
+  if (!telemetry) {
+    return doExecuteEsqlQuery(params);
+  }
+
+  return runWithSpan({
+    name: `entityStore.logs_extraction.${telemetry.name}`,
+    namespace: telemetry.namespace,
+    attributes: {
+      'entity_store.logs_extraction.operation': telemetry.name,
+      'entity_store.entity.type': telemetry.type,
+    },
+    cb: () => doExecuteEsqlQuery(params),
+  });
 };
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Store] Use ES|QL SAMPLE for the logs-extraction pagination probe (#276211)](https://github.com/elastic/kibana/pull/276211)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rômulo Farias","email":"romulo.farias@elastic.co"},"sourceCommit":{"committedDate":"2026-07-06T15:44:59Z","message":"[Entity Store] Use ES|QL SAMPLE for the logs-extraction pagination probe (#276211)\n\n## Summary\n\nReplaces the exact `SORT | LIMIT | STATS` boundary probe run before\nevery log slice with an ES|QL `SAMPLE`-based probe, adopting the\napproach investigated in #273261.\n\n- The probe now prepends `| SAMPLE p` before the sort, which pushes down\nto Lucene and cuts scanned docs ~6-8x at the default `p=0.1`, while the\nsampled boundary's relative error stays within ~1-2% (validated against\nthe theoretical variance model, `relative error ≈\n1/√(p·maxLogsPerPage)`).\n- The real extraction query always re-scans the resulting `[start, end]`\nwindow and ingests idempotently, so sampling cannot drop data —\n**except** at loop termination, which required an explicit fix: a\nnon-saturated or empty probe now always sweeps the final page to the\nwindow's fixed end (not the sampled boundary) before the loop stops,\nsince a sampled probe returning zero rows does not prove zero real docs\nremain (e.g. a couple of docs left, ~90% chance neither gets sampled at\n`p=0.1`).\n- Sampling probability is **adaptive** (`pickSampleProbability`): it\nescalates above the `0.1` target as `maxLogsPerPage` shrinks, falling\nback to `p=1` (an exact, unsampled probe — byte-for-byte identical to\nthe original query) once `maxLogsPerPage` is too small (`<= 2500`) for\nthe sampling estimator's accuracy guarantee to hold. This keeps\nsmall-scale/test configurations exact and deterministic.\n- Volume-cap accounting (`maxLogsPerWindow`) now uses the estimated real\nlog count (`sliceLogCount = round(sampledCount / p)`) rather than the\nexact sampled count.\n\n## Benchmark\n\nValidated against a real cluster (host + user entity definitions, 600+\nsampled probe windows): pushdown confirmed (docs scanned scale with\n`p`), and mean processed-log count stayed within 0.3% of the page target\nacross all tested sampling probabilities.\n\n## Test plan\n\n- [x] Unit tests updated/added across\n`log_pagination_probe_query_builder.test.ts`,\n`logs_extraction_client.test.ts`,\n`remote_logs_extraction_client.test.ts`, and new\n`effective_page_limits.test.ts` (171 tests passing)\n- [x] `node scripts/type_check` clean\n- [x] Scout API tests (`ccs_logs_extraction.spec.ts`,\n`logs_extraction_volume_cap.spec.ts`) pass against a local cluster with\nno test-file changes required\n\nRef: https://github.com/elastic/kibana/issues/273261\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","sha":"16aed3a4353b48b3cc55a782793cc74de304901c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:cloud-deploy","ci:project-deploy-security","backport:version","reviewer:claude","v9.5.0","v9.4.4"],"title":"[Entity Store] Use ES|QL SAMPLE for the logs-extraction pagination probe","number":276211,"url":"https://github.com/elastic/kibana/pull/276211","mergeCommit":{"message":"[Entity Store] Use ES|QL SAMPLE for the logs-extraction pagination probe (#276211)\n\n## Summary\n\nReplaces the exact `SORT | LIMIT | STATS` boundary probe run before\nevery log slice with an ES|QL `SAMPLE`-based probe, adopting the\napproach investigated in #273261.\n\n- The probe now prepends `| SAMPLE p` before the sort, which pushes down\nto Lucene and cuts scanned docs ~6-8x at the default `p=0.1`, while the\nsampled boundary's relative error stays within ~1-2% (validated against\nthe theoretical variance model, `relative error ≈\n1/√(p·maxLogsPerPage)`).\n- The real extraction query always re-scans the resulting `[start, end]`\nwindow and ingests idempotently, so sampling cannot drop data —\n**except** at loop termination, which required an explicit fix: a\nnon-saturated or empty probe now always sweeps the final page to the\nwindow's fixed end (not the sampled boundary) before the loop stops,\nsince a sampled probe returning zero rows does not prove zero real docs\nremain (e.g. a couple of docs left, ~90% chance neither gets sampled at\n`p=0.1`).\n- Sampling probability is **adaptive** (`pickSampleProbability`): it\nescalates above the `0.1` target as `maxLogsPerPage` shrinks, falling\nback to `p=1` (an exact, unsampled probe — byte-for-byte identical to\nthe original query) once `maxLogsPerPage` is too small (`<= 2500`) for\nthe sampling estimator's accuracy guarantee to hold. This keeps\nsmall-scale/test configurations exact and deterministic.\n- Volume-cap accounting (`maxLogsPerWindow`) now uses the estimated real\nlog count (`sliceLogCount = round(sampledCount / p)`) rather than the\nexact sampled count.\n\n## Benchmark\n\nValidated against a real cluster (host + user entity definitions, 600+\nsampled probe windows): pushdown confirmed (docs scanned scale with\n`p`), and mean processed-log count stayed within 0.3% of the page target\nacross all tested sampling probabilities.\n\n## Test plan\n\n- [x] Unit tests updated/added across\n`log_pagination_probe_query_builder.test.ts`,\n`logs_extraction_client.test.ts`,\n`remote_logs_extraction_client.test.ts`, and new\n`effective_page_limits.test.ts` (171 tests passing)\n- [x] `node scripts/type_check` clean\n- [x] Scout API tests (`ccs_logs_extraction.spec.ts`,\n`logs_extraction_volume_cap.spec.ts`) pass against a local cluster with\nno test-file changes required\n\nRef: https://github.com/elastic/kibana/issues/273261\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","sha":"16aed3a4353b48b3cc55a782793cc74de304901c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276211","number":276211,"mergeCommit":{"message":"[Entity Store] Use ES|QL SAMPLE for the logs-extraction pagination probe (#276211)\n\n## Summary\n\nReplaces the exact `SORT | LIMIT | STATS` boundary probe run before\nevery log slice with an ES|QL `SAMPLE`-based probe, adopting the\napproach investigated in #273261.\n\n- The probe now prepends `| SAMPLE p` before the sort, which pushes down\nto Lucene and cuts scanned docs ~6-8x at the default `p=0.1`, while the\nsampled boundary's relative error stays within ~1-2% (validated against\nthe theoretical variance model, `relative error ≈\n1/√(p·maxLogsPerPage)`).\n- The real extraction query always re-scans the resulting `[start, end]`\nwindow and ingests idempotently, so sampling cannot drop data —\n**except** at loop termination, which required an explicit fix: a\nnon-saturated or empty probe now always sweeps the final page to the\nwindow's fixed end (not the sampled boundary) before the loop stops,\nsince a sampled probe returning zero rows does not prove zero real docs\nremain (e.g. a couple of docs left, ~90% chance neither gets sampled at\n`p=0.1`).\n- Sampling probability is **adaptive** (`pickSampleProbability`): it\nescalates above the `0.1` target as `maxLogsPerPage` shrinks, falling\nback to `p=1` (an exact, unsampled probe — byte-for-byte identical to\nthe original query) once `maxLogsPerPage` is too small (`<= 2500`) for\nthe sampling estimator's accuracy guarantee to hold. This keeps\nsmall-scale/test configurations exact and deterministic.\n- Volume-cap accounting (`maxLogsPerWindow`) now uses the estimated real\nlog count (`sliceLogCount = round(sampledCount / p)`) rather than the\nexact sampled count.\n\n## Benchmark\n\nValidated against a real cluster (host + user entity definitions, 600+\nsampled probe windows): pushdown confirmed (docs scanned scale with\n`p`), and mean processed-log count stayed within 0.3% of the page target\nacross all tested sampling probabilities.\n\n## Test plan\n\n- [x] Unit tests updated/added across\n`log_pagination_probe_query_builder.test.ts`,\n`logs_extraction_client.test.ts`,\n`remote_logs_extraction_client.test.ts`, and new\n`effective_page_limits.test.ts` (171 tests passing)\n- [x] `node scripts/type_check` clean\n- [x] Scout API tests (`ccs_logs_extraction.spec.ts`,\n`logs_extraction_volume_cap.spec.ts`) pass against a local cluster with\nno test-file changes required\n\nRef: https://github.com/elastic/kibana/issues/273261\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","sha":"16aed3a4353b48b3cc55a782793cc74de304901c"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->