### PR TITLE
[DO NOT MERGE] Add metering cluster id debug logs

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/metering/metering_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/metering/metering_service.ts
@@ -50,17 +50,42 @@ export class WorkflowsMeteringService {
     const instanceGroupId = projectId || deploymentId;
     const instanceGroupType = projectId ? 'serverless_project' : 'stateful_deployment';
 
+    this.logger.debug(() => {
+      return `[reportWorkflowExecution] Preparing workflow metering report: ${JSON.stringify({
+        executionId: execution.id,
+        workflowId: execution.workflowId,
+        status: execution.status,
+        projectId,
+        deploymentId,
+        instanceGroupId,
+        instanceGroupType,
+        cloudIdPresent: Boolean(cloudSetup?.cloudId),
+        csp: cloudSetup?.csp,
+        region: cloudSetup?.region,
+        elasticsearchClusterId: cloudSetup?.elasticsearchClusterId,
+      })}`;
+    });
+
     // Self-managed: no metering (no projectId or deploymentId available)
     if (!instanceGroupId) {
+      this.logger.debug(
+        `[reportWorkflowExecution] Skipping workflow metering report for execution ${execution.id}: missing projectId/deploymentId`
+      );
       return;
     }
 
     // Only report for terminal states; skip SKIPPED executions since they
     // were dropped by concurrency limits and never actually ran.
     if (!isTerminalStatus(execution.status as ExecutionStatus)) {
+      this.logger.debug(
+        `[reportWorkflowExecution] Skipping workflow metering report for execution ${execution.id}: non-terminal status ${execution.status}`
+      );
       return;
     }
     if (execution.status === ExecutionStatus.SKIPPED) {
+      this.logger.debug(
+        `[reportWorkflowExecution] Skipping workflow metering report for execution ${execution.id}: skipped execution`
+      );
       return;
     }
 
@@ -72,14 +97,34 @@ export class WorkflowsMeteringService {
     );
 
     try {
+      this.logger.debug(() => {
+        return `[reportWorkflowExecution] Sending workflow metering record: ${JSON.stringify(
+          usageRecord,
+          undefined,
+          2
+        )}`;
+      });
       await this.usageReportingService.reportUsage([usageRecord]);
+      this.logger.debug(() => {
+        return `[reportWorkflowExecution] Successfully sent workflow metering record: ${JSON.stringify(
+          {
+            executionId: execution.id,
+            recordId: usageRecord.id,
+            source: usageRecord.source,
+          },
+          undefined,
+          2
+        )}`;
+      });
     } catch (err) {
       // Log with billing-relevant details per monitoring requirements:
       // project ID, type, and count for impact assessment
       const errorMessage = err instanceof Error ? err.message : String(err);
       this.logger.error(
         `Failed to report workflow metering for execution ${execution.id} ` +
-          `(instanceGroupId=${instanceGroupId}, type=${WORKFLOWS_USAGE_TYPE}, quantity=1): ${errorMessage}`
+          `(instanceGroupId=${instanceGroupId}, type=${WORKFLOWS_USAGE_TYPE}, quantity=1, source=${JSON.stringify(
+            usageRecord.source
+          )}): ${errorMessage}`
       );
     }
   }
