### PR TITLE
[CI] disable auto-commits from local_check.sh

### DIFF
--- a/.buildkite/scripts/steps/checks/local_check.sh
+++ b/.buildkite/scripts/steps/checks/local_check.sh
@@ -29,7 +29,7 @@ if [[ "$FAILED" == "true" ]]; then
 fi
 
 if is_pr && ! is_auto_commit_disabled; then
-  check_for_changed_files "node scripts/check" true
+  check_for_changed_files "node scripts/check" false
 fi
 
 if [[ "$FAILED" == "true" ]]; then


### PR DESCRIPTION
## Summary
Local checks are running a subset of checks focused on the changed files/projects compared to a remote merge base. 

While fixes from these checks are useful in development, they're competing with automatic fixes from the ESLint / Quick Checks jobs on the same build, and, in odd cases, they're generating and committing unwanted files.

My suggestion is to turn auto-commits of changed files off, we should just keep the failure as an indication to the dev.