### PR TITLE
[Task Manager] Limit concurrent Elasticsearch requests issued by background tasks

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/config.test.ts
@@ -20,6 +20,9 @@ describe('config validation', () => {
           "active_nodes_lookback": "30s",
           "interval": 10000,
         },
+        "es_request_limits": Object {
+          "enabled": false,
+        },
         "event_loop_delay": Object {
           "monitor": true,
           "warn_threshold": 5000,
@@ -84,6 +87,9 @@ describe('config validation', () => {
           "active_nodes_lookback": "30s",
           "interval": 10000,
         },
+        "es_request_limits": Object {
+          "enabled": false,
+        },
         "event_loop_delay": Object {
           "monitor": true,
           "warn_threshold": 5000,
@@ -145,6 +151,9 @@ describe('config validation', () => {
         "discovery": Object {
           "active_nodes_lookback": "30s",
           "interval": 10000,
+        },
+        "es_request_limits": Object {
+          "enabled": false,
         },
         "event_loop_delay": Object {
           "monitor": true,

--- a/x-pack/platform/plugins/shared/task_manager/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/config.test.ts
@@ -319,4 +319,58 @@ describe('config validation', () => {
 
     expect(() => configSchema.validate(config)).not.toThrow();
   });
+
+  describe('es_request_limits scopes', () => {
+    test('accepts a known scope with limits within the global budget', () => {
+      expect(() =>
+        configSchema.validate({
+          es_request_limits: {
+            enabled: true,
+            search: { cluster_wide: 50 },
+            write: { cluster_wide: 50 },
+            scopes: { alerting: { search: 20, write: 10 } },
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test('throws on an unknown scope name', () => {
+      expect(() =>
+        configSchema.validate({
+          es_request_limits: {
+            enabled: true,
+            search: { cluster_wide: 50 },
+            scopes: { bogus: { search: 10 } },
+          },
+        })
+      ).toThrowError(/Unknown es_request_limits scope "bogus"/);
+    });
+
+    test('throws when a scope limit exceeds the global category budget', () => {
+      expect(() =>
+        configSchema.validate({
+          es_request_limits: {
+            enabled: true,
+            search: { cluster_wide: 50 },
+            scopes: { alerting: { search: 60 } },
+          },
+        })
+      ).toThrowError(
+        /es_request_limits\.scopes\.alerting\.search \(60\) cannot exceed the global search\.cluster_wide \(50\)/
+      );
+    });
+
+    test('throws when a scope limit is set without a global category budget', () => {
+      expect(() =>
+        configSchema.validate({
+          es_request_limits: {
+            enabled: true,
+            scopes: { alerting: { search: 10 } },
+          },
+        })
+      ).toThrowError(
+        /es_request_limits\.scopes\.alerting\.search is set but no global search\.cluster_wide budget is configured/
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/config.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/config.ts
@@ -83,6 +83,27 @@ const requestTimeoutsConfig = schema.object({
   update_by_query: schema.number({ defaultValue: 1000 * 30, min: 1000 * 10, max: 1000 * 60 * 10 }),
 });
 
+/*
+ * Per-category budget for Elasticsearch requests issued by running tasks.
+ * `cluster_wide` is the total number of concurrent requests allowed across all
+ * background-task Kibana nodes; each node enforces its partitioned share of it.
+ */
+const esRequestCategoryLimitSchema = schema.object({
+  cluster_wide: schema.number({ min: 1 }),
+});
+
+/*
+ * Limits on the number of concurrent Elasticsearch requests that tasks may issue
+ * through the Task Manager provided client (`RunContext.esClient`). Disabled by
+ * default; when enabled, requests over the per-category budget are rejected with
+ * a 429-shaped error so the task fails fast instead of overloading Elasticsearch.
+ */
+const esRequestLimitsSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+  search: schema.maybe(esRequestCategoryLimitSchema),
+  write: schema.maybe(esRequestCategoryLimitSchema),
+});
+
 const validateDuration = (duration: string) => {
   try {
     parseIntervalAsMillisecond(duration);
@@ -223,6 +244,7 @@ export const configSchema = schema.object(
     claim_strategy: schema.string({ defaultValue: CLAIM_STRATEGY_MGET }),
     request_timeouts: requestTimeoutsConfig,
     auto_calculate_default_ech_capacity: schema.boolean({ defaultValue: false }),
+    es_request_limits: esRequestLimitsSchema,
   },
   {
     validate: (config) => {
@@ -241,3 +263,4 @@ export type TaskManagerConfig = TypeOf<typeof configSchema>;
 export type TaskExecutionFailureThreshold = TypeOf<typeof taskExecutionFailureThresholdSchema>;
 export type EventLoopDelayConfig = TypeOf<typeof eventLoopDelaySchema>;
 export type RequestTimeoutsConfig = TypeOf<typeof requestTimeoutsConfig>;
+export type EsRequestLimitsConfig = TypeOf<typeof esRequestLimitsSchema>;

--- a/x-pack/platform/plugins/shared/task_manager/server/config.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/config.ts
@@ -8,6 +8,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { parseIntervalAsMillisecond } from './lib/intervals';
+import { KNOWN_ES_REQUEST_SCOPES } from './es_request_limiter/es_request_scopes';
 
 export const MAX_WORKERS_LIMIT = 100;
 export const DEFAULT_CAPACITY = 10;
@@ -93,16 +94,67 @@ const esRequestCategoryLimitSchema = schema.object({
 });
 
 /*
+ * Per-scope sub-budget nested under the global category budgets. A scope groups
+ * task types (see `es_request_limiter/es_request_scopes`) so a subset of tasks —
+ * e.g. `alerting` — can be capped below the global budget. Each value is a
+ * cluster-wide total (partitioned per node like the category budget) and must be
+ * less than or equal to the matching global `cluster_wide`.
+ */
+const esRequestScopeLimitSchema = schema.object({
+  search: schema.maybe(schema.number({ min: 1 })),
+  write: schema.maybe(schema.number({ min: 1 })),
+});
+
+/*
  * Limits on the number of concurrent Elasticsearch requests that tasks may issue
  * through the Task Manager provided client (`RunContext.esClient`). Disabled by
- * default; when enabled, requests over the per-category budget are rejected with
- * a 429-shaped error so the task fails fast instead of overloading Elasticsearch.
+ * default; when enabled, requests over the per-category budget (or a per-scope
+ * sub-budget) are rejected with a 429-shaped error so the task fails fast instead
+ * of overloading Elasticsearch.
  */
-const esRequestLimitsSchema = schema.object({
-  enabled: schema.boolean({ defaultValue: false }),
-  search: schema.maybe(esRequestCategoryLimitSchema),
-  write: schema.maybe(esRequestCategoryLimitSchema),
-});
+const esRequestLimitsSchema = schema.object(
+  {
+    enabled: schema.boolean({ defaultValue: false }),
+    search: schema.maybe(esRequestCategoryLimitSchema),
+    write: schema.maybe(esRequestCategoryLimitSchema),
+    /*
+     * Optional per-scope sub-budgets keyed by scope name. Keys must be a scope
+     * known to the hardcoded membership map; each value must be <= the matching
+     * global category budget.
+     */
+    scopes: schema.maybe(schema.recordOf(schema.string(), esRequestScopeLimitSchema)),
+  },
+  {
+    validate: (config) => {
+      if (!config.scopes) {
+        return;
+      }
+      for (const [scope, limits] of Object.entries(config.scopes)) {
+        if (!KNOWN_ES_REQUEST_SCOPES.includes(scope)) {
+          return `Unknown es_request_limits scope "${scope}". Known scopes: ${KNOWN_ES_REQUEST_SCOPES.join(
+            ', '
+          )}.`;
+        }
+        if (limits.search !== undefined) {
+          if (config.search === undefined) {
+            return `es_request_limits.scopes.${scope}.search is set but no global search.cluster_wide budget is configured.`;
+          }
+          if (limits.search > config.search.cluster_wide) {
+            return `es_request_limits.scopes.${scope}.search (${limits.search}) cannot exceed the global search.cluster_wide (${config.search.cluster_wide}).`;
+          }
+        }
+        if (limits.write !== undefined) {
+          if (config.write === undefined) {
+            return `es_request_limits.scopes.${scope}.write is set but no global write.cluster_wide budget is configured.`;
+          }
+          if (limits.write > config.write.cluster_wide) {
+            return `es_request_limits.scopes.${scope}.write (${limits.write}) cannot exceed the global write.cluster_wide (${config.write.cluster_wide}).`;
+          }
+        }
+      }
+    },
+  }
+);
 
 const validateDuration = (duration: string) => {
   try {

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import type { EsRequestLimitsConfig } from '../config';
+import { EsRequestLimiter } from './es_request_limiter';
+import { EsRequestLimitReachedError } from './errors';
+import { EsRequestCategory } from './es_request_categories';
+import { buildTaskEsClient, createLimitedEsClient } from './create_limited_es_client';
+
+const createLimiter = (config: EsRequestLimitsConfig) =>
+  new EsRequestLimiter({ config, logger: loggingSystemMock.createLogger() });
+
+describe('createLimitedEsClient', () => {
+  it('meters a search request through the limiter and releases afterwards', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    const tryAcquire = jest.spyOn(limiter, 'tryAcquire');
+    const release = jest.spyOn(limiter, 'release');
+    const client = elasticsearchServiceMock.createElasticsearchClient();
+
+    const wrapped = createLimitedEsClient({
+      client,
+      limiter,
+      taskType: 'my-task',
+      esRequestLimits: { search: 3 },
+    });
+
+    await wrapped.search({ index: 'foo' });
+
+    expect(client.search).toHaveBeenCalledWith({ index: 'foo' });
+    expect(tryAcquire).toHaveBeenCalledWith(EsRequestCategory.Search, {
+      taskType: 'my-task',
+      scope: 'my-task',
+      scopeLimit: 3,
+    });
+    expect(release).toHaveBeenCalledWith(EsRequestCategory.Search, {
+      taskType: 'my-task',
+      scope: 'my-task',
+      scopeLimit: 3,
+    });
+  });
+
+  it('uses the declared scope so multiple task types can share a budget', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    const tryAcquire = jest.spyOn(limiter, 'tryAcquire');
+    const client = elasticsearchServiceMock.createElasticsearchClient();
+
+    const wrapped = createLimitedEsClient({
+      client,
+      limiter,
+      taskType: 'my-task',
+      esRequestLimits: { scope: 'shared-workload', search: 2 },
+    });
+
+    await wrapped.search({ index: 'foo' });
+
+    expect(tryAcquire).toHaveBeenCalledWith(EsRequestCategory.Search, {
+      taskType: 'my-task',
+      scope: 'shared-workload',
+      scopeLimit: 2,
+    });
+  });
+
+  it('categorizes write methods separately', async () => {
+    const limiter = createLimiter({ enabled: true, write: { cluster_wide: 5 } });
+    const tryAcquire = jest.spyOn(limiter, 'tryAcquire');
+    const client = elasticsearchServiceMock.createElasticsearchClient();
+
+    const wrapped = createLimitedEsClient({ client, limiter, taskType: 'my-task' });
+    await wrapped.bulk({ operations: [] });
+
+    expect(tryAcquire).toHaveBeenCalledWith(EsRequestCategory.Write, {
+      taskType: 'my-task',
+      scope: 'my-task',
+      scopeLimit: undefined,
+    });
+  });
+
+  it('throws a 429-shaped error and skips the request when the budget is exhausted', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    jest.spyOn(limiter, 'tryAcquire').mockReturnValue(false);
+    const release = jest.spyOn(limiter, 'release');
+    const client = elasticsearchServiceMock.createElasticsearchClient();
+
+    const wrapped = createLimitedEsClient({ client, limiter, taskType: 'my-task' });
+
+    await expect(wrapped.search({ index: 'foo' })).rejects.toBeInstanceOf(
+      EsRequestLimitReachedError
+    );
+    await expect(wrapped.search({ index: 'foo' })).rejects.toMatchObject({ statusCode: 429 });
+    expect(client.search).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('releases even when the underlying request throws', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    const release = jest.spyOn(limiter, 'release');
+    const client = elasticsearchServiceMock.createElasticsearchClient();
+    client.search.mockRejectedValueOnce(new Error('boom'));
+
+    const wrapped = createLimitedEsClient({ client, limiter, taskType: 'my-task' });
+
+    await expect(wrapped.search({ index: 'foo' })).rejects.toThrow('boom');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes non-metered methods through without touching the limiter', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    const tryAcquire = jest.spyOn(limiter, 'tryAcquire');
+    const client = elasticsearchServiceMock.createElasticsearchClient();
+
+    const wrapped = createLimitedEsClient({ client, limiter, taskType: 'my-task' });
+    await wrapped.ping();
+
+    expect(client.ping).toHaveBeenCalled();
+    expect(tryAcquire).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildTaskEsClient', () => {
+  it('wraps asInternalUser and asCurrentUser when an API key request is present', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    const tryAcquire = jest.spyOn(limiter, 'tryAcquire');
+    const clusterClient = elasticsearchServiceMock.createClusterClient();
+    const fakeRequest = httpServerMock.createKibanaRequest();
+
+    const esClient = buildTaskEsClient({
+      clusterClient,
+      fakeRequest,
+      limiter,
+      taskType: 'my-task',
+    });
+
+    await esClient.asInternalUser.search({ index: 'foo' });
+    await esClient.asCurrentUser.search({ index: 'bar' });
+
+    expect(clusterClient.asScoped).toHaveBeenCalledWith(fakeRequest);
+    expect(clusterClient.asInternalUser.search).toHaveBeenCalledWith({ index: 'foo' });
+    expect(tryAcquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('makes asInternalUser available but throws on asCurrentUser use when there is no API key', async () => {
+    const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+    const clusterClient = elasticsearchServiceMock.createClusterClient();
+
+    const esClient = buildTaskEsClient({
+      clusterClient,
+      fakeRequest: undefined,
+      limiter,
+      taskType: 'my-task',
+    });
+
+    await expect(esClient.asInternalUser.search({ index: 'foo' })).resolves.not.toThrow();
+    expect(clusterClient.asScoped).not.toHaveBeenCalled();
+    expect(() => esClient.asCurrentUser.search).toThrow(/scheduled without an API key/);
+    expect(() => esClient.asSecondaryAuthUser.search).toThrow(/scheduled without an API key/);
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.test.ts
@@ -23,46 +23,36 @@ describe('createLimitedEsClient', () => {
     const release = jest.spyOn(limiter, 'release');
     const client = elasticsearchServiceMock.createElasticsearchClient();
 
-    const wrapped = createLimitedEsClient({
-      client,
-      limiter,
-      taskType: 'my-task',
-      esRequestLimits: { search: 3 },
-    });
+    // Task type is not grouped into a scope, so no scope is passed.
+    const wrapped = createLimitedEsClient({ client, limiter, taskType: 'my-task' });
 
     await wrapped.search({ index: 'foo' });
 
     expect(client.search).toHaveBeenCalledWith({ index: 'foo' });
     expect(tryAcquire).toHaveBeenCalledWith(EsRequestCategory.Search, {
       taskType: 'my-task',
-      scope: 'my-task',
-      scopeLimit: 3,
+      scope: undefined,
     });
     expect(release).toHaveBeenCalledWith(EsRequestCategory.Search, {
       taskType: 'my-task',
-      scope: 'my-task',
-      scopeLimit: 3,
+      scope: undefined,
     });
   });
 
-  it('uses the declared scope so multiple task types can share a budget', async () => {
+  it('resolves the scope from the task type via the membership map', async () => {
     const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
     const tryAcquire = jest.spyOn(limiter, 'tryAcquire');
     const client = elasticsearchServiceMock.createElasticsearchClient();
 
-    const wrapped = createLimitedEsClient({
-      client,
-      limiter,
-      taskType: 'my-task',
-      esRequestLimits: { scope: 'shared-workload', search: 2 },
-    });
+    // Alerting rule executors register as `alerting:${ruleTypeId}` and map to
+    // the shared `alerting` scope.
+    const wrapped = createLimitedEsClient({ client, limiter, taskType: 'alerting:.es-query' });
 
     await wrapped.search({ index: 'foo' });
 
     expect(tryAcquire).toHaveBeenCalledWith(EsRequestCategory.Search, {
-      taskType: 'my-task',
-      scope: 'shared-workload',
-      scopeLimit: 2,
+      taskType: 'alerting:.es-query',
+      scope: 'alerting',
     });
   });
 
@@ -76,8 +66,7 @@ describe('createLimitedEsClient', () => {
 
     expect(tryAcquire).toHaveBeenCalledWith(EsRequestCategory.Write, {
       taskType: 'my-task',
-      scope: 'my-task',
-      scopeLimit: undefined,
+      scope: undefined,
     });
   });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  ElasticsearchClient,
+  IClusterClient,
+  IScopedClusterClient,
+  KibanaRequest,
+} from '@kbn/core/server';
+import { getCategoryForMethod } from './es_request_categories';
+import type { EsRequestLimiter } from './es_request_limiter';
+import { EsRequestLimitReachedError } from './errors';
+
+/**
+ * Cluster-wide concurrency caps per request category, optionally shared across
+ * task types via `scope` (defaults to the task type when omitted).
+ */
+export interface ScopedEsRequestLimits {
+  scope?: string;
+  search?: number;
+  write?: number;
+}
+
+interface CreateLimitedEsClientOpts {
+  client: ElasticsearchClient;
+  limiter: EsRequestLimiter;
+  taskType: string;
+  esRequestLimits?: ScopedEsRequestLimits;
+}
+
+/**
+ * Wraps an Elasticsearch client so that metered methods (see
+ * `es_request_categories`) pass through the {@link EsRequestLimiter} before
+ * executing. When the budget for the request's category is exhausted the call
+ * rejects with {@link EsRequestLimitReachedError} instead of hitting
+ * Elasticsearch. Non-metered properties pass through unchanged.
+ */
+export const createLimitedEsClient = ({
+  client,
+  limiter,
+  taskType,
+  esRequestLimits,
+}: CreateLimitedEsClientOpts): ElasticsearchClient => {
+  const scope = esRequestLimits?.scope ?? taskType;
+
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (typeof prop !== 'string' || typeof value !== 'function') {
+        return value;
+      }
+
+      const category = getCategoryForMethod(prop);
+      if (!category) {
+        // Preserve `this` binding for non-metered client methods.
+        return value.bind(target);
+      }
+
+      const scopeLimit = esRequestLimits?.[category];
+      const acquireOptions = { taskType, scope, scopeLimit };
+      const originalMethod = value as (...args: unknown[]) => unknown;
+
+      return async (...args: unknown[]) => {
+        if (!limiter.tryAcquire(category, acquireOptions)) {
+          throw new EsRequestLimitReachedError(category, taskType);
+        }
+        try {
+          return await originalMethod.apply(target, args);
+        } finally {
+          limiter.release(category, acquireOptions);
+        }
+      };
+    },
+  }) as unknown as ElasticsearchClient;
+};
+
+/**
+ * A client accessor that throws on use. Returned for `asCurrentUser` /
+ * `asSecondaryAuthUser` when a task was scheduled without an API key, so those
+ * credentials-scoped clients are unavailable while `asInternalUser` still works.
+ */
+const createUnavailableClient = (taskType: string): ElasticsearchClient => {
+  const message =
+    `The credentials-scoped Elasticsearch client is not available for task "${taskType}" ` +
+    `because it was scheduled without an API key. Use "asInternalUser" or schedule the task with a request.`;
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (typeof prop === 'symbol') {
+          return undefined;
+        }
+        throw new Error(message);
+      },
+    }
+  ) as unknown as ElasticsearchClient;
+};
+
+interface BuildTaskEsClientOpts {
+  clusterClient: IClusterClient;
+  fakeRequest?: KibanaRequest;
+  limiter: EsRequestLimiter;
+  taskType: string;
+  esRequestLimits?: ScopedEsRequestLimits;
+}
+
+/**
+ * Builds the {@link IScopedClusterClient} exposed to a running task via
+ * `RunContext.esClient`. Every accessor is wrapped with the request limiter.
+ *
+ * - `asInternalUser` is always available (Kibana system user).
+ * - `asCurrentUser` / `asSecondaryAuthUser` are scoped to the task's API key when
+ *   one exists; otherwise they throw on use.
+ */
+export const buildTaskEsClient = ({
+  clusterClient,
+  fakeRequest,
+  limiter,
+  taskType,
+  esRequestLimits,
+}: BuildTaskEsClientOpts): IScopedClusterClient => {
+  const wrap = (client: ElasticsearchClient) =>
+    createLimitedEsClient({ client, limiter, taskType, esRequestLimits });
+
+  const asInternalUser = wrap(clusterClient.asInternalUser);
+
+  if (!fakeRequest) {
+    const unavailable = createUnavailableClient(taskType);
+    return {
+      asInternalUser,
+      asCurrentUser: unavailable,
+      asSecondaryAuthUser: unavailable,
+    };
+  }
+
+  const scoped = clusterClient.asScoped(fakeRequest);
+  return {
+    asInternalUser,
+    asCurrentUser: wrap(scoped.asCurrentUser),
+    asSecondaryAuthUser: wrap(scoped.asSecondaryAuthUser),
+  };
+};

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/create_limited_es_client.ts
@@ -13,39 +13,31 @@ import type {
 } from '@kbn/core/server';
 import { getCategoryForMethod } from './es_request_categories';
 import type { EsRequestLimiter } from './es_request_limiter';
+import { resolveEsRequestScope } from './es_request_scopes';
 import { EsRequestLimitReachedError } from './errors';
-
-/**
- * Cluster-wide concurrency caps per request category, optionally shared across
- * task types via `scope` (defaults to the task type when omitted).
- */
-export interface ScopedEsRequestLimits {
-  scope?: string;
-  search?: number;
-  write?: number;
-}
 
 interface CreateLimitedEsClientOpts {
   client: ElasticsearchClient;
   limiter: EsRequestLimiter;
   taskType: string;
-  esRequestLimits?: ScopedEsRequestLimits;
 }
 
 /**
  * Wraps an Elasticsearch client so that metered methods (see
  * `es_request_categories`) pass through the {@link EsRequestLimiter} before
- * executing. When the budget for the request's category is exhausted the call
- * rejects with {@link EsRequestLimitReachedError} instead of hitting
- * Elasticsearch. Non-metered properties pass through unchanged.
+ * executing. The task type's scope (resolved from the hardcoded membership map)
+ * is passed to the limiter so a configured per-scope sub-budget is enforced on
+ * top of the category budget. When a budget is exhausted the call rejects with
+ * {@link EsRequestLimitReachedError} instead of hitting Elasticsearch.
+ * Non-metered properties pass through unchanged.
  */
 export const createLimitedEsClient = ({
   client,
   limiter,
   taskType,
-  esRequestLimits,
 }: CreateLimitedEsClientOpts): ElasticsearchClient => {
-  const scope = esRequestLimits?.scope ?? taskType;
+  const scope = resolveEsRequestScope(taskType);
+  const acquireOptions = { taskType, scope };
 
   return new Proxy(client, {
     get(target, prop, receiver) {
@@ -61,8 +53,6 @@ export const createLimitedEsClient = ({
         return value.bind(target);
       }
 
-      const scopeLimit = esRequestLimits?.[category];
-      const acquireOptions = { taskType, scope, scopeLimit };
       const originalMethod = value as (...args: unknown[]) => unknown;
 
       return async (...args: unknown[]) => {
@@ -106,7 +96,6 @@ interface BuildTaskEsClientOpts {
   fakeRequest?: KibanaRequest;
   limiter: EsRequestLimiter;
   taskType: string;
-  esRequestLimits?: ScopedEsRequestLimits;
 }
 
 /**
@@ -122,10 +111,9 @@ export const buildTaskEsClient = ({
   fakeRequest,
   limiter,
   taskType,
-  esRequestLimits,
 }: BuildTaskEsClientOpts): IScopedClusterClient => {
   const wrap = (client: ElasticsearchClient) =>
-    createLimitedEsClient({ client, limiter, taskType, esRequestLimits });
+    createLimitedEsClient({ client, limiter, taskType });
 
   const asInternalUser = wrap(clusterClient.asInternalUser);
 

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/errors.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/errors.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsRequestCategory } from './es_request_categories';
+
+/**
+ * Error thrown when a task's Elasticsearch request is rejected because the
+ * configured concurrency budget for its category has been reached. It mimics an
+ * Elasticsearch "too many requests" response (`statusCode: 429`) so callers that
+ * already handle ES backpressure treat it the same way. Task Manager retries it
+ * through the normal failure/backoff path.
+ */
+export class EsRequestLimitReachedError extends Error {
+  public readonly statusCode = 429;
+
+  constructor(category: EsRequestCategory, taskType?: string) {
+    super(
+      `Elasticsearch ${category} request limit reached${
+        taskType ? ` while running task "${taskType}"` : ''
+      }. The request was rejected to protect Elasticsearch.`
+    );
+    this.name = 'EsRequestLimitReachedError';
+  }
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_categories.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_categories.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * The categories of Elasticsearch requests that Task Manager can budget
+ * independently. The string values double as the config keys under
+ * `xpack.task_manager.es_request_limits`.
+ */
+export enum EsRequestCategory {
+  Search = 'search',
+  Write = 'write',
+}
+
+/**
+ * Maps Elasticsearch client method names to the request category used for
+ * limiting. Only methods listed here are metered; every other property on the
+ * client passes through unlimited. Cleanup-style calls (e.g. `closePointInTime`)
+ * are intentionally excluded so tasks can always release resources.
+ */
+const ES_METHOD_CATEGORY: Readonly<Record<string, EsRequestCategory>> = {
+  // Reads / searches
+  search: EsRequestCategory.Search,
+  msearch: EsRequestCategory.Search,
+  mget: EsRequestCategory.Search,
+  get: EsRequestCategory.Search,
+  count: EsRequestCategory.Search,
+  scroll: EsRequestCategory.Search,
+  openPointInTime: EsRequestCategory.Search,
+  fieldCaps: EsRequestCategory.Search,
+  termsEnum: EsRequestCategory.Search,
+  explain: EsRequestCategory.Search,
+  searchShards: EsRequestCategory.Search,
+  // Writes
+  bulk: EsRequestCategory.Write,
+  index: EsRequestCategory.Write,
+  create: EsRequestCategory.Write,
+  update: EsRequestCategory.Write,
+  delete: EsRequestCategory.Write,
+  deleteByQuery: EsRequestCategory.Write,
+  updateByQuery: EsRequestCategory.Write,
+};
+
+/**
+ * Returns the request category for an Elasticsearch client method, or
+ * `undefined` if the method is not metered.
+ */
+export const getCategoryForMethod = (method: string): EsRequestCategory | undefined =>
+  ES_METHOD_CATEGORY[method];

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { EsRequestLimitsConfig } from '../config';
+import { EsRequestLimiter } from './es_request_limiter';
+import { EsRequestCategory } from './es_request_categories';
+
+const createLimiter = (config: EsRequestLimitsConfig) =>
+  new EsRequestLimiter({ config, logger: loggingSystemMock.createLogger() });
+
+describe('EsRequestLimiter', () => {
+  describe('when disabled', () => {
+    it('always allows acquisition and never counts in-flight requests', () => {
+      const limiter = createLimiter({ enabled: false, search: { cluster_wide: 1 } });
+
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+
+      const stats = limiter.getStats();
+      expect(stats.enabled).toBe(false);
+      expect(stats.categories[EsRequestCategory.Search].inFlight).toBe(0);
+    });
+  });
+
+  describe('uncapped categories', () => {
+    it('allows requests without counting when the category has no configured budget', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 1 } });
+
+      // write has no budget configured
+      expect(limiter.tryAcquire(EsRequestCategory.Write)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Write)).toBe(true);
+      expect(limiter.getStats().categories[EsRequestCategory.Write].inFlight).toBe(0);
+    });
+  });
+
+  describe('category budget', () => {
+    it('rejects once the per-node ceiling is reached and recovers after release', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 2 } });
+
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(false);
+
+      expect(limiter.getStats().categories[EsRequestCategory.Search]).toEqual({
+        nodeCeiling: 2,
+        inFlight: 2,
+        rejections: 1,
+      });
+
+      limiter.release(EsRequestCategory.Search);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.getStats().categories[EsRequestCategory.Search].inFlight).toBe(2);
+    });
+
+    it('does not decrement below zero on extra releases', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 2 } });
+      limiter.release(EsRequestCategory.Search);
+      expect(limiter.getStats().categories[EsRequestCategory.Search].inFlight).toBe(0);
+    });
+  });
+
+  describe('cluster-wide partitioning by active node count', () => {
+    it('divides the cluster-wide budget across active nodes (floor)', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
+      limiter.setActiveNodeCount(5);
+
+      expect(limiter.getStats().categories[EsRequestCategory.Search].nodeCeiling).toBe(2);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(false);
+    });
+
+    it('guarantees each node at least one slot even when nodes outnumber the budget', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 1 } });
+      limiter.setActiveNodeCount(5);
+
+      expect(limiter.getStats().categories[EsRequestCategory.Search].nodeCeiling).toBe(1);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search)).toBe(false);
+    });
+
+    it('treats a node count below one as a single node', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 4 } });
+      limiter.setActiveNodeCount(0);
+      expect(limiter.getStats().categories[EsRequestCategory.Search].nodeCeiling).toBe(4);
+    });
+  });
+
+  describe('scope limits', () => {
+    it('applies a scope cap in addition to the category budget', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
+
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+      ).toBe(true);
+      // second request of the same scope is rejected by the scope cap
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+      ).toBe(false);
+      // a different scope still has category capacity
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', scope: 'b', scopeLimit: 1 })
+      ).toBe(true);
+    });
+
+    it('shares one budget across task types that declare the same scope', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
+      const shared = { scope: 'shared', scopeLimit: 1 };
+
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
+      // different task type, same scope -> shares the single slot and is rejected
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', ...shared })).toBe(
+        false
+      );
+
+      limiter.release(EsRequestCategory.Search, { taskType: 'a', ...shared });
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', ...shared })).toBe(true);
+    });
+
+    it('defaults the scope to the task type when no scope is provided', () => {
+      const limiter = createLimiter({ enabled: true });
+
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scopeLimit: 1 })).toBe(
+        true
+      );
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scopeLimit: 1 })).toBe(
+        false
+      );
+      // a different task type gets its own default scope
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', scopeLimit: 1 })).toBe(
+        true
+      );
+    });
+
+    it('partitions the cluster-wide scope limit across active nodes', () => {
+      const limiter = createLimiter({ enabled: true });
+      limiter.setActiveNodeCount(5);
+      const shared = { scope: 'shared', scopeLimit: 10 };
+
+      // ceiling per node = floor(10 / 5) = 2
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(
+        false
+      );
+    });
+
+    it('enforces scope caps even when the category is uncapped', () => {
+      const limiter = createLimiter({ enabled: true });
+
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+      ).toBe(true);
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+      ).toBe(false);
+
+      limiter.release(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 });
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+      ).toBe(true);
+    });
+
+    it('does not reserve a category slot when the scope gate rejects', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
+
+      limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 });
+      // rejected by scope cap, so no additional category slot should be taken
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+      ).toBe(false);
+      expect(limiter.getStats().categories[EsRequestCategory.Search].inFlight).toBe(1);
+    });
+  });
+
+  describe('getStats scopes', () => {
+    it('reports per-scope in-flight, ceiling, and rejections', () => {
+      const limiter = createLimiter({ enabled: true });
+      limiter.setActiveNodeCount(2);
+      const shared = { scope: 'shared', scopeLimit: 2 };
+
+      // ceiling per node = floor(2 / 2) = 1
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', ...shared })).toBe(
+        false
+      );
+
+      const { scopes } = limiter.getStats();
+      expect(scopes).toEqual([
+        {
+          scope: 'shared',
+          category: EsRequestCategory.Search,
+          clusterWideLimit: 2,
+          nodeCeiling: 1,
+          inFlight: 1,
+          rejections: 1,
+        },
+      ]);
+    });
+
+    it('reports no scopes when none are configured', () => {
+      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 5 } });
+      limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a' });
+      expect(limiter.getStats().scopes).toEqual([]);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.test.ts
@@ -91,109 +91,118 @@ describe('EsRequestLimiter', () => {
     });
   });
 
