### PR TITLE
[Entity Store][Bug Fix] Keep indices and data streams while any engine is present

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -231,6 +231,59 @@ describe('AssetManagerClient', () => {
     });
   });
 
+  describe('uninstall', () => {
+    // getAll is called twice in uninstall: once via getStatus (before delete) and once
+    // to compute remainingEngines (after delete). Sequence the mock accordingly.
+    it('keeps shared assets when other engines remain (see: https://github.com/elastic/security-team/issues/18143)', async () => {
+      mockEngineDescriptorClient.getAll
+        .mockResolvedValueOnce([
+          { type: 'host', status: 'started' },
+          { type: 'user', status: 'started' },
+        ])
+        .mockResolvedValueOnce([{ type: 'user', status: 'started' }]);
+
+      const result = await client.uninstall('host');
+
+      expect(result).toBe(true);
+      expect(mockEngineDescriptorClient.delete).toHaveBeenCalledWith('host');
+      // Shared, per-namespace / cluster assets must survive.
+      expect(mockUninstallElasticsearchAssets).not.toHaveBeenCalled();
+      expect(mockDeleteEuidStoredScripts).not.toHaveBeenCalled();
+      expect(mockGlobalStateClient.delete).not.toHaveBeenCalled();
+      expect(mockStopStatusReportTask).not.toHaveBeenCalled();
+      expect(mockStopHistorySnapshotTask).not.toHaveBeenCalled();
+    });
+
+    it('deletes shared assets when the last engine is uninstalled', async () => {
+      mockEngineDescriptorClient.getAll
+        .mockResolvedValueOnce([{ type: 'host', status: 'started' }])
+        .mockResolvedValueOnce([]);
+
+      const result = await client.uninstall('host');
+
+      expect(result).toBe(true);
+      expect(mockEngineDescriptorClient.delete).toHaveBeenCalledWith('host');
+      expect(mockUninstallElasticsearchAssets).toHaveBeenCalledTimes(1);
+      expect(mockDeleteEuidStoredScripts).toHaveBeenCalledTimes(1);
+      expect(mockGlobalStateClient.delete).toHaveBeenCalledTimes(1);
+      expect(mockStopStatusReportTask).toHaveBeenCalledTimes(1);
+      expect(mockStopHistorySnapshotTask).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when the type is not installed', async () => {
+      mockEngineDescriptorClient.getAll.mockResolvedValueOnce([
+        { type: 'user', status: 'started' },
+      ]);
+
+      const result = await client.uninstall('host');
+
+      expect(result).toBe(false);
+      expect(mockEngineDescriptorClient.delete).not.toHaveBeenCalled();
+      expect(mockUninstallElasticsearchAssets).not.toHaveBeenCalled();
+      expect(mockDeleteEuidStoredScripts).not.toHaveBeenCalled();
+    });
+  });
+
   describe('logsExtraction resolution on install', () => {
     const existingLogsExtraction = {
       additionalIndexPatterns: ['existing-*'],

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -233,24 +233,29 @@ export class AssetManagerClient {
       }
       await this.stop(type);
 
+      // Per-type saved objects — always safe to remove for this type alone.
       await Promise.all([
         this.engineDescriptorClient.delete(type),
         this.remoteLogExtractionStateClient.delete(type),
-        uninstallElasticsearchAssets({
-          esClient: this.esClient,
-          logger: this.logger.get(type),
-          namespace: this.namespace,
-        }),
-        deleteEuidStoredScripts({
-          esClient: this.esClient,
-          logger: this.logger,
-        }),
       ]);
 
+      // The ES indices/data streams and the EUID stored scripts are shared across all
+      // entity types in the namespace (their names carry the namespace, not the type).
+      // Only remove them once no engine remains — otherwise the surviving engines lose
+      // the read/write targets and scripts their extraction queries still depend on.
       const remainingEngines = await this.engineDescriptorClient.getAll();
       if (remainingEngines.length === 0) {
-        this.logger.debug(`Deleting global state because last engine was uninstalled`);
+        this.logger.debug(`Removing shared assets because last engine was uninstalled`);
         await Promise.all([
+          uninstallElasticsearchAssets({
+            esClient: this.esClient,
+            logger: this.logger.get(type),
+            namespace: this.namespace,
+          }),
+          deleteEuidStoredScripts({
+            esClient: this.esClient,
+            logger: this.logger,
+          }),
           this.globalStateClient.delete(),
           stopStatusReportTask({
             taskManager: this.taskManager,

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/uninstall.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/uninstall.spec.ts
@@ -9,10 +9,13 @@ import { apiTest } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/api';
 import {
   PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
   ENTITY_STORE_ROUTES,
   ENTITY_STORE_TAGS,
   LATEST_INDEX,
+  UPDATES_INDEX,
 } from '../fixtures/constants';
+import { forceLogExtraction } from '../fixtures/helpers';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
 
 type ApiWorkerFixtures = Parameters<Parameters<typeof apiTest>[2]>[0];
@@ -25,12 +28,17 @@ const getExtractEntityTaskId = (entityType: string) =>
 
 apiTest.describe('Entity Store uninstall', { tag: ENTITY_STORE_TAGS }, () => {
   let defaultHeaders: Record<string, string>;
+  let internalHeaders: Record<string, string>;
 
   apiTest.beforeAll(async ({ samlAuth, kbnClient }) => {
     const credentials = await samlAuth.asInteractiveUser('admin');
     defaultHeaders = {
       ...credentials.cookieHeader,
       ...PUBLIC_HEADERS,
+    };
+    internalHeaders = {
+      ...credentials.cookieHeader,
+      ...INTERNAL_HEADERS,
     };
     await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
   });
@@ -119,6 +127,47 @@ apiTest.describe('Entity Store uninstall', { tag: ENTITY_STORE_TAGS }, () => {
     const existsAfter = await esClient.indices.exists({ index: LATEST_INDEX });
     expect(existsAfter).toBe(false);
   });
+
+  // Regression for https://github.com/elastic/security-team/issues/18143:
+  // the latest index, updates/metadata data streams and EUID scripts are shared per
+  // namespace. Uninstalling one entity type must NOT delete them while other engines
+  // are still installed — otherwise the surviving engines' extraction fails with
+  // `verification_exception: Unknown index [...]` / `index_not_found_exception`.
+  apiTest(
+    'keeps shared assets when only one of several engines is uninstalled',
+    async ({ apiClient, esClient }) => {
+      await install(apiClient, { entityTypes: ['user', 'host'] });
+
+      // Shared assets exist after install.
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(true);
+      const updatesBefore = await esClient.indices.getDataStream({ name: UPDATES_INDEX });
+      expect(updatesBefore.data_streams).toHaveLength(1);
+
+      // Uninstall a single type; the other engine stays installed.
+      await uninstall(apiClient, { entityTypes: ['host'] });
+
+      // Shared assets must still exist for the surviving `user` engine.
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(true);
+      const updatesAfter = await esClient.indices.getDataStream({ name: UPDATES_INDEX });
+      expect(updatesAfter.data_streams).toHaveLength(1);
+
+      // End-to-end: the surviving engine's extraction still succeeds (this is what
+      // fails in production when the shared index/data stream get deleted).
+      const extraction = await forceLogExtraction(
+        apiClient,
+        internalHeaders,
+        'user',
+        '2026-01-20T11:00:00Z',
+        '2026-01-20T13:00:00Z'
+      );
+      expect(extraction.statusCode).toBe(200);
+      expect(extraction.body).toMatchObject({ success: true });
+
+      // Uninstalling the last remaining engine tears the shared index down as expected.
+      await uninstall(apiClient, { entityTypes: ['user'] });
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(false);
+    }
+  );
 
   apiTest('uninstall is a no-op when entity store is not installed', async ({ apiClient }) => {
     const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {


### PR DESCRIPTION
## Summary

This PR closes https://github.com/elastic/security-team/issues/18143. It changes `AssetManagerClient.uninstall()` by placing `uninstallElasticsearchAssets` and `deleteEuidStoredScripts` behind a guard, so that they are kept while at least one engine is running. This prevents user from deleting the indices accidentally while calling `/api/security/entity_store/uninstall` and removing some, not all, engines.

Jest and Scout tests are added to confirm the fix and prevent regressions.


### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->