### PR TITLE
[Alerting V2][POC] Rule sequence builder (rules-on-rules chaining with time windows)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/build_flow_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/build_flow_flyout.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiFormRow,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
+import type { RuleApiResponse } from '../../services/rules_api';
+import { buildFlowRuleData } from '../../queries/build_flow/build_flow_rule';
+
+const LOOKBACK_OPTIONS = [
+  { value: '5m', text: '5 minutes' },
+  { value: '15m', text: '15 minutes' },
+  { value: '1h', text: '1 hour' },
+  { value: '6h', text: '6 hours' },
+  { value: '24h', text: '24 hours' },
+];
+
+export interface BuildFlowFlyoutProps {
+  rules: [RuleApiResponse, RuleApiResponse];
+  isSaving: boolean;
+  onClose: () => void;
+  onCreate: (payload: CreateRuleData) => void;
+}
+
+const ruleLabel = (rule: RuleApiResponse) => rule.metadata?.name ?? rule.id;
+
+export const BuildFlowFlyout: React.FC<BuildFlowFlyoutProps> = ({
+  rules,
+  isSaving,
+  onClose,
+  onCreate,
+}) => {
+  const titleId = useGeneratedHtmlId({ prefix: 'buildFlowFlyoutTitle' });
+  const [order, setOrder] = useState<[RuleApiResponse, RuleApiResponse]>(rules);
+  const [lookback, setLookback] = useState('24h');
+  const [name, setName] = useState(
+    () => `${ruleLabel(rules[0])} → ${ruleLabel(rules[1])}`
+  );
+  const [nameEdited, setNameEdited] = useState(false);
+
+  const [firstRule, thenRule] = order;
+
+  const swapOrder = () => {
+    setOrder(([a, b]) => [b, a]);
+    if (!nameEdited) {
+      setName(`${ruleLabel(order[1])} → ${ruleLabel(order[0])}`);
+    }
+  };
+
+  const preview = useMemo(
+    () =>
+      buildFlowRuleData({
+        name,
+        ruleIds: [firstRule.id, thenRule.id],
+        lookback,
+      }),
+    [name, firstRule.id, thenRule.id, lookback]
+  );
+
+  return (
+    <EuiFlyout onClose={onClose} aria-labelledby={titleId} size="m" data-test-subj="buildFlowFlyout">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id={titleId}>
+            <FormattedMessage
+              id="xpack.alertingV2.buildFlow.title"
+              defaultMessage="Build a Flow"
+            />
+          </h2>
+        </EuiTitle>
+        <EuiText size="s" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.buildFlow.subtitle"
+            defaultMessage="Create a new rule that fires when these two rules occur in sequence, within a time window. Neither source rule is modified."
+          />
+        </EuiText>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiFlexGroup alignItems="center" gutterSize="s">
+          <EuiFlexItem>
+            <EuiPanel hasBorder paddingSize="m" data-test-subj="buildFlowFirstRule">
+              <EuiText size="xs" color="subdued">
+                <FormattedMessage id="xpack.alertingV2.buildFlow.firstLabel" defaultMessage="First" />
+              </EuiText>
+              <EuiText size="s">
+                <strong>{ruleLabel(firstRule)}</strong>
+              </EuiText>
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="sortRight"
+              display="base"
+              size="m"
+              onClick={swapOrder}
+              aria-label={i18n.translate('xpack.alertingV2.buildFlow.swapOrder', {
+                defaultMessage: 'Swap order',
+              })}
+              data-test-subj="buildFlowSwapOrder"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiPanel hasBorder paddingSize="m" data-test-subj="buildFlowThenRule">
+              <EuiText size="xs" color="subdued">
+                <FormattedMessage id="xpack.alertingV2.buildFlow.thenLabel" defaultMessage="Then" />
+              </EuiText>
+              <EuiText size="s">
+                <strong>{ruleLabel(thenRule)}</strong>
+              </EuiText>
+            </EuiPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size="l" />
+
+        <EuiFormRow
+          label={i18n.translate('xpack.alertingV2.buildFlow.windowLabel', {
+            defaultMessage: 'Within',
+          })}
+          helpText={i18n.translate('xpack.alertingV2.buildFlow.windowHelp', {
+            defaultMessage: 'How long after "{first}" should "{then}" still count as related?',
+            values: { first: ruleLabel(firstRule), then: ruleLabel(thenRule) },
+          })}
+        >
+          <EuiSelect
+            options={LOOKBACK_OPTIONS}
+            value={lookback}
+            onChange={(e) => setLookback(e.target.value)}
+            data-test-subj="buildFlowWindowSelect"
+          />
+        </EuiFormRow>
+
+        <EuiSpacer size="m" />
+
+        <EuiFormRow
+          label={i18n.translate('xpack.alertingV2.buildFlow.nameLabel', { defaultMessage: 'Flow name' })}
+        >
+          <EuiFieldText
+            value={name}
+            onChange={(e) => {
+              setNameEdited(true);
+              setName(e.target.value);
+            }}
+            data-test-subj="buildFlowNameInput"
+          />
+        </EuiFormRow>
+
+        <EuiSpacer size="l" />
+
+        <EuiText size="xs" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.buildFlow.previewLabel"
+            defaultMessage="Generated ES|QL (editable after creation):"
+          />
+        </EuiText>
+        <EuiSpacer size="xs" />
+        <EuiPanel color="subdued" paddingSize="s" data-test-subj="buildFlowEsqlPreview">
+          <EuiText size="xs">
+            <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>
+              {preview.query.format === 'standalone' ? preview.query.breach.query : ''}
+            </pre>
+          </EuiText>
+        </EuiPanel>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={onClose} data-test-subj="buildFlowCancel">
+              <FormattedMessage id="xpack.alertingV2.buildFlow.cancel" defaultMessage="Cancel" />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              isLoading={isSaving}
+              onClick={() => onCreate(preview)}
+              data-test-subj="buildFlowSubmit"
+            >
+              <FormattedMessage id="xpack.alertingV2.buildFlow.submit" defaultMessage="Create flow rule" />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/layout_sequence.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/layout_sequence.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import dagre, { graphlib } from '@dagrejs/dagre';
+import { MarkerType, Position } from '@xyflow/react';
+import type { SequenceNodeType } from './sequence_node';
+import type { SequenceEdgeType } from './sequence_edge';
+
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 48;
+const COL_GAP = NODE_WIDTH + 130;
+const ROW_GAP = NODE_HEIGHT + 130;
+/** Beyond this many stages, wrap into new rows instead of growing endlessly
+ * to the right (a single row gets unreadably cramped past ~4 nodes). */
+const MAX_STAGES_PER_ROW = 3;
+
+const buildEdges = (
+  stages: Array<{ ruleId: string; ruleName: string }>,
+  hopWindows: string[],
+  onHopWindowChange: (hopIndex: number, value: string) => void,
+  closeAllTick: number
+): SequenceEdgeType[] => {
+  const edges: SequenceEdgeType[] = [];
+  for (let i = 0; i < stages.length - 1; i++) {
+    const source = stages[i].ruleId;
+    const target = stages[i + 1].ruleId;
+    const wrapsToNextRow = Math.floor(i / MAX_STAGES_PER_ROW) !== Math.floor((i + 1) / MAX_STAGES_PER_ROW);
+    edges.push({
+      id: `${source}->${target}`,
+      source,
+      target,
+      type: 'sequenceHop',
+      markerEnd: { type: MarkerType.ArrowClosed },
+      data: {
+        window: hopWindows[i],
+        onChange: (value: string) => onHopWindowChange(i, value),
+        isRowWrap: wrapsToNextRow,
+        closeAllTick,
+      },
+    });
+  }
+  return edges;
+};
+
+/**
+ * Sequence order is the array order of `stages` (rule IDs), not node
+ * position — layout only decides *where things are drawn*. Edges are always
+ * consecutive stage[i] -> stage[i+1], each carrying its own independently
+ * configurable time window.
+ *
+ * Up to MAX_STAGES_PER_ROW stages, a single dagre left-to-right row (matches
+ * the original design). Beyond that, wrap into additional rows (left-aligned,
+ * like text wrapping) rather than growing arbitrarily wide — the row-wrap
+ * edges render as an elbow/step path via `SequenceEdge`, everything else
+ * stays a flat horizontal connector.
+ */
+export const layoutSequence = (
+  stages: Array<{ ruleId: string; ruleName: string }>,
+  hopWindows: string[],
+  onRemove: (ruleId: string) => void,
+  onHopWindowChange: (hopIndex: number, value: string) => void,
+  closeAllTick: number = 0
+): { nodes: SequenceNodeType[]; edges: SequenceEdgeType[] } => {
+  const edges = buildEdges(stages, hopWindows, onHopWindowChange, closeAllTick);
+
+  if (stages.length <= MAX_STAGES_PER_ROW) {
+    const dagreGraph = new graphlib.Graph();
+    dagreGraph.setDefaultEdgeLabel(() => ({}));
+    dagreGraph.setGraph({ rankdir: 'LR', nodesep: 40, ranksep: 130 });
+    stages.forEach((stage) => dagreGraph.setNode(stage.ruleId, { width: NODE_WIDTH, height: NODE_HEIGHT }));
+    edges.forEach((edge) => dagreGraph.setEdge(edge.source, edge.target));
+    dagre.layout(dagreGraph);
+
+    const nodes: SequenceNodeType[] = stages.map((stage, index) => {
+      const dagreNode = dagreGraph.node(stage.ruleId);
+      return {
+        id: stage.ruleId,
+        type: 'sequenceStage',
+        position: { x: dagreNode.x - NODE_WIDTH / 2, y: dagreNode.y - NODE_HEIGHT / 2 },
+        style: { width: NODE_WIDTH, height: NODE_HEIGHT },
+        targetPosition: Position.Left,
+        sourcePosition: Position.Right,
+        data: { ruleId: stage.ruleId, ruleName: stage.ruleName, stageIndex: index, onRemove },
+      };
+    });
+    return { nodes, edges };
+  }
+
+  // Wrapped, multi-row, left-aligned layout — no dagre needed, it's a fixed grid.
+  const nodes: SequenceNodeType[] = stages.map((stage, index) => {
+    const row = Math.floor(index / MAX_STAGES_PER_ROW);
+    const col = index % MAX_STAGES_PER_ROW;
+    return {
+      id: stage.ruleId,
+      type: 'sequenceStage',
+      position: { x: col * COL_GAP, y: row * ROW_GAP },
+      style: { width: NODE_WIDTH, height: NODE_HEIGHT },
+      targetPosition: Position.Left,
+      sourcePosition: Position.Right,
+      data: { ruleId: stage.ruleId, ruleName: stage.ruleName, stageIndex: index, onRemove },
+    };
+  });
+
+  return { nodes, edges };
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/sequence_builder_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/sequence_builder_flyout.tsx
@@ -1,0 +1,412 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFieldSearch,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiFormRow,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { ColorMode, ReactFlowInstance } from '@xyflow/react';
+import { Background, Controls, Panel, ReactFlow, ReactFlowProvider } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
+import { useFetchRules } from '../../hooks/use_fetch_rules';
+import type { RuleApiResponse } from '../../services/rules_api';
+import { buildFlowRuleData } from '../../queries/build_flow/build_flow_rule';
+import { layoutSequence } from './layout_sequence';
+import { SequenceNode } from './sequence_node';
+import { SequenceEdge } from './sequence_edge';
+import { DEFAULT_HOP_WINDOW } from './window_options';
+
+const nodeTypes = { sequenceStage: SequenceNode };
+const edgeTypes = { sequenceHop: SequenceEdge };
+
+const RULE_DRAG_MIME_TYPE = 'application/x-alerting-v2-rule-id';
+
+export interface SequenceBuilderFlyoutProps {
+  isSaving: boolean;
+  onClose: () => void;
+  onCreate: (payload: CreateRuleData) => void;
+}
+
+export const SequenceBuilderFlyout: React.FC<SequenceBuilderFlyoutProps> = ({
+  isSaving,
+  onClose,
+  onCreate,
+}) => {
+  const titleId = useGeneratedHtmlId({ prefix: 'sequenceBuilderTitle' });
+  const { colorMode } = useEuiTheme();
+  const reactFlowInstanceRef = useRef<ReactFlowInstance | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [stages, setStages] = useState<
+    Array<{ ruleId: string; ruleName: string; groupingFields: string[] }>
+  >([]);
+  // One window per hop between consecutive stages — each relationship is
+  // independently configurable, not one global window for the sequence.
+  const [hopWindows, setHopWindows] = useState<string[]>([]);
+  const [name, setName] = useState('');
+  const [nameEdited, setNameEdited] = useState(false);
+  // Whole-flow correlation key (v1: single field, exact-match across every
+  // stage's own `grouping.fields` — see build_flow_rule.ts module doc for
+  // why this is `group_hash`-based and why it can't yet do partial/per-hop
+  // correlation). Undefined = today's default: fires for any matching
+  // instances, globally, uncorrelated.
+  const [correlateBy, setCorrelateBy] = useState<string | undefined>(undefined);
+
+  const { data: rulesData } = useFetchRules({ page: 1, perPage: 100, search: search || undefined });
+  const availableRules = useMemo(
+    () => (rulesData?.items ?? []).filter((r) => !stages.some((s) => s.ruleId === r.id)),
+    [rulesData, stages]
+  );
+
+  const addStage = useCallback(
+    (rule: RuleApiResponse) => {
+      setStages((prev) => {
+        if (prev.some((s) => s.ruleId === rule.id)) return prev;
+        const next = [
+          ...prev,
+          {
+            ruleId: rule.id,
+            ruleName: rule.metadata?.name ?? rule.id,
+            groupingFields: rule.grouping?.fields ?? [],
+          },
+        ];
+        if (!nameEdited) {
+          setName(next.map((s) => s.ruleName).join(' → '));
+        }
+        return next;
+      });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [nameEdited]
+  );
+
+  // Offerable only when every stage's grouping.fields is *exactly* the same
+  // single-field set — group_hash correlation is all-or-nothing across the
+  // whole field set, not a loose intersection (see build_flow_rule.ts).
+  // Multi-field grouping sets are excluded from v1's UI for simplicity, even
+  // though they'd technically hash-match if identical everywhere.
+  const commonGroupingField = useMemo(() => {
+    if (stages.length < 2) return undefined;
+    const [first, ...rest] = stages;
+    if (first.groupingFields.length !== 1) return undefined;
+    const candidate = first.groupingFields[0];
+    const allMatch = rest.every(
+      (s) => s.groupingFields.length === 1 && s.groupingFields[0] === candidate
+    );
+    return allMatch ? candidate : undefined;
+  }, [stages]);
+
+  // Clear the selection if it's no longer offerable (e.g. a stage with a
+  // different/no grouping field was added or removed).
+  useEffect(() => {
+    if (correlateBy && correlateBy !== commonGroupingField) {
+      setCorrelateBy(undefined);
+    }
+  }, [correlateBy, commonGroupingField]);
+
+  // Keep hopWindows in sync with stages.length - 1 (one entry per hop),
+  // preserving already-set windows when stages are added/removed.
+  useEffect(() => {
+    const neededHops = Math.max(0, stages.length - 1);
+    setHopWindows((prev) => {
+      if (prev.length === neededHops) return prev;
+      if (prev.length < neededHops) {
+        return [...prev, ...Array(neededHops - prev.length).fill(DEFAULT_HOP_WINDOW)];
+      }
+      return prev.slice(0, neededHops);
+    });
+  }, [stages.length]);
+
+  const removeStage = useCallback(
+    (ruleId: string) => {
+      setStages((prev) => {
+        const next = prev.filter((s) => s.ruleId !== ruleId);
+        if (!nameEdited) {
+          setName(next.map((s) => s.ruleName).join(' → '));
+        }
+        return next;
+      });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [nameEdited]
+  );
+
+  const onHopWindowChange = useCallback((hopIndex: number, value: string) => {
+    setHopWindows((prev) => prev.map((w, i) => (i === hopIndex ? value : w)));
+  }, []);
+
+  // Bumped on any click elsewhere in the canvas so open hop-window popovers
+  // close — React Flow's pane swallows the pointer event before it reaches
+  // EUI's document-level outside-click detector, so we signal edges directly.
+  const [closeAllHopPopoversTick, setCloseAllHopPopoversTick] = useState(0);
+  const closeAllHopPopovers = useCallback(() => setCloseAllHopPopoversTick((t) => t + 1), []);
+
+  const { nodes, edges } = useMemo(
+    () => layoutSequence(stages, hopWindows, removeStage, onHopWindowChange, closeAllHopPopoversTick),
+    [stages, hopWindows, removeStage, onHopWindowChange, closeAllHopPopoversTick]
+  );
+
+  // Auto-fit the view every time a stage is added or removed, so the whole
+  // sequence stays visible without the user manually zooming/panning.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      reactFlowInstanceRef.current?.fitView({ padding: 0.4, duration: 300, maxZoom: 1.2 });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [nodes.length]);
+
+  const canCreate =
+    stages.length >= 2 && hopWindows.length === stages.length - 1 && name.trim().length > 0;
+
+  const preview = useMemo(() => {
+    if (!canCreate) return null;
+    return buildFlowRuleData({
+      name,
+      ruleIds: stages.map((s) => s.ruleId),
+      hopWindows,
+      correlateBy,
+    });
+  }, [canCreate, name, stages, hopWindows, correlateBy]);
+
+  const handleDropOnCanvas = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      const ruleId = event.dataTransfer.getData(RULE_DRAG_MIME_TYPE);
+      const rule = availableRules.find((r) => r.id === ruleId);
+      if (rule) addStage(rule);
+    },
+    [availableRules, addStage]
+  );
+
+  return (
+    <EuiFlyout
+      onClose={onClose}
+      aria-labelledby={titleId}
+      size="90%"
+      data-test-subj="sequenceBuilderFlyout"
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id={titleId}>
+            <FormattedMessage
+              id="xpack.alertingV2.sequenceBuilder.title"
+              defaultMessage="Build a Sequence"
+            />
+          </h2>
+        </EuiTitle>
+        <EuiText size="s" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.sequenceBuilder.subtitle"
+            defaultMessage="Drag rules from the left, in order, to build a new rule that fires when they occur in sequence. Each arrow has its own time window. None of the source rules are modified."
+          />
+        </EuiText>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody css={{ '.euiFlyoutBody__overflowContent': { height: '100%', padding: 0 } }}>
+        <EuiFlexGroup css={{ height: '100%' }} gutterSize="none">
+          <EuiFlexItem grow={false} css={{ width: 300, borderRight: '1px solid #d3dae6' }}>
+            <EuiPanel paddingSize="m" hasShadow={false} css={{ height: '100%', overflowY: 'auto' }}>
+              <EuiFieldSearch
+                fullWidth
+                isClearable
+                placeholder={i18n.translate('xpack.alertingV2.sequenceBuilder.searchPlaceholder', {
+                  defaultMessage: 'Search rules',
+                })}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                data-test-subj="sequenceBuilderRuleSearch"
+              />
+              <EuiSpacer size="m" />
+              <EuiFlexGroup direction="column" gutterSize="s">
+                {availableRules.map((rule) => (
+                  <EuiFlexItem key={rule.id} grow={false}>
+                    <EuiPanel
+                      paddingSize="s"
+                      hasBorder
+                      draggable
+                      onDragStart={(e: React.DragEvent) => {
+                        e.dataTransfer.setData(RULE_DRAG_MIME_TYPE, rule.id);
+                        e.dataTransfer.effectAllowed = 'copy';
+                      }}
+                      onDoubleClick={() => addStage(rule)}
+                      css={{ cursor: 'grab' }}
+                      data-test-subj={`sequenceBuilderDraggableRule-${rule.id}`}
+                    >
+                      <EuiText size="s">{rule.metadata?.name ?? rule.id}</EuiText>
+                    </EuiPanel>
+                  </EuiFlexItem>
+                ))}
+                {availableRules.length === 0 ? (
+                  <EuiText size="xs" color="subdued">
+                    <FormattedMessage
+                      id="xpack.alertingV2.sequenceBuilder.noMoreRules"
+                      defaultMessage="No more rules to add."
+                    />
+                  </EuiText>
+                ) : null}
+              </EuiFlexGroup>
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem
+            css={{ height: '100%' }}
+            onDragOver={(e: React.DragEvent) => e.preventDefault()}
+            onDrop={handleDropOnCanvas}
+            data-test-subj="sequenceBuilderCanvas"
+          >
+            {/* ReactFlow stays mounted even with zero nodes — mounting it fresh
+                the moment the first (edge-less) node appears left that node
+                permanently stuck at visibility:hidden (React Flow's own
+                "not yet measured" state never resolved for a lone node with
+                no edges at initial mount, though later-added nodes recovered
+                fine via a different code path). Mounting once, always, with
+                an overlay for the empty state, sidesteps that entirely. */}
+            <ReactFlowProvider>
+              <ReactFlow
+                onInit={(instance) => {
+                  reactFlowInstanceRef.current = instance;
+                }}
+                nodes={nodes}
+                edges={edges}
+                nodeTypes={nodeTypes}
+                edgeTypes={edgeTypes}
+                fitView
+                fitViewOptions={{ padding: 0.4 }}
+                nodesDraggable={false}
+                nodesConnectable={false}
+                onPaneClick={closeAllHopPopovers}
+                onNodeClick={closeAllHopPopovers}
+                onMoveStart={closeAllHopPopovers}
+                proOptions={{ hideAttribution: true }}
+                colorMode={colorMode.toLowerCase() as ColorMode}
+              >
+                <Controls showInteractive={false} />
+                <Background />
+                {stages.length === 0 ? (
+                  <Panel position="top-center" style={{ marginTop: '40%' }}>
+                    <EuiText color="subdued">
+                      <FormattedMessage
+                        id="xpack.alertingV2.sequenceBuilder.emptyCanvas"
+                        defaultMessage="Drag rules here, in the order you want them to occur"
+                      />
+                    </EuiText>
+                  </Panel>
+                ) : null}
+              </ReactFlow>
+            </ReactFlowProvider>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem>
+            <EuiFormRow
+              label={i18n.translate('xpack.alertingV2.sequenceBuilder.nameLabel', {
+                defaultMessage: 'Sequence name',
+              })}
+              display="rowCompressed"
+            >
+              <EuiFieldText
+                compressed
+                value={name}
+                onChange={(e) => {
+                  setNameEdited(true);
+                  setName(e.target.value);
+                }}
+                data-test-subj="sequenceBuilderNameInput"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false} css={{ width: 220 }}>
+            <EuiFormRow
+              label={i18n.translate('xpack.alertingV2.sequenceBuilder.correlateByLabel', {
+                defaultMessage: 'Correlate by',
+              })}
+              display="rowCompressed"
+              helpText={
+                commonGroupingField
+                  ? undefined
+                  : i18n.translate('xpack.alertingV2.sequenceBuilder.correlateByHelp', {
+                      defaultMessage: 'No grouping field is shared by every stage.',
+                    })
+              }
+            >
+              <EuiSelect
+                compressed
+                disabled={!commonGroupingField}
+                options={[
+                  {
+                    value: '',
+                    text: i18n.translate('xpack.alertingV2.sequenceBuilder.correlateByNone', {
+                      defaultMessage: 'None (any matching instances)',
+                    }),
+                  },
+                  ...(commonGroupingField
+                    ? [{ value: commonGroupingField, text: commonGroupingField }]
+                    : []),
+                ]}
+                value={correlateBy ?? ''}
+                onChange={(e) => setCorrelateBy(e.target.value || undefined)}
+                data-test-subj="sequenceBuilderCorrelateBySelect"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={onClose} data-test-subj="sequenceBuilderCancel">
+              <FormattedMessage id="xpack.alertingV2.sequenceBuilder.cancel" defaultMessage="Cancel" />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              isDisabled={!canCreate}
+              isLoading={isSaving}
+              onClick={() => preview && onCreate(preview)}
+              data-test-subj="sequenceBuilderSubmit"
+            >
+              <FormattedMessage
+                id="xpack.alertingV2.sequenceBuilder.submit"
+                defaultMessage="Create sequence rule"
+              />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {stages.length === 1 ? (
+          <>
+            <EuiSpacer size="s" />
+            <EuiCallOut
+              size="s"
+              color="subdued"
+              title={i18n.translate('xpack.alertingV2.sequenceBuilder.needTwoStages', {
+                defaultMessage: 'Add at least one more rule to create a sequence.',
+              })}
+            />
+          </>
+        ) : null}
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/sequence_edge.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/sequence_edge.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { EuiBadge, EuiPopover, EuiSelect } from '@elastic/eui';
+import type { Edge, EdgeProps } from '@xyflow/react';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, getSmoothStepPath } from '@xyflow/react';
+import { WINDOW_OPTIONS } from './window_options';
+
+export interface SequenceEdgeData extends Record<string, unknown> {
+  window: string;
+  onChange: (value: string) => void;
+  /** Row-wrap connector (last stage of one row -> first stage of the next) —
+   * rendered as an elbow/step path instead of a flat bezier. */
+  isRowWrap?: boolean;
+  /** Bumped whenever the canvas is clicked elsewhere; edges close their own
+   * popover in response instead of relying on document-level outside-click
+   * detection, which the React Flow pane's own pointer handling swallows. */
+  closeAllTick?: number;
+}
+
+export type SequenceEdgeType = Edge<SequenceEdgeData, 'sequenceHop'>;
+
+const windowLabel = (value: string | undefined) =>
+  WINDOW_OPTIONS.find((o) => o.value === value)?.text ?? value;
+
+/**
+ * Each hop between two stages has its own independently configurable time
+ * window — not one global window for the whole sequence. Collapsed to a
+ * small badge (rather than an always-open control) so it stays legible as
+ * more relationship types (AND/OR, entity matching) get added here later.
+ */
+export const SequenceEdge: React.FC<EdgeProps<SequenceEdgeType>> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [data?.closeAllTick]);
+
+  const [edgePath, labelX, labelY] = data?.isRowWrap
+    ? getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 12 })
+    : getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition });
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan"
+          style={{
+            position: 'absolute',
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: 'all',
+          }}
+        >
+          <EuiPopover
+            button={
+              <EuiBadge
+                color="hollow"
+                onClick={() => setIsOpen((open) => !open)}
+                onClickAriaLabel={`Edit time window: within ${windowLabel(data?.window)}`}
+                data-test-subj={`sequenceHopBadge-${id}`}
+              >
+                within {windowLabel(data?.window)}
+              </EuiBadge>
+            }
+            isOpen={isOpen}
+            closePopover={() => setIsOpen(false)}
+            panelPaddingSize="s"
+            anchorPosition="upCenter"
+          >
+            <EuiSelect
+              compressed
+              options={WINDOW_OPTIONS}
+              value={data?.window}
+              onChange={(e) => data?.onChange(e.target.value)}
+              data-test-subj={`sequenceHopWindow-${id}`}
+            />
+          </EuiPopover>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/sequence_node.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/sequence_node.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon, euiShadow, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
+import type { Node, NodeProps } from '@xyflow/react';
+import { Handle, Position } from '@xyflow/react';
+
+export interface SequenceNodeData extends Record<string, unknown> {
+  ruleId: string;
+  ruleName: string;
+  stageIndex: number;
+  onRemove: (ruleId: string) => void;
+}
+
+export type SequenceNodeType = Node<SequenceNodeData, 'sequenceStage'>;
+
+const componentStyles = {
+  node: (euiThemeContext: { euiTheme: ReturnType<typeof useEuiTheme>['euiTheme'] }) => css`
+    width: 100%;
+    height: 100%;
+    background-color: ${euiThemeContext.euiTheme.colors.backgroundBasePlain};
+    border: 1px solid ${euiThemeContext.euiTheme.colors.borderBaseFloating};
+    border-radius: 8px;
+    padding: 8px 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    ${euiShadow(euiThemeContext as Parameters<typeof euiShadow>[0], 'xs', { direction: 'down' })}
+  `,
+};
+
+export const SequenceNode: React.FC<NodeProps<SequenceNodeType>> = ({ data }) => {
+  const euiThemeContext = useEuiTheme();
+  const styles = useMemoCss(componentStyles);
+
+  return (
+    <EuiFlexGroup css={{ width: '100%', height: '100%' }} gutterSize="none">
+      <Handle type="target" position={Position.Left} style={{ visibility: data.stageIndex === 0 ? 'hidden' : 'visible' }} />
+      <EuiFlexItem css={styles.node}>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <div
+              css={{
+                width: '22px',
+                height: '22px',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '11px',
+                fontWeight: 'bold',
+                color: euiThemeContext.euiTheme.colors.emptyShade,
+                backgroundColor: euiThemeContext.euiTheme.colors.primary,
+                flexShrink: 0,
+              }}
+            >
+              {data.stageIndex + 1}
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem css={{ minWidth: 0 }}>
+            <div
+              css={{
+                fontSize: '13px',
+                fontWeight: 600,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+              title={data.ruleName}
+            >
+              {data.ruleName}
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="cross"
+              size="xs"
+              color="text"
+              aria-label={`Remove ${data.ruleName} from sequence`}
+              onClick={() => data.onRemove(data.ruleId)}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <Handle type="source" position={Position.Right} />
+    </EuiFlexGroup>
+  );
+};
+
+export const SEQUENCE_DRAG_MIME_TYPE = 'application/x-alerting-v2-rule';
+
+export const DraggableRulePreviewIcon = () => <EuiIcon type="grabHorizontal" color="subdued" />;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/window_options.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/build_flow/window_options.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const WINDOW_OPTIONS = [
+  { value: '5m', text: '5 minutes' },
+  { value: '15m', text: '15 minutes' },
+  { value: '1h', text: '1 hour' },
+  { value: '6h', text: '6 hours' },
+  { value: '24h', text: '24 hours' },
+];
+
+export const DEFAULT_HOP_WINDOW = '1h';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -39,6 +39,8 @@ import { TagsFilterPopover } from '../../components/rule/popovers/tag_filter_pop
 import { buildRulesListFilter } from './utils';
 import { RuleCreateOptionsPanel } from '../../components/rule_create_options/rule_create_options_panel';
 import { RuleCreateOptionsFlyout } from '../../components/rule_create_options/rule_create_options_flyout';
+import { SequenceBuilderFlyout } from '../../components/build_flow/sequence_builder_flyout';
+import { useCreateRule } from '../../hooks/use_create_rule';
 
 const DEFAULT_PER_PAGE = 20;
 export const SEARCH_DEBOUNCE_MS = 300;
@@ -51,10 +53,12 @@ const getRulesListMenu = ({
   onCreateRule,
   onCreateEsqlRule,
   onCreateWithAgent,
+  onBuildSequence,
 }: {
   onCreateRule: () => void;
   onCreateEsqlRule: () => void;
   onCreateWithAgent?: () => void;
+  onBuildSequence: () => void;
 }): AppHeaderMenu => ({
   primaryActionItem: {
     id: 'createRule',
@@ -95,6 +99,16 @@ const getRulesListMenu = ({
               },
             ]
           : []),
+        {
+          id: 'buildSequence',
+          label: i18n.translate('xpack.alertingV2.rulesList.buildSequenceButton', {
+            defaultMessage: 'Build a Sequence',
+          }),
+          iconType: 'branch',
+          order: 2,
+          run: onBuildSequence,
+          testId: 'buildSequenceButton',
+        },
       ],
     },
   },
@@ -117,10 +131,13 @@ export const RulesListPage = () => {
     isCreateOptionsFlyoutOpen,
     { on: openCreateOptionsFlyout, off: closeCreateOptionsFlyout },
   ] = useBoolean(false);
+  const [isSequenceBuilderOpen, { on: openSequenceBuilder, off: closeSequenceBuilder }] =
+    useBoolean(false);
   const { flyout, openCreateFlyout, openCreateBuilderFlyout, openEditFlyout, openCloneFlyout } =
     useComposeDiscoverFlyout();
   const navigateToAgentBuilder = useNavigateToAgentBuilder();
   const isRuleManagementABSkillAvailable = useIsRuleManagementABSkillAvailable();
+  const createSequenceRuleMutation = useCreateRule();
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
@@ -213,9 +230,10 @@ export const RulesListPage = () => {
             onCreateRule: openCreateOptionsFlyout,
             onCreateEsqlRule: openCreateFlyout,
             onCreateWithAgent,
+            onBuildSequence: openSequenceBuilder,
           })
         : undefined,