-  describe('scope limits', () => {
-    it('applies a scope cap in addition to the category budget', () => {
-      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
+  describe('scope sub-budgets', () => {
+    it('applies a configured scope cap in addition to the category budget', () => {
+      const limiter = createLimiter({
+        enabled: true,
+        search: { cluster_wide: 10 },
+        scopes: { alerting: { search: 1 } },
+      });
 
       expect(
-        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:x', scope: 'alerting' })
       ).toBe(true);
       // second request of the same scope is rejected by the scope cap
       expect(
-        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 })
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:y', scope: 'alerting' })
       ).toBe(false);
-      // a different scope still has category capacity
+      // an ungrouped task still has category capacity
+      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'other' })).toBe(true);
+    });
+
+    it('shares one budget across task types that resolve to the same scope', () => {
+      const limiter = createLimiter({
+        enabled: true,
+        search: { cluster_wide: 10 },
+        scopes: { alerting: { search: 1 } },
+      });
+
       expect(
-        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', scope: 'b', scopeLimit: 1 })
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:x', scope: 'alerting' })
+      ).toBe(true);
+      // different task type, same scope -> shares the single slot and is rejected
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:y', scope: 'alerting' })
+      ).toBe(false);
+
+      limiter.release(EsRequestCategory.Search, { taskType: 'alerting:x', scope: 'alerting' });
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:y', scope: 'alerting' })
       ).toBe(true);
     });
 
