### PR TITLE
[UIAM OAuth] Integrate with UIAM users API to resolve "connected by" details

### DIFF
--- a/src/core/packages/security/server/src/authentication/index.ts
+++ b/src/core/packages/security/server/src/authentication/index.ts
@@ -48,6 +48,8 @@ export type {
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,
   UpdateUiamOAuthConnectionParams,
+  UiamUserInfo,
+  UiamResolvedUsersResponse,
 } from './oauth';
 
 export { HTTPAuthorizationHeader } from './http_authentication';

--- a/src/core/packages/security/server/src/authentication/oauth/index.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/index.ts
@@ -17,4 +17,6 @@ export type {
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,
   UpdateUiamOAuthConnectionParams,
+  UiamUserInfo,
+  UiamResolvedUsersResponse,
 } from './uiam_oauth';

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -71,6 +71,16 @@ export interface UpdateUiamOAuthConnectionParams {
   name: string;
 }
 
+export interface UiamUserInfo {
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface UiamResolvedUsersResponse {
+  users: Record<string, UiamUserInfo>;
+}
+
 /**
  * Interface for managing UIAM OAuth client and connection operations.
  */
@@ -158,4 +168,14 @@ export interface UiamOAuthType {
     connectionId: string,
     reason?: string
   ): Promise<UiamOAuthConnectionResponse | null>;
+
+  /**
+   * Resolves one or more user IDs into basic user information.
+   * @param request The Kibana request containing the authorization header.
+   * @param userIds The user IDs to resolve.
+   */
+  resolveUsers(
+    request: KibanaRequest,
+    userIds: string[]
+  ): Promise<UiamResolvedUsersResponse | null>;
 }

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -367,7 +367,7 @@ describe('ApplicationConnections', () => {
     expect(queryByText('Scopes')).not.toBeInTheDocument();
   });
 
