### PR TITLE
[9.3] [Fleet] Add dryRun option to bulk agent API endpoints

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -22433,6 +22433,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "enrollment_token": {
                     "type": "string"
                   },
@@ -22508,16 +22511,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -22612,6 +22631,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "user_info": {
                     "additionalProperties": false,
                     "properties": {
@@ -22648,16 +22670,32 @@
                   }
                 },
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -22748,6 +22786,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "includeInactive": {
                     "default": false,
                     "type": "boolean"
@@ -22770,16 +22811,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -22871,6 +22928,9 @@
                   },
                   "batchSize": {
                     "type": "number"
+                  },
+                  "dryRun": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -22886,16 +22946,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -22990,6 +23066,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "includeInactive": {
                     "default": false,
                     "type": "boolean"
@@ -23018,20 +23097,37 @@
                   }
                 },
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionIds": {
-                      "items": {
-                        "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionIds": {
+                          "items": {
+                            "maxLength": 36,
+                            "type": "string"
+                          },
+                          "maxItems": 10000,
+                          "type": "array"
+                        }
                       },
-                      "maxItems": 10000,
-                      "type": "array"
+                      "required": [
+                        "actionIds"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionIds"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -23124,6 +23220,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "force": {
                     "description": "Unenrolls hosted agents too",
                     "type": "boolean"
@@ -23150,16 +23249,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -23242,6 +23357,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "includeInactive": {
                     "default": false,
                     "type": "boolean"
@@ -23274,16 +23392,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -23366,6 +23500,9 @@
                   "batchSize": {
                     "type": "number"
                   },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
                   "force": {
                     "type": "boolean"
                   },
@@ -23404,16 +23541,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },
@@ -25702,16 +25855,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "actionId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionId"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "actionId"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -33598,13 +33598,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34299,6 +34307,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 enrollment_token:
                   type: string
                 settings:
@@ -34348,13 +34358,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34426,6 +34444,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 user_info:
                   additionalProperties: false
                   type: object
@@ -34447,13 +34467,21 @@ paths:
                   value:
                     actionId: actionId
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34522,6 +34550,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 includeInactive:
                   default: false
                   type: boolean
@@ -34535,13 +34565,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34612,6 +34650,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
               required:
                 - agents
       responses:
@@ -34619,13 +34659,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34697,6 +34745,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 includeInactive:
                   default: false
                   type: boolean
@@ -34713,16 +34763,25 @@ paths:
                       - actionId1
                       - actionId2
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionIds:
-                    items:
-                      type: string
-                    maxItems: 10000
-                    type: array
-                required:
-                  - actionIds
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionIds:
+                        items:
+                          maxLength: 36
+                          type: string
+                        maxItems: 10000
+                        type: array
+                    required:
+                      - actionIds
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34793,6 +34852,8 @@ paths:
                       type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 force:
                   description: Unenrolls hosted agents too
                   type: boolean
@@ -34809,13 +34870,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34879,6 +34948,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 includeInactive:
                   default: false
                   type: boolean
@@ -34899,13 +34970,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:
@@ -34969,6 +35048,8 @@ paths:
                     - type: string
                 batchSize:
                   type: number
+                dryRun:
+                  type: boolean
                 force:
                   type: boolean
                 includeInactive:
@@ -34993,13 +35074,21 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: false
-                type: object
-                properties:
-                  actionId:
-                    type: string
-                required:
-                  - actionId
+                anyOf:
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      actionId:
+                        type: string
+                    required:
+                      - actionId
+                  - additionalProperties: false
+                    type: object
+                    properties:
+                      count:
+                        type: number
+                    required:
+                      - count
           description: 'OK: A successful request.'
         '400':
           content:

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agent.ts
@@ -96,6 +96,7 @@ export interface PostBulkAgentUnenrollRequest {
     force?: boolean;
     revoke?: boolean;
     includeInactive?: boolean;
+    dryRun?: boolean;
   };
 }
 
@@ -103,7 +104,11 @@ export interface BulkAgentAction {
   actionId: string;
 }
 
-export type PostBulkAgentUnenrollResponse = BulkAgentAction;
+export interface BulkAgentActionDryRun {
+  count: number;
+}
+
+export type PostBulkAgentUnenrollResponse = BulkAgentAction | BulkAgentActionDryRun;
 
 export interface PostAgentUpgradeRequest {
   params: {
@@ -125,10 +130,11 @@ export interface PostBulkAgentUpgradeRequest {
     start_time?: string;
     force?: boolean;
     includeInactive?: boolean;
+    dryRun?: boolean;
   };
 }
 
-export type PostBulkAgentUpgradeResponse = BulkAgentAction;
+export type PostBulkAgentUpgradeResponse = BulkAgentAction | BulkAgentActionDryRun;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PostAgentUpgradeResponse {}
@@ -148,12 +154,11 @@ export interface PostBulkAgentRollbackRequest {
     agents: string[] | string;
     batchSize?: number;
     includeInactive?: boolean;
+    dryRun?: boolean;
   };
 }
 