-    it('shares one budget across task types that declare the same scope', () => {
+    it('ignores a scope that has no configured limit', () => {
       const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
-      const shared = { scope: 'shared', scopeLimit: 1 };
 
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
-      // different task type, same scope -> shares the single slot and is rejected
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', ...shared })).toBe(
-        false
-      );
-
-      limiter.release(EsRequestCategory.Search, { taskType: 'a', ...shared });
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', ...shared })).toBe(true);
-    });
-
-    it('defaults the scope to the task type when no scope is provided', () => {
-      const limiter = createLimiter({ enabled: true });
-
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scopeLimit: 1 })).toBe(
-        true
-      );
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scopeLimit: 1 })).toBe(
-        false
-      );
-      // a different task type gets its own default scope
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', scopeLimit: 1 })).toBe(
-        true
-      );
+      // scope has no configured sub-budget, so only the category budget applies
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:x', scope: 'alerting' })
+      ).toBe(true);
+      expect(
+        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'alerting:y', scope: 'alerting' })
+      ).toBe(true);
+      expect(limiter.getStats().scopes).toEqual([]);
     });
 
     it('partitions the cluster-wide scope limit across active nodes', () => {
-      const limiter = createLimiter({ enabled: true });
+      const limiter = createLimiter({
+        enabled: true,
+        search: { cluster_wide: 50 },
+        scopes: { alerting: { search: 10 } },
+      });
       limiter.setActiveNodeCount(5);
-      const shared = { scope: 'shared', scopeLimit: 10 };
+      const opts = { taskType: 'alerting:x', scope: 'alerting' };
 
       // ceiling per node = floor(10 / 5) = 2
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(
-        false
-      );
+      expect(limiter.tryAcquire(EsRequestCategory.Search, opts)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, opts)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, opts)).toBe(false);
     });
 
     it('enforces scope caps even when the category is uncapped', () => {
-      const limiter = createLimiter({ enabled: true });
+      const limiter = createLimiter({ enabled: true, scopes: { alerting: { write: 1 } } });
+      const opts = { taskType: 'alerting:x', scope: 'alerting' };
 
-      expect(
-        limiter.tryAcquire(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 })
-      ).toBe(true);
-      expect(
-        limiter.tryAcquire(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 })
-      ).toBe(false);
+      expect(limiter.tryAcquire(EsRequestCategory.Write, opts)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Write, opts)).toBe(false);
 
-      limiter.release(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 });
-      expect(
-        limiter.tryAcquire(EsRequestCategory.Write, { taskType: 'a', scope: 'a', scopeLimit: 1 })
-      ).toBe(true);
+      limiter.release(EsRequestCategory.Write, opts);
+      expect(limiter.tryAcquire(EsRequestCategory.Write, opts)).toBe(true);
     });
 
     it('does not reserve a category slot when the scope gate rejects', () => {
-      const limiter = createLimiter({ enabled: true, search: { cluster_wide: 10 } });
+      const limiter = createLimiter({
+        enabled: true,
+        search: { cluster_wide: 10 },
+        scopes: { alerting: { search: 1 } },
+      });
+      const opts = { taskType: 'alerting:x', scope: 'alerting' };
 
-      limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 });
+      limiter.tryAcquire(EsRequestCategory.Search, opts);
       // rejected by scope cap, so no additional category slot should be taken
