### PR TITLE
[9.4] Backport #276697 to 9.4.x

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { AssetManagerClient } from './asset_manager_client';
+import { uninstallElasticsearchAssets } from './install_assets';
+import { deleteEuidStoredScripts } from './euid_stored_scripts';
+import { stopExtractEntityTask } from '../../tasks/extract_entity_task';
+import { stopHistorySnapshotTask } from '../../tasks/history_snapshot_task';
+import { stopStatusReportTask } from '../../tasks/status_report_task';
+
+jest.mock('./install_assets');
+jest.mock('./euid_stored_scripts');
+jest.mock('../../tasks/extract_entity_task');
+jest.mock('../../tasks/history_snapshot_task');
+jest.mock('../../tasks/status_report_task');
+
+const mockUninstallElasticsearchAssets = uninstallElasticsearchAssets as jest.MockedFunction<
+  typeof uninstallElasticsearchAssets
+>;
+const mockDeleteEuidStoredScripts = deleteEuidStoredScripts as jest.MockedFunction<
+  typeof deleteEuidStoredScripts
+>;
+const mockStopExtractEntityTask = stopExtractEntityTask as jest.MockedFunction<
+  typeof stopExtractEntityTask
+>;
+const mockStopHistorySnapshotTask = stopHistorySnapshotTask as jest.MockedFunction<
+  typeof stopHistorySnapshotTask
+>;
+const mockStopStatusReportTask = stopStatusReportTask as jest.MockedFunction<
+  typeof stopStatusReportTask
+>;
+
+describe('AssetManagerClient', () => {
+  const namespace = 'default';
+
+  let client: AssetManagerClient;
+  let mockEngineDescriptorClient: {
+    getAll: jest.Mock;
+    init: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+  let mockGlobalStateClient: {
+    init: jest.Mock;
+    findOrThrow: jest.Mock;
+    find: jest.Mock;
+    delete: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUninstallElasticsearchAssets.mockResolvedValue(undefined);
+    mockDeleteEuidStoredScripts.mockResolvedValue(undefined);
+    mockStopExtractEntityTask.mockResolvedValue(undefined);
+    mockStopHistorySnapshotTask.mockResolvedValue(undefined);
+    mockStopStatusReportTask.mockResolvedValue(undefined);
+
+    mockEngineDescriptorClient = {
+      getAll: jest.fn().mockResolvedValue([]),
+      init: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockGlobalStateClient = {
+      init: jest.fn().mockResolvedValue(undefined),
+      findOrThrow: jest.fn().mockResolvedValue({
+        historySnapshot: {},
+        logsExtraction: {},
+      }),
+      find: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    client = new AssetManagerClient({
+      logger: loggerMock.create(),
+      esClient: {} as jest.Mocked<ElasticsearchClient>,
+      taskManager: {} as jest.Mocked<TaskManagerStartContract>,
+      engineDescriptorClient:
+        mockEngineDescriptorClient as unknown as import('../saved_objects').EngineDescriptorClient,
+      globalStateClient:
+        mockGlobalStateClient as unknown as import('../saved_objects').EntityStoreGlobalStateClient,
+      ccsLogExtractionStateClient: {
+        delete: jest.fn().mockResolvedValue(undefined),
+      } as unknown as import('../saved_objects/ccs_log_extraction_state').CcsLogExtractionStateClient,
+      namespace,
+      isServerless: false,
+      logsExtractionClient: {} as unknown as import('../logs_extraction').LogsExtractionClient,
+      security: {} as SecurityPluginStart,
+      analytics: {
+        reportEvent: jest.fn(),
+      } as unknown as import('../../telemetry/events').TelemetryReporter,
+      savedObjectsClient: {} as SavedObjectsClientContract,
+    });
+  });
+
+  describe('uninstall', () => {
+    // getAll is called twice in uninstall: once via getStatus (before delete) and once
+    // to compute remainingEngines (after delete). Sequence the mock accordingly.
+    it('keeps shared assets when other engines remain (see: https://github.com/elastic/security-team/issues/18143)', async () => {
+      mockEngineDescriptorClient.getAll
+        .mockResolvedValueOnce([
+          { type: 'host', status: 'started' },
+          { type: 'user', status: 'started' },
+        ])
+        .mockResolvedValueOnce([{ type: 'user', status: 'started' }]);
+
+      const result = await client.uninstall('host');
+
+      expect(result).toBe(true);
+      expect(mockEngineDescriptorClient.delete).toHaveBeenCalledWith('host');
+      // Shared, per-namespace / cluster assets must survive.
+      expect(mockUninstallElasticsearchAssets).not.toHaveBeenCalled();
+      expect(mockDeleteEuidStoredScripts).not.toHaveBeenCalled();
+      expect(mockGlobalStateClient.delete).not.toHaveBeenCalled();
+      expect(mockStopStatusReportTask).not.toHaveBeenCalled();
+      expect(mockStopHistorySnapshotTask).not.toHaveBeenCalled();
+    });
+
+    it('deletes shared assets when the last engine is uninstalled', async () => {
+      mockEngineDescriptorClient.getAll
+        .mockResolvedValueOnce([{ type: 'host', status: 'started' }])
+        .mockResolvedValueOnce([]);
+
+      const result = await client.uninstall('host');
+
+      expect(result).toBe(true);
+      expect(mockEngineDescriptorClient.delete).toHaveBeenCalledWith('host');
+      expect(mockUninstallElasticsearchAssets).toHaveBeenCalledTimes(1);
+      expect(mockDeleteEuidStoredScripts).toHaveBeenCalledTimes(1);
+      expect(mockGlobalStateClient.delete).toHaveBeenCalledTimes(1);
+      expect(mockStopStatusReportTask).toHaveBeenCalledTimes(1);
+      expect(mockStopHistorySnapshotTask).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when the type is not installed', async () => {
+      mockEngineDescriptorClient.getAll.mockResolvedValueOnce([
+        { type: 'user', status: 'started' },
+      ]);
+
+      const result = await client.uninstall('host');
+
+      expect(result).toBe(false);
+      expect(mockEngineDescriptorClient.delete).not.toHaveBeenCalled();
+      expect(mockUninstallElasticsearchAssets).not.toHaveBeenCalled();
+      expect(mockDeleteEuidStoredScripts).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -234,24 +234,29 @@ export class AssetManagerClient {
       }
       await this.stop(type);
 
+      // Per-type saved objects — always safe to remove for this type alone.
       await Promise.all([
         this.engineDescriptorClient.delete(type),
         this.ccsLogExtractionStateClient.delete(type),
-        uninstallElasticsearchAssets({
-          esClient: this.esClient,
-          logger: this.logger.get(type),
-          namespace: this.namespace,
-        }),
-        deleteEuidStoredScripts({
-          esClient: this.esClient,
-          logger: this.logger,
-        }),
       ]);
 
+      // The ES indices/data streams and the EUID stored scripts are shared across all
+      // entity types in the namespace (their names carry the namespace, not the type).
+      // Only remove them once no engine remains — otherwise the surviving engines lose
+      // the read/write targets and scripts their extraction queries still depend on.
       const remainingEngines = await this.engineDescriptorClient.getAll();
       if (remainingEngines.length === 0) {
-        this.logger.debug(`Deleting global state because last engine was uninstalled`);
+        this.logger.debug(`Removing shared assets because last engine was uninstalled`);
         await Promise.all([
+          uninstallElasticsearchAssets({
+            esClient: this.esClient,
+            logger: this.logger.get(type),
+            namespace: this.namespace,
+          }),
+          deleteEuidStoredScripts({
+            esClient: this.esClient,
+            logger: this.logger,
+          }),
           this.globalStateClient.delete(),
           stopStatusReportTask({
             taskManager: this.taskManager,

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/uninstall.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/uninstall.spec.ts
@@ -9,10 +9,13 @@ import { apiTest } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/api';
 import {
   PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
   ENTITY_STORE_ROUTES,
   ENTITY_STORE_TAGS,
   LATEST_INDEX,
+  UPDATES_INDEX,
 } from '../fixtures/constants';
+import { forceLogExtraction } from '../fixtures/helpers';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
 
 type ApiWorkerFixtures = Parameters<Parameters<typeof apiTest>[2]>[0];
@@ -25,12 +28,17 @@ const getExtractEntityTaskId = (entityType: string) =>
 
 apiTest.describe('Entity Store uninstall', { tag: ENTITY_STORE_TAGS }, () => {
   let defaultHeaders: Record<string, string>;
+  let internalHeaders: Record<string, string>;
 
   apiTest.beforeAll(async ({ samlAuth, kbnClient }) => {
     const credentials = await samlAuth.asInteractiveUser('admin');
     defaultHeaders = {
       ...credentials.cookieHeader,
       ...PUBLIC_HEADERS,
+    };
+    internalHeaders = {
+      ...credentials.cookieHeader,
+      ...INTERNAL_HEADERS,
     };
     await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
   });
@@ -119,6 +127,47 @@ apiTest.describe('Entity Store uninstall', { tag: ENTITY_STORE_TAGS }, () => {
     const existsAfter = await esClient.indices.exists({ index: LATEST_INDEX });
     expect(existsAfter).toBe(false);
   });
+
+  // Regression for https://github.com/elastic/security-team/issues/18143:
+  // the latest index, updates/metadata data streams and EUID scripts are shared per
+  // namespace. Uninstalling one entity type must NOT delete them while other engines
+  // are still installed — otherwise the surviving engines' extraction fails with
+  // `verification_exception: Unknown index [...]` / `index_not_found_exception`.
+  apiTest(
+    'keeps shared assets when only one of several engines is uninstalled',
+    async ({ apiClient, esClient }) => {
+      await install(apiClient, { entityTypes: ['user', 'host'] });
+
+      // Shared assets exist after install.
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(true);
+      const updatesBefore = await esClient.indices.getDataStream({ name: UPDATES_INDEX });
+      expect(updatesBefore.data_streams).toHaveLength(1);
+
+      // Uninstall a single type; the other engine stays installed.
+      await uninstall(apiClient, { entityTypes: ['host'] });
+
+      // Shared assets must still exist for the surviving `user` engine.
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(true);
+      const updatesAfter = await esClient.indices.getDataStream({ name: UPDATES_INDEX });
+      expect(updatesAfter.data_streams).toHaveLength(1);
+
+      // End-to-end: the surviving engine's extraction still succeeds (this is what
+      // fails in production when the shared index/data stream get deleted).
+      const extraction = await forceLogExtraction(
+        apiClient,
+        internalHeaders,
+        'user',
+        '2026-01-20T11:00:00Z',
+        '2026-01-20T13:00:00Z'
+      );
+      expect(extraction.statusCode).toBe(200);
+      expect(extraction.body).toMatchObject({ success: true });
+
+      // Uninstalling the last remaining engine tears the shared index down as expected.
+      await uninstall(apiClient, { entityTypes: ['user'] });
+      expect(await esClient.indices.exists({ index: LATEST_INDEX })).toBe(false);
+    }
+  );
 
   apiTest('uninstall is a no-op when entity store is not installed', async ({ apiClient }) => {
     const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {


### PR DESCRIPTION
## Summary

Backport https://github.com/elastic/kibana/pull/276697
Tracked by https://github.com/elastic/security-team/issues/18143

Automatic backport failed due to code differences between 9.4 and 9.5


