### PR TITLE
Stabilize saved search embeddable Scout test

### DIFF
--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
@@ -74,7 +74,7 @@ test.describe('Discover app - saved search embeddable', { tag: tags.deploymentAg
       SAVED_SEARCH_TITLE,
       testData.DATA_VIEW_ID.LOGSTASH
     );
-    await pageObjects.dashboard.addPanelFromLibrary(SAVED_SEARCH_TITLE);
+    await pageObjects.dashboard.addSavedSearch(SAVED_SEARCH_TITLE);
     await page.testSubj.locator('savedSearchTotalDocuments').waitFor({
       state: 'visible',
     });


### PR DESCRIPTION
## Summary

Fixes a flaky Scout dashboard-library interaction in the Discover saved search embeddable test by using the dashboard page object's saved-search-specific helper.

The failing path typed `TempSearch` into the add-from-library flyout and immediately clicked the derived title selector. In the RSPack failure artifact, the flyout search input contained `TempSearch`, but the result list still showed unrelated managed panels and never exposed `savedObjectTitleTempSearch` within the click timeout.

`addSavedSearch()` uses the same page object coverage but scopes the library query to saved searches, waits for the finder loading indicator after typing, verifies the title before clicking, and waits for the add-success signal.

## Validation

- `node scripts/eslint x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts`

Planned flaky runner validation:

- 40x on `main` with `KBN_USE_RSPACK=true`
- 40x on this PR with `KBN_USE_RSPACK=true`
