### PR TITLE
[Buildkite] Remove left-over reference to unsupported-ftrs pipeline

### DIFF
--- a/.buildkite/scripts/steps/version_bump/update_pipeline_resource_definitions.sh
+++ b/.buildkite/scripts/steps/version_bump/update_pipeline_resource_definitions.sh
@@ -13,7 +13,6 @@ FILES=(
   ".buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml"
   ".buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml"
   ".buildkite/pipeline-resource-definitions/kibana-on-merge.yml"
-  ".buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml"
 )
 
 for file in "${FILES[@]}"; do


### PR DESCRIPTION
## Summary

The "unsupported FTRs" Buildkite pipeline was removed in #264105, which deleted:
- `.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml`
- `.buildkite/pipelines/on_merge_unsupported_ftrs.yml`
- `.buildkite/scripts/steps/functional/on_merge_unsupported_ftrs.sh`
- its trigger step in `.buildkite/pipelines/on_merge.yml`
- its entry in `.buildkite/pipeline-resource-definitions/locations.yml`

That cleanup missed one reference: `update_pipeline_resource_definitions.sh` (used by the version-bump automation to update `branch_configuration` across pipeline resource definitions on new branch creation) still listed the now-deleted `kibana-on-merge-unsupported-ftrs.yml` in its `FILES` array.

This PR removes that dangling reference. I verified there are no other remaining references to the unsupported-ftrs pipeline anywhere in the repository.

### Checklist

- [x] This is a CI/tooling-only change with no user-facing impact.


Made with [Cursor](https://cursor.com)