### PR TITLE
[One Workflow] Use ui setting feature flag for executions view instead of plugin config

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/constants.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/constants.ts
@@ -37,6 +37,17 @@ export const WORKFLOW_EXECUTION_STATS_BAR_SETTING_ID = 'workflows:executionStats
 export const WORKFLOWS_LIBRARY_ENABLED_SETTING_ID = 'workflowsManagement:library:enabled';
 
 /**
+ * Global Advanced Setting gating the global Workflow Executions view
+ * (`/app/workflows/executions`).
+ *
+ * Registered as a global uiSetting (not per-space) so the same toggle is
+ * readable from any browser plugin that consumes the workflows UI without
+ * taking a runtime dep on `workflows_management`.
+ */
+export const WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID =
+  'workflowsManagement:globalExecutionsView:enabled';
+
+/**
  * Map of regular (saved object) connector types -> their system connector equivalents.
  * Use this map to make the `connector-id` step config property optional for a given connector step type, allowing it to be executed via its linked system connector.
  * Pre-requisite for this to work:

--- a/src/platform/plugins/shared/workflows_management/public/components/workflow_executions_route_gate.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflow_executions_route_gate.test.tsx
@@ -10,11 +10,17 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { of } from 'rxjs';
 import { I18nProviderMock } from '@kbn/core-i18n-browser-mocks/src/i18n_context_mock';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { MemoryRouter, Route, Routes } from '@kbn/shared-ux-router';
 import { WorkflowExecutionsRouteGate } from './workflow_executions_route_gate';
-import { createStartServicesMock } from '../mocks';
+import { createStartServicesMock, type StartServicesMock } from '../mocks';
+
+const setExecutionsViewEnabled = (services: StartServicesMock, enabled: boolean) => {
+  services.settings.globalClient.get.mockReturnValue(enabled);
+  services.settings.globalClient.get$.mockReturnValue(of(enabled));
+};
 
 jest.mock('../pages/executions', () => ({
   WorkflowExecutionsPage: () => <div data-test-subj="workflowExecutionsPage" />,
@@ -39,7 +45,7 @@ describe('WorkflowExecutionsRouteGate', () => {
 
   it('redirects to workflows home when the executions view feature flag is off', () => {
     const services = createStartServicesMock();
-    services.workflowsManagement.globalExecutionsView.enabled = false;
+    setExecutionsViewEnabled(services, false);
 
     renderGate(services);
 
@@ -49,7 +55,7 @@ describe('WorkflowExecutionsRouteGate', () => {
 
   it('renders the executions page when the executions view feature flag is on', () => {
     const services = createStartServicesMock();
-    services.workflowsManagement.globalExecutionsView.enabled = true;
+    setExecutionsViewEnabled(services, true);
 
     renderGate(services);
 

--- a/src/platform/plugins/shared/workflows_management/public/components/workflow_executions_route_gate.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflow_executions_route_gate.tsx
@@ -9,14 +9,11 @@
 
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { useKibana } from '../hooks/use_kibana';
+import { useGlobalExecutionsViewEnabled } from '../hooks/use_global_executions_view_enabled';
 import { WorkflowExecutionsPage } from '../pages/executions';
 
 export const WorkflowExecutionsRouteGate = React.memo(() => {
-  const {
-    workflowsManagement: { globalExecutionsView },
-  } = useKibana().services;
-  const isExecutionsViewEnabled = globalExecutionsView.enabled;
+  const isExecutionsViewEnabled = useGlobalExecutionsViewEnabled();
 
   if (!isExecutionsViewEnabled) {
     return <Redirect to="/" />;

--- a/src/platform/plugins/shared/workflows_management/public/deep_links.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.ts
@@ -22,14 +22,14 @@ export enum WorkflowsDeepLinks {
 }
 
 export interface DeepLinksParams {
-  executionsViewEnabled: boolean;
+  executionsViewEnabled?: boolean;
   libraryEnabled?: boolean;
 }
 
 export function getDeepLinks({
-  executionsViewEnabled,
+  executionsViewEnabled = false,
   libraryEnabled = true,
-}: DeepLinksParams): AppDeepLink[] {
+}: DeepLinksParams = {}): AppDeepLink[] {
   const links: AppDeepLink[] = [
     {
       id: WorkflowsDeepLinks.workflowsList,

--- a/src/platform/plugins/shared/workflows_management/public/hooks/use_global_executions_view_enabled.ts
+++ b/src/platform/plugins/shared/workflows_management/public/hooks/use_global_executions_view_enabled.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EMPTY } from 'rxjs';
+import { useObservable } from '@kbn/use-observable';
+import { WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID } from '@kbn/workflows/common/constants';
+import { useKibana } from './use_kibana';
+
+/**
+ * Returns whether the global Workflow Executions view is enabled, reading the
+ * global (not per-space) `workflowsManagement:globalExecutionsView:enabled`
+ * uiSetting. Reactive — re-renders when an admin flips the setting.
+ */
+export function useGlobalExecutionsViewEnabled(): boolean {
+  const {
+    services: { settings },
+  } = useKibana();
+  const client = settings?.globalClient;
+
+  const observable =
+    client?.get$<boolean>(WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID, false) ?? EMPTY;
+  const defaultValue =
+    client?.get<boolean>(WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID, false) ?? false;
+
+  return useObservable(observable, defaultValue) === true;
+}

