### PR TITLE
[Osquery] Add pack export/import as JSON

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
@@ -32,8 +32,8 @@ export const allowedExperimentalValues = Object.freeze({
   exportResults: true,
   /**
    * Enables the per-pack "Export pack" row action in the Packs table, which
-   * serializes a pack to an osquery-standard `.conf` file and downloads it
-   * (round-trips through the existing pack importer). Read-only; requires only
+   * serializes a pack to a portable Kibana-pack `.json` file and downloads it
+   * (re-imports via the existing pack uploader). Read-only; requires only
    * pack read access.
    */
   exportPack: false,

--- a/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
@@ -31,6 +31,13 @@ export const allowedExperimentalValues = Object.freeze({
    */
   exportResults: true,
   /**
+   * Enables the per-pack "Export pack" row action in the Packs table, which
+   * serializes a pack to an osquery-standard `.conf` file and downloads it
+   * (round-trips through the existing pack importer). Read-only; requires only
+   * pack read access.
+   */
+  exportPack: false,
+  /**
    * Enables RFC 5545 RRULE-based recurrence scheduling for packs and pack queries
    * as an alternative to native interval-based scheduling. When enabled, the
    * pack form and pack query flyout expose a Schedule section, the API accepts

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
@@ -146,6 +146,23 @@ describe('RowActionsMenu', () => {
       expect(screen.getByText('Export')).toBeInTheDocument();
     });
 
+    it('renders the export item last, after edit/duplicate/delete', () => {
+      const onExport = jest.fn();
+      renderWithIntl(
+        React.createElement(RowActionsMenu, {
+          ...defaultProps,
+          exportAction: { onExport, label: 'Export' },
+        })
+      );
+      fireEvent.click(screen.getByLabelText('Actions for test-item'));
+
+      const labels = screen
+        .getAllByRole('menuitem')
+        .map((item) => item.textContent);
+
+      expect(labels).toEqual(['Edit', 'Duplicate', 'Delete', 'Export']);
+    });
+
     it('renders the export item even when canWrite is false (read-only operation)', () => {
       const onExport = jest.fn();
       renderWithIntl(

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
@@ -126,17 +126,20 @@ describe('RowActionsMenu', () => {
   });
 
   describe('export action', () => {
-    it('does not render an export item when onExport is not provided', () => {
+    it('does not render an export item when exportAction is not provided', () => {
       renderWithIntl(React.createElement(RowActionsMenu, defaultProps));
       fireEvent.click(screen.getByLabelText('Actions for test-item'));
 
       expect(screen.queryByText('Export')).not.toBeInTheDocument();
     });
 
-    it('renders an export item when onExport is provided', () => {
+    it('renders an export item when exportAction is provided', () => {
       const onExport = jest.fn();
       renderWithIntl(
-        React.createElement(RowActionsMenu, { ...defaultProps, onExport, exportLabel: 'Export' })
+        React.createElement(RowActionsMenu, {
+          ...defaultProps,
+          exportAction: { onExport, label: 'Export' },
+        })
       );
       fireEvent.click(screen.getByLabelText('Actions for test-item'));
 
@@ -149,8 +152,7 @@ describe('RowActionsMenu', () => {
         React.createElement(RowActionsMenu, {
           ...defaultProps,
           canWrite: false,
-          onExport,
-          exportLabel: 'Export',
+          exportAction: { onExport, label: 'Export' },
         })
       );
       fireEvent.click(screen.getByLabelText('Actions for test-item'));
@@ -162,7 +164,10 @@ describe('RowActionsMenu', () => {
     it('calls onExport when export is clicked', () => {
       const onExport = jest.fn();
       renderWithIntl(
-        React.createElement(RowActionsMenu, { ...defaultProps, onExport, exportLabel: 'Export' })
+        React.createElement(RowActionsMenu, {
+          ...defaultProps,
+          exportAction: { onExport, label: 'Export' },
+        })
       );
       fireEvent.click(screen.getByLabelText('Actions for test-item'));
       fireEvent.click(screen.getByText('Export'));

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
@@ -156,9 +156,7 @@ describe('RowActionsMenu', () => {
       );
       fireEvent.click(screen.getByLabelText('Actions for test-item'));
 
-      const labels = screen
-        .getAllByRole('menuitem')
-        .map((item) => item.textContent);
+      const labels = screen.getAllByRole('menuitem').map((item) => item.textContent);
 
       expect(labels).toEqual(['Edit', 'Duplicate', 'Delete', 'Export']);
     });

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.test.tsx
@@ -124,4 +124,50 @@ describe('RowActionsMenu', () => {
     expect(screen.queryByText('Delete this item?')).not.toBeInTheDocument();
     expect(defaultProps.onDelete).not.toHaveBeenCalled();
   });
+
+  describe('export action', () => {
+    it('does not render an export item when onExport is not provided', () => {
+      renderWithIntl(React.createElement(RowActionsMenu, defaultProps));
+      fireEvent.click(screen.getByLabelText('Actions for test-item'));
+
+      expect(screen.queryByText('Export')).not.toBeInTheDocument();
+    });
+
+    it('renders an export item when onExport is provided', () => {
+      const onExport = jest.fn();
+      renderWithIntl(
+        React.createElement(RowActionsMenu, { ...defaultProps, onExport, exportLabel: 'Export' })
+      );
+      fireEvent.click(screen.getByLabelText('Actions for test-item'));
+
+      expect(screen.getByText('Export')).toBeInTheDocument();
+    });
+
+    it('renders the export item even when canWrite is false (read-only operation)', () => {
+      const onExport = jest.fn();
+      renderWithIntl(
+        React.createElement(RowActionsMenu, {
+          ...defaultProps,
+          canWrite: false,
+          onExport,
+          exportLabel: 'Export',
+        })
+      );
+      fireEvent.click(screen.getByLabelText('Actions for test-item'));
+
+      expect(screen.getByText('Export')).toBeInTheDocument();
+      expect(screen.queryByText('Duplicate')).not.toBeInTheDocument();
+    });
+
+    it('calls onExport when export is clicked', () => {
+      const onExport = jest.fn();
+      renderWithIntl(
+        React.createElement(RowActionsMenu, { ...defaultProps, onExport, exportLabel: 'Export' })
+      );
+      fireEvent.click(screen.getByLabelText('Actions for test-item'));
+      fireEvent.click(screen.getByText('Export'));
+
+      expect(onExport).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.tsx
@@ -43,11 +43,11 @@ interface RowActionsMenuProps {
   /**
    * Optional export action. When provided, an "Export" item is rendered
    * regardless of write permissions (export is a read-only operation).
-   * Consumers that do not provide it (e.g. the saved-query list) render an
-   * unchanged menu.
+   * Grouping the handler and label into a single prop enforces the invariant
+   * that a label is always present whenever the action is enabled. Consumers
+   * that do not provide it (e.g. the saved-query list) render an unchanged menu.
    */
-  onExport?: () => void;
-  exportLabel?: string;
+  exportAction?: { onExport: () => void; label: string };
 }
 
 /**
@@ -69,8 +69,7 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
   onEdit,
   onDuplicate,
   onDelete,
-  onExport,
-  exportLabel,
+  exportAction,
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
@@ -101,8 +100,8 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
 
   const handleExportClick = useCallback(() => {
     closePopover();
-    onExport?.();
-  }, [closePopover, onExport]);
+    exportAction?.onExport();
+  }, [closePopover, exportAction]);
 
   const handleCloseDeleteModal = useCallback(() => {
     setIsDeleteModalVisible(false);
@@ -121,10 +120,10 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
       </EuiContextMenuItem>,
     ];
 
-    if (onExport) {
+    if (exportAction) {
       items.push(
         <EuiContextMenuItem key="export" icon="export" onClick={handleExportClick}>
-          {exportLabel}
+          {exportAction.label}
         </EuiContextMenuItem>
       );
     }
@@ -153,9 +152,8 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
     handleDeleteClick,
     canWrite,
     isReadOnly,
-    onExport,
+    exportAction,
     editLabel,
-    exportLabel,
     duplicateLabel,
     deleteLabel,
   ]);

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.tsx
@@ -40,6 +40,14 @@ interface RowActionsMenuProps {
   onEdit: () => void;
   onDuplicate: () => void;
   onDelete: () => Promise<unknown>;
+  /**
+   * Optional export action. When provided, an "Export" item is rendered
+   * regardless of write permissions (export is a read-only operation).
+   * Consumers that do not provide it (e.g. the saved-query list) render an
+   * unchanged menu.
+   */
+  onExport?: () => void;
+  exportLabel?: string;
 }
 
 /**
@@ -61,6 +69,8 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
   onEdit,
   onDuplicate,
   onDelete,
+  onExport,
+  exportLabel,
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
@@ -89,6 +99,11 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
     setIsDeleteModalVisible(true);
   }, [closePopover]);
 
+  const handleExportClick = useCallback(() => {
+    closePopover();
+    onExport?.();
+  }, [closePopover, onExport]);
+
   const handleCloseDeleteModal = useCallback(() => {
     setIsDeleteModalVisible(false);
   }, []);
@@ -105,6 +120,14 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
         {editLabel}
       </EuiContextMenuItem>,
     ];
+
+    if (onExport) {
+      items.push(
+        <EuiContextMenuItem key="export" icon="export" onClick={handleExportClick}>
+          {exportLabel}
+        </EuiContextMenuItem>
+      );
+    }
 
     if (canWrite) {
       items.push(
@@ -125,11 +148,14 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
     return items;
   }, [
     handleEditClick,
+    handleExportClick,
     handleDuplicateClick,
     handleDeleteClick,
     canWrite,
     isReadOnly,
+    onExport,
     editLabel,
+    exportLabel,
     duplicateLabel,
     deleteLabel,
   ]);

--- a/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/row_actions_menu.tsx
@@ -120,14 +120,6 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
       </EuiContextMenuItem>,
     ];
 
-    if (exportAction) {
-      items.push(
-        <EuiContextMenuItem key="export" icon="export" onClick={handleExportClick}>
-          {exportAction.label}
-        </EuiContextMenuItem>
-      );
-    }
-
     if (canWrite) {
       items.push(
         <EuiContextMenuItem key="duplicate" icon="copy" onClick={handleDuplicateClick}>
@@ -142,6 +134,14 @@ const RowActionsMenuComponent: React.FC<RowActionsMenuProps> = ({
           </EuiContextMenuItem>
         );
       }
+    }
+
+    if (exportAction) {
+      items.push(
+        <EuiContextMenuItem key="export" icon="export" onClick={handleExportClick}>
+          {exportAction.label}
+        </EuiContextMenuItem>
+      );
     }
 
     return items;

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/index.tsx
@@ -455,7 +455,7 @@ const PackFormComponent: React.FC<PackFormProps> = ({
 
         <EuiHorizontalRule />
 
-        <QueriesField euiFieldProps={euiFieldProps} />
+        <QueriesField euiFieldProps={euiFieldProps} editMode={editMode} />
       </FormProvider>
       <EuiSpacer size="xxl" />
       <EuiSpacer size="xxl" />

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.test.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { serializePack, packExportFilename, downloadPackAsJson } from './pack_serializer';
+
+// URL.revokeObjectURL is absent from jsdom; install a no-op so the deferred
+// revocation in downloadPackAsJson doesn't throw. (createObjectURL exists but
+// is non-configurable, so we don't touch it — see the download test note.)
+if (typeof URL.revokeObjectURL !== 'function') {
+  (URL as unknown as Record<string, unknown>).revokeObjectURL = jest.fn();
+}
+
+/**
+ * The public packs API shape the Packs table actually holds (verified at
+ * runtime): `queries` is an ARRAY, the query name lives in `id`, `ecs_mapping`
+ * is an ARRAY of `{ key, value }`, and cluster-internal fields (schedule_id,
+ * start_date, policy_ids, shards) ride along. This is the primary fixture — the
+ * exporter must read exactly this and drop the cluster-specific fields.
+ */
+const buildApiPack = (overrides: Record<string, unknown> = {}) =>
+  ({
+    saved_object_id: 'so-id-1',
+    name: 'my-pack',
+    description: 'a pack',
+    enabled: true,
+    created_at: '2026-07-07T00:00:00.000Z',
+    created_by: 'elastic',
+    updated_at: '2026-07-07T00:00:00.000Z',
+    updated_by: 'elastic',
+    policy_ids: ['policy-1'],
+    shards: [],
+    queries: [
+      {
+        id: 'processes_elastic',
+        query: 'SELECT  *   FROM processes;',
+        interval: 60,
+        platform: 'linux',
+        ecs_mapping: [{ key: 'process.pid', value: { field: 'pid' } }],
+        schedule_id: 'sched-abc',
+        start_date: '2026-07-07T00:00:00.000Z',
+      },
+    ],
+    ...overrides,
+  } as any);
+
+describe('pack_serializer', () => {
+  describe('serializePack — pack metadata', () => {
+    it('emits the pack name and description', () => {
+      const exported = serializePack(buildApiPack());
+      expect(exported.name).toBe('my-pack');
+      expect(exported.description).toBe('a pack');
+    });
+
+    it('omits description when absent', () => {
+      const exported = serializePack(buildApiPack({ description: undefined }));
+      expect(exported).not.toHaveProperty('description');
+    });
+
+    it('never emits `enabled` (imported packs land disabled)', () => {
+      const exported = serializePack(buildApiPack());
+      expect(exported).not.toHaveProperty('enabled');
+      expect(JSON.stringify(exported)).not.toContain('enabled');
+    });
+
+    it('carries an rrule pack-level schedule when present', () => {
+      const rrule = { rrule: 'FREQ=DAILY', start_date: '2026-07-07T00:00:00.000Z' };
+      const exported = serializePack(
+        buildApiPack({ schedule_type: 'rrule', rrule_schedule: rrule })
+      );
+      expect(exported.schedule_type).toBe('rrule');
+      expect(exported.rrule_schedule).toEqual(rrule);
+      expect(exported).not.toHaveProperty('interval');
+    });
+
+    it('carries an interval pack-level schedule when present', () => {
+      const exported = serializePack(buildApiPack({ schedule_type: 'interval', interval: 900 }));
+      expect(exported.schedule_type).toBe('interval');
+      expect(exported.interval).toBe(900);
+      expect(exported).not.toHaveProperty('rrule_schedule');
+    });
+
+    it('omits pack-level schedule when the pack has none', () => {
+      const exported = serializePack(buildApiPack());
+      expect(exported).not.toHaveProperty('schedule_type');
+      expect(exported).not.toHaveProperty('rrule_schedule');
+      expect(exported).not.toHaveProperty('interval');
+    });
+
+    it('drops cluster-specific and saved-object fields', () => {
+      const serialized = JSON.stringify(serializePack(buildApiPack()));
+      [
+        'saved_object_id',
+        'policy_ids',
+        'shards',
+        'created_at',
+        'created_by',
+        'updated_at',
+        'updated_by',
+        'schedule_id',
+        'start_date',
+        // top-level keys only: name/description/queries.
+      ].forEach((field) => {
+        expect(serialized).not.toContain(field);
+      });
+      expect(Object.keys(serializePack(buildApiPack())).sort()).toEqual([
+        'description',
+        'name',
+        'queries',
+      ]);
+    });
+  });
+
+  describe('serializePack — queries (public-API array shape)', () => {
+    it('keys queries by the query NAME (from id), not the array index', () => {
+      const exported = serializePack(buildApiPack());
+      expect(Object.keys(exported.queries)).toEqual(['processes_elastic']);
+      expect(exported.queries.processes_elastic.query).toBe('SELECT  *   FROM processes;');
+    });
+
+    it('emits interval as a number', () => {
+      const exported = serializePack(buildApiPack());
+      expect(exported.queries.processes_elastic.interval).toBe(60);
+      expect(typeof exported.queries.processes_elastic.interval).toBe('number');
+    });
+
+    it('converts ecs_mapping array back to the osquery object form', () => {
+      const exported = serializePack(buildApiPack());
+      expect(exported.queries.processes_elastic.ecs_mapping).toEqual({
+        'process.pid': { field: 'pid' },
+      });
+    });
+
+    it('carries timeout, snapshot, and removed when present', () => {
+      const exported = serializePack(
+        buildApiPack({
+          queries: [
+            {
+              id: 'q',
+              query: 'SELECT 1;',
+              interval: 30,
+              timeout: 120,
+              snapshot: false,
+              removed: true,
+            },
+          ],
+        })
+      );
+      expect(exported.queries.q).toMatchObject({ timeout: 120, snapshot: false, removed: true });
+    });
+
+    it('omits platform, version, and ecs_mapping when absent', () => {
+      const exported = serializePack(
+        buildApiPack({ queries: [{ id: 'minimal', query: 'SELECT 1;', interval: 30 }] })
+      );
+      expect(exported.queries.minimal).toEqual({ query: 'SELECT 1;', interval: 30 });
+    });
+
+    it('omits an empty ecs_mapping array', () => {
+      const exported = serializePack(
+        buildApiPack({ queries: [{ id: 'q', query: 'SELECT 1;', interval: 30, ecs_mapping: [] }] })
+      );
+      expect(exported.queries.q).not.toHaveProperty('ecs_mapping');
+    });
+
+    it('serializes every query in a multi-query pack', () => {
+      const exported = serializePack(
+        buildApiPack({
+          queries: [
+            { id: 'a', query: 'SELECT 1;', interval: 10 },
+            { id: 'b', query: 'SELECT 2;', interval: 20 },
+          ],
+        })
+      );
+      expect(Object.keys(exported.queries)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('serializePack — name-keyed object fallback', () => {
+    it('handles the saved-object object shape with object ecs_mapping', () => {
+      const exported = serializePack({
+        name: 'obj-pack',
+
+        queries: {
+          processes: {
+            query: 'SELECT * FROM processes;',
+            interval: '60',
+            platform: 'linux',
+            ecs_mapping: { 'process.pid': { field: 'pid' } },
+          },
+        } as any,
+      });
+      expect(Object.keys(exported.queries)).toEqual(['processes']);
+      expect(exported.queries.processes.interval).toBe(60);
+      expect(exported.queries.processes.ecs_mapping).toEqual({ 'process.pid': { field: 'pid' } });
+    });
+  });
+
+  describe('packExportFilename', () => {
+    it('derives a .json filename from the pack name, preserving hyphens', () => {
+      expect(packExportFilename('my-pack')).toBe('my-pack.json');
+    });
+
+    it('replaces spaces', () => {
+      expect(packExportFilename('My Test Pack')).toBe('My_Test_Pack.json');
+    });
+
+    it('replaces illegal filesystem characters (trailing separator trimmed)', () => {
+      expect(packExportFilename('a/b:c*d?')).toBe('a_b_c_d.json');
+    });
+
+    it('handles unicode names without producing an empty filename', () => {
+      const result = packExportFilename('パック');
+      expect(result.endsWith('.json')).toBe(true);
+      expect(result).not.toBe('.json');
+    });
+
+    it('falls back for an empty or all-illegal name', () => {
+      expect(packExportFilename('')).toBe('pack.json');
+      expect(packExportFilename('///')).toBe('pack.json');
+    });
+  });
+
+  describe('downloadPackAsJson', () => {
+    let clickSpy: jest.Mock;
+    let anchor: Partial<HTMLAnchorElement>;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.useFakeTimers();
+
+      clickSpy = jest.fn();
+      anchor = { href: '', download: '', click: clickSpy };
+
+      const originalCreateElement = document.createElement.bind(document);
+      jest
+        .spyOn(document, 'createElement')
+        .mockImplementation((tag: string, options?: ElementCreationOptions) => {
+          if (tag === 'a') return anchor as HTMLAnchorElement;
+
+          return originalCreateElement(tag, options);
+        });
+      jest.spyOn(document.body, 'appendChild').mockImplementation((n) => n);
+      jest.spyOn(document.body, 'removeChild').mockImplementation((n) => n);
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    // URL.createObjectURL is non-configurable in jest jsdom setup, so download
+    // behavior is verified through the anchor element, not the URL API (matches
+    // results/use_export_results.test.ts).
+    it('triggers an anchor download named after the pack (.json)', () => {
+      downloadPackAsJson(buildApiPack({ name: 'My Pack' }));
+
+      expect(anchor.download).toBe('My_Pack.json');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.test.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { serializePack, packExportFilename, downloadPackAsJson } from './pack_serializer';
+import {
+  serializePack,
+  packExportFilename,
+  downloadPackAsJson,
+  DEFAULT_PACK_QUERY_INTERVAL_SECONDS,
+} from './pack_serializer';
 
 // URL.revokeObjectURL is absent from jsdom; install a no-op so the deferred
 // revocation in downloadPackAsJson doesn't throw. (createObjectURL exists but
@@ -118,6 +123,10 @@ describe('pack_serializer', () => {
     it('keys queries by the query NAME (from id), not the array index', () => {
       const exported = serializePack(buildApiPack());
       expect(Object.keys(exported.queries)).toEqual(['processes_elastic']);
+      // Query text is copied VERBATIM on export — internal whitespace is not
+      // collapsed. The uploader reviver preserves it on the way back in, so the
+      // multi-space SQL is a fixed point across export→import (round-trip proven
+      // end-to-end in queries_field.test.tsx).
       expect(exported.queries.processes_elastic.query).toBe('SELECT  *   FROM processes;');
     });
 
@@ -177,6 +186,35 @@ describe('pack_serializer', () => {
       );
       expect(Object.keys(exported.queries)).toEqual(['a', 'b']);
     });
+
+    it('preserves internal query whitespace verbatim (no collapsing on export)', () => {
+      const exported = serializePack(
+        buildApiPack({
+          queries: [{ id: 'ws', query: 'SELECT   a,    b   FROM   t;', interval: 30 }],
+        })
+      );
+      expect(exported.queries.ws.query).toBe('SELECT   a,    b   FROM   t;');
+    });
+
+    it('falls back to the default interval when a query interval is unparsable', () => {
+      const exported = serializePack(
+        buildApiPack({ queries: [{ id: 'q', query: 'SELECT 1;', interval: 'not-a-number' }] })
+      );
+      expect(exported.queries.q.interval).toBe(DEFAULT_PACK_QUERY_INTERVAL_SECONDS);
+    });
+  });
+
+  describe('serializePack — empty / zero-query packs', () => {
+    it('returns an empty queries object for the array form (queries: [])', () => {
+      const exported = serializePack(buildApiPack({ queries: [] }));
+      expect(exported.queries).toEqual({});
+      expect(exported.name).toBe('my-pack');
+    });
+
+    it('returns an empty queries object for the object form (queries: {})', () => {
+      const exported = serializePack({ name: 'empty', queries: {} });
+      expect(exported).toEqual({ name: 'empty', queries: {} });
+    });
   });
 
   describe('serializePack — name-keyed object fallback', () => {
@@ -221,6 +259,45 @@ describe('pack_serializer', () => {
     it('falls back for an empty or all-illegal name', () => {
       expect(packExportFilename('')).toBe('pack.json');
       expect(packExportFilename('///')).toBe('pack.json');
+    });
+
+    it('prefixes Windows-reserved device names so they are no longer reserved', () => {
+      expect(packExportFilename('CON')).toBe('_CON.json');
+      expect(packExportFilename('COM1')).toBe('_COM1.json');
+      expect(packExportFilename('NUL')).toBe('_NUL.json');
+      // Case-insensitive.
+      expect(packExportFilename('con')).toBe('_con.json');
+      expect(packExportFilename('lpt9')).toBe('_lpt9.json');
+    });
+
+    it('does not prefix names that merely start with a reserved token', () => {
+      // `console` is not a reserved device name.
+      expect(packExportFilename('console')).toBe('console.json');
+    });
+
+    it('strips control characters including NUL', () => {
+      // NUL (0x00), unit separator (0x1F), and DEL (0x7F) interleaved with text.
+      const NUL = String.fromCharCode(0x00);
+      const US = String.fromCharCode(0x1f);
+      const DEL = String.fromCharCode(0x7f);
+      const result = packExportFilename(`a${NUL}b${US}c${DEL}d`);
+      // Each control char is replaced with `_`.
+      expect(result).toBe('a_b_c_d.json');
+      // No raw control char (0x00-0x1F, 0x7F-0x9F) leaks into the filename.
+      const hasControlChar = result.split('').some((ch) => {
+        const code = ch.charCodeAt(0);
+
+        return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+      });
+      expect(hasControlChar).toBe(false);
+    });
+
+    it('caps the base length so the final filename stays under the filesystem limit', () => {
+      const longName = 'a'.repeat(500);
+      const result = packExportFilename(longName);
+      const base = result.replace(/\.json$/, '');
+      expect(base.length).toBeLessThanOrEqual(200);
+      expect(result.endsWith('.json')).toBe(true);
     });
   });
 

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ECSMapping } from '@kbn/osquery-io-ts-types';
+import type { RRuleScheduleConfig, ScheduleType } from '../../../common/schedule';
+
+/**
+ * A single query as it appears on a pack fetched from the public packs API and
+ * held by the Packs table. Note this is NOT the saved-object *type*: the public
+ * API returns `queries` as an ARRAY where the query name lives in `id`, and
+ * `ecs_mapping` as an ARRAY of `{ key, value }` (not the osquery object form).
+ * This shape is the ground truth the exporter reads — verified at runtime. All
+ * fields are optional/loose because the static `PackSavedObject` type does not
+ * match this runtime shape; the serializer narrows defensively.
+ */
+interface ApiPackQuery {
+  id?: string;
+  query?: string;
+  interval?: number | string;
+  timeout?: number;
+  platform?: string | string[];
+  version?: string | string[];
+  snapshot?: boolean;
+  removed?: boolean;
+  ecs_mapping?: ECSMapping | Array<{ key: string; value: ECSMapping[string] }>;
+  [key: string]: unknown;
+}
+
+/**
+ * The exporter reads a pack's `name`, `description`, and `queries`. `queries` is
+ * typed loosely (array or record) so callers can pass their real
+ * `PackSavedObject` / `PackItem` without a cast — the static SO type declares
+ * `queries` as a name-keyed record, but at runtime the public API delivers an
+ * array (name in `id`). Both are handled at runtime.
+ */
+interface ExportablePack {
+  name: string;
+  description?: string;
+  queries: unknown;
+  // Pack-level schedule. Only present when the `rruleScheduling` feature is on
+  // (the read API strips it otherwise), so "export when present" is self-gating.
+  schedule_type?: ScheduleType;
+  interval?: number;
+  rrule_schedule?: RRuleScheduleConfig;
+}
+
+/**
+ * A single query in an exported pack. `interval` is emitted as a number and
+ * `ecs_mapping` in the osquery object form. Cluster-internal / saved-object
+ * fields (id, schedule_id, start_date, policy references, …) are never included.
+ */
+export interface ExportedPackQuery {
+  query: string;
+  interval: number;
+  timeout?: number;
+  platform?: string;
+  version?: string;
+  snapshot?: boolean;
+  removed?: boolean;
+  ecs_mapping?: ECSMapping;
+}
+
+/**
+ * A pack exported as portable Kibana-pack JSON. Carries the pack `name` and
+ * `description` so it can be reconstructed 1:1 on another cluster, plus the
+ * queries keyed by name. Deliberately omits `enabled` (imported packs land
+ * disabled) and all cluster-specific data (policy_ids, shards, internal IDs).
+ */
+export interface ExportedPack {
+  name: string;
+  description?: string;
+  /**
+   * Pack-level schedule, carried only when the source pack has one (i.e. the
+   * `rruleScheduling` feature is enabled and a pack-level schedule is set).
+   * `rrule` packs carry `rrule_schedule`; `interval` packs carry `interval`.
+   */
+  schedule_type?: ScheduleType;
+  interval?: number;
+  rrule_schedule?: RRuleScheduleConfig;
+  queries: Record<string, ExportedPackQuery>;
+}
+
+/**
+ * Normalize `ecs_mapping` to the osquery object form `{ <ecs-field>: { … } }`.
+ * The public API returns it as an array of `{ key, value }`; the object form is
+ * passed through unchanged. Returns undefined when empty so the field is omitted.
+ */
+const normalizeEcsMapping = (ecsMapping: ApiPackQuery['ecs_mapping']): ECSMapping | undefined => {
+  if (!ecsMapping) {
+    return undefined;
+  }
+
+  if (Array.isArray(ecsMapping)) {
+    if (!ecsMapping.length) {
+      return undefined;
+    }
+
+    return ecsMapping.reduce<ECSMapping>((acc, { key, value }) => {
+      if (key) {
+        acc[key] = value;
+      }
+
+      return acc;
+    }, {});
+  }
+
+  return Object.keys(ecsMapping).length ? ecsMapping : undefined;
+};
+
+const serializeQuery = (name: string, source: ApiPackQuery): [string, ExportedPackQuery] => {
+  // `interval` may be a number (public API) or a string (saved object); the
+  // exported form uses a number.
+  const parsedInterval =
+    typeof source.interval === 'number' ? source.interval : parseInt(`${source.interval}`, 10);
+
+  const query: ExportedPackQuery = {
+    query: source.query ?? '',
+    interval: Number.isFinite(parsedInterval) ? parsedInterval : 3600,
+  };
+
+  if (typeof source.timeout === 'number') {
+    query.timeout = source.timeout;
+  }
+
+  if (source.platform) {
+    query.platform = Array.isArray(source.platform) ? source.platform.join(',') : source.platform;
+  }
+
+  if (source.version) {
+    query.version = Array.isArray(source.version) ? source.version[0] : source.version;
+  }
+
+  if (typeof source.snapshot === 'boolean') {
+    query.snapshot = source.snapshot;
+  }
+
+  if (typeof source.removed === 'boolean') {
+    query.removed = source.removed;
+  }
+
+  const ecsMapping = normalizeEcsMapping(source.ecs_mapping);
+  if (ecsMapping) {
+    query.ecs_mapping = ecsMapping;
+  }
+
+  return [name, query];
+};
+
+/**
+ * Serialize a pack into portable Kibana-pack JSON.
+ *
+ * Emits `name`, `description` (when present), and `queries` keyed by the query
+ * NAME. Reads whichever query shape the pack carries — the public-API array
+ * (name in `id`) or the name-keyed object — converts `ecs_mapping` to the
+ * osquery object form and `interval` to a number, and drops all
+ * cluster-internal / saved-object fields (and `enabled`) by construction: we
+ * only ever copy the portable fields onto the output.
+ */
+export const serializePack = (pack: ExportablePack): ExportedPack => {
+  const entries = Array.isArray(pack.queries)
+    ? // Public-API array form: the query name lives in `id`.
+      (pack.queries as ApiPackQuery[]).map((q, index) => serializeQuery(q.id ?? `${index}`, q))
+    : // Name-keyed object form (saved object / internal API).
+      Object.entries((pack.queries ?? {}) as Record<string, ApiPackQuery>).map(([name, q]) =>
+        serializeQuery(name, q)
+      );
+
+  const exported: ExportedPack = {
+    name: pack.name,
+    queries: Object.fromEntries(entries),
+  };
+
+  if (pack.description) {
+    exported.description = pack.description;
+  }
+
+  // Pack-level schedule — carry it through 1:1 when present. It only appears on
+  // the source pack when `rruleScheduling` is enabled, so this is dormant until
+  // that feature ships.
+  if (pack.schedule_type === 'rrule' && pack.rrule_schedule) {
+    exported.schedule_type = 'rrule';
+    exported.rrule_schedule = pack.rrule_schedule;
+  } else if (pack.schedule_type === 'interval' && pack.interval != null) {
+    exported.schedule_type = 'interval';
+    exported.interval = pack.interval;
+  }
+
+  return exported;
+};
+
+const FILENAME_FALLBACK = 'pack';
+
+// Windows-reserved chars, path separators, and any whitespace/control char.
+const ILLEGAL_FILENAME_CHARS = /[<>:"/\\|?*\s]/g;
+
+/**
+ * Derive a safe, cross-platform `.json` filename from a pack name. Illegal
+ * filesystem characters and whitespace are replaced with `_`; surrounding dots
+ * and underscores are trimmed; an empty result falls back to a stable default
+ * so the download is never empty or misleading.
+ */
+export const packExportFilename = (name: string): string => {
+  const base = (name ?? '').replace(ILLEGAL_FILENAME_CHARS, '_').replace(/^[._]+|[._]+$/g, '');
+
+  return `${base || FILENAME_FALLBACK}.json`;
+};
+
+/**
+ * Serialize a pack and trigger a browser download of the `.json` file. Uses the
+ * same anchor + `URL.createObjectURL` pattern (with deferred revocation) as
+ * `results/use_export_results.ts` to avoid a race where the object URL is
+ * revoked before the browser starts the download. Does not navigate away.
+ */
+export const downloadPackAsJson = (pack: ExportablePack): void => {
+  const exported = serializePack(pack);
+  const blob = new Blob([JSON.stringify(exported, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = packExportFilename(pack.name);
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  // Defer revocation so the browser can pick up the URL before we drop it
+  // (Safari / older Chromium schedule the download asynchronously).
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_serializer.ts
@@ -9,13 +9,23 @@ import type { ECSMapping } from '@kbn/osquery-io-ts-types';
 import type { RRuleScheduleConfig, ScheduleType } from '../../../common/schedule';
 
 /**
- * A single query as it appears on a pack fetched from the public packs API and
- * held by the Packs table. Note this is NOT the saved-object *type*: the public
- * API returns `queries` as an ARRAY where the query name lives in `id`, and
- * `ecs_mapping` as an ARRAY of `{ key, value }` (not the osquery object form).
- * This shape is the ground truth the exporter reads — verified at runtime. All
- * fields are optional/loose because the static `PackSavedObject` type does not
- * match this runtime shape; the serializer narrows defensively.
+ * Default query interval (seconds) applied when a pack query carries no parsable
+ * interval. Mirrors the osquery scheduling default of one hour.
+ */
+export const DEFAULT_PACK_QUERY_INTERVAL_SECONDS = 3600;
+
+/**
+ * AUTHORITATIVE NOTE ON QUERY SHAPES.
+ *
+ * A pack's `queries` arrive in one of two shapes, and BOTH are live:
+ *  - the public-API ARRAY form (the `find` route) where the query name lives in
+ *    `id` and `ecs_mapping` is an ARRAY of `{ key, value }`; and
+ *  - the name-keyed RECORD form (the saved-object `read` route / internal API)
+ *    where the key is the query name and `ecs_mapping` is the osquery object.
+ *
+ * Neither branch is dead code. The serializer detects the shape at runtime and
+ * narrows defensively — the static `PackSavedObject` type does not match the
+ * runtime array shape, so `ApiPackQuery` fields are kept optional/loose.
  */
 interface ApiPackQuery {
   id?: string;
@@ -27,20 +37,18 @@ interface ApiPackQuery {
   snapshot?: boolean;
   removed?: boolean;
   ecs_mapping?: ECSMapping | Array<{ key: string; value: ECSMapping[string] }>;
-  [key: string]: unknown;
 }
 
 /**
  * The exporter reads a pack's `name`, `description`, and `queries`. `queries` is
- * typed loosely (array or record) so callers can pass their real
- * `PackSavedObject` / `PackItem` without a cast — the static SO type declares
- * `queries` as a name-keyed record, but at runtime the public API delivers an
- * array (name in `id`). Both are handled at runtime.
+ * typed as either shape (see the authoritative note above) so callers can pass
+ * their real `PackSavedObject` / `PackItem` — `Array.isArray` narrows the union
+ * at runtime instead of relying on a blind cast.
  */
 interface ExportablePack {
   name: string;
   description?: string;
-  queries: unknown;
+  queries: ApiPackQuery[] | Record<string, ApiPackQuery>;
   // Pack-level schedule. Only present when the `rruleScheduling` feature is on
   // (the read API strips it otherwise), so "export when present" is self-gating.
   schedule_type?: ScheduleType;
@@ -65,10 +73,12 @@ export interface ExportedPackQuery {
 }
 
 /**
- * A pack exported as portable Kibana-pack JSON. Carries the pack `name` and
- * `description` so it can be reconstructed 1:1 on another cluster, plus the
- * queries keyed by name. Deliberately omits `enabled` (imported packs land
- * disabled) and all cluster-specific data (policy_ids, shards, internal IDs).
+ * A pack exported as portable Kibana-pack JSON. Round-trips the portable fields
+ * (name / description / queries / schedule); cluster-specific state and
+ * enablement are reassigned on import. The export is intentionally lossy: it
+ * omits `enabled` (the importer force-sets imported packs to disabled),
+ * `policy_ids`, `shards`, and all internal IDs, and narrows a query's `version`
+ * array to its first element.
  */
 export interface ExportedPack {
   name: string;
@@ -119,7 +129,9 @@ const serializeQuery = (name: string, source: ApiPackQuery): [string, ExportedPa
 
   const query: ExportedPackQuery = {
     query: source.query ?? '',
-    interval: Number.isFinite(parsedInterval) ? parsedInterval : 3600,
+    interval: Number.isFinite(parsedInterval)
+      ? parsedInterval
+      : DEFAULT_PACK_QUERY_INTERVAL_SECONDS,
   };
 
   if (typeof source.timeout === 'number') {
@@ -131,6 +143,8 @@ const serializeQuery = (name: string, source: ApiPackQuery): [string, ExportedPa
   }
 
   if (source.version) {
+    // By design we export a single osquery version (version is conventionally a
+    // scalar minimum), so an array source is narrowed to its first element.
     query.version = Array.isArray(source.version) ? source.version[0] : source.version;
   }
 
@@ -154,20 +168,18 @@ const serializeQuery = (name: string, source: ApiPackQuery): [string, ExportedPa
  * Serialize a pack into portable Kibana-pack JSON.
  *
  * Emits `name`, `description` (when present), and `queries` keyed by the query
- * NAME. Reads whichever query shape the pack carries — the public-API array
- * (name in `id`) or the name-keyed object — converts `ecs_mapping` to the
- * osquery object form and `interval` to a number, and drops all
- * cluster-internal / saved-object fields (and `enabled`) by construction: we
- * only ever copy the portable fields onto the output.
+ * NAME. Reads whichever query shape the pack carries (see the authoritative
+ * note at the top of this file), converts `ecs_mapping` to the osquery object
+ * form and `interval` to a number, and drops all cluster-internal /
+ * saved-object fields (and `enabled`) by construction: we only ever copy the
+ * portable fields onto the output.
  */
 export const serializePack = (pack: ExportablePack): ExportedPack => {
   const entries = Array.isArray(pack.queries)
     ? // Public-API array form: the query name lives in `id`.
-      (pack.queries as ApiPackQuery[]).map((q, index) => serializeQuery(q.id ?? `${index}`, q))
+      pack.queries.map((q, index) => serializeQuery(q.id ?? `${index}`, q))
     : // Name-keyed object form (saved object / internal API).
-      Object.entries((pack.queries ?? {}) as Record<string, ApiPackQuery>).map(([name, q]) =>
-        serializeQuery(name, q)
-      );
+      Object.entries(pack.queries ?? {}).map(([name, q]) => serializeQuery(name, q));
 
   const exported: ExportedPack = {
     name: pack.name,
@@ -178,9 +190,9 @@ export const serializePack = (pack: ExportablePack): ExportedPack => {
     exported.description = pack.description;
   }
 
-  // Pack-level schedule — carry it through 1:1 when present. It only appears on
-  // the source pack when `rruleScheduling` is enabled, so this is dormant until
-  // that feature ships.
+  // Pack-level schedule — carry the portable schedule fields through when
+  // present. It only appears on the source pack when `rruleScheduling` is
+  // enabled, so this is dormant until that feature ships.
   if (pack.schedule_type === 'rrule' && pack.rrule_schedule) {
     exported.schedule_type = 'rrule';
     exported.rrule_schedule = pack.rrule_schedule;
@@ -194,17 +206,56 @@ export const serializePack = (pack: ExportablePack): ExportedPack => {
 
 const FILENAME_FALLBACK = 'pack';
 
-// Windows-reserved chars, path separators, and any whitespace/control char.
+// Windows-reserved chars, path separators, and any whitespace. Control chars
+// (C0/C1, NUL, DEL) are handled separately in `stripIllegalChars` to keep this
+// regex free of control-char literals.
 const ILLEGAL_FILENAME_CHARS = /[<>:"/\\|?*\s]/g;
+
+// Windows-reserved device names (case-insensitive), which cannot be used as a
+// bare basename even with an extension.
+const WINDOWS_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+// Cap the base so the final filename stays well under the 255-byte limit
+// common to most filesystems, leaving room for the `.json` extension.
+const MAX_FILENAME_BASE_LENGTH = 200;
+
+const trimSeparators = (value: string): string => value.replace(/^[._]+|[._]+$/g, '');
+
+/**
+ * Replace illegal filename characters with `_`: the Windows-reserved chars,
+ * path separators, and whitespace via `ILLEGAL_FILENAME_CHARS`, plus C0/C1
+ * control chars (0x00–0x1F, 0x7F–0x9F) matched by code point so no control-char
+ * literal appears in a regex.
+ */
+const stripIllegalChars = (value: string): string =>
+  value
+    .replace(ILLEGAL_FILENAME_CHARS, '_')
+    .split('')
+    .map((char) => {
+      const code = char.charCodeAt(0);
+
+      return code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? '_' : char;
+    })
+    .join('');
 
 /**
  * Derive a safe, cross-platform `.json` filename from a pack name. Illegal
- * filesystem characters and whitespace are replaced with `_`; surrounding dots
- * and underscores are trimmed; an empty result falls back to a stable default
- * so the download is never empty or misleading.
+ * filesystem characters, control chars, and whitespace are replaced with `_`;
+ * surrounding dots and underscores are trimmed; the base is length-capped;
+ * Windows-reserved device names (CON, PRN, …) are prefixed so they are no
+ * longer reserved; and an empty result falls back to a stable default so the
+ * download is never empty or misleading.
  */
 export const packExportFilename = (name: string): string => {
-  const base = (name ?? '').replace(ILLEGAL_FILENAME_CHARS, '_').replace(/^[._]+|[._]+$/g, '');
+  let base = trimSeparators(stripIllegalChars(name ?? ''));
+
+  if (base.length > MAX_FILENAME_BASE_LENGTH) {
+    base = trimSeparators(base.slice(0, MAX_FILENAME_BASE_LENGTH));
+  }
+
+  if (WINDOWS_RESERVED_NAMES.test(base)) {
+    base = `_${base}`;
+  }
 
   return `${base || FILENAME_FALLBACK}.json`;
 };

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_uploader.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/pack_uploader.tsx
@@ -47,10 +47,12 @@ const OsqueryPackUploaderComponent: React.FC<OsqueryPackUploaderProps> = ({ onCh
 
     try {
       parsedContent = JSON.parse(content.replaceAll('\\\n', ''), (key, value) => {
-        if (key === 'query') {
-          // remove any multiple spaces from the query
-          return value.replaceAll(/\s(?=\s)/gm, '');
-        }
+        // Query text is preserved verbatim: collapsing internal whitespace
+        // broke the export→import round-trip (an exported query no longer
+        // matched what was imported). osquery accepts multi-space SQL as-is, so
+        // keeping the text untouched is both lossless and a fixed point for the
+        // JSON round-trip. Both `.json` and legacy `.conf` packs flow through
+        // this same reviver, so neither path collapses whitespace anymore.
 
         if (key === 'interval') {
           // convert interval int to string

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.test.tsx
@@ -99,11 +99,25 @@ interface UploadedQueryState {
   interval?: string | number;
   timeout?: number;
   query?: string;
+  ecs_mapping?: Record<string, unknown>;
 }
 let capturedQueriesState: UploadedQueryState[] = [];
+let capturedPackState: {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  schedule?: { scheduleType?: string } & Record<string, unknown>;
+} = {};
 const FormStateProbe: React.FC = () => {
   const queries = useWatch({ name: 'queries' }) as UploadedQueryState[] | undefined;
+  const name = useWatch({ name: 'name' }) as string | undefined;
+  const description = useWatch({ name: 'description' }) as string | undefined;
+  const enabled = useWatch({ name: 'enabled' }) as boolean | undefined;
+  const schedule = useWatch({ name: 'schedule' }) as
+    | ({ scheduleType?: string } & Record<string, unknown>)
+    | undefined;
   capturedQueriesState = queries ?? [];
+  capturedPackState = { name, description, enabled, schedule };
 
   return null;
 };
@@ -114,6 +128,8 @@ const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const methods = useForm<Record<string, unknown>>({
     defaultValues: {
       name: '',
+      description: '',
+      enabled: true,
       queries: [],
       schedule_type: undefined,
       interval: undefined,
@@ -147,6 +163,7 @@ describe('QueriesField', () => {
   beforeEach(() => {
     capturedUploaderOnChange = null;
     capturedQueriesState = [];
+    capturedPackState = {};
     jest.clearAllMocks();
   });
 
@@ -194,6 +211,151 @@ describe('QueriesField', () => {
       // populated from the uploaded content, not left empty.
       expect(byId['uptime-check'].query).toBe('select * from uptime;');
       expect(byId['fallback-query'].query).toBe('select 1;');
+    });
+
+    it('preserves per-query ecs_mapping on import', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            queries: {
+              proc: {
+                query: 'select * from processes;',
+                interval: '60',
+                ecs_mapping: { 'process.pid': { field: 'pid' } },
+              },
+            },
+          },
+          'test-pack'
+        );
+      });
+
+      const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
+      expect(byId.proc.ecs_mapping).toEqual({ 'process.pid': { field: 'pid' } });
+    });
+
+    it('falls back to a top-level ecs_mapping when a query has none', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            ecs_mapping: { 'host.name': { field: 'hostname' } },
+            queries: { q: { query: 'select 1;', interval: '60' } },
+          },
+          'test-pack'
+        );
+      });
+
+      const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
+      expect(byId.q.ecs_mapping).toEqual({ 'host.name': { field: 'hostname' } });
+    });
+
+    it('leaves queries without ecs_mapping untouched', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          { queries: { q: { query: 'select 1;', interval: '60' } } },
+          'test-pack'
+        );
+      });
+
+      const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
+      expect(byId.q).not.toHaveProperty('ecs_mapping');
+    });
+
+    it('uses the in-file pack name over the filename (1:1 across clusters)', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          { name: 'forensics-pack', queries: { q: { query: 'select 1;', interval: '60' } } },
+          'renamed-file'
+        );
+      });
+
+      expect(capturedPackState.name).toBe('forensics-pack');
+    });
+
+    it('falls back to the filename when the file has no name (community .conf)', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          { queries: { q: { query: 'select 1;', interval: '60' } } },
+          'from-filename'
+        );
+      });
+
+      expect(capturedPackState.name).toBe('from-filename');
+    });
+
+    it('imports the pack description', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'p',
+            description: 'imported description',
+            queries: { q: { query: 'select 1;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      expect(capturedPackState.description).toBe('imported description');
+    });
+
+    it('lands the imported pack disabled regardless of any enabled in the file', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'p',
+            enabled: true,
+            queries: { q: { query: 'select 1;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      expect(capturedPackState.enabled).toBe(false);
+    });
+
+    it('restores a pack-level rrule schedule from the file when present', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'p',
+            schedule_type: 'rrule',
+            rrule_schedule: { rrule: 'FREQ=DAILY', start_date: '2026-07-07T00:00:00.000Z' },
+            queries: { q: { query: 'select 1;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      expect(capturedPackState.schedule?.scheduleType).toBe('rrule');
+    });
+
+    it('does not set a schedule when the file has no pack-level schedule', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          { name: 'p', queries: { q: { query: 'select 1;', interval: '60' } } },
+          'file'
+        );
+      });
+
+      // Left at the form default (undefined here) — import did not touch it.
+      expect(capturedPackState.schedule).toBeUndefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.test.tsx
@@ -6,20 +6,28 @@
  */
 
 /**
- * Pins the pack uploader's current behavior: an uploaded pack JSON injects each
- * query's `interval` from the file (or the hardcoded '3600' default). The
- * serializer in `use_pack_query_form` is the downstream defense that strips
- * `interval` for `schedule_type: 'rrule'` packs — exercised separately.
+ * Covers the pack-upload path in `queries_field.tsx` (`handlePackUpload`):
+ *  - CREATE mode adopts the file's name/description/schedule and forces the
+ *    imported pack disabled;
+ *  - EDIT mode preserves the existing pack's enabled/name/description/schedule;
+ *  - per-query numeric/boolean fields (interval/timeout/snapshot/removed) and
+ *    ecs_mapping survive the import keep-predicate.
+ *
+ * A dedicated round-trip test (bottom of file) wires the REAL serializer
+ * (`serializePack`) and the REAL uploader reviver (`OsqueryPackUploader`, driven
+ * through a genuine File + FileReader — NOT re-implemented) into the REAL import
+ * handler, and asserts the exported→imported pack is functionally equivalent.
  */
 
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, fireEvent, waitFor } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { EuiProvider } from '@elastic/eui';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import { ExperimentalFeaturesService } from '../../common/experimental_features_service';
 import { allowedExperimentalValues } from '../../../common/experimental_features';
+import { serializePack } from './pack_serializer';
 
 // ---------------------------------------------------------------------------
 // Stubs for heavy child components
@@ -49,13 +57,13 @@ jest.mock('../queries/query_flyout', () => ({
 }));
 
 jest.mock('../pack_queries_table', () => ({
-  PackQueriesTable: ({ data }: { data: unknown[] }) => (
-    <div data-test-subj="pack-queries-table">{`rows: ${data.length}`}</div>
-  ),
+  PackQueriesTable: () => <div data-test-subj="pack-queries-table">Table</div>,
 }));
 
 // Capture the onChange callback from OsqueryPackUploader so we can trigger
-// an upload from the test without filesystem interaction.
+// an upload from the test without filesystem interaction. The real uploader
+// (and its reviver) is exercised separately in the round-trip test via
+// `jest.requireActual`.
 let capturedUploaderOnChange: ((content: Record<string, unknown>, name: string) => void) | null =
   null;
 
@@ -69,10 +77,6 @@ jest.mock('./pack_uploader', () => ({
 
     return <div data-test-subj="osquery-pack-uploader">Upload</div>;
   },
-}));
-
-jest.mock('../pack_queries_table', () => ({
-  PackQueriesTable: () => <div data-test-subj="pack-queries-table">Table</div>,
 }));
 
 // ---------------------------------------------------------------------------
@@ -98,6 +102,8 @@ interface UploadedQueryState {
   id?: string;
   interval?: string | number;
   timeout?: number;
+  snapshot?: boolean;
+  removed?: boolean;
   query?: string;
   ecs_mapping?: Record<string, unknown>;
 }
@@ -106,7 +112,7 @@ let capturedPackState: {
   name?: string;
   description?: string;
   enabled?: boolean;
-  schedule?: { scheduleType?: string } & Record<string, unknown>;
+  schedule?: { scheduleType?: string; interval?: number } & Record<string, unknown>;
 } = {};
 const FormStateProbe: React.FC = () => {
   const queries = useWatch({ name: 'queries' }) as UploadedQueryState[] | undefined;
@@ -114,7 +120,7 @@ const FormStateProbe: React.FC = () => {
   const description = useWatch({ name: 'description' }) as string | undefined;
   const enabled = useWatch({ name: 'enabled' }) as boolean | undefined;
   const schedule = useWatch({ name: 'schedule' }) as
-    | ({ scheduleType?: string } & Record<string, unknown>)
+    | ({ scheduleType?: string; interval?: number } & Record<string, unknown>)
     | undefined;
   capturedQueriesState = queries ?? [];
   capturedPackState = { name, description, enabled, schedule };
@@ -122,9 +128,15 @@ const FormStateProbe: React.FC = () => {
   return null;
 };
 
+interface FormWrapperProps {
+  children: React.ReactNode;
+  defaultValues?: Record<string, unknown>;
+}
+
 // Wrapper that provides FormProvider with a fresh useForm instance matching
-// the shape QueriesField reads via useWatch().
-const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+// the shape QueriesField reads via useWatch(). `defaultValues` lets an EDIT-mode
+// test seed the form as if an existing pack were being edited.
+const FormWrapper: React.FC<FormWrapperProps> = ({ children, defaultValues }) => {
   const methods = useForm<Record<string, unknown>>({
     defaultValues: {
       name: '',
@@ -134,6 +146,7 @@ const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       schedule_type: undefined,
       interval: undefined,
       rrule_schedule: undefined,
+      ...defaultValues,
     },
   });
 
@@ -145,12 +158,15 @@ const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   );
 };
 
-const renderQueriesField = () =>
+const renderQueriesField = (
+  { editMode = false }: { editMode?: boolean } = {},
+  defaultValues?: Record<string, unknown>
+) =>
   render(
     <EuiProvider>
       <IntlProvider locale="en">
-        <FormWrapper>
-          <QueriesField euiFieldProps={{}} />
+        <FormWrapper defaultValues={defaultValues}>
+          <QueriesField euiFieldProps={{}} editMode={editMode} />
         </FormWrapper>
       </IntlProvider>
     </EuiProvider>
@@ -167,23 +183,17 @@ describe('QueriesField', () => {
     jest.clearAllMocks();
   });
 
-  describe('pack uploader', () => {
-    it('D1: should inject interval onto each uploaded query in RHF form state (serializer is the downstream defense)', () => {
+  describe('handlePackUpload — per-query fields', () => {
+    it('should inject interval onto each uploaded query, using the 3600 fallback when the file omits it', () => {
       // The uploader callback (handlePackUpload in queries_field.tsx) maps
       //   `interval: newQuery.interval ?? parsedContent.interval ?? '3600'`
       // onto each query and writes the result into the `queries` form array.
-      // The serializer in use_pack_query_form.tsx is the downstream defense
-      // that strips `interval` when a query inherits an rrule pack schedule.
-      //
       // This asserts the RESULTING RHF state after upload (not the input
       // literal), so it fails if the uploader stops injecting interval.
       renderQueriesField();
 
       expect(capturedUploaderOnChange).not.toBeNull();
 
-      // Upload a pack JSON with a string interval (survives the uploader's
-      // `pickBy(!isEmpty)` filter) and one query with NO interval (must get the
-      // hardcoded '3600' fallback). Assert the RHF form array the uploader wrote.
       act(() => {
         capturedUploaderOnChange!(
           {
@@ -213,7 +223,42 @@ describe('QueriesField', () => {
       expect(byId['fallback-query'].query).toBe('select 1;');
     });
 
-    it('preserves per-query ecs_mapping on import', () => {
+    it('should preserve numeric timeout and boolean snapshot/removed (keep-predicate no longer drops them)', () => {
+      // The keep-predicate is `v !== undefined && v !== null && v !== ''`, so
+      // numeric `timeout` and booleans `snapshot`/`removed` (incl. `true`) now
+      // survive. `snapshot: false` also survives.
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            queries: {
+              a: {
+                query: 'select 1;',
+                interval: '60',
+                timeout: 120,
+                snapshot: true,
+                removed: true,
+              },
+              b: {
+                query: 'select 2;',
+                interval: '60',
+                snapshot: false,
+              },
+            },
+          },
+          'test-pack'
+        );
+      });
+
+      const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
+      expect(byId.a).toMatchObject({ timeout: 120, snapshot: true, removed: true });
+      // `snapshot: false` is a specified value and must survive (it is not
+      // undefined/null/'').
+      expect(byId.b.snapshot).toBe(false);
+    });
+
+    it('should preserve per-query ecs_mapping on import', () => {
       renderQueriesField();
 
       act(() => {
@@ -235,7 +280,7 @@ describe('QueriesField', () => {
       expect(byId.proc.ecs_mapping).toEqual({ 'process.pid': { field: 'pid' } });
     });
 
-    it('falls back to a top-level ecs_mapping when a query has none', () => {
+    it('should fall back to a top-level ecs_mapping when a query has none', () => {
       renderQueriesField();
 
       act(() => {
@@ -252,7 +297,7 @@ describe('QueriesField', () => {
       expect(byId.q.ecs_mapping).toEqual({ 'host.name': { field: 'hostname' } });
     });
 
-    it('leaves queries without ecs_mapping untouched', () => {
+    it('should leave queries without ecs_mapping untouched', () => {
       renderQueriesField();
 
       act(() => {
@@ -265,8 +310,10 @@ describe('QueriesField', () => {
       const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
       expect(byId.q).not.toHaveProperty('ecs_mapping');
     });
+  });
 
-    it('uses the in-file pack name over the filename (1:1 across clusters)', () => {
+  describe('handlePackUpload — CREATE mode', () => {
+    it('should use the in-file pack name over the filename (1:1 across clusters)', () => {
       renderQueriesField();
 
       act(() => {
@@ -279,7 +326,7 @@ describe('QueriesField', () => {
       expect(capturedPackState.name).toBe('forensics-pack');
     });
 
-    it('falls back to the filename when the file has no name (community .conf)', () => {
+    it('should fall back to the filename when the file has no name (community .conf)', () => {
       renderQueriesField();
 
       act(() => {
@@ -292,7 +339,7 @@ describe('QueriesField', () => {
       expect(capturedPackState.name).toBe('from-filename');
     });
 
-    it('imports the pack description', () => {
+    it('should import the pack description', () => {
       renderQueriesField();
 
       act(() => {
@@ -309,7 +356,7 @@ describe('QueriesField', () => {
       expect(capturedPackState.description).toBe('imported description');
     });
 
-    it('lands the imported pack disabled regardless of any enabled in the file', () => {
+    it('should land the imported pack disabled regardless of any enabled in the file', () => {
       renderQueriesField();
 
       act(() => {
@@ -326,7 +373,7 @@ describe('QueriesField', () => {
       expect(capturedPackState.enabled).toBe(false);
     });
 
-    it('restores a pack-level rrule schedule from the file when present', () => {
+    it('should restore a pack-level rrule schedule from the file when present', () => {
       renderQueriesField();
 
       act(() => {
@@ -344,7 +391,7 @@ describe('QueriesField', () => {
       expect(capturedPackState.schedule?.scheduleType).toBe('rrule');
     });
 
-    it('does not set a schedule when the file has no pack-level schedule', () => {
+    it('should not set a schedule when the file has no pack-level schedule', () => {
       renderQueriesField();
 
       act(() => {
@@ -356,6 +403,270 @@ describe('QueriesField', () => {
 
       // Left at the form default (undefined here) — import did not touch it.
       expect(capturedPackState.schedule).toBeUndefined();
+    });
+  });
+
+  describe('handlePackUpload — EDIT mode', () => {
+    // Seed the form as if an existing pack were being edited. An upload in EDIT
+    // mode must import only the queries and NOT clobber the existing pack's
+    // name/description/enabled/schedule.
+    const existingPackDefaults = {
+      name: 'existing-pack',
+      description: 'existing description',
+      enabled: true,
+      queries: [{ id: 'existing-query', query: 'select existing;', interval: '900' }],
+      schedule: { scheduleType: 'interval', interval: 900 },
+    };
+
+    it('should preserve the existing enabled flag (does not force disabled)', () => {
+      renderQueriesField({ editMode: true }, existingPackDefaults);
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'file-pack',
+            enabled: true,
+            queries: { imported: { query: 'select imported;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      // CREATE would force `enabled: false`; EDIT must leave the seeded `true`.
+      expect(capturedPackState.enabled).toBe(true);
+    });
+
+    it('should preserve the existing pack name (does not overwrite from the file)', () => {
+      renderQueriesField({ editMode: true }, existingPackDefaults);
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'file-pack',
+            queries: { imported: { query: 'select imported;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      expect(capturedPackState.name).toBe('existing-pack');
+    });
+
+    it('should preserve the existing description (does not overwrite from the file)', () => {
+      renderQueriesField({ editMode: true }, existingPackDefaults);
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'file-pack',
+            description: 'file description',
+            queries: { imported: { query: 'select imported;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      expect(capturedPackState.description).toBe('existing description');
+    });
+
+    it('should preserve the existing schedule (does not overwrite from the file)', () => {
+      renderQueriesField({ editMode: true }, existingPackDefaults);
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'file-pack',
+            schedule_type: 'rrule',
+            rrule_schedule: { rrule: 'FREQ=DAILY', start_date: '2026-07-07T00:00:00.000Z' },
+            queries: { imported: { query: 'select imported;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      // Seeded interval schedule is untouched — the file's rrule schedule is
+      // ignored in EDIT mode.
+      expect(capturedPackState.schedule?.scheduleType).toBe('interval');
+    });
+
+    it('should still replace the query array with the imported queries', () => {
+      renderQueriesField({ editMode: true }, existingPackDefaults);
+
+      act(() => {
+        capturedUploaderOnChange!(
+          {
+            name: 'file-pack',
+            queries: { imported: { query: 'select imported;', interval: '60' } },
+          },
+          'file'
+        );
+      });
+
+      const ids = capturedQueriesState.map((q) => q.id);
+      expect(ids).toEqual(['imported']);
+    });
+  });
+
+  describe('handlePackUpload — legacy plain pack (no metadata)', () => {
+    // AC#6 regression: a legacy .conf-style pack with NO name/description/
+    // schedule/ecs_mapping must still import cleanly.
+    const legacyContent = {
+      queries: {
+        legacy_query: { query: 'select * from processes;', interval: '30' },
+      },
+    };
+
+    it('should derive the name from the filename in CREATE mode', () => {
+      renderQueriesField();
+
+      act(() => {
+        capturedUploaderOnChange!({ ...legacyContent }, 'osquery-community');
+      });
+
+      expect(capturedPackState.name).toBe('osquery-community');
+      expect(capturedPackState.enabled).toBe(false);
+      const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
+      expect(byId.legacy_query.query).toBe('select * from processes;');
+      expect(byId.legacy_query.interval).toBe('30');
+    });
+
+    it('should leave the existing enabled flag untouched in EDIT mode', () => {
+      renderQueriesField(
+        { editMode: true },
+        {
+          name: 'existing-pack',
+          enabled: true,
+          queries: [{ id: 'existing-query', query: 'select existing;', interval: '900' }],
+        }
+      );
+
+      act(() => {
+        capturedUploaderOnChange!({ ...legacyContent }, 'osquery-community');
+      });
+
+      expect(capturedPackState.enabled).toBe(true);
+      expect(capturedPackState.name).toBe('existing-pack');
+      const ids = capturedQueriesState.map((q) => q.id);
+      expect(ids).toEqual(['legacy_query']);
+    });
+  });
+
+  describe('export → import round-trip (real serializer + real reviver + real importer)', () => {
+    // The real uploader (and its JSON reviver) — NOT the mocked stub. Driving
+    // this through a genuine File + FileReader exercises the actual parse path
+    // (whitespace-preserving reviver + interval stringification) end to end.
+    const { OsqueryPackUploader: RealUploader } = jest.requireActual('./pack_uploader');
+
+    // Run the exported JSON through the real uploader reviver by uploading it as
+    // a File and capturing what `onChange` receives.
+    const parseWithRealReviver = async (
+      exportedJson: string,
+      fileName: string
+    ): Promise<{ content: Record<string, unknown>; name: string }> => {
+      let received: { content: Record<string, unknown>; name: string } | null = null;
+      const onChange = (content: Record<string, unknown>, name: string) => {
+        received = { content, name };
+      };
+
+      const { container } = render(
+        <EuiProvider>
+          <IntlProvider locale="en">
+            <RealUploader onChange={onChange} />
+          </IntlProvider>
+        </EuiProvider>
+      );
+
+      const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+      const file = new File([exportedJson], fileName, { type: 'application/json' });
+
+      await act(async () => {
+        fireEvent.change(input, { target: { files: [file] } });
+      });
+
+      await waitFor(() => {
+        expect(received).not.toBeNull();
+      });
+
+      return received!;
+    };
+
+    it('should preserve name, description, verbatim query text, ecs_mapping, per-query numeric/boolean fields, and interval schedule', async () => {
+      // Realistic public-API pack fixture (array `queries`, name in `id`,
+      // ecs_mapping as `{ key, value }` array) — the exact shape the Packs table
+      // holds. Query text intentionally contains multiple internal spaces to
+      // prove the reviver preserves whitespace verbatim now.
+      const apiPack = {
+        saved_object_id: 'so-id-1',
+        name: 'forensics-pack',
+        description: 'A realistic forensics pack',
+        enabled: true,
+        policy_ids: ['policy-1'],
+        shards: [],
+        schedule_type: 'interval',
+        interval: 900,
+        queries: [
+          {
+            id: 'processes_elastic',
+            query: 'SELECT  *   FROM processes WHERE  pid > 0;',
+            interval: 60,
+            timeout: 120,
+            snapshot: false,
+            removed: true,
+            platform: 'linux',
+            ecs_mapping: [{ key: 'process.pid', value: { field: 'pid' } }],
+          },
+          {
+            id: 'listening_ports',
+            query: 'SELECT * FROM listening_ports;',
+            interval: 30,
+          },
+        ],
+      } as never;
+
+      // 1) Serialize with the REAL serializer, 2) JSON stringify.
+      const exported = serializePack(apiPack);
+      const json = JSON.stringify(exported, null, 2);
+
+      // 3) Parse through the REAL uploader reviver (File + FileReader).
+      const { content, name } = await parseWithRealReviver(json, 'forensics-pack.json');
+
+      // 4) Feed the parsed content through the REAL import handler in CREATE
+      //    mode (renders QueriesField → handlePackUpload).
+      renderQueriesField();
+      act(() => {
+        capturedUploaderOnChange!(content, name);
+      });
+
+      // --- Functional equivalence assertions ---
+
+      // Pack metadata.
+      expect(capturedPackState.name).toBe('forensics-pack');
+      expect(capturedPackState.description).toBe('A realistic forensics pack');
+      // Imported packs always land disabled.
+      expect(capturedPackState.enabled).toBe(false);
+      // Interval pack-level schedule survives the reviver's interval
+      // stringification (deserializeSchedule Number()-coerces it).
+      expect(capturedPackState.schedule?.scheduleType).toBe('interval');
+      expect(capturedPackState.schedule?.interval).toBe(900);
+
+      // Queries.
+      const byId = Object.fromEntries(capturedQueriesState.map((q) => [q.id, q]));
+      expect(Object.keys(byId).sort()).toEqual(['listening_ports', 'processes_elastic']);
+
+      // Query text is preserved VERBATIM (multi-space SQL survives).
+      expect(byId.processes_elastic.query).toBe('SELECT  *   FROM processes WHERE  pid > 0;');
+      expect(byId.listening_ports.query).toBe('SELECT * FROM listening_ports;');
+
+      // Per-query numeric/boolean fields survive. Intervals are stringified by
+      // the reviver (form stores them as strings).
+      expect(byId.processes_elastic.interval).toBe('60');
+      expect(byId.processes_elastic.timeout).toBe(120);
+      expect(byId.processes_elastic.snapshot).toBe(false);
+      expect(byId.processes_elastic.removed).toBe(true);
+      expect(byId.listening_ports.interval).toBe('30');
+
+      // ecs_mapping round-trips to the osquery object form.
+      expect(byId.processes_elastic.ecs_mapping).toEqual({ 'process.pid': { field: 'pid' } });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.tsx
@@ -25,9 +25,13 @@ import type { ScheduleFormData } from '../../components/schedule_section/types';
 
 interface QueriesFieldProps {
   euiFieldProps: EuiComboBoxProps<{}>;
+  editMode?: boolean;
 }
 
-const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({ euiFieldProps }) => {
+const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({
+  euiFieldProps,
+  editMode = false,
+}) => {
   const {
     field: { value: fieldValue },
   } = useController<{ queries: PackQueryFormData[] }, 'queries'>({
@@ -171,45 +175,57 @@ const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({ euiFieldProps }) =
               // here is what makes an exported pack round-trip 1:1.
               ecs_mapping: newQuery.ecs_mapping ?? parsedContent.ecs_mapping,
             },
-            (value) => !isEmpty(value) || value === false
+            // Keep every value the file actually specified. `isEmpty` cannot be
+            // used as the keep-predicate here: `isEmpty(number)` and
+            // `isEmpty(boolean)` both return true, so numeric `timeout`/`interval`
+            // and boolean `snapshot`/`removed` (including `true`) would be
+            // silently dropped on re-import. Keep anything that is not
+            // undefined/null/'' so numbers and booleans survive verbatim.
+            (value) => value !== undefined && value !== null && value !== ''
           )
         )
       );
 
-      // A Kibana-pack JSON carries its own `name`/`description`; prefer those so
-      // the pack reconstructs 1:1 across clusters. Fall back to the filename for
-      // community `.conf` files that have no in-file name.
-      if (!isEmpty(parsedContent.name)) {
-        setValue('name', parsedContent.name);
-      } else {
-        handleNameChange(uploadedPackName);
-      }
+      // In EDIT mode the form is already populated with the existing pack's
+      // metadata/schedule/enabled flag; an upload must not clobber it. Only a
+      // fresh CREATE flow adopts the file's name/description/schedule and forces
+      // the pack disabled.
+      if (!editMode) {
+        // A Kibana-pack JSON carries its own `name`/`description`; prefer those
+        // so the pack reconstructs 1:1 across clusters. Fall back to the
+        // filename for community `.conf` files that have no in-file name.
+        if (!isEmpty(parsedContent.name)) {
+          setValue('name', parsedContent.name);
+        } else {
+          handleNameChange(uploadedPackName);
+        }
 
-      if (!isEmpty(parsedContent.description)) {
-        setValue('description', parsedContent.description);
-      }
+        if (!isEmpty(parsedContent.description)) {
+          setValue('description', parsedContent.description);
+        }
 
-      // Imported packs land disabled regardless of any `enabled` in the file:
-      // the operator assigns target-cluster policies and enables deliberately.
-      setValue('enabled', false);
+        // Imported packs land disabled regardless of any `enabled` in the file:
+        // the operator assigns target-cluster policies and enables deliberately.
+        setValue('enabled', false);
 
-      // Pack-level schedule (rrule / interval), carried 1:1 when the file has
-      // one. Presence is the gate: export only emits it when the source pack
-      // had a schedule (rruleScheduling on), and on a flag-off target the form's
-      // deserializer/submit path strips it — so setting it here is safe either
-      // way and dormant until the feature ships.
-      if (!isEmpty(parsedContent.schedule_type)) {
-        setValue(
-          'schedule',
-          deserializeSchedule({
-            schedule_type: parsedContent.schedule_type,
-            interval: parsedContent.interval,
-            rrule_schedule: parsedContent.rrule_schedule,
-          })
-        );
+        // Pack-level schedule (rrule / interval), carried 1:1 when the file has
+        // one. Presence is the gate: export only emits it when the source pack
+        // had a schedule (rruleScheduling on), and on a flag-off target the
+        // form's deserializer/submit path strips it — so setting it here is safe
+        // either way and dormant until the feature ships.
+        if (!isEmpty(parsedContent.schedule_type)) {
+          setValue(
+            'schedule',
+            deserializeSchedule({
+              schedule_type: parsedContent.schedule_type,
+              interval: parsedContent.interval,
+              rrule_schedule: parsedContent.rrule_schedule,
+            })
+          );
+        }
       }
     },
-    [handleNameChange, replace, setValue]
+    [editMode, handleNameChange, replace, setValue]
   );
 
   const tableData = useMemo(() => (fieldValue?.length ? fieldValue : []), [fieldValue]);

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/queries_field.tsx
@@ -20,7 +20,7 @@ import { QueryFlyout } from '../queries/query_flyout';
 import { OsqueryPackUploader } from './pack_uploader';
 import { getSupportedPlatforms } from '../queries/platforms';
 import type { PackQueryFormData } from '../queries/use_pack_query_form';
-import { serializeSchedule } from './schedule_serializer';
+import { serializeSchedule, deserializeSchedule } from './schedule_serializer';
 import type { ScheduleFormData } from '../../components/schedule_section/types';
 
 interface QueriesFieldProps {
@@ -165,15 +165,51 @@ const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({ euiFieldProps }) =
               snapshot: newQuery.snapshot ?? parsedContent.snapshot,
               removed: newQuery.removed ?? parsedContent.removed,
               platform: getSupportedPlatforms(newQuery.platform ?? parsedContent.platform),
+              // ECS mappings ride in the osquery object form, which is what the
+              // pack form field (`PackQueryFormData.ecs_mapping`) stores — pass
+              // through as-is (mirrors the manual query-edit path). Preserving it
+              // here is what makes an exported pack round-trip 1:1.
+              ecs_mapping: newQuery.ecs_mapping ?? parsedContent.ecs_mapping,
             },
             (value) => !isEmpty(value) || value === false
           )
         )
       );
 
-      handleNameChange(uploadedPackName);
+      // A Kibana-pack JSON carries its own `name`/`description`; prefer those so
+      // the pack reconstructs 1:1 across clusters. Fall back to the filename for
+      // community `.conf` files that have no in-file name.
+      if (!isEmpty(parsedContent.name)) {
+        setValue('name', parsedContent.name);
+      } else {
+        handleNameChange(uploadedPackName);
+      }
+
+      if (!isEmpty(parsedContent.description)) {
+        setValue('description', parsedContent.description);
+      }
+
+      // Imported packs land disabled regardless of any `enabled` in the file:
+      // the operator assigns target-cluster policies and enables deliberately.
+      setValue('enabled', false);
+
+      // Pack-level schedule (rrule / interval), carried 1:1 when the file has
+      // one. Presence is the gate: export only emits it when the source pack
+      // had a schedule (rruleScheduling on), and on a flag-off target the form's
+      // deserializer/submit path strips it — so setting it here is safe either
+      // way and dormant until the feature ships.
+      if (!isEmpty(parsedContent.schedule_type)) {
+        setValue(
+          'schedule',
+          deserializeSchedule({
+            schedule_type: parsedContent.schedule_type,
+            interval: parsedContent.interval,
+            rrule_schedule: parsedContent.rrule_schedule,
+          })
+        );
+      }
     },
-    [handleNameChange, replace]
+    [handleNameChange, replace, setValue]
   );
 
   const tableData = useMemo(() => (fieldValue?.length ? fieldValue : []), [fieldValue]);

--- a/x-pack/platform/plugins/shared/osquery/public/packs/form/schedule_serializer.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/form/schedule_serializer.ts
@@ -391,10 +391,14 @@ export const deserializeSchedule = (
     };
   }
 
-  // Interval mode (explicit or legacy fallback).
+  // Interval mode (explicit or legacy fallback). Coerce with `Number()` so a
+  // numeric-string interval survives — the pack-upload reviver stringifies every
+  // `interval` key, so a re-imported interval-schedule pack arrives here as a
+  // string (e.g. "3600") and must not fall through to the default.
+  const parsedInterval = Number(input.interval);
   const interval =
-    typeof input.interval === 'number' && input.interval > 0
-      ? input.interval
+    Number.isFinite(parsedInterval) && parsedInterval > 0
+      ? parsedInterval
       : DEFAULT_INTERVAL_SECONDS;
 
   return {

--- a/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.test.tsx
@@ -35,11 +35,22 @@ jest.mock('./use_delete_pack', () => ({
   useDeletePack: () => ({ mutateAsync: jest.fn().mockResolvedValue(undefined) }),
 }));
 
+// handleExport reports success/failure through the notifications service, so the
+// mock must expose toasts (matches the real Kibana core notifications shape).
+const mockAddSuccess = jest.fn();
+const mockAddDanger = jest.fn();
+let mockWritePacksCapability = true;
+
 jest.mock('../common/lib/kibana', () => ({
   useKibana: () => ({
-    services: { application: { capabilities: { osquery: { writePacks: true } } } },
+    services: {
+      application: { capabilities: { osquery: { writePacks: mockWritePacksCapability } } },
+      notifications: { toasts: { addSuccess: mockAddSuccess, addDanger: mockAddDanger } },
+    },
   }),
 }));
+
+const downloadPackAsJsonMock = downloadPackAsJson as jest.MockedFunction<typeof downloadPackAsJson>;
 
 const item = {
   saved_object_id: 'so-1',
@@ -53,26 +64,72 @@ const renderWithIntl = (ui: React.ReactElement) =>
 describe('PackRowActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWritePacksCapability = true;
     useIsExperimentalFeatureEnabledMock.mockReturnValue(true);
   });
 
-  it('exports the row pack when Export pack is clicked (flag on)', () => {
-    renderWithIntl(React.createElement(PackRowActions, { item }));
+  describe('export gating', () => {
+    it('exports the row pack when Export pack is clicked (flag on, writePacks true)', () => {
+      renderWithIntl(React.createElement(PackRowActions, { item }));
 
-    fireEvent.click(screen.getByLabelText('Actions for My Pack'));
-    fireEvent.click(screen.getByText('Export pack'));
+      fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+      fireEvent.click(screen.getByText('Export pack'));
 
-    expect(downloadPackAsJson).toHaveBeenCalledTimes(1);
-    expect(downloadPackAsJson).toHaveBeenCalledWith(item);
+      expect(downloadPackAsJsonMock).toHaveBeenCalledTimes(1);
+      expect(downloadPackAsJsonMock).toHaveBeenCalledWith(item);
+    });
+
+    it('renders and exports even when writePacks is false (export is read-gated, not write-gated)', () => {
+      mockWritePacksCapability = false;
+      renderWithIntl(React.createElement(PackRowActions, { item }));
+
+      fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+
+      // Export stays available; write-only actions (Duplicate/Delete) do not.
+      expect(screen.getByText('Export pack')).toBeInTheDocument();
+      expect(screen.queryByText('Duplicate pack')).not.toBeInTheDocument();
+      expect(screen.queryByText('Delete pack')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Export pack'));
+      expect(downloadPackAsJsonMock).toHaveBeenCalledTimes(1);
+      expect(downloadPackAsJsonMock).toHaveBeenCalledWith(item);
+    });
+
+    it('does not render the Export pack action when the flag is off', () => {
+      useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
+      renderWithIntl(React.createElement(PackRowActions, { item }));
+
+      fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+
+      expect(screen.queryByText('Export pack')).not.toBeInTheDocument();
+      expect(downloadPackAsJsonMock).not.toHaveBeenCalled();
+    });
   });
 
-  it('does not render the Export pack action when the flag is off', () => {
-    useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
-    renderWithIntl(React.createElement(PackRowActions, { item }));
+  describe('export toasts', () => {
+    it('shows a success toast when the export succeeds', () => {
+      renderWithIntl(React.createElement(PackRowActions, { item }));
 
-    fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+      fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+      fireEvent.click(screen.getByText('Export pack'));
 
-    expect(screen.queryByText('Export pack')).not.toBeInTheDocument();
-    expect(downloadPackAsJson).not.toHaveBeenCalled();
+      expect(mockAddSuccess).toHaveBeenCalledTimes(1);
+      expect(mockAddDanger).not.toHaveBeenCalled();
+    });
+
+    it('shows a danger toast and does not throw when the export fails', () => {
+      downloadPackAsJsonMock.mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+      renderWithIntl(React.createElement(PackRowActions, { item }));
+
+      fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+
+      // The click must not throw even though downloadPackAsJson does.
+      expect(() => fireEvent.click(screen.getByText('Export pack'))).not.toThrow();
+
+      expect(mockAddDanger).toHaveBeenCalledTimes(1);
+      expect(mockAddSuccess).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { PackRowActions } from './pack_row_actions';
+import { downloadPackAsJson } from './form/pack_serializer';
+import { useIsExperimentalFeatureEnabled } from '../common/experimental_features_context';
+import type { PackSavedObject } from './types';
+
+jest.mock('./form/pack_serializer', () => ({
+  downloadPackAsJson: jest.fn(),
+}));
+
+jest.mock('../common/experimental_features_context');
+
+const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.MockedFunction<
+  typeof useIsExperimentalFeatureEnabled
+>;
+
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('./use_copy_pack', () => ({
+  useCopyPack: () => ({ mutateAsync: jest.fn() }),
+}));
+
+jest.mock('./use_delete_pack', () => ({
+  useDeletePack: () => ({ mutateAsync: jest.fn().mockResolvedValue(undefined) }),
+}));
+
+jest.mock('../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: { application: { capabilities: { osquery: { writePacks: true } } } },
+  }),
+}));
+
+const item = {
+  saved_object_id: 'so-1',
+  name: 'My Pack',
+  queries: { q: { query: 'SELECT 1;', interval: '60' } },
+} as unknown as PackSavedObject & { read_only?: boolean };
+
+const renderWithIntl = (ui: React.ReactElement) =>
+  render(React.createElement(IntlProvider, { locale: 'en' }, ui));
+
+describe('PackRowActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useIsExperimentalFeatureEnabledMock.mockReturnValue(true);
+  });
+
+  it('exports the row pack when Export pack is clicked (flag on)', () => {
+    renderWithIntl(React.createElement(PackRowActions, { item }));
+
+    fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+    fireEvent.click(screen.getByText('Export pack'));
+
+    expect(downloadPackAsJson).toHaveBeenCalledTimes(1);
+    expect(downloadPackAsJson).toHaveBeenCalledWith(item);
+  });
+
+  it('does not render the Export pack action when the flag is off', () => {
+    useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
+    renderWithIntl(React.createElement(PackRowActions, { item }));
+
+    fireEvent.click(screen.getByLabelText('Actions for My Pack'));
+
+    expect(screen.queryByText('Export pack')).not.toBeInTheDocument();
+    expect(downloadPackAsJson).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.tsx
@@ -11,9 +11,11 @@ import { i18n } from '@kbn/i18n';
 import { useHistory } from 'react-router-dom';
 
 import { useKibana } from '../common/lib/kibana';
+import { useIsExperimentalFeatureEnabled } from '../common/experimental_features_context';
 import { useCopyPack } from './use_copy_pack';
 import { useDeletePack } from './use_delete_pack';
 import { RowActionsMenu } from '../components/row_actions_menu';
+import { downloadPackAsJson } from './form/pack_serializer';
 import type { PackSavedObject } from './types';
 
 interface PackRowActionsProps {
@@ -33,6 +35,7 @@ const DELETE_MODAL_CONFIG = {
 
 const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
   const permissions = useKibana().services.application.capabilities.osquery;
+  const isExportPackEnabled = useIsExperimentalFeatureEnabled('exportPack');
   const { push } = useHistory();
 
   const copyPackMutation = useCopyPack({ packId: item.saved_object_id });
@@ -47,6 +50,10 @@ const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
   }, [copyPackMutation]);
 
   const handleDelete = useCallback(() => deletePackMutation.mutateAsync(), [deletePackMutation]);
+
+  const handleExport = useCallback(() => {
+    downloadPackAsJson(item);
+  }, [item]);
 
   const actionsAriaLabel = useMemo(
     () =>
@@ -81,6 +88,14 @@ const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
     []
   );
 
+  const exportLabel = useMemo(
+    () =>
+      i18n.translate('xpack.osquery.packList.rowActions.exportLabel', {
+        defaultMessage: 'Export pack',
+      }),
+    []
+  );
+
   return (
     <RowActionsMenu
       itemName={item.name}
@@ -94,6 +109,8 @@ const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
       onEdit={handleEdit}
       onDuplicate={handleDuplicate}
       onDelete={handleDelete}
+      onExport={isExportPackEnabled ? handleExport : undefined}
+      exportLabel={isExportPackEnabled ? exportLabel : undefined}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/pack_row_actions.tsx
@@ -34,7 +34,8 @@ const DELETE_MODAL_CONFIG = {
 };
 
 const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
-  const permissions = useKibana().services.application.capabilities.osquery;
+  const { application, notifications } = useKibana().services;
+  const permissions = application.capabilities.osquery;
   const isExportPackEnabled = useIsExperimentalFeatureEnabled('exportPack');
   const { push } = useHistory();
 
@@ -52,8 +53,22 @@ const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
   const handleDelete = useCallback(() => deletePackMutation.mutateAsync(), [deletePackMutation]);
 
   const handleExport = useCallback(() => {
-    downloadPackAsJson(item);
-  }, [item]);
+    try {
+      downloadPackAsJson(item);
+      notifications.toasts.addSuccess(
+        i18n.translate('xpack.osquery.packList.rowActions.exportSuccessToast', {
+          defaultMessage: 'Pack exported successfully',
+        })
+      );
+    } catch (error) {
+      notifications.toasts.addDanger(
+        error?.body?.message ??
+          i18n.translate('xpack.osquery.packList.rowActions.exportErrorToast', {
+            defaultMessage: 'Failed to export pack',
+          })
+      );
+    }
+  }, [item, notifications]);
 
   const actionsAriaLabel = useMemo(
     () =>
@@ -96,6 +111,11 @@ const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
     []
   );
 
+  const exportAction = useMemo(
+    () => (isExportPackEnabled ? { onExport: handleExport, label: exportLabel } : undefined),
+    [isExportPackEnabled, handleExport, exportLabel]
+  );
+
   return (
     <RowActionsMenu
       itemName={item.name}
@@ -109,8 +129,7 @@ const PackRowActionsComponent: React.FC<PackRowActionsProps> = ({ item }) => {
       onEdit={handleEdit}
       onDuplicate={handleDuplicate}
       onDelete={handleDelete}
-      onExport={isExportPackEnabled ? handleExport : undefined}
-      exportLabel={isExportPackEnabled ? exportLabel : undefined}
+      exportAction={exportAction}
     />
   );
 };


### PR DESCRIPTION
## Summary

Adds the ability to **export an Osquery pack to a JSON file and import it back** — enabling a pack to be copied across clusters. Export serializes a pack (name, description, queries with ECS mappings, and pack-level RRULE schedule) to a portable `.json`; import reads that metadata back so the pack's portable fields reconstruct on another cluster. Cluster-specific state (policy assignments, shards, internal IDs) and enablement are intentionally not carried and are reassigned on import.

Gated behind a new `exportPack` experimental flag (**default off**).

## Key changes

- **Export**: new client-side `pack_serializer` (`serializePack` / `downloadPackAsJson`); a per-pack **Export pack** row-menu action, exposed via an optional `exportAction={{ onExport, label }}` prop on the shared `RowActionsMenu` (grouped so a handler can never be supplied without a label; saved-query views are unaffected). The Export item is positioned **last** in the menu (Edit → Duplicate → Delete → Export). Export is available with pack **read** access and renders regardless of write permissions.
- **Export filename safety**: the download name is derived from the pack name and hardened — illegal/​control characters (incl. NUL) stripped, Windows reserved device names (CON, NUL, COM1…) prefixed, length capped, with a safe fallback.
- **Import**: `handlePackUpload` reads `name` (in-file name wins over filename), `description`, per-query `ecs_mapping`, and the pack-level schedule (`schedule_type` / `rrule_schedule` / `interval`). These metadata writes apply in **create mode only** — uploading a file while **editing an existing pack** no longer overwrites its name/description/schedule or its `enabled` state (only the queries are replaced).
- **Safety**: on import in create mode the pack lands **disabled**, so imported detection content never auto-activates; the operator assigns target-cluster policies and enables deliberately.

<details>
<summary>Implementation details</summary>

- The exporter reads the public-API pack shape held by the Packs table (queries as an array with the name in `id`, `ecs_mapping` as `{ key, value }`), normalizes `ecs_mapping` to the osquery object form, and keys queries by name. Output is built field-by-field via an allowlist, so all cluster-internal / saved-object fields are dropped by construction (no `enabled`, `policy_ids`, `shards`, or IDs).
- Import round-trip fidelity fixes: query text is preserved verbatim (the importer no longer collapses whitespace); per-query numeric/boolean fields (`timeout`, `snapshot`, `removed`) survive re-import (the keep-predicate no longer drops falsy-but-meaningful values); and a stringified pack-level `interval` is coerced back to a number so an interval schedule is no longer reset to the default.
- The importer path (`handlePackUpload`) already `JSON.parse`s any uploaded file, so no new format machinery is needed — it additionally reads pack-level metadata and per-query `ecs_mapping` (mirroring the manual query-edit path), scoped to create mode.
- Pack-level RRULE schedule is carried only when present. This is self-gating on the `rruleScheduling` feature flag: when that flag is off, the read API strips the schedule so there is nothing to export, and a flag-off target's form deserializer strips it on submit — dormant and safe until that feature ships.

</details>

<details>
<summary>Testing / verification</summary>

Verified end-to-end in a running Kibana with `rruleScheduling` enabled: exported an RRULE-scheduled pack with a description and ECS mappings, re-imported the JSON, and confirmed **name**, **description**, **RRULE schedule (Daily)**, and **both ECS mappings** reconstructed; the imported pack landed **disabled**.

Unit coverage includes:
- A genuine **executable round-trip** test — `serializePack` output is fed through the **real** pack-uploader parse path (not a re-implemented reviver), asserting verbatim query text, per-query interval/timeout/snapshot/removed, ecs_mapping, and the interval schedule survive.
- **Edit-mode** upload preserves existing name/description/schedule/`enabled`; **create-mode** adopts them.
- Legacy no-metadata import regression; **zero-query** packs; **reserved-filename** / control-char / truncation cases; read-only (`writePacks: false`) authorization for the Export action; Export renders last.

Scoped checks green:
- Jest (osquery plugin): all suites pass
- ESLint: clean
- Type check: exited 0

Known minor (follow-up): an RRULE-inheriting query exports a nominal `interval: 3600` (harmless — re-import re-applies the pack RRULE and the mode invariant holds).

</details>

## Checklist

- [x] Behind `exportPack` experimental flag (default off); not flipped for merge
- [x] Unit tests for export serialization + import mapping (executable round-trip, edit-mode preservation, filename safety, authz)
- [x] Verified export → import round-trip in a running instance

**AI-Assisted**: This PR was assisted by **Claude Code**
