### PR TITLE
Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 
-import { agentPolicyService } from '../agent_policy';
-import { packagePolicyService } from '../package_policy';
+import { agentPolicyService, getAgentPolicySavedObjectType } from '../agent_policy';
+import { packagePolicyService, getPackagePolicySavedObjectType } from '../package_policy';
 import { PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE } from '../../constants';
 import { setupFleet } from '../setup';
 import { getAgentsByKuery, forceUnenrollAgent } from '../agents';
@@ -36,6 +37,11 @@ const mockedListEnrollmentApiKeys = listEnrollmentApiKeys as jest.MockedFunction
 
 const mockedAgentPolicyService = agentPolicyService as jest.Mocked<typeof agentPolicyService>;
 const mockedPackagePolicyService = packagePolicyService as jest.Mocked<typeof packagePolicyService>;
+const mockedGetAgentPolicySavedObjectType = getAgentPolicySavedObjectType as jest.MockedFunction<
+  typeof getAgentPolicySavedObjectType
+>;
+const mockedGetPackagePolicySavedObjectType =
+  getPackagePolicySavedObjectType as jest.MockedFunction<typeof getPackagePolicySavedObjectType>;
 
 jest.mock('../app_context', () => ({
   appContextService: {
@@ -116,5 +122,124 @@ describe('reset agent policies', () => {
     expect(mockedSetupFleet).toBeCalled();
     expect(mockedForceUnenrollAgent).toBeCalled();
     expect(mockedDeleteEnrollmentApiKeys).toBeCalled();
+  });
+
+  describe('_deleteGhostPackagePolicies with legacy (non-space-aware) saved object types', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockedGetAgentPolicySavedObjectType.mockResolvedValue('ingest-agent-policies');
+      mockedGetPackagePolicySavedObjectType.mockResolvedValue('ingest-package-policies');
+      mockedAgentPolicyService.list.mockResolvedValueOnce({ items: [] } as any);
+    });
+
+    it('should resolve the legacy agent policy type and not delete a package policy whose parent agent policy exists', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [{ id: 'policy1', type: 'ingest-agent-policies', attributes: {} }],
+      } as any);
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await resetPreconfiguredAgentPolicies(soClient, esClient);
+
+      expect(soClient.bulkGet).toBeCalledWith([{ id: 'policy1', type: 'ingest-agent-policies' }]);
+      expect(soClient.delete).not.toBeCalled();
+      expect(mockedSetupFleet).toBeCalled();
+    });
+
+    it('should delete a ghost package policy using the resolved legacy package policy type', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'policy1',
+            type: 'ingest-agent-policies',
+            error: { statusCode: 404, message: 'Not found', error: 'Not Found' },
+          },
+        ],
+      } as any);
+      soClient.delete.mockResolvedValueOnce(undefined as any);
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await resetPreconfiguredAgentPolicies(soClient, esClient);
+
+      expect(soClient.delete).toBeCalledWith('ingest-package-policies', 'pkgPolicy1');
+      expect(mockedSetupFleet).toBeCalled();
+    });
+
+    it('should not abort the reset when deleting a ghost package policy 404s', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'policy1',
+            type: 'ingest-agent-policies',
+            error: { statusCode: 404, message: 'Not found', error: 'Not Found' },
+          },
+        ],
+      } as any);
+      soClient.delete.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError('ingest-package-policies', 'pkgPolicy1')
+      );
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await expect(resetPreconfiguredAgentPolicies(soClient, esClient)).resolves.not.toThrow();
+
+      expect(mockedSetupFleet).toBeCalled();
+    });
+
+    it('should propagate non-404 errors from deleting a ghost package policy', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'policy1',
+            type: 'ingest-agent-policies',
+            error: { statusCode: 404, message: 'Not found', error: 'Not Found' },
+          },
+        ],
+      } as any);
+      soClient.delete.mockRejectedValueOnce(new Error('boom'));
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await expect(resetPreconfiguredAgentPolicies(soClient, esClient)).rejects.toThrow('boom');
+
+      expect(mockedSetupFleet).not.toBeCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.ts
@@ -15,11 +15,10 @@ import { setupFleet } from '../setup';
 import {
   AGENT_POLICY_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
-  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE,
 } from '../../constants';
