### PR TITLE
Stabilize ML anomaly detection alert flyout FTR test

### DIFF
--- a/x-pack/platform/test/functional_with_es_ssl/page_objects/triggers_actions_ui_page.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/page_objects/triggers_actions_ui_page.ts
@@ -192,9 +192,8 @@ export function TriggersActionsPageProvider({ getService }: FtrProviderContext) 
     },
     async saveAlert() {
       await testSubjects.click('rulePageFooterSaveButton');
-      const isConfirmationModalVisible = await testSubjects.isDisplayed('confirmCreateRuleModal');
-      expect(isConfirmationModalVisible).to.eql(true, 'Expect confirmation modal to be visible');
-      await testSubjects.click('confirmModalConfirmButton');
+      await testSubjects.existOrFail('confirmCreateRuleModal');
+      await testSubjects.click('confirmCreateRuleModal > confirmModalConfirmButton');
     },
     async ensureRuleActionStatusApplied(
       ruleName: string,


### PR DESCRIPTION
## Summary

This stabilizes the ML anomaly detection alert flyout FTR test that has been flaky in RSPack runs when creating an anomaly detection rule with no actions.

The failing run clicked the rule create footer save button and immediately checked whether `confirmCreateRuleModal` was displayed. The screenshot showed the confirmation modal was already on screen, but it was still in the EUI modal fade-in state, so Selenium's `isDisplayed()` could return `false` because elements with `opacity: 0` are treated as hidden.

## Evidence

- Latest investigated RSPack FTR failure artifact: [anomaly detection alert flyout failure report](https://web.buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/019df498-83c7-41cf-ab8a-722570e4e92e/019f3b60-7fff-4e3c-b223-2b9cf85fc048/019f3b88-0193-402a-8183-8ec2f35eba7f/target/test_failures/019f3b88-0193-402a-8183-8ec2f35eba7f_9c12d2f4dbc50b35900dc9458ec5beb5e8ec782cddc7b246696b82a0081847b7.html)
- Failing test: `ML app anomaly detection alert overview page alert flyout controls can create an anomaly detection alert`
- Failing file: `x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/ml/alert_flyout.ts`
- Failing check: `TestSubjects.isDisplayed(confirmCreateRuleModal)`
- Failure mode: the confirmation modal was visible in the screenshot, but the page object sampled display state immediately after clicking save and failed before the modal transition settled.

## Fix

- replace the one-shot `isDisplayed()` assertion with `existOrFail('confirmCreateRuleModal')`, matching the durable pattern already used by adjacent alerting FTR tests
- scope the confirm click through `confirmCreateRuleModal > confirmModalConfirmButton` so the test interacts with the button inside the expected modal

## Model used

- Codex, GPT-5-based coding agent

## Verification

- `node scripts/eslint x-pack/platform/test/functional_with_es_ssl/page_objects/triggers_actions_ui_page.ts`

No existing issue.
