### PR TITLE
[Search] Filter Query Rules name

### DIFF
--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_delete_query_rules_rule.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_delete_query_rules_rule.ts
@@ -25,7 +25,9 @@ export const useDeleteRulesetRule = (onSuccess?: () => void, onError?: (error: s
   return useMutation(
     async ({ rulesetId, ruleId }: MutationArgs) => {
       return await http.delete<{ acknowledged: boolean }>(
-        `/internal/search_query_rules/ruleset/${rulesetId}/rule/${ruleId}`
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(
+          rulesetId
+        )}/rule/${encodeURIComponent(ruleId)}`
       );
     },
     {

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_delete_query_rules_ruleset.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_delete_query_rules_ruleset.ts
@@ -24,7 +24,7 @@ export const useDeleteRuleset = (onSuccess?: () => void, onError?: (error: strin
   return useMutation(
     async ({ rulesetId }: MutationArgs) => {
       return await http.delete<{ acknowledged: boolean }>(
-        `/internal/search_query_rules/ruleset/${rulesetId}`
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(rulesetId)}`
       );
     },
     {

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_fetch_query_rule.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_fetch_query_rule.ts
@@ -27,7 +27,9 @@ export const useFetchQueryRule = (
     queryKey: [QUERY_RULES_QUERY_RULE_FETCH_KEY, ruleId],
     queryFn: async () => {
       return await http.get<SearchQueryRulesQueryRule>(
-        `/internal/search_query_rules/ruleset/${rulesetId}/rule/${ruleId}`
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(
+          rulesetId
+        )}/rule/${encodeURIComponent(ruleId)}`
       );
     },
   });

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_fetch_query_ruleset.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_fetch_query_ruleset.ts
@@ -20,7 +20,7 @@ export const useFetchQueryRuleset = (rulesetId: string, enabled = true) => {
     queryKey: [QUERY_RULES_QUERY_RULESET_FETCH_KEY, rulesetId],
     queryFn: async () => {
       return await http.get<QueryRulesQueryRuleset>(
-        `/internal/search_query_rules/ruleset/${rulesetId}`
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(rulesetId)}`
       );
     },
     retry: false,

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_fetch_ruleset_exists.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_fetch_ruleset_exists.ts
@@ -23,7 +23,7 @@ export const useFetchQueryRulesetExist = (
     queryKey: [QUERY_RULES_QUERY_RULESET_EXISTS_KEY, rulesetId],
     queryFn: async () => {
       const { exists } = await http.get<{ exists: boolean }>(
-        `/internal/search_query_rules/ruleset/${rulesetId}/exists`
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(rulesetId)}/exists`
       );
       if (!exists && onNoConflict) {
         onNoConflict();

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_generate_rule_id.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_generate_rule_id.ts
@@ -16,7 +16,7 @@ export const useGenerateRuleId = (rulesetId: string) => {
   return useMutation<string>({
     mutationFn: async () => {
       const response = await http.post<{ ruleId: string }>(
-        `/internal/search_query_rules/ruleset/${rulesetId}/generate_rule_id`
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(rulesetId)}/generate_rule_id`
       );
       return response.ruleId;
     },

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_put_query_rules_ruleset.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_put_query_rules_ruleset.ts
@@ -35,7 +35,7 @@ export const usePutRuleset = (
   return useMutation(
     async ({ rulesetId, forceWrite, rules }: MutationArgs) => {
       return await http.put<QueryRulesQueryRuleset>(
-        `/internal/search_query_rules/ruleset/${rulesetId}`,
+        `/internal/search_query_rules/ruleset/${encodeURIComponent(rulesetId)}`,
         {
           query: { forceWrite },
           ...(rules ? { body: JSON.stringify({ rules }) } : {}),

--- a/x-pack/solutions/search/plugins/search_query_rules/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/server/routes.ts
@@ -23,6 +23,16 @@ import { putRuleset } from './lib/put_query_rules_ruleset_set';
 import { errorHandler } from './utils/error_handler';
 import { checkPrivileges } from './utils/privilege_check';
 
+const RESOURCE_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+const resourceIdSchema = schema.string({
+  maxLength: 512,
+  validate: (value) =>
+    RESOURCE_ID_REGEX.test(value)
+      ? undefined
+      : 'must only contain letters, numbers, hyphens (-), and underscores (_)',
+});
+
 export function defineRoutes({ logger, router }: { logger: Logger; router: IRouter }) {
   router.get(
     {
@@ -74,7 +84,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          ruleset_id: schema.string(),
+          ruleset_id: resourceIdSchema,
         }),
       },
     },
@@ -114,7 +124,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          ruleset_id: schema.string(),
+          ruleset_id: resourceIdSchema,
         }),
         query: schema.object({
           forceWrite: schema.boolean({ defaultValue: false }),
@@ -194,7 +204,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          rulesetId: schema.string(),
+          rulesetId: resourceIdSchema,
         }),
       },
     },
@@ -231,7 +241,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          ruleset_id: schema.string(),
+          ruleset_id: resourceIdSchema,
         }),
       },
     },