-    [showHeaderMenu, openCreateOptionsFlyout, openCreateFlyout, onCreateWithAgent]
+    [showHeaderMenu, openCreateOptionsFlyout, openCreateFlyout, onCreateWithAgent, openSequenceBuilder]
   );
 
   return (
@@ -311,6 +329,15 @@ export const RulesListPage = () => {
           onCreateEsqlRule={onCreateEsqlRuleFromOptionsFlyout}
           onCreateWithAgent={onCreateWithAgentFromFlyout}
           onCreateThresholdAlert={onCreateThresholdAlertFromOptionsFlyout}
+        />
+      ) : null}
+      {isSequenceBuilderOpen ? (
+        <SequenceBuilderFlyout
+          isSaving={createSequenceRuleMutation.isLoading}
+          onClose={closeSequenceBuilder}
+          onCreate={(payload) =>
+            createSequenceRuleMutation.mutate(payload, { onSuccess: closeSequenceBuilder })
+          }
         />
       ) : null}
       {flyout}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -90,6 +90,8 @@ export interface RulesListTableProps {
   onBulkEnable: () => void;
   onBulkDisable: () => void;
   onBulkDelete: () => void;
+  /** Only offered when exactly 2 rules are selected (not in select-all mode). */
+  onBuildFlow?: () => void;
 
   /** Row action callbacks */
   onNavigateToDetails: (rule: RuleApiResponse) => void;
@@ -125,6 +127,7 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
   onBulkEnable,
   onBulkDisable,
   onBulkDelete,
+  onBuildFlow,
   onNavigateToDetails,
   onExpand,
   onQuickEdit,
@@ -162,6 +165,11 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
   const handleBulkDelete = () => {
     setIsBulkActionsOpen(false);
     onBulkDelete();
+  };
+
+  const handleBuildFlow = () => {
+    setIsBulkActionsOpen(false);
+    onBuildFlow?.();
   };
 
   const pagination = {
@@ -466,6 +474,20 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
               >
                 <EuiContextMenuPanel
                   items={[
+                    ...(onBuildFlow && selectedCount === 2
+                      ? [
+                          <EuiContextMenuItem
+                            key="buildFlow"
+                            icon={<EuiIcon type="branch" size="m" aria-hidden={true} />}
+                            onClick={handleBuildFlow}
+                            data-test-subj="bulkBuildFlow"
+                          >
+                            {i18n.translate('xpack.alertingV2.rulesList.bulkAction.buildFlow', {
+                              defaultMessage: 'Build a Flow',
+                            })}
+                          </EuiContextMenuItem>,
+                        ]
+                      : []),
                     <EuiContextMenuItem
                       key="enable"
                       icon={<EuiIcon type="checkCircle" size="m" aria-hidden={true} />}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
@@ -8,14 +8,17 @@
 import React, { useState } from 'react';
 import { CoreStart, useService } from '@kbn/core-di-browser';
 import type { Criteria } from '@elastic/eui';
+import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
 import type { RuleApiResponse } from '../../services/rules_api';
 import { useBulkSelect } from '../../hooks/use_bulk_select';
 import { useDeleteRule } from '../../hooks/use_delete_rule';
 import { useBulkDeleteRules } from '../../hooks/use_bulk_delete_rules';
 import { useBulkEnableRules, useBulkDisableRules } from '../../hooks/use_bulk_enable_disable_rules';
 import { useToggleRuleEnabled } from '../../hooks/use_toggle_rule_enabled';
+import { useCreateRule } from '../../hooks/use_create_rule';
 import { DeleteConfirmationModal } from '../../components/rule/modals/delete_confirmation_modal';
 import { RuleSummaryFlyout } from '../../components/rule/flyouts';
+import { BuildFlowFlyout } from '../../components/build_flow/build_flow_flyout';
 import { paths } from '../../constants';
 import { RulesListTable, type RulesListTableSortField } from './rules_list_table';
 
@@ -57,6 +60,7 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
   const [ruleToDelete, setRuleToDelete] = useState<RuleApiResponse | null>(null);
   const [expandedRuleId, setExpandedRuleId] = useState<string | null>(null);
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
+  const [isBuildFlowOpen, setIsBuildFlowOpen] = useState(false);
 
   const expandedRule = expandedRuleId ? items.find((r) => r.id === expandedRuleId) ?? null : null;
 
@@ -65,6 +69,7 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
   const bulkEnableMutation = useBulkEnableRules();
   const bulkDisableMutation = useBulkDisableRules();
   const toggleEnabledMutation = useToggleRuleEnabled();
+  const createRuleMutation = useCreateRule();
 
   const {
     isAllSelected,
@@ -83,8 +88,26 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
     search: search || undefined,
   });
 
+  // Deliberately not gated on !isAllSelected: with only 2 total rules, clicking
+  // the "Select all 2 rules" link after already checking both individually is a
+  // natural next click, and selectedCount/isRowSelected already resolve correctly
+  // in that mode (see useBulkSelect's inverse-exclusion logic).
+  const selectedForFlow =
+    selectedCount === 2
+      ? (items.filter((r) => isRowSelected(r.id)) as [RuleApiResponse, RuleApiResponse])
+      : null;
+
   const handleBulkDelete = () => {
     setShowBulkDeleteConfirm(true);
+  };
+
+  const handleBuildFlowCreate = (payload: CreateRuleData) => {
+    createRuleMutation.mutate(payload, {
+      onSuccess: () => {
+        setIsBuildFlowOpen(false);
+        onClearSelection();
+      },
+    });
   };
 
   const onBulkDeleteConfirm = () => {
@@ -145,6 +168,7 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
         onBulkEnable={handleBulkEnable}
         onBulkDisable={handleBulkDisable}
         onBulkDelete={handleBulkDelete}
+        onBuildFlow={selectedForFlow ? () => setIsBuildFlowOpen(true) : undefined}
         onNavigateToDetails={(r) => navigateToUrl(basePath.prepend(paths.ruleDetails(r.id)))}
         onExpand={(r) => setExpandedRuleId(r.id)}
         onQuickEdit={(r) => onEditInFlyout(r)}
@@ -188,6 +212,14 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
           onCancel={() => setShowBulkDeleteConfirm(false)}
           onConfirm={onBulkDeleteConfirm}
           isLoading={bulkDeleteMutation.isLoading}
+        />
+      ) : null}
+      {isBuildFlowOpen && selectedForFlow ? (
+        <BuildFlowFlyout
+          rules={selectedForFlow}
+          isSaving={createRuleMutation.isLoading}
+          onClose={() => setIsBuildFlowOpen(false)}
+          onCreate={handleBuildFlowCreate}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/queries/build_flow/build_flow_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/queries/build_flow/build_flow_rule.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
+
+export interface BuildFlowRuleOptions {
+  name: string;
+  /** Ordered sequence of rule IDs, e.g. [A, B, C] for A -> B -> C. Minimum 2.
+   * No AND/OR per stage yet — one rule per position. */
+  ruleIds: string[];
+  /** One window per hop, `hopWindows[i]` bounds the gap between `ruleIds[i]`
+   * and `ruleIds[i + 1]`. Length must be `ruleIds.length - 1`. Duration
+   * strings, e.g. '5m', '1h', '24h' — each relationship gets its own window,
+   * they are NOT a single global sequence window. */
+  hopWindows: string[];
+  /**
+   * When set, correlate stages by entity instead of firing on any matching
+   * instances globally — every stage's rule must declare the exact same
+   * `grouping.fields` for this to work (see build_flow_rule README notes on
+   * `group_hash`). The field name itself is only used for UI display /
+   * validation; it never appears in the generated ES|QL, which keys off the
+   * platform's own `group_hash` column instead (see module doc below for
+   * why). Omit for today's default: fires for any matching instances,
+   * globally, uncorrelated.
+   */
+  correlateBy?: string;
+  /**
+   * Which stage's own recovery governs the flow rule's recovery — defaults
+   * to the last stage (today's only behavior). Exposed now so a future
+   * "recovers when: [stage picker]" UI is a clean addition, not a rework;
+   * no UI sets this yet.
+   */
+  recoveryRuleId?: string;
+}
+
+const escapeEsqlStringLiteral = (value: string) => value.replace(/"/g, '\\"');
+
+const DURATION_RE = /^(\d+)(ms|s|m|h|d|w)$/;
+const DURATION_UNIT_TO_SECONDS: Record<string, number> = {
+  ms: 0.001,
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+  w: 604800,
+};
+
+const durationToSeconds = (value: string): number => {
+  const match = DURATION_RE.exec(value);
+  if (!match) {
+    throw new Error(`Invalid duration "${value}", expected e.g. "5m", "1h", "24h"`);
+  }
+  return Number(match[1]) * DURATION_UNIT_TO_SECONDS[match[2]];
+};
+
+/**
+ * v2 alerting doesn't maintain a stable episode/group_hash across executions
+ * for ungrouped queries (each run gets a fresh one, so episodes can never
+ * progress past "pending" or be recognized as "still active" for recovery
+ * purposes) — a known platform limitation, not specific to flow rules. Every
+ * *uncorrelated* flow rule declares this single constant grouping key so its
+ * episode identity is stable across runs.
+ *
+ * Correlated flows (see `correlateBy`) instead group by the real `group_hash`
+ * column already present on every `.rule-events` doc. `group_hash` is
+ * computed server-side as `sha256(groupFields.join('|') + '|' +
+ * groupFields.map(f => rowDoc[f]).join('|'))` (see
+ * `server/lib/rule_executor/build_alert_events.ts`, `buildGroupHash`) — a
+ * pure function of the grouping field names/values, with no rule ID baked
+ * in. That means two *different* stage rules that both declare
+ * `grouping: { fields: ['host.name'] }` produce the identical `group_hash`
+ * for the same host, which is exactly the correlation key we want, already
+ * computed and already a queryable top-level `keyword` column. This is a
+ * deliberate v1 choice: it requires every stage's `grouping.fields` to match
+ * *exactly* (order included), which can't express partial/per-hop
+ * correlation (e.g. an ungrouped root-cause stage feeding two grouped
+ * downstream stages) — real field-value correlation would need either a new
+ * top-level mapped field populated at write time, or `METADATA _source` +
+ * extraction (both viable, deliberately deferred; ES|QL cannot reliably
+ * `STATS`/`SORT`/compare on `.rule-events`' `data` column directly, since
+ * it's mapped as `flattened` and Kibana's own ES|QL tooling excludes
+ * flattened sub-fields from grouping and sorting).
+ */
+const FLOW_GROUP_FIELD = 'flow_group';
+const FLOW_GROUP_VALUE = 'flow';
+const CORRELATION_GROUP_FIELD = 'group_hash';
+
+const stageColumn = (index: number) => `t${index}`;
+
+/**
+ * N-stage flow query: an ordered sequence of rule IDs, no AND/OR within a
+ * stage yet (one rule per position — that's a follow-up). Generalizes the
+ * two-rule case: one column per stage, then a chain of
+ * `t(n) > t(n-1) AND DATE_DIFF(...) <= hopWindows[n-1]` comparisons — each
+ * hop has its own independently configurable window, not one global window
+ * for the whole sequence.
+ *
+ * Uses `VALUES(CASE(...))` (collect every occurrence) + `MV_EXPAND` per stage
+ * — not `MAX(CASE(...))` — deliberately. `MAX` alone only compares each
+ * stage's single *latest* occurrence within the lookback, which silently
+ * breaks the moment any stage fires more than once in the window (the normal
+ * lifecycle for a persistently-breaching rule, not an edge case): a genuine
+ * "A at 0:00, then B at 0:05" pattern would be missed if A later re-fires at
+ * 0:20, since MAX(A)=0:20 no longer precedes B. Expanding every stage's full
+ * occurrence list produces the cross-product of all (t0, t1, ..., tn) tuples
+ * for the group, so the final WHERE correctly finds *any* qualifying
+ * sequence of occurrences, not just whichever happened most recently.
+ * Verified against a live repro of the MAX-only false negative before
+ * shipping this — see dev/rule-chaining-poc history.md, 2026-07-06.
+ */
+export const buildFlowSequenceEsql = ({
+  ruleIds,
+  hopWindows,
+  correlateBy,
+}: Pick<BuildFlowRuleOptions, 'ruleIds' | 'hopWindows' | 'correlateBy'>): string => {
+  if (ruleIds.length < 2) {
+    throw new Error('buildFlowSequenceEsql requires at least 2 rule IDs');
+  }
+  if (hopWindows.length !== ruleIds.length - 1) {
+    throw new Error('hopWindows must have exactly ruleIds.length - 1 entries');
+  }
+  const ids = ruleIds.map(escapeEsqlStringLiteral);
+  const columns = ids.map((_, i) => stageColumn(i));
+
+  const statsColumns = ids
+    .map((id, i) => `${columns[i]} = VALUES(CASE(rule.id == "${id}", @timestamp, NULL))`)
+    .join(',\n        ');
+
+  const mvExpandLines = columns.map((c) => `| MV_EXPAND ${c}`).join('\n');
+
+  const notNullChecks = columns.map((c) => `${c} IS NOT NULL`).join(' AND ');
+  const hopChecks = columns
+    .slice(1)
+    .map((c, i) => {
+      const prev = columns[i];
+      const hopSeconds = Math.ceil(durationToSeconds(hopWindows[i]));
+      return `${c} > ${prev} AND DATE_DIFF("seconds", ${prev}, ${c}) <= ${hopSeconds}`;
+    })
+    .join(' AND ');
+
+  const groupByField = correlateBy ? CORRELATION_GROUP_FIELD : FLOW_GROUP_FIELD;
+
+  return [
+    'FROM .rule-events',
+    `| WHERE type == "alert" AND rule.id IN (${ids.map((id) => `"${id}"`).join(', ')})`,
+    ...(correlateBy ? [] : [`| EVAL ${FLOW_GROUP_FIELD} = "${FLOW_GROUP_VALUE}"`]),
+    `| STATS ${statsColumns}`,
+    `        BY ${groupByField}`,
+    mvExpandLines,
+    `| WHERE ${notNullChecks} AND ${hopChecks}`,
+  ].join('\n');
+};
+
+/**
+ * Recovery is intentionally decoupled from the trigger condition: once the
+ * flow has fired, earlier stages aging out of the lookback shouldn't clear
+ * it — only the governing stage (defaults to the last one in the sequence)
+ * recovering should. Rows returned here mean "recovered" (opposite polarity
+ * from the breach query), per `CreateRecoveryEventsStep`.
+ *
+ * Uncorrelated: the governing rule's own most recent event already carries a
+ * top-level `status` of "breached" or "recovered", so this just checks that
+ * latest status directly (global, not per-entity).
+ *
+ * Correlated: a global "most recent event" check can't work per-entity — it
+ * would recover every entity whenever any one of them recovers. Instead,
+ * emit one row per `group_hash` whose most recent event for the governing
+ * rule is "recovered" (i.e. no *later* non-recovered event exists for that
+ * entity), which is exactly what `CreateRecoveryEventsStep` needs to match
+ * against the correlated flow rule's active per-entity episodes.
+ */
+export const buildFlowRecoveryEsql = ({
+  ruleIds,
+  correlateBy,
+  recoveryRuleId,
+}: Pick<BuildFlowRuleOptions, 'ruleIds' | 'correlateBy' | 'recoveryRuleId'>): string => {
+  const governingRuleId = escapeEsqlStringLiteral(recoveryRuleId ?? ruleIds[ruleIds.length - 1]);
+
+  if (correlateBy) {
+    return [
+      'FROM .rule-events',
+      `| WHERE type == "alert" AND rule.id == "${governingRuleId}"`,
+      '| STATS latest_recovered = MAX(CASE(status == "recovered", @timestamp, NULL)),',
+      '        latest_any       = MAX(@timestamp)',
+      `        BY ${CORRELATION_GROUP_FIELD}`,
+      '| WHERE latest_recovered == latest_any',
+    ].join('\n');
+  }
+
+  return [
+    'FROM .rule-events',
+    `| WHERE type == "alert" AND rule.id == "${governingRuleId}"`,
+    '| SORT @timestamp DESC',
+    '| LIMIT 1',
+    `| EVAL ${FLOW_GROUP_FIELD} = "${FLOW_GROUP_VALUE}"`,
+    '| WHERE status == "recovered"',
+  ].join('\n');
+};
+
+/**
+ * The rule's own schedule.lookback must cover the full span of the sequence
+ * (sum of all hop windows) — each hop's own DATE_DIFF check is what actually
+ * enforces the per-relationship window; the lookback just needs to be large
+ * enough that STATS can still see the earliest stage's event when the latest
+ * one comes in. Formatted in seconds to avoid unit-rounding surprises.
+ */
+const buildTotalLookback = (hopWindows: string[]): string => {
+  const totalSeconds = hopWindows.reduce((sum, w) => sum + durationToSeconds(w), 0);
+  return `${Math.ceil(totalSeconds)}s`;
+};
+
+export const buildFlowRuleData = ({
+  name,
+  ruleIds,
+  hopWindows,
+  correlateBy,
+  recoveryRuleId,
+}: BuildFlowRuleOptions): CreateRuleData => ({
+  kind: 'alert',
+  metadata: { name, tags: ['flow'] },
+  time_field: '@timestamp',
+  schedule: { every: '1m', lookback: buildTotalLookback(hopWindows) },
+  query: {
+    format: 'standalone',
+    breach: { query: buildFlowSequenceEsql({ ruleIds, hopWindows, correlateBy }) },
+    recovery: { query: buildFlowRecoveryEsql({ ruleIds, correlateBy, recoveryRuleId }) },
+  },
+  recovery_strategy: 'query',
+  grouping: { fields: [correlateBy ? CORRELATION_GROUP_FIELD : FLOW_GROUP_FIELD] },
+  state_transition: { pending_count: 1, recovering_count: 1 },
+});


### PR DESCRIPTION
## Summary

This is an experimental prototype for detecting **ordered sequences of rule occurrences**: "first X happens, then Y happens within N minutes, then Z happens within M minutes." Today, expressing this requires hand-writing an ES|QL query against `.rule-events` with the ordering/timing logic baked in by hand — there's no guided way to compose it, and as this PR found, the naive way to write that ES|QL by hand produces a query that's subtly wrong.

This PR adds a "Build a Sequence" flow: pick 2+ existing, independently-authored rules, arrange them in the order they should occur, set a time window per step, and generate a new rule that fires only when they occur in that exact order — without modifying the source rules.

**This is a prototype, not a finished feature**, and it addresses one specific, narrow pattern — temporal ordering — not general rule-relatedness or correlation. Posted as a draft to get early feedback on the approach, especially the ES|QL generation strategy.

## Problem

- v2 alerting can already correlate rules by querying `.rule-events` from another rule, but there's no way to express "in this specific order, within these windows" without hand-writing the ES|QL for it every time.
- That hand-written ES|QL is easy to get subtly wrong — the obvious approach (compare each rule's most recent occurrence) silently breaks the moment a rule fires more than once, which is the normal case, not an edge case (see Approach below).
- There's no UI for composing or visualizing an ordered chain of rules.

## Approach

**Composition, not coupling.** Source rules are never modified. A new rule is generated whose ES|QL queries `.rule-events`, filtered to the selected rule IDs, with the ordering/timing logic baked into the generated query — the same mechanism a hand-written sequencing query would use today, just generated correctly instead of hand-authored.

**Sequence detection in ES|QL.** For N steps, the generated query collects every occurrence of each step's alert events via `STATS ... VALUES(CASE(rule.id == <id>, @timestamp, NULL))`, then uses `MV_EXPAND` on each step's column to produce the full cross-product of occurrence tuples, filtering with a chained `t(n) > t(n-1) AND DATE_DIFF(...) <= windowFor(n-1)` per step. Each step-to-step transition gets its own independently configurable time window rather than one global window for the whole sequence.

This is deliberately **not** `MAX(CASE(...))` comparison, which was the initial implementation. Comparing only each rule's single latest occurrence produces wrong results the moment any rule in the sequence fires more than once within the lookback (the normal lifecycle of any rule watching a persisting condition): a genuine earlier match can be masked by a later, unrelated occurrence of the same rule, and conversely, two unrelated persistently-firing rules can appear to be "in sequence" based on incidental execution timing rather than real ordering. `VALUES()` + `MV_EXPAND` avoids this by considering every occurrence, not just the latest.

**Recovery decoupled from the trigger.** The generated rule recovers based on a single governing step's own recovery status (configurable internally, currently always the last step) rather than on the trigger condition re-evaluating false — so the sequence stays "active" for as long as the final step is still an active problem, independent of whether earlier steps have aged out of the window.

**Optional entity correlation via `group_hash`.** When every selected rule shares the exact same `grouping.fields` configuration, the generated query can group by the platform's existing `group_hash` column instead of a constant value, so the sequence only fires when the *same* entity moves through every step (e.g. the same host), not any matching instances globally. This intentionally reuses an existing computed field rather than reading raw field values out of `.rule-events`' `data` column, which is mapped as `flattened` and not reliably usable in `STATS`/`SORT`/comparisons in ES|QL today.

## Limitations (known, out of scope for this prototype)

- This addresses ordered sequencing specifically — it is not a general rule-relatedness or correlation model.
- Correlation requires an exact match of `grouping.fields` across every selected rule — no partial correlation (e.g. one ungrouped first step feeding two correlated later steps) and no cross-rule field renaming.
- No AND/OR combination of multiple rules within a single step.
- No configurable recovery-step picker in the UI yet (the underlying option exists, unused).
- Canvas layout auto-wraps past 3 steps with a simple heuristic, not a general-purpose layout algorithm.

## Testing

Verified directly against `.rule-events` with synthetic and real rule data: N-step sequence detection (positive/negative/out-of-order cases), per-step time window enforcement, entity correlation (confirmed two different rules sharing `grouping.fields` produce identical `group_hash` for the same entity), and a live repro of the `MAX`-vs-`VALUES` correctness fix (before/after).