-      expect(
-        limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', scope: 'a', scopeLimit: 1 })
-      ).toBe(false);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, opts)).toBe(false);
       expect(limiter.getStats().categories[EsRequestCategory.Search].inFlight).toBe(1);
     });
   });
 
   describe('getStats scopes', () => {
     it('reports per-scope in-flight, ceiling, and rejections', () => {
-      const limiter = createLimiter({ enabled: true });
+      const limiter = createLimiter({
+        enabled: true,
+        search: { cluster_wide: 10 },
+        scopes: { alerting: { search: 2 } },
+      });
       limiter.setActiveNodeCount(2);
-      const shared = { scope: 'shared', scopeLimit: 2 };
+      const opts = { taskType: 'alerting:x', scope: 'alerting' };
 
       // ceiling per node = floor(2 / 2) = 1
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'a', ...shared })).toBe(true);
-      expect(limiter.tryAcquire(EsRequestCategory.Search, { taskType: 'b', ...shared })).toBe(
-        false
-      );
+      expect(limiter.tryAcquire(EsRequestCategory.Search, opts)).toBe(true);
+      expect(limiter.tryAcquire(EsRequestCategory.Search, opts)).toBe(false);
 
       const { scopes } = limiter.getStats();
       expect(scopes).toEqual([
         {
-          scope: 'shared',
+          scope: 'alerting',
           category: EsRequestCategory.Search,
           clusterWideLimit: 2,
           nodeCeiling: 1,

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { EsRequestLimitsConfig } from '../config';
+import { EsRequestCategory } from './es_request_categories';
+
+export interface AcquireOptions {
+  /** The task type issuing the request, used for logging and as the default scope. */
+  taskType?: string;
+  /**
+   * Grouping key for the sub-limit so multiple task types can share one budget.
+   * Defaults to `taskType` when omitted.
+   */
+  scope?: string;
+  /**
+   * Cluster-wide concurrency cap for this scope and category. Partitioned across
+   * active nodes like the category budget. Undefined means the scope is uncapped.
+   */
+  scopeLimit?: number;
+}
+
+export interface EsRequestCategoryStats {
+  /** The effective per-node ceiling, or `undefined` when the category is uncapped. */
+  nodeCeiling?: number;
+  /** Number of in-flight requests currently counted against the category budget. */
+  inFlight: number;
+  /** Number of requests rejected since startup for this category budget. */
+  rejections: number;
+}
+
+export interface EsRequestScopeStats {
+  /** The scope grouping key (a shared name, or a task type by default). */
+  scope: string;
+  /** The request category this budget applies to. */
+  category: EsRequestCategory;
+  /** The configured cluster-wide limit for this scope and category. */
+  clusterWideLimit: number;
+  /** The effective per-node ceiling after partitioning across active nodes. */
+  nodeCeiling: number;
+  /** Number of in-flight requests currently counted against this scope budget. */
+  inFlight: number;
+  /** Number of requests rejected since startup for this scope budget. */
+  rejections: number;
+}
+
+export interface EsRequestLimiterStats {
+  enabled: boolean;
+  activeNodeCount: number;
+  categories: Record<EsRequestCategory, EsRequestCategoryStats>;
+  scopes: EsRequestScopeStats[];
+}
+
+interface ScopeState {
+  scope: string;
+  category: EsRequestCategory;
+  clusterWideLimit: number;
+  inFlight: number;
+  rejections: number;
+}
+
+const CATEGORIES: readonly EsRequestCategory[] = [
+  EsRequestCategory.Search,
+  EsRequestCategory.Write,
+];
+
+/**
+ * Enforces a per-node share of a cluster-wide budget of concurrent Elasticsearch
+ * requests, per category. The cluster-wide budget is configured statically; each
+ * node computes its share as `floor(clusterWide / activeNodeCount)` (min 1) using
+ * the live active-node count from the Kibana discovery service.
+ *
+ * The limiter is a plain in-memory counter — acquiring never queues. When a
+ * category (or per-type) budget is exhausted, `tryAcquire` returns `false` and
+ * the caller is expected to fail fast.
+ */
+export class EsRequestLimiter {
+  private readonly logger: Logger;
+  private readonly enabled: boolean;
+  private readonly clusterWideByCategory: Map<EsRequestCategory, number> = new Map();
+  private activeNodeCount = 1;
+
+  private readonly inFlightByCategory: Map<EsRequestCategory, number> = new Map();
+  private readonly rejectionsByCategory: Map<EsRequestCategory, number> = new Map();
+  private readonly scopeStateByKey: Map<string, ScopeState> = new Map();
+
+  constructor({ config, logger }: { config: EsRequestLimitsConfig; logger: Logger }) {
+    this.logger = logger;
+    this.enabled = config.enabled;
+
+    if (config.search) {
+      this.clusterWideByCategory.set(EsRequestCategory.Search, config.search.cluster_wide);
+    }
+    if (config.write) {
+      this.clusterWideByCategory.set(EsRequestCategory.Write, config.write.cluster_wide);
+    }
+  }
+
+  /**
+   * Updates the number of active background-task Kibana nodes. Called whenever
+   * the discovery service recounts the cluster so each node's share of the
+   * cluster-wide budget stays roughly `clusterWide / activeNodeCount`.
+   */
+  public setActiveNodeCount(count: number): void {
+    this.activeNodeCount = Math.max(1, count);
+  }
+
+  /**
+   * Partitions a cluster-wide limit into this node's share, guaranteeing each
+   * node at least one slot.
+   */
+  private partition(clusterWide: number): number {
+    return Math.max(1, Math.floor(clusterWide / this.activeNodeCount));
+  }
+
+  /**
+   * The effective per-node ceiling for a category, or `undefined` when the
+   * category has no configured budget (uncapped).
+   */
+  private getNodeCeiling(category: EsRequestCategory): number | undefined {
+    const clusterWide = this.clusterWideByCategory.get(category);
+    if (clusterWide === undefined) {
+      return undefined;
+    }
+    return this.partition(clusterWide);
+  }
+
+  private isCategoryCapped(category: EsRequestCategory): boolean {
+    return this.clusterWideByCategory.has(category);
+  }
+
+  /** The scope grouping key for a request, defaulting to the task type. */
+  private resolveScope(options: AcquireOptions): string | undefined {
+    return options.scope ?? options.taskType;
+  }
+
+  private getOrCreateScopeState(
+    scope: string,
+    category: EsRequestCategory,
+    clusterWideLimit: number
+  ): ScopeState {
+    const key = this.getScopeKey(scope, category);
+    let state = this.scopeStateByKey.get(key);
+    if (!state) {
+      state = { scope, category, clusterWideLimit, inFlight: 0, rejections: 0 };
+      this.scopeStateByKey.set(key, state);
+    } else {
+      // Keep the latest declared limit in case it changed between registrations.
+      state.clusterWideLimit = clusterWideLimit;
+    }
+    return state;
+  }
+
+  /**
+   * Attempts to reserve one slot for a request of the given category. Returns
+   * `true` and increments the relevant counters when both the category ceiling
+   * and any per-type limit have capacity; otherwise records a rejection and
+   * returns `false` without reserving anything. Every successful `tryAcquire`
+   * must be matched by exactly one `release` with the same arguments.
+   */
+  public tryAcquire(category: EsRequestCategory, options: AcquireOptions = {}): boolean {
+    if (!this.enabled) {
+      return true;
+    }
+
+    const { taskType, scopeLimit } = options;
+    const scope = this.resolveScope(options);
+    const ceiling = this.getNodeCeiling(category);
+    const scopeState =
+      scope !== undefined && scopeLimit !== undefined
+        ? this.getOrCreateScopeState(scope, category, scopeLimit)
+        : undefined;
+
+    // Check every gate before reserving anything so a partial reservation is
+    // never left behind when one gate rejects.
+    if (ceiling !== undefined && (this.inFlightByCategory.get(category) ?? 0) >= ceiling) {
+      this.recordCategoryRejection(category, taskType);
+      return false;
+    }
+
+    if (
+      scopeState !== undefined &&
+      scopeState.inFlight >= this.partition(scopeState.clusterWideLimit)
+    ) {
+      this.recordScopeRejection(scopeState, taskType);
+      return false;
+    }
+
+    if (this.isCategoryCapped(category)) {
+      this.inFlightByCategory.set(category, (this.inFlightByCategory.get(category) ?? 0) + 1);
+    }
+    if (scopeState !== undefined) {
+      scopeState.inFlight += 1;
+    }
+
+    return true;
+  }
+
+  /**
+   * Releases a slot previously reserved by `tryAcquire`. Must be called with the
+   * same category and options that were passed to the matching `tryAcquire`.
+   */
+  public release(category: EsRequestCategory, options: AcquireOptions = {}): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const { scopeLimit } = options;
+    const scope = this.resolveScope(options);
+
+    if (this.isCategoryCapped(category)) {
+      const current = this.inFlightByCategory.get(category) ?? 0;
+      if (current > 0) {
+        this.inFlightByCategory.set(category, current - 1);
+      }
+    }
+
+    if (scope !== undefined && scopeLimit !== undefined) {
+      const scopeState = this.scopeStateByKey.get(this.getScopeKey(scope, category));
+      if (scopeState && scopeState.inFlight > 0) {
+        scopeState.inFlight -= 1;
+      }
+    }
+  }
+
+  public getStats(): EsRequestLimiterStats {
+    const categories = CATEGORIES.reduce((acc, category) => {
+      acc[category] = {
+        nodeCeiling: this.getNodeCeiling(category),
+        inFlight: this.inFlightByCategory.get(category) ?? 0,
+        rejections: this.rejectionsByCategory.get(category) ?? 0,
+      };
+      return acc;
+    }, {} as Record<EsRequestCategory, EsRequestCategoryStats>);
+
+    const scopes = [...this.scopeStateByKey.values()].map<EsRequestScopeStats>((state) => ({
+      scope: state.scope,
+      category: state.category,
+      clusterWideLimit: state.clusterWideLimit,
+      nodeCeiling: this.partition(state.clusterWideLimit),
+      inFlight: state.inFlight,
+      rejections: state.rejections,
+    }));
+
+    return {
+      enabled: this.enabled,
+      activeNodeCount: this.activeNodeCount,
+      categories,
+      scopes,
+    };
+  }
+
+  private getScopeKey(scope: string, category: EsRequestCategory): string {
+    return `${scope}:${category}`;
+  }
+
+  private recordCategoryRejection(category: EsRequestCategory, taskType?: string): void {
+    this.rejectionsByCategory.set(category, (this.rejectionsByCategory.get(category) ?? 0) + 1);
+    this.logger.debug(
+      `Elasticsearch ${category} request rejected${
+        taskType ? ` for task "${taskType}"` : ''
+      }: node category budget reached (ceiling=${this.getNodeCeiling(category)}, activeNodes=${
+        this.activeNodeCount
+      }).`
+    );
+  }
+
+  private recordScopeRejection(scopeState: ScopeState, taskType?: string): void {
+    scopeState.rejections += 1;
+    this.logger.debug(
+      `Elasticsearch ${scopeState.category} request rejected${
+        taskType ? ` for task "${taskType}"` : ''
+      }: node budget reached for scope "${scopeState.scope}" (ceiling=${this.partition(
+        scopeState.clusterWideLimit
+      )}, activeNodes=${this.activeNodeCount}).`
+    );
+  }
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_limiter.ts
@@ -10,18 +10,15 @@ import type { EsRequestLimitsConfig } from '../config';
 import { EsRequestCategory } from './es_request_categories';
 
 export interface AcquireOptions {
-  /** The task type issuing the request, used for logging and as the default scope. */
+  /** The task type issuing the request, used for logging. */
   taskType?: string;
   /**
-   * Grouping key for the sub-limit so multiple task types can share one budget.
-   * Defaults to `taskType` when omitted.
+   * The scope the task belongs to (resolved from its task type via the hardcoded
+   * membership map). When the scope has a configured sub-budget, the request is
+   * gated on it in addition to the category budget. Undefined when the task type
+   * is not grouped into a scope.
    */
   scope?: string;
-  /**
-   * Cluster-wide concurrency cap for this scope and category. Partitioned across
-   * active nodes like the category budget. Undefined means the scope is uncapped.
-   */
-  scopeLimit?: number;
 }
 
 export interface EsRequestCategoryStats {
@@ -70,13 +67,20 @@ const CATEGORIES: readonly EsRequestCategory[] = [
 
 /**
  * Enforces a per-node share of a cluster-wide budget of concurrent Elasticsearch
- * requests, per category. The cluster-wide budget is configured statically; each
- * node computes its share as `floor(clusterWide / activeNodeCount)` (min 1) using
- * the live active-node count from the Kibana discovery service.
+ * requests, per category and (optionally) per scope. The cluster-wide budgets are
+ * configured statically; each node computes its share as
+ * `floor(clusterWide / activeNodeCount)` (min 1) using the live active-node count
+ * from the Kibana discovery service.
+ *
+ * A scope is a configured sub-budget nested under a category budget: a request
+ * with a scope that has a configured limit must have capacity in both the
+ * category budget and the scope budget. Scope membership is resolved from the
+ * task type by the caller (see `es_request_scopes`); the scope's limit comes from
+ * `xpack.task_manager.es_request_limits.scopes`.
  *
  * The limiter is a plain in-memory counter — acquiring never queues. When a
- * category (or per-type) budget is exhausted, `tryAcquire` returns `false` and
- * the caller is expected to fail fast.
+ * category (or scope) budget is exhausted, `tryAcquire` returns `false` and the
+ * caller is expected to fail fast.
  */
 export class EsRequestLimiter {
   private readonly logger: Logger;
@@ -98,6 +102,33 @@ export class EsRequestLimiter {
     if (config.write) {
       this.clusterWideByCategory.set(EsRequestCategory.Write, config.write.cluster_wide);
     }
+
+    // Pre-populate scope state for every configured scope sub-budget so scopes
+    // are enforced (and reported in stats) from startup, before any traffic.
+    if (config.scopes) {
+      for (const [scope, limits] of Object.entries(config.scopes)) {
+        if (limits.search !== undefined) {
+          this.registerScopeLimit(EsRequestCategory.Search, scope, limits.search);
+        }
+        if (limits.write !== undefined) {
+          this.registerScopeLimit(EsRequestCategory.Write, scope, limits.write);
+        }
+      }
+    }
+  }
+
+  private registerScopeLimit(
+    category: EsRequestCategory,
+    scope: string,
+    clusterWideLimit: number
+  ): void {
+    this.scopeStateByKey.set(this.getScopeKey(scope, category), {
+      scope,
+      category,
+      clusterWideLimit,
+      inFlight: 0,
+      rejections: 0,
+    });
   }
 
   /**
@@ -133,47 +164,29 @@ export class EsRequestLimiter {
     return this.clusterWideByCategory.has(category);
   }
 
-  /** The scope grouping key for a request, defaulting to the task type. */
-  private resolveScope(options: AcquireOptions): string | undefined {
-    return options.scope ?? options.taskType;
-  }
-
-  private getOrCreateScopeState(
-    scope: string,
-    category: EsRequestCategory,
-    clusterWideLimit: number
-  ): ScopeState {
-    const key = this.getScopeKey(scope, category);
-    let state = this.scopeStateByKey.get(key);
-    if (!state) {
-      state = { scope, category, clusterWideLimit, inFlight: 0, rejections: 0 };
-      this.scopeStateByKey.set(key, state);
-    } else {
-      // Keep the latest declared limit in case it changed between registrations.
-      state.clusterWideLimit = clusterWideLimit;
-    }
-    return state;
+  /** The scope sub-budget state for a request, or undefined when the scope is uncapped. */
+  private getScopeState(category: EsRequestCategory, scope?: string): ScopeState | undefined {
+    return scope !== undefined
+      ? this.scopeStateByKey.get(this.getScopeKey(scope, category))
+      : undefined;
   }
 
   /**
    * Attempts to reserve one slot for a request of the given category. Returns
    * `true` and increments the relevant counters when both the category ceiling
-   * and any per-type limit have capacity; otherwise records a rejection and
-   * returns `false` without reserving anything. Every successful `tryAcquire`
-   * must be matched by exactly one `release` with the same arguments.
+   * and the scope sub-budget (when the scope is configured) have capacity;
+   * otherwise records a rejection and returns `false` without reserving anything.
+   * Every successful `tryAcquire` must be matched by exactly one `release` with
+   * the same arguments.
    */
   public tryAcquire(category: EsRequestCategory, options: AcquireOptions = {}): boolean {
     if (!this.enabled) {
       return true;
     }
 
-    const { taskType, scopeLimit } = options;
-    const scope = this.resolveScope(options);
+    const { taskType, scope } = options;
     const ceiling = this.getNodeCeiling(category);
-    const scopeState =
-      scope !== undefined && scopeLimit !== undefined
-        ? this.getOrCreateScopeState(scope, category, scopeLimit)
-        : undefined;
+    const scopeState = this.getScopeState(category, scope);
 
     // Check every gate before reserving anything so a partial reservation is
     // never left behind when one gate rejects.
@@ -209,9 +222,6 @@ export class EsRequestLimiter {
       return;
     }
 
-    const { scopeLimit } = options;
-    const scope = this.resolveScope(options);
-
     if (this.isCategoryCapped(category)) {
       const current = this.inFlightByCategory.get(category) ?? 0;
       if (current > 0) {
@@ -219,11 +229,9 @@ export class EsRequestLimiter {
       }
     }
 
-    if (scope !== undefined && scopeLimit !== undefined) {
-      const scopeState = this.scopeStateByKey.get(this.getScopeKey(scope, category));
-      if (scopeState && scopeState.inFlight > 0) {
-        scopeState.inFlight -= 1;
-      }
+    const scopeState = this.getScopeState(category, options.scope);
+    if (scopeState && scopeState.inFlight > 0) {
+      scopeState.inFlight -= 1;
     }
   }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_scopes.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_scopes.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ES_REQUEST_SCOPE_GROUPS,
+  KNOWN_ES_REQUEST_SCOPES,
+  resolveEsRequestScope,
+} from './es_request_scopes';
+
+describe('resolveEsRequestScope', () => {
+  it('resolves alerting v1 rule executor task types to the alerting scope', () => {
+    expect(resolveEsRequestScope('alerting:.es-query')).toBe('alerting');
+    expect(resolveEsRequestScope('alerting:xpack.uptime.alerts.monitorStatus')).toBe('alerting');
+  });
+
+  it('resolves the alerting v2 rule executor to its own scope, without colliding with v1', () => {
+    expect(resolveEsRequestScope('alerting_v2:rule_executor')).toBe('alerting_v2');
+    // the v1 `alerting:` prefix must not grab the v2 task type
+    expect(resolveEsRequestScope('alerting_v2:rule_executor')).not.toBe('alerting');
+    // other alerting_v2 tasks are infra, not rules, so they stay unscoped
+    expect(resolveEsRequestScope('alerting_v2:dispatcher')).toBeUndefined();
+    expect(resolveEsRequestScope('alerting_v2:telemetry')).toBeUndefined();
+  });
+
+  it('resolves action executor task types to the actions scope', () => {
+    expect(resolveEsRequestScope('actions:.email')).toBe('actions');
+  });
+
+  it('resolves exact test task types', () => {
+    expect(resolveEsRequestScope('sampleTaskWithScopedEsRequestLimit')).toBe(
+      'sampleEsRequestScope'
+    );
+  });
+
+  it('returns undefined for task types that are not grouped', () => {
+    expect(resolveEsRequestScope('report:execute')).toBeUndefined();
+    expect(resolveEsRequestScope('some-random-task')).toBeUndefined();
+    // a prefix must match at the start, not anywhere in the string
+    expect(resolveEsRequestScope('not-alerting:foo')).toBeUndefined();
+  });
+});
+
+describe('KNOWN_ES_REQUEST_SCOPES', () => {
+  it('lists every group scope exactly once', () => {
+    const scopes = ES_REQUEST_SCOPE_GROUPS.map((group) => group.scope);
+    expect([...KNOWN_ES_REQUEST_SCOPES].sort()).toEqual([...new Set(scopes)].sort());
+    expect(KNOWN_ES_REQUEST_SCOPES.length).toBe(new Set(KNOWN_ES_REQUEST_SCOPES).size);
+  });
+
+  it('includes the alerting, alerting_v2, and actions scopes', () => {
+    expect(KNOWN_ES_REQUEST_SCOPES).toContain('alerting');
+    expect(KNOWN_ES_REQUEST_SCOPES).toContain('alerting_v2');
+    expect(KNOWN_ES_REQUEST_SCOPES).toContain('actions');
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_scopes.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/es_request_scopes.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * A "scope" groups task types that should share a sub-budget of the global
+ * Elasticsearch request category budget (see `es_request_categories`). The
+ * per-scope limits themselves are operator-configured under
+ * `xpack.task_manager.es_request_limits.scopes.<scope>`; this file only owns the
+ * *membership* map — which task types belong to which scope.
+ *
+ * Membership is resolved from the task **type**, which is fixed and reliable,
+ * rather than from per-task-instance data (e.g. `TaskInstance.scope`) that may be
+ * missing or wrong on individual documents. Keeping the map here also lets an
+ * operator cap a group's Elasticsearch load without the owning team changing
+ * their task definitions.
+ */
+export interface EsRequestScopeGroup {
+  /** The scope name; matches a key under `es_request_limits.scopes`. */
+  scope: string;
+  /** Task types whose name starts with any of these prefixes belong to the scope. */
+  taskTypePrefixes?: string[];
+  /** Exact task types that belong to the scope. */
+  taskTypes?: string[];
+}
+
+/**
+ * The hardcoded task-type → scope membership map. Add an entry here to make a
+ * group eligible for an `es_request_limits.scopes.<scope>` sub-budget. First
+ * matching group wins, so keep groups mutually exclusive.
+ */
+export const ES_REQUEST_SCOPE_GROUPS: readonly EsRequestScopeGroup[] = [
+  // Alerting rule executors are registered as `alerting:${ruleType.id}`.
+  { scope: 'alerting', taskTypePrefixes: ['alerting:'] },
+
+  // Alerting v2 (ES|QL) rules all run under a single fixed task type
+  // (`alerting_v2:rule_executor`, i.e. ALERTING_RULE_EXECUTOR_TASK_TYPE — not
+  // imported here to avoid a task_manager -> alerting_v2 dependency). Kept as its
+  // own scope so the v1 and v2 engines can be budgeted independently. The other
+  // `alerting_v2:*` tasks (dispatcher, telemetry, api key invalidation) are infra,
+  // not rule executions, so they are intentionally excluded.
+  { scope: 'alerting_v2', taskTypes: ['alerting_v2:rule_executor'] },
+
+  // Action executors are registered as `actions:${actionTypeId}`.
+  { scope: 'actions', taskTypePrefixes: ['actions:'] },
+
+  // For testing — exercised by the plugin API integration suite.
+  { scope: 'sampleEsRequestScope', taskTypes: ['sampleTaskWithScopedEsRequestLimit'] },
+];
+
+/** The set of scope names known to the membership map, for config validation. */
+export const KNOWN_ES_REQUEST_SCOPES: readonly string[] = [
+  ...new Set(ES_REQUEST_SCOPE_GROUPS.map((group) => group.scope)),
+];
+
+/**
+ * Resolves the Elasticsearch-request scope a task type belongs to, or
+ * `undefined` when the task type is not grouped. First matching group wins.
+ */
+export const resolveEsRequestScope = (taskType: string): string | undefined => {
+  for (const group of ES_REQUEST_SCOPE_GROUPS) {
+    if (group.taskTypes?.includes(taskType)) {
+      return group.scope;
+    }
+    if (group.taskTypePrefixes?.some((prefix) => taskType.startsWith(prefix))) {
+      return group.scope;
+    }
+  }
+  return undefined;
+};

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EsRequestCategory, getCategoryForMethod } from './es_request_categories';
+export { EsRequestLimitReachedError } from './errors';
+export {
+  EsRequestLimiter,
+  type AcquireOptions,
+  type EsRequestLimiterStats,
+  type EsRequestCategoryStats,
+  type EsRequestScopeStats,
+} from './es_request_limiter';
+export {
+  createLimitedEsClient,
+  buildTaskEsClient,
+  type ScopedEsRequestLimits,
+} from './create_limited_es_client';

--- a/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/es_request_limiter/index.ts
@@ -8,14 +8,16 @@
 export { EsRequestCategory, getCategoryForMethod } from './es_request_categories';
 export { EsRequestLimitReachedError } from './errors';
 export {
+  ES_REQUEST_SCOPE_GROUPS,
+  KNOWN_ES_REQUEST_SCOPES,
+  resolveEsRequestScope,
+  type EsRequestScopeGroup,
+} from './es_request_scopes';
+export {
   EsRequestLimiter,
   type AcquireOptions,
   type EsRequestLimiterStats,
   type EsRequestCategoryStats,
   type EsRequestScopeStats,
 } from './es_request_limiter';
-export {
-  createLimitedEsClient,
-  buildTaskEsClient,
-  type ScopedEsRequestLimits,
-} from './create_limited_es_client';
+export { createLimitedEsClient, buildTaskEsClient } from './create_limited_es_client';

--- a/x-pack/platform/plugins/shared/task_manager/server/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/index.ts
@@ -33,6 +33,8 @@ export {
 export type { RruleSchedule } from './task';
 export { TaskStatus, TaskPriority, TaskCost, InstanceTaskCost } from './task';
 
+export { EsRequestCategory, EsRequestLimitReachedError } from './es_request_limiter';
+
 export type { TaskRegisterDefinition, TaskDefinitionRegistry } from './task_type_dictionary';
 
 export { asInterval } from './lib/intervals';

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/managed_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/managed_configuration.test.ts
@@ -108,6 +108,7 @@ describe('managed configuration', () => {
     auto_calculate_default_ech_capacity: false,
     api_key_type: ApiKeyType.ES,
     grant_uiam_api_keys: false,
+    es_request_limits: { enabled: false },
   };
 
   async function runSetTimeout0() {

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/calculate_health_status.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/calculate_health_status.test.ts
@@ -65,6 +65,7 @@ const config = {
   auto_calculate_default_ech_capacity: false,
   api_key_type: ApiKeyType.ES,
   grant_uiam_api_keys: false,
+  es_request_limits: { enabled: false },
 };
 
 const getStatsWithTimestamp = ({

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/create_aggregator.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/create_aggregator.test.ts
@@ -84,6 +84,7 @@ const config: TaskManagerConfig = {
   auto_calculate_default_ech_capacity: false,
   api_key_type: ApiKeyType.ES,
   grant_uiam_api_keys: false,
+  es_request_limits: { enabled: false },
 };
 
 describe('createAggregator', () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/configuration_statistics.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/configuration_statistics.test.ts
@@ -71,6 +71,7 @@ describe('Configuration Statistics Aggregator', () => {
       auto_calculate_default_ech_capacity: false,
       api_key_type: ApiKeyType.ES,
       grant_uiam_api_keys: false,
+      es_request_limits: { enabled: false },
     };
 
     return new Promise<void>(async (resolve, reject) => {

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.test.ts
@@ -76,6 +76,9 @@ const pluginInitializerContextParams = {
   auto_calculate_default_ech_capacity: false,
   api_key_type: ApiKeyType.ES,
   grant_uiam_api_keys: false,
+  es_request_limits: {
+    enabled: false,
+  },
 };
 
 describe('TaskManagerPlugin', () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -33,6 +33,7 @@ import {
 } from './kibana_discovery_service/delete_inactive_nodes_task';
 import { KibanaDiscoveryService } from './kibana_discovery_service';
 import { TaskPollingLifecycle } from './polling_lifecycle';
+import { EsRequestLimiter } from './es_request_limiter';
 import type { TaskManagerConfig } from './config';
 import type { Middleware } from './lib/middleware';
 import { createInitialMiddleware, addMiddlewareToChain } from './lib/middleware';
@@ -438,6 +439,17 @@ export class TaskManagerPlugin
 
     // Only poll for tasks if configured to run tasks
     if (this.shouldRunBackgroundTasks) {
+      // Limits the number of concurrent Elasticsearch requests running tasks may
+      // issue through RunContext.esClient. The cluster-wide budget is partitioned
+      // across active nodes using the live node count from the discovery service.
+      const esRequestLimiter = new EsRequestLimiter({
+        config: this.config.es_request_limits,
+        logger: this.logger,
+      });
+      this.numOfKibanaInstances$
+        .pipe(distinctUntilChanged())
+        .subscribe((numOfNodes) => esRequestLimiter.setActiveNodeCount(numOfNodes));
+
       this.taskManagerMetricsCollector = new TaskManagerMetricsCollector({
         logger: this.logger,
         store: taskStore,
@@ -466,6 +478,8 @@ export class TaskManagerPlugin
         apiKeyStrategy,
         eventLogger: this.taskEventLogger!,
         enrichFakeRequest,
+        clusterClient: elasticsearch.client,
+        esRequestLimiter,
       });
     }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -124,6 +124,7 @@ describe('TaskPollingLifecycle', () => {
       auto_calculate_default_ech_capacity: false,
       api_key_type: ApiKeyType.ES,
       grant_uiam_api_keys: false,
+      es_request_limits: { enabled: false },
     },
     taskStore: mockTaskStore,
     logger: taskManagerLogger,

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -12,8 +12,9 @@ import { pipe } from 'fp-ts/pipeable';
 import { map as mapOptional, none } from 'fp-ts/Option';
 import { tap } from 'rxjs';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
-import type { Logger, ExecutionContextStart } from '@kbn/core/server';
+import type { Logger, ExecutionContextStart, IClusterClient } from '@kbn/core/server';
 import type { FakeRequestEnricher } from '@kbn/core-security-server';
+import type { EsRequestLimiter } from './es_request_limiter';
 
 import type { Result } from './lib/result_type';
 import { asErr, mapErr, asOk, map, mapOk, isOk } from './lib/result_type';
@@ -84,6 +85,8 @@ export interface TaskPollingLifecycleOpts {
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
   enrichFakeRequest?: FakeRequestEnricher;
+  clusterClient?: IClusterClient;
+  esRequestLimiter?: EsRequestLimiter;
 }
 
 export type TaskLifecycleEvent =
@@ -126,6 +129,8 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
   private apiKeyStrategy: ApiKeyStrategy;
   private currentTmUtilization$ = new BehaviorSubject<number>(0);
   private enrichFakeRequest?: FakeRequestEnricher;
+  private clusterClient?: IClusterClient;
+  private esRequestLimiter?: EsRequestLimiter;
 
   private eventLogger: TaskEventLogger;
 
@@ -149,6 +154,8 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     apiKeyStrategy,
     eventLogger,
     enrichFakeRequest,
+    clusterClient,
+    esRequestLimiter,
   }: TaskPollingLifecycleOpts) {
     this.logger = logger;
     this.middleware = middleware;
@@ -159,6 +166,8 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     this.config = config;
     this.apiKeyStrategy = apiKeyStrategy;
     this.enrichFakeRequest = enrichFakeRequest;
+    this.clusterClient = clusterClient;
+    this.esRequestLimiter = esRequestLimiter;
     const { poll_interval: pollInterval, claim_strategy: claimStrategy } = config;
     this.currentPollInterval = pollInterval;
     this.eventLogger = eventLogger;
@@ -287,6 +296,8 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
       apiKeyStrategy: this.apiKeyStrategy,
       eventLogger: this.eventLogger,
       enrichFakeRequest: this.enrichFakeRequest,
+      clusterClient: this.clusterClient,
+      esRequestLimiter: this.esRequestLimiter,
     });
   };
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -10,7 +10,7 @@
 import type { ObjectType, TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { isNumber } from 'lodash';
-import type { KibanaRequest } from '@kbn/core/server';
+import type { IScopedClusterClient, KibanaRequest } from '@kbn/core/server';
 import type { IntervalSchedule, RruleSchedule } from '@kbn/response-ops-scheduling-types';
 import { isErr, tryAsResult } from './lib/result_type';
 import { isInterval, parseIntervalAsMillisecond } from './lib/intervals';
@@ -93,6 +93,16 @@ export interface RunContext {
    */
   fakeRequest?: KibanaRequest;
   abortController: AbortController;
+
+  /**
+   * A scoped Elasticsearch client provided by Task Manager. Requests made through
+   * it are subject to the configured Elasticsearch request concurrency limits
+   * (`xpack.task_manager.es_request_limits`). `asInternalUser` is always
+   * available; `asCurrentUser` / `asSecondaryAuthUser` are scoped to the task's
+   * API key and throw on use when the task was scheduled without one. Undefined
+   * when Task Manager could not construct a client for this run.
+   */
+  esClient?: IScopedClusterClient;
 
   /**
    * If the task has a known `profile_uid`, binds it to a child fake request
@@ -230,6 +240,22 @@ export const taskDefinitionSchema = schema.object(
     maxConcurrency: schema.maybe(
       schema.number({
         min: 0,
+      })
+    ),
+    /**
+     * Optional caps on the number of concurrent Elasticsearch requests issued
+     * through `RunContext.esClient`, per request category. The limits are
+     * cluster-wide and partitioned across active nodes, and are keyed by `scope`
+     * so multiple task types can share one budget (scope defaults to the task
+     * type when omitted). Task types that share a scope must declare identical
+     * limits. These layer on top of the cluster-wide category budgets configured
+     * via `xpack.task_manager.es_request_limits`.
+     */
+    esRequestLimits: schema.maybe(
+      schema.object({
+        scope: schema.maybe(schema.string()),
+        search: schema.maybe(schema.number({ min: 1 })),
+        write: schema.maybe(schema.number({ min: 1 })),
       })
     ),
     stateSchemaByVersion: schema.maybe(

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -242,22 +242,6 @@ export const taskDefinitionSchema = schema.object(
         min: 0,
       })
     ),
-    /**
-     * Optional caps on the number of concurrent Elasticsearch requests issued
-     * through `RunContext.esClient`, per request category. The limits are
-     * cluster-wide and partitioned across active nodes, and are keyed by `scope`
-     * so multiple task types can share one budget (scope defaults to the task
-     * type when omitted). Task types that share a scope must declare identical
-     * limits. These layer on top of the cluster-wide category budgets configured
-     * via `xpack.task_manager.es_request_limits`.
-     */
-    esRequestLimits: schema.maybe(
-      schema.object({
-        scope: schema.maybe(schema.string()),
-        search: schema.maybe(schema.number({ min: 1 })),
-        write: schema.maybe(schema.number({ min: 1 })),
-      })
-    ),
     stateSchemaByVersion: schema.maybe(
       schema.recordOf(
         schema.string(),

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -16,10 +16,12 @@ import { withActiveSpan } from '@kbn/tracing-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { addSpanLabels, withSpan } from '@kbn/apm-utils';
 import { flow, identity, omit } from 'lodash';
-import type { ExecutionContextStart, Logger } from '@kbn/core/server';
+import type { ExecutionContextStart, IClusterClient, Logger } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { FakeRequestEnricher } from '@kbn/core-security-server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
+import type { EsRequestLimiter } from '../es_request_limiter';
+import { buildTaskEsClient } from '../es_request_limiter';
 import { buildChildRequestEnricher, buildTaskFakeRequest } from './fake_request_factory';
 import type { Middleware } from '../lib/middleware';
 import type { Result } from '../lib/result_type';
@@ -133,6 +135,8 @@ type Opts = {
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
   enrichFakeRequest?: FakeRequestEnricher;
+  clusterClient?: IClusterClient;
+  esRequestLimiter?: EsRequestLimiter;
 } & Pick<Middleware, 'beforeRun' | 'beforeMarkRunning'>;
 
 export enum TaskRunResult {
@@ -191,6 +195,8 @@ export class TaskManagerRunner implements TaskRunner {
   private eventLogger: TaskEventLogger;
   private isCancelled = false;
   private readonly enrichFakeRequest?: FakeRequestEnricher;
+  private readonly clusterClient?: IClusterClient;
+  private readonly esRequestLimiter?: EsRequestLimiter;
 
   /**
    * Creates an instance of TaskManagerRunner.
@@ -220,6 +226,8 @@ export class TaskManagerRunner implements TaskRunner {
     apiKeyStrategy,
     eventLogger,
     enrichFakeRequest,
+    clusterClient,
+    esRequestLimiter,
   }: Opts) {
     this.instance = asPending(sanitizeInstance(instance));
     this.definitions = definitions;
@@ -243,6 +251,8 @@ export class TaskManagerRunner implements TaskRunner {
     this.apiKeyStrategy = apiKeyStrategy;
     this.eventLogger = eventLogger;
     this.enrichFakeRequest = enrichFakeRequest;
+    this.clusterClient = clusterClient;
+    this.esRequestLimiter = esRequestLimiter;
   }
 
   /**
@@ -466,9 +476,21 @@ export class TaskManagerRunner implements TaskRunner {
 
           const abortController = new AbortController();
 
+          const esClient =
+            this.clusterClient && this.esRequestLimiter
+              ? buildTaskEsClient({
+                  clusterClient: this.clusterClient,
+                  fakeRequest,
+                  limiter: this.esRequestLimiter,
+                  taskType: this.taskType,
+                  esRequestLimits: definition.esRequestLimits,
+                })
+              : undefined;
+
           this.task = definition.createTaskRunner({
             taskInstance: sanitizedTaskInstance,
             fakeRequest,
+            esClient,
             abortController,
             enrichRequest,
             executionUuid: this.uuid,

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -483,7 +483,6 @@ export class TaskManagerRunner implements TaskRunner {
                   fakeRequest,
                   limiter: this.esRequestLimiter,
                   taskType: this.taskType,
-                  esRequestLimits: definition.esRequestLimits,
                 })
               : undefined;
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.test.ts
@@ -389,5 +389,44 @@ describe('taskTypeDictionary', () => {
         `"Task type \\"sampleTaskSharedConcurrencyType2\\" shares concurrency limits with sampleTaskSharedConcurrencyType1 but has a different cost."`
       );
     });
+
+    it('allows task types to share an Elasticsearch request limits scope with identical limits', () => {
+      expect(() => {
+        definitions.registerTaskDefinitions({
+          esLimitA: {
+            title: 'A',
+            esRequestLimits: { scope: 'shared', search: 5 },
+            createTaskRunner: jest.fn(),
+          },
+          esLimitB: {
+            title: 'B',
+            esRequestLimits: { scope: 'shared', search: 5 },
+            createTaskRunner: jest.fn(),
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('throws when task types share an Elasticsearch request limits scope with different limits', () => {
+      definitions.registerTaskDefinitions({
+        esLimitA: {
+          title: 'A',
+          esRequestLimits: { scope: 'shared', search: 5 },
+          createTaskRunner: jest.fn(),
+        },
+      });
+
+      expect(() => {
+        definitions.registerTaskDefinitions({
+          esLimitB: {
+            title: 'B',
+            esRequestLimits: { scope: 'shared', search: 3 },
+            createTaskRunner: jest.fn(),
+          },
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"Task type \\"esLimitB\\" shares Elasticsearch request limits scope \\"shared\\" with \\"esLimitA\\" but declares different limits."`
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.test.ts
@@ -389,44 +389,5 @@ describe('taskTypeDictionary', () => {
         `"Task type \\"sampleTaskSharedConcurrencyType2\\" shares concurrency limits with sampleTaskSharedConcurrencyType1 but has a different cost."`
       );
     });
-
-    it('allows task types to share an Elasticsearch request limits scope with identical limits', () => {
-      expect(() => {
-        definitions.registerTaskDefinitions({
-          esLimitA: {
-            title: 'A',
-            esRequestLimits: { scope: 'shared', search: 5 },
-            createTaskRunner: jest.fn(),
-          },
-          esLimitB: {
-            title: 'B',
-            esRequestLimits: { scope: 'shared', search: 5 },
-            createTaskRunner: jest.fn(),
-          },
-        });
-      }).not.toThrow();
-    });
-
-    it('throws when task types share an Elasticsearch request limits scope with different limits', () => {
-      definitions.registerTaskDefinitions({
-        esLimitA: {
-          title: 'A',
-          esRequestLimits: { scope: 'shared', search: 5 },
-          createTaskRunner: jest.fn(),
-        },
-      });
-
-      expect(() => {
-        definitions.registerTaskDefinitions({
-          esLimitB: {
-            title: 'B',
-            esRequestLimits: { scope: 'shared', search: 3 },
-            createTaskRunner: jest.fn(),
-          },
-        });
-      }).toThrowErrorMatchingInlineSnapshot(
-        `"Task type \\"esLimitB\\" shares Elasticsearch request limits scope \\"shared\\" with \\"esLimitA\\" but declares different limits."`
-      );
-    });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.ts
@@ -104,6 +104,20 @@ export interface TaskRegisterDefinition {
    * The default value, if not given, is 0.
    */
   maxConcurrency?: number;
+  /**
+   * Optional caps on the number of concurrent Elasticsearch requests issued
+   * through `RunContext.esClient`, per request category. The limits are
+   * cluster-wide and partitioned across active nodes, and are keyed by `scope`
+   * so multiple task types can share one budget (scope defaults to the task type
+   * when omitted). Task types that share a scope must declare identical limits.
+   * These layer on top of the cluster-wide category budgets configured via
+   * `xpack.task_manager.es_request_limits`.
+   */
+  esRequestLimits?: {
+    scope?: string;
+    search?: number;
+    write?: number;
+  };
   stateSchemaByVersion?: Record<
     number,
     {
@@ -199,6 +213,13 @@ export class TaskTypeDictionary {
           taskDefinitions[taskType].cost
         );
       }
+
+      // Task types that share an Elasticsearch request limits scope must declare
+      // identical limits, since they draw from a single shared budget.
+      const esRequestLimits = taskDefinitions[taskType].esRequestLimits;
+      if (esRequestLimits?.scope) {
+        this.verifySharedEsRequestLimits(taskType, esRequestLimits, taskDefinitions);
+      }
     }
 
     try {
@@ -207,6 +228,33 @@ export class TaskTypeDictionary {
       }
     } catch (e) {
       this.logger.error(`Could not sanitize task definitions: ${e.message}`);
+    }
+  }
+
+  private verifySharedEsRequestLimits(
+    taskType: string,
+    limits: NonNullable<TaskRegisterDefinition['esRequestLimits']>,
+    batch: TaskDefinitionRegistry
+  ) {
+    const differs = (other?: TaskRegisterDefinition['esRequestLimits']) =>
+      other?.scope === limits.scope &&
+      (other?.search !== limits.search || other?.write !== limits.write);
+
+    const conflictMessage = (otherTaskType: string) =>
+      `Task type "${taskType}" shares Elasticsearch request limits scope "${limits.scope}" with "${otherTaskType}" but declares different limits.`;
+
+    // Check against already-registered task types.
+    for (const [otherTaskType, otherDef] of this.definitions) {
+      if (otherTaskType !== taskType && differs(otherDef.esRequestLimits)) {
+        throw new Error(conflictMessage(otherTaskType));
+      }
+    }
+
+    // Check against other task types being registered in the same batch.
+    for (const otherTaskType of Object.keys(batch)) {
+      if (otherTaskType !== taskType && differs(batch[otherTaskType].esRequestLimits)) {
+        throw new Error(conflictMessage(otherTaskType));
+      }
     }
   }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.ts
@@ -104,20 +104,6 @@ export interface TaskRegisterDefinition {
    * The default value, if not given, is 0.
    */
   maxConcurrency?: number;
-  /**
-   * Optional caps on the number of concurrent Elasticsearch requests issued
-   * through `RunContext.esClient`, per request category. The limits are
-   * cluster-wide and partitioned across active nodes, and are keyed by `scope`
-   * so multiple task types can share one budget (scope defaults to the task type
-   * when omitted). Task types that share a scope must declare identical limits.
-   * These layer on top of the cluster-wide category budgets configured via
-   * `xpack.task_manager.es_request_limits`.
-   */
-  esRequestLimits?: {
-    scope?: string;
-    search?: number;
-    write?: number;
-  };
   stateSchemaByVersion?: Record<
     number,
     {
@@ -213,13 +199,6 @@ export class TaskTypeDictionary {
           taskDefinitions[taskType].cost
         );
       }
-
-      // Task types that share an Elasticsearch request limits scope must declare
-      // identical limits, since they draw from a single shared budget.
-      const esRequestLimits = taskDefinitions[taskType].esRequestLimits;
-      if (esRequestLimits?.scope) {
-        this.verifySharedEsRequestLimits(taskType, esRequestLimits, taskDefinitions);
-      }
     }
 
     try {
@@ -228,33 +207,6 @@ export class TaskTypeDictionary {
       }
     } catch (e) {
       this.logger.error(`Could not sanitize task definitions: ${e.message}`);
-    }
-  }
-
-  private verifySharedEsRequestLimits(
-    taskType: string,
-    limits: NonNullable<TaskRegisterDefinition['esRequestLimits']>,
-    batch: TaskDefinitionRegistry
-  ) {
-    const differs = (other?: TaskRegisterDefinition['esRequestLimits']) =>
-      other?.scope === limits.scope &&
-      (other?.search !== limits.search || other?.write !== limits.write);
-
-    const conflictMessage = (otherTaskType: string) =>
-      `Task type "${taskType}" shares Elasticsearch request limits scope "${limits.scope}" with "${otherTaskType}" but declares different limits.`;
-
-    // Check against already-registered task types.
-    for (const [otherTaskType, otherDef] of this.definitions) {
-      if (otherTaskType !== taskType && differs(otherDef.esRequestLimits)) {
-        throw new Error(conflictMessage(otherTaskType));
-      }
-    }
-
-    // Check against other task types being registered in the same batch.
-    for (const otherTaskType of Object.keys(batch)) {
-      if (otherTaskType !== taskType && differs(batch[otherTaskType].esRequestLimits)) {
-        throw new Error(conflictMessage(otherTaskType));
-      }
     }
   }
 

--- a/x-pack/platform/test/plugin_api_integration/config.ts
+++ b/x-pack/platform/test/plugin_api_integration/config.ts
@@ -38,6 +38,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.eventLog.indexEntries=true',
         '--xpack.task_manager.monitored_aggregated_stats_refresh_rate=5000',
         '--xpack.task_manager.invalidate_api_key_task.removalDelay="1s"',
+        // Enable Elasticsearch request limits with small budgets so the
+        // es_request_limits integration test can exercise rejections. Only tasks
+        // that opt into RunContext.esClient are affected by these budgets.
+        '--xpack.task_manager.es_request_limits.enabled=true',
+        '--xpack.task_manager.es_request_limits.search.cluster_wide=2',
+        '--xpack.task_manager.es_request_limits.write.cluster_wide=2',
         `--xpack.stack_connectors.enableExperimental=${JSON.stringify([
           'crowdstrikeConnectorOn',
           'microsoftDefenderEndpointOn',

--- a/x-pack/platform/test/plugin_api_integration/config.ts
+++ b/x-pack/platform/test/plugin_api_integration/config.ts
@@ -40,10 +40,13 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.task_manager.invalidate_api_key_task.removalDelay="1s"',
         // Enable Elasticsearch request limits with small budgets so the
         // es_request_limits integration test can exercise rejections. Only tasks
-        // that opt into RunContext.esClient are affected by these budgets.
+        // that opt into RunContext.esClient are affected by these budgets. The
+        // per-scope sub-limit caps the hardcoded "sampleEsRequestScope" group
+        // (see es_request_scopes) below the category budget.
         '--xpack.task_manager.es_request_limits.enabled=true',
         '--xpack.task_manager.es_request_limits.search.cluster_wide=2',
         '--xpack.task_manager.es_request_limits.write.cluster_wide=2',
+        '--xpack.task_manager.es_request_limits.scopes.sampleEsRequestScope.search=1',
         `--xpack.stack_connectors.enableExperimental=${JSON.stringify([
           'crowdstrikeConnectorOn',
           'microsoftDefenderEndpointOn',

--- a/x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
+++ b/x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
@@ -7,7 +7,13 @@
 
 import { random } from 'lodash';
 import { schema } from '@kbn/config-schema';
-import type { Plugin, CoreSetup, CoreStart, KibanaRequest } from '@kbn/core/server';
+import type {
+  Plugin,
+  CoreSetup,
+  CoreStart,
+  KibanaRequest,
+  IScopedClusterClient,
+} from '@kbn/core/server';
 import { throwRetryableError } from '@kbn/task-manager-plugin/server/task_running';
 import { EventEmitter } from 'events';
 import { firstValueFrom, Subject } from 'rxjs';
@@ -559,6 +565,70 @@ export class SampleTaskManagerFixturePlugin
           },
         }),
       },
+      sampleTaskUsingLimitedEsClient: {
+        title: 'Sample Task Using Limited ES Client',
+        description:
+          'Fires concurrent Elasticsearch requests through RunContext.esClient to exercise the es_request_limits category budgets.',
+        timeout: '1m',
+        maxAttempts: 1,
+        createTaskRunner: ({ taskInstance, esClient }: RunContext) => ({
+          async run() {
+            const category = taskInstance.params.category === 'write' ? 'write' : 'search';
+            const totalRequests = taskInstance.params.totalRequests ?? 5;
+            const outcome = await runLimitedEsRequests({ esClient, category, totalRequests });
+
+            const [{ elasticsearch }] = await core.getStartServices();
+            await elasticsearch.client.asInternalUser.index({
+              index: '.kibana_task_manager_test_result',
+              document: {
+                type: 'es-limit-result',
+                taskId: taskInstance.id,
+                taskType: 'sampleTaskUsingLimitedEsClient',
+                category,
+                ...outcome,
+                ranAt: new Date(),
+              },
+              refresh: true,
+            });
+
+            return { state: {} };
+          },
+        }),
+      },
+      sampleTaskWithScopedEsRequestLimit: {
+        title: 'Sample Task With Scoped ES Request Limit',
+        description:
+          'Uses a per-scope es_request_limits sub-limit to cap concurrent search requests below the category budget.',
+        timeout: '1m',
+        maxAttempts: 1,
+        esRequestLimits: { scope: 'sampleScopedEsLimit', search: 1 },
+        createTaskRunner: ({ taskInstance, esClient }: RunContext) => ({
+          async run() {
+            const totalRequests = taskInstance.params.totalRequests ?? 3;
+            const outcome = await runLimitedEsRequests({
+              esClient,
+              category: 'search',
+              totalRequests,
+            });
+
+            const [{ elasticsearch }] = await core.getStartServices();
+            await elasticsearch.client.asInternalUser.index({
+              index: '.kibana_task_manager_test_result',
+              document: {
+                type: 'es-limit-result',
+                taskId: taskInstance.id,
+                taskType: 'sampleTaskWithScopedEsRequestLimit',
+                category: 'search',
+                ...outcome,
+                ranAt: new Date(),
+              },
+              refresh: true,
+            });
+
+            return { state: {} };
+          },
+        }),
+      },
     });
 
     const taskWithTiming = {
@@ -655,6 +725,64 @@ export class SampleTaskManagerFixturePlugin
     this.taskManagerStart$.complete();
   }
   public stop() {}
+}
+
+interface LimitedEsRequestsOutcome {
+  totalRequests: number;
+  succeeded: number;
+  rejected: number;
+  limitRejected: number;
+}
+
+/**
+ * Fires `totalRequests` concurrent Elasticsearch requests of the given category
+ * through the Task Manager provided (rate-limited) `RunContext.esClient` and
+ * tallies how many succeeded versus were rejected by the request limiter (which
+ * throws a 429-shaped error). Requests are issued synchronously before any
+ * awaits resolve, so the limiter's in-flight counter is deterministic.
+ */
+async function runLimitedEsRequests({
+  esClient,
+  category,
+  totalRequests,
+}: {
+  esClient?: IScopedClusterClient;
+  category: 'search' | 'write';
+  totalRequests: number;
+}): Promise<LimitedEsRequestsOutcome> {
+  if (!esClient) {
+    throw new Error(
+      'RunContext.esClient was not provided; xpack.task_manager.es_request_limits must be enabled'
+    );
+  }
+
+  const client = esClient.asInternalUser;
+  const issueOne = () =>
+    category === 'search'
+      ? client.search({ index: '.kibana_task_manager', size: 0 })
+      : client.index({
+          index: '.kibana_task_manager_test_result',
+          document: { type: 'es-limit-write-probe', ranAt: new Date() },
+          refresh: false,
+        });
+
+  const results = await Promise.allSettled(Array.from({ length: totalRequests }, () => issueOne()));
+
+  return results.reduce<LimitedEsRequestsOutcome>(
+    (outcome, result) => {
+      if (result.status === 'fulfilled') {
+        outcome.succeeded += 1;
+      } else {
+        outcome.rejected += 1;
+        const reason = result.reason as { statusCode?: number } | undefined;
+        if (reason?.statusCode === 429) {
+          outcome.limitRejected += 1;
+        }
+      }
+      return outcome;
+    },
+    { totalRequests, succeeded: 0, rejected: 0, limitRejected: 0 }
+  );
 }
 
 function millisecondsFromNow(ms: number) {

--- a/x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
+++ b/x-pack/platform/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
@@ -598,10 +598,9 @@ export class SampleTaskManagerFixturePlugin
       sampleTaskWithScopedEsRequestLimit: {
         title: 'Sample Task With Scoped ES Request Limit',
         description:
-          'Uses a per-scope es_request_limits sub-limit to cap concurrent search requests below the category budget.',
+          'Belongs to the hardcoded "sampleEsRequestScope" group so a configured per-scope es_request_limits sub-limit caps its concurrent search requests below the category budget.',
         timeout: '1m',
         maxAttempts: 1,
-        esRequestLimits: { scope: 'sampleScopedEsLimit', search: 1 },
         createTaskRunner: ({ taskInstance, esClient }: RunContext) => ({
           async run() {
             const totalRequests = taskInstance.params.totalRequests ?? 3;

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -34,6 +34,8 @@ export default function ({ getService }: FtrProviderContext) {
     'sampleRecurringTaskWhichHangs',
     'sampleRecurringTaskThatDeletesItself',
     'sampleTask',
+    'sampleTaskUsingLimitedEsClient',
+    'sampleTaskWithScopedEsRequestLimit',
     'sampleRecurringTask',
     'sampleTaskWithLimitedConcurrency',
     'sampleTaskWithSingleConcurrency',

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/es_request_limits.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/es_request_limits.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { estypes } from '@elastic/elasticsearch';
+import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import { scheduleTask } from './test_utils';
+
+const { properties: taskManagerIndexMapping } = TaskManagerMapping;
+
+interface EsLimitResult {
+  taskId: string;
+  taskType: string;
+  category: 'search' | 'write';
+  totalRequests: number;
+  succeeded: number;
+  rejected: number;
+  limitRejected: number;
+}
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const retry = getService('retry');
+  const supertest = getService('supertest');
+  const testHistoryIndex = '.kibana_task_manager_test_result';
+
+  // Budgets configured in the FTR config for a single-node cluster
+  // (xpack.task_manager.es_request_limits.{search,write}.cluster_wide = 2).
+  const CATEGORY_NODE_CEILING = 2;
+
+  async function getResult(taskId: string): Promise<EsLimitResult> {
+    const response = await es.search<EsLimitResult>({
+      index: testHistoryIndex,
+      query: {
+        bool: {
+          filter: [{ term: { type: 'es-limit-result' } }, { term: { taskId } }],
+        },
+      },
+    });
+    const hit = response.hits.hits[0];
+    expect(hit).to.be.ok();
+    return hit._source as EsLimitResult;
+  }
+
+  describe('es request limits', () => {
+    beforeEach(async () => {
+      const exists = await es.indices.exists({ index: testHistoryIndex });
+      if (exists) {
+        await es.deleteByQuery({
+          index: testHistoryIndex,
+          refresh: true,
+          query: { match_all: {} },
+        });
+      } else {
+        await es.indices.create({
+          index: testHistoryIndex,
+          mappings: {
+            properties: {
+              type: { type: 'keyword' },
+              taskId: { type: 'keyword' },
+              taskType: { type: 'keyword' },
+              category: { type: 'keyword' },
+              totalRequests: { type: 'long' },
+              succeeded: { type: 'long' },
+              rejected: { type: 'long' },
+              limitRejected: { type: 'long' },
+              params: taskManagerIndexMapping.params,
+              state: taskManagerIndexMapping.state,
+              runAt: taskManagerIndexMapping.runAt,
+            } as Record<string, estypes.MappingProperty>,
+          },
+        });
+      }
+    });
+
+    afterEach(async () => {
+      await supertest.delete('/api/sample_tasks').set('kbn-xsrf', 'xxx').expect(200);
+    });
+
+    it('rejects concurrent search requests over the category budget', async () => {
+      const task = await scheduleTask(supertest, {
+        taskType: 'sampleTaskUsingLimitedEsClient',
+        params: { category: 'search', totalRequests: 5 },
+      });
+
+      await retry.try(async () => {
+        const result = await getResult(task.id);
+        expect(result.totalRequests).to.eql(5);
+        expect(result.succeeded).to.eql(CATEGORY_NODE_CEILING);
+        expect(result.rejected).to.eql(5 - CATEGORY_NODE_CEILING);
+        // every rejection must be the limiter's 429-shaped error
+        expect(result.limitRejected).to.eql(result.rejected);
+      });
+    });
+
+    it('rejects concurrent write requests over the category budget', async () => {
+      const task = await scheduleTask(supertest, {
+        taskType: 'sampleTaskUsingLimitedEsClient',
+        params: { category: 'write', totalRequests: 5 },
+      });
+
+      await retry.try(async () => {
+        const result = await getResult(task.id);
+        expect(result.totalRequests).to.eql(5);
+        expect(result.succeeded).to.eql(CATEGORY_NODE_CEILING);
+        expect(result.rejected).to.eql(5 - CATEGORY_NODE_CEILING);
+        expect(result.limitRejected).to.eql(result.rejected);
+      });
+    });
+
+    it('allows concurrent requests within the category budget', async () => {
+      const task = await scheduleTask(supertest, {
+        taskType: 'sampleTaskUsingLimitedEsClient',
+        params: { category: 'search', totalRequests: CATEGORY_NODE_CEILING },
+      });
+
+      await retry.try(async () => {
+        const result = await getResult(task.id);
+        expect(result.totalRequests).to.eql(CATEGORY_NODE_CEILING);
+        expect(result.succeeded).to.eql(CATEGORY_NODE_CEILING);
+        expect(result.rejected).to.eql(0);
+        expect(result.limitRejected).to.eql(0);
+      });
+    });
+
+    it('enforces a per-scope sub-limit below the category budget', async () => {
+      // The scope declares a search sub-limit of 1, stricter than the category
+      // ceiling of 2, so only a single concurrent search should succeed.
+      const task = await scheduleTask(supertest, {
+        taskType: 'sampleTaskWithScopedEsRequestLimit',
+        params: { totalRequests: 3 },
+      });
+
+      await retry.try(async () => {
+        const result = await getResult(task.id);
+        expect(result.totalRequests).to.eql(3);
+        expect(result.succeeded).to.eql(1);
+        expect(result.rejected).to.eql(2);
+        expect(result.limitRejected).to.eql(2);
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/es_request_limits.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/es_request_limits.ts
@@ -129,8 +129,9 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('enforces a per-scope sub-limit below the category budget', async () => {
-      // The scope declares a search sub-limit of 1, stricter than the category
-      // ceiling of 2, so only a single concurrent search should succeed.
+      // The task type belongs to the hardcoded "sampleEsRequestScope" group,
+      // which the FTR config caps at a search sub-limit of 1 — stricter than the
+      // category ceiling of 2 — so only a single concurrent search should succeed.
       const task = await scheduleTask(supertest, {
         taskType: 'sampleTaskWithScopedEsRequestLimit',
         params: { totalRequests: 3 },

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/index.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/index.ts
@@ -20,6 +20,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./kibana_discovery_service'));
     loadTestFile(require.resolve('./task_partitions'));
     loadTestFile(require.resolve('./task_cost'));
+    loadTestFile(require.resolve('./es_request_limits'));
     loadTestFile(require.resolve('./task_event_log'));
 
     loadTestFile(require.resolve('./migrations'));


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism for Task Manager to cap the number of concurrent Elasticsearch requests that background tasks issue, protecting Elasticsearch from being overwhelmed by expensive queries while still running as many tasks as possible.

Tasks opt in by using a Task-Manager-provided, rate-limited `IScopedClusterClient` exposed on `RunContext.esClient`. Metered client methods (searches, writes) pass through a limiter before executing; when a budget is exhausted the call rejects with a 429-shaped `EsRequestLimitReachedError`, so the task fails fast (a normal failed execution consuming `maxAttempts`) instead of piling load onto Elasticsearch.

### How it works

- **Categorized budgets** — separate `search` and `write` concurrency budgets, configured via `xpack.task_manager.es_request_limits`.
- **Cluster-wide, partitioned** — each budget is a cluster-wide total; every node enforces its share (`floor(cluster_wide / activeNodeCount)`, min 1) using the live active-node count from the Kibana discovery service — no extra ES calls in the hot path.
- **Config-driven per-scope sub-limits** — a *scope* groups task types so a subset of tasks can be capped below the global budget. Scope membership is resolved from the **task type** via a hardcoded map (`server/es_request_limiter/es_request_scopes.ts`), so a group can be limited without depending on per-task-document data and without the owning team changing their task definitions. The limit *values* are operator-configured under `xpack.task_manager.es_request_limits.scopes.<scope>` and validated to be a known scope and `<=` the matching global category budget. A metered request must have capacity in both its category budget and its scope budget (both partitioned per node).
- **Seeded scopes** — `alerting` (`alerting:*` rule executors), `alerting_v2` (the `alerting_v2:rule_executor` ES|QL executor), and `actions` (`actions:*`). Adding or adjusting a group is a one-line map entry.
- **Fail-fast** — over-budget requests reject immediately, freeing the task pool slot; Task Manager's existing retry/backoff handles rescheduling.
- Disabled by default; only tasks that use `RunContext.esClient` are affected.

### Configuration

```yaml
xpack.task_manager.es_request_limits.enabled: true
xpack.task_manager.es_request_limits.search.cluster_wide: 50
xpack.task_manager.es_request_limits.write.cluster_wide: 50
# Optional per-scope sub-limits — each value must be <= the matching global category budget:
xpack.task_manager.es_request_limits.scopes.alerting.search: 20
xpack.task_manager.es_request_limits.scopes.alerting_v2.search: 15
xpack.task_manager.es_request_limits.scopes.actions.write: 10
```

## Testing

- Unit tests for the limiter, wrapped client, the scope resolver (`es_request_scopes`), the config schema (scope-name and `<=` global validation), and the task type dictionary.
- Plugin API integration coverage (`test_suites/task_manager/es_request_limits.ts`) exercising category budgets, within-budget success, and a config-driven per-scope sub-limit end-to-end against a real Kibana + ES.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

### Identify risks

- New config keys under `xpack.task_manager.es_request_limits` (including `scopes.<scope>.{search,write}`) — need cloud allowlisting / docker list review before use in Cloud.
- Feature is disabled by default and only affects tasks that opt into `RunContext.esClient`, so risk to existing tasks is minimal.
- Scope membership is a hardcoded task-type map, so adding or re-grouping a scope is a code change (by design, for reliability). Configured scope names are validated against that map, and each per-scope limit is validated not to exceed its global category budget.
- The per-node partitioning of a cluster-wide budget is approximate (based on the discovery service's active-node count); a stale count could over- or under-provision a node's share temporarily.