@@ -266,8 +276,8 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          ruleset_id: schema.string(),
-          rule_id: schema.string(),
+          ruleset_id: resourceIdSchema,
+          rule_id: resourceIdSchema,
         }),
       },
     },
@@ -303,8 +313,8 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          ruleset_id: schema.string(),
-          rule_id: schema.string(),
+          ruleset_id: resourceIdSchema,
+          rule_id: resourceIdSchema,
         }),
       },
     },
@@ -426,7 +436,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          rulesetId: schema.string(),
+          rulesetId: resourceIdSchema,
         }),
       },
     },

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonym_rule.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonym_rule.ts
@@ -25,7 +25,9 @@ export const useDeleteSynonymRule = (onSuccess?: () => void, onError?: (error: s
   return useMutation(
     async ({ synonymsSetId, ruleId }: MutationArgs) => {
       return await http.delete<{ acknowledged: boolean }>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}/${ruleId}`
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(
+          synonymsSetId
+        )}/${encodeURIComponent(ruleId)}`
       );
     },
     {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonyms_set.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonyms_set.ts
@@ -24,7 +24,7 @@ export const useDeleteSynonymsSet = (onSuccess?: () => void, onError?: (error: s
   return useMutation(
     async ({ synonymsSetId }: MutationArgs) => {
       return await http.delete<{ acknowledged: boolean }>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}`
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(synonymsSetId)}`
       );
     },
     {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_generated_rule_id.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_generated_rule_id.ts
@@ -18,7 +18,7 @@ export const useFetchGeneratedRuleId = (
   return useMutation(
     async ({ synonymsSetId }: { synonymsSetId: string }) => {
       return await http.post<{ id: string }>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}/generate`
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(synonymsSetId)}/generate`
       );
     },
     {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonym_rule.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonym_rule.ts
@@ -19,7 +19,9 @@ export const useFetchSynonymRule = (synonymsSetId: string, ruleId: string) => {
     queryKey: [SYNONYMS_RULE_FETCH_QUERY_KEY, synonymsSetId, ruleId],
     queryFn: async () => {
       return await http.get<SynonymsSynonymRule>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}/${ruleId}`
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(
+          synonymsSetId
+        )}/${encodeURIComponent(ruleId)}`
       );
     },
     enabled: !!synonymsSetId && !!ruleId,

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonyms_set.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonyms_set.ts
@@ -20,7 +20,7 @@ export const useFetchSynonymsSet = (synonymsSetId: string, page: Page = DEFAULT_
     queryKey: [SYNONYMS_SETS_QUERY_KEY, synonymsSetId, page.from, page.size],
     queryFn: async () => {
       return await http.get<Paginate<SynonymsSynonymRule> & { id: string }>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}`,
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(synonymsSetId)}`,
         {
           query: { from: page.from, size: page.size },
         }

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_rule.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_rule.ts
@@ -26,7 +26,9 @@ export const usePutSynonymsRule = (onSuccess?: () => void, onError?: (error: str
   return useMutation(
     async ({ synonymsSetId, ruleId, synonyms }: MutationArgs) => {
       return await http.put<SynonymsPutSynonymRuleResponse>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}/${ruleId}`,
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(
+          synonymsSetId
+        )}/${encodeURIComponent(ruleId)}`,
         {
           body: JSON.stringify({
             synonyms,

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_set.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_set.ts
@@ -30,7 +30,7 @@ export const usePutSynonymsSet = (
   return useMutation(
     async ({ synonymsSetId, forceWrite }: MutationArgs) => {
       return await http.put<SynonymsPutSynonymResponse>(
-        `/internal/search_synonyms/synonyms/${synonymsSetId}`,
+        `/internal/search_synonyms/synonyms/${encodeURIComponent(synonymsSetId)}`,
         {
           query: { forceWrite },
         }

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -22,6 +22,16 @@ import { fetchUniqueRuleId } from './lib/fetch_unique_rule_id';
 import { putSynonymsRule } from './lib/put_synonyms_rule';
 import { fetchSynonymsSetExists } from './lib/fetch_synonyms_set_exists';
 
+const RESOURCE_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+const resourceIdSchema = schema.string({
+  maxLength: 512,
+  validate: (value) =>
+    RESOURCE_ID_REGEX.test(value)
+      ? undefined
+      : 'must only contain letters, numbers, hyphens (-), and underscores (_)',
+});
+
 export function defineRoutes({ logger, router }: { logger: Logger; router: IRouter }) {
   router.get(
     {
@@ -87,7 +97,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
+          synonymsSetId: resourceIdSchema,
         }),
       },
     },
@@ -127,7 +137,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
+          synonymsSetId: resourceIdSchema,
         }),
         query: schema.object({
           from: schema.number({ defaultValue: DEFAULT_PAGE_VALUE.from }),
@@ -184,8 +194,8 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
-          ruleId: schema.string(),
+          synonymsSetId: resourceIdSchema,
+          ruleId: resourceIdSchema,
         }),
       },
     },
@@ -234,8 +244,8 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
-          ruleId: schema.string(),
+          synonymsSetId: resourceIdSchema,
+          ruleId: resourceIdSchema,
         }),
       },
     },
@@ -284,7 +294,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
+          synonymsSetId: resourceIdSchema,
         }),
         query: schema.object({
           forceWrite: schema.boolean({ defaultValue: false }),
@@ -349,7 +359,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
+          synonymsSetId: resourceIdSchema,
         }),
       },
     },
@@ -397,8 +407,8 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       },
       validate: {
         params: schema.object({
-          synonymsSetId: schema.string(),
-          ruleId: schema.string(),
+          synonymsSetId: resourceIdSchema,
+          ruleId: resourceIdSchema,
         }),
         body: schema.object({
           synonyms: schema.string({ maxLength: 4096 }),


### PR DESCRIPTION
## Summary

Filter the query rules name

**Fix:** added a `resourceIdSchema` validator in both plugins that enforces the allowlist `[a-zA-Z0-9_-]+` with `maxLength: 512` on all path params (`ruleset_id`, `rule_id`, `synonymsSetId`, `ruleId`). Invalid IDs are rejected with HTTP 400 before any Elasticsearch call is made.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- The allowlist `[a-zA-Z0-9_-]` is stricter than Elasticsearch's own ID validation. Any existing ruleset or synonym set whose name contains characters outside this set (e.g. dots, spaces, colons) would now receive a 400 when accessed via the Kibana API. This is intentional and consistent with the agreed fix in Slack.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->