-  it('renders the current user display name when "Connected by" matches the signed-in user', async () => {
+  it('renders the user display name when "Connected by" is resolved', async () => {
     setupHttpResponses(coreStart, {
       clients: {
         clients: [
@@ -385,7 +385,8 @@ describe('ApplicationConnections', () => {
             client_id: 'client-a',
             name: 'Laptop session',
             resource: 'cluster:elastic',
-            user_id: 'current_user',
+            user_id: 'cloud_user_id',
+            user: { email: 'ada@example.com', first_name: 'Ada', last_name: 'Lovelace' },
           },
         ],
       },
@@ -398,12 +399,12 @@ describe('ApplicationConnections', () => {
 
     await waitFor(() => {
       expect(getByTestId('applicationConnectionConnectedBy-conn-1')).toHaveTextContent(
-        'Current User'
+        'Ada Lovelace'
       );
     });
   });
 
-  it('falls back to the raw user_id when "Connected by" does not match the signed-in user', async () => {
+  it('falls back to the raw user_id when "Connected by" cannot be resolved', async () => {
     setupHttpResponses(coreStart, {
       clients: {
         clients: [
@@ -479,7 +480,7 @@ describe('ApplicationConnections', () => {
     );
   });
 
-  it('renders the "Connected by" column in the revoke modal with current-user resolution', async () => {
+  it('renders the "Connected by" column in the revoke modal with user resolution', async () => {
     setupHttpResponses(coreStart, {
       clients: {
         clients: [
@@ -497,7 +498,8 @@ describe('ApplicationConnections', () => {
             client_id: 'client-a',
             name: 'Laptop session',
             resource: 'cluster:elastic',
-            user_id: 'current_user',
+            user_id: 'cloud_user_id',
+            user: { email: 'ada@example.com', first_name: 'Ada', last_name: 'Lovelace' },
           },
           {
             id: 'conn-2',
@@ -525,7 +527,7 @@ describe('ApplicationConnections', () => {
     fireEvent.click(revokeLink);
     let modal = await findByTestId('applicationConnectionsRevokeModal');
     expect(within(modal).getByText('Connected by')).toBeInTheDocument();
-    expect(within(modal).getByText('Current User')).toBeInTheDocument();
+    expect(within(modal).getByText('Ada Lovelace')).toBeInTheDocument();
     fireEvent.click(within(modal).getByTestId('applicationConnectionsRevokeCancelButton'));
 
     fireEvent.click(await findByTestId('revokeConnection-conn-2'));

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -399,7 +399,7 @@ describe('ApplicationConnections', () => {
 
     await waitFor(() => {
       expect(getByTestId('applicationConnectionConnectedBy-conn-1')).toHaveTextContent(
-        'Ada Lovelace'
+        'ada@example.com'
       );
     });
   });
@@ -527,7 +527,7 @@ describe('ApplicationConnections', () => {
     fireEvent.click(revokeLink);
     let modal = await findByTestId('applicationConnectionsRevokeModal');
     expect(within(modal).getByText('Connected by')).toBeInTheDocument();
-    expect(within(modal).getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(within(modal).getByText('ada@example.com')).toBeInTheDocument();
     fireEvent.click(within(modal).getByTestId('applicationConnectionsRevokeCancelButton'));
 
     fireEvent.click(await findByTestId('revokeConnection-conn-2'));

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table.tsx
@@ -108,6 +108,7 @@ export const ApplicationConnectionsTable = () => {
             connectionId: connection.id,
             connectionName: connection.name,
             userId: connection.user_id,
+            user: connection.user,
           },
         ];
       }),

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connected_by.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connected_by.tsx
@@ -19,10 +19,7 @@ export const getConnectedByDisplayName = ({
   userId,
   user,
 }: ConnectedByOptions): string | undefined => {
-  const { first_name, last_name, email } = user ?? {};
-  const fullName = [first_name, last_name].filter(Boolean).join(' ').trim();
-
-  return fullName || email || userId;
+  return user?.email || userId;
 };
 
 export interface ConnectedByProps extends ConnectedByOptions {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connected_by.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connected_by.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiAvatar, EuiFlexGroup, EuiText } from '@elastic/eui';
+import { EuiAvatar, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import React from 'react';
 
 import type { OAuthConnectionUser } from '../service/application_connections_api_client';
@@ -47,7 +47,11 @@ export const ConnectedBy = ({ userId, user, 'data-test-subj': dataTestSubj }: Co
       responsive={false}
       data-test-subj={dataTestSubj}
     >
-      {user && <EuiAvatar name={displayName ?? ''} size="s" />}
+      {user && (
+        <EuiFlexItem grow={false}>
+          <EuiAvatar name={displayName ?? ''} size="s" />
+        </EuiFlexItem>
+      )}
       <EuiText size="s">{displayName}</EuiText>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connected_by.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connected_by.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiAvatar, EuiFlexGroup, EuiText } from '@elastic/eui';
+import React from 'react';
+
+import type { OAuthConnectionUser } from '../service/application_connections_api_client';
+
+export interface ConnectedByOptions {
+  userId?: string;
+  user?: OAuthConnectionUser;
+}
+
+export const getConnectedByDisplayName = ({
+  userId,
+  user,
+}: ConnectedByOptions): string | undefined => {
+  const { first_name, last_name, email } = user ?? {};
+  const fullName = [first_name, last_name].filter(Boolean).join(' ').trim();
+
+  return fullName || email || userId;
+};
+
+export interface ConnectedByProps extends ConnectedByOptions {
+  ['data-test-subj']?: string;
+}
+
+export const ConnectedBy = ({ userId, user, 'data-test-subj': dataTestSubj }: ConnectedByProps) => {
+  if (!userId && !user) {
+    return (
+      <EuiText color="subdued" size="s" data-test-subj={dataTestSubj}>
+        {'—'}
+      </EuiText>
+    );
+  }
+
+  const displayName = getConnectedByDisplayName({ userId, user });
+
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      responsive={false}
+      data-test-subj={dataTestSubj}
+    >
+      {user && <EuiAvatar name={displayName ?? ''} size="s" />}
+      <EuiText size="s">{displayName}</EuiText>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connection_table_columns.tsx
@@ -13,10 +13,8 @@ import type {
 import { EuiHealth, EuiLink, EuiText, EuiTextColor, EuiToolTip, formatDate } from '@elastic/eui';
 import React, { useMemo } from 'react';
 
-import { getUserDisplayName } from '@kbn/user-profile-components';
-
+import { ConnectedBy, getConnectedByDisplayName } from './connected_by';
 import { InlineEditConnectionName } from './inline_edit_connection_name';
-import { useCurrentUser } from '../../../components/use_current_user';
 import { labels } from '../constants/i18n';
 import type { ApplicationConnection } from '../constants/types';
 import { useApplicationConnectionsActions } from '../context/application_connections_provider';
@@ -34,7 +32,6 @@ export const useConnectionTableColumns = ({
   withClientNameColumn = true,
 }: ConnectionTableColumnsOptions = {}): Array<EuiBasicTableColumn<ApplicationConnection>> => {
   const { revokeConnections, viewClientDetails } = useApplicationConnectionsActions();
-  const { value: currentUser } = useCurrentUser();
 
   return useMemo(() => {
     const connectionNameColumn: EuiTableFieldDataColumnType<ApplicationConnection> = {
@@ -98,27 +95,15 @@ export const useConnectionTableColumns = ({
 
     const connectedByColumn: EuiTableComputedColumnType<ApplicationConnection> = {
       name: labels.connectionColumns.connectedBy,
-      sortable: ({ connection }) => connection.user_id ?? '',
-      truncateText: true,
-      render: ({ connection }: ApplicationConnection) => {
-        const dataTestSubj = `applicationConnectionConnectedBy-${connection.id}`;
-        if (!connection.user_id) {
-          return (
-            <EuiText color="subdued" size="s" data-test-subj={dataTestSubj}>
-              {'—'}
-            </EuiText>
-          );
-        }
-        const displayName =
-          currentUser && connection.user_id === currentUser.username
-            ? getUserDisplayName(currentUser)
-            : connection.user_id;
-        return (
-          <EuiText size="s" data-test-subj={dataTestSubj}>
-            {displayName}
-          </EuiText>
-        );
-      },
+      sortable: ({ connection }) =>
+        getConnectedByDisplayName({ userId: connection.user_id, user: connection.user }) ?? '',
+      render: ({ connection }: ApplicationConnection) => (
+        <ConnectedBy
+          userId={connection.user_id}
+          user={connection.user}
+          data-test-subj={`applicationConnectionConnectedBy-${connection.id}`}
+        />
+      ),
     };
 
     const statusColumn: EuiTableComputedColumnType<ApplicationConnection> = {
@@ -159,6 +144,7 @@ export const useConnectionTableColumns = ({
                   connectionId: connection.id,
                   connectionName: connection.name,
                   userId: connection.user_id,
+                  user: connection.user,
                 },
               ])
             }
@@ -177,5 +163,5 @@ export const useConnectionTableColumns = ({
       statusColumn,
       actionsColumn,
     ];
-  }, [currentUser, revokeConnections, viewClientDetails, withClientNameColumn]);
+  }, [revokeConnections, viewClientDetails, withClientNameColumn]);
 };

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/types.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/types.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { OAuthClient, OAuthConnection } from '../service/application_connections_api_client';
+import type {
+  OAuthClient,
+  OAuthConnection,
+  OAuthConnectionUser,
+} from '../service/application_connections_api_client';
 
 export interface ApplicationConnections {
   client: OAuthClient;
@@ -27,6 +31,7 @@ export interface RevokeApplicationConnectionsModalConnection {
   connectionId: string;
   connectionName?: string;
   userId?: string;
+  user?: OAuthConnectionUser;
   client: OAuthClient;
 }
 

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/revoke_application_connections_modal.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/revoke_application_connections_modal.tsx
@@ -17,7 +17,6 @@ import {
   EuiModalHeaderTitle,
   EuiSpacer,
   EuiText,
-  EuiTextColor,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
@@ -25,8 +24,8 @@ import React, { useCallback } from 'react';
 
 import type { CoreStart } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { getUserDisplayName } from '@kbn/user-profile-components';
 
+import { ConnectedBy } from './application_connections_table/connected_by';
 import { labels } from './constants/i18n';
 import type {
   RevokeApplicationConnectionsModalConnection,
@@ -34,7 +33,6 @@ import type {
 } from './constants/types';
 import { useRevokeConnections } from './hooks/use_revoke_connections';
 import { RevokeClientDetailsPopover } from './revoke_client_details_popover';
-import { useCurrentUser } from '../../components/use_current_user';
 
 export interface RevokeApplicationConnectionsModalProps {
   connections: RevokeApplicationConnectionsModalConnection[];
@@ -51,7 +49,6 @@ export const RevokeApplicationConnectionsModal = ({
   const { revokeConnections, isRevoking } = useRevokeConnections();
   const { services } = useKibana<CoreStart>();
   const { toasts } = services.notifications;
-  const { value: currentUser } = useCurrentUser();
 
   const count = connections.length;
 
@@ -110,14 +107,7 @@ export const RevokeApplicationConnectionsModal = ({
     {
       field: 'userId',
       name: labels.revoke.connectedByColumn,
-      render: (_value, item) => {
-        if (!item.userId) {
-          return <EuiTextColor color="subdued">{'—'}</EuiTextColor>;
-        }
-        return currentUser && item.userId === currentUser.username
-          ? getUserDisplayName(currentUser)
-          : item.userId;
-      },
+      render: (_value, item) => <ConnectedBy userId={item.userId} user={item.user} />,
     },
   ];
 

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/service/application_connections_api_client.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/service/application_connections_api_client.ts
@@ -14,6 +14,12 @@ export type {
   OAuthClientConnectionsSummary,
 } from '@kbn/agent-builder-common';
 
+export interface OAuthConnectionUser {
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
 export interface OAuthConnection {
   id: string;
   client_id: string;
@@ -25,6 +31,7 @@ export interface OAuthConnection {
   revocation_reason?: string;
   scopes?: string[];
   user_id?: string;
+  user?: OAuthConnectionUser;
 }
 
 export interface ListOAuthClientsResponse {

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
@@ -57,6 +57,7 @@ describe('UiamAPIKeys', () => {
       listOAuthConnections: jest.fn(),
       updateOAuthConnection: jest.fn(),
       revokeOAuthConnection: jest.fn(),
+      resolveUsers: jest.fn(),
     };
 
     uiamApiKeys = new UiamAPIKeys({

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.mock.ts
@@ -21,6 +21,7 @@ export const authenticationServiceMock = {
       listConnections: jest.fn(),
       updateConnection: jest.fn(),
       revokeConnection: jest.fn(),
+      resolveUsers: jest.fn(),
     },
     login: jest.fn(),
     logout: jest.fn(),

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
@@ -485,6 +485,7 @@ export class AuthenticationService {
             listConnections: uiamOAuth.listConnections.bind(uiamOAuth),
             updateConnection: uiamOAuth.updateConnection.bind(uiamOAuth),
             revokeConnection: uiamOAuth.revokeConnection.bind(uiamOAuth),
+            resolveUsers: uiamOAuth.resolveUsers.bind(uiamOAuth),
           }
         : null,
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -335,6 +335,42 @@ describe('UiamOAuth', () => {
     });
   });
 
+  describe('resolveUsers()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.resolveUsers(request, ['user-1']);
+
+      expect(result).toBeNull();
+      expect(mockUiam.resolveUsers).not.toHaveBeenCalled();
+    });
+
+    it('resolves users successfully', async () => {
+      const mockResponse = {
+        users: {
+          'user-1': { email: 'a@example.com', first_name: 'Ada', last_name: 'Lovelace' },
+        },
+      };
+      mockUiam.resolveUsers.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.resolveUsers(request, ['user-1']);
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.resolveUsers).toHaveBeenCalledWith('essu_access_token', ['user-1']);
+    });
+
+    it('logs and throws error when UIAM call fails', async () => {
+      mockUiam.resolveUsers.mockRejectedValue(new Error('UIAM error'));
+      const request = createMockRequest('Bearer essu_access_token');
+
+      await expect(uiamOAuth.resolveUsers(request, ['user-1'])).rejects.toThrow('UIAM error');
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to resolve users: UIAM error');
+    });
+  });
+
   describe('getAccessToken()', () => {
     it('extracts UIAM access token from request', () => {
       const request = createMockRequest('Bearer essu_my_token');

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -361,13 +361,11 @@ describe('UiamOAuth', () => {
       expect(mockUiam.resolveUsers).toHaveBeenCalledWith('essu_access_token', ['user-1']);
     });
 
-    it('logs and throws error when UIAM call fails', async () => {
+    it('propagates the error when UIAM call fails', async () => {
       mockUiam.resolveUsers.mockRejectedValue(new Error('UIAM error'));
       const request = createMockRequest('Bearer essu_access_token');
 
       await expect(uiamOAuth.resolveUsers(request, ['user-1'])).rejects.toThrow('UIAM error');
-
-      expect(logger.error).toHaveBeenCalledWith('Failed to resolve users: UIAM error');
     });
   });
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -14,6 +14,7 @@ import type {
   UiamOAuthClientResponse,
   UiamOAuthConnectionResponse,
   UiamOAuthType,
+  UiamResolvedUsersResponse,
   UpdateUiamOAuthClientParams,
   UpdateUiamOAuthConnectionParams,
 } from '@kbn/core-security-server';
@@ -203,6 +204,27 @@ export class UiamOAuth implements UiamOAuthType {
       this.logger.error(
         `Failed to revoke OAuth connection ${connectionId}: ${getDetailedErrorMessage(e)}`
       );
+      throw e;
+    }
+  }
+
+  async resolveUsers(
+    request: KibanaRequest,
+    userIds: string[]
+  ): Promise<UiamResolvedUsersResponse | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug(`Attempting to resolve ${userIds.length} user(s)`);
+
+    try {
+      const result = await this.uiam.resolveUsers(accessToken, userIds);
+      this.logger.debug('Users resolved successfully');
+      return result;
+    } catch (e) {
+      this.logger.error(`Failed to resolve users: ${getDetailedErrorMessage(e)}`);
       throw e;
     }
   }

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -45,6 +45,9 @@ export class UiamOAuth implements UiamOAuthType {
     params: CreateUiamOAuthClientParams
   ): Promise<UiamOAuthClientResponse | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth client creation: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -66,6 +69,9 @@ export class UiamOAuth implements UiamOAuthType {
     clientId?: string
   ): Promise<{ clients: UiamOAuthClientResponse[] } | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth client listing: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -88,6 +94,9 @@ export class UiamOAuth implements UiamOAuthType {
     params: UpdateUiamOAuthClientParams
   ): Promise<UiamOAuthClientResponse | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth client update: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -110,6 +119,9 @@ export class UiamOAuth implements UiamOAuthType {
     reason?: string
   ): Promise<UiamOAuthClientResponse | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth client revocation: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -132,6 +144,9 @@ export class UiamOAuth implements UiamOAuthType {
     connectionId?: string
   ): Promise<{ connections: UiamOAuthConnectionResponse[] } | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth connection listing: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -155,6 +170,9 @@ export class UiamOAuth implements UiamOAuthType {
     params: UpdateUiamOAuthConnectionParams
   ): Promise<UiamOAuthConnectionResponse | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth connection update: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -185,6 +203,9 @@ export class UiamOAuth implements UiamOAuthType {
     reason?: string
   ): Promise<UiamOAuthConnectionResponse | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping OAuth connection revocation: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 
@@ -213,6 +234,9 @@ export class UiamOAuth implements UiamOAuthType {
     userIds: string[]
   ): Promise<UiamResolvedUsersResponse | null> {
     if (!this.license.isEnabled()) {
+      this.logger.debug(
+        'Skipping user resolution: security features are disabled in Elasticsearch.'
+      );
       return null;
     }
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -219,14 +219,7 @@ export class UiamOAuth implements UiamOAuthType {
     const accessToken = UiamOAuth.getAccessToken(request);
     this.logger.debug(`Attempting to resolve ${userIds.length} user(s)`);
 
-    try {
-      const result = await this.uiam.resolveUsers(accessToken, userIds);
-      this.logger.debug('Users resolved successfully');
-      return result;
-    } catch (e) {
-      this.logger.error(`Failed to resolve users: ${getDetailedErrorMessage(e)}`);
-      throw e;
-    }
+    return this.uiam.resolveUsers(accessToken, userIds);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -120,7 +120,7 @@ describe('List OAuth Connections route', () => {
     });
   });
 
-  it('deduplicates user ids before resolving and skips resolution when there are none', async () => {
+  it('forwards the user ids from connections for resolution', async () => {
     oauthMock.listConnections.mockResolvedValue({
       connections: [
         {
@@ -145,7 +145,7 @@ describe('List OAuth Connections route', () => {
       kibanaResponseFactory
     );
 
-    expect(oauthMock.resolveUsers).toHaveBeenCalledWith(expect.anything(), ['user-1']);
+    expect(oauthMock.resolveUsers).toHaveBeenCalledWith(expect.anything(), ['user-1', 'user-1']);
   });
 
   it('does not call resolveUsers when no connection has a user id', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -200,6 +200,38 @@ describe('List OAuth Connections route', () => {
     });
   });
 
+  it('degrades gracefully when user resolution is skipped (returns null)', async () => {
+    oauthMock.listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+      ],
+    });
+    oauthMock.resolveUsers.mockResolvedValue(null);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+      ],
+    });
+  });
+
   it('returns 404 when OAuth is not available', async () => {
     authc.oauth = null;
 

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -70,6 +70,136 @@ describe('List OAuth Connections route', () => {
     expect(response.payload).toEqual(mockResponse);
   });
 
+  it('adds user information to connections when available', async () => {
+    oauthMock.listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+        {
+          id: 'conn2',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-2',
+        },
+      ],
+    });
+    oauthMock.resolveUsers.mockResolvedValue({
+      users: {
+        'user-1': { email: 'a@example.com', first_name: 'Ada', last_name: 'Lovelace' },
+      },
+    });
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(oauthMock.resolveUsers).toHaveBeenCalledWith(expect.anything(), ['user-1', 'user-2']);
+    expect(response.payload).toEqual({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+          user: { email: 'a@example.com', first_name: 'Ada', last_name: 'Lovelace' },
+        },
+        {
+          id: 'conn2',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-2',
+        },
+      ],
+    });
+  });
+
+  it('deduplicates user ids before resolving and skips resolution when there are none', async () => {
+    oauthMock.listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+        {
+          id: 'conn2',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+      ],
+    });
+    oauthMock.resolveUsers.mockResolvedValue({ users: {} });
+
+    await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(oauthMock.resolveUsers).toHaveBeenCalledWith(expect.anything(), ['user-1']);
+  });
+
+  it('does not call resolveUsers when no connection has a user id', async () => {
+    oauthMock.listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        },
+      ],
+    });
+
+    await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(oauthMock.resolveUsers).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully when user resolution fails', async () => {
+    oauthMock.listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+      ],
+    });
+    oauthMock.resolveUsers.mockRejectedValue(Boom.internal('resolve failed'));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual({
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          user_id: 'user-1',
+        },
+      ],
+    });
+  });
+
   it('returns 404 when OAuth is not available', async () => {
     authc.oauth = null;
 

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import type { UiamUserInfo } from '@kbn/core-security-server';
 
 import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
@@ -15,6 +16,7 @@ import { createLicensedRouteHandler } from '../licensed_route_handler';
 
 export function defineListOAuthConnectionsRoute({
   router,
+  logger,
   getAuthenticationService,
 }: RouteDefinitionParams) {
   router.get(
@@ -64,7 +66,38 @@ export function defineListOAuthConnectionsRoute({
             });
           }
 
-          return response.ok({ body: result });
+          const userIds = [
+            ...new Set(
+              result.connections
+                .map((connection) => connection.user_id)
+                .filter((userId): userId is string => Boolean(userId))
+            ),
+          ];
+
+          let users: Record<string, UiamUserInfo> = {};
+          if (userIds.length > 0) {
+            try {
+              const resolved = await oauth.resolveUsers(request, userIds);
+              users = resolved?.users ?? {};
+            } catch (error) {
+              logger.warn(
+                `Failed to resolve user information for OAuth connections: ${
+                  error instanceof Error ? error.message : String(error)
+                }`
+              );
+            }
+          }
+
+          return response.ok({
+            body: {
+              connections: result.connections.map((connection) => ({
+                ...connection,
+                ...(connection.user_id && users[connection.user_id]
+                  ? { user: users[connection.user_id] }
+                  : {}),
+              })),
+            },
+          });
         } catch (error) {
           return response.customError(wrapIntoCustomErrorResponse(error));
         }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -74,6 +74,11 @@ export function defineListOAuthConnectionsRoute({
           if (userIds.length > 0) {
             try {
               const resolved = await oauth.resolveUsers(request, userIds);
+              if (resolved === null) {
+                logger.warn(
+                  'Skipping user resolution for OAuth connections: security features are disabled in Elasticsearch.'
+                );
+              }
               users = resolved?.users ?? {};
             } catch (error) {
               logger.warn(

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -66,13 +66,9 @@ export function defineListOAuthConnectionsRoute({
             });
           }
 
-          const userIds = [
-            ...new Set(
-              result.connections
-                .map((connection) => connection.user_id)
-                .filter((userId): userId is string => Boolean(userId))
-            ),
-          ];
+          const userIds = result.connections
+            .map((connection) => connection.user_id)
+            .filter((userId): userId is string => Boolean(userId));
 
           let users: Record<string, UiamUserInfo> = {};
           if (userIds.length > 0) {

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
@@ -54,5 +54,6 @@ export const uiamServiceMock = {
       resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
       revoked: true,
     }),
+    resolveUsers: jest.fn().mockResolvedValue({ users: {} }),
   }),
 };

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -1486,6 +1486,35 @@ describe('UiamService', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(3);
     });
 
+    it('returns partial results when some batches fail', async () => {
+      const userIds = Array.from({ length: 120 }, (_, i) => `user-${i}`);
+
+      fetchSpy
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ users: { 'user-0': { first_name: 'First' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          headers: new Headers(),
+          json: async () => ({ error: { message: 'Internal Server Error' } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ users: { 'user-100': { first_name: 'Third' } } }),
+        });
+
+      await expect(uiamService.resolveUsers('access-token', userIds)).resolves.toEqual({
+        users: {
+          'user-0': { first_name: 'First' },
+          'user-100': { first_name: 'Third' },
+        },
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
     it('throws error if resolution fails', async () => {
       fetchSpy.mockResolvedValue({
         ok: false,

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -1459,7 +1459,7 @@ describe('UiamService', () => {
     });
 
     it('splits large lists into batches and merges the results', async () => {
-      const userIds = Array.from({ length: 150 }, (_, i) => `user-${i}`);
+      const userIds = Array.from({ length: 120 }, (_, i) => `user-${i}`);
 
       fetchSpy
         .mockResolvedValueOnce({
@@ -1468,17 +1468,22 @@ describe('UiamService', () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ users: { 'user-100': { first_name: 'Second' } } }),
+          json: async () => ({ users: { 'user-50': { first_name: 'Second' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ users: { 'user-100': { first_name: 'Third' } } }),
         });
 
       await expect(uiamService.resolveUsers('access-token', userIds)).resolves.toEqual({
         users: {
           'user-0': { first_name: 'First' },
-          'user-100': { first_name: 'Second' },
+          'user-50': { first_name: 'Second' },
+          'user-100': { first_name: 'Third' },
         },
       });
 
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
     });
 
     it('throws error if resolution fails', async () => {

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -1459,7 +1459,7 @@ describe('UiamService', () => {
     });
 
     it('splits large lists into batches and merges the results', async () => {
-      const userIds = Array.from({ length: 120 }, (_, i) => `user-${i}`);
+      const userIds = Array.from({ length: 250 }, (_, i) => `user-${i}`);
 
       fetchSpy
         .mockResolvedValueOnce({
@@ -1468,18 +1468,18 @@ describe('UiamService', () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ users: { 'user-50': { first_name: 'Second' } } }),
+          json: async () => ({ users: { 'user-100': { first_name: 'Second' } } }),
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ users: { 'user-100': { first_name: 'Third' } } }),
+          json: async () => ({ users: { 'user-200': { first_name: 'Third' } } }),
         });
 
       await expect(uiamService.resolveUsers('access-token', userIds)).resolves.toEqual({
         users: {
           'user-0': { first_name: 'First' },
-          'user-50': { first_name: 'Second' },
-          'user-100': { first_name: 'Third' },
+          'user-100': { first_name: 'Second' },
+          'user-200': { first_name: 'Third' },
         },
       });
 
@@ -1487,7 +1487,7 @@ describe('UiamService', () => {
     });
 
     it('returns partial results when some batches fail', async () => {
-      const userIds = Array.from({ length: 120 }, (_, i) => `user-${i}`);
+      const userIds = Array.from({ length: 250 }, (_, i) => `user-${i}`);
 
       fetchSpy
         .mockResolvedValueOnce({
@@ -1502,13 +1502,13 @@ describe('UiamService', () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ users: { 'user-100': { first_name: 'Third' } } }),
+          json: async () => ({ users: { 'user-200': { first_name: 'Third' } } }),
         });
 
       await expect(uiamService.resolveUsers('access-token', userIds)).resolves.toEqual({
         users: {
           'user-0': { first_name: 'First' },
-          'user-100': { first_name: 'Third' },
+          'user-200': { first_name: 'Third' },
         },
       });
 

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -1410,4 +1410,88 @@ describe('UiamService', () => {
       );
     });
   });
+
+  describe('#resolveUsers', () => {
+    it('returns an empty map without calling UIAM when there are no user ids', async () => {
+      await expect(uiamService.resolveUsers('access-token', [])).resolves.toEqual({ users: {} });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('resolves a single user id', async () => {
+      const mockResponse = {
+        users: {
+          'user-1': { email: 'a@example.com', first_name: 'Ada', last_name: 'Lovelace' },
+        },
+      };
+
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => mockResponse });
+
+      await expect(uiamService.resolveUsers('access-token', ['user-1'])).resolves.toEqual(
+        mockResponse
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/users?user_id=user-1',
+        {
+          method: 'GET',
+          headers: {
+            'User-Agent': 'Kibana/9.0.0',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('comma-joins and deduplicates user ids', async () => {
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => ({ users: {} }) });
+
+      await uiamService.resolveUsers('access-token', ['user-1', 'user-2', 'user-1']);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/users?user_id=user-1%2Cuser-2',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('splits large lists into batches and merges the results', async () => {
+      const userIds = Array.from({ length: 150 }, (_, i) => `user-${i}`);
+
+      fetchSpy
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ users: { 'user-0': { first_name: 'First' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ users: { 'user-100': { first_name: 'Second' } } }),
+        });
+
+      await expect(uiamService.resolveUsers('access-token', userIds)).resolves.toEqual({
+        users: {
+          'user-0': { first_name: 'First' },
+          'user-100': { first_name: 'Second' },
+        },
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws error if resolution fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Internal Server Error' } }),
+      });
+
+      await expect(uiamService.resolveUsers('access-token', ['user-1'])).rejects.toThrowError(
+        'Internal Server Error'
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -7,6 +7,7 @@
 
 import Boom from '@hapi/boom';
 import { readFileSync } from 'fs';
+import { chunk } from 'lodash';
 import { Agent } from 'undici';
 
 import type { Logger } from '@kbn/core/server';
@@ -17,6 +18,7 @@ import type {
   UiamOAuthClientResponse,
   UiamOAuthClientType,
   UiamOAuthConnectionResponse,
+  UiamResolvedUsersResponse,
   UpdateUiamOAuthClientParams,
   UpdateUiamOAuthConnectionParams,
 } from '@kbn/core-security-server';
@@ -106,6 +108,12 @@ export type OAuthConnectionResponse = UiamOAuthConnectionResponse;
 export type CreateOAuthClientRequestBody = CreateUiamOAuthClientParams;
 export type PatchOAuthClientRequestBody = UpdateUiamOAuthClientParams;
 export type PatchOAuthConnectionRequestBody = UpdateUiamOAuthConnectionParams;
+export type ResolvedUsersResponse = UiamResolvedUsersResponse;
+
+/**
+ * The maximum number of user IDs to resolve in a single UIAM request (avoids overly long URLs).
+ */
+const RESOLVE_USERS_BATCH_SIZE = 50;
 
 /**
  * Shape of the `error` object inside a UIAM non-2xx response payload, mirroring
@@ -278,6 +286,13 @@ export interface UiamServicePublic {
     connectionId: string,
     reason?: string
   ): Promise<OAuthConnectionResponse>;
+
+  /**
+   * Resolves one or more user IDs into basic user information via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param userIds The user IDs to resolve.
+   */
+  resolveUsers(accessToken: string, userIds: string[]): Promise<ResolvedUsersResponse>;
 }
 
 interface UiamServiceOptions {
@@ -829,6 +844,53 @@ export class UiamService implements UiamServicePublic {
       this.#logger.error(
         () => `Failed to revoke OAuth connection ${connectionId}: ${getDetailedErrorMessage(err)}`
       );
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.resolveUsers}.
+   */
+  async resolveUsers(accessToken: string, userIds: string[]): Promise<ResolvedUsersResponse> {
+    const uniqueUserIds = [...new Set(userIds)];
+    if (uniqueUserIds.length === 0) {
+      return { users: {} };
+    }
+
+    try {
+      this.#logger.debug(`Attempting to resolve ${uniqueUserIds.length} user(s).`);
+
+      const responses = await Promise.all(
+        chunk(uniqueUserIds, RESOLVE_USERS_BATCH_SIZE).map(
+          async (batch): Promise<ResolvedUsersResponse> => {
+            const url = new URL(`${this.#config.url}/uiam/api/v1/users`);
+            url.searchParams.set('user_id', batch.join(','));
+
+            return UiamService.#parseUiamResponse(
+              await fetch(url.toString(), {
+                method: 'GET',
+                headers: {
+                  'User-Agent': this.#userAgentHeader,
+                  [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+                  Authorization: `Bearer ${accessToken}`,
+                },
+                // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+                dispatcher: this.#dispatcher,
+              })
+            );
+          }
+        )
+      );
+
+      const users: ResolvedUsersResponse['users'] = Object.assign(
+        {},
+        ...responses.map((response) => response.users)
+      );
+
+      this.#logger.debug('Successfully resolved users.');
+      return { users };
+    } catch (err) {
+      this.#logger.error(() => `Failed to resolve users: ${getDetailedErrorMessage(err)}`);
       throw err;
     }
   }

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -7,7 +7,7 @@
 
 import Boom from '@hapi/boom';
 import { readFileSync } from 'fs';
-import { chunk } from 'lodash';
+import { chunk, partition } from 'lodash';
 import { Agent } from 'undici';
 
 import type { Logger } from '@kbn/core/server';
@@ -857,42 +857,53 @@ export class UiamService implements UiamServicePublic {
       return { users: {} };
     }
 
-    try {
-      this.#logger.debug(`Attempting to resolve ${uniqueUserIds.length} user(s).`);
+    this.#logger.debug(`Attempting to resolve ${uniqueUserIds.length} user(s).`);
 
-      const responses = await Promise.all(
-        chunk(uniqueUserIds, RESOLVE_USERS_BATCH_SIZE).map(
-          async (batch): Promise<ResolvedUsersResponse> => {
-            const url = new URL(`${this.#config.url}/uiam/api/v1/users`);
-            url.searchParams.set('user_id', batch.join(','));
+    const batches = chunk(uniqueUserIds, RESOLVE_USERS_BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batches.map(async (batch): Promise<ResolvedUsersResponse> => {
+        const url = new URL(`${this.#config.url}/uiam/api/v1/users`);
+        url.searchParams.set('user_id', batch.join(','));
 
-            return UiamService.#parseUiamResponse(
-              await fetch(url.toString(), {
-                method: 'GET',
-                headers: {
-                  'User-Agent': this.#userAgentHeader,
-                  [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
-                  Authorization: `Bearer ${accessToken}`,
-                },
-                // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
-                dispatcher: this.#dispatcher,
-              })
-            );
-          }
-        )
-      );
+        return UiamService.#parseUiamResponse(
+          await fetch(url.toString(), {
+            method: 'GET',
+            headers: {
+              'User-Agent': this.#userAgentHeader,
+              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+            dispatcher: this.#dispatcher,
+          })
+        );
+      })
+    );
 
-      const users: ResolvedUsersResponse['users'] = Object.assign(
-        {},
-        ...responses.map((response) => response.users)
-      );
+    const [fulfilled, failures] = partition(
+      results,
+      (result): result is PromiseFulfilledResult<ResolvedUsersResponse> =>
+        result.status === 'fulfilled'
+    );
 
-      this.#logger.debug('Successfully resolved users.');
-      return { users };
-    } catch (err) {
-      this.#logger.error(() => `Failed to resolve users: ${getDetailedErrorMessage(err)}`);
-      throw err;
+    const users: ResolvedUsersResponse['users'] = Object.assign(
+      {},
+      ...fulfilled.map((result) => result.value.users)
+    );
+
+    if (failures.length === batches.length) {
+      throw failures[0].reason;
     }
+
+    if (failures.length > 0) {
+      this.#logger.warn(
+        () =>
+          `Failed to resolve ${failures.length} of ${batches.length} user batch(es); returning partial results.`
+      );
+    }
+
+    this.#logger.debug('Successfully resolved users.');
+    return { users };
   }
 
   /**

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -111,9 +111,9 @@ export type PatchOAuthConnectionRequestBody = UpdateUiamOAuthConnectionParams;
 export type ResolvedUsersResponse = UiamResolvedUsersResponse;
 
 /**
- * The maximum number of user IDs to resolve in a single UIAM request (avoids overly long URLs).
+ * Maximum number of user IDs in a single request (aligned with UIAM limit).
  */
-const RESOLVE_USERS_BATCH_SIZE = 50;
+const RESOLVE_USERS_BATCH_SIZE = 100;
 
 /**
  * Shape of the `error` object inside a UIAM non-2xx response payload, mirroring


### PR DESCRIPTION
## Summary

Resolves the "Connected by" details on the Application Connections page by integrating with the UIAM users API, so admins see emails for connections created by any user (currently shows raw user IDs for everyone except the signed-in user). Changes include:

- New `resolveUsers` capability across layers: `UiamService.resolveUsers` calls the UIAM `/uiam/api/v1/users` endpoint (deduplicating IDs and batching large lists).
- The list connections route now resolves the user IDs for the returned connections and attaches the resolved `user` info to each one, degrading gracefully to raw IDs when resolution fails.
- New `ConnectedBy` component (with a `getConnectedByDisplayName` helper) that renders a user's email (or the raw user ID as a fallback) alongside an avatar.

### Demo

<img width="1392" height="885" alt="Screenshot 2026-07-07 at 13 14 27" src="https://github.com/user-attachments/assets/c05fa9db-ce50-4f7c-a0a9-7ff6bfd566f8" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
