### PR TITLE
[Fleet] Fix offline OTel collector showing live metrics from re-enrolled collector on same host

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
@@ -61,6 +61,18 @@ export const ActiveAgentStatuses = [
   'orphaned',
 ]; // excluded: unenrolling, unenrolled, inactive, uninstalled
 
+// OTel (OpAMP) collectors in these states are not actively reporting telemetry.
+// Used in metric queries to prevent a newly enrolled collector on the same host from
+// leaking its live metrics to a stale/offline agent entry (same service.instance.id).
+// Must stay in sync across the server (agent_metrics.ts) and client (CollectorContext).
+// See https://github.com/elastic/kibana/issues/274843
+export const OPAMP_NON_REPORTING_STATUSES = [
+  'offline',
+  'inactive',
+  'unenrolled',
+  'uninstalled',
+] as const satisfies ReadonlyArray<(typeof AgentStatuses)[number]>;
+
 // Kueries for finding unprivileged and privileged agents
 // Privileged is `not` because the metadata field can be undefined
 export const UNPRIVILEGED_AGENT_KUERY = `${AGENTS_PREFIX}.local_metadata.elastic.agent.unprivileged: true`;

--- a/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
@@ -66,12 +66,12 @@ export const ActiveAgentStatuses = [
 // leaking its live metrics to a stale/offline agent entry (same service.instance.id).
 // Must stay in sync across the server (agent_metrics.ts) and client (CollectorContext).
 // See https://github.com/elastic/kibana/issues/274843
-export const OPAMP_NON_REPORTING_STATUSES = [
+export const OPAMP_NON_REPORTING_STATUSES: ReadonlyArray<(typeof AgentStatuses)[number]> = [
   'offline',
   'inactive',
   'unenrolled',
   'uninstalled',
-] as const satisfies ReadonlyArray<(typeof AgentStatuses)[number]>;
+];
 
 // Kueries for finding unprivileged and privileged agents
 // Privileged is `not` because the metadata field can be undefined

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_collector_config/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_collector_config/index.tsx
@@ -13,18 +13,14 @@ import type { Agent } from '../../../../../types';
 import { useGetAgentEffectiveConfigQuery } from '../../../../../hooks';
 import { CollectorConfigView } from '../../../../../../../components/otel_ui';
 import { CollectorContextProvider } from '../../../../../../../components/otel_ui/collector_config_view/collector_context';
-
-const NON_REPORTING_STATUSES: Array<NonNullable<Agent['status']>> = [
-  'offline',
-  'inactive',
-  'unenrolled',
-  'uninstalled',
-];
+import { OPAMP_NON_REPORTING_STATUSES } from '../../../../../../../../common/constants';
 
 export const AgentCollectorConfig: React.FunctionComponent<{ agent: Agent }> = ({ agent }) => {
   const { data: agentData, isLoading } = useGetAgentEffectiveConfigQuery(agent.id);
   const offlineAt =
-    agent.status && NON_REPORTING_STATUSES.includes(agent.status) ? agent.last_checkin : undefined;
+    agent.status && OPAMP_NON_REPORTING_STATUSES.includes(agent.status)
+      ? agent.last_checkin
+      : undefined;
 
   if (isLoading) {
     return <EuiLoadingSpinner />;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_collector_config/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_collector_config/index.tsx
@@ -14,8 +14,17 @@ import { useGetAgentEffectiveConfigQuery } from '../../../../../hooks';
 import { CollectorConfigView } from '../../../../../../../components/otel_ui';
 import { CollectorContextProvider } from '../../../../../../../components/otel_ui/collector_config_view/collector_context';
 
+const NON_REPORTING_STATUSES: Array<NonNullable<Agent['status']>> = [
+  'offline',
+  'inactive',
+  'unenrolled',
+  'uninstalled',
+];
+
 export const AgentCollectorConfig: React.FunctionComponent<{ agent: Agent }> = ({ agent }) => {
   const { data: agentData, isLoading } = useGetAgentEffectiveConfigQuery(agent.id);
+  const offlineAt =
+    agent.status && NON_REPORTING_STATUSES.includes(agent.status) ? agent.last_checkin : undefined;
 
   if (isLoading) {
     return <EuiLoadingSpinner />;
@@ -26,6 +35,7 @@ export const AgentCollectorConfig: React.FunctionComponent<{ agent: Agent }> = (
       serviceInstanceId={String(
         agent.non_identifying_attributes?.['elastic.display.name'] ?? agent.id
       )}
+      offlineAt={offlineAt}
     >
       <CollectorConfigView config={agentData?.effective_config ?? {}} health={agent.health} />
       <EuiSpacer size="l" />

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/collector_detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/collector_detail/index.tsx
@@ -16,19 +16,32 @@ import { CollectorContextProvider } from '../../../../../../../components/otel_u
 import { CollectorDetailTabs } from '../../../../../../../components/otel_ui/collector_config_view/collector_detail/collector_detail_tabs';
 import { ErrorPatternPanel } from '../../../../../../../components/otel_ui/collector_config_view/error_pattern_panel';
 
+const NON_REPORTING_STATUSES: Array<NonNullable<Agent['status']>> = [
+  'offline',
+  'inactive',
+  'unenrolled',
+  'uninstalled',
+];
+
 export const CollectorDetailsContent: React.FunctionComponent<{ agent: Agent }> = ({ agent }) => {
   const { data: configData, isLoading } = useGetAgentEffectiveConfigQuery(agent.id);
   const config = configData?.effective_config ?? {};
   const serviceInstanceId = String(
     agent.non_identifying_attributes?.['elastic.display.name'] ?? agent.id
   );
+  const offlineAt =
+    agent.status && NON_REPORTING_STATUSES.includes(agent.status) ? agent.last_checkin : undefined;
 
   if (isLoading) {
     return <EuiLoadingSpinner />;
   }
 
   return (
-    <CollectorContextProvider serviceInstanceId={serviceInstanceId} enrolledAt={agent.enrolled_at}>
+    <CollectorContextProvider
+      serviceInstanceId={serviceInstanceId}
+      enrolledAt={agent.enrolled_at}
+      offlineAt={offlineAt}
+    >
       <EuiPanel paddingSize="m" hasBorder>
         <CollectorConfigView config={config} health={agent.health} />
       </EuiPanel>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/collector_detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/collector_detail/index.tsx
@@ -15,13 +15,7 @@ import { CollectorConfigView } from '../../../../../../../components/otel_ui';
 import { CollectorContextProvider } from '../../../../../../../components/otel_ui/collector_config_view/collector_context';
 import { CollectorDetailTabs } from '../../../../../../../components/otel_ui/collector_config_view/collector_detail/collector_detail_tabs';
 import { ErrorPatternPanel } from '../../../../../../../components/otel_ui/collector_config_view/error_pattern_panel';
-
-const NON_REPORTING_STATUSES: Array<NonNullable<Agent['status']>> = [
-  'offline',
-  'inactive',
-  'unenrolled',
-  'uninstalled',
-];
+import { OPAMP_NON_REPORTING_STATUSES } from '../../../../../../../../common/constants';
 
 export const CollectorDetailsContent: React.FunctionComponent<{ agent: Agent }> = ({ agent }) => {
   const { data: configData, isLoading } = useGetAgentEffectiveConfigQuery(agent.id);
@@ -30,7 +24,9 @@ export const CollectorDetailsContent: React.FunctionComponent<{ agent: Agent }> 
     agent.non_identifying_attributes?.['elastic.display.name'] ?? agent.id
   );
   const offlineAt =
-    agent.status && NON_REPORTING_STATUSES.includes(agent.status) ? agent.last_checkin : undefined;
+    agent.status && OPAMP_NON_REPORTING_STATUSES.includes(agent.status)
+      ? agent.last_checkin
+      : undefined;
 
   if (isLoading) {
     return <EuiLoadingSpinner />;

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_context.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_context.tsx
@@ -10,6 +10,10 @@ import React, { createContext, useContext, useMemo } from 'react';
 interface CollectorContextValue {
   serviceInstanceId?: string;
   enrolledAt?: string;
+  /** ISO timestamp of the last check-in for an offline/inactive collector. When set, metric
+   * queries cap their upper bound at this time so they show the collector's last reported values
+   * rather than leaking live metrics from a newly enrolled collector on the same host. */
+  offlineAt?: string;
 }
 
 const CollectorContext = createContext<CollectorContextValue>({});
@@ -17,9 +21,13 @@ const CollectorContext = createContext<CollectorContextValue>({});
 export const CollectorContextProvider: React.FC<{
   serviceInstanceId?: string;
   enrolledAt?: string;
+  offlineAt?: string;
   children: React.ReactNode;
-}> = ({ serviceInstanceId, enrolledAt, children }) => {
-  const value = useMemo(() => ({ serviceInstanceId, enrolledAt }), [serviceInstanceId, enrolledAt]);
+}> = ({ serviceInstanceId, enrolledAt, offlineAt, children }) => {
+  const value = useMemo(
+    () => ({ serviceInstanceId, enrolledAt, offlineAt }),
+    [serviceInstanceId, enrolledAt, offlineAt]
+  );
   return <CollectorContext.Provider value={value}>{children}</CollectorContext.Provider>;
 };
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
@@ -26,6 +26,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedDate, FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
 
 import type { Agent, ComponentHealth, OTelCollectorConfig } from '../../../../../common/types';
+import { OPAMP_NON_REPORTING_STATUSES } from '../../../../../common/constants';
 
 import type { OTelComponentType } from '../constants';
 import { COMPONENT_TYPE_LABELS } from '../constants';
@@ -38,13 +39,6 @@ import {
   nanosToMs,
   type ComponentHealthStatus,
 } from '../utils';
-
-const NON_REPORTING_STATUSES: Array<Agent['status']> = [
-  'offline',
-  'inactive',
-  'unenrolled',
-  'uninstalled',
-];
 
 interface CollectorDetailHealthProps {
   health?: ComponentHealth;
@@ -373,7 +367,7 @@ export const CollectorDetailHealth: React.FC<CollectorDetailHealthProps> = ({
 
   const { euiTheme } = useEuiTheme();
 
-  if (agentStatus && NON_REPORTING_STATUSES.includes(agentStatus)) {
+  if (agentStatus && OPAMP_NON_REPORTING_STATUSES.includes(agentStatus)) {
     return (
       <EuiCallOut
         color="warning"

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/use_component_metrics.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/use_component_metrics.test.ts
@@ -13,7 +13,7 @@ describe('buildComponentQuery', () => {
   const timeRangeGte = now - timeRangeMs;
   const fixedInterval = '1m';
 
-  it('uses now - timeRangeMs as @timestamp.gte when enrolledAt is not provided', () => {
+  it('uses now - timeRangeMs as @timestamp.gte and now as lte when enrolledAt/offlineAt are not provided', () => {
     const query = buildComponentQuery(
       'my-host',
       'my-exporter',
@@ -71,6 +71,39 @@ describe('buildComponentQuery', () => {
     );
     const range = getTimestampRange(query!);
     expect(range.gte).toEqual(timeRangeGte);
+  });
+
+  it('caps @timestamp.lte at offlineAt when the collector is offline', () => {
+    const offlineAt = new Date(now - 3 * 60 * 1000).toISOString(); // 3 min ago
+    const offlineAtMs = Date.parse(offlineAt);
+    const query = buildComponentQuery(
+      'my-host',
+      'my-exporter',
+      'exporter',
+      now,
+      timeRangeMs,
+      fixedInterval,
+      undefined,
+      offlineAt
+    );
+    const range = getTimestampRange(query!);
+    expect(range.lte).toEqual(offlineAtMs);
+    expect(range.lte).toBeLessThan(now);
+  });
+
+  it('uses now as lte when offlineAt is an invalid date string', () => {
+    const query = buildComponentQuery(
+      'my-host',
+      'my-exporter',
+      'exporter',
+      now,
+      timeRangeMs,
+      fixedInterval,
+      undefined,
+      'not-a-date'
+    );
+    const range = getTimestampRange(query!);
+    expect(range.lte).toEqual(now);
   });
 
   it('returns undefined for an unknown componentType', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/use_component_metrics.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/use_component_metrics.ts
@@ -128,7 +128,8 @@ export const buildComponentQuery = (
   now: number,
   timeRangeMs: number,
   fixedInterval: string,
-  enrolledAt?: string
+  enrolledAt?: string,
+  offlineAt?: string
 ) => {
   const config = COMPONENT_METRICS[componentType];
   if (!config) {
@@ -138,6 +139,12 @@ export const buildComponentQuery = (
   const enrolledAtMs = enrolledAt ? Date.parse(enrolledAt) : NaN;
   const timeRangeGte = now - timeRangeMs;
   const gte = !isNaN(enrolledAtMs) && enrolledAtMs > timeRangeGte ? enrolledAtMs : timeRangeGte;
+
+  // Cap the upper bound at the last check-in time for offline collectors so we show their last
+  // reported values rather than leaking live metrics from a newly enrolled collector on the same
+  // host (same service.instance.id / hostname). See https://github.com/elastic/kibana/issues/274843
+  const offlineAtMs = offlineAt ? Date.parse(offlineAt) : NaN;
+  const lte = !isNaN(offlineAtMs) ? offlineAtMs : now;
   const subAggs: Record<string, unknown> = {};
   for (const group of config.metricGroups) {
     for (const { field, aggType } of group.metrics) {
@@ -161,7 +168,7 @@ export const buildComponentQuery = (
             filter: [
               { term: { 'service.instance.id': serviceInstanceId } },
               { term: { [config.filterField]: componentId } },
-              { range: { '@timestamp': { gte, lte: now } } },
+              { range: { '@timestamp': { gte, lte } } },
             ],
           },
         },
@@ -219,7 +226,7 @@ export const useComponentMetrics = ({
   fixedInterval: string;
 }): UseComponentMetricsResult => {
   const { data } = useStartServices();
-  const { serviceInstanceId, enrolledAt } = useCollectorContext();
+  const { serviceInstanceId, enrolledAt, offlineAt } = useCollectorContext();
 
   const [groups, setGroups] = useState<MetricGroup[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -247,7 +254,8 @@ export const useComponentMetrics = ({
           now,
           timeRangeMs,
           fixedInterval,
-          enrolledAt
+          enrolledAt,
+          offlineAt
         );
 
         if (!searchRequest) {
@@ -293,6 +301,7 @@ export const useComponentMetrics = ({
     componentType,
     serviceInstanceId,
     enrolledAt,
+    offlineAt,
     data.search,
     timeRangeMs,
     fixedInterval,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.test.ts
@@ -194,7 +194,7 @@ describe('fetchAndAssignAgentMetrics', () => {
     expect(esClient.search).toHaveBeenCalledTimes(1);
   });
 
-  it('assigns the same metrics bucket to all agents sharing the same elastic.display.name', async () => {
+  it('assigns metrics only to the most-recently-enrolled agent when two share the same elastic.display.name', async () => {
     const esClient = {
       search: jest
         .fn()
@@ -213,16 +213,19 @@ describe('fetchAndAssignAgentMetrics', () => {
       {
         id: 'opamp-id-1',
         type: 'OPAMP',
+        enrolled_at: '2024-01-01T00:00:00.000Z',
         non_identifying_attributes: { 'elastic.display.name': 'shared-host' },
       },
       {
         id: 'opamp-id-2',
         type: 'OPAMP',
+        enrolled_at: '2024-01-02T00:00:00.000Z', // newer — wins the hostname
         non_identifying_attributes: { 'elastic.display.name': 'shared-host' },
       },
     ];
     const result = await fetchAndAssignAgentMetrics(esClient as any, agents as any);
-    expect(result[0].metrics).toEqual({ cpu_avg: 0.3, memory_size_byte_avg: 768 });
+    // Only the newer agent receives the shared-host metrics bucket
+    expect(result[0].metrics).toEqual({ cpu_avg: undefined, memory_size_byte_avg: undefined });
     expect(result[1].metrics).toEqual({ cpu_avg: 0.3, memory_size_byte_avg: 768 });
     // Only one unique instanceId should be queried
     const otelSearchCall = esClient.search.mock.calls[1][0];

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.ts
@@ -53,14 +53,22 @@ export async function fetchAndAssignAgentMetrics(esClient: ElasticsearchClient, 
 }
 
 async function _fetchAndAssignOtelMetrics(esClient: ElasticsearchClient, agents: Agent[]) {
-  // Map service.instance.id (hostname from elastic.display.name) → agentIds.
-  // Multiple agents can share the same display name, and all should receive the same metrics bucket.
-  // Collectors report service.instance.id as their hostname, not their Fleet agent ID.
+  // Map service.instance.id (hostname from elastic.display.name) → the single active agent that
+  // should receive metrics for that host. Collectors report service.instance.id as their hostname,
+  // not their Fleet agent ID, so multiple agent entries can share the same key.
   //
-  // Only include agents that are actively reporting. Offline/inactive/unenrolled agents must not
-  // be included in the query: they share the same hostname as any newly enrolled collector on the
-  // same host, so they would otherwise receive that collector's live metrics.
-  const instanceIdToAgentIds = new Map<string, string[]>();
+  // Two rules keep stale/re-enrolled collectors from receiving a live collector's metrics:
+  //
+  // 1. Offline/inactive/unenrolled agents are excluded entirely (they have already timed out).
+  //
+  // 2. When multiple *online* agents share a hostname — the ~5-minute transition window after
+  //    a collector is stopped but before Fleet marks it offline — only the most recently enrolled
+  //    agent wins the hostname. Its telemetry supersedes the older agent's because re-enrollment
+  //    always produces a newer enrolled_at timestamp.
+  //
+  // See https://github.com/elastic/kibana/issues/274843
+  const agentById = new Map(agents.map((a) => [a.id, a]));
+  const instanceIdToAgentId = new Map<string, string>();
   for (const agent of agents) {
     if (agent.status && NON_REPORTING_OPAMP_STATUSES.includes(agent.status)) {
       continue;
@@ -68,14 +76,17 @@ async function _fetchAndAssignOtelMetrics(esClient: ElasticsearchClient, agents:
     const instanceId =
       (agent.non_identifying_attributes?.['elastic.display.name'] as string | undefined) ??
       agent.id;
-    const ids = instanceIdToAgentIds.get(instanceId);
-    if (ids) {
-      ids.push(agent.id);
+    const existingId = instanceIdToAgentId.get(instanceId);
+    if (!existingId) {
+      instanceIdToAgentId.set(instanceId, agent.id);
     } else {
-      instanceIdToAgentIds.set(instanceId, [agent.id]);
+      const existing = agentById.get(existingId);
+      if ((agent.enrolled_at ?? '') > (existing?.enrolled_at ?? '')) {
+        instanceIdToAgentId.set(instanceId, agent.id);
+      }
     }
   }
-  const instanceIds = Array.from(instanceIdToAgentIds.keys());
+  const instanceIds = Array.from(instanceIdToAgentId.keys());
 
   // If no agents are actively reporting, skip the ES query entirely.
   if (instanceIds.length === 0) {
@@ -101,14 +112,12 @@ async function _fetchAndAssignOtelMetrics(esClient: ElasticsearchClient, agents:
 
   const formattedResults =
     res.aggregations?.agents.buckets.reduce((acc, bucket) => {
-      const agentIds = instanceIdToAgentIds.get(bucket.key);
-      if (agentIds) {
-        for (const agentId of agentIds) {
-          acc[agentId] = {
-            avg_memory_size: bucket.max_memory_size.value,
-            avg_cpu: bucket.avg_cpu.value,
-          };
-        }
+      const agentId = instanceIdToAgentId.get(bucket.key);
+      if (agentId) {
+        acc[agentId] = {
+          avg_memory_size: bucket.max_memory_size.value,
+          avg_cpu: bucket.avg_cpu.value,
+        };
       }
       return acc;
     }, {} as Record<string, { avg_memory_size: number; avg_cpu: number }>) ?? {};

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.ts
@@ -9,20 +9,9 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 
 import type { Agent } from '../../types';
 import { appContextService } from '../app_context';
-import { DATA_TIERS } from '../../../common/constants';
+import { DATA_TIERS, OPAMP_NON_REPORTING_STATUSES } from '../../../common/constants';
 
 const AGGREGATION_MAX_SIZE = 1000;
-
-// Agents in these states are not actively reporting OTel telemetry.
-// Excluding them from the hostname-keyed metrics query prevents a newly enrolled collector
-// on the same host from leaking its live metrics to a stale/offline agent entry.
-// See https://github.com/elastic/kibana/issues/274843
-const NON_REPORTING_OPAMP_STATUSES: Array<NonNullable<Agent['status']>> = [
-  'offline',
-  'inactive',
-  'unenrolled',
-  'uninstalled',
-];
 
 export async function fetchAndAssignAgentMetrics(esClient: ElasticsearchClient, agents: Agent[]) {
   const logger = appContextService.getLogger();
@@ -70,7 +59,7 @@ async function _fetchAndAssignOtelMetrics(esClient: ElasticsearchClient, agents:
   const agentById = new Map(agents.map((a) => [a.id, a]));
   const instanceIdToAgentId = new Map<string, string>();
   for (const agent of agents) {
-    if (agent.status && NON_REPORTING_OPAMP_STATUSES.includes(agent.status)) {
+    if (agent.status && OPAMP_NON_REPORTING_STATUSES.includes(agent.status)) {
       continue;
     }
     const instanceId =


### PR DESCRIPTION
## Summary

Closes #274843

The server-side fix (filtering offline agents from the hostname-keyed ES query in `agent_metrics.ts`) stopped the metric leak in the **agent list view** after the 5-minute rolling window — but the client-side **component-detail charts** (`use_component_metrics.ts`) had the same unguarded hostname query, so the offline collector's detail page (exporter/receiver/processor metrics tabs) continued showing the newly-enrolled collector's live data regardless.

**Root cause:** `buildComponentQuery` filtered `service.instance.id` (the hostname) with `gte: enrolledAt` but no upper-bound `lte`. Both the offline and newly-enrolled collector share the same hostname, so the query returned the new collector's live metrics to the offline collector's view.

## Test plan

- [x] Enroll an OTel collector, verify it shows CPU/memory/throughput in the detail page
- [x] Stop the collector
- [x] Re-enroll a new collector on the same host
- [x] Open the previous collector's detail page — component metrics tabs should show the last values from before it went offline, not the new collector's live data
- [x] Open the **healthy** collector's detail page — should show live metrics normally
- [x] Unit tests: `use_component_metrics.test.ts` (two new cases for `offlineAt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1523" height="719" alt="image" src="https://github.com/user-attachments/assets/755643a1-5b1f-4b80-a456-95613798e1ca" />
