### PR TITLE
Fix data view picker fetching fields for every data view on mount

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.test.tsx
@@ -39,12 +39,12 @@ const selectedDataView = {
   getName: () => 'kibana_sample_data_logs',
 } as unknown as DataView;
 
-const dataViewIds = [
-  'mock-data-logs-id',
-  'mock-ecommerce-id',
-  'mock-test-id',
-  'mock-ad-hoc-id',
-  'mock-ad-hoc-esql-id',
+const dataViewListItems = [
+  { id: 'mock-data-logs-id', title: 'kibana_sample_data_logs' },
+  { id: 'mock-ecommerce-id', title: 'kibana_sample_data_ecommerce' },
+  { id: 'mock-test-id', title: 'test' },
+  { id: 'mock-ad-hoc-id', title: 'ad-hoc data view' },
+  { id: 'mock-ad-hoc-esql-id', title: 'ad-hoc data view esql', type: ESQL_TYPE },
 ];
 
 const dataViewOptions = [
@@ -98,7 +98,9 @@ const dataViewOptions = [
 
 const mount = () => {
   const dataViewsMock = dataViewPluginMocks.createStartContract();
-  dataViewsMock.getIds = jest.fn().mockImplementation(() => Promise.resolve(dataViewIds));
+  dataViewsMock.getIdsWithTitle = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(dataViewListItems));
   dataViewsMock.get = jest
     .fn()
     .mockImplementation((id: string) =>
@@ -123,20 +125,23 @@ describe('DataViewSelectPopover', () => {
     const { dataViewsMock } = mount();
 
     await waitFor(() => {
-      expect(dataViewsMock.getIds).toHaveBeenCalled();
+      expect(dataViewsMock.getIdsWithTitle).toHaveBeenCalled();
     });
 
     expect(screen.getByTestId('selectDataViewExpression')).toBeInTheDocument();
 
-    const getIdsResult = await dataViewsMock.getIds.mock.results[0].value;
-    expect(getIdsResult).toBe(dataViewIds);
+    // Only the lightweight id/title listing should be used to populate the
+    // picker — it must not hydrate every data view via `get()`.
+    const getIdsWithTitleResult = await dataViewsMock.getIdsWithTitle.mock.results[0].value;
+    expect(getIdsWithTitleResult).toBe(dataViewListItems);
+    expect(dataViewsMock.get).not.toHaveBeenCalled();
   });
 
   test('should open a popover on click and display loaded data views', async () => {
     const { dataViewsMock } = mount();
 
     await waitFor(() => {
-      expect(dataViewsMock.getIds).toHaveBeenCalled();
+      expect(dataViewsMock.getIdsWithTitle).toHaveBeenCalled();
     });
 
     await userEvent.click(screen.getByTestId('selectDataViewExpression'));
@@ -144,7 +149,7 @@ describe('DataViewSelectPopover', () => {
     await screen.findByTestId('chooseDataViewPopoverContent');
 
     // Verify the DataViewSelector received the correct filtered data views
-    // (excludes flights which isn't in dataViewIds)
+    // (excludes flights which isn't in dataViewListItems)
     const lastCall = MockedDataViewSelector.mock.calls.at(-1)![0];
     const dataViewTitles = lastCall.dataViewsList.map((dv: { title: string }) => dv.title);
     expect(dataViewTitles).toEqual([

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.tsx
@@ -103,10 +103,12 @@ export const DataViewSelectPopover: React.FunctionComponent<DataViewSelectPopove
   const loadPersistedDataViews = useCallback(async () => {
     setLoadingDataViews(true);
     try {
-      // Calling getIds with refresh = true to make sure we don't get stale data
-      const ids = await dataViews.getIds(true);
-      const dataViewsList = await Promise.all(ids.map((id) => dataViews.get(id)));
-      setDataViewsItems(dataViewsList.map(toDataViewListItem));
+      // Calling with refresh = true to make sure we don't get stale data. This only
+      // fetches id/title metadata, it does not hydrate every data view's fields
+      // (see https://github.com/elastic/kibana/issues/276539) — full hydration
+      // happens on demand for the data view actually selected, in onChangeDataView.
+      const dataViewsList = await dataViews.getIdsWithTitle(true);
+      setDataViewsItems(dataViewsList);
     } catch (e) {
       // Error fetching data views
     }


### PR DESCRIPTION
Fixes #276539

## Summary

`DataViewSelectPopover`, used by the Elasticsearch Query, Custom Threshold, and Dataset Quality rule forms, fetched the id of every data view in the space on mount and then hydrated each one, fields included, just to render a picker list. In a space with hundreds of data views this fired hundreds of parallel `/internal/data_views/fields` requests, and any data view whose index pattern could not be resolved (for example a removed remote cluster) produced its own toast error, unrelated to the rule actually being edited.

This PR replaces the `getIds` and per id `get` loop with `getIdsWithTitle`, which returns id and title without hydrating fields. The data view actually selected by the user, or already in use by the rule being edited, is still fully loaded through `get()`, unchanged.

## Testing

- Updated `data_view_select_popover.test.tsx` to mock `getIdsWithTitle` and assert `get()` is not called while populating the list.
- `node scripts/jest --config x-pack/platform/plugins/shared/stack_alerts/jest.config.js .../data_view_select_popover.test.tsx` passes.
- Typecheck (`tsc -b x-pack/platform/plugins/shared/stack_alerts/tsconfig.type_check.json`) passes.
- Lint passes on both changed files.

## Test plan

- [x] Unit tests updated and passing
- [x] Typecheck passing
- [ ] Manual verification in a space with many data views (network tab should show a single lightweight list call, not one per data view)