### PR TITLE
[9.4] Fix @elastic/eui/icon-accessibility-rules violations in @elastic/search-kibana files (#275358)

### DIFF
--- a/x-pack/solutions/search/packages/shared-ui/src/search_empty_prompt/search_empty_prompt.tsx
+++ b/x-pack/solutions/search/packages/shared-ui/src/search_empty_prompt/search_empty_prompt.tsx
@@ -58,7 +58,7 @@ export const SearchEmptyPrompt: React.FC<SearchEmptyPromptProps> = ({
         )}
         {icon && (
           <EuiFlexItem>
-            <EuiIcon aria-hidden={true} size="xxl" type={icon} />
+            <EuiIcon aria-hidden size="xxl" type={icon} />
           </EuiFlexItem>
         )}
         <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/access_control_index_selector/access_control_index_selector.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/access_control_index_selector/access_control_index_selector.tsx
@@ -91,7 +91,13 @@ export const AccessControlIndexSelector: React.FC<IndexSelectorProps> = ({
             <EuiFlexGroup direction="row" alignItems="center" gutterSize="m">
               {option.error ? (
                 <EuiFlexItem grow={false} align>
-                  <EuiIcon type={'warning'} />{' '}
+                  <EuiIcon
+                    type={'warning'}
+                    aria-label={i18n.translate(
+                      'xpack.enterpriseSearch.content.index.accessControl.selector.optionWarning',
+                      { defaultMessage: 'Warning' }
+                    )}
+                  />{' '}
                 </EuiFlexItem>
               ) : null}
               <EuiFlexGroup direction="column" gutterSize="none">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/multi_field_selector.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/multi_field_selector.tsx
@@ -170,7 +170,7 @@ export const MultiFieldMapping: React.FC = () => {
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ paddingTop: '32px' }}>
-          <EuiIcon type="sortRight" />
+          <EuiIcon type="sortRight" aria-hidden />
         </EuiFlexItem>
         <EuiFlexItem grow={4}>
           <EuiFormRow
@@ -240,7 +240,7 @@ export const SelectedFieldMappings: React.FC<SelectedFieldMappingsProps> = ({ is
     {
       align: 'left',
       name: '',
-      render: () => <EuiIcon type="sortRight" />,
+      render: () => <EuiIcon type="sortRight" aria-hidden />,
       width: '60px',
     },
     {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.tsx
@@ -28,7 +28,7 @@ export const PipelineSelectOptionDisabled: React.FC<{ disabledReason?: string }>
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
       <EuiFlexItem grow={false}>
-        <EuiIcon type="warning" color="warning" />
+        <EuiIcon type="warning" color="warning" aria-hidden />
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTextColor color="warning">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployed.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployed.tsx
@@ -41,7 +41,7 @@ export const ModelDeployed = ({
         <EuiFlexItem grow>
           <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiIcon color="success" type="checkCircleFill" />
+              <EuiIcon color="success" type="checkCircleFill" aria-hidden />
             </EuiFlexItem>
             <EuiFlexItem grow>
               <EuiText color="success" size="xs">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployment_in_progress.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployment_in_progress.tsx
@@ -22,7 +22,7 @@ export const ModelDeploymentInProgress = ({
       <EuiFlexItem grow>
         <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon color="success" type="clock" />
+            <EuiIcon color="success" type="clock" aria-hidden />
           </EuiFlexItem>
           <EuiFlexItem grow>
             <EuiText color="success" size="xs">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_started.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_started.tsx
@@ -38,7 +38,7 @@ export const ModelStarted = ({
       <EuiFlexItem grow>
         <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="checkCircleFill" color="success" />
+            <EuiIcon type="checkCircleFill" color="success" aria-hidden />
           </EuiFlexItem>
           <EuiFlexItem grow>
             <EuiText color="success" size="xs">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_context_menu.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_context_menu.tsx
@@ -148,7 +148,7 @@ export const SyncsContextMenu: React.FC<SyncsContextMenuProps> = ({ disabled = f
           'data-telemetry-id': `entSearchContent-connector-header-sync-cancelSync`,
           disabled:
             (isCanceling && ingestionStatus !== IngestionStatus.ERROR) || status === Status.LOADING,
-          icon: <EuiIcon type="cross" size="m" color="danger" />,
+          icon: <EuiIcon type="cross" size="m" color="danger" aria-hidden />,
           name: (
             <EuiText color="danger" size="s">
               <p>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/data_panel/data_panel.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/data_panel/data_panel.tsx
@@ -75,7 +75,7 @@ export const DataPanel: React.FC<Props> = ({
             >
               {iconType && (
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type={iconType} />
+                  <EuiIcon type={iconType} aria-hidden />
                 </EuiFlexItem>
               )}
               <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -97,7 +97,16 @@ export const useEnterpriseSearchApplicationNav = (
                   {i18n.translate('xpack.enterpriseSearch.nav.searchApplication.contentTitle', {
                     defaultMessage: 'Content',
                   })}
-                  {hasSchemaConflicts && <EuiIcon type="warning" color="danger" />}
+                  {hasSchemaConflicts && (
+                    <EuiIcon
+                      type="warning"
+                      color="danger"
+                      aria-label={i18n.translate(
+                        'xpack.enterpriseSearch.nav.schemaConflictsWarning',
+                        { defaultMessage: 'Schema conflicts' }
+                      )}
+                    />
+                  )}
                 </EuiFlexGroup>
               ),
               // Required for the new side nav

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -64,7 +64,7 @@ export const DraggableBodyRow = <Item extends object>({
                       { defaultMessage: 'Drag handle' }
                     )}
                   >
-                    <EuiIcon type="dragVertical" />
+                    <EuiIcon type="dragVertical" aria-hidden />
                   </div>
                 )}
               </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/language_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/language_selector.tsx
@@ -44,7 +44,7 @@ export const LanguageSelector = ({
         'data-test-subj': `lang-option-${lang.id}`,
         inputDisplay: (
           <EuiFlexGroup gutterSize="s" alignItems="center">
-            <EuiIcon type={`${assetBasePath}/${lang.icon}`} />
+            <EuiIcon type={`${assetBasePath}/${lang.icon}`} aria-hidden />
             <EuiText>{lang.title}</EuiText>
           </EuiFlexGroup>
         ),

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/section_heading/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/section_heading/index.tsx
@@ -20,7 +20,7 @@ export const SearchGettingStartedSectionHeading = ({ title, icon, description }:
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiPanel color="subdued" paddingSize="s" grow={false}>
-              <EuiIcon type={icon} size="m" color="subdued" />
+              <EuiIcon type={icon} size="m" color="subdued" aria-hidden />
             </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/feature_update_group.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/feature_update_group.tsx
@@ -19,7 +19,7 @@ export const FeatureUpdateGroup: React.FC<FeatureUpdateGroupProps> = ({ updates 
         <EuiFlexItem grow={false} key={index}>
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="checkCircleFill" color="primary" />
+              <EuiIcon type="checkCircleFill" color="primary" aria-hidden />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>{update}</EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_fields_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_fields_panel.tsx
@@ -153,7 +153,7 @@ export const QueryFieldsPanel = ({
             <EuiFlexGroup>
               <EuiFlexItem>
                 <EuiText size="s" color="subdued" data-test-subj={`${index}-skippedFields`}>
-                  <EuiIcon type="eyeSlash" />
+                  <EuiIcon type="eyeSlash" aria-hidden />
                   {` `}
                   <FormattedMessage
                     id="xpack.searchPlayground.viewQuery.flyout.hiddenFields"

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_more_options.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_more_options.tsx
@@ -57,7 +57,7 @@ export const PlaygroundMoreOptionsMenu = ({
   const menuItems = [
     <EuiContextMenuItem
       key="savePlaygroundAs"
-      icon={<EuiIcon type="save" />}
+      icon={<EuiIcon type="save" aria-hidden />}
       size="s"
       onClick={onOpenSaveAs}
       data-test-subj="moreOptionsSavePlaygroundAs"
@@ -72,7 +72,7 @@ export const PlaygroundMoreOptionsMenu = ({
     </EuiContextMenuItem>,
     <EuiContextMenuItem
       key="deletePlayground"
-      icon={<EuiIcon color="danger" type="trash" />}
+      icon={<EuiIcon color="danger" type="trash" aria-hidden />}
       size="s"
       onClick={onOpenDeleteConfirm}
       data-test-subj="moreOptionsDeletePlayground"

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.tsx
@@ -64,7 +64,7 @@ export const ConnectLLMButton: React.FC = () => {
       {hasConnectors ? (
         <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="successConnectLLMText">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="checkCircleFill" color="success" />
+            <EuiIcon type="checkCircleFill" color="success" aria-hidden />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             {hasElasticConnector ? (

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
@@ -57,7 +57,7 @@ export const SummarizationModel: React.FC<SummarizationModelProps> = ({
         inputDisplay: (
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type={model.icon} aria-hidden={true} />
+              <EuiIcon type={model.icon} aria-hidden />
             </EuiFlexItem>
             <EuiFlexGroup
               justifyContent="spaceBetween"
@@ -83,7 +83,7 @@ export const SummarizationModel: React.FC<SummarizationModelProps> = ({
         dropdownDisplay: (
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type={model.icon} aria-hidden={true} />
+              <EuiIcon type={model.icon} aria-hidden />
             </EuiFlexItem>
             <EuiFlexGroup
               gutterSize="xs"

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/empty_prompt/empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/empty_prompt/empty_prompt.tsx
@@ -127,7 +127,7 @@ export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) =>
                 <EuiFlexGroup gutterSize="m" direction="column">
                   <EuiFlexGroup responsive={false} gutterSize="s" direction="row">
                     <EuiFlexItem grow={false}>
-                      <EuiIcon type="check" />
+                      <EuiIcon type="check" aria-hidden />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup responsive={false} gutterSize="xs" direction="column">
@@ -156,7 +156,7 @@ export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) =>
                   </EuiFlexGroup>
                   <EuiFlexGroup responsive={false} gutterSize="s" direction="row">
                     <EuiFlexItem grow={false}>
-                      <EuiIcon type="check" />
+                      <EuiIcon type="check" aria-hidden />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup responsive={false} gutterSize="xs" direction="column">
@@ -185,7 +185,7 @@ export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) =>
                   </EuiFlexGroup>
                   <EuiFlexGroup responsive={false} gutterSize="s" direction="row">
                     <EuiFlexItem grow={false}>
-                      <EuiIcon type="check" />
+                      <EuiIcon type="check" aria-hidden />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup responsive={false} gutterSize="xs" direction="column">

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_draggable_list/query_rule_draggable_item_action_type_badge.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_draggable_list/query_rule_draggable_item_action_type_badge.tsx
@@ -9,6 +9,7 @@ import type { QueryRulesQueryRule } from '@elastic/elasticsearch/lib/api/types';
 import { EuiFlexGroup, EuiFlexItem, EuiBadge, EuiIcon, useEuiTheme } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import {
   DocsColumnContainer,
   ActionTypeIconBadgeContainer,
@@ -48,7 +49,13 @@ export const QueryRuleDraggableListItemActionTypeBadge: React.FC<{
       <EuiFlexItem grow={false} css={DocumentCountLabelContainer(euiTheme)}>
         <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="documents" />
+            <EuiIcon
+              type="documents"
+              aria-label={i18n.translate(
+                'xpack.search.queryRulesetDetail.queryRuleDraggableList.documentsIconAriaLabel',
+                { defaultMessage: 'Documents' }
+              )}
+            />
           </EuiFlexItem>
           <EuiFlexItem grow={false} css={DocumentCountLabelStyle(euiTheme)}>
             {queryRule.actions.docs?.length ?? 0}

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_draggable_list/query_rule_list_item_content.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_draggable_list/query_rule_list_item_content.tsx
@@ -149,7 +149,7 @@ export const QueryRuleListItemContent: React.FC<QueryRuleListItemContentProps> =
                   }
                 )}
               >
-                <EuiIcon type="dragVertical" aria-hidden={true} />
+                <EuiIcon type="dragVertical" aria-hidden />
               </EuiPanel>
             ) : (
               <EuiPanel

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/document_selector/document_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/document_selector/document_selector.tsx
@@ -62,7 +62,7 @@ export const DocumentSelector: React.FC<DocumentSelectorProps> = ({
             <EuiPanel color="transparent" paddingSize="s" aria-label="Drag Handle">
               <EuiFlexGroup alignItems="center" gutterSize="s" direction="row" responsive={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="dragVertical" />
+                  <EuiIcon type="dragVertical" aria-hidden />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiNotificationBadge color="subdued">{(indexDoc ?? 0) + 1}</EuiNotificationBadge>

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/document_selector/rule_type_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/document_selector/rule_type_selector.tsx
@@ -27,7 +27,7 @@ export const QueryRuleTypeSelector: React.FC<QueryRuleTypeSelectorProps> = ({
         id: 'pinned',
         label: (
           <>
-            <EuiIcon type="pin" size="m" />
+            <EuiIcon type="pin" size="m" aria-hidden />
             &nbsp;
             <FormattedMessage
               id="xpack.search.queryRulesetDetail.queryRuleFlyout.actionType.pinned"
@@ -41,7 +41,7 @@ export const QueryRuleTypeSelector: React.FC<QueryRuleTypeSelectorProps> = ({
         id: 'exclude',
         label: (
           <>
-            <EuiIcon type="eyeSlash" size="m" />
+            <EuiIcon type="eyeSlash" size="m" aria-hidden />
             &nbsp;
             <FormattedMessage
               id="xpack.search.queryRulesetDetail.queryRuleFlyout.actionType.exclude"

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.tsx
@@ -242,7 +242,7 @@ export const QueryRulesetDetail: React.FC<QueryRulesetDetailProps> = ({ createMo
             {
               text: (
                 <>
-                  <EuiIcon size="s" type="chevronSingleLeft" />{' '}
+                  <EuiIcon size="s" type="chevronSingleLeft" aria-hidden />{' '}
                   {i18n.translate('xpack.queryRules.queryRulesetDetail.backButton', {
                     defaultMessage: 'Back',
                   })}

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.tsx
@@ -84,7 +84,7 @@ export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) =>
                         <EuiFlexItem grow={false}>
                           <EuiFlexGroup responsive={false} gutterSize="s">
                             <EuiFlexItem grow={false}>
-                              <EuiIcon type="check" />
+                              <EuiIcon type="check" aria-hidden />
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
                               <EuiTitle size="xxs">
@@ -116,7 +116,7 @@ export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) =>
                         <EuiFlexItem grow={false}>
                           <EuiFlexGroup responsive={false} gutterSize="s">
                             <EuiFlexItem grow={false}>
-                              <EuiIcon type="check" />
+                              <EuiIcon type="check" aria-hidden />
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
                               <EuiTitle size="xxs">
@@ -148,7 +148,7 @@ export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) =>
                         <EuiFlexItem grow={false}>
                           <EuiFlexGroup responsive={false} gutterSize="s">
                             <EuiFlexItem grow={false}>
-                              <EuiIcon type="check" />
+                              <EuiIcon type="check" aria-hidden />
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
                               <EuiTitle size="xxs">

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_service_type.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_service_type.tsx
@@ -146,7 +146,7 @@ export const EditServiceType: React.FC<EditServiceTypeProps> = ({ connector, isD
         label: conn.name,
         value: {
           _icon,
-          _badges: <EuiIcon size="l" type={conn.iconPath} />,
+          _badges: <EuiIcon size="l" type={conn.iconPath} aria-hidden />,
           serviceType: conn.serviceType,
         },
         'aria-label': conn.name + _ariaLabelAppend,

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/elastic_managed_connectors_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/elastic_managed_connectors_empty_prompt.tsx
@@ -71,7 +71,7 @@ export const ElasticManagedConnectorsEmptyPrompt: React.FC = () => {
                           <React.Fragment key={connector.serviceType}>
                             {index === Math.floor(connectorExamples.length / 2) && (
                               <EuiFlexItem grow={false}>
-                                <EuiIcon color="primary" size="l" type="documents" />
+                                <EuiIcon color="primary" size="l" type="documents" aria-hidden />
                               </EuiFlexItem>
                             )}
                             <EuiFlexItem grow={false}>
@@ -111,10 +111,10 @@ export const ElasticManagedConnectorsEmptyPrompt: React.FC = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="plugs" />
+                          <EuiIcon color="primary" size="l" type="plugs" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElastic" />
+                          <EuiIcon color="primary" size="l" type="logoElastic" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
@@ -69,7 +69,7 @@ export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
                           <React.Fragment key={connector.serviceType}>
                             {index === Math.floor(connectorExamples.length / 2) && (
                               <EuiFlexItem grow={false}>
-                                <EuiIcon color="primary" size="l" type="documents" />
+                                <EuiIcon color="primary" size="l" type="documents" aria-hidden />
                               </EuiFlexItem>
                             )}
                             <EuiFlexItem grow={false}>
@@ -108,13 +108,13 @@ export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
                       justifyContent="center"
                     >
                       <EuiFlexItem grow={false}>
-                        <EuiIcon color="primary" size="l" type="plugs" />
+                        <EuiIcon color="primary" size="l" type="plugs" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon size="m" type="sortRight" />
+                        <EuiIcon size="m" type="sortRight" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon color="primary" size="l" type="rocket" />
+                        <EuiIcon color="primary" size="l" type="rocket" aria-hidden />
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiFlexItem>
@@ -165,19 +165,19 @@ export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="documents" />
+                          <EuiIcon color="primary" size="l" type="documents" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="plugs" />
+                          <EuiIcon color="primary" size="l" type="plugs" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElasticsearch" />
+                          <EuiIcon color="primary" size="l" type="logoElasticsearch" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/elastic_managed_web_crawlers_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/elastic_managed_web_crawlers_empty_prompt.tsx
@@ -60,7 +60,7 @@ export const ElasticManagedWebCrawlersEmptyPrompt = () => {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -88,10 +88,10 @@ export const ElasticManagedWebCrawlersEmptyPrompt = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="web" />
+                          <EuiIcon color="primary" size="l" type="web" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElastic" />
+                          <EuiIcon color="primary" size="l" type="logoElastic" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/self_managed_web_crawlers_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/self_managed_web_crawlers_empty_prompt.tsx
@@ -56,13 +56,13 @@ export const SelfManagedWebCrawlersEmptyPrompt = () => {
                       justifyContent="center"
                     >
                       <EuiFlexItem grow={false}>
-                        <EuiIcon color="primary" size="l" type="web" />
+                        <EuiIcon color="primary" size="l" type="web" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon size="m" type="sortRight" />
+                        <EuiIcon size="m" type="sortRight" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon color="primary" size="l" type="rocket" />
+                        <EuiIcon color="primary" size="l" type="rocket" aria-hidden />
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiFlexItem>
@@ -115,7 +115,7 @@ export const SelfManagedWebCrawlersEmptyPrompt = () => {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -144,19 +144,19 @@ export const SelfManagedWebCrawlersEmptyPrompt = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="web" />
+                          <EuiIcon color="primary" size="l" type="web" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElasticsearch" />
+                          <EuiIcon color="primary" size="l" type="logoElasticsearch" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix @elastic/eui/icon-accessibility-rules violations in @elastic/search-kibana files (#275358)](https://github.com/elastic/kibana/pull/275358)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-07-07T12:41:00Z","message":"Fix @elastic/eui/icon-accessibility-rules violations in @elastic/search-kibana files (#275358)\n\n## Summary\n\nFix 50 `@elastic/eui/icon-accessibility-rules` ESLint violations across\n24 files in the `@elastic/search-kibana` team's codebase.\n\nEach `EuiIcon` was classified as either **decorative**\n(`aria-hidden={true}`) or **meaningful** (`aria-label`):\n\n- **Decorative** (icon accompanies visible text that conveys the same\nmeaning): `aria-hidden={true}` — e.g. checkmarks next to feature\ndescriptions, drag handles, flow-diagram arrows, step icons with text\n- **Meaningful** (icon is the primary or sole conveyor of information):\n`aria-label` with i18n translation — e.g. warning icon for schema\nconflicts in nav, warning icon for index options with errors, documents\ncount icon\n\n## PR checklist\n\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCloses #275356\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>","sha":"8d26520b81dbd43f415f04bd18136d3e3aaf810e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport:version","a11y:agent-pr","v9.5.0","v9.4.4"],"title":"Fix @elastic/eui/icon-accessibility-rules violations in @elastic/search-kibana files","number":275358,"url":"https://github.com/elastic/kibana/pull/275358","mergeCommit":{"message":"Fix @elastic/eui/icon-accessibility-rules violations in @elastic/search-kibana files (#275358)\n\n## Summary\n\nFix 50 `@elastic/eui/icon-accessibility-rules` ESLint violations across\n24 files in the `@elastic/search-kibana` team's codebase.\n\nEach `EuiIcon` was classified as either **decorative**\n(`aria-hidden={true}`) or **meaningful** (`aria-label`):\n\n- **Decorative** (icon accompanies visible text that conveys the same\nmeaning): `aria-hidden={true}` — e.g. checkmarks next to feature\ndescriptions, drag handles, flow-diagram arrows, step icons with text\n- **Meaningful** (icon is the primary or sole conveyor of information):\n`aria-label` with i18n translation — e.g. warning icon for schema\nconflicts in nav, warning icon for index options with errors, documents\ncount icon\n\n## PR checklist\n\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCloses #275356\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>","sha":"8d26520b81dbd43f415f04bd18136d3e3aaf810e"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275358","number":275358,"mergeCommit":{"message":"Fix @elastic/eui/icon-accessibility-rules violations in @elastic/search-kibana files (#275358)\n\n## Summary\n\nFix 50 `@elastic/eui/icon-accessibility-rules` ESLint violations across\n24 files in the `@elastic/search-kibana` team's codebase.\n\nEach `EuiIcon` was classified as either **decorative**\n(`aria-hidden={true}`) or **meaningful** (`aria-label`):\n\n- **Decorative** (icon accompanies visible text that conveys the same\nmeaning): `aria-hidden={true}` — e.g. checkmarks next to feature\ndescriptions, drag handles, flow-diagram arrows, step icons with text\n- **Meaningful** (icon is the primary or sole conveyor of information):\n`aria-label` with i18n translation — e.g. warning icon for schema\nconflicts in nav, warning icon for index options with errors, documents\ncount icon\n\n## PR checklist\n\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCloses #275356\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>","sha":"8d26520b81dbd43f415f04bd18136d3e3aaf810e"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->