-import { agentPolicyService } from '../agent_policy';
-import { packagePolicyService } from '../package_policy';
+import { agentPolicyService, getAgentPolicySavedObjectType } from '../agent_policy';
+import { packagePolicyService, getPackagePolicySavedObjectType } from '../package_policy';
 import { getAgentsByKuery, forceUnenrollAgent } from '../agents';
 import { listEnrollmentApiKeys, deleteEnrollmentApiKeys } from '../api_keys';
 import type { AgentPolicy } from '../../types';
@@ -64,7 +63,8 @@ async function _deleteGhostPackagePolicies(
     return;
   }
 
-  const objects = policyIds.map((id) => ({ id, type: AGENT_POLICY_SAVED_OBJECT_TYPE }));
+  const savedObjectType = await getAgentPolicySavedObjectType();
+  const objects = policyIds.map((id) => ({ id, type: savedObjectType }));
   const agentPolicyExistsMap = (await soClient.bulkGet(objects)).saved_objects.reduce((acc, so) => {
     if (isSavedObjectErrorResult(so) && so.error.statusCode === 404) {
       acc.set(so.id, false);
@@ -74,6 +74,7 @@ async function _deleteGhostPackagePolicies(
     return acc;
   }, new Map<string, boolean>());
 
+  const packagePolicySavedObjectType = await getPackagePolicySavedObjectType();
   await pMap(
     packagePolicies,
     (packagePolicy) => {
@@ -81,7 +82,12 @@ async function _deleteGhostPackagePolicies(
         packagePolicy.policy_ids.every((policyId) => agentPolicyExistsMap.get(policyId) === false)
       ) {
         logger.info(`Deleting ghost package policy ${packagePolicy.name} (${packagePolicy.id})`);
-        return soClient.delete(PACKAGE_POLICY_SAVED_OBJECT_TYPE, packagePolicy.id);
+        return soClient.delete(packagePolicySavedObjectType, packagePolicy.id).catch((err) => {
+          if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
+            return undefined;
+          }
+          throw err;
+        });
       }
     },
     {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/273838

On deployments with space awareness disabled, agent/package policies live under `ingest-agent-policies`/`ingest-package-policies` rather than the `fleet-*` types. Currently, the code always queries/deletes using the `fleet-*` types, so `bulkGet` throws 404 which aborts the whole reset before `setupFleet` can rebuild the preconfigured policy.

Changes made in `_deleteGhostPackagePolicies`:
* Replace the hardcoded `AGENT_POLICY_SAVED_OBJECT_TYPE` used for the `bulkGet` parent-policy check with `await getAgentPolicySavedObjectType()`
* Replace the hardcoded `PACKAGE_POLICY_SAVED_OBJECT_TYP used for the ghost-policy delete with `await getPackagePolicySavedObjectType()`
* Add a `.catch` guard on the delete that swallows `isNotFoundError` (matching the existing pattern in `_deletePreconfigurationDeleteRecord` in the same file) and rethrows anything else

Unit tests added for:
* the legacy type being used for the existence check
* ghost deletion using the resolved legacy type
* 404-on-delete no longer aborting the reset
* non-404 errors still propagating correctly

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk, narrowly scoped:
* Only `_deleteGhostPackagePolicies is touched`: `_deleteExistingData` and `_deletePreconfigurationDeleteRecord` are unchanged
* On space-aware deployments, `getAgentPolicySavedObjectType()`/`getPackagePolicySavedObjectType()` resolve to the same `fleet-*` constants that were hardcoded before
* The new 404 guard only widens tolerance (a previously-fatal 404 is now a no-op), it doesn't suppress other error types

## Release note

Fixes a bug where `POST /internal/fleet/reset_preconfigured_agent_policies/{id}` always aborts before `setupFleet` runs on deployments where space awareness is disabled.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.6"]} ONMERGE-->