--- a/src/platform/plugins/shared/workflows_management/public/mocks.ts
+++ b/src/platform/plugins/shared/workflows_management/public/mocks.ts
@@ -49,9 +49,6 @@ export const createStartServicesMock = () => ({
       reportEvent: jest.fn(),
     },
     availability: createAvailabilityServiceMock(),
-    globalExecutionsView: {
-      enabled: false,
-    },
   },
 });
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/executions_page.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/executions_page.test.tsx
@@ -37,7 +37,6 @@ jest.mock('@kbn/cell-actions', () => ({
 describe('WorkflowExecutionsPage', () => {
   it('renders the executions page with search, filters, and table', async () => {
     const services = createStartServicesMock();
-    services.workflowsManagement.globalExecutionsView.enabled = true;
     services.spaces.getActiveSpace = jest.fn().mockResolvedValue({ id: 'default' });
     const SearchBarStub = () => <div data-test-subj="searchBarStub" />;
     services.unifiedSearch.ui.SearchBar = SearchBarStub;

--- a/src/platform/plugins/shared/workflows_management/public/plugin.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.test.ts
@@ -12,6 +12,7 @@ import type { App, AppUpdatableFields, AppUpdater } from '@kbn/core/public';
 import { coreMock } from '@kbn/core/public/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 import {
+  WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID,
   WORKFLOWS_MANAGEMENT_FEATURE_ID,
   WORKFLOWS_UI_SETTING_ID,
 } from '@kbn/workflows/common/constants';
@@ -42,13 +43,12 @@ jest.mock('./connectors/workflows', () => ({
   getWorkflowsConnectorType: jest.fn(() => ({ id: 'workflows', actionTypeId: 'workflows' })),
 }));
 
-const createPlugin = (globalExecutionsViewEnabled = false) =>
+const createPlugin = () =>
   new WorkflowsPlugin(
     coreMock.createPluginInitializerContext({
       enabled: true,
       logging: { console: false },
       available: true,
-      globalExecutionsView: { enabled: globalExecutionsViewEnabled },
     })
   );
 
@@ -89,8 +89,8 @@ describe('WorkflowsPlugin', () => {
       expect(coreSetup.application.register).not.toHaveBeenCalled();
     });
 
-    it('should register the workflows list and library deep links but not executions when the executions view flag is off in bootstrap', () => {
-      plugin = createPlugin(false);
+    it('should register the workflows list and library deep links but not executions at bootstrap', () => {
+      plugin = createPlugin();
       coreSetup.uiSettings.get.mockImplementation((key: string, fallback?: unknown) => {
         if (key === WORKFLOWS_UI_SETTING_ID) return true;
         return fallback;
@@ -104,8 +104,8 @@ describe('WorkflowsPlugin', () => {
           id: PLUGIN_ID,
           title: 'Workflows',
           appRoute: '/app/workflows',
-          // Library is registered by default at bootstrap; the executions link is
-          // gated by the flag (off here). Both are refined at start().
+          // Library is registered by default at bootstrap; the executions link is gated by the
+          // global uiSetting (off by default). Both are refined reactively at start().
           deepLinks: [
             expect.objectContaining({ id: 'workflowsList', path: '/' }),
             expect.objectContaining({ id: 'library', path: '/library' }),
@@ -113,25 +113,6 @@ describe('WorkflowsPlugin', () => {
         })
       );
       expect(result).toEqual({});
-    });
-
-    it('should register the executions deep link when executions view flag is on in bootstrap', () => {
-      plugin = createPlugin(true);
-      coreSetup.uiSettings.get.mockImplementation((key: string, fallback?: unknown) => {
-        if (key === WORKFLOWS_UI_SETTING_ID) return true;
-        return fallback;
-      });
-
-      plugin.setup(coreSetup, setupDeps as any);
-
-      expect(coreSetup.application.register).toHaveBeenCalledWith(
-        expect.objectContaining({
-          deepLinks: expect.arrayContaining([
-            expect.objectContaining({ id: 'workflowsList', path: '/' }),
-            expect.objectContaining({ id: 'executions', path: '/executions' }),
-          ]),
-        })
-      );
     });
   });
 
@@ -299,6 +280,28 @@ describe('WorkflowsPlugin', () => {
 
         expect(updates.length).toBeGreaterThan(emissionsBefore);
         expect(updates[updates.length - 1].deepLinks).toBeDefined();
+      });
+
+      it('should add the executions deep link when the executions view uiSetting is enabled', () => {
+        setReadCapability(true);
+        setLicenseValid(true);
+        const updates = captureAppUpdates();
+
+        plugin.start(coreStart, startDeps as any);
+
+        // Off by default → no executions deep link.
+        expect(updates[updates.length - 1].deepLinks).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'executions' })])
+        );
+
+        // Enabling the global uiSetting adds the executions deep link reactively.
+        deepLinkSettings$.get(WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID)?.next(true);
+
+        expect(updates[updates.length - 1].deepLinks).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: 'executions', path: '/executions' }),
+          ])
+        );
       });
     });
   });

--- a/src/platform/plugins/shared/workflows_management/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { combineLatest, filter, type Observable, of, Subject, type Subscription } from 'rxjs';
+import { combineLatest, filter, type Observable, Subject, type Subscription } from 'rxjs';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type {
   AppDeepLinkLocations,
@@ -22,6 +22,7 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { Logger } from '@kbn/logging';
 import {
+  WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID,
   WORKFLOWS_LIBRARY_ENABLED_SETTING_ID,
   WORKFLOWS_UI_SETTING_ID,
 } from '@kbn/workflows/common/constants';
@@ -42,7 +43,6 @@ import type {
 } from './types';
 import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { stepSchemas } from '../common/step_schemas';
-import type { WorkflowsManagementConfig } from '../server/config';
 
 export class WorkflowsPlugin
   implements
@@ -61,14 +61,12 @@ export class WorkflowsPlugin
   private agentBuilderPromise: Promise<AgentBuilderPluginStart | undefined> | undefined;
   private settingsSubscription?: Subscription;
   private appVisibilitySubscription?: Subscription;
-  private readonly pluginConfig: WorkflowsManagementConfig;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get('WorkflowsManagement');
     this.appUpdater$ = new Subject<AppUpdater>();
     this.telemetryService = new TelemetryService();
     this.availabilityService = new AvailabilityService();
-    this.pluginConfig = initializerContext.config.get<WorkflowsManagementConfig>();
   }
 
   public setup(
@@ -98,8 +96,6 @@ export class WorkflowsPlugin
 
     this.setupAgentBuilderStart(core);
 
-    const executionsViewEnabled = this.pluginConfig.globalExecutionsView.enabled;
-
     core.application.register({
       id: PLUGIN_ID,
       title: PLUGIN_NAME,
@@ -109,7 +105,9 @@ export class WorkflowsPlugin
       category: DEFAULT_APP_CATEGORIES.management, // Only for the classic navigation
       order: 9015,
       updater$: this.appUpdater$,
-      deepLinks: getDeepLinks({ executionsViewEnabled }),
+      // Deep links are refined reactively in start() from global uiSettings; at bootstrap the
+      // executions link stays off (default) and the library link on, matching getDeepLinks defaults.
+      deepLinks: getDeepLinks(),
       mount: async (params: AppMountParameters) => {
         // Load application bundle
         const { renderApp } = await import('./application');
@@ -195,7 +193,10 @@ export class WorkflowsPlugin
         WORKFLOWS_LIBRARY_ENABLED_SETTING_ID,
         false
       ),
-      executionsViewEnabled: of(this.pluginConfig.globalExecutionsView.enabled),
+      executionsViewEnabled: core.settings.globalClient.get$<boolean>(
+        WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID,
+        false
+      ),
     });
 
     this.appVisibilitySubscription = combineLatest([isAvailable$, deepLinksFlags$]).subscribe(
@@ -270,7 +271,6 @@ export class WorkflowsPlugin
         availability: this.availabilityService,
         telemetry: this.telemetryService.getClient(),
         agentBuilder,
-        globalExecutionsView: this.pluginConfig.globalExecutionsView,
       },
     };
 

--- a/src/platform/plugins/shared/workflows_management/public/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/types.ts
@@ -90,9 +90,6 @@ export interface WorkflowsPublicPluginStartAdditionalServices {
     telemetry: TelemetryServiceClient;
     agentBuilder?: AgentBuilderPluginStart;
     availability: AvailabilityService;
-    globalExecutionsView: {
-      enabled: boolean;
-    };
   };
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/config.ts
+++ b/src/platform/plugins/shared/workflows_management/server/config.ts
@@ -56,13 +56,6 @@ const configSchema = schema.object({
    */
   available: schema.boolean({ defaultValue: true }),
   /**
-   * Global workflow executions list (`/app/workflows/executions`). Not exposed in Advanced Settings;
-   * enable via `workflowsManagement.globalExecutionsView.enabled` in `kibana.yml`.
-   */
-  globalExecutionsView: schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
-  }),
-  /**
    * Workflow Template Library — fetches the curated catalog and exposes it at
    * `/internal/workflows/library/*`. Server-only infrastructure settings; the
    * tech-preview enable/disable toggle is the `workflowsManagement:library:enabled`
@@ -76,7 +69,4 @@ export type WorkflowsManagementConfig = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<WorkflowsManagementConfig> = {
   schema: configSchema,
-  exposeToBrowser: {
-    globalExecutionsView: true,
-  },
 };

--- a/src/platform/plugins/shared/workflows_management/server/plugin.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.test.ts
@@ -38,7 +38,6 @@ describe('WorkflowsPlugin', () => {
       enabled: true,
       logging: { console: false },
       available: true,
-      globalExecutionsView: { enabled: false },
       library: { ttlMs: 600_000 },
     });
 

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.test.ts
@@ -10,6 +10,7 @@
 import { createCoreSetupMock } from '@kbn/core-lifecycle-server-mocks/src/core_setup.mock';
 import {
   WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID,
+  WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID,
   WORKFLOWS_LIBRARY_ENABLED_SETTING_ID,
   WORKFLOWS_UI_SETTING_ID,
   WORKFLOWS_UI_SHOW_MANAGED_WORKFLOWS_SETTING_ID,
@@ -69,6 +70,13 @@ describe('Workflows Management UI Settings', () => {
       expect.objectContaining({
         [WORKFLOWS_LIBRARY_ENABLED_SETTING_ID]: expect.objectContaining({
           name: 'Workflow Template Library',
+          value: false,
+          readonly: true,
+          readonlyMode: 'ui',
+          requiresPageReload: true,
+        }),
+        [WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID]: expect.objectContaining({
+          name: 'Workflow Executions view',
           value: false,
           readonly: true,
           readonlyMode: 'ui',

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -12,6 +12,7 @@ import type { CoreSetup } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import {
   WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID,
+  WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID,
   WORKFLOWS_LIBRARY_ENABLED_SETTING_ID,
   WORKFLOWS_UI_SETTING_ID,
   WORKFLOWS_UI_SHOW_MANAGED_WORKFLOWS_SETTING_ID,
@@ -99,6 +100,22 @@ export const registerUISettings = (
       description: i18n.translate('workflowsManagement.uiSettings.libraryEnabled.description', {
         defaultMessage: 'Enables the Workflow Template Library.',
       }),
+      schema: schema.boolean(),
+      value: false,
+      readonly: true,
+      readonlyMode: 'ui',
+      requiresPageReload: true,
+    },
+    [WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID]: {
+      name: i18n.translate('workflowsManagement.uiSettings.globalExecutionsViewEnabled.name', {
+        defaultMessage: 'Workflow Executions view',
+      }),
+      description: i18n.translate(
+        'workflowsManagement.uiSettings.globalExecutionsViewEnabled.description',
+        {
+          defaultMessage: 'Enables the global Workflow Executions view.',
+        }
+      ),
       schema: schema.boolean(),
       value: false,
       readonly: true,


### PR DESCRIPTION
Migrate the global Workflow Executions view flag from plugin config to a global uiSetting (following the Library flag pattern).

## Summary
- Replaced workflowsManagement.globalExecutionsView.enabled (kibana.yml plugin config) with a global uiSetting workflowsManagement:globalExecutionsView:enabled (registerGlobal, default false, readonly: 'ui', requiresPageReload).
- Added the shared constant WORKFLOWS_GLOBAL_EXECUTIONS_VIEW_ENABLED_SETTING_ID in @kbn/workflows.
- Added a reactive useGlobalExecutionsViewEnabled hook; the route gate and app deep links now read the setting via settings.globalClient (reactive) instead of a frozen config snapshot.
- Removed the old config schema, exposeToBrowser, start-service injection, and related types/mocks.