### PR TITLE
[9.4] [js-yaml to yaml migration] @elastic/kibana-cases (#252350)

### DIFF
--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/manage_templates_sub_privilege.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/manage_templates_sub_privilege.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import yaml from 'js-yaml';
+import { stringify } from 'yaml';
 
 import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { deleteAllCaseItems, getSpaceUrlPrefix } from '../../../common/lib/api';
@@ -22,7 +22,7 @@ const TEMPLATES_BULK_DELETE_URL = '/internal/cases/templates/_bulk_delete';
 const buildCreateTemplateBody = (owner: string) => ({
   name: 'Test Template',
   owner,
-  definition: yaml.dump({
+  definition: stringify({
     name: 'Test Template',
     fields: [{ control: 'INPUT_TEXT', name: 'field_one', label: 'Field One', type: 'keyword' }],
   }),
@@ -152,7 +152,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .set('kbn-xsrf', 'true')
           .send({
             owner: 'securitySolutionFixture',
-            definition: yaml.dump({
+            definition: stringify({
               name: 'Updated',
               fields: [{ control: 'INPUT_TEXT', name: 'f', label: 'F', type: 'keyword' }],
             }),
@@ -167,7 +167,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .set('kbn-xsrf', 'true')
           .send({
             owner: 'securitySolutionFixture',
-            definition: yaml.dump({
+            definition: stringify({
               name: 'Updated',
               fields: [{ control: 'INPUT_TEXT', name: 'f', label: 'F', type: 'keyword' }],
             }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[js-yaml to yaml migration] @elastic/kibana-cases (#252350)](https://github.com/elastic/kibana/pull/252350)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-07T07:37:38Z","message":"[js-yaml to yaml migration] @elastic/kibana-cases (#252350)\n\nCloses #267872\n\n## Migration: js-yaml → yaml\n\nThis PR migrates the 2 files owned by @elastic/kibana-cases that\nreference `js-yaml` over to the `yaml` package.\n\nBoth files are FTR API integration tests under\n`x-pack/platform/test/cases_api_integration/`. They use the YAML\nserializer only to build the `definition` string for case-template test\npayloads. Using the `yaml` package here matches the convention already\nestablished by sibling tests in the same suite (e.g.\n`internal/extended_fields_global.ts`, `internal/required_on_close.ts`).\n\n### Changes\n- Replaced `import yaml from 'js-yaml'` with `import { stringify } from\n'yaml'`.\n- Replaced `yaml.dump(...)` with `stringify(...)` (4 call sites total: 3\nin `manage_templates_sub_privilege.ts`, 1 in\n`search_cases_extended_fields.ts`).\n\nNo option mapping was required — the calls passed no options, and\n`stringify()` produces equivalent valid YAML for these payloads.\n\n### Files Changed\n-\n`x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/manage_templates_sub_privilege.ts`\n-\n`x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/search_cases_extended_fields.ts`\n\n### Testing\n- Type check passes: `node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`.\n\n---\n\n**Note:** Part of the broader `js-yaml` → `yaml` migration effort; other\nteams' files are tracked in separate PRs.\n\n🤖 This PR was co-authored by one or more robots.","sha":"39043795033017f1394abbc494ae49d7c9ddaf73","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0"],"title":"[js-yaml to yaml migration] @elastic/kibana-cases","number":252350,"url":"https://github.com/elastic/kibana/pull/252350","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/kibana-cases (#252350)\n\nCloses #267872\n\n## Migration: js-yaml → yaml\n\nThis PR migrates the 2 files owned by @elastic/kibana-cases that\nreference `js-yaml` over to the `yaml` package.\n\nBoth files are FTR API integration tests under\n`x-pack/platform/test/cases_api_integration/`. They use the YAML\nserializer only to build the `definition` string for case-template test\npayloads. Using the `yaml` package here matches the convention already\nestablished by sibling tests in the same suite (e.g.\n`internal/extended_fields_global.ts`, `internal/required_on_close.ts`).\n\n### Changes\n- Replaced `import yaml from 'js-yaml'` with `import { stringify } from\n'yaml'`.\n- Replaced `yaml.dump(...)` with `stringify(...)` (4 call sites total: 3\nin `manage_templates_sub_privilege.ts`, 1 in\n`search_cases_extended_fields.ts`).\n\nNo option mapping was required — the calls passed no options, and\n`stringify()` produces equivalent valid YAML for these payloads.\n\n### Files Changed\n-\n`x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/manage_templates_sub_privilege.ts`\n-\n`x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/search_cases_extended_fields.ts`\n\n### Testing\n- Type check passes: `node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`.\n\n---\n\n**Note:** Part of the broader `js-yaml` → `yaml` migration effort; other\nteams' files are tracked in separate PRs.\n\n🤖 This PR was co-authored by one or more robots.","sha":"39043795033017f1394abbc494ae49d7c9ddaf73"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252350","number":252350,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/kibana-cases (#252350)\n\nCloses #267872\n\n## Migration: js-yaml → yaml\n\nThis PR migrates the 2 files owned by @elastic/kibana-cases that\nreference `js-yaml` over to the `yaml` package.\n\nBoth files are FTR API integration tests under\n`x-pack/platform/test/cases_api_integration/`. They use the YAML\nserializer only to build the `definition` string for case-template test\npayloads. Using the `yaml` package here matches the convention already\nestablished by sibling tests in the same suite (e.g.\n`internal/extended_fields_global.ts`, `internal/required_on_close.ts`).\n\n### Changes\n- Replaced `import yaml from 'js-yaml'` with `import { stringify } from\n'yaml'`.\n- Replaced `yaml.dump(...)` with `stringify(...)` (4 call sites total: 3\nin `manage_templates_sub_privilege.ts`, 1 in\n`search_cases_extended_fields.ts`).\n\nNo option mapping was required — the calls passed no options, and\n`stringify()` produces equivalent valid YAML for these payloads.\n\n### Files Changed\n-\n`x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/manage_templates_sub_privilege.ts`\n-\n`x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/search_cases_extended_fields.ts`\n\n### Testing\n- Type check passes: `node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`.\n\n---\n\n**Note:** Part of the broader `js-yaml` → `yaml` migration effort; other\nteams' files are tracked in separate PRs.\n\n🤖 This PR was co-authored by one or more robots.","sha":"39043795033017f1394abbc494ae49d7c9ddaf73"}}]}] BACKPORT-->