### PR TITLE
[ResponseOps][Alerting v2] Align rule/episode flyout headers with the shared AppHeader

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/actions/tags_overflow_badge_row.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/actions/tags_overflow_badge_row.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { getTagsOverflowLimits, TagsOverflowBadgeRow } from './tags_overflow_badge_row';
+
+describe('getTagsOverflowLimits', () => {
+  it('returns the full budget when there are no other badges', () => {
+    expect(getTagsOverflowLimits(0)).toEqual({ overflowSize: 3, maxVisible: 2 });
+  });
+
+  it('reduces the budget by the number of non-tag badges already in the row', () => {
+    expect(getTagsOverflowLimits(2)).toEqual({ overflowSize: 1, maxVisible: 0 });
+  });
+
+  it('clamps at zero once non-tag badges exceed the row budget', () => {
+    expect(getTagsOverflowLimits(5)).toEqual({ overflowSize: 0, maxVisible: 0 });
+  });
+});
+
+describe('TagsOverflowBadgeRow', () => {
+  it('renders nothing when there are no tags', () => {
+    const { container } = render(
+      <I18nProvider>
+        <TagsOverflowBadgeRow tags={[]} overflowSize={3} maxVisible={2} />
+      </I18nProvider>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders every tag individually and no overflow badge when below the threshold', () => {
+    render(
+      <I18nProvider>
+        <TagsOverflowBadgeRow tags={['a', 'b', 'c']} overflowSize={3} maxVisible={2} />
+      </I18nProvider>
+    );
+
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.getByText('c')).toBeInTheDocument();
+    expect(screen.queryByTestId('tagsOverflowBadgeRowMoreBadge')).not.toBeInTheDocument();
+  });
+
+  it('collapses tags past maxVisible into a "+N" badge once above the threshold', () => {
+    render(
+      <I18nProvider>
+        <TagsOverflowBadgeRow tags={['a', 'b', 'c', 'd']} overflowSize={3} maxVisible={2} />
+      </I18nProvider>
+    );
+
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.queryByText('c')).not.toBeInTheDocument();
+    expect(screen.queryByText('d')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tagsOverflowBadgeRowMoreBadge')).toHaveTextContent('+2');
+  });
+
+  it('collapses every tag into the overflow badge when maxVisible is 0', () => {
+    render(
+      <I18nProvider>
+        <TagsOverflowBadgeRow tags={['a', 'b']} overflowSize={0} maxVisible={0} />
+      </I18nProvider>
+    );
+
+    expect(screen.queryByText('a')).not.toBeInTheDocument();
+    expect(screen.queryByText('b')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tagsOverflowBadgeRowMoreBadge')).toHaveTextContent('+2');
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/actions/tags_overflow_badge_row.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/actions/tags_overflow_badge_row.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+
+// Shared by both the rule and episode summary badge rows: once the combined (non-tag + tag)
+// badge count exceeds OVERFLOW_THRESHOLD, only MAX_VISIBLE_BADGES stay visible and the rest
+// collapse into a single "+N" badge. Mirrors the app header's own badge row (`AppBadges`).
+export const BADGE_ROW_MAX_VISIBLE_BADGES = 2;
+export const BADGE_ROW_OVERFLOW_THRESHOLD = 3;
+
+/**
+ * Given how many non-tag badges (kind, status, severity, etc.) already sit in the same row,
+ * returns the tag-specific `overflowSize`/`maxVisible` for {@link TagsOverflowBadgeRow}.
+ */
+export const getTagsOverflowLimits = (nonTagBadgeCount: number) => ({
+  overflowSize: Math.max(0, BADGE_ROW_OVERFLOW_THRESHOLD - nonTagBadgeCount),
+  maxVisible: Math.max(0, BADGE_ROW_MAX_VISIBLE_BADGES - nonTagBadgeCount),
+});
+
+export interface TagsOverflowBadgeRowProps {
+  tags: string[];
+  /** Tags stay individually visible until `tags.length` exceeds this. */
+  overflowSize: number;
+  /** How many tags stay visible once overflow kicks in; the rest fold into "+N". */
+  maxVisible: number;
+  'data-test-subj'?: string;
+}
+
+/**
+ * Renders tags as hollow badges, collapsing into a "+N" popover once they exceed `overflowSize`.
+ * Used by both the rule summary flyout and the episode details flyout badge rows — no existing
+ * chrome/sharedux component covers "plain string tags with a +N overflow badge" (the closest,
+ * `@kbn/content-management-tags`, is bound to the saved-object tag registry and doesn't
+ * implement overflow), so this is the shared home for that behavior instead of duplicating it
+ * per consumer.
+ */
+export const TagsOverflowBadgeRow: React.FC<TagsOverflowBadgeRowProps> = ({
+  tags,
+  overflowSize,
+  maxVisible,
+  'data-test-subj': dataTestSubj,
+}) => {
+  const [isMoreTagsOpen, setIsMoreTagsOpen] = useState(false);
+  const shouldOverflow = tags.length > overflowSize;
+  const visibleCount = shouldOverflow ? maxVisible : tags.length;
+  const visibleTags = tags.slice(0, visibleCount);
+  const overflowTags = tags.slice(visibleCount);
+
+  if (tags.length === 0) {
+    return null;
+  }
+
+  const moreTagsButton = shouldOverflow && (
+    <EuiBadge
+      key="more"
+      onClick={() => setIsMoreTagsOpen((isOpen) => !isOpen)}
+      onClickAriaLabel={i18n.translate(
+        'xpack.alertingV2EpisodesUi.actions.tagsOverflowBadgeRow.moreTagsAriaLabel',
+        {
+          defaultMessage: 'Show {count} more tags',
+          values: { count: overflowTags.length },
+        }
+      )}
+      color="hollow"
+      data-test-subj="tagsOverflowBadgeRowMoreBadge"
+    >
+      <FormattedMessage
+        id="xpack.alertingV2EpisodesUi.actions.tagsOverflowBadgeRow.moreTags"
+        defaultMessage="+{number}"
+        values={{ number: overflowTags.length }}
+      />
+    </EuiBadge>
+  );
+
+  return (
+    <EuiFlexItem grow={false} data-test-subj={dataTestSubj}>
+      <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center" wrap={false}>
+        {visibleTags.map((tag) => (
+          <EuiFlexItem key={tag} grow={false}>
+            <EuiBadge color="hollow">{tag}</EuiBadge>
+          </EuiFlexItem>
+        ))}
+        {moreTagsButton && (
+          <EuiFlexItem grow={false}>
+            <EuiPopover
+              aria-label={i18n.translate(
+                'xpack.alertingV2EpisodesUi.actions.tagsOverflowBadgeRow.moreTagsPopoverLabel',
+                { defaultMessage: 'More tags' }
+              )}
+              button={moreTagsButton}
+              isOpen={isMoreTagsOpen}
+              closePopover={() => setIsMoreTagsOpen(false)}
+              // EuiPopover defaults its anchor to `display: inline-block`, which misaligns the
+              // "+N" badge against its plain sibling badges in the flex row.
+              display="flex"
+            >
+              <EuiFlexGroup direction="column" gutterSize="xs" alignItems="center">
+                {overflowTags.map((tag) => (
+                  <EuiFlexItem key={tag} grow={false}>
+                    <EuiBadge color="hollow">{tag}</EuiBadge>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </EuiPopover>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_flyout.tsx
@@ -137,7 +137,7 @@ export const AlertEpisodeDetailsFlyout = ({
           <AlertEpisodeDetailsHeaderSection
             episodeId={episodeId}
             services={services}
-            titleSize="m"
+            titleSize="s"
           />
           <EuiTabs bottomBorder={false}>
             <EuiTab

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_header.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_header.tsx
@@ -8,11 +8,12 @@
 import React from 'react';
 import type { EuiTitleSize } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
 import { AlertEpisodeStatusBadges } from '../status/status_badges';
-import { AlertEpisodeTags } from '../actions/tags';
 import { AlertEpisodeSeverityBadge } from '../severity/episode_severity_badge';
 import { isSupportedEpisodeSeverity } from '../severity/severity_utils';
+import { TagsOverflowBadgeRow, getTagsOverflowLimits } from '../actions/tags_overflow_badge_row';
 import type { EpisodeActionState, AlertEpisodeGroupAction } from '../../types/action';
 import { isRuleLoaded, isRuleLoading, type RuleState } from '../../types/rule_state';
 import * as i18n from './translations';
@@ -46,44 +47,67 @@ export const AlertEpisodeDetailsHeader = ({
     : i18n.HEADER_EPISODE_TITLE_FALLBACK;
   const description = isRuleLoaded(ruleState) ? ruleState.rule.metadata.description : undefined;
   const showTags = tags.length > 0;
+  const showBadgeRow = Boolean(status) || isSupportedEpisodeSeverity(severity) || showTags;
+  const nonTagBadgeCount = (status ? 1 : 0) + (isSupportedEpisodeSeverity(severity) ? 1 : 0);
+  const { overflowSize: tagsOverflowSize, maxVisible: tagsMaxVisibleOnOverflow } =
+    getTagsOverflowLimits(nonTagBadgeCount);
 
   return (
     <>
-      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+      {/* Single wrapping row (not a fixed title-row + badges-row split) so the badges naturally
+          drop to a second line only when the title doesn't leave room for them, instead of
+          always reserving a dedicated row for badges even when they'd fit next to the title.
+          The badges are grouped into one flex item (wrap={false} inside) so they jump down
+          together as a unit rather than wrapping individually mid-cluster. */}
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
         <EuiFlexItem grow={false}>
           <EuiTitle size={titleSize}>
             <h1 data-test-subj="alertingV2EpisodeDetailsHeaderTitle">{titleContent}</h1>
           </EuiTitle>
         </EuiFlexItem>
-        {status ? (
+        {showBadgeRow ? (
           <EuiFlexItem grow={false}>
-            <AlertEpisodeStatusBadges
-              status={status}
-              episodeAction={episodeAction}
-              groupAction={groupAction}
-            />
-          </EuiFlexItem>
-        ) : null}
-        {isSupportedEpisodeSeverity(severity) ? (
-          <EuiFlexItem grow={false}>
-            <AlertEpisodeSeverityBadge severity={severity} />
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+              {status ? (
+                <EuiFlexItem grow={false}>
+                  <AlertEpisodeStatusBadges
+                    status={status}
+                    episodeAction={episodeAction}
+                    groupAction={groupAction}
+                  />
+                </EuiFlexItem>
+              ) : null}
+              {isSupportedEpisodeSeverity(severity) ? (
+                <EuiFlexItem grow={false}>
+                  <AlertEpisodeSeverityBadge severity={severity} />
+                </EuiFlexItem>
+              ) : null}
+              {showTags ? (
+                <TagsOverflowBadgeRow
+                  tags={tags}
+                  overflowSize={tagsOverflowSize}
+                  maxVisible={tagsMaxVisibleOnOverflow}
+                  data-test-subj="alertingV2EpisodeDetailsHeaderTags"
+                />
+              ) : null}
+            </EuiFlexGroup>
           </EuiFlexItem>
         ) : null}
       </EuiFlexGroup>
       {description ? (
         <>
           <EuiSpacer size="s" />
-          <EuiText size="s" color="subdued">
+          {/* EuiText has no font-weight prop, so a lighter-than-bold weight for the
+              description has to be set via css instead of a design-token size/color prop. */}
+          <EuiText
+            size="s"
+            color="subdued"
+            css={css`
+              font-weight: 450;
+            `}
+          >
             {description}
           </EuiText>
-        </>
-      ) : null}
-      {showTags ? (
-        <>
-          <EuiSpacer size="s" />
-          <div data-test-subj="alertingV2EpisodeDetailsHeaderTags">
-            <AlertEpisodeTags tags={tags} />
-          </div>
         </>
       ) : null}
     </>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_header.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_header.tsx
@@ -62,7 +62,7 @@ export const AlertEpisodeDetailsHeader = ({
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
         <EuiFlexItem grow={false}>
           <EuiTitle size={titleSize}>
-            <h1 data-test-subj="alertingV2EpisodeDetailsHeaderTitle">{titleContent}</h1>
+            <h2 data-test-subj="alertingV2EpisodeDetailsHeaderTitle">{titleContent}</h2>
           </EuiTitle>
         </EuiFlexItem>
         {showBadgeRow ? (

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_header.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/details_header.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import type { EuiTitleSize } from '@elastic/eui';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AlertEpisodeStatus } from '@kbn/alerting-v2-schemas';
 import { AlertEpisodeStatusBadges } from '../status/status_badges';
@@ -39,6 +39,7 @@ export const AlertEpisodeDetailsHeader = ({
   groupAction,
   titleSize = 'l',
 }: AlertEpisodeDetailsHeaderProps) => {
+  const { euiTheme } = useEuiTheme();
   const isLoading = isLoadingEpisode || isRuleLoading(ruleState);
   const titleContent = isLoading
     ? i18n.HEADER_LOADING_TITLE
@@ -103,7 +104,7 @@ export const AlertEpisodeDetailsHeader = ({
             size="s"
             color="subdued"
             css={css`
-              font-weight: 450;
+              font-weight: ${euiTheme.font.weight.medium};
             `}
           >
             {description}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_attachment_definition.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_attachment_definition.test.tsx
@@ -41,8 +41,9 @@ jest.mock('../../components/rule_details/rule_context', () => ({
   RuleProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-jest.mock('../../components/rule_details/rule_header_description', () => ({
+jest.mock('../../components/rule_details/rule_summary_header', () => ({
   RuleHeaderDescription: () => <div data-test-subj="mockRuleHeaderDescription" />,
+  RuleTagsList: () => <div data-test-subj="mockRuleTagsList" />,
 }));
 
 jest.mock('../../components/rule_details/sidebar/rule_sidebar', () => ({

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.test.tsx
@@ -34,8 +34,9 @@ jest.mock('../../components/rule_details/rule_context', () => ({
   RuleProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-jest.mock('../../components/rule_details/rule_header_description', () => ({
+jest.mock('../../components/rule_details/rule_summary_header', () => ({
   RuleHeaderDescription: () => <div data-test-subj="mockRuleHeaderDescription" />,
+  RuleTagsList: () => <div data-test-subj="mockRuleTagsList" />,
 }));
 
 jest.mock('../../components/rule_details/sidebar/rule_sidebar', () => ({

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.tsx
@@ -15,7 +15,10 @@ import {
 import { CoreStart, useService } from '@kbn/core-di-browser';
 import { i18n } from '@kbn/i18n';
 import { RuleProvider } from '../../components/rule_details/rule_context';
-import { RuleHeaderDescription } from '../../components/rule_details/rule_header_description';
+import {
+  RuleHeaderDescription,
+  RuleTagsList,
+} from '../../components/rule_details/rule_summary_header';
 import { RuleSidebar } from '../../components/rule_details/sidebar/rule_sidebar';
 import { paths } from '../../constants';
 import { RulesApi, type RuleApiResponse } from '../../services/rules_api';
@@ -120,8 +123,18 @@ export const RuleCanvasContent = ({
   return (
     <RuleProvider rule={data as unknown as RuleApiResponse}>
       <EuiPanel paddingSize="l" hasShadow={false}>
-        <RuleHeaderDescription />
-        <EuiSpacer size="m" />
+        {data.metadata.description && (
+          <>
+            <RuleHeaderDescription />
+            <EuiSpacer size="m" />
+          </>
+        )}
+        {data.metadata.tags && data.metadata.tags.length > 0 && (
+          <>
+            <RuleTagsList />
+            <EuiSpacer size="m" />
+          </>
+        )}
         <RuleSidebar showQueryPreview />
       </EuiPanel>
     </RuleProvider>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.test.tsx
@@ -40,7 +40,7 @@ jest.mock('../../../pages/rules_list_page/rule_actions_menu', () => ({
   ),
 }));
 
-jest.mock('../../rule_details/rule_header_description', () => ({
+jest.mock('../../rule_details/rule_summary_header', () => ({
   RuleHeaderDescription: () => <div data-test-subj="mockRuleHeaderDescription" />,
   RuleTitleWithBadges: ({ variant }: { variant?: string }) => (
     <span data-test-subj="mockRuleTitleWithBadges" data-variant={variant}>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
@@ -157,7 +157,7 @@ export const RuleSummaryFlyout = ({
               </h2>
             </EuiTitle>
             <EuiSpacer size="s" />
-            <RuleHeaderDescription />
+            <RuleHeaderDescription showTags={false} />
           </EuiPanel>
           <EuiHorizontalRule margin="xs" />
           <EuiPanel

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
@@ -157,7 +157,7 @@ export const RuleSummaryFlyout = ({
               </h2>
             </EuiTitle>
             <EuiSpacer size="s" />
-            <RuleHeaderDescription showTags={false} />
+            <RuleHeaderDescription renderTags={false} />
           </EuiPanel>
           <EuiHorizontalRule margin="xs" />
           <EuiPanel

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
@@ -28,10 +28,7 @@ import React from 'react';
 import { paths } from '../../../constants';
 import { RuleActionsMenu } from '../../../pages/rules_list_page/rule_actions_menu';
 import { RuleProvider } from '../../rule_details/rule_context';
-import {
-  RuleHeaderDescription,
-  RuleTitleWithBadges,
-} from '../../rule_details/rule_header_description';
+import { RuleHeaderDescription, RuleTitleWithBadges } from '../../rule_details/rule_summary_header';
 import { RuleConditions } from '../../rule_details/sidebar/rule_conditions';
 import { RuleMetadata } from '../../rule_details/sidebar/rule_metadata';
 import type { RuleApiResponse } from '../../../services/rules_api';
@@ -157,7 +154,7 @@ export const RuleSummaryFlyout = ({
               </h2>
             </EuiTitle>
             <EuiSpacer size="s" />
-            <RuleHeaderDescription renderTags={false} />
+            <RuleHeaderDescription />
           </EuiPanel>
           <EuiHorizontalRule margin="xs" />
           <EuiPanel

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.test.tsx
@@ -74,8 +74,8 @@ jest.mock('@kbn/app-header', () => {
 });
 
 const mockRuleKindBadgeRender = jest.fn();
-jest.mock('./rule_header_description', () => {
-  const actual = jest.requireActual('./rule_header_description');
+jest.mock('./rule_summary_header', () => {
+  const actual = jest.requireActual('./rule_summary_header');
   return {
     ...actual,
     RuleKindBadge: (props: { kind: string }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
@@ -27,7 +27,7 @@ import { useComposeDiscoverFlyout } from '../../hooks/use_compose_discover_flyou
 import { useToggleRuleEnabled } from '../../hooks/use_toggle_rule_enabled';
 import { paths } from '../../constants';
 import { DeleteConfirmationModal } from '../rule/modals/delete_confirmation_modal';
-import { RuleKindBadge } from './rule_header_description';
+import { RuleKindBadge } from './rule_summary_header';
 import { RuleOverviewSection } from './overview';
 import { RuleSidebar } from './sidebar/rule_sidebar';
 import { useRule } from './rule_context';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
@@ -184,9 +184,17 @@ export const RuleDetailPage: React.FunctionComponent = () => {
     [rule, onEdit, handleToggleEnabled, isToggling, onClone, showDeleteConfirmationModal]
   );
 
+  // AppHeaderMetadata bolds `label` (it's meant to be the key of a label/value pair) and renders
+  // `value` at a lighter weight, so the description is passed as `value` with an empty `label`
+  // to get the lighter weight without touching the shared app-header component.
   const metadata = rule.metadata?.description
     ? ([
-        { type: 'text', label: rule.metadata.description, 'data-test-subj': 'ruleDescription' },
+        {
+          type: 'text',
+          label: '',
+          value: rule.metadata.description,
+          'data-test-subj': 'ruleDescription',
+        },
       ] as AppHeaderMetadataItems)
     : undefined;
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import React from 'react';
@@ -22,16 +29,20 @@ const { overflowSize: TAGS_OVERFLOW_SIZE, maxVisible: TAGS_MAX_VISIBLE_ON_OVERFL
   getTagsOverflowLimits(2);
 
 export interface RuleHeaderDescriptionProps {
-  /** Set to `false` when tags are already rendered elsewhere, e.g. alongside the summary badges row. */
-  showTags?: boolean;
+  /**
+   * Set to `false` when tags are already rendered elsewhere, e.g. alongside the summary badges
+   * row. Unrelated to whether the rule actually has tags — that's `hasTags` below.
+   */
+  renderTags?: boolean;
 }
 
 export const RuleHeaderDescription: React.FC<RuleHeaderDescriptionProps> = ({
-  showTags = true,
+  renderTags = true,
 }) => {
   const rule = useRule();
+  const { euiTheme } = useEuiTheme();
   const { description, tags } = rule.metadata;
-  const hasTags = showTags && tags && tags.length > 0;
+  const hasTags = renderTags && tags && tags.length > 0;
 
   if (!description && !hasTags) {
     return null;
@@ -47,7 +58,7 @@ export const RuleHeaderDescription: React.FC<RuleHeaderDescriptionProps> = ({
             size="s"
             color="subdued"
             css={css`
-              font-weight: 450;
+              font-weight: ${euiTheme.font.weight.medium};
             `}
             data-test-subj="ruleDescription"
           >

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
@@ -7,15 +7,31 @@
 
 import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import React from 'react';
 import { RULE_KIND_ICONS, RULE_KIND_LABELS, RULE_KIND_TOOLTIPS } from '@kbn/alerting-v2-constants';
+import {
+  TagsOverflowBadgeRow,
+  getTagsOverflowLimits,
+} from '@kbn/alerting-v2-episodes-ui/components/actions/tags_overflow_badge_row';
 import { useRule } from './rule_context';
 import type { RuleApiResponse } from '../../services/rules_api';
 
-export const RuleHeaderDescription: React.FC = () => {
+// The summary badges row always has 2 non-tag badges: kind and enabled/disabled.
+const { overflowSize: TAGS_OVERFLOW_SIZE, maxVisible: TAGS_MAX_VISIBLE_ON_OVERFLOW } =
+  getTagsOverflowLimits(2);
+
+export interface RuleHeaderDescriptionProps {
+  /** Set to `false` when tags are already rendered elsewhere, e.g. alongside the summary badges row. */
+  showTags?: boolean;
+}
+
+export const RuleHeaderDescription: React.FC<RuleHeaderDescriptionProps> = ({
+  showTags = true,
+}) => {
   const rule = useRule();
   const { description, tags } = rule.metadata;
-  const hasTags = tags && tags.length > 0;
+  const hasTags = showTags && tags && tags.length > 0;
 
   if (!description && !hasTags) {
     return null;
@@ -25,7 +41,16 @@ export const RuleHeaderDescription: React.FC = () => {
     <EuiFlexGroup direction="column" gutterSize="m">
       {description && (
         <EuiFlexItem grow={false}>
-          <EuiText size="s" color="subdued" data-test-subj="ruleDescription">
+          {/* EuiText has no font-weight prop, so a lighter-than-bold weight for the
+              description has to be set via css instead of a design-token size/color prop. */}
+          <EuiText
+            size="s"
+            color="subdued"
+            css={css`
+              font-weight: 450;
+            `}
+            data-test-subj="ruleDescription"
+          >
             {description}
           </EuiText>
         </EuiFlexItem>
@@ -53,8 +78,11 @@ export interface RuleKindBadgeProps {
  * Hollow badge showing the rule kind, with its icon and a descriptive tooltip.
  * Shared between the inline/summary title and the rule details app header.
  */
+// Flex anchor avoids inline line-height missizing (see status_badges.tsx for the same fix).
+const tooltipAnchorProps = { css: { display: 'flex' } };
+
 export const RuleKindBadge: React.FC<RuleKindBadgeProps> = ({ kind }) => (
-  <EuiToolTip content={RULE_KIND_TOOLTIPS[kind]}>
+  <EuiToolTip content={RULE_KIND_TOOLTIPS[kind]} anchorProps={tooltipAnchorProps}>
     <EuiBadge
       color="hollow"
       iconType={RULE_KIND_ICONS[kind] ?? 'dot'}
@@ -107,16 +135,27 @@ export const RuleTitleWithBadges: React.FC<RuleTitleWithBadgesProps> = ({ varian
   );
 
   if (isSummary) {
+    const tags = rule.metadata.tags ?? [];
+
+    // Single wrapping row (not a fixed name-row + badges-row split) so the badges naturally
+    // drop to a second line only when the name doesn't leave room for them, instead of always
+    // reserving a dedicated row for badges even when they'd fit next to the name. The badges
+    // are grouped into one flex item (wrap={false} inside) so they jump down together as a
+    // unit rather than wrapping individually mid-cluster.
     return (
-      <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexGroup alignItems="center" gutterSize="s" wrap responsive={false}>
         <EuiFlexItem grow={false}>
           <span data-test-subj="ruleName">{rule.metadata.name}</span>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center" gutterSize="m" wrap={false} responsive={false}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" wrap={false} responsive={false}>
             <EuiFlexItem grow={false}>{kindBadge}</EuiFlexItem>
-            <EuiFlexItem grow={false}>{divider}</EuiFlexItem>
             <EuiFlexItem grow={false}>{statusBadge}</EuiFlexItem>
+            <TagsOverflowBadgeRow
+              tags={tags}
+              overflowSize={TAGS_OVERFLOW_SIZE}
+              maxVisible={TAGS_MAX_VISIBLE_ON_OVERFLOW}
+            />
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_kind_badge.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_kind_badge.test.tsx
@@ -10,7 +10,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { RULE_KIND_ICONS, RULE_KIND_LABELS, RULE_KIND_TOOLTIPS } from '@kbn/alerting-v2-constants';
 import type { RuleKind } from '@kbn/alerting-v2-schemas';
-import { RuleKindBadge } from './rule_header_description';
+import { RuleKindBadge } from './rule_summary_header';
 
 const wrap = (ui: React.ReactElement) => render(<I18nProvider>{ui}</I18nProvider>);
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_summary_header.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_summary_header.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { RULE_KIND_TOOLTIPS } from '@kbn/alerting-v2-constants';
-import { RuleHeaderDescription, RuleTitleWithBadges } from './rule_header_description';
+import { RuleHeaderDescription, RuleTagsList, RuleTitleWithBadges } from './rule_summary_header';
 import { RuleProvider } from './rule_context';
 import type { RuleApiResponse } from '../../services/rules_api';
 
@@ -28,13 +28,6 @@ const wrap = (ui: React.ReactElement, rule: RuleApiResponse = baseRule) =>
   );
 
 describe('RuleHeaderDescription', () => {
-  it('renders tags as badges', () => {
-    wrap(<RuleHeaderDescription />);
-    expect(screen.getByTestId('ruleTags')).toBeInTheDocument();
-    expect(screen.getByText('prod')).toBeInTheDocument();
-    expect(screen.getByText('infra')).toBeInTheDocument();
-  });
-
   it('renders description text', () => {
     const rule = {
       ...baseRule,
@@ -46,46 +39,33 @@ describe('RuleHeaderDescription', () => {
     );
   });
 
-  it('renders both description and tags when both are present', () => {
-    const rule = {
-      ...baseRule,
-      metadata: {
-        name: 'My Rule',
-        description: 'Some description',
-        tags: ['prod', 'infra'],
-      },
-    } as RuleApiResponse;
-    wrap(<RuleHeaderDescription />, rule);
-    expect(screen.getByTestId('ruleDescription')).toBeInTheDocument();
+  it('returns null when there is no description', () => {
+    const rule = { ...baseRule, metadata: { name: 'No Description' } } as RuleApiResponse;
+    const { container } = wrap(<RuleHeaderDescription />, rule);
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('RuleTagsList', () => {
+  it('renders tags as badges', () => {
+    wrap(<RuleTagsList />);
     expect(screen.getByTestId('ruleTags')).toBeInTheDocument();
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('infra')).toBeInTheDocument();
   });
 
-  it('returns null when tags are empty and no description', () => {
-    const { container } = wrap(<RuleHeaderDescription />, {
+  it('returns null when tags are empty', () => {
+    const { container } = wrap(<RuleTagsList />, {
       ...baseRule,
-      metadata: { name: 'No Tags' },
+      metadata: { name: 'No Tags', tags: [] },
     } as RuleApiResponse);
     expect(container.innerHTML).toBe('');
   });
 
-  it('returns null when tags are undefined and no description', () => {
+  it('returns null when tags are undefined', () => {
     const rule = { ...baseRule, metadata: { name: 'No Tags' } } as RuleApiResponse;
-    const { container } = wrap(<RuleHeaderDescription />, rule);
+    const { container } = wrap(<RuleTagsList />, rule);
     expect(container.innerHTML).toBe('');
-  });
-
-  it('renders both description and tags by default', () => {
-    const rule = {
-      ...baseRule,
-      metadata: {
-        name: 'My Rule',
-        description: 'Some description',
-        tags: ['prod', 'infra'],
-      },
-    } as RuleApiResponse;
-    wrap(<RuleHeaderDescription />, rule);
-    expect(screen.getByTestId('ruleDescription')).toBeInTheDocument();
-    expect(screen.getByTestId('ruleTags')).toBeInTheDocument();
   });
 });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_summary_header.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_summary_header.tsx
@@ -28,55 +28,55 @@ import type { RuleApiResponse } from '../../services/rules_api';
 const { overflowSize: TAGS_OVERFLOW_SIZE, maxVisible: TAGS_MAX_VISIBLE_ON_OVERFLOW } =
   getTagsOverflowLimits(2);
 
-export interface RuleHeaderDescriptionProps {
-  /**
-   * Set to `false` when tags are already rendered elsewhere, e.g. alongside the summary badges
-   * row. Unrelated to whether the rule actually has tags — that's `hasTags` below.
-   */
-  renderTags?: boolean;
-}
-
-export const RuleHeaderDescription: React.FC<RuleHeaderDescriptionProps> = ({
-  renderTags = true,
-}) => {
+/**
+ * Rule description text. Renders nothing when the rule has no description.
+ */
+export const RuleHeaderDescription: React.FC = () => {
   const rule = useRule();
   const { euiTheme } = useEuiTheme();
-  const { description, tags } = rule.metadata;
-  const hasTags = renderTags && tags && tags.length > 0;
+  const { description } = rule.metadata;
 
-  if (!description && !hasTags) {
+  if (!description) {
     return null;
   }
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="m">
-      {description && (
-        <EuiFlexItem grow={false}>
-          {/* EuiText has no font-weight prop, so a lighter-than-bold weight for the
-              description has to be set via css instead of a design-token size/color prop. */}
-          <EuiText
-            size="s"
-            color="subdued"
-            css={css`
-              font-weight: ${euiTheme.font.weight.medium};
-            `}
-            data-test-subj="ruleDescription"
-          >
-            {description}
-          </EuiText>
+    // EuiText has no font-weight prop, so a lighter-than-bold weight for the description
+    // has to be set via css instead of a design-token size/color prop.
+    <EuiText
+      size="s"
+      color="subdued"
+      css={css`
+        font-weight: ${euiTheme.font.weight.medium};
+      `}
+      data-test-subj="ruleDescription"
+    >
+      {description}
+    </EuiText>
+  );
+};
+
+/**
+ * Rule tags as plain hollow badges. Renders nothing when the rule has no tags.
+ *
+ * Only used standalone (e.g. the agent builder rule attachment) where tags aren't already shown
+ * alongside the kind/status badges — see `RuleTitleWithBadges`'s `'summary'` variant for that.
+ */
+export const RuleTagsList: React.FC = () => {
+  const rule = useRule();
+  const { tags } = rule.metadata;
+
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <EuiFlexGroup gutterSize="xs" wrap responsive={false} data-test-subj="ruleTags">
+      {tags.map((tag) => (
+        <EuiFlexItem key={tag} grow={false}>
+          <EuiBadge color="hollow">{tag}</EuiBadge>
         </EuiFlexItem>
-      )}
-      {hasTags && (
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="xs" wrap responsive={false} data-test-subj="ruleTags">
-            {tags!.map((tag) => (
-              <EuiFlexItem key={tag} grow={false}>
-                <EuiBadge color="hollow">{tag}</EuiBadge>
-              </EuiFlexItem>
-            ))}
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      )}
+      ))}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
@@ -360,11 +360,15 @@ export function EpisodeDetailsPage() {
     </EuiSplitPanel.Inner>
   );
 
+  // AppHeaderMetadata bolds `label` (it's meant to be the key of a label/value pair) and renders
+  // `value` at a lighter weight, so the description is passed as `value` with an empty `label`
+  // to get the lighter weight without touching the shared app-header component.
   const metadata = ruleDescription
     ? ([
         {
           type: 'text',
-          label: ruleDescription,
+          label: '',
+          value: ruleDescription,
           'data-test-subj': 'alertingV2EpisodeDetailsHeaderDescription',
         },
       ] as AppHeaderMetadataItems)

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/utils/get_episode_header_badges.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/utils/get_episode_header_badges.tsx
@@ -96,7 +96,11 @@ const renderIconBadge =
   (iconType: string, tooltip: string, dataTestSubj: string) =>
   ({ badgeText }: { badgeText: string }) =>
     (
-      <EuiToolTip content={tooltip} disableScreenReaderOutput>
+      <EuiToolTip
+        content={tooltip}
+        disableScreenReaderOutput
+        anchorProps={{ css: { display: 'flex' } }}
+      >
         <EuiBadge
           color="hollow"
           iconType={iconType}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -34,7 +34,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
 import type { RuleApiResponse } from '../../services/rules_api';
-import { RuleKindBadge } from '../../components/rule_details/rule_header_description';
+import { RuleKindBadge } from '../../components/rule_details/rule_summary_header';
 import { RuleActionsMenu } from './rule_actions_menu';
 
 const labelsContainerStyle = css`


### PR DESCRIPTION
## Summary

Aligns the rule summary flyout and episode details flyout headers with the shared `AppHeader` look:

- Description text renders at a lighter font weight instead of bold, matching the AppHeader's metadata row.
- Status/severity/tags badges live in a single wrapping row next to the title (jumping down to a second line together as a unit, instead of wrapping badge-by-badge) with a plain "+N" overflow badge once they exceed the AppHeader's own badge-row thresholds.
- Fixes a couple of EUI alignment quirks along the way (`EuiToolTip`/`EuiPopover` anchors default to `display: inline-block`, which misaligns a badge against its plain siblings unless forced to `display: flex`).
- Extracts the tags-with-overflow rendering into a shared `TagsOverflowBadgeRow` (in `@kbn/alerting-v2-episodes-ui`) so the rule and episode flyouts don't each carry their own copy.
- Aligns the episode details flyout title to `<h2>`, matching every other flyout in `alerting_v2` (`<h1>` is reserved for page-level `AppHeader` titles).

<img width="888" height="155" alt="SCR-20260707-mcdi" src="https://github.com/user-attachments/assets/f586dc2a-2927-4ad3-863b-f3e6b1f85fb7" />

<img width="630" height="129" alt="SCR-20260707-mchs" src="https://github.com/user-attachments/assets/12b82281-8d4f-4ec1-9cf5-da48228f5f7c" />

## Review follow-ups

- Sourced the description's font weight from `euiTheme.font.weight.medium` (which is exactly `450`) instead of a hardcoded magic number, in both the rule and episode flyout headers.
- Added unit tests for `TagsOverflowBadgeRow`/`getTagsOverflowLimits` covering below-threshold, above-threshold, and `maxVisible: 0` cases.
- Split `RuleHeaderDescription` (description only) and a new `RuleTagsList` (tags only) apart, and removed the `showTags`/`renderTags` toggle prop entirely — it only had one caller and its name collided with an unrelated `tags.length > 0` check elsewhere in the diff, which is what prompted a review comment questioning whether the logic was redundant.
- Renamed `rule_header_description.tsx` to `rule_summary_header.tsx`, since the file holds everything used to render a rule's compact summary (title, kind badge, status badge, tags, description) across both the summary flyout and the agent-builder canvas attachment, not just the description.
