### PR TITLE
[EDR Workflows] Enable CCS support for Elastic Defend with remote ES output

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -70,10 +70,10 @@ export const allowedExperimentalValues = Object.freeze({
 
   /**
    * Enables CCS prefixing of endpoint indices so a Defend agent shipping to a remote ES output
-   * (Fleet remote output) is visible from the managing cluster's Kibana. Off by default while
-   * we test impact on other features.
+   * (Fleet remote output) is visible from the managing cluster's Kibana.
+   * Release: 9.5
    */
-  defendRemoteOutputCcs: false,
+  defendRemoteOutputCcs: true,
 
   /**
    * Enables the Assistant Model Evaluation advanced setting and API endpoint, introduced in `8.11.0`.


### PR DESCRIPTION
Flips the `defendRemoteOutputCcs` experimental flag on by default, enabling the CCS read paths for Elastic Defend when an agent ships to a remote Elasticsearch output. The read-path awareness shipped behind this flag in #271559; this turns it on for 9.5. CCS is stateful-only, so on serverless / no-remote clusters it is a no-op (the flag gates a `_remote/info` check that finds no remotes).

<details>
<summary>LLM description</summary>

One-line change: `defendRemoteOutputCcs: false -> true` in `common/experimental_features.ts`. This lets `EndpointAppContextService.isCcsEnabled()` actually consult connected remotes (it short-circuits to `false` when the flag is off). Downstream, endpoint read paths (metadata list/by-id, response-action reads, policy responses, suggestions + endpoint fields, workflow insights) apply `prefixIndexPatternsWithCcs` only when a remote cluster is connected.

Depends on `elastic/endpoint-package#756` (the `*:` metadata_united transform, merged) for the endpoint list, and `elastic/elasticsearch#152211` (fleet-server-remote grants, merged) for response-action completion. No other refs to the flag; no test asserts its default; snapshots clean; the `isCcsEnabled` unit tests set the flag explicitly.

</details>
