### PR TITLE
[Scout] Code owners for namespaced config manifests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3673,7 +3673,9 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 
 # Appex QA to own auto-generated scout metadata
 /**/scout/.meta/**
+/**/scout/*/.meta/**
 /**/scout_*/.meta/**
+/**/scout_*/*/.meta/**
 
 # Macroscope Check Run Agents
 /.macroscope/backport-review.md @elastic/appex-qa


### PR DESCRIPTION
## Summary

Accounts for manifest files produced for [namespaced Scout test configs](https://github.com/elastic/kibana/pull/275087).

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->