@@ -143,6 +188,15 @@ export class WorkflowsMeteringService {
       source.region = cloudSetup?.region;
 
       const clusterId = cloudSetup?.elasticsearchClusterId;
+      this.logger.debug(() => {
+        return `[buildUsageRecord] Workflow stateful source enrichment: ${JSON.stringify({
+          instanceGroupId,
+          provider: source.provider,
+          region: source.region,
+          elasticsearchClusterId: clusterId,
+          hasClusterMetadata: Boolean(clusterId),
+        })}`;
+      });
       if (clusterId) {
         source.metadata = { cluster_id: clusterId };
       }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/metering/metering_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/metering/metering_service.ts
@@ -49,9 +49,17 @@ class MeteringServiceImpl implements MeteringService {
 
   public async reportExecution(execution: AgentExecutionUsage) {
     if (!this.cloud || !this.usageApi?.usageReporting) {
-      this.logger.debug(
-        `[reportExecution] Skipping reporting due to missing cloud or usage reporting dependencies.`
-      );
+      this.logger.debug(() => {
+        return `[reportExecution] Skipping agent builder metering report due to missing dependencies: ${JSON.stringify(
+          {
+            hasCloud: Boolean(this.cloud),
+            hasUsageApi: Boolean(this.usageApi),
+            hasUsageReporting: Boolean(this.usageApi?.usageReporting),
+            executionId: execution.executionId,
+            agentId: execution.agentId,
+          }
+        )}`;
+      });
       return;
     }
 
@@ -59,8 +67,25 @@ class MeteringServiceImpl implements MeteringService {
     const projectOrDeploymentId = projectId ?? this.cloud.deploymentId;
     const instanceGroupType = projectId ? 'serverless_project' : 'stateful_deployment';
 
+    this.logger.debug(() => {
+      return `[reportExecution] Preparing agent builder metering report: ${JSON.stringify({
+        executionId: execution.executionId,
+        agentId: execution.agentId,
+        projectId,
+        deploymentId: this.cloud?.deploymentId,
+        instanceGroupId: projectOrDeploymentId,
+        instanceGroupType,
+        cloudIdPresent: Boolean(this.cloud?.cloudId),
+        csp: this.cloud?.csp,
+        region: this.cloud?.region,
+        elasticsearchClusterId: this.cloud?.elasticsearchClusterId,
+      })}`;
+    });
+
     if (!projectOrDeploymentId) {
-      this.logger.debug(`[reportExecution] Skipping reporting due to project or deployment ID.`);
+      this.logger.debug(
+        `[reportExecution] Skipping agent builder metering report for execution ${execution.executionId}: missing projectId/deploymentId`
+      );
       return;
     }
 
@@ -107,6 +132,16 @@ class MeteringServiceImpl implements MeteringService {
       source.region = this.cloud.region;
 
       const clusterId = this.cloud.elasticsearchClusterId;
+      this.logger.debug(() => {
+        return `[reportExecution] Agent builder stateful source enrichment: ${JSON.stringify({
+          executionId,
+          instanceGroupId: projectOrDeploymentId,
+          provider: source.provider,
+          region: source.region,
+          elasticsearchClusterId: clusterId,
+          hasClusterMetadata: Boolean(clusterId),
+        })}`;
+      });
       if (clusterId) {
         source.metadata = { cluster_id: clusterId };
       }
@@ -126,9 +161,24 @@ class MeteringServiceImpl implements MeteringService {
     };
 
     this.logger.debug(() => {
-      return `[reportExecution] Reporting usage: ${JSON.stringify(record, undefined, 2)}`;
+      return `[reportExecution] Sending agent builder metering record: ${JSON.stringify(
+        record,
+        undefined,
+        2
+      )}`;
     });
 
     await this.usageApi.usageReporting.reportUsage([record]);
+    this.logger.debug(() => {
+      return `[reportExecution] Successfully sent agent builder metering record: ${JSON.stringify(
+        {
+          executionId,
+          recordId: record.id,
+          source: record.source,
+        },
+        undefined,
+        2
+      )}`;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Replacement debug PR branched directly from latest `upstream/main` after closing https://github.com/elastic/kibana/pull/276481.
- Adds verbose debug logging around Workflows and Agent Builder metering inputs, source enrichment, final UsageRecords, send success, and Workflows error context.
- Intended to build a QA image and verify whether `elasticsearchClusterId` is present and copied into `source.metadata.cluster_id`.

## Test plan
- Not run; this PR is only for QA debug image validation.
- Pre-commit hook linted the two changed files successfully.

## Notes
- Logs include whether Cloud ID is present, provider/region, deployment/project ids, derived `elasticsearchClusterId`, and final `source.metadata`.
- This should not be merged as-is.

Made with [Cursor](https://cursor.com)