-export interface PostBulkAgentRollbackResponse {
-  actionIds: string[];
-}
+export type PostBulkAgentRollbackResponse = { actionIds: string[] } | BulkAgentActionDryRun;
 
 export interface PostAgentReassignRequest {
   params: {
@@ -171,6 +176,7 @@ export interface PostBulkAgentReassignRequest {
     agents: string[] | string;
     batchSize?: number;
     includeInactive?: boolean;
+    dryRun?: boolean;
   };
 }
 
@@ -185,19 +191,20 @@ export interface PostRequestDiagnosticsRequest {
 }
 
 export type PostRequestDiagnosticsResponse = BulkAgentAction;
-export type PostBulkRequestDiagnosticsResponse = BulkAgentAction;
+export type PostBulkRequestDiagnosticsResponse = BulkAgentAction | BulkAgentActionDryRun;
 
 export interface PostRequestBulkDiagnosticsRequest {
   body: {
     agents: string[] | string;
     batchSize?: number;
     additional_metrics: RequestDiagnosticsAdditionalMetrics[];
+    dryRun?: boolean;
   };
 }
 
-export type PostBulkAgentReassignResponse = BulkAgentAction;
+export type PostBulkAgentReassignResponse = BulkAgentAction | BulkAgentActionDryRun;
 
-export type PostBulkUpdateAgentTagsResponse = BulkAgentAction;
+export type PostBulkUpdateAgentTagsResponse = BulkAgentAction | BulkAgentActionDryRun;
 
 export interface DeleteAgentRequest {
   params: {
@@ -248,11 +255,10 @@ export interface BulkMigrateAgentsRequest {
       staging?: string;
       tags?: string;
     };
+    dryRun?: boolean;
   };
 }
-export interface BulkMigrateAgentsResponse {
-  actionId: string;
-}
+export type BulkMigrateAgentsResponse = BulkAgentAction | BulkAgentActionDryRun;
 export interface UpdateAgentRequest {
   params: {
     agentId: string;
@@ -269,6 +275,7 @@ export interface PostBulkUpdateAgentTagsRequest {
     tagsToAdd?: string[];
     tagsToRemove?: string[];
     includeInactive?: boolean;
+    dryRun?: boolean;
   };
 }
 
@@ -361,9 +368,8 @@ export interface BulkChangeAgentPrivilegeLevelRequest {
   body: {
     agents: string[] | string;
     user_info?: AgentPrivilegeLevelChangeUserInfo;
+    dryRun?: boolean;
   };
 }
 
-export interface BulkChangeAgentPrivilegeLevelResponse {
-  actionId: string;
-}
+export type BulkChangeAgentPrivilegeLevelResponse = BulkAgentAction | BulkAgentActionDryRun;

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/change_privilege_level_handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/change_privilege_level_handlers.ts
@@ -42,9 +42,12 @@ export const bulkChangeAgentsPrivilegeLevelHandler: FleetRequestHandler<
   const { agents, ...options } = request.body;
   const agentOptions = Array.isArray(agents) ? { agentIds: agents } : { kuery: agents };
 
-  const body = await bulkChangeAgentsPrivilegeLevel(esClient, soClient, {
+  const result = await bulkChangeAgentsPrivilegeLevel(esClient, soClient, {
     ...options,
     ...agentOptions,
   });
-  return response.ok({ body });
+  if (options.dryRun) {
+    return response.ok({ body: { count: (result as { count: number }).count } });
+  }
+  return response.ok({ body: result as { actionId: string } });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
@@ -169,12 +169,15 @@ export const bulkUpdateAgentTagsHandler: RequestHandler<
   const results = await AgentService.updateAgentTags(
     soClient,
     esClient,
-    { ...agentOptions, batchSize: request.body.batchSize },
+    { ...agentOptions, batchSize: request.body.batchSize, dryRun: request.body.dryRun },
     request.body.tagsToAdd ?? [],
     request.body.tagsToRemove ?? []
   );
 
-  return response.ok({ body: { actionId: results.actionId } });
+  if (request.body.dryRun) {
+    return response.ok({ body: { count: (results as { count: number }).count } });
+  }
+  return response.ok({ body: { actionId: (results as { actionId: string }).actionId } });
 };
 
 export const getAgentsHandler: FleetRequestHandler<
@@ -292,11 +295,14 @@ export const postBulkAgentReassignHandler: RequestHandler<
   const results = await AgentService.reassignAgents(
     soClient,
     esClient,
-    { ...agentOptions, batchSize: request.body.batchSize },
+    { ...agentOptions, batchSize: request.body.batchSize, dryRun: request.body.dryRun },
     request.body.policy_id
   );
 
-  return response.ok({ body: { actionId: results.actionId } });
+  if (request.body.dryRun) {
+    return response.ok({ body: { count: (results as { count: number }).count } });
+  }
+  return response.ok({ body: { actionId: (results as { actionId: string }).actionId } });
 };
 
 export const getAgentStatusForAgentPolicyHandler: FleetRequestHandler<

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/index.test.ts
@@ -11,6 +11,7 @@ import type { FleetRequestHandlerContext } from '../..';
 
 import { xpackMocks } from '../../mocks';
 import {
+  BulkChangeAgentsPrivilegeLevelResponseSchema,
   BulkMigrateAgentsResponseSchema,
   ChangeAgentPrivilegeLevelResponseSchema,
   DeleteAgentResponseSchema,
@@ -24,6 +25,7 @@ import {
   ListAgentUploadsResponseSchema,
   MigrateSingleAgentResponseSchema,
   PostBulkActionResponseSchema,
+  PostBulkAgentRollbackResponseSchema,
   PostNewAgentActionResponseSchema,
   PostRetrieveAgentsByActionsResponseSchema,
 } from '../../types/rest_spec/agent';
@@ -537,5 +539,27 @@ describe('schema validation', () => {
     });
     const validationResp = ChangeAgentPrivilegeLevelResponseSchema.validate(expectedResponse);
     expect(validationResp).toEqual(expectedResponse);
+  });
+
+  it('bulk action dry-run response { count } passes PostBulkActionResponseSchema', () => {
+    const dryRunResponse = { count: 42 };
+    expect(PostBulkActionResponseSchema.validate(dryRunResponse)).toEqual(dryRunResponse);
+  });
+
+  it('bulk migrate dry-run response { count } passes BulkMigrateAgentsResponseSchema', () => {
+    const dryRunResponse = { count: 7 };
+    expect(BulkMigrateAgentsResponseSchema.validate(dryRunResponse)).toEqual(dryRunResponse);
+  });
+
+  it('bulk privilege level change dry-run response { count } passes BulkChangeAgentsPrivilegeLevelResponseSchema', () => {
+    const dryRunResponse = { count: 3 };
+    expect(BulkChangeAgentsPrivilegeLevelResponseSchema.validate(dryRunResponse)).toEqual(
+      dryRunResponse
+    );
+  });
+
+  it('bulk rollback dry-run response { count } passes PostBulkAgentRollbackResponseSchema', () => {
+    const dryRunResponse = { count: 15 };
+    expect(PostBulkAgentRollbackResponseSchema.validate(dryRunResponse)).toEqual(dryRunResponse);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/migrate_handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/migrate_handlers.ts
@@ -59,10 +59,13 @@ export const bulkMigrateAgentsHandler: FleetRequestHandler<
 
   const agentOptions = Array.isArray(agents) ? { agentIds: agents } : { kuery: agents };
 
-  const body = await AgentService.bulkMigrateAgents(esClient, soClient, {
+  const result = await AgentService.bulkMigrateAgents(esClient, soClient, {
     ...options,
     ...agentOptions,
   });
 
-  return response.ok({ body });
+  if (options.dryRun) {
+    return response.ok({ body: { count: (result as { count: number }).count } });
+  }
+  return response.ok({ body: result as { actionId: string } });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/request_diagnostics_handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/request_diagnostics_handler.ts
@@ -61,7 +61,11 @@ export const bulkRequestDiagnosticsHandler: FleetRequestHandler<
     ...agentOptions,
     batchSize: request.body.batchSize,
     additionalMetrics: request.body.additional_metrics,
+    dryRun: request.body.dryRun,
   });
 
-  return response.ok({ body: { actionId: result.actionId } });
+  if (request.body.dryRun) {
+    return response.ok({ body: { count: (result as { count: number }).count } });
+  }
+  return response.ok({ body: { actionId: (result as { actionId: string }).actionId } });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/rollback_handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/rollback_handlers.ts
@@ -42,7 +42,7 @@ export const bulkRollbackAgentHandler: RequestHandler<
   const coreContext = await context.core;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const soClient = coreContext.savedObjects.client;
-  const { agents, batchSize, includeInactive } = request.body;
+  const { agents, batchSize, includeInactive, dryRun } = request.body;
   const agentOptions = Array.isArray(agents)
     ? { agentIds: agents }
     : { kuery: agents, showInactive: includeInactive };
@@ -50,7 +50,11 @@ export const bulkRollbackAgentHandler: RequestHandler<
     ...agentOptions,
     batchSize,
     includeInactive,
+    dryRun,
   });
 
-  return response.ok({ body: { actionIds: results.actionIds } });
+  if (dryRun) {
+    return response.ok({ body: { count: (results as { count: number }).count } });
+  }
+  return response.ok({ body: { actionIds: (results as { actionIds: string[] }).actionIds } });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/unenroll_handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/unenroll_handler.ts
@@ -50,7 +50,11 @@ export const postBulkAgentsUnenrollHandler: RequestHandler<
     force: request.body?.force,
     batchSize: request.body?.batchSize,
     showInactive: request.body?.includeInactive,
+    dryRun: request.body?.dryRun,
   });
 
