### PR TITLE
[APM] Migrate storage_explorer route params to zod (io-ts -> zod migration, part 4)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_chart.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_chart.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { indexLifecyclePhaseRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { indexLifecyclePhaseSchema, environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, probabilitySchema } from '../../default_api_types';
 
 export type SizeTimeseriesResponse = Array<{
   serviceName: string;
@@ -21,7 +20,11 @@ export interface StorageChartRouteResponse {
 
 export const storageChartRoute = defineRoute<StorageChartRouteResponse>()({
   endpoint: 'GET /internal/apm/storage_chart',
-  params: t.type({
-    query: t.intersection([indexLifecyclePhaseRt, probabilityRt, environmentRt, kueryRt, rangeRt]),
+  params: z.object({
+    query: indexLifecyclePhaseSchema
+      .merge(probabilitySchema)
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { indexLifecyclePhaseRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { indexLifecyclePhaseSchema, environmentSchema } from '@kbn/apm-types';
 import type { AgentName } from '@kbn/elastic-agent-utils';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, probabilitySchema } from '../../default_api_types';
 
 export type StorageExplorerServiceStatisticsResponse = Array<{
   serviceName: string;
@@ -25,7 +24,11 @@ export interface StorageExplorerRouteResponse {
 
 export const storageExplorerRoute = defineRoute<StorageExplorerRouteResponse>()({
   endpoint: 'GET /internal/apm/storage_explorer',
-  params: t.type({
-    query: t.intersection([indexLifecyclePhaseRt, probabilityRt, environmentRt, kueryRt, rangeRt]),
+  params: z.object({
+    query: indexLifecyclePhaseSchema
+      .merge(probabilitySchema)
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_get_services.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_get_services.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { indexLifecyclePhaseRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { indexLifecyclePhaseSchema, environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface StorageExplorerGetServicesResponse {
   services: Array<{
@@ -18,7 +17,7 @@ export interface StorageExplorerGetServicesResponse {
 
 export const storageExplorerGetServicesRoute = defineRoute<StorageExplorerGetServicesResponse>()({
   endpoint: 'GET /internal/apm/storage_explorer/get_services',
-  params: t.type({
-    query: t.intersection([indexLifecyclePhaseRt, environmentRt, kueryRt, rangeRt]),
+  params: z.object({
+    query: indexLifecyclePhaseSchema.merge(environmentSchema).merge(kuerySchema).merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_params.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { storageExplorerRoute } from './storage_explorer';
+import { storageExplorerSummaryStatsRoute } from './storage_explorer_summary_stats';
+import { storageExplorerGetServicesRoute } from './storage_explorer_get_services';
+import { storageExplorerServiceDetailsRoute } from './storage_explorer_service_details';
+import { storageChartRoute } from './storage_chart';
+
+const validQueryWithProbability = {
+  indexLifecyclePhase: 'all',
+  probability: '1',
+  environment: 'production',
+  kuery: '',
+  start: '2023-01-01T00:00:00.000Z',
+  end: '2023-01-02T00:00:00.000Z',
+};
+
+const expectedParsedQuery = {
+  indexLifecyclePhase: 'all',
+  probability: 1,
+  environment: 'production',
+  kuery: '',
+  start: new Date(validQueryWithProbability.start).getTime(),
+  end: new Date(validQueryWithProbability.end).getTime(),
+};
+
+describe('storage_explorer route params', () => {
+  it('storageExplorerRoute accepts a merged query with indexLifecyclePhase/probability/environment/kuery/range', () => {
+    const result = storageExplorerRoute.params!.shape.query.safeParse(validQueryWithProbability);
+
+    expectParseSuccess(result);
+    expect(result.data).toEqual(expectedParsedQuery);
+  });
+
+  it('storageExplorerSummaryStatsRoute accepts the same merged query', () => {
+    const result =
+      storageExplorerSummaryStatsRoute.params!.shape.query.safeParse(validQueryWithProbability);
+
+    expectParseSuccess(result);
+    expect(result.data).toEqual(expectedParsedQuery);
+  });
+
+  it('storageChartRoute accepts the same merged query', () => {
+    const result = storageChartRoute.params!.shape.query.safeParse(validQueryWithProbability);
+
+    expectParseSuccess(result);
+    expect(result.data).toEqual(expectedParsedQuery);
+  });
+
+  it('storageExplorerGetServicesRoute accepts a merged query without probability', () => {
+    const { probability, ...queryWithoutProbability } = validQueryWithProbability;
+
+    const result =
+      storageExplorerGetServicesRoute.params!.shape.query.safeParse(queryWithoutProbability);
+
+    expectParseSuccess(result);
+  });
+
+  it('storageExplorerServiceDetailsRoute validates both path and query', () => {
+    const result = storageExplorerServiceDetailsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: validQueryWithProbability,
+    });
+
+    expectParseSuccess(result);
+    expect(result.data.path).toEqual({ serviceName: 'opbeans-java' });
+  });
+
+  it('rejects an unknown indexLifecyclePhase', () => {
+    const result = storageExplorerRoute.params!.shape.query.safeParse({
+      ...validQueryWithProbability,
+      indexLifecyclePhase: 'melting',
+    });
+
+    expectParseError(result);
+  });
+
+  it('rejects a missing required field', () => {
+    const { environment, ...withoutEnvironment } = validQueryWithProbability;
+
+    const result = storageExplorerRoute.params!.shape.query.safeParse(withoutEnvironment);
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_service_details.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_service_details.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { ProcessorEvent } from '@kbn/apm-types-shared';
-import { indexLifecyclePhaseRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { indexLifecyclePhaseSchema, environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, probabilitySchema } from '../../default_api_types';
 
 export interface StorageDetailsResponse {
   processorEventStats: Array<{
@@ -30,10 +29,14 @@ export interface StorageDetailsResponse {
 
 export const storageExplorerServiceDetailsRoute = defineRoute<StorageDetailsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/storage_details',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([indexLifecyclePhaseRt, probabilityRt, environmentRt, kueryRt, rangeRt]),
+    query: indexLifecyclePhaseSchema
+      .merge(probabilitySchema)
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_summary_stats.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_summary_stats.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { indexLifecyclePhaseRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { indexLifecyclePhaseSchema, environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, probabilitySchema } from '../../default_api_types';
 
 export interface StorageExplorerSummaryStatisticsResponse {
   tracesPerMinute: number;
@@ -22,13 +21,11 @@ export interface StorageExplorerSummaryStatisticsResponse {
 export const storageExplorerSummaryStatsRoute =
   defineRoute<StorageExplorerSummaryStatisticsResponse>()({
     endpoint: 'GET /internal/apm/storage_explorer_summary_stats',
-    params: t.type({
-      query: t.intersection([
-        indexLifecyclePhaseRt,
-        probabilityRt,
-        environmentRt,
-        kueryRt,
-        rangeRt,
-      ]),
+    params: z.object({
+      query: indexLifecyclePhaseSchema
+        .merge(probabilitySchema)
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema),
     }),
   });


### PR DESCRIPTION
## Summary

Part of #243355 (migrate `io-ts` to `@kbn/zod` in APM).

**Stacked on #276634** (which is itself stacked on #276618 and #276617)
— the diff below includes all three prior commits until they merge. The
only new commit here is the fourth one; please review those first.

This is the first "route group" migration under the strategy from
#276634: swap an io-ts `t.intersection([...])` composition for the
matching zod `.merge()` chain built from the additive schemas added
there, so the route flips onto the zod validation path from #276617.

## Changes

All 5 `storage_explorer` endpoints:
- `GET /internal/apm/storage_explorer`
- `GET /internal/apm/storage_explorer_summary_stats`
- `GET /internal/apm/storage_chart`
- `GET /internal/apm/storage_explorer/get_services`
- `GET /internal/apm/services/{serviceName}/storage_details`

swap `t.intersection([indexLifecyclePhaseRt, probabilityRt (where
present), environmentRt, kueryRt, rangeRt])` for
`indexLifecyclePhaseSchema.merge(probabilitySchema).merge(environmentSchema).merge(kuerySchema).merge(rangeSchema)`.
No handler code changes — the destructured field names
(`indexLifecyclePhase`, `probability`, `environment`, `kuery`, `start`,
`end`) and their post-coercion types are identical to before.

## Test plan

- [x] New `storage_explorer_params.test.ts` — covers each endpoint's
      merged query schema (valid merge, missing required field,
      unknown literal value), plus the path+query combination for the
      `storage_details` endpoint (21/21 passing package-wide)
- [x] `node scripts/type_check` on `kbn-apm-api-shared` and the APM
      plugin (confirms the handler destructuring in
      `server/routes/storage_explorer/route.ts` still type-checks
      against the zod-inferred params)
- [x] Existing `is_cross_cluster_search.test.ts` still green (unaffected
      endpoint in the same route repository)
- [x] `node scripts/lint_ts_projects.js`
- [ ] No FTR/API-integration coverage added for this group specifically
      — flagging in case reviewers want it before merge, same as the
      earlier AI-agent endpoints in #276618.
   - [x] Manual API tests in Kibana dev tools
     - [x] storage_explorer
     ```
      GET kbn:internal/apm/storage_explorer?indexLifecyclePhase=all&probability=1&environment=production&kuery=&start=2026-07-08T14:30:00.000Z&end=2026-07-08T14:45:00.000Z
      ```
    - [x] Missing required environment — expect 400

     ```
      GET kbn:internal/apm/storage_explorer?indexLifecyclePhase=all&probability=1&kuery=&start=2026-07-08T14:00:00.000Z&end=2026-07-08T14:15:00.000Z
     ```
     
    - [x] storageExplorerSummaryStatsRoute — valid

      ```
        GET kbn:internal/apm/storage_explorer_summary_stats?indexLifecyclePhase=all&probability=1&environment=production&kuery=&start=2026-07-08T14:00:00.000Z&end=2026-07-08T14:15:00.000Z
      ```

     - [x] storageChartRoute — valid

        ```
          GET kbn:internal/apm/storage_chart?indexLifecyclePhase=all&probability=1&environment=production&kuery=&start=2026-07-08T14:00:00.000Z&end=2026-07-08T14:15:00.000Z
        ```
    - [x] storageExplorerGetServicesRoute — valid (no probability field on this one)

      ```
        GET kbn:internal/apm/storage_explorer/get_services?indexLifecyclePhase=all&environment=production&kuery=&start=2026-07-08T14:00:00.000Z&end=2026-07-08T14:15:00.000Z
      ```

     - [x] storageExplorerServiceDetailsRoute — path + query, valid

      ``` 
       GET kbn:internal/apm/services/opbeans-java/storage_details?indexLifecyclePhase=all&probability=1&environment=production&kuery=&start=2026-07-08T14:00:00.000Z&end=2026-07-08T14:15:00.000Z
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)