### PR TITLE
[Transforms] Add source.project_routing schema plumbing

### DIFF
--- a/x-pack/platform/plugins/private/transform/public/app/common/request.test.ts
+++ b/x-pack/platform/plugins/private/transform/public/app/common/request.test.ts
@@ -136,6 +136,35 @@ describe('Transform: Common', () => {
     });
   });
 
+  test('getPreviewTransformRequestBody() with project routing', () => {
+    const query = getTransformConfigQuery('the-query');
+    const request = getPreviewTransformRequestBody(
+      { getIndexPattern: () => 'the-data-view-title' } as DataView,
+      query,
+      {
+        pivot: {
+          aggregations: { 'the-agg-agg-name': { avg: { field: 'the-agg-field' } } },
+          group_by: { 'the-group-by-agg-name': { terms: { field: 'the-group-by-field' } } },
+        },
+      },
+      undefined,
+      undefined,
+      '_alias:*'
+    );
+
+    expect(request).toEqual({
+      pivot: {
+        aggregations: { 'the-agg-agg-name': { avg: { field: 'the-agg-field' } } },
+        group_by: { 'the-group-by-agg-name': { terms: { field: 'the-group-by-field' } } },
+      },
+      source: {
+        index: ['the-data-view-title'],
+        query: { query_string: { default_operator: 'AND', query: 'the-query' } },
+        project_routing: '_alias:*',
+      },
+    });
+  });
+
   test('getMissingBucketConfig()', () => {
     expect(getMissingBucketConfig(groupByTerms)).toEqual({});
     expect(getMissingBucketConfig({ ...groupByTerms, ...{ missing_bucket: true } })).toEqual({
@@ -341,7 +370,8 @@ describe('Transform: Common', () => {
     const request = getCreateTransformRequestBody(
       { getIndexPattern: () => 'the-data-view-title' } as DataView,
       pivotState,
-      transformDetailsState
+      transformDetailsState,
+      '_alias:*'
     );
 
     expect(request).toEqual({
@@ -360,6 +390,7 @@ describe('Transform: Common', () => {
       source: {
         index: ['the-data-view-title'],
         query: { query_string: { default_operator: 'AND', query: 'the-search-query' } },
+        project_routing: '_alias:*',
         runtime_mappings: runtimeMappings,
       },
       sync: {

--- a/x-pack/platform/plugins/private/transform/public/app/common/request.ts
+++ b/x-pack/platform/plugins/private/transform/public/app/common/request.ts
@@ -128,7 +128,8 @@ export function getPreviewTransformRequestBody(
   transformConfigQuery: TransformConfigQuery,
   partialRequest?: StepDefineExposedState['previewRequest'],
   runtimeMappings?: StepDefineExposedState['runtimeMappings'],
-  timeRangeMs?: StepDefineExposedState['timeRangeMs']
+  timeRangeMs?: StepDefineExposedState['timeRangeMs'],
+  projectRouting?: PostTransformsPreviewRequestSchema['source']['project_routing']
 ): PostTransformsPreviewRequestSchema {
   const dataViewTitle = dataView.getIndexPattern();
   const index = dataViewTitle.split(',').map((name: string) => name.trim());
@@ -158,6 +159,7 @@ export function getPreviewTransformRequestBody(
       index,
       ...(isDefaultQuery(query) ? {} : { query }),
       ...(isPopulatedObject(runtimeMappings) ? { runtime_mappings: runtimeMappings } : {}),
+      ...(projectRouting !== undefined ? { project_routing: projectRouting } : {}),
     },
     ...(partialRequest ?? {}),
   };
@@ -189,7 +191,8 @@ export const getCreateTransformSettingsRequestBody = (
 export const getCreateTransformRequestBody = (
   dataView: DataView,
   transformConfigState: StepDefineExposedState,
-  transformDetailsState: StepDetailsExposedState
+  transformDetailsState: StepDetailsExposedState,
+  projectRouting?: PutTransformsRequestSchema['source']['project_routing']
 ): PutTransformsPivotRequestSchema | PutTransformsLatestRequestSchema => ({
   ...getPreviewTransformRequestBody(
     dataView,
@@ -198,7 +201,8 @@ export const getCreateTransformRequestBody = (
     transformConfigState.runtimeMappings,
     transformConfigState.isDatePickerApplyEnabled && transformConfigState.timeRangeMs
       ? transformConfigState.timeRangeMs
-      : undefined
+      : undefined,
+    projectRouting
   ),
   // conditionally add optional description
   ...(transformDetailsState.transformDescription !== ''

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/transforms.test.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/transforms.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sourceSchema } from './transforms';
+
+describe('transform source schema', () => {
+  it('accepts project routing', () => {
+    expect(
+      sourceSchema.validate({
+        index: ['the-data-view-title'],
+        project_routing: '_alias:*',
+      })
+    ).toEqual({
+      index: ['the-data-view-title'],
+      project_routing: '_alias:*',
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/transform/server/routes/api_schemas/transforms.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/api_schemas/transforms.ts
@@ -84,6 +84,7 @@ export const sourceSchema = schema.object({
     schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
   ]),
   query: schema.maybe(schema.recordOf(schema.string({ maxLength: 1000 }), schema.any())),
+  project_routing: schema.maybe(schema.string({ maxLength: 1000 })),
 });
 
 export const syncSchema = schema.object({


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/275953

## Summary

- Adds optional `source.project_routing` support to the shared Transform source API schema.
- Adds typed optional `projectRouting` arguments to Transform preview/create request builders.
- Adds focused coverage for request payload generation and schema validation.

## Scope

This PR only adds type/schema/request plumbing for future CPS work. It does not add project scope UI, wizard state, list/details display changes, edit flyout changes, UIAM behavior, or bulk actions.



