### PR TITLE
[APM][Service Flyout] Make charts grid responsive to flyout width

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/index.tsx
@@ -108,6 +108,7 @@ export function ServiceFlyout({
         size="m"
         paddingSize="m"
         resizable
+        minWidth={400}
         session="start"
         flyoutMenuProps={{ title }}
         aria-labelledby={titleId}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIconTip,
@@ -14,7 +13,9 @@ import {
   EuiSkeletonTitle,
   EuiSpacer,
   EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { ServiceFlyoutTransactionsSection } from '@kbn/apm-ui-shared';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo, useState } from 'react';
@@ -74,7 +75,6 @@ function ServiceFlyoutChartsSection({
   title,
   description,
   charts,
-  columns = 2,
   rangeFrom,
   rangeTo,
   refreshToken,
@@ -83,11 +83,12 @@ function ServiceFlyoutChartsSection({
   title: string;
   description?: string;
   charts: FlyoutLensChartDefinition[];
-  columns?: 2 | 3;
   rangeFrom: string;
   rangeTo: string;
   refreshToken: number;
 }) {
+  const { euiTheme } = useEuiTheme();
+
   return (
     <>
       <EuiFlexGroup
@@ -108,21 +109,26 @@ function ServiceFlyoutChartsSection({
         ) : null}
       </EuiFlexGroup>
       <EuiSpacer size="s" />
-      <EuiFlexGrid columns={columns} responsive={false} gutterSize="m">
+      <div
+        css={css`
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+          gap: ${euiTheme.size.m};
+        `}
+      >
         {charts.map((chart) => (
-          <EuiFlexItem key={chart.id}>
-            <ServiceFlyoutLensChart
-              id={chart.id}
-              title={chart.title}
-              titleAction={chart.titleAction}
-              config={chart.config}
-              rangeFrom={rangeFrom}
-              rangeTo={rangeTo}
-              refreshToken={refreshToken}
-            />
-          </EuiFlexItem>
+          <ServiceFlyoutLensChart
+            key={chart.id}
+            id={chart.id}
+            title={chart.title}
+            titleAction={chart.titleAction}
+            config={chart.config}
+            rangeFrom={rangeFrom}
+            rangeTo={rangeTo}
+            refreshToken={refreshToken}
+          />
         ))}
-      </EuiFlexGrid>
+      </div>
     </>
   );
 }
@@ -193,7 +199,6 @@ export function ServiceFlyoutOverview({
             id="keyMetrics"
             title={KEY_METRICS_SECTION_TITLE}
             charts={keyMetrics}
-            columns={3}
             rangeFrom={rangeFrom}
             rangeTo={rangeTo}
             refreshToken={refreshToken}


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/266716

The service flyout metrics charts used a fixed 3-column `EuiFlexGrid` with `responsive={false}`, meaning they never adapted regardless of how narrow the flyout was.

The chart grid is replaced with a CSS grid using `repeat(auto-fit, minmax(200px, 1fr))`, making it container-aware: columns are added or removed based on the flyout's actual width rather than the viewport. `auto-fit` ensures that when charts don't fill a complete row, they expand to fill the available space rather than leaving gaps. A `minWidth` of 400px is also set on the flyout so it cannot be resized to an unusable size.


Before|After
|-|-|
|<img alt="service_flyout_layout_before" src="https://github.com/user-attachments/assets/949468ba-bb6a-4bd6-98ab-3ab8182c6c9d" />|<img alt="service_flyout_layout_after" src="https://github.com/user-attachments/assets/4bdcc0db-26b8-42e7-aaff-c906c653adb4" />|