-  return response.ok({ body: { actionId: results.actionId } });
+  if (request.body.dryRun) {
+    return response.ok({ body: { count: (results as { count: number }).count } });
+  }
+  return response.ok({ body: { actionId: (results as { actionId: string }).actionId } });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/upgrade_handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/upgrade_handler.ts
@@ -152,6 +152,7 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
     rollout_duration_seconds: upgradeDurationSeconds,
     start_time: startTime,
     batchSize,
+    dryRun,
   } = request.body;
   const kibanaVersion = appContextService.getKibanaVersion();
   try {
@@ -179,10 +180,14 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
     upgradeDurationSeconds,
     startTime,
     batchSize,
+    dryRun,
   };
   const results = await AgentService.sendUpgradeAgentsActions(soClient, esClient, upgradeOptions);
 
-  return response.ok({ body: { actionId: results.actionId } });
+  if (dryRun) {
+    return response.ok({ body: { count: (results as { count: number }).count } });
+  }
+  return response.ok({ body: { actionId: (results as { actionId: string }).actionId } });
 };
 
 export const checkKibanaVersion = (version: string, kibanaVersion: string, force = false) => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/change_privilege_level.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/change_privilege_level.ts
@@ -88,11 +88,16 @@ export async function bulkChangeAgentsPrivilegeLevel(
     actionId?: string;
     total?: number;
     user_info?: AgentPrivilegeLevelChangeUserInfo;
+    dryRun?: boolean;
   }
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   const currentSpaceId = getCurrentNamespace(soClient);
 
   if ('agentIds' in options) {
+    if (options.dryRun) {
+      const agents = await getAgents(esClient, soClient, options);
+      return { count: agents.length };
+    }
     const givenAgents = await getAgents(esClient, soClient, options);
     return await bulkChangePrivilegeAgentsBatch(esClient, soClient, givenAgents, {
       ...options,
@@ -109,6 +114,9 @@ export async function bulkChangeAgentsPrivilegeLevel(
     page: 1,
     perPage: batchSize,
   });
+  if (options.dryRun) {
+    return { count: res.total };
+  }
   if (res.total <= batchSize) {
     return await bulkChangePrivilegeAgentsBatch(esClient, soClient, res.agents, {
       ...options,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
@@ -25,7 +25,11 @@ import { createAgentAction } from './actions';
 import type { GetAgentsOptions } from './crud';
 import { getAgents, getAgentsByKuery, openPointInTime } from './crud';
 
-import { MigrateActionRunner, bulkMigrateAgentsBatch } from './migrate_action_runner';
+import {
+  MigrateActionRunner,
+  bulkMigrateAgentsBatch,
+  partitionAgentsForMigration,
+} from './migrate_action_runner';
 import { detectTargetClusterType } from './detect_target_cluster_type';
 
 export async function migrateSingleAgent(
@@ -126,8 +130,9 @@ export async function bulkMigrateAgents(
     enrollment_token: string;
     uri: string;
     settings?: Record<string, any>;
+    dryRun?: boolean;
   }
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   // Check the user has the correct license
   if (!licenseService.hasAtLeast(LICENSE_FOR_AGENT_MIGRATION)) {
     throw new FleetUnauthorizedError(
@@ -151,6 +156,14 @@ export async function bulkMigrateAgents(
   };
 
   if ('agentIds' in options) {
+    if (options.dryRun) {
+      // Count only agents that would actually be migrated — protected-policy,
+      // fleet-server, and migration-unsupported agents are dropped by
+      // bulkMigrateAgentsBatch, so exclude them here to avoid over-reporting.
+      const agents = await getAgents(esClient, soClient, options);
+      const { agentsToAction } = await partitionAgentsForMigration(soClient, agents);
+      return { count: agentsToAction.length };
+    }
     const givenAgents = await getAgents(esClient, soClient, options);
     const response = await bulkMigrateAgentsBatch(esClient, soClient, givenAgents, {
       enrollment_token: options.enrollment_token,
@@ -171,6 +184,9 @@ export async function bulkMigrateAgents(
     page: 1,
     perPage: batchSize,
   });
+  if (options.dryRun) {
+    return { count: res.total };
+  }
   if (res.total <= batchSize) {
     const response = await bulkMigrateAgentsBatch(esClient, soClient, res.agents, {
       enrollment_token: options.enrollment_token,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate_action_runner.ts
@@ -33,21 +33,17 @@ export class MigrateActionRunner extends ActionRunner {
   }
 }
 
-export async function bulkMigrateAgentsBatch(
-  esClient: ElasticsearchClient,
+/**
+ * Splits the given agents into those that can be migrated and those that cannot,
+ * mirroring the eligibility rules applied by `bulkMigrateAgentsBatch`. Agents in a
+ * protected policy, fleet-server agents, and migration-unsupported/containerized
+ * agents are collected as errors; the rest are returned in `agentsToAction`.
+ */
+export async function partitionAgentsForMigration(
   soClient: SavedObjectsClientContract,
-  agents: Agent[],
-  options: {
-    actionId?: string;
-    total?: number;
-    spaceId?: string;
-    enrollment_token?: string;
-    uri?: string;
-    settings?: Record<string, any>;
-  }
-) {
+  agents: Agent[]
+): Promise<{ agentsToAction: Agent[]; errors: Record<Agent['id'], Error> }> {
   const errors: Record<Agent['id'], Error> = {};
-  const now = new Date().toISOString();
 
   const agentPolicies = await getAgentPolicyForAgents(soClient, agents);
   const protectedAgentPolicies = agentPolicies.filter((agentPolicy) => agentPolicy?.is_protected);
@@ -81,6 +77,26 @@ export async function bulkMigrateAgentsBatch(
       agentsToAction.push(agent);
     }
   });
+
+  return { agentsToAction, errors };
+}
+
+export async function bulkMigrateAgentsBatch(
+  esClient: ElasticsearchClient,
+  soClient: SavedObjectsClientContract,
+  agents: Agent[],
+  options: {
+    actionId?: string;
+    total?: number;
+    spaceId?: string;
+    enrollment_token?: string;
+    uri?: string;
+    settings?: Record<string, any>;
+  }
+) {
+  const now = new Date().toISOString();
+
+  const { agentsToAction, errors } = await partitionAgentsForMigration(soClient, agents);
   const actionId = options.actionId ?? uuidv4();
   const agentIds = agentsToAction.map((agent) => agent.id);
   const total = options.total ?? agentIds.length;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.test.ts
@@ -224,3 +224,170 @@ describe('reassignAgents kuery construction', () => {
     );
   });
 });
+
+describe('reassignAgents kuery path — sync/async branching', () => {
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockOpenPointInTime: jest.SpyInstance;
+  let mockReassignBatch: jest.SpyInstance;
+  let mockReassignActionRunner: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { soClient } = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        internal: soClient,
+        withoutSpaceExtensions: soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery');
+    mockOpenPointInTime = jest.spyOn(crud, 'openPointInTime').mockResolvedValue('pit-id');
+    mockReassignBatch = jest
+      .spyOn(reassignActionRunner, 'reassignBatch')
+      .mockResolvedValue({ actionId: 'test-action-id' });
+    mockReassignActionRunner = jest
+      .spyOn(reassignActionRunner, 'ReassignActionRunner')
+      .mockImplementation(
+        () =>
+          ({
+            runActionAsyncTask: jest.fn().mockResolvedValue({ actionId: 'async-action-id' }),
+          } as any)
+      );
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockOpenPointInTime.mockRestore();
+    mockReassignBatch.mockRestore();
+    mockReassignActionRunner.mockRestore();
+    appContextService.stop();
+  });
+
+  it('runs inline and fetches agents when total <= batchSize', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const agents = [{ id: 'agent-1' } as any];
+    mockGetAgentsByKuery.mockResolvedValue({ agents, total: 5, page: 1, perPage: SO_SEARCH_LIMIT });
+
+    await reassignAgents(soClient, esClient, { kuery: 'status:online' }, regularAgentPolicySO2.id);
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ perPage: SO_SEARCH_LIMIT })
+    );
+    expect(mockReassignBatch).toHaveBeenCalledWith(
+      esClient,
+      expect.anything(),
+      agents,
+      expect.anything()
+    );
+    expect(mockReassignActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('schedules async task and returns actionId immediately when total > batchSize', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const batchSize = 100;
+    mockGetAgentsByKuery.mockResolvedValue({
+      agents: [],
+      total: 500,
+      page: 1,
+      perPage: batchSize,
+    });
+
+    const result = await reassignAgents(
+      soClient,
+      esClient,
+      { kuery: 'status:online', batchSize },
+      regularAgentPolicySO2.id
+    );
+
+    expect(result).toEqual({ actionId: 'async-action-id' });
+    expect(mockGetAgentsByKuery).toHaveBeenCalledTimes(1);
+    expect(mockReassignActionRunner).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ batchSize, total: 500 }),
+      expect.anything()
+    );
+    expect(mockReassignBatch).not.toHaveBeenCalled();
+  });
+
+  it('uses caller-supplied batchSize as the async threshold', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const batchSize = 50;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 60, page: 1, perPage: batchSize });
+
+    const result = await reassignAgents(
+      soClient,
+      esClient,
+      { kuery: 'status:online', batchSize },
+      regularAgentPolicySO2.id
+    );
+
+    expect(result).toEqual({ actionId: 'async-action-id' });
+    expect(mockReassignActionRunner).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ batchSize, total: 60 }),
+      expect.anything()
+    );
+  });
+
+  it('runs inline when total equals batchSize (boundary)', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const batchSize = 100;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 100, page: 1, perPage: batchSize });
+
+    await reassignAgents(
+      soClient,
+      esClient,
+      { kuery: 'status:online', batchSize },
+      regularAgentPolicySO2.id
+    );
+
+    expect(mockReassignBatch).toHaveBeenCalled();
+    expect(mockReassignActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('dry run (kuery) returns count without writing', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    mockGetAgentsByKuery.mockResolvedValue({
+      agents: [],
+      total: 25,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+
+    const result = await reassignAgents(
+      soClient,
+      esClient,
+      { kuery: 'status:online', dryRun: true },
+      regularAgentPolicySO2.id
+    );
+
+    expect(result).toEqual({ count: 25 });
+    expect(mockReassignBatch).not.toHaveBeenCalled();
+    expect(mockReassignActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('dry run (agentIds) returns count of found agents only', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const mockGetAgentsById = jest
+      .spyOn(crud, 'getAgentsById')
+      .mockResolvedValue([
+        { id: 'agent-1' } as any,
+        { notFound: true, id: 'missing-1' },
+        { id: 'agent-2' } as any,
+      ] as any);
+
+    const result = await reassignAgents(
+      soClient,
+      esClient,
+      { agentIds: ['agent-1', 'missing-1', 'agent-2'], dryRun: true },
+      regularAgentPolicySO2.id
+    );
+
+    expect(result).toEqual({ count: 2 });
+    expect(mockReassignBatch).not.toHaveBeenCalled();
+    mockGetAgentsById.mockRestore();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
@@ -100,17 +100,25 @@ export async function reassignAgents(
   options: ({ agents: Agent[] } | GetAgentsOptions) & {
     force?: boolean;
     batchSize?: number;
+    dryRun?: boolean;
   },
   newAgentPolicyId: string
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   await verifyNewAgentPolicy(soClient, newAgentPolicyId);
 
   const currentSpaceId = getCurrentNamespace(soClient);
   const outgoingErrors: Record<Agent['id'], Error> = {};
   let givenAgents: Agent[] = [];
   if ('agents' in options) {
+    if (options.dryRun) {
+      return { count: options.agents.length };
+    }
     givenAgents = options.agents;
   } else if ('agentIds' in options) {
+    if (options.dryRun) {
+      const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
+      return { count: maybeAgents.filter((a) => !('notFound' in a)).length };
+    }
     const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
     for (const maybeAgent of maybeAgents) {
       if ('notFound' in maybeAgent) {
@@ -132,6 +140,9 @@ export async function reassignAgents(
       page: 1,
       perPage: batchSize,
     });
+    if (options.dryRun) {
+      return { count: res.total };
+    }
     // running action in async mode for >10k agents (or actions > batchSize for testing purposes)
     if (res.total <= batchSize) {
       givenAgents = res.agents;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/request_diagnostics.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/request_diagnostics.ts
@@ -49,11 +49,16 @@ export async function bulkRequestDiagnostics(
   options: GetAgentsOptions & {
     batchSize?: number;
     additionalMetrics?: RequestDiagnosticsAdditionalMetrics[];
+    dryRun?: boolean;
   }
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   const currentSpaceId = getCurrentNamespace(soClient);
 
   if ('agentIds' in options) {
+    if (options.dryRun) {
+      const agents = await getAgents(esClient, soClient, options);
+      return { count: agents.length };
+    }
     const givenAgents = await getAgents(esClient, soClient, options);
     return await requestDiagnosticsBatch(esClient, givenAgents, {
       additionalMetrics: options.additionalMetrics,
@@ -70,6 +75,9 @@ export async function bulkRequestDiagnostics(
     page: 1,
     perPage: batchSize,
   });
+  if (options.dryRun) {
+    return { count: res.total };
+  }
   if (res.total <= batchSize) {
     return await requestDiagnosticsBatch(esClient, res.agents, {
       additionalMetrics: options.additionalMetrics,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.test.ts
@@ -588,7 +588,7 @@ describe('rollback', () => {
           agents,
         });
 
-        expect(result.actionIds).toEqual([mockActionId1, mockActionId2]);
+        expect(result).toHaveProperty('actionIds', [mockActionId1, mockActionId2]);
         expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, agents, {}, {}, ['default']);
       });
 
@@ -601,7 +601,7 @@ describe('rollback', () => {
           agents: [],
         });
 
-        expect(result.actionIds).toEqual([]);
+        expect(result).toHaveProperty('actionIds', []);
         expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, [], {}, {}, ['default']);
       });
     });
@@ -635,7 +635,7 @@ describe('rollback', () => {
           agentIds,
         });
 
-        expect(result.actionIds).toEqual([mockActionId1]);
+        expect(result).toHaveProperty('actionIds', [mockActionId1]);
         expect(mockGetAgentsById).toHaveBeenCalledWith(esClient, soClient, agentIds);
         expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, agents, {}, {}, ['default']);
       });
@@ -659,7 +659,7 @@ describe('rollback', () => {
           agentIds,
         });
 
-        expect(result.actionIds).toEqual([mockActionId1]);
+        expect(result).toHaveProperty('actionIds', [mockActionId1]);
         expect(mockRollbackBatch).toHaveBeenCalledWith(
           esClient,
           [agent1],
@@ -697,7 +697,7 @@ describe('rollback', () => {
           kuery,
         });
 
-        expect(result.actionIds).toEqual([mockActionId1]);
+        expect(result).toHaveProperty('actionIds', [mockActionId1]);
         expect(mockGetAgentsByKuery).toHaveBeenCalledWith(esClient, soClient, {
           kuery: `(${kuery})`,
           showAgentless: undefined,
@@ -733,7 +733,7 @@ describe('rollback', () => {
           batchSize,
         });
 
-        expect(result.actionIds).toEqual([mockActionId1, mockActionId2]);
+        expect(result).toHaveProperty('actionIds', [mockActionId1, mockActionId2]);
         expect(mockGetAgentsByKuery).toHaveBeenCalledWith(esClient, soClient, {
           kuery: `(${kuery})`,
           showAgentless: undefined,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.ts
@@ -114,8 +114,9 @@ export async function sendRollbackAgentsActions(
   options: ({ agents: Agent[] } | GetAgentsOptions) & {
     batchSize?: number;
     includeInactive?: boolean;
+    dryRun?: boolean;
   }
-): Promise<{ actionIds: string[] }> {
+): Promise<{ actionIds: string[] } | { count: number }> {
   checkLicense();
 
   const currentSpaceId = getCurrentNamespace(soClient);
@@ -123,8 +124,15 @@ export async function sendRollbackAgentsActions(
   let givenAgents: Agent[] = [];
 
   if ('agents' in options) {
+    if (options.dryRun) {
+      return { count: options.agents.length };
+    }
     givenAgents = options.agents;
   } else if ('agentIds' in options) {
+    if (options.dryRun) {
+      const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
+      return { count: maybeAgents.filter((a) => !('notFound' in a)).length };
+    }
     const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
     for (const maybeAgent of maybeAgents) {
       if ('notFound' in maybeAgent) {
@@ -145,6 +153,9 @@ export async function sendRollbackAgentsActions(
       page: 1,
       perPage: batchSize,
     });
+    if (options.dryRun) {
+      return { count: res.total };
+    }
 
     if (res.total <= batchSize) {
       givenAgents = res.agents;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
@@ -25,6 +25,7 @@ import { unenrollAgent, unenrollAgents } from './unenroll';
 import { invalidateAPIKeysForAgents, isAgentUnenrolled } from './unenroll_action_runner';
 import { createClientMock } from './action.mock';
 import * as crud from './crud';
+import * as unenrollActionRunner from './unenroll_action_runner';
 
 jest.mock('../api_keys');
 
@@ -245,7 +246,7 @@ describe('unenroll', () => {
         agentIds: idsToUnenroll,
         revoke: true,
       });
-      expect(unenrolledResponse.actionId).toBeDefined();
+      expect(unenrolledResponse).toHaveProperty('actionId');
 
       // calls ES update with correct values
       const onlyRegular = [agentInRegularDoc._id, agentInRegularDoc2._id];
@@ -309,7 +310,7 @@ describe('unenroll', () => {
         force: true,
       });
 
-      expect(unenrolledResponse.actionId).toBeDefined();
+      expect(unenrolledResponse).toHaveProperty('actionId');
 
       // calls ES update with correct values
       const calledWith = esClient.bulk.mock.calls[0][0];
@@ -460,5 +461,144 @@ describe('unenrollAgents kuery construction', () => {
         kuery: `(namespaces:custom_space) AND (${kuery})`,
       })
     );
+  });
+});
+
+describe('unenrollAgents kuery path — sync/async branching', () => {
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockOpenPointInTime: jest.SpyInstance;
+  let mockUnenrollBatch: jest.SpyInstance;
+  let mockUnenrollActionRunner: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { soClient } = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        withoutSpaceExtensions: soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery');
+    mockOpenPointInTime = jest.spyOn(crud, 'openPointInTime').mockResolvedValue('pit-id');
+    mockUnenrollBatch = jest
+      .spyOn(unenrollActionRunner, 'unenrollBatch')
+      .mockResolvedValue({ actionId: 'test-action-id' });
+    mockUnenrollActionRunner = jest
+      .spyOn(unenrollActionRunner, 'UnenrollActionRunner')
+      .mockImplementation(
+        () =>
+          ({
+            runActionAsyncTask: jest.fn().mockResolvedValue({ actionId: 'async-action-id' }),
+          } as any)
+      );
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockOpenPointInTime.mockRestore();
+    mockUnenrollBatch.mockRestore();
+    mockUnenrollActionRunner.mockRestore();
+    appContextService.stop();
+  });
+
+  it('runs inline and fetches agents when total <= batchSize', async () => {
+    const { soClient, esClient } = createClientMock();
+    const agents = [{ id: 'agent-1' } as any];
+    mockGetAgentsByKuery.mockResolvedValue({ agents, total: 5, page: 1, perPage: SO_SEARCH_LIMIT });
+
+    await unenrollAgents(soClient, esClient, { kuery: 'status:online' });
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ perPage: SO_SEARCH_LIMIT })
+    );
+    expect(mockUnenrollBatch).toHaveBeenCalledWith(soClient, esClient, agents, expect.anything());
+    expect(mockUnenrollActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('schedules async task and returns actionId immediately when total > batchSize', async () => {
+    const { soClient, esClient } = createClientMock();
+    const batchSize = 100;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 500, page: 1, perPage: batchSize });
+
+    const result = await unenrollAgents(soClient, esClient, {
+      kuery: 'status:online',
+      batchSize,
+    });
+
+    expect(result).toEqual({ actionId: 'async-action-id' });
+    expect(mockGetAgentsByKuery).toHaveBeenCalledTimes(1);
+    expect(mockUnenrollActionRunner).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ batchSize, total: 500 }),
+      expect.anything()
+    );
+    expect(mockUnenrollBatch).not.toHaveBeenCalled();
+  });
+
+  it('uses caller-supplied batchSize as the async threshold', async () => {
+    const { soClient, esClient } = createClientMock();
+    const batchSize = 50;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 60, page: 1, perPage: batchSize });
+
+    const result = await unenrollAgents(soClient, esClient, {
+      kuery: 'status:online',
+      batchSize,
+    });
+
+    expect(result).toEqual({ actionId: 'async-action-id' });
+    expect(mockUnenrollActionRunner).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ batchSize, total: 60 }),
+      expect.anything()
+    );
+  });
+
+  it('runs inline when total equals batchSize (boundary)', async () => {
+    const { soClient, esClient } = createClientMock();
+    const batchSize = 100;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 100, page: 1, perPage: batchSize });
+
+    await unenrollAgents(soClient, esClient, { kuery: 'status:online', batchSize });
+
+    expect(mockUnenrollBatch).toHaveBeenCalled();
+    expect(mockUnenrollActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('dry run (kuery) returns count without writing', async () => {
+    const { soClient, esClient } = createClientMock();
+    mockGetAgentsByKuery.mockResolvedValue({
+      agents: [],
+      total: 42,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+
+    const result = await unenrollAgents(soClient, esClient, {
+      kuery: 'status:online',
+      dryRun: true,
+    });
+
+    expect(result).toEqual({ count: 42 });
+    expect(mockUnenrollBatch).not.toHaveBeenCalled();
+    expect(mockUnenrollActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('dry run (agentIds) returns count of found agents only', async () => {
+    const { soClient, esClient } = createClientMock();
+    const mockGetAgents = jest
+      .spyOn(crud, 'getAgents')
+      .mockResolvedValue([{ id: 'agent-1' }, { id: 'agent-2' }] as any);
+
+    const result = await unenrollAgents(soClient, esClient, {
+      agentIds: ['agent-1', 'agent-2', 'missing-1'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({ count: 2 });
+    expect(mockUnenrollBatch).not.toHaveBeenCalled();
+    mockGetAgents.mockRestore();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
@@ -89,11 +89,16 @@ export async function unenrollAgents(
     revoke?: boolean;
     batchSize?: number;
     showInactive?: boolean;
+    dryRun?: boolean;
   }
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   const spaceId = getCurrentNamespace(soClient);
 
   if ('agentIds' in options) {
+    if (options.dryRun) {
+      const agents = await getAgents(esClient, soClient, options);
+      return { count: agents.length };
+    }
     const givenAgents = await getAgents(esClient, soClient, options);
     return await unenrollBatch(soClient, esClient, givenAgents, {
       ...options,
@@ -111,6 +116,9 @@ export async function unenrollAgents(
     page: 1,
     perPage: batchSize,
   });
+  if (options.dryRun) {
+    return { count: res.total };
+  }
   if (res.total <= batchSize) {
     return await unenrollBatch(soClient, esClient, res.agents, {
       ...options,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.ts
@@ -17,22 +17,31 @@ import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/
 
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
-import { getAgentsById, getAgentsByKuery, openPointInTime } from './crud';
+import { closePointInTime, getAgentsById, getAgentsByKuery, openPointInTime } from './crud';
 import type { GetAgentsOptions } from '.';
 import { UpdateAgentTagsActionRunner, updateTagsBatch } from './update_agent_tags_action_runner';
 
 export async function updateAgentTags(
   soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient,
-  options: ({ agents: Agent[] } | GetAgentsOptions) & { batchSize?: number },
+  options: ({ agents: Agent[] } | GetAgentsOptions) & { batchSize?: number; dryRun?: boolean },
   tagsToAdd: string[],
   tagsToRemove: string[]
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   const currentSpaceId = getCurrentNamespace(soClient);
   const outgoingErrors: Record<Agent['id'], Error> = {};
   const givenAgents: Agent[] = [];
 
-  if ('agentIds' in options) {
+  if ('agents' in options) {
+    if (options.dryRun) {
+      return { count: options.agents.length };
+    }
+    givenAgents.push(...options.agents);
+  } else if ('agentIds' in options) {
+    if (options.dryRun) {
+      const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
+      return { count: maybeAgents.filter((a) => !('notFound' in a)).length };
+    }
     const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
     for (const maybeAgent of maybeAgents) {
       if ('notFound' in maybeAgent) {
@@ -64,14 +73,22 @@ export async function updateAgentTags(
     const kuery = filters.join(' AND ');
     const pitId = await openPointInTime(esClient);
 
-    // calculate total count
+    // calculate total count; close PIT before propagating any ES error
     const res = await getAgentsByKuery(esClient, soClient, {
       kuery,
       showAgentless: options.showAgentless,
       showInactive: options.showInactive ?? false,
       perPage: 0,
       pitId,
+    }).catch(async (error) => {
+      await closePointInTime(esClient, pitId);
+      throw error;
     });
+
+    if (options.dryRun) {
+      await closePointInTime(esClient, pitId);
+      return { count: res.total };
+    }
 
     return await new UpdateAgentTagsActionRunner(
       esClient,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
@@ -19,6 +19,7 @@ import { sendUpgradeAgentsActions } from './upgrade';
 import { createClientMock } from './action.mock';
 import { getRollingUpgradeOptions, upgradeBatch } from './upgrade_action_runner';
 import * as crud from './crud';
+import * as upgradeActionRunner from './upgrade_action_runner';
 
 jest.mock('./versions', () => {
   return {
@@ -214,5 +215,143 @@ describe('sendUpgradeAgentsActions kuery construction', () => {
         kuery: `(namespaces:custom_space) AND (${kuery})`,
       })
     );
+  });
+});
+
+describe('sendUpgradeAgentsActions kuery path — sync/async branching', () => {
+  let upgradeMocks: ReturnType<typeof createClientMock>;
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockOpenPointInTime: jest.SpyInstance;
+  let mockUpgradeBatch: jest.SpyInstance;
+  let mockUpgradeActionRunner: jest.SpyInstance;
+
+  beforeEach(async () => {
+    upgradeMocks = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        internal: upgradeMocks.soClient,
+        withoutSpaceExtensions: upgradeMocks.soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery');
+    mockOpenPointInTime = jest.spyOn(crud, 'openPointInTime').mockResolvedValue('pit-id');
+    mockUpgradeBatch = jest
+      .spyOn(upgradeActionRunner, 'upgradeBatch')
+      .mockResolvedValue({ actionId: 'test-action-id' });
+    mockUpgradeActionRunner = jest
+      .spyOn(upgradeActionRunner, 'UpgradeActionRunner')
+      .mockImplementation(
+        () =>
+          ({
+            runActionAsyncTask: jest.fn().mockResolvedValue({ actionId: 'async-action-id' }),
+          } as any)
+      );
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockOpenPointInTime.mockRestore();
+    mockUpgradeBatch.mockRestore();
+    mockUpgradeActionRunner.mockRestore();
+    appContextService.stop();
+  });
+
+  it('runs inline and fetches agents when total <= batchSize', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    const agents = [{ id: 'agent-1' } as any];
+    mockGetAgentsByKuery.mockResolvedValue({ agents, total: 5, page: 1, perPage: SO_SEARCH_LIMIT });
+
+    await sendUpgradeAgentsActions(soClient, esClient, {
+      kuery: 'status:online',
+      version: '8.5.0',
+    });
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ perPage: SO_SEARCH_LIMIT })
+    );
+    expect(mockUpgradeBatch).toHaveBeenCalledWith(
+      esClient,
+      agents,
+      expect.anything(),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockUpgradeActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('schedules async task and returns actionId immediately when total > batchSize', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    const batchSize = 100;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 500, page: 1, perPage: batchSize });
+
+    const result = await sendUpgradeAgentsActions(soClient, esClient, {
+      kuery: 'status:online',
+      version: '8.5.0',
+      batchSize,
+    });
+
+    expect(result).toEqual({ actionId: 'async-action-id' });
+    expect(mockGetAgentsByKuery).toHaveBeenCalledTimes(1);
+    expect(mockUpgradeActionRunner).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({ batchSize, total: 500 }),
+      expect.anything()
+    );
+    expect(mockUpgradeBatch).not.toHaveBeenCalled();
+  });
+
+  it('runs inline when total equals batchSize (boundary)', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    const batchSize = 100;
+    mockGetAgentsByKuery.mockResolvedValue({ agents: [], total: 100, page: 1, perPage: batchSize });
+
+    await sendUpgradeAgentsActions(soClient, esClient, {
+      kuery: 'status:online',
+      version: '8.5.0',
+      batchSize,
+    });
+
+    expect(mockUpgradeBatch).toHaveBeenCalled();
+    expect(mockUpgradeActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('dry run (kuery) returns count without writing', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    mockGetAgentsByKuery.mockResolvedValue({
+      agents: [],
+      total: 17,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+
+    const result = await sendUpgradeAgentsActions(soClient, esClient, {
+      kuery: 'status:online',
+      version: '8.5.0',
+      dryRun: true,
+    });
+
+    expect(result).toEqual({ count: 17 });
+    expect(mockUpgradeBatch).not.toHaveBeenCalled();
+    expect(mockUpgradeActionRunner).not.toHaveBeenCalled();
+  });
+
+  it('dry run (agentIds) returns count of found agents only', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    const mockGetAgentsById = jest
+      .spyOn(crud, 'getAgentsById')
+      .mockResolvedValue([{ id: 'a1' } as Agent, { notFound: true, id: 'missing' }] as any);
+
+    const result = await sendUpgradeAgentsActions(soClient, esClient, {
+      agentIds: ['a1', 'missing'],
+      version: '8.5.0',
+      dryRun: true,
+    });
+
+    expect(result).toEqual({ count: 1 });
+    expect(mockUpgradeBatch).not.toHaveBeenCalled();
+    mockGetAgentsById.mockRestore();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
@@ -74,16 +74,24 @@ export async function sendUpgradeAgentsActions(
     startTime?: string;
     batchSize?: number;
     isAutomatic?: boolean;
+    dryRun?: boolean;
   }
-): Promise<{ actionId: string }> {
+): Promise<{ actionId: string } | { count: number }> {
   const currentSpaceId = getCurrentNamespace(soClient);
   // Full set of agents
   const outgoingErrors: Record<Agent['id'], Error> = {};
   let givenAgents: Agent[] = [];
 
   if ('agents' in options) {
+    if (options.dryRun) {
+      return { count: options.agents.length };
+    }
     givenAgents = options.agents;
   } else if ('agentIds' in options) {
+    if (options.dryRun) {
+      const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
+      return { count: maybeAgents.filter((a) => !('notFound' in a)).length };
+    }
     const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
     for (const maybeAgent of maybeAgents) {
       if ('notFound' in maybeAgent) {
@@ -104,6 +112,9 @@ export async function sendUpgradeAgentsActions(
       page: 1,
       perPage: batchSize,
     });
+    if (options.dryRun) {
+      return { count: res.total };
+    }
 
     if (res.total <= batchSize) {
       givenAgents = res.agents;

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
@@ -447,6 +447,7 @@ export const PostBulkAgentUnenrollRequestSchema = {
         },
       })
     ),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
@@ -489,6 +490,7 @@ export const PostBulkAgentUpgradeRequestSchema = {
     ),
     batchSize: schema.maybe(schema.number()),
     includeInactive: schema.boolean({ defaultValue: false }),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
@@ -525,6 +527,7 @@ export const PostBulkRequestDiagnosticsActionRequestSchema = {
         maxSize: 1,
       })
     ),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
@@ -580,6 +583,7 @@ export const PostBulkAgentReassignRequestSchema = {
     agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     batchSize: schema.maybe(schema.number()),
     includeInactive: schema.boolean({ defaultValue: false }),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
@@ -623,10 +627,13 @@ export const BulkMigrateAgentsRequestSchema = {
     enrollment_token: schema.string(),
     settings: schema.maybe(schema.object(BulkMigrateOptionsSchema)),
     batchSize: schema.maybe(schema.number()),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
-export const BulkMigrateAgentsResponseSchema = ActionIdSchema;
+const DryRunCountSchema = schema.object({ count: schema.number() });
+
+export const BulkMigrateAgentsResponseSchema = schema.oneOf([ActionIdSchema, DryRunCountSchema]);
 
 export const PostBulkUpdateAgentTagsRequestSchema = {
   body: schema.object({
@@ -635,10 +642,11 @@ export const PostBulkUpdateAgentTagsRequestSchema = {
     tagsToRemove: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
     batchSize: schema.maybe(schema.number()),
     includeInactive: schema.boolean({ defaultValue: false }),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
-export const PostBulkActionResponseSchema = ActionIdSchema;
+export const PostBulkActionResponseSchema = schema.oneOf([ActionIdSchema, DryRunCountSchema]);
 
 export const GetAgentStatusRequestSchema = {
   query: schema.object({
@@ -867,10 +875,14 @@ export const BulkChangeAgentsPrivilegeLevelRequestSchema = {
         password: schema.maybe(schema.string()),
       })
     ),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
-export const BulkChangeAgentsPrivilegeLevelResponseSchema = ActionIdSchema;
+export const BulkChangeAgentsPrivilegeLevelResponseSchema = schema.oneOf([
+  ActionIdSchema,
+  DryRunCountSchema,
+]);
 
 export const PostAgentRollbackRequestSchema = {
   params: schema.object({
@@ -887,9 +899,13 @@ export const PostBulkAgentRollbackRequestSchema = {
     agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     batchSize: schema.maybe(schema.number()),
     includeInactive: schema.boolean({ defaultValue: false }),
+    dryRun: schema.maybe(schema.boolean()),
   }),
 };
 
-export const PostBulkAgentRollbackResponseSchema = schema.object({
-  actionIds: schema.arrayOf(schema.string(), { maxSize: 10000 }),
-});
+export const PostBulkAgentRollbackResponseSchema = schema.oneOf([
+  schema.object({
+    actionIds: schema.arrayOf(schema.string({ maxLength: 36 }), { maxSize: 10000 }),
+  }),
+  DryRunCountSchema,
+]);

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
@@ -1,0 +1,351 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { AGENT_ACTIONS_INDEX } from '@kbn/fleet-plugin/common';
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { skipIfNoDockerRegistry } from '../../helpers';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const fleetAndAgents = getService('fleetAndAgents');
+
+  describe('fleet_bulk_agent_dry_run', () => {
+    skipIfNoDockerRegistry(providerContext);
+
+    before(async () => {
+      await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+      await fleetAndAgents.setup();
+    });
+
+    beforeEach(async () => {
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+      await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/agents');
+      await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxx').send();
+    });
+
+    afterEach(async () => {
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/agents');
+      await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+    });
+
+    async function getActionCount(): Promise<number> {
+      const res = await es.count({ index: AGENT_ACTIONS_INDEX });
+      return res.count;
+    }
+
+    describe('bulk_unenroll', () => {
+      it('returns { count } by agent ids without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_unenroll')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: ['agent1', 'agent2'], dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+
+        const { body: agent1Body } = await supertest.get('/api/fleet/agents/agent1');
+        expect(agent1Body.item.unenrollment_started_at).to.be(undefined);
+        expect(agent1Body.item.active).to.eql(true);
+      });
+
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_unenroll')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+        expect(body.count).to.be.greaterThan(0);
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_reassign', () => {
+      it('returns { count } by agent ids without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_reassign')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: ['agent1', 'agent2'], policy_id: 'policy2', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+
+        const { body: agent1Body } = await supertest.get('/api/fleet/agents/agent1');
+        expect(agent1Body.item.policy_id).to.eql('policy1');
+      });
+
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_reassign')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', policy_id: 'policy2', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+        expect(body.count).to.be.greaterThan(0);
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_upgrade', () => {
+      it('returns { count } by agent ids without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_upgrade')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: ['agent1', 'agent2'], version: '8.5.0', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_upgrade')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', version: '8.5.0', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+        expect(body.count).to.be.greaterThan(0);
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_request_diagnostics', () => {
+      it('returns { count } by agent ids without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_request_diagnostics')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: ['agent1', 'agent2'], dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_request_diagnostics')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+        expect(body.count).to.be.greaterThan(0);
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_update_agent_tags', () => {
+      it('returns { count } by agent ids without modifying agents', async () => {
+        const { body: agent1Before } = await supertest.get('/api/fleet/agents/agent1');
+        const tagsBefore = agent1Before.item.tags ?? [];
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_update_agent_tags')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: ['agent1', 'agent2'], tagsToAdd: ['dry-run-tag'], dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const { body: agent1After } = await supertest.get('/api/fleet/agents/agent1');
+        expect(agent1After.item.tags ?? []).to.eql(tagsBefore);
+      });
+
+      it('returns { count } by kuery without modifying agents', async () => {
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_update_agent_tags')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', tagsToAdd: ['dry-run-tag'], dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+        expect(body.count).to.be.greaterThan(0);
+      });
+    });
+
+    describe('bulk_rollback', () => {
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_rollback')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', dryRun: true })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_migrate', () => {
+      it('returns { count } by agent ids without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_migrate')
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            agents: ['agent1', 'agent2'],
+            uri: 'https://example.com',
+            enrollment_token: 'test-token',
+            dryRun: true,
+          })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_migrate')
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            agents: 'active:true',
+            uri: 'https://example.com',
+            enrollment_token: 'test-token',
+            dryRun: true,
+          })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_privilege_level_change', () => {
+      it('returns { count } by agent ids without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_privilege_level_change')
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            agents: ['agent1', 'agent2'],
+            user_info: { username: 'user1', groupname: 'group1', password: 'password' },
+            dryRun: true,
+          })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+
+      it('returns { count } by kuery without creating actions', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_privilege_level_change')
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            agents: 'active:true',
+            user_info: { username: 'user1', groupname: 'group1', password: 'password' },
+            dryRun: true,
+          })
+          .expect(200);
+
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+
+    describe('bulk_remove_collectors', () => {
+      it('returns { count } counting only OPAMP agents when mixed agents are passed by kuery', async () => {
+        const actionsBefore = await getActionCount();
+
+        const { body } = await supertest
+          .post('/api/fleet/agents/bulk_remove_collectors')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agents: 'active:true', dryRun: true })
+          .expect(200);
+
+        // The fixture agents (agent1–agent4) are PERMANENT type, not OPAMP,
+        // so the dry-run count must be 0 — not the total active agent count.
+        expect(body).to.have.property('count');
+        expect(body.count).to.be.a('number');
+        expect(body.count).to.eql(0);
+
+        const actionsAfter = await getActionCount();
+        expect(actionsAfter).to.eql(actionsBefore);
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
@@ -326,6 +326,5 @@ export default function (providerContext: FtrProviderContext) {
         expect(actionsAfter).to.eql(actionsBefore);
       });
     });
-
   });
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
@@ -327,8 +327,5 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
-    });
-  });
-}
   });
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/bulk_dry_run.ts
@@ -327,25 +327,8 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
-    describe('bulk_remove_collectors', () => {
-      it('returns { count } counting only OPAMP agents when mixed agents are passed by kuery', async () => {
-        const actionsBefore = await getActionCount();
-
-        const { body } = await supertest
-          .post('/api/fleet/agents/bulk_remove_collectors')
-          .set('kbn-xsrf', 'xxx')
-          .send({ agents: 'active:true', dryRun: true })
-          .expect(200);
-
-        // The fixture agents (agent1–agent4) are PERMANENT type, not OPAMP,
-        // so the dry-run count must be 0 — not the total active agent count.
-        expect(body).to.have.property('count');
-        expect(body.count).to.be.a('number');
-        expect(body.count).to.eql(0);
-
-        const actionsAfter = await getActionCount();
-        expect(actionsAfter).to.eql(actionsBefore);
-      });
     });
+  });
+}
   });
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/index.js
@@ -31,5 +31,6 @@ export default function loadTests({ loadTestFile, getService }) {
     loadTestFile(require.resolve('./privilege_level_change'));
     loadTestFile(require.resolve('./last_known_status'));
     loadTestFile(require.resolve('./rollback'));
+    loadTestFile(require.resolve('./bulk_dry_run'));
   });
 }


### PR DESCRIPTION
## Summary

Backport of #276377 to 9.3.

Adds a `dryRun: true` option to all 9 bulk agent API endpoints. When set, returns `{ count: N }` immediately — the number of agents that would be affected — without writing anything.

Endpoints covered:
- `POST /api/fleet/agents/bulk_upgrade`
- `POST /api/fleet/agents/bulk_unenroll`
- `POST /api/fleet/agents/bulk_reassign`
- `POST /api/fleet/agents/bulk_request_diagnostics`
- `POST /api/fleet/agents/bulk_update_agent_tags`
- `POST /api/fleet/agents/bulk_migrate`
- `POST /api/fleet/agents/bulk_privilege_level_change`
- `POST /api/fleet/agents/bulk_rollback`

## Conflict resolution

9.3 uses a single `getAgentsByKuery` call (no cheap `perPage:0` pre-count), so the `dryRun` checks return `res.total` instead of a separate `total` variable. Test blocks updated to match single-call pattern. `remove_collector` files excluded (not present in 9.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)