### PR TITLE
[Fleet] Block legacy policy APIs for agentless behind `disableAgentlessLegacyAPI`

### DIFF
--- a/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml
@@ -199,6 +199,7 @@ enabled:
   - x-pack/platform/test/examples/config.ts
   - x-pack/platform/test/fleet_api_integration/config.agent.ts
   - x-pack/platform/test/fleet_api_integration/config.agentless.ts
+  - x-pack/platform/test/fleet_api_integration/config.agentless_legacy_disabled.ts
   - x-pack/platform/test/fleet_api_integration/config.agent_policy.ts
   - x-pack/platform/test/fleet_api_integration/config.epm.ts
   - x-pack/platform/test/fleet_api_integration/config.event_ingested.ts

--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -21,8 +21,8 @@ const _allowedExperimentalValues = {
   installIntegrationsKnowledge: true,
   enableFleetPolicyRevisionsCleanupTask: true,
   enableAgentRollback: true, // When enabled, agent upgrade rollback will be available in the API and UI.
-  disableAgentlessLegacyAPI: false, // When enabled, the legacy agent/package policy APIs reject agentless create, update, upgrade, and copy.
-  enableAgentlessPoliciesUI: true, // When enabled, the UI reads/writes agentless integration policies through the agentless policies API. Disable as a kill switch to fall back to the legacy package-policy/agent-policy APIs.
+  disableAgentlessLegacyAPI: false, // When enabled, the legacy agent/package policy APIs reject agentless create, update, upgrade, and copy. Forces enableAgentlessPoliciesUI on (see below).
+  enableAgentlessPoliciesUI: true, // When enabled, the UI reads/writes agentless integration policies through the agentless policies API. Disable as a kill switch to fall back to the legacy APIs — but disableAgentlessLegacyAPI overrides it (the fallback would 400).
   enableEsqlViewInstall: false,
   enableSloTemplates: true,
   newBrowseIntegrationUx: true, // When enabled integrations, browse integrations page will use the new UX.

--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -21,7 +21,7 @@ const _allowedExperimentalValues = {
   installIntegrationsKnowledge: true,
   enableFleetPolicyRevisionsCleanupTask: true,
   enableAgentRollback: true, // When enabled, agent upgrade rollback will be available in the API and UI.
-  disableAgentlessLegacyAPI: false, // When enabled, it will disable creating agentless policies via agent or package policies API.
+  disableAgentlessLegacyAPI: false, // When enabled, the legacy agent/package policy APIs reject agentless create, update, upgrade, and copy.
   enableAgentlessPoliciesUI: true, // When enabled, the UI reads/writes agentless integration policies through the agentless policies API. Disable as a kill switch to fall back to the legacy package-policy/agent-policy APIs.
   enableEsqlViewInstall: false,
   enableSloTemplates: true,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -729,6 +729,9 @@ describe('usePackagePolicy - agentless', () => {
 
     // The fast-path agentless read effect must not run when the hint is missing.
     expect(sendGetAgentlessPolicy).not.toHaveBeenCalled();
+    // With the legacy-block flag off (default), the legacy dry-run still drives the upgrade
+    // preview and must keep running even for a detected-agentless policy.
+    expect(sendUpgradePackagePolicyDryRun).toHaveBeenCalledWith(['agentless-detect']);
 
     let saveResult: any;
     await act(async () => {
@@ -918,6 +921,48 @@ describe('usePackagePolicy - agentless', () => {
 
     // The superseded agentless response is discarded — the legacy load still wins.
     expect(result.current.packagePolicy?.name).toBe('nginx-1');
+  });
+});
+
+describe('usePackagePolicy - agentless with disableAgentlessLegacyAPI enabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // The legacy-block flag makes the package-policy upgrade dry-run 400 for agentless policies
+    // server-side. `enableAgentlessPoliciesUI` stays on (its default) so the save still routes
+    // through the agentless API.
+    jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+      ...allowedExperimentalValues,
+      disableAgentlessLegacyAPI: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('skips the legacy upgrade dry-run for a detected-agentless policy read without the hint', async () => {
+    // A hint-less entry point (deep link, or the policies table's per-row upgrade action) reads
+    // via the package-policy API. With the flag on, the legacy dry-run would 400, so it must be
+    // skipped for the detected-agentless policy — the edit form loads instead of an error page.
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('agentless-detect', {})
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('nginx-1'));
+
+    expect(sendGetAgentlessPolicy).not.toHaveBeenCalled();
+    expect(sendUpgradePackagePolicyDryRun).not.toHaveBeenCalled();
+  });
+
+  it('still runs the legacy dry-run for a non-agentless policy', async () => {
+    // The skip is scoped to agentless policies; regular policies keep their upgrade dry-run.
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('package-policy-1', {})
+    );
+    await waitFor(() => expect(result.current.packagePolicy?.name).toBe('nginx-1'));
+
+    expect(sendUpgradePackagePolicyDryRun).toHaveBeenCalledWith(['package-policy-1']);
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -267,7 +267,8 @@ export function usePackagePolicyWithRelatedData(
         // raised) on every load: this hook can re-run with a different `packagePolicyId` without
         // a remount, and a stale `true` from a previously loaded agentless policy would route the
         // next policy's save through the agentless PUT, which the server rejects.
-        setDetectedAgentless(Boolean(packagePolicyData?.item?.supports_agentless));
+        const isAgentlessInstance = Boolean(packagePolicyData?.item?.supports_agentless);
+        setDetectedAgentless(isAgentlessInstance);
 
         if (packagePolicyData!.item.policy_ids && packagePolicyData!.item.policy_ids.length > 0) {
           const { data, error: agentPolicyError } = await sendBulkGetAgentPolicies(
@@ -285,15 +286,27 @@ export function usePackagePolicyWithRelatedData(
           setAgentPolicies(data?.items ?? []);
         }
 
-        const { data: upgradePackagePolicyDryRunData, error: upgradePackagePolicyDryRunError } =
-          await sendUpgradePackagePolicyDryRun([packagePolicyId]);
+        // Skip the legacy upgrade dry-run for agentless policies only when the legacy API is disabled;
+        // forced-upgrade entry points would otherwise 400 before rendering the edit page.
+        const legacyAgentlessApiDisabled =
+          ExperimentalFeaturesService.get().disableAgentlessLegacyAPI;
+        let upgradePackagePolicyDryRunData: UpgradePackagePolicyDryRunResponse | undefined;
+        if (legacyAgentlessApiDisabled && isAgentlessInstance) {
+          // Clear any upgrade state left over from a previously loaded policy.
+          setDryRunData(undefined);
+        } else {
+          const { data, error: upgradePackagePolicyDryRunError } =
+            await sendUpgradePackagePolicyDryRun([packagePolicyId]);
 
-        if (upgradePackagePolicyDryRunError) {
-          throw upgradePackagePolicyDryRunError;
-        }
+          if (upgradePackagePolicyDryRunError) {
+            throw upgradePackagePolicyDryRunError;
+          }
 
-        if (ignore) {
-          return;
+          if (ignore) {
+            return;
+          }
+
+          upgradePackagePolicyDryRunData = data ?? undefined;
         }
 
         const hasUpgrade = upgradePackagePolicyDryRunData

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -286,6 +286,7 @@ export const AgentlessPackagePoliciesTable = ({
                     packagePolicy={packagePolicy}
                     agentPolicies={agentPolicies}
                     from={from || 'integrations-policy-list'}
+                    onUpgraded={refreshPackagePolicies}
                   />
                 </EuiFlexGroup>
               );
@@ -424,6 +425,7 @@ export const AgentlessPackagePoliciesTable = ({
                         })}?from=${upgradeFrom}`
                       : undefined
                   }
+                  onUpgraded={refreshPackagePolicies}
                   from={from}
                 />
               );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { act, fireEvent } from '@testing-library/react';
+
+import type { AgentPolicy, InMemoryPackagePolicy } from '../../../../../../types';
+import { ExperimentalFeaturesService } from '../../../../../../services';
+import { createIntegrationsTestRendererMock } from '../../../../../../../../mock';
+import { allowedExperimentalValues } from '../../../../../../../../../common/experimental_features';
+
+import { PackagePolicyUpgradeCell } from './package_policy_upgrade_cell';
+
+jest.mock('../../../../../../hooks', () => ({
+  ...jest.requireActual('../../../../../../hooks'),
+  // `useConfirmForceInstall` is undefined from `requireActual` on this barrel (circular deps);
+  // the renderer's provider tree calls it, so stub it like the sibling table tests do.
+  useConfirmForceInstall: jest.fn(),
+  // Stubbed so opening the confirm modal never risks a real request; the actual upgrade call +
+  // refresh are covered end-to-end by the shared hook via `package_policy_actions_menu.test.tsx`.
+  sendBulkUpgradeAgentlessPolicies: jest.fn(),
+}));
+
+const agentPolicies = [
+  { id: 'agentless-1', name: 'Agentless', supports_agentless: true },
+] as AgentPolicy[];
+
+const createPackagePolicy = (props: Partial<InMemoryPackagePolicy> = {}): InMemoryPackagePolicy =>
+  ({
+    id: 'pp-1',
+    name: 'my-agentless-policy',
+    hasUpgrade: true,
+    upgradeVersion: '0.5.0',
+    package: { name: 'nginx', title: 'Nginx', version: '0.4.0' },
+    ...props,
+  } as InMemoryPackagePolicy);
+
+function renderCell(props: Partial<React.ComponentProps<typeof PackagePolicyUpgradeCell>> = {}) {
+  const renderer = createIntegrationsTestRendererMock();
+  return renderer.render(
+    <PackagePolicyUpgradeCell
+      agentPolicies={agentPolicies}
+      packagePolicy={createPackagePolicy()}
+      {...props}
+    />
+  );
+}
+
+describe('PackagePolicyUpgradeCell', () => {
+  afterEach(() => {
+    if (jest.isMockFunction(ExperimentalFeaturesService.get)) {
+      jest.mocked(ExperimentalFeaturesService.get).mockRestore();
+    }
+  });
+
+  it('links to the legacy upgrade route for a non-agentless policy', async () => {
+    const utils = renderCell({ packagePolicy: createPackagePolicy({ supports_agentless: false }) });
+    const button = await utils.findByTestId('integrationPolicyUpgradeBtn');
+    expect(button).toHaveAttribute('href');
+  });
+
+  it('links to the legacy upgrade route for an agentless policy while disableAgentlessLegacyAPI is off', async () => {
+    const utils = renderCell({ packagePolicy: createPackagePolicy({ supports_agentless: true }) });
+    const button = await utils.findByTestId('integrationPolicyUpgradeBtn');
+    // Flag off (default): the legacy edit-page upgrade still works, so the link is untouched.
+    expect(button).toHaveAttribute('href');
+  });
+
+  describe('with disableAgentlessLegacyAPI enabled', () => {
+    beforeEach(() => {
+      jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+        ...allowedExperimentalValues,
+        disableAgentlessLegacyAPI: true,
+      });
+    });
+
+    it('opens the agentless upgrade confirm modal instead of linking to the legacy route', async () => {
+      const utils = renderCell({
+        packagePolicy: createPackagePolicy({ supports_agentless: true }),
+      });
+
+      const button = await utils.findByTestId('integrationPolicyUpgradeBtn');
+      // The agentless upgrade opens a confirm modal instead of linking to the (blocked) legacy route.
+      expect(button).not.toHaveAttribute('href');
+
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      // The shared agentless-upgrade confirm modal is shown.
+      expect(await utils.findByTestId('confirmModalConfirmButton')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_upgrade_cell.tsx
@@ -15,13 +15,22 @@ import type { AgentPolicy, InMemoryPackagePolicy } from '../../../../../../types
 import { useLink, useAuthz } from '../../../../../../hooks';
 import { PendingUpgradeReviewStatus } from '../../../installed_integrations/components/pending_upgrade_review_status';
 
+import { useAgentlessPolicyUpgrade } from './use_agentless_policy_upgrade';
+
 export const PackagePolicyUpgradeCell: React.FC<{
   packagePolicy: InMemoryPackagePolicy;
   agentPolicies: AgentPolicy[];
   from?: string;
-}> = ({ packagePolicy, agentPolicies, from = 'integrations-policy-list' }) => {
+  // Refetch callback used only for the agentless upgrade path (agentless row +
+  // `disableAgentlessLegacyAPI`), so the deployments table refreshes after the upgrade.
+  onUpgraded?: () => void;
+}> = ({ packagePolicy, agentPolicies, from = 'integrations-policy-list', onUpgraded }) => {
   const { getHref } = useLink();
   const canWriteIntegrationPolicies = useAuthz().integrations.writeIntegrationPolicies;
+  const { isAgentlessUpgrade, openModal, confirmModal } = useAgentlessPolicyUpgrade({
+    packagePolicy,
+    onUpgraded,
+  });
 
   if (agentPolicies.length === 0 || !packagePolicy.hasUpgrade) {
     return null;
@@ -65,10 +74,14 @@ export const PackagePolicyUpgradeCell: React.FC<{
         <EuiButton
           size="s"
           minWidth="0"
-          href={`${getHref('upgrade_package_policy', {
-            policyId: agentPolicies[0].id,
-            packagePolicyId: packagePolicy.id,
-          })}?from=${from}`}
+          {...(isAgentlessUpgrade
+            ? { onClick: openModal }
+            : {
+                href: `${getHref('upgrade_package_policy', {
+                  policyId: agentPolicies[0].id,
+                  packagePolicyId: packagePolicy.id,
+                })}?from=${from}`,
+              })}
           data-test-subj="integrationPolicyUpgradeBtn"
           isDisabled={!canWriteIntegrationPolicies}
         >
@@ -78,6 +91,7 @@ export const PackagePolicyUpgradeCell: React.FC<{
           />
         </EuiButton>
       </EuiFlexItem>
+      {confirmModal}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/use_agentless_policy_upgrade.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/use_agentless_policy_upgrade.tsx
@@ -74,8 +74,9 @@ export const useAgentlessPolicyUpgrade = ({
             values: { name: packagePolicy.name },
           })
         );
+        // Only refetch on success; on failure nothing changed server-side.
+        onUpgraded?.();
       }
-      onUpgraded?.();
     } catch (error) {
       notifications.toasts.addError(error, {
         title: i18n.translate('xpack.fleet.agentlessUpgrade.errorToast.title', {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/use_agentless_policy_upgrade.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/use_agentless_policy_upgrade.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+
+import type { InMemoryPackagePolicy } from '../../../../../../types';
+import { sendBulkUpgradeAgentlessPolicies, useStartServices } from '../../../../../../hooks';
+import { ExperimentalFeaturesService } from '../../../../../../services';
+
+/**
+ * Shared per-row agentless upgrade action for the deployments-table upgrade controls
+ * (the inline `PackagePolicyUpgradeCell` button and the `PackagePolicyActionsMenu` item).
+ *
+ * Once `disableAgentlessLegacyAPI` is on, the legacy `upgrade_package_policy` edit route those
+ * controls link to is blocked for agentless policies (the edit-page dry-run 400s and the flow
+ * no-ops). When `isAgentlessUpgrade` is true, callers should render an action that calls
+ * `openModal` instead of linking to that route; the returned `confirmModal` performs the upgrade
+ * through the agentless API and calls `onUpgraded` so the caller can refetch. While the flag is
+ * off the legacy edit-page upgrade still works, so `isAgentlessUpgrade` is false and callers keep
+ * their existing link.
+ */
+export const useAgentlessPolicyUpgrade = ({
+  packagePolicy,
+  onUpgraded,
+}: {
+  packagePolicy: Pick<InMemoryPackagePolicy, 'id' | 'name' | 'supports_agentless'>;
+  onUpgraded?: () => void;
+}): {
+  isAgentlessUpgrade: boolean;
+  openModal: () => void;
+  confirmModal: React.ReactNode;
+} => {
+  const { notifications } = useStartServices();
+  const isAgentlessUpgrade =
+    Boolean(packagePolicy.supports_agentless) &&
+    ExperimentalFeaturesService.get().disableAgentlessLegacyAPI;
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isUpgrading, setIsUpgrading] = useState(false);
+  const modalTitleId = useGeneratedHtmlId();
+
+  const openModal = useCallback(() => setIsModalVisible(true), []);
+
+  const handleConfirm = useCallback(async () => {
+    setIsUpgrading(true);
+    try {
+      const results = await sendBulkUpgradeAgentlessPolicies([packagePolicy.id]);
+      const failed = results.filter((result) => !result.success);
+      if (failed.length > 0) {
+        const errorMessage = failed.find((result) => result.body?.message)?.body?.message;
+        notifications.toasts.addWarning({
+          title: i18n.translate('xpack.fleet.agentlessUpgrade.errorToast.title', {
+            defaultMessage: 'Error upgrading agentless integration policy',
+          }),
+          text: errorMessage
+            ? i18n.translate('xpack.fleet.agentlessUpgrade.errorToast.messageWithError', {
+                defaultMessage: 'Upgrade it manually.\nError: {error}',
+                values: { error: errorMessage },
+              })
+            : i18n.translate('xpack.fleet.agentlessUpgrade.errorToast.message', {
+                defaultMessage: 'Upgrade it manually.',
+              }),
+        });
+      } else {
+        notifications.toasts.addSuccess(
+          i18n.translate('xpack.fleet.agentlessUpgrade.successToast.title', {
+            defaultMessage: 'Upgraded {name}',
+            values: { name: packagePolicy.name },
+          })
+        );
+      }
+      onUpgraded?.();
+    } catch (error) {
+      notifications.toasts.addError(error, {
+        title: i18n.translate('xpack.fleet.agentlessUpgrade.errorToast.title', {
+          defaultMessage: 'Error upgrading agentless integration policy',
+        }),
+      });
+    } finally {
+      setIsUpgrading(false);
+      setIsModalVisible(false);
+    }
+  }, [notifications.toasts, onUpgraded, packagePolicy.id, packagePolicy.name]);
+
+  const confirmModal = isModalVisible ? (
+    <EuiConfirmModal
+      aria-labelledby={modalTitleId}
+      titleProps={{ id: modalTitleId }}
+      title={i18n.translate('xpack.fleet.agentlessUpgrade.confirmModal.title', {
+        defaultMessage: 'Upgrade {name}?',
+        values: { name: packagePolicy.name },
+      })}
+      onCancel={() => setIsModalVisible(false)}
+      onConfirm={handleConfirm}
+      cancelButtonText={i18n.translate('xpack.fleet.agentlessUpgrade.confirmModal.cancel', {
+        defaultMessage: 'Cancel',
+      })}
+      confirmButtonText={i18n.translate('xpack.fleet.agentlessUpgrade.confirmModal.confirm', {
+        defaultMessage: 'Upgrade integration policy',
+      })}
+      isLoading={isUpgrading}
+      buttonColor="primary"
+    >
+      <FormattedMessage
+        id="xpack.fleet.agentlessUpgrade.confirmModal.body"
+        defaultMessage="This upgrades the integration policy to the latest package version and deploys the change to the agentless deployment."
+      />
+    </EuiConfirmModal>
+  ) : null;
+
+  return { isAgentlessUpgrade, openModal, confirmModal };
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.test.tsx
@@ -15,6 +15,9 @@ jest.mock('../../../../../hooks', () => {
   return {
     ...jest.requireActual('../../../../../hooks'),
     useGetPackagePoliciesQuery: jest.fn().mockReturnValue({ data: { items: [] } }),
+    useBulkGetAgentPoliciesQuery: jest
+      .fn()
+      .mockReturnValue({ data: { items: [] }, isLoading: false }),
     useGetPackageInstallStatus: jest.fn(),
     useGetSettingsQuery: jest.fn().mockReturnValue({
       data: { item: { integration_knowledge_enabled: true } },
@@ -76,6 +79,7 @@ import {
   useGetPackageInstallStatus,
   useAuthz,
   useGetPackagePoliciesQuery,
+  useBulkGetAgentPoliciesQuery,
   useUpgradePackagePolicyDryRunQuery,
   useUpgradeAgentlessPoliciesDryRunQuery,
 } from '../../../../../hooks';
@@ -238,6 +242,9 @@ describe('SettingsPage', () => {
 
     afterEach(() => {
       jest.mocked(useGetPackagePoliciesQuery).mockReturnValue({ data: { items: [] } } as any);
+      jest
+        .mocked(useBulkGetAgentPoliciesQuery)
+        .mockReturnValue({ data: { items: [] }, isLoading: false } as any);
       jest.mocked(isAgentlessPoliciesUIEnabled).mockReturnValue(true);
     });
 
@@ -267,6 +274,57 @@ describe('SettingsPage', () => {
         'agentless-policy',
       ]);
       expect(jest.mocked(useUpgradeAgentlessPoliciesDryRunQuery).mock.calls[0][0]).toEqual([]);
+    });
+
+    it('routes a parent-only agentless policy (no own supports_agentless flag) to the agentless dry-run', () => {
+      // Older agentless policies carry the flag only on their parent agent policy; the server's
+      // block matches them via the parent, so the client must too or they poison the legacy batch.
+      jest.mocked(useGetPackagePoliciesQuery).mockReturnValue({
+        data: {
+          items: [
+            { id: 'agent-based-policy', supports_agentless: false, policy_ids: ['regular-agent'] },
+            { id: 'legacy-agentless', supports_agentless: false, policy_ids: ['agentless-agent'] },
+          ],
+        },
+      } as any);
+      jest.mocked(useBulkGetAgentPoliciesQuery).mockReturnValue({
+        data: {
+          items: [
+            { id: 'regular-agent', supports_agentless: false },
+            { id: 'agentless-agent', supports_agentless: true },
+          ],
+        },
+        isLoading: false,
+      } as any);
+
+      renderComponent(installedPackageInfo);
+
+      expect(jest.mocked(useUpgradePackagePolicyDryRunQuery).mock.calls[0][0]).toEqual([
+        'agent-based-policy',
+      ]);
+      expect(jest.mocked(useUpgradeAgentlessPoliciesDryRunQuery).mock.calls[0][0]).toEqual([
+        'legacy-agentless',
+      ]);
+    });
+
+    it('holds the legacy dry-run (enabled: false) until the parent agent-policy lookup resolves', () => {
+      jest.mocked(useGetPackagePoliciesQuery).mockReturnValue({
+        data: {
+          items: [
+            { id: 'agent-based-policy', supports_agentless: false, policy_ids: ['regular-agent'] },
+          ],
+        },
+      } as any);
+      jest.mocked(useBulkGetAgentPoliciesQuery).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      } as any);
+
+      renderComponent(installedPackageInfo);
+
+      // While the parent lookup is loading, the legacy dry-run must not fire (a still-hidden
+      // parent-only agentless policy could otherwise 400 the whole batch).
+      expect(jest.mocked(useUpgradePackagePolicyDryRunQuery).mock.calls[0][2]?.enabled).toBe(false);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -27,6 +27,7 @@ import type { FleetStartServices } from '../../../../../../../plugin';
 import type { PackageInfo, PackageMetadata, RegistryPolicyTemplate } from '../../../../../types';
 import { InstallStatus } from '../../../../../types';
 import {
+  useBulkGetAgentPoliciesQuery,
   useGetPackagePoliciesQuery,
   useGetPackageInstallStatus,
   useLink,
@@ -145,41 +146,73 @@ export const SettingsPage: React.FC<Props> = memo(
     } = useChangelog(name, latestVersion, version);
 
     // Agentless package policies must upgrade through the agentless API, not the
-    // (deprecated-for-agentless) package-policy API. Partition by `supports_agentless`
-    // so each set goes to its own upgrade + dry-run endpoint. When the agentless policies UI
-    // kill switch is off, everything stays on the legacy package-policy upgrade path (the
-    // agentless partition is empty, so its dry-run and upgrade calls never fire).
+    // (deprecated-for-agentless) package-policy API. Partition by whether each policy is
+    // effectively agentless so each set goes to its own upgrade + dry-run endpoint. When the
+    // agentless policies UI kill switch is off, everything stays on the legacy package-policy
+    // upgrade path (the agentless partition is empty, so its dry-run and upgrade calls never fire).
     const agentlessUIEnabled = isAgentlessPoliciesUIEnabled();
-    const agentlessPolicyIds = useMemo(
-      () =>
-        agentlessUIEnabled
-          ? packagePoliciesData?.items
-              .filter((packagePolicy) => packagePolicy.supports_agentless === true)
-              .map(({ id }) => id) ?? []
-          : [],
-      [packagePoliciesData, agentlessUIEnabled]
-    );
-
-    const packagePolicyIds = useMemo(
-      () =>
-        packagePoliciesData?.items
-          .filter(
-            (packagePolicy) => !agentlessUIEnabled || packagePolicy.supports_agentless !== true
-          )
-          .map(({ id }) => id) ?? [],
-      [packagePoliciesData, agentlessUIEnabled]
-    );
 
     const agentPolicyIds = useMemo(
       () => packagePoliciesData?.items.flatMap((packagePolicy) => packagePolicy.policy_ids) ?? [],
       [packagePoliciesData]
     );
 
+    // The server's legacy-API block treats a policy as agentless if its own `supports_agentless`
+    // flag is set OR its parent agent policy is agentless (older policies predate the per-policy
+    // flag). Mirror that fallback so such a policy is routed to the agentless upgrade path instead
+    // of poisoning the legacy batch — otherwise, with `disableAgentlessLegacyAPI` on, the whole
+    // legacy dry-run/upgrade 400s and takes the user's regular policies down with it. Only needed
+    // when the agentless UI is enabled; the query stays disabled otherwise.
+    const { data: agentPoliciesData, isLoading: isAgentPoliciesLoading } =
+      useBulkGetAgentPoliciesQuery(agentPolicyIds, {
+        ignoreMissing: true,
+        enabled: agentlessUIEnabled && agentPolicyIds.length > 0,
+      });
+    const agentlessParentPolicyIds = useMemo(
+      () =>
+        new Set(
+          (agentPoliciesData?.items ?? [])
+            .filter((agentPolicy) => agentPolicy.supports_agentless)
+            .map(({ id }) => id)
+        ),
+      [agentPoliciesData]
+    );
+    const isEffectivelyAgentless = useCallback(
+      (packagePolicy: { supports_agentless?: boolean | null; policy_ids?: string[] }) =>
+        packagePolicy.supports_agentless === true ||
+        (packagePolicy.policy_ids ?? []).some((id) => agentlessParentPolicyIds.has(id)),
+      [agentlessParentPolicyIds]
+    );
+    // While the parent lookup is still resolving, an older (parent-only) agentless policy would be
+    // mis-classified as legacy; hold the legacy dry-run until it settles so we never fire it with a
+    // still-hidden agentless policy in the batch. The guard short-circuits before reading the
+    // loading state when the query is disabled (a disabled react-query reports `isLoading` forever).
+    const isAgentlessDetectionPending =
+      agentlessUIEnabled && agentPolicyIds.length > 0 && isAgentPoliciesLoading;
+
+    const agentlessPolicyIds = useMemo(
+      () =>
+        agentlessUIEnabled
+          ? packagePoliciesData?.items
+              .filter((packagePolicy) => isEffectivelyAgentless(packagePolicy))
+              .map(({ id }) => id) ?? []
+          : [],
+      [packagePoliciesData, agentlessUIEnabled, isEffectivelyAgentless]
+    );
+
+    const packagePolicyIds = useMemo(
+      () =>
+        packagePoliciesData?.items
+          .filter((packagePolicy) => !agentlessUIEnabled || !isEffectivelyAgentless(packagePolicy))
+          .map(({ id }) => id) ?? [],
+      [packagePoliciesData, agentlessUIEnabled, isEffectivelyAgentless]
+    );
+
     const { data: dryRunData } = useUpgradePackagePolicyDryRunQuery(
       packagePolicyIds,
       latestVersion,
       {
-        enabled: packagePolicyIds.length > 0,
+        enabled: packagePolicyIds.length > 0 && !isAgentlessDetectionPending,
       }
     );
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 
-import { waitFor } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 
 import type { AgentPolicy, InMemoryPackagePolicy } from '../types';
 import { createIntegrationsTestRendererMock } from '../mock';
 
-import { useMultipleAgentPolicies, useLink, useGetOneAgentPolicy } from '../hooks';
+import {
+  useMultipleAgentPolicies,
+  useLink,
+  useGetOneAgentPolicy,
+  sendBulkUpgradeAgentlessPolicies,
+} from '../hooks';
 import { allowedExperimentalValues } from '../../common/experimental_features';
 import { ExperimentalFeaturesService } from '../services';
 
@@ -23,12 +28,13 @@ jest.mock('../hooks', () => {
     ...jest.requireActual('../hooks'),
     useMultipleAgentPolicies: jest.fn(),
     useGetOneAgentPolicy: jest.fn().mockReturnValue({ data: undefined, isLoading: false }),
+    sendBulkUpgradeAgentlessPolicies: jest.fn(),
     useStartServices: jest.fn().mockReturnValue({
       application: {
         navigateToApp: jest.fn(),
       },
       notifications: {
-        toasts: { addSuccess: jest.fn() },
+        toasts: { addSuccess: jest.fn(), addWarning: jest.fn(), addError: jest.fn() },
       },
       cloud: {
         isCloudEnabled: true,
@@ -88,11 +94,13 @@ function renderMenu({
   packagePolicy,
   showAddAgent = false,
   defaultIsOpen = true,
+  onUpgraded,
 }: {
   agentPolicies: AgentPolicy[];
   packagePolicy: InMemoryPackagePolicy;
   showAddAgent?: boolean;
   defaultIsOpen?: boolean;
+  onUpgraded?: () => void;
 }) {
   const renderer = createIntegrationsTestRendererMock();
 
@@ -103,6 +111,7 @@ function renderMenu({
       showAddAgent={showAddAgent}
       upgradePackagePolicyHref="/test/upgrade-link"
       defaultIsOpen={defaultIsOpen}
+      onUpgraded={onUpgraded}
       key="test1"
     />
   );
@@ -178,6 +187,70 @@ describe('PackagePolicyActionsMenu', () => {
       const upgradeButton = utils.getByTestId('PackagePolicyActionsUpgradeItem');
       expect(upgradeButton).not.toBeDisabled();
     });
+  });
+
+  describe('agentless upgrade (disableAgentlessLegacyAPI enabled)', () => {
+    beforeEach(() => {
+      jest.mocked(sendBulkUpgradeAgentlessPolicies).mockReset();
+      jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({
+        ...allowedExperimentalValues,
+        disableAgentlessLegacyAPI: true,
+      });
+    });
+
+    afterEach(() => {
+      jest.mocked(ExperimentalFeaturesService.get).mockRestore();
+    });
+
+    it('upgrades an agentless policy through the agentless API and refreshes on confirm', async () => {
+      jest
+        .mocked(sendBulkUpgradeAgentlessPolicies)
+        .mockResolvedValue([
+          { id: 'some-uuid2', name: 'mock-package-policy', success: true },
+        ] as any);
+      const onUpgraded = jest.fn();
+      const agentPolicies = createMockAgentPolicies({ supports_agentless: true });
+      const packagePolicy = createMockPackagePolicy({ hasUpgrade: true, supports_agentless: true });
+      const { utils } = renderMenu({ agentPolicies, packagePolicy, onUpgraded });
+
+      const upgradeButton = await utils.findByTestId('PackagePolicyActionsUpgradeItem');
+      // With the legacy API disabled, the agentless upgrade opens a confirm modal instead of
+      // linking to the (now-blocked) legacy edit route.
+      expect(upgradeButton).not.toHaveAttribute('href');
+
+      await act(async () => {
+        fireEvent.click(upgradeButton);
+      });
+
+      const confirmButton = await utils.findByTestId('confirmModalConfirmButton');
+      await act(async () => {
+        fireEvent.click(confirmButton);
+      });
+
+      await waitFor(() => {
+        expect(sendBulkUpgradeAgentlessPolicies).toHaveBeenCalledWith(['some-uuid2']);
+      });
+      expect(onUpgraded).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the legacy upgrade link for a non-agentless policy', async () => {
+      const agentPolicies = createMockAgentPolicies();
+      const packagePolicy = createMockPackagePolicy({ hasUpgrade: true });
+      const { utils } = renderMenu({ agentPolicies, packagePolicy });
+
+      const upgradeButton = await utils.findByTestId('PackagePolicyActionsUpgradeItem');
+      expect(upgradeButton).toHaveAttribute('href', '/test/upgrade-link');
+    });
+  });
+
+  it('keeps the legacy upgrade link for an agentless policy while disableAgentlessLegacyAPI is off', async () => {
+    const agentPolicies = createMockAgentPolicies({ supports_agentless: true });
+    const packagePolicy = createMockPackagePolicy({ hasUpgrade: true, supports_agentless: true });
+    const { utils } = renderMenu({ agentPolicies, packagePolicy });
+
+    const upgradeButton = await utils.findByTestId('PackagePolicyActionsUpgradeItem');
+    // Flag off (default): the legacy edit-page upgrade still works, so the link is untouched.
+    expect(upgradeButton).toHaveAttribute('href', '/test/upgrade-link');
   });
 
   it('Should not be able to delete integration from a managed policy', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
@@ -29,6 +29,7 @@ import {
 import { isAgentlessPoliciesUIEnabled, policyHasFleetServer } from '../services';
 
 import { scheduleAutoOpenModal } from '../applications/integrations/sections/epm/screens/installed_integrations/components/pending_upgrade_review_status';
+import { useAgentlessPolicyUpgrade } from '../applications/integrations/sections/epm/screens/detail/policies/components/use_agentless_policy_upgrade';
 
 import { AgentEnrollmentFlyout } from './agent_enrollment_flyout';
 import { ContextMenuActions } from './context_menu_actions';
@@ -44,6 +45,9 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   defaultIsOpen?: boolean;
   upgradePackagePolicyHref?: string;
   from?: 'fleet-policy-list' | 'installed-integrations' | undefined;
+  // Called after a successful agentless upgrade so the caller can refetch its list. Only relevant
+  // when the agentless upgrade action is used (agentless row + `disableAgentlessLegacyAPI`).
+  onUpgraded?: () => void;
 }> = ({
   agentPolicies,
   packagePolicy,
@@ -51,6 +55,7 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   upgradePackagePolicyHref,
   defaultIsOpen = false,
   from,
+  onUpgraded,
 }) => {
   const [isEnrollmentFlyoutOpen, setIsEnrollmentFlyoutOpen] = useState(false);
   const { getHref } = useLink();
@@ -70,6 +75,12 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   const agentPolicyIsManaged = Boolean(agentPolicy?.is_managed);
   const isOrphanedPolicy = !agentPolicy && packagePolicy.policy_ids.length === 0;
   const isAgentlessPolicy = packagePolicy.supports_agentless;
+
+  const {
+    isAgentlessUpgrade,
+    openModal: openAgentlessUpgradeModal,
+    confirmModal: agentlessUpgradeModal,
+  } = useAgentlessPolicyUpgrade({ packagePolicy, onUpgraded });
 
   // For agentless policies the agentPolicies prop may be empty (the parent hook doesn't always
   // fetch them) or a minimal synthesized policy without `agentless` details (the agentless
@@ -246,9 +257,18 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
       ? [
           <EuiContextMenuItem
             data-test-subj="PackagePolicyActionsUpgradeItem"
-            disabled={!canWriteIntegrationPolicies || !upgradePackagePolicyHref}
+            disabled={
+              !canWriteIntegrationPolicies || (!isAgentlessUpgrade && !upgradePackagePolicyHref)
+            }
             icon="refresh"
-            href={upgradePackagePolicyHref}
+            {...(isAgentlessUpgrade
+              ? {
+                  onClick: () => {
+                    setIsActionsMenuOpen(false);
+                    openAgentlessUpgradeModal();
+                  },
+                }
+              : { href: upgradePackagePolicyHref })}
             key="packagePolicyUpgrade"
           >
             <FormattedMessage
@@ -364,6 +384,7 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   }
   return (
     <>
+      {agentlessUpgradeModal}
       {isEnrollmentFlyoutOpen && (
         <EuiPortal>
           <AgentEnrollmentFlyout

--- a/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { allowedExperimentalValues } from '../../common/experimental_features';
+
+import { ExperimentalFeaturesService } from './experimental_features';
+import { isAgentlessPoliciesUIEnabled } from './agentless_policies_ui';
+
+describe('isAgentlessPoliciesUIEnabled', () => {
+  const init = (overrides: Partial<typeof allowedExperimentalValues>) =>
+    ExperimentalFeaturesService.init({ ...allowedExperimentalValues, ...overrides });
+
+  it('is true when the kill switch is on', () => {
+    init({ enableAgentlessPoliciesUI: true, disableAgentlessLegacyAPI: false });
+    expect(isAgentlessPoliciesUIEnabled()).toBe(true);
+  });
+
+  it('is false when the kill switch is off and the legacy API is available', () => {
+    init({ enableAgentlessPoliciesUI: false, disableAgentlessLegacyAPI: false });
+    expect(isAgentlessPoliciesUIEnabled()).toBe(false);
+  });
+
+  it('ignores the kill switch when disableAgentlessLegacyAPI is on (legacy fallback would 400)', () => {
+    init({ enableAgentlessPoliciesUI: false, disableAgentlessLegacyAPI: true });
+    expect(isAgentlessPoliciesUIEnabled()).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/services/agentless_policies_ui.ts
@@ -17,7 +17,13 @@ import { ExperimentalFeaturesService } from './experimental_features';
  * upgrade) are gated. Agentless policy create and delete are NOT gated — they have been calling
  * the agentless API in production for a while and predate this switch, so they stay on it even
  * when the flag is off.
+ *
+ * The kill switch falls back to the legacy APIs, but `disableAgentlessLegacyAPI` blocks those for
+ * agentless — so when that flag is on, ignore the kill switch and keep the UI on the agentless API
+ * (otherwise agentless would be unmanageable).
  */
 export const isAgentlessPoliciesUIEnabled = (): boolean => {
-  return ExperimentalFeaturesService.get().enableAgentlessPoliciesUI;
+  const { enableAgentlessPoliciesUI, disableAgentlessLegacyAPI } =
+    ExperimentalFeaturesService.get();
+  return enableAgentlessPoliciesUI || disableAgentlessLegacyAPI;
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
@@ -141,7 +141,7 @@ describe('Agent policy API handlers', () => {
       } as AgentPolicy);
 
       await expect(copyAgentPolicyHandler(context, getCopyRequest(), response)).rejects.toThrow(
-        /Agentless agent policies cannot be copied/
+        /Agentless agent policies cannot be copied.*Source agent policy: source-policy\./
       );
       expect(agentPolicyServiceMock.copy).not.toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
@@ -89,6 +89,25 @@ describe('Agent policy API handlers', () => {
       expect(response.ok).toHaveBeenCalledWith({
         body: { item: createdAgentPolicy },
       });
+      // Flag off: the legacy agentless write is allowed but logged so it stays
+      // measurable before the flag is flipped fleet-wide.
+      expect(appContextService.getLogger().warn).toHaveBeenCalledWith(
+        expect.stringContaining('legacy_agentless_write_deprecation')
+      );
+    });
+
+    it('should not log the legacy agentless deprecation for non-agentless agent policies when the flag is disabled', async () => {
+      appContextService.start(createAppContextStartContractMock());
+      const request = httpServerMock.createKibanaRequest({
+        body: { name: 'Regular policy', namespace: 'default' },
+      });
+
+      await createAgentPolicyHandler(context, request, response);
+
+      expect(response.ok).toHaveBeenCalled();
+      expect(appContextService.getLogger().warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('legacy_agentless_write_deprecation')
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
@@ -7,15 +7,18 @@
 
 import { httpServerMock } from '@kbn/core/server/mocks';
 
-import { agentPolicyService } from '../../services';
+import { agentPolicyService, appContextService } from '../../services';
 
 import type { FleetRequestHandlerContext } from '../..';
-import { xpackMocks } from '../../mocks';
+import { createAppContextStartContractMock, xpackMocks } from '../../mocks';
 import type { AgentClient } from '../../services/agents';
 import type { AgentPolicy } from '../../types';
+import { createAgentPolicyWithPackages } from '../../services/agent_policy_create';
 
 import {
   bulkGetAgentPoliciesHandler,
+  copyAgentPolicyHandler,
+  createAgentPolicyHandler,
   GetListAgentPolicyOutputsHandler,
   populateAssignedAgentsCount,
 } from './handlers';
@@ -23,9 +26,17 @@ import {
 jest.mock('../../services/agent_policy', () => {
   return {
     agentPolicyService: {
+      get: jest.fn(),
       getByIds: jest.fn(),
+      copy: jest.fn(),
       listAllOutputsForPolicies: jest.fn(),
     },
+  };
+});
+
+jest.mock('../../services/agent_policy_create', () => {
+  return {
+    createAgentPolicyWithPackages: jest.fn(),
   };
 });
 
@@ -38,6 +49,109 @@ describe('Agent policy API handlers', () => {
   beforeEach(async () => {
     context = xpackMocks.createRequestHandlerContext() as unknown as FleetRequestHandlerContext;
     response = httpServerMock.createResponseFactory();
+  });
+
+  describe('createAgentPolicyHandler', () => {
+    const createdAgentPolicy = { id: 'new-policy', name: 'New policy' } as AgentPolicy;
+
+    beforeEach(() => {
+      (createAgentPolicyWithPackages as jest.Mock).mockResolvedValue(createdAgentPolicy);
+    });
+
+    afterEach(() => {
+      appContextService.stop();
+    });
+
+    it('should reject agentless agent policies when disableAgentlessLegacyAPI is enabled', async () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, false, undefined, {
+          disableAgentlessLegacyAPI: true,
+        })
+      );
+      const request = httpServerMock.createKibanaRequest({
+        body: { name: 'Agentless policy', namespace: 'default', supports_agentless: true },
+      });
+
+      await expect(createAgentPolicyHandler(context, request, response)).rejects.toThrow(
+        /To create agentless agent policies/
+      );
+      expect(createAgentPolicyWithPackages).not.toHaveBeenCalled();
+    });
+
+    it('should allow agentless agent policies when disableAgentlessLegacyAPI is disabled', async () => {
+      appContextService.start(createAppContextStartContractMock());
+      const request = httpServerMock.createKibanaRequest({
+        body: { name: 'Agentless policy', namespace: 'default', supports_agentless: true },
+      });
+
+      await createAgentPolicyHandler(context, request, response);
+
+      expect(response.ok).toHaveBeenCalledWith({
+        body: { item: createdAgentPolicy },
+      });
+    });
+  });
+
+  describe('copyAgentPolicyHandler', () => {
+    const copiedAgentPolicy = { id: 'copied-policy', name: 'Copied policy' } as AgentPolicy;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      agentPolicyServiceMock.copy.mockResolvedValue(copiedAgentPolicy);
+    });
+
+    afterEach(() => {
+      appContextService.stop();
+    });
+
+    const getCopyRequest = () =>
+      httpServerMock.createKibanaRequest({
+        params: { agentPolicyId: 'source-policy' },
+        body: { name: 'Copied policy', description: '' },
+      });
+
+    it('should reject copying agentless agent policies when disableAgentlessLegacyAPI is enabled', async () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, false, undefined, {
+          disableAgentlessLegacyAPI: true,
+        })
+      );
+      agentPolicyServiceMock.get.mockResolvedValue({
+        id: 'source-policy',
+        supports_agentless: true,
+      } as AgentPolicy);
+
+      await expect(copyAgentPolicyHandler(context, getCopyRequest(), response)).rejects.toThrow(
+        /Agentless agent policies cannot be copied/
+      );
+      expect(agentPolicyServiceMock.copy).not.toHaveBeenCalled();
+    });
+
+    it('should allow copying regular agent policies when disableAgentlessLegacyAPI is enabled', async () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, false, undefined, {
+          disableAgentlessLegacyAPI: true,
+        })
+      );
+      agentPolicyServiceMock.get.mockResolvedValue({ id: 'source-policy' } as AgentPolicy);
+
+      await copyAgentPolicyHandler(context, getCopyRequest(), response);
+
+      expect(response.ok).toHaveBeenCalledWith({
+        body: { item: copiedAgentPolicy },
+      });
+    });
+
+    it('should allow copying agentless agent policies when disableAgentlessLegacyAPI is disabled', async () => {
+      appContextService.start(createAppContextStartContractMock());
+
+      await copyAgentPolicyHandler(context, getCopyRequest(), response);
+
+      expect(response.ok).toHaveBeenCalledWith({
+        body: { item: copiedAgentPolicy },
+      });
+      expect(agentPolicyServiceMock.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('GetListAgentPolicyOutputsHandler', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -433,9 +433,7 @@ export const createAgentPolicyHandler: FleetRequestHandler<
       appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI &&
       request.body.supports_agentless
     ) {
-      throw new FleetError(
-        'To create agentless agent policies, use the Fleet agentless policies API.'
-      );
+      throw new FleetError('To create agentless agent policies, use the agentless policies API.');
     }
 
     const agentPolicy = await createAgentPolicyWithPackages({
@@ -643,9 +641,7 @@ export const updateAgentPolicyHandler: FleetRequestHandler<
       false
     );
     if (existingAgentPolicy?.supports_agentless || data.supports_agentless) {
-      throw new FleetError(
-        'To update agentless agent policies, use the Fleet agentless policies API.'
-      );
+      throw new FleetError('To update agentless agent policies, use the agentless policies API.');
     }
 
     const agentPolicy = await agentPolicyService.update(
@@ -701,6 +697,20 @@ export const copyAgentPolicyHandler: RequestHandler<
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = appContextService.getSecurityCore().authc.getCurrentUser(request) || undefined;
   try {
+    if (appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
+      const sourceAgentPolicy = await agentPolicyService.get(
+        soClient,
+        request.params.agentPolicyId,
+        false
+      );
+      // A missing source falls through to `copy`, which reports the not-found error.
+      if (sourceAgentPolicy?.supports_agentless) {
+        throw new FleetError(
+          'Agentless agent policies cannot be copied. To create agentless deployments, use the agentless policies API.'
+        );
+      }
+    }
+
     const agentPolicy = await agentPolicyService.copy(
       soClient,
       esClient,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -34,6 +34,7 @@ import {
   licenseService,
 } from '../../services';
 import { type AgentClient } from '../../services/agents';
+import { logLegacyAgentlessWriteDeprecation } from '../../services/utils/agentless';
 import { UNPRIVILEGED_AGENT_KUERY } from '../../constants';
 import type {
   GetAgentPoliciesRequestSchema,
@@ -429,11 +430,14 @@ export const createAgentPolicyHandler: FleetRequestHandler<
       }
     }
 
-    if (
-      appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI &&
-      request.body.supports_agentless
-    ) {
-      throw new FleetError('To create agentless agent policies, use the agentless policies API.');
+    // The cheap `supports_agentless` detection runs regardless of the flag so
+    // legacy agentless usage is measurable (deprecation warn) before the flag is
+    // flipped fleet-wide — the flip is what starts rejecting these callers.
+    if (request.body.supports_agentless) {
+      if (appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
+        throw new FleetError('To create agentless agent policies, use the agentless policies API.');
+      }
+      logLegacyAgentlessWriteDeprecation('create agent policy');
     }
 
     const agentPolicy = await createAgentPolicyWithPackages({

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -710,7 +710,7 @@ export const copyAgentPolicyHandler: RequestHandler<
       // A missing source falls through to `copy`, which reports the not-found error.
       if (sourceAgentPolicy?.supports_agentless) {
         throw new FleetError(
-          'Agentless agent policies cannot be copied. To create agentless deployments, use the agentless policies API.'
+          `Agentless agent policies cannot be copied. To create agentless deployments, use the agentless policies API. Source agent policy: ${request.params.agentPolicyId}.`
         );
       }
     }

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
@@ -669,6 +669,20 @@ describe('When calling package policy', () => {
       await routeHandler(context, getUpdateKibanaRequest(), response);
 
       expect(response.ok).toHaveBeenCalled();
+      // Flag off: the legacy agentless write is allowed but logged so it stays
+      // measurable before the flag is flipped fleet-wide.
+      expect(appContextService.getLogger().warn).toHaveBeenCalledWith(
+        expect.stringContaining('legacy_agentless_write_deprecation')
+      );
+    });
+
+    it('should not log the legacy agentless deprecation for non-agentless updates when the flag is disabled', async () => {
+      await routeHandler(context, getUpdateKibanaRequest(), response);
+
+      expect(response.ok).toHaveBeenCalled();
+      expect(appContextService.getLogger().warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('legacy_agentless_write_deprecation')
+      );
     });
   });
 
@@ -970,6 +984,27 @@ describe('When calling package policy', () => {
       expect(response.ok).toHaveBeenCalled();
       expect(getPackageInfo).not.toHaveBeenCalled();
       expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+      // Flag off: the legacy agentless write is allowed but logged so it stays
+      // measurable before the flag is flipped fleet-wide.
+      expect(appContextService.getLogger().warn).toHaveBeenCalledWith(
+        expect.stringContaining('legacy_agentless_write_deprecation')
+      );
+    });
+
+    it('should not log the legacy agentless deprecation for non-agentless creates when the flag is disabled', async () => {
+      packagePolicyServiceMock.get.mockResolvedValue(testPackagePolicy);
+      (
+        (await context.fleet).packagePolicyService.asCurrentUser as jest.Mocked<PackagePolicyClient>
+      ).create.mockResolvedValue(testPackagePolicy);
+
+      const request = httpServerMock.createKibanaRequest({ body: testPackagePolicy });
+
+      await createPackagePolicyHandler(context, request, response);
+
+      expect(response.ok).toHaveBeenCalled();
+      expect(appContextService.getLogger().warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('legacy_agentless_write_deprecation')
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
@@ -600,7 +600,7 @@ describe('When calling package policy', () => {
         });
 
         await expect(routeHandler(context, getUpdateKibanaRequest(), response)).rejects.toThrow(
-          /To update agentless package policies/
+          /To update agentless package policies.*Offending package policy: 1\./
         );
         expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
       });
@@ -618,7 +618,7 @@ describe('When calling package policy', () => {
 
       it('should reject when request policy_ids target an agentless agent policy', async () => {
         (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
-          { is_managed: false, supports_agentless: true },
+          { id: 'agentless', is_managed: false, supports_agentless: true },
         ]);
 
         await expect(
@@ -627,13 +627,15 @@ describe('When calling package policy', () => {
             getUpdateKibanaRequest({ policy_ids: ['agentless'] } as any),
             response
           )
-        ).rejects.toThrow(/To add integrations to an agentless agent policy/);
+        ).rejects.toThrow(
+          /To add integrations to an agentless agent policy.*Agentless agent policies: agentless\./
+        );
         expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
       });
 
       it('should reject when request policy_id targets an agentless agent policy', async () => {
         (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
-          { is_managed: false, supports_agentless: true },
+          { id: 'agentless', is_managed: false, supports_agentless: true },
         ]);
 
         await expect(
@@ -644,11 +646,11 @@ describe('When calling package policy', () => {
 
       it('should reject when a parent agent policy is agentless', async () => {
         (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
-          { is_managed: false, supports_agentless: true },
+          { id: '2', is_managed: false, supports_agentless: true },
         ]);
 
         await expect(routeHandler(context, getUpdateKibanaRequest(), response)).rejects.toThrow(
-          /To update agentless package policies/
+          /To update agentless package policies.*Offending package policy: 1\./
         );
         expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
       });
@@ -1192,8 +1194,9 @@ describe('When calling package policy', () => {
           },
         });
 
+        // Only the offending id is named, so a batch owner can self-remediate.
         await expect(upgradePackagePolicyHandler(context, request, response)).rejects.toThrow(
-          /To upgrade agentless package policies/
+          /To upgrade agentless package policies.*Agentless package policies in this request: 2\./
         );
         expect(packagePolicyServiceMock.bulkUpgrade).not.toHaveBeenCalled();
       });
@@ -1213,7 +1216,7 @@ describe('When calling package policy', () => {
         });
 
         await expect(upgradePackagePolicyHandler(context, request, response)).rejects.toThrow(
-          /To upgrade agentless package policies/
+          /Agentless package policies in this request: 1\./
         );
         expect(packagePolicyServiceMock.bulkUpgrade).not.toHaveBeenCalled();
       });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
@@ -968,6 +968,25 @@ describe('When calling package policy', () => {
 
         expect(response.ok).toHaveBeenCalled();
       });
+
+      it('should resolve the agentless-only check with skipArchive to avoid a full archive download', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          policy_templates: [mixedTemplate],
+        });
+        (
+          (await context.fleet).packagePolicyService
+            .asCurrentUser as jest.Mocked<PackagePolicyClient>
+        ).create.mockResolvedValue(testPackagePolicy);
+
+        const request = httpServerMock.createKibanaRequest({ body: testPackagePolicy });
+
+        await createPackagePolicyHandler(context, request, response);
+
+        // The pre-`try` agentless-only detection only needs deployment_modes, so it
+        // must resolve from the registry manifest (skipArchive) rather than pulling
+        // and verifying the full archive before any other validation.
+        expect(getPackageInfo).toHaveBeenCalledWith(expect.objectContaining({ skipArchive: true }));
+      });
     });
 
     it('should allow to create agentless package policies when disableAgentlessLegacyAPI is disabled', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.test.ts
@@ -47,6 +47,7 @@ import {
 import type { PackagePolicy } from '../../types';
 
 import { ListResponseSchema } from '../schema/utils';
+import { getInstallation, getPackageInfo, removeInstallation } from '../../services/epm/packages';
 
 import {
   bulkGetPackagePoliciesHandler,
@@ -149,6 +150,7 @@ jest.mock('../../services/epm/packages', () => {
     ensureInstalledPackage: jest.fn(() => Promise.resolve()),
     getPackageInfo: jest.fn(() => Promise.resolve()),
     getInstallation: jest.fn(),
+    removeInstallation: jest.fn(),
     getInstallations: jest.fn().mockResolvedValue({
       saved_objects: [
         {
@@ -581,6 +583,93 @@ describe('When calling package policy', () => {
       const validationResp = PackagePolicyResponseSchema.validate(responseItem);
       expect(validationResp).toEqual(responseItem);
     });
+
+    describe('when disableAgentlessLegacyAPI is enabled', () => {
+      beforeEach(() => {
+        appContextService.start(
+          createAppContextStartContractMock({}, false, undefined, {
+            disableAgentlessLegacyAPI: true,
+          })
+        );
+      });
+
+      it('should reject when the existing package policy is agentless', async () => {
+        packagePolicyServiceMock.get.mockResolvedValue({
+          ...existingPolicy,
+          supports_agentless: true,
+        });
+
+        await expect(routeHandler(context, getUpdateKibanaRequest(), response)).rejects.toThrow(
+          /To update agentless package policies/
+        );
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject when the request body sets supports_agentless', async () => {
+        await expect(
+          routeHandler(
+            context,
+            getUpdateKibanaRequest({ supports_agentless: true } as any),
+            response
+          )
+        ).rejects.toThrow(/To update agentless package policies/);
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject when request policy_ids target an agentless agent policy', async () => {
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { is_managed: false, supports_agentless: true },
+        ]);
+
+        await expect(
+          routeHandler(
+            context,
+            getUpdateKibanaRequest({ policy_ids: ['agentless'] } as any),
+            response
+          )
+        ).rejects.toThrow(/To add integrations to an agentless agent policy/);
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject when request policy_id targets an agentless agent policy', async () => {
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { is_managed: false, supports_agentless: true },
+        ]);
+
+        await expect(
+          routeHandler(context, getUpdateKibanaRequest({ policy_id: 'agentless' } as any), response)
+        ).rejects.toThrow(/To add integrations to an agentless agent policy/);
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject when a parent agent policy is agentless', async () => {
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { is_managed: false, supports_agentless: true },
+        ]);
+
+        await expect(routeHandler(context, getUpdateKibanaRequest(), response)).rejects.toThrow(
+          /To update agentless package policies/
+        );
+        expect(packagePolicyServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should allow updating non-agentless package policies', async () => {
+        await routeHandler(context, getUpdateKibanaRequest(), response);
+
+        expect(response.ok).toHaveBeenCalled();
+      });
+    });
+
+    it('should allow updating agentless package policies when disableAgentlessLegacyAPI is disabled', async () => {
+      packagePolicyServiceMock.get.mockResolvedValue({
+        ...existingPolicy,
+        supports_agentless: true,
+      });
+
+      await routeHandler(context, getUpdateKibanaRequest(), response);
+
+      expect(response.ok).toHaveBeenCalled();
+    });
   });
 
   describe('list api handler', () => {
@@ -772,7 +861,7 @@ describe('When calling package policy', () => {
       });
 
       await expect(createPackagePolicyHandler(context, request, response)).rejects.toThrow(
-        /To create agentless package policies, use the Fleet agentless policies API./
+        /To create agentless package policies, use the agentless policies API./
       );
     });
 
@@ -791,6 +880,96 @@ describe('When calling package policy', () => {
       });
       const validationResp = CreatePackagePolicyResponseSchema.validate(expectedResponse);
       expect(validationResp).toEqual(expectedResponse);
+    });
+
+    describe('when disableAgentlessLegacyAPI is enabled', () => {
+      const agentlessOnlyTemplate = {
+        name: 'template',
+        deployment_modes: { agentless: { enabled: true }, default: { enabled: false } },
+      };
+      const mixedTemplate = {
+        name: 'template',
+        deployment_modes: { agentless: { enabled: true }, default: { enabled: true } },
+      };
+
+      beforeEach(() => {
+        appContextService.start(
+          createAppContextStartContractMock({}, false, undefined, {
+            disableAgentlessLegacyAPI: true,
+          })
+        );
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([{ is_managed: false }]);
+      });
+
+      it('should reject packages that only support agentless deployment', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          policy_templates: [agentlessOnlyTemplate],
+        });
+        (getInstallation as jest.Mock).mockResolvedValue({ install_status: 'installing' });
+
+        const request = httpServerMock.createKibanaRequest({
+          body: testPackagePolicy,
+        });
+
+        await expect(createPackagePolicyHandler(context, request, response)).rejects.toThrow(
+          /only supports agentless deployment/
+        );
+        // The rejection happens before anything is installed or created, so the
+        // catch-block rollback must not run — even when a concurrent request has
+        // the package mid-install.
+        expect(removeInstallation).not.toHaveBeenCalled();
+      });
+
+      it('should reject when a target agent policy is agentless', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          policy_templates: [mixedTemplate],
+        });
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { supports_agentless: true },
+        ]);
+
+        const request = httpServerMock.createKibanaRequest({
+          body: testPackagePolicy,
+        });
+
+        await expect(createPackagePolicyHandler(context, request, response)).rejects.toThrow(
+          /To add integrations to an agentless agent policy/
+        );
+      });
+
+      it('should allow mixed-deployment packages in default mode', async () => {
+        (getPackageInfo as jest.Mock).mockResolvedValue({
+          policy_templates: [mixedTemplate],
+        });
+        (
+          (await context.fleet).packagePolicyService
+            .asCurrentUser as jest.Mocked<PackagePolicyClient>
+        ).create.mockResolvedValue(testPackagePolicy);
+
+        const request = httpServerMock.createKibanaRequest({
+          body: testPackagePolicy,
+        });
+
+        await createPackagePolicyHandler(context, request, response);
+
+        expect(response.ok).toHaveBeenCalled();
+      });
+    });
+
+    it('should allow to create agentless package policies when disableAgentlessLegacyAPI is disabled', async () => {
+      (
+        (await context.fleet).packagePolicyService.asCurrentUser as jest.Mocked<PackagePolicyClient>
+      ).create.mockResolvedValue(testPackagePolicy);
+
+      const request = httpServerMock.createKibanaRequest({
+        body: { ...testPackagePolicy, supports_agentless: true },
+      });
+
+      await createPackagePolicyHandler(context, request, response);
+
+      expect(response.ok).toHaveBeenCalled();
+      expect(getPackageInfo).not.toHaveBeenCalled();
+      expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
     });
   });
 
@@ -923,6 +1102,88 @@ describe('When calling package policy', () => {
         body: responseBody,
       });
     });
+
+    it('should not look up target policies when disableAgentlessLegacyAPI is disabled', async () => {
+      packagePolicyServiceMock.bulkUpgrade.mockResolvedValue(responseBody);
+      const request = httpServerMock.createKibanaRequest({
+        body: {
+          packagePolicyIds: ['1'],
+        },
+      });
+      await upgradePackagePolicyHandler(context, request, response);
+      expect(response.ok).toHaveBeenCalledWith({
+        body: responseBody,
+      });
+      expect(packagePolicyServiceMock.getByIDs).not.toHaveBeenCalled();
+    });
+
+    describe('when disableAgentlessLegacyAPI is enabled', () => {
+      beforeEach(() => {
+        appContextService.start(
+          createAppContextStartContractMock({}, false, undefined, {
+            disableAgentlessLegacyAPI: true,
+          })
+        );
+      });
+
+      it('should reject the whole request when any target package policy is agentless', async () => {
+        packagePolicyServiceMock.getByIDs.mockResolvedValue([
+          { id: '1', policy_ids: [] },
+          { id: '2', policy_ids: [], supports_agentless: true },
+        ] as unknown as PackagePolicy[]);
+
+        const request = httpServerMock.createKibanaRequest({
+          body: {
+            packagePolicyIds: ['1', '2'],
+          },
+        });
+
+        await expect(upgradePackagePolicyHandler(context, request, response)).rejects.toThrow(
+          /To upgrade agentless package policies/
+        );
+        expect(packagePolicyServiceMock.bulkUpgrade).not.toHaveBeenCalled();
+      });
+
+      it('should reject when a target package policy belongs to an agentless agent policy', async () => {
+        packagePolicyServiceMock.getByIDs.mockResolvedValue([
+          { id: '1', policy_ids: ['agentless-ap'] },
+        ] as unknown as PackagePolicy[]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([
+          { id: 'agentless-ap', supports_agentless: true },
+        ]);
+
+        const request = httpServerMock.createKibanaRequest({
+          body: {
+            packagePolicyIds: ['1'],
+          },
+        });
+
+        await expect(upgradePackagePolicyHandler(context, request, response)).rejects.toThrow(
+          /To upgrade agentless package policies/
+        );
+        expect(packagePolicyServiceMock.bulkUpgrade).not.toHaveBeenCalled();
+      });
+
+      it('should upgrade regular package policies', async () => {
+        packagePolicyServiceMock.getByIDs.mockResolvedValue([
+          { id: '1', policy_ids: ['regular-ap'] },
+        ] as unknown as PackagePolicy[]);
+        (agentPolicyService.getByIds as jest.Mock).mockResolvedValue([{ id: 'regular-ap' }]);
+        packagePolicyServiceMock.bulkUpgrade.mockResolvedValue(responseBody);
+
+        const request = httpServerMock.createKibanaRequest({
+          body: {
+            packagePolicyIds: ['1'],
+          },
+        });
+
+        await upgradePackagePolicyHandler(context, request, response);
+
+        expect(response.ok).toHaveBeenCalledWith({
+          body: responseBody,
+        });
+      });
+    });
   });
 
   describe('dry run upgrade api handler', () => {
@@ -1031,6 +1292,42 @@ describe('When calling package policy', () => {
       expect(response.ok).toHaveBeenCalledWith({
         body: responseBody,
       });
+    });
+
+    it('should not look up target policies when disableAgentlessLegacyAPI is disabled', async () => {
+      const request = httpServerMock.createKibanaRequest({
+        body: {
+          packagePolicyIds: ['1', '2'],
+        },
+      });
+      await dryRunUpgradePackagePolicyHandler(context, request, response);
+      expect(response.ok).toHaveBeenCalledWith({
+        body: responseBody,
+      });
+      expect(packagePolicyServiceMock.getByIDs).not.toHaveBeenCalled();
+    });
+
+    it('should reject agentless package policies when disableAgentlessLegacyAPI is enabled', async () => {
+      appContextService.start(
+        createAppContextStartContractMock({}, false, undefined, {
+          disableAgentlessLegacyAPI: true,
+        })
+      );
+      packagePolicyServiceMock.getByIDs.mockResolvedValue([
+        { id: '1', policy_ids: [] },
+        { id: '2', policy_ids: [], supports_agentless: true },
+      ] as unknown as PackagePolicy[]);
+
+      const request = httpServerMock.createKibanaRequest({
+        body: {
+          packagePolicyIds: ['1', '2'],
+        },
+      });
+
+      await expect(dryRunUpgradePackagePolicyHandler(context, request, response)).rejects.toThrow(
+        /To upgrade agentless package policies/
+      );
+      expect(packagePolicyServiceMock.getUpgradeDryRunDiff).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -259,12 +259,14 @@ export const createPackagePolicyHandler: FleetRequestHandler<
   // flag-gated to avoid adding cost to normal (flag-off) traffic.
   if (legacyAgentlessApiDisabled) {
     if (pkg) {
+      // skipArchive: only deployment_modes is needed here, avoid the archive download.
       const pkgInfo = await getPackageInfo({
         savedObjectsClient: soClient,
         pkgName: pkg.name,
         pkgVersion: pkg.version,
         ignoreUnverified: force,
         prerelease: true,
+        skipArchive: true,
       });
       if (isOnlyAgentlessIntegration(pkgInfo)) {
         throw new FleetError(

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -65,6 +65,7 @@ import { runWithCache } from '../../services/epm/packages/cache';
 
 import {
   alignInputsAndStreams,
+  getAgentlessAgentPolicyIds,
   haveAgentlessAgentPolicies,
   isSimplifiedCreatePackagePolicyRequest,
   removeFieldsFromInputSchema,
@@ -427,10 +428,13 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
   // The cheap own/body-flag detection runs regardless of the flag so legacy
   // agentless usage is measurable before the flip. The body flag is checked to
   // prevent converting a regular package policy into an agentless one.
+  const { packagePolicyId } = request.params;
   const isAgentless = Boolean(packagePolicy.supports_agentless || request.body.supports_agentless);
   if (isAgentless) {
     if (legacyAgentlessApiDisabled) {
-      throw new FleetError('To update agentless package policies, use the agentless policies API.');
+      throw new FleetError(
+        `To update agentless package policies, use the agentless policies API. Offending package policy: ${packagePolicyId}.`
+      );
     }
     logLegacyAgentlessWriteDeprecation('update package policy');
   }
@@ -442,14 +446,19 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
       ...(request.body.policy_ids ?? []),
       ...(request.body.policy_id ? [request.body.policy_id] : []),
     ];
-    if (await haveAgentlessAgentPolicies(soClient, targetParentPolicyIds)) {
+    const agentlessTargetIds = await getAgentlessAgentPolicyIds(soClient, targetParentPolicyIds);
+    if (agentlessTargetIds.length > 0) {
       throw new FleetError(
-        'To add integrations to an agentless agent policy, use the agentless policies API.'
+        `To add integrations to an agentless agent policy, use the agentless policies API. Agentless agent policies: ${agentlessTargetIds.join(
+          ', '
+        )}.`
       );
     }
 
     if (await haveAgentlessAgentPolicies(soClient, packagePolicy.policy_ids ?? [])) {
-      throw new FleetError('To update agentless package policies, use the agentless policies API.');
+      throw new FleetError(
+        `To update agentless package policies, use the agentless policies API. Offending package policy: ${packagePolicyId}.`
+      );
     }
   }
 
@@ -643,14 +652,27 @@ const throwIfTargetsAgentlessPolicies = async (
   const packagePolicies =
     (await packagePolicyService.getByIDs(soClient, packagePolicyIds, { ignoreMissing: true })) ??
     [];
-  let hasAgentless = packagePolicies.some((packagePolicy) => packagePolicy.supports_agentless);
-  if (!hasAgentless) {
-    // Older agentless package policies may not carry the flag themselves — check parents.
-    const parentPolicyIds = packagePolicies.flatMap((packagePolicy) => packagePolicy.policy_ids);
-    hasAgentless = await haveAgentlessAgentPolicies(soClient, parentPolicyIds);
-  }
-  if (hasAgentless) {
-    throw new FleetError(`To upgrade agentless package policies, use the agentless policies API.`);
+  // Older agentless package policies may not carry the flag themselves — check parents too.
+  const agentlessParentIds = new Set(
+    await getAgentlessAgentPolicyIds(
+      soClient,
+      packagePolicies.flatMap((packagePolicy) => packagePolicy.policy_ids)
+    )
+  );
+  const offendingIds = packagePolicies
+    .filter(
+      (packagePolicy) =>
+        packagePolicy.supports_agentless ||
+        packagePolicy.policy_ids.some((id) => agentlessParentIds.has(id))
+    )
+    .map(({ id }) => id);
+  if (offendingIds.length > 0) {
+    // The whole batch is rejected, so name the offenders for self-remediation.
+    throw new FleetError(
+      `To upgrade agentless package policies, use the agentless policies API. Agentless package policies in this request: ${offendingIds.join(
+        ', '
+      )}.`
+    );
   }
 };
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -41,6 +41,7 @@ import type {
   UpgradePackagePolicyResponse,
 } from '../../../common/types';
 import { isOnlyAgentlessIntegration } from '../../../common/services/agentless_policy_helper';
+import { logLegacyAgentlessWriteDeprecation } from '../../services/utils/agentless';
 import { inputsFormat, installationStatuses } from '../../../common/constants';
 import {
   CustomPackagePolicyNotAllowedForAgentlessError,
@@ -241,10 +242,22 @@ export const createPackagePolicyHandler: FleetRequestHandler<
   // These checks run before the try block on purpose: its catch treats errors as
   // creation failures (error log + package installation rollback), which must not
   // run for these pure validation rejections.
-  if (appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
-    if (request.body.supports_agentless) {
+  const legacyAgentlessApiDisabled =
+    appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI;
+
+  // The cheap `supports_agentless` detection runs regardless of the flag so legacy
+  // agentless usage is measurable (deprecation warn) before the flag is flipped
+  // fleet-wide — the flip is what starts rejecting these callers.
+  if (request.body.supports_agentless) {
+    if (legacyAgentlessApiDisabled) {
       throw new FleetError('To create agentless package policies, use the agentless policies API.');
     }
+    logLegacyAgentlessWriteDeprecation('create package policy');
+  }
+
+  // The remaining detections need extra SO/registry lookups, so they stay
+  // flag-gated to avoid adding cost to normal (flag-off) traffic.
+  if (legacyAgentlessApiDisabled) {
     if (pkg) {
       const pkgInfo = await getPackageInfo({
         savedObjectsClient: soClient,
@@ -410,17 +423,23 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
     }
   }
 
-  if (appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
-    // Older agentless package policies may not carry the flag themselves, so the
-    // parent agent policy is checked too; the body flag is checked to prevent
-    // converting a regular package policy into an agentless one.
-    const isAgentless = Boolean(
-      packagePolicy.supports_agentless || request.body.supports_agentless
-    );
-    if (isAgentless) {
+  const legacyAgentlessApiDisabled =
+    appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI;
+
+  // The cheap own/body-flag detection runs regardless of the flag so legacy
+  // agentless usage is measurable before the flip. The body flag is checked to
+  // prevent converting a regular package policy into an agentless one.
+  const isAgentless = Boolean(packagePolicy.supports_agentless || request.body.supports_agentless);
+  if (isAgentless) {
+    if (legacyAgentlessApiDisabled) {
       throw new FleetError('To update agentless package policies, use the agentless policies API.');
     }
+    logLegacyAgentlessWriteDeprecation('update package policy');
+  }
 
+  // The parent-agent-policy detections need extra SO lookups, so they stay flag-gated to avoid
+  // adding cost to normal (flag-off) traffic.
+  if (legacyAgentlessApiDisabled) {
     const targetParentPolicyIds = deduplicateIds([
       ...(request.body.policy_ids ?? []),
       ...(request.body.policy_id ? [request.body.policy_id] : []),

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -65,6 +65,7 @@ import { runWithCache } from '../../services/epm/packages/cache';
 
 import {
   alignInputsAndStreams,
+  haveAgentlessAgentPolicies,
   isSimplifiedCreatePackagePolicyRequest,
   removeFieldsFromInputSchema,
   renameAgentlessAgentPolicy,
@@ -274,19 +275,14 @@ export const createPackagePolicyHandler: FleetRequestHandler<
         );
       }
     }
-    const parentPolicyIds = deduplicateIds([
+    const parentPolicyIds = [
       ...(newPolicy.policy_ids ?? []),
       ...(newPolicy.policy_id ? [newPolicy.policy_id] : []),
-    ]);
-    if (parentPolicyIds.length > 0) {
-      const parentAgentPolicies = await agentPolicyService.getByIds(soClient, parentPolicyIds, {
-        ignoreMissing: true,
-      });
-      if (parentAgentPolicies.some((agentPolicy) => agentPolicy.supports_agentless)) {
-        throw new FleetError(
-          'To add integrations to an agentless agent policy, use the agentless policies API.'
-        );
-      }
+    ];
+    if (await haveAgentlessAgentPolicies(soClient, parentPolicyIds)) {
+      throw new FleetError(
+        'To add integrations to an agentless agent policy, use the agentless policies API.'
+      );
     }
   }
 
@@ -442,37 +438,18 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
   // The parent-agent-policy detections need extra SO lookups, so they stay flag-gated to avoid
   // adding cost to normal (flag-off) traffic.
   if (legacyAgentlessApiDisabled) {
-    const targetParentPolicyIds = deduplicateIds([
+    const targetParentPolicyIds = [
       ...(request.body.policy_ids ?? []),
       ...(request.body.policy_id ? [request.body.policy_id] : []),
-    ]);
-    if (targetParentPolicyIds.length > 0) {
-      const targetParentAgentPolicies = await agentPolicyService.getByIds(
-        soClient,
-        targetParentPolicyIds,
-        { ignoreMissing: true }
+    ];
+    if (await haveAgentlessAgentPolicies(soClient, targetParentPolicyIds)) {
+      throw new FleetError(
+        'To add integrations to an agentless agent policy, use the agentless policies API.'
       );
-      if (targetParentAgentPolicies.some((agentPolicy) => agentPolicy.supports_agentless)) {
-        throw new FleetError(
-          'To add integrations to an agentless agent policy, use the agentless policies API.'
-        );
-      }
     }
 
-    if ((packagePolicy.policy_ids ?? []).length > 0) {
-      const parentAgentPolicies = await agentPolicyService.getByIds(
-        soClient,
-        packagePolicy.policy_ids ?? [],
-        { ignoreMissing: true }
-      );
-      const isParentPolicyAgentless = parentAgentPolicies.some(
-        (agentPolicy) => agentPolicy.supports_agentless
-      );
-      if (isParentPolicyAgentless) {
-        throw new FleetError(
-          'To update agentless package policies, use the agentless policies API.'
-        );
-      }
+    if (await haveAgentlessAgentPolicies(soClient, packagePolicy.policy_ids ?? [])) {
+      throw new FleetError('To update agentless package policies, use the agentless policies API.');
     }
   }
 
@@ -669,15 +646,8 @@ const throwIfTargetsAgentlessPolicies = async (
   let hasAgentless = packagePolicies.some((packagePolicy) => packagePolicy.supports_agentless);
   if (!hasAgentless) {
     // Older agentless package policies may not carry the flag themselves — check parents.
-    const parentPolicyIds = deduplicateIds(
-      packagePolicies.flatMap((packagePolicy) => packagePolicy.policy_ids)
-    );
-    if (parentPolicyIds.length > 0) {
-      const parentAgentPolicies = await agentPolicyService.getByIds(soClient, parentPolicyIds, {
-        ignoreMissing: true,
-      });
-      hasAgentless = parentAgentPolicies.some((agentPolicy) => agentPolicy.supports_agentless);
-    }
+    const parentPolicyIds = packagePolicies.flatMap((packagePolicy) => packagePolicy.policy_ids);
+    hasAgentless = await haveAgentlessAgentPolicies(soClient, parentPolicyIds);
   }
   if (hasAgentless) {
     throw new FleetError(`To upgrade agentless package policies, use the agentless policies API.`);

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -7,8 +7,8 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 
+import type { RequestHandler, SavedObjectsClientContract } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
-import type { RequestHandler } from '@kbn/core/server';
 
 import { groupBy, isEmpty, isEqual, keyBy, uniq } from 'lodash';
 
@@ -21,31 +21,32 @@ import {
   packagePolicyService,
 } from '../../services';
 import type {
-  GetPackagePoliciesRequestSchema,
-  GetOnePackagePolicyRequestSchema,
+  BulkGetPackagePoliciesRequestSchema,
   CreatePackagePolicyRequestSchema,
-  UpdatePackagePolicyRequestSchema,
+  DeleteOnePackagePolicyRequestSchema,
   DeletePackagePoliciesRequestSchema,
-  UpgradePackagePoliciesRequestSchema,
   DryRunPackagePoliciesRequestSchema,
   FleetRequestHandler,
+  GetOnePackagePolicyRequestSchema,
+  GetPackagePoliciesRequestSchema,
   PackagePolicy,
-  DeleteOnePackagePolicyRequestSchema,
-  BulkGetPackagePoliciesRequestSchema,
   UpdatePackagePolicyRequestBodySchema,
+  UpdatePackagePolicyRequestSchema,
+  UpgradePackagePoliciesRequestSchema,
 } from '../../types';
 import type {
-  PostDeletePackagePoliciesResponse,
   NewPackagePolicy,
+  PostDeletePackagePoliciesResponse,
   UpgradePackagePolicyDryRunResponse,
   UpgradePackagePolicyResponse,
 } from '../../../common/types';
-import { installationStatuses, inputsFormat } from '../../../common/constants';
+import { isOnlyAgentlessIntegration } from '../../../common/services/agentless_policy_helper';
+import { inputsFormat, installationStatuses } from '../../../common/constants';
 import {
-  PackagePolicyNotFoundError,
-  PackagePolicyRequestError,
   CustomPackagePolicyNotAllowedForAgentlessError,
   FleetError,
+  PackagePolicyNotFoundError,
+  PackagePolicyRequestError,
 } from '../../errors';
 import {
   getInstallation,
@@ -54,19 +55,18 @@ import {
   removeInstallation,
 } from '../../services/epm/packages';
 import { PACKAGES_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../constants';
-import {
-  simplifiedPackagePolicytoNewPackagePolicy,
-  packagePolicyToSimplifiedPackagePolicy,
-} from '../../../common/services/simplified_package_policy_helper';
-
 import type { SimplifiedPackagePolicy } from '../../../common/services/simplified_package_policy_helper';
+import {
+  packagePolicyToSimplifiedPackagePolicy,
+  simplifiedPackagePolicytoNewPackagePolicy,
+} from '../../../common/services/simplified_package_policy_helper';
 import { runWithCache } from '../../services/epm/packages/cache';
 
 import {
+  alignInputsAndStreams,
   isSimplifiedCreatePackagePolicyRequest,
   removeFieldsFromInputSchema,
   renameAgentlessAgentPolicy,
-  alignInputsAndStreams,
 } from './utils';
 
 export const isNotNull = <T>(value: T | null): value is T => value !== null;
@@ -238,13 +238,41 @@ export const createPackagePolicyHandler: FleetRequestHandler<
 
   const spaceId = fleetContext.spaceId;
 
-  if (
-    appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI &&
-    request.body.supports_agentless
-  ) {
-    throw new FleetError(
-      'To create agentless package policies, use the Fleet agentless policies API.'
-    );
+  // These checks run before the try block on purpose: its catch treats errors as
+  // creation failures (error log + package installation rollback), which must not
+  // run for these pure validation rejections.
+  if (appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
+    if (request.body.supports_agentless) {
+      throw new FleetError('To create agentless package policies, use the agentless policies API.');
+    }
+    if (pkg) {
+      const pkgInfo = await getPackageInfo({
+        savedObjectsClient: soClient,
+        pkgName: pkg.name,
+        pkgVersion: pkg.version,
+        ignoreUnverified: force,
+        prerelease: true,
+      });
+      if (isOnlyAgentlessIntegration(pkgInfo)) {
+        throw new FleetError(
+          `Package ${pkg.name} only supports agentless deployment. To create agentless package policies, use the agentless policies API.`
+        );
+      }
+    }
+    const parentPolicyIds = deduplicateIds([
+      ...(newPolicy.policy_ids ?? []),
+      ...(newPolicy.policy_id ? [newPolicy.policy_id] : []),
+    ]);
+    if (parentPolicyIds.length > 0) {
+      const parentAgentPolicies = await agentPolicyService.getByIds(soClient, parentPolicyIds, {
+        ignoreMissing: true,
+      });
+      if (parentAgentPolicies.some((agentPolicy) => agentPolicy.supports_agentless)) {
+        throw new FleetError(
+          'To add integrations to an agentless agent policy, use the agentless policies API.'
+        );
+      }
+    }
   }
 
   try {
@@ -379,6 +407,51 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
       return response.forbidden({
         body: { message: `Update for package name ${packageName} is not authorized.` },
       });
+    }
+  }
+
+  if (appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
+    // Older agentless package policies may not carry the flag themselves, so the
+    // parent agent policy is checked too; the body flag is checked to prevent
+    // converting a regular package policy into an agentless one.
+    const isAgentless = Boolean(
+      packagePolicy.supports_agentless || request.body.supports_agentless
+    );
+    if (isAgentless) {
+      throw new FleetError('To update agentless package policies, use the agentless policies API.');
+    }
+
+    const targetParentPolicyIds = deduplicateIds([
+      ...(request.body.policy_ids ?? []),
+      ...(request.body.policy_id ? [request.body.policy_id] : []),
+    ]);
+    if (targetParentPolicyIds.length > 0) {
+      const targetParentAgentPolicies = await agentPolicyService.getByIds(
+        soClient,
+        targetParentPolicyIds,
+        { ignoreMissing: true }
+      );
+      if (targetParentAgentPolicies.some((agentPolicy) => agentPolicy.supports_agentless)) {
+        throw new FleetError(
+          'To add integrations to an agentless agent policy, use the agentless policies API.'
+        );
+      }
+    }
+
+    if ((packagePolicy.policy_ids ?? []).length > 0) {
+      const parentAgentPolicies = await agentPolicyService.getByIds(
+        soClient,
+        packagePolicy.policy_ids ?? [],
+        { ignoreMissing: true }
+      );
+      const isParentPolicyAgentless = parentAgentPolicies.some(
+        (agentPolicy) => agentPolicy.supports_agentless
+      );
+      if (isParentPolicyAgentless) {
+        throw new FleetError(
+          'To update agentless package policies, use the agentless policies API.'
+        );
+      }
     }
   }
 
@@ -560,6 +633,36 @@ export const deleteOnePackagePolicyHandler: RequestHandler<
   });
 };
 
+// Missing policies are skipped here (ignoreMissing) so the upgrade/dry-run
+// handlers keep reporting them as per-item 404s.
+const throwIfTargetsAgentlessPolicies = async (
+  soClient: SavedObjectsClientContract,
+  packagePolicyIds: string[]
+): Promise<void> => {
+  if (!appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI) {
+    return;
+  }
+  const packagePolicies =
+    (await packagePolicyService.getByIDs(soClient, packagePolicyIds, { ignoreMissing: true })) ??
+    [];
+  let hasAgentless = packagePolicies.some((packagePolicy) => packagePolicy.supports_agentless);
+  if (!hasAgentless) {
+    // Older agentless package policies may not carry the flag themselves — check parents.
+    const parentPolicyIds = deduplicateIds(
+      packagePolicies.flatMap((packagePolicy) => packagePolicy.policy_ids)
+    );
+    if (parentPolicyIds.length > 0) {
+      const parentAgentPolicies = await agentPolicyService.getByIds(soClient, parentPolicyIds, {
+        ignoreMissing: true,
+      });
+      hasAgentless = parentAgentPolicies.some((agentPolicy) => agentPolicy.supports_agentless);
+    }
+  }
+  if (hasAgentless) {
+    throw new FleetError(`To upgrade agentless package policies, use the agentless policies API.`);
+  }
+};
+
 export const upgradePackagePolicyHandler: RequestHandler<
   unknown,
   unknown,
@@ -570,6 +673,9 @@ export const upgradePackagePolicyHandler: RequestHandler<
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = appContextService.getSecurityCore().authc.getCurrentUser(request) || undefined;
   const packagePolicyIds = deduplicateIds(request.body.packagePolicyIds);
+
+  await throwIfTargetsAgentlessPolicies(soClient, packagePolicyIds);
+
   const body: UpgradePackagePolicyResponse = await packagePolicyService.bulkUpgrade(
     soClient,
     esClient,
@@ -599,6 +705,9 @@ export const dryRunUpgradePackagePolicyHandler: RequestHandler<
 
   const body: UpgradePackagePolicyDryRunResponse = [];
   const packagePolicyIds = deduplicateIds(request.body.packagePolicyIds);
+
+  await throwIfTargetsAgentlessPolicies(soClient, packagePolicyIds);
+
   await runWithCache(async () => {
     for (const id of packagePolicyIds) {
       const result = await packagePolicyService.getUpgradeDryRunDiff(soClient, id);

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.test.ts
@@ -8,7 +8,12 @@
 import { agentPolicyService } from '../../../services';
 import { isAgentlessEnabled } from '../../../services/utils/agentless';
 
-import { alignInputsAndStreams, haveAgentlessAgentPolicies, renameAgentlessAgentPolicy } from '.';
+import {
+  alignInputsAndStreams,
+  getAgentlessAgentPolicyIds,
+  haveAgentlessAgentPolicies,
+  renameAgentlessAgentPolicy,
+} from '.';
 
 jest.mock('../../../services/utils/agentless', () => ({
   isAgentlessEnabled: jest.fn(),
@@ -42,6 +47,31 @@ function makeAgentPolicy(overrides: Record<string, any> = {}): any {
     ...overrides,
   };
 }
+
+describe('getAgentlessAgentPolicyIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns [] without a lookup when no ids are given', async () => {
+    expect(await getAgentlessAgentPolicyIds(mockSoClient, [])).toEqual([]);
+    expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+  });
+
+  it('returns only the ids of the agentless parents', async () => {
+    jest
+      .mocked(agentPolicyService.getByIds)
+      .mockResolvedValue([
+        makeAgentPolicy({ id: 'a', supports_agentless: false }),
+        makeAgentPolicy({ id: 'b', supports_agentless: true }),
+      ]);
+
+    expect(await getAgentlessAgentPolicyIds(mockSoClient, ['a', 'a', 'b'])).toEqual(['b']);
+    expect(agentPolicyService.getByIds).toHaveBeenCalledWith(mockSoClient, ['a', 'b'], {
+      ignoreMissing: true,
+    });
+  });
+});
 
 describe('haveAgentlessAgentPolicies', () => {
   beforeEach(() => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.test.ts
@@ -8,7 +8,7 @@
 import { agentPolicyService } from '../../../services';
 import { isAgentlessEnabled } from '../../../services/utils/agentless';
 
-import { alignInputsAndStreams, renameAgentlessAgentPolicy } from '.';
+import { alignInputsAndStreams, haveAgentlessAgentPolicies, renameAgentlessAgentPolicy } from '.';
 
 jest.mock('../../../services/utils/agentless', () => ({
   isAgentlessEnabled: jest.fn(),
@@ -17,6 +17,7 @@ jest.mock('../../../services/utils/agentless', () => ({
 jest.mock('../../../services', () => ({
   agentPolicyService: {
     get: jest.fn(),
+    getByIds: jest.fn(),
     update: jest.fn(),
   },
 }));
@@ -41,6 +42,43 @@ function makeAgentPolicy(overrides: Record<string, any> = {}): any {
     ...overrides,
   };
 }
+
+describe('haveAgentlessAgentPolicies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns false without a lookup when no ids are given', async () => {
+    expect(await haveAgentlessAgentPolicies(mockSoClient, [])).toBe(false);
+    expect(agentPolicyService.getByIds).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates ids and looks them up with ignoreMissing', async () => {
+    jest.mocked(agentPolicyService.getByIds).mockResolvedValue([makeAgentPolicy()]);
+
+    await haveAgentlessAgentPolicies(mockSoClient, ['a', 'a', 'b']);
+
+    expect(agentPolicyService.getByIds).toHaveBeenCalledWith(mockSoClient, ['a', 'b'], {
+      ignoreMissing: true,
+    });
+  });
+
+  it('returns true when any parent policy is agentless', async () => {
+    jest
+      .mocked(agentPolicyService.getByIds)
+      .mockResolvedValue([makeAgentPolicy({ supports_agentless: false }), makeAgentPolicy()]);
+
+    expect(await haveAgentlessAgentPolicies(mockSoClient, ['a', 'b'])).toBe(true);
+  });
+
+  it('returns false when no parent policy is agentless', async () => {
+    jest
+      .mocked(agentPolicyService.getByIds)
+      .mockResolvedValue([makeAgentPolicy({ supports_agentless: false })]);
+
+    expect(await haveAgentlessAgentPolicies(mockSoClient, ['a'])).toBe(false);
+  });
+});
 
 describe('renameAgentlessAgentPolicy', () => {
   beforeEach(() => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { uniq } from 'lodash';
+
 import type { TypeOf } from '@kbn/config-schema';
 
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
@@ -25,6 +27,20 @@ import { agentPolicyService } from '../../../services';
 import type { SimplifiedPackagePolicy } from '../../../../common/services/simplified_package_policy_helper';
 import { PackagePolicyRequestError } from '../../../errors';
 import type { NewPackagePolicyInputStream } from '../../../../common';
+
+// True if any given id belongs to an agentless agent policy. Shared by the
+// legacy-API blocks so parent detection can't drift between sites.
+export async function haveAgentlessAgentPolicies(
+  soClient: SavedObjectsClientContract,
+  agentPolicyIds: string[]
+): Promise<boolean> {
+  const ids = uniq(agentPolicyIds);
+  if (ids.length === 0) {
+    return false;
+  }
+  const agentPolicies = await agentPolicyService.getByIds(soClient, ids, { ignoreMissing: true });
+  return agentPolicies.some((agentPolicy) => agentPolicy.supports_agentless);
+}
 
 export function isSimplifiedCreatePackagePolicyRequest(
   body: Omit<TypeOf<typeof CreatePackagePolicyRequestSchema.body>, 'force' | 'package'>

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/utils/index.ts
@@ -28,18 +28,25 @@ import type { SimplifiedPackagePolicy } from '../../../../common/services/simpli
 import { PackagePolicyRequestError } from '../../../errors';
 import type { NewPackagePolicyInputStream } from '../../../../common';
 
-// True if any given id belongs to an agentless agent policy. Shared by the
-// legacy-API blocks so parent detection can't drift between sites.
+// The subset of the given ids that belong to an agentless agent policy. Shared by
+// the legacy-API blocks so parent detection can't drift between sites.
+export async function getAgentlessAgentPolicyIds(
+  soClient: SavedObjectsClientContract,
+  agentPolicyIds: string[]
+): Promise<string[]> {
+  const ids = uniq(agentPolicyIds);
+  if (ids.length === 0) {
+    return [];
+  }
+  const agentPolicies = await agentPolicyService.getByIds(soClient, ids, { ignoreMissing: true });
+  return agentPolicies.filter((agentPolicy) => agentPolicy.supports_agentless).map(({ id }) => id);
+}
+
 export async function haveAgentlessAgentPolicies(
   soClient: SavedObjectsClientContract,
   agentPolicyIds: string[]
 ): Promise<boolean> {
-  const ids = uniq(agentPolicyIds);
-  if (ids.length === 0) {
-    return false;
-  }
-  const agentPolicies = await agentPolicyService.getByIds(soClient, ids, { ignoreMissing: true });
-  return agentPolicies.some((agentPolicy) => agentPolicy.supports_agentless);
+  return (await getAgentlessAgentPolicyIds(soClient, agentPolicyIds)).length > 0;
 }
 
 export function isSimplifiedCreatePackagePolicyRequest(

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/managed_package_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/managed_package_policies.ts
@@ -365,6 +365,10 @@ async function upgradePackagePolicy(
   }
 
   try {
+    // Agentless is intentionally NOT filtered out under disableAgentlessLegacyAPI: the flag targets
+    // the public legacy policy APIs, not this managed/keep_policies_up_to_date auto-upgrade — which
+    // is the only automatic upgrader for those packages. Same engine the agentless API uses, and the
+    // periodic deployment-sync task reconciles the workload by revision.
     await packagePolicyService.upgrade(
       soClient,
       esClient,

--- a/x-pack/platform/plugins/shared/fleet/server/services/utils/agentless.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/utils/agentless.test.ts
@@ -9,7 +9,12 @@ import { securityMock } from '@kbn/security-plugin/server/mocks';
 
 import { appContextService } from '../app_context';
 
-import { isAgentlessEnabled, prependAgentlessApiBasePathToEndpoint } from './agentless';
+import {
+  isAgentlessEnabled,
+  prependAgentlessApiBasePathToEndpoint,
+  logLegacyAgentlessWriteDeprecation,
+  LEGACY_AGENTLESS_WRITE_DEPRECATION_MARKER,
+} from './agentless';
 
 jest.mock('../app_context');
 
@@ -54,6 +59,28 @@ describe('isAgentlessEnabled', () => {
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
 
     expect(isAgentlessEnabled()).toBe(true);
+  });
+});
+
+describe('logLegacyAgentlessWriteDeprecation', () => {
+  const warn = jest.fn();
+
+  beforeEach(() => {
+    warn.mockReset();
+    jest.spyOn(appContextService, 'getLogger').mockReturnValue({ warn } as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('warns with the stable marker and the operation', () => {
+    logLegacyAgentlessWriteDeprecation('create package policy');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toContain(LEGACY_AGENTLESS_WRITE_DEPRECATION_MARKER);
+    expect(message).toContain('create package policy');
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/utils/agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/utils/agentless.ts
@@ -15,6 +15,26 @@ export const isAgentlessEnabled = () => {
   return Boolean(isHosted && appContextService.getConfig()?.agentless?.enabled);
 };
 
+/**
+ * Stable, greppable marker prefixing every legacy agentless write deprecation log
+ * line, so they can be aggregated regardless of the surrounding message text.
+ */
+export const LEGACY_AGENTLESS_WRITE_DEPRECATION_MARKER = 'legacy_agentless_write_deprecation';
+
+/**
+ * Emits a deprecation warning when a legacy agent/package policy API is used to
+ * write an agentless policy while `disableAgentlessLegacyAPI` is OFF.
+ */
+export const logLegacyAgentlessWriteDeprecation = (operation: string) => {
+  appContextService
+    .getLogger()
+    .warn(
+      `[${LEGACY_AGENTLESS_WRITE_DEPRECATION_MARKER}] Legacy agentless write via ${operation}. ` +
+        `Migrate to the agentless policies API; this request will be rejected once the ` +
+        `disableAgentlessLegacyAPI feature flag is enabled.`
+    );
+};
+
 const AGENTLESS_ESS_API_BASE_PATH = '/api/v1/ess';
 const AGENTLESS_SERVERLESS_API_BASE_PATH = '/api/v1/serverless';
 

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/packages_bulk_operations/run_bulk_upgrade.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/packages_bulk_operations/run_bulk_upgrade.ts
@@ -126,6 +126,9 @@ async function bulkUpgradePackagePolicies({
   });
 
   if (policyIdsToUpgrade.items.length) {
+    // Agentless is intentionally NOT filtered out under disableAgentlessLegacyAPI: the flag targets
+    // the public legacy policy APIs, not this system path. Same engine the agentless API uses, and
+    // the periodic deployment-sync task reconciles the workload by revision.
     const upgradePackagePoliciesResults = await packagePolicyService.bulkUpgrade(
       savedObjectsClient,
       esClient,

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -1423,7 +1423,7 @@ export default function (providerContext: FtrProviderContext) {
               namespace: 'default',
               description: 'tata',
             }),
-          /400 "Bad Request" To update agentless agent policies, use the Fleet agentless policies API./
+          /400 "Bad Request" To update agentless agent policies, use the agentless policies API./
         );
       });
     });

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless_legacy_disabled/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless_legacy_disabled/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export default function loadTests({ loadTestFile }) {
+  describe('Agentless legacy API disabled', () => {
+    loadTestFile(require.resolve('./legacy_blocks'));
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless_legacy_disabled/legacy_blocks.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless_legacy_disabled/legacy_blocks.ts
@@ -57,7 +57,6 @@ export default function (providerContext: FtrProviderContext) {
       if (initialized) {
         return;
       }
-      initialized = true;
       await kibanaServer.savedObjects.cleanStandardList();
       await cleanFleetIndices(es);
       await apiClient.setup();
@@ -107,6 +106,10 @@ export default function (providerContext: FtrProviderContext) {
         },
       });
       regularPackagePolicyId = regularPackagePolicy.item.id;
+
+      // Only mark done after setup succeeds; otherwise a transient failure would
+      // permanently skip setup and fail every later test on undefined ids.
+      initialized = true;
     });
 
     after(async () => {

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless_legacy_disabled/legacy_blocks.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless_legacy_disabled/legacy_blocks.ts
@@ -1,0 +1,350 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type * as http from 'http';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupMockServer } from '../agents/helpers/mock_agentless_api';
+import { SpaceTestApiClient } from '../space_awareness/api_helper';
+import { cleanFleetIndices } from '../space_awareness/helpers';
+
+interface LegacyBlockResponse {
+  status: number;
+  body: {
+    message: string;
+  };
+}
+
+export default function (providerContext: FtrProviderContext) {
+  describe('Legacy policy API blocks for agentless', () => {
+    const { getService } = providerContext;
+    const es = getService('es');
+    const supertest = getService('supertest');
+    const kibanaServer = getService('kibanaServer');
+
+    skipIfNoDockerRegistry(providerContext);
+
+    const apiClient = new SpaceTestApiClient(supertest);
+
+    const expectLegacyBlock = (res: LegacyBlockResponse, messagePattern: RegExp) => {
+      expect(res.status).to.be(400);
+      expect(res.body.message).to.match(messagePattern);
+    };
+
+    let mockApiServer: http.Server;
+    // For agentless policies the package policy, the paired agent policy, and the
+    // agentless policy all share the same id.
+    let agentlessId: string;
+    let regularAgentPolicyId: string;
+    let regularPackagePolicyId: string;
+
+    before(async () => {
+      mockApiServer = await setupMockServer().listen(8089);
+    });
+
+    // Lazy one-time setup in a beforeEach: `skipIfNoDockerRegistry` guards with a
+    // beforeEach, and before-all hooks would run ahead of it and fail instead of
+    // skipping when the package registry is not running.
+    let initialized = false;
+    beforeEach(async () => {
+      if (initialized) {
+        return;
+      }
+      initialized = true;
+      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanFleetIndices(es);
+      await apiClient.setup();
+
+      const agentlessPolicy = await apiClient.createAgentlessPolicy({
+        id: uuidv4(),
+        package: {
+          name: 'test_agentless',
+          version: '1.0.0',
+        },
+        name: `test_agentless-${Date.now()}`,
+        description: 'test agentless policy',
+        namespace: 'default',
+        inputs: {
+          'sample-httpjson': {
+            enabled: true,
+            vars: {
+              api_key: 'TEST_VALUE_API_KEY',
+            },
+            streams: {},
+          },
+        },
+      });
+      agentlessId = agentlessPolicy.item.id;
+
+      const regularAgentPolicy = await apiClient.createAgentPolicy();
+      regularAgentPolicyId = regularAgentPolicy.item.id;
+
+      const regularPackagePolicy = await apiClient.createPackagePolicy(undefined, {
+        id: uuidv4(),
+        policy_ids: [regularAgentPolicyId],
+        name: `test_agentless-regular-${Date.now()}`,
+        description: 'regular package policy on the mixed-deployment test package',
+        namespace: 'default',
+        package: {
+          name: 'test_agentless',
+          version: '1.0.0',
+        },
+        inputs: {
+          'sample-httpjson': {
+            enabled: true,
+            vars: {
+              api_key: 'TEST_VALUE_API_KEY',
+            },
+            streams: {},
+          },
+        },
+      });
+      regularPackagePolicyId = regularPackagePolicy.item.id;
+    });
+
+    after(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanFleetIndices(es);
+      await mockApiServer.close();
+    });
+
+    describe('POST /api/fleet/package_policies', () => {
+      it('should reject requests with supports_agentless', async () => {
+        const res = await supertest
+          .post('/api/fleet/package_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `agentless-${uuidv4()}`,
+            description: '',
+            namespace: 'default',
+            policy_ids: [],
+            supports_agentless: true,
+            inputs: [],
+            package: {
+              name: 'test_agentless',
+              version: '1.0.0',
+            },
+          });
+
+        expectLegacyBlock(
+          res,
+          /To create agentless package policies, use the agentless policies API/
+        );
+      });
+
+      it('should reject packages that only support agentless deployment', async () => {
+        const res = await supertest
+          .post('/api/fleet/package_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `agentless-only-${uuidv4()}`,
+            description: '',
+            namespace: 'default',
+            policy_ids: [],
+            inputs: [],
+            package: {
+              name: 'test_agentless_only',
+              version: '1.0.0',
+            },
+          });
+
+        expectLegacyBlock(res, /only supports agentless deployment/);
+      });
+
+      it('should reject requests targeting an agentless agent policy', async () => {
+        const res = await supertest
+          .post('/api/fleet/package_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `on-agentless-parent-${uuidv4()}`,
+            description: '',
+            namespace: 'default',
+            policy_ids: [agentlessId],
+            inputs: [],
+            package: {
+              name: 'test_agentless',
+              version: '1.0.0',
+            },
+          });
+
+        expectLegacyBlock(res, /To add integrations to an agentless agent policy/);
+      });
+    });
+
+    describe('PUT /api/fleet/package_policies/{id}', () => {
+      it('should reject updates to agentless package policies', async () => {
+        const res = await supertest
+          .put(`/api/fleet/package_policies/${agentlessId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `renamed-${Date.now()}`,
+          });
+
+        expectLegacyBlock(
+          res,
+          /To update agentless package policies, use the agentless policies API/
+        );
+      });
+
+      it('should reject re-parenting regular package policies to an agentless agent policy', async () => {
+        const res = await supertest
+          .put(`/api/fleet/package_policies/${regularPackagePolicyId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            policy_ids: [agentlessId],
+          });
+
+        expectLegacyBlock(res, /To add integrations to an agentless agent policy/);
+      });
+    });
+
+    describe('POST /api/fleet/package_policies/upgrade', () => {
+      it('should reject upgrades targeting agentless package policies', async () => {
+        const res = await supertest
+          .post('/api/fleet/package_policies/upgrade')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ packagePolicyIds: [agentlessId] });
+
+        expectLegacyBlock(
+          res,
+          /To upgrade agentless package policies, use the agentless policies API/
+        );
+      });
+
+      it('should reject the whole request when the batch mixes agentless and regular policies', async () => {
+        const res = await supertest
+          .post('/api/fleet/package_policies/upgrade')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ packagePolicyIds: [regularPackagePolicyId, agentlessId] });
+
+        expectLegacyBlock(
+          res,
+          /To upgrade agentless package policies, use the agentless policies API/
+        );
+      });
+
+      it('should reject dry runs targeting agentless package policies', async () => {
+        const res = await supertest
+          .post('/api/fleet/package_policies/upgrade/dryrun')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ packagePolicyIds: [agentlessId] });
+
+        expectLegacyBlock(
+          res,
+          /To upgrade agentless package policies, use the agentless policies API/
+        );
+      });
+    });
+
+    describe('agent policy endpoints', () => {
+      it('should reject creating agent policies with supports_agentless', async () => {
+        const res = await supertest
+          .post('/api/fleet/agent_policies')
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `agentless-agent-policy-${uuidv4()}`,
+            namespace: 'default',
+            supports_agentless: true,
+          });
+
+        expectLegacyBlock(
+          res,
+          /To create agentless agent policies, use the agentless policies API/
+        );
+      });
+
+      it('should reject updating agentless agent policies', async () => {
+        const res = await supertest
+          .put(`/api/fleet/agent_policies/${agentlessId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `renamed-${Date.now()}`,
+            namespace: 'default',
+            description: '',
+          });
+
+        expectLegacyBlock(
+          res,
+          /To update agentless agent policies, use the agentless policies API/
+        );
+      });
+
+      it('should reject copying agentless agent policies', async () => {
+        const res = await supertest
+          .post(`/api/fleet/agent_policies/${agentlessId}/copy`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `copied-agentless-${uuidv4()}`,
+            description: '',
+          });
+
+        expectLegacyBlock(res, /Agentless agent policies cannot be copied/);
+      });
+    });
+
+    describe('unaffected flows', () => {
+      it('should still allow managing agentless policies through the agentless policies API', async () => {
+        const updatedName = `test_agentless-updated-${Date.now()}`;
+        const { item } = await apiClient.updateAgentlessPolicy(agentlessId, {
+          package: { name: 'test_agentless', version: '1.0.0' },
+          name: updatedName,
+          description: 'updated through the agentless API',
+          namespace: 'default',
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: { api_key: 'UPDATED_VALUE_API_KEY' },
+              streams: {},
+            },
+          },
+        });
+
+        expect(item.id).to.be(agentlessId);
+        expect(item.name).to.be(updatedName);
+      });
+
+      it('should still allow legacy updates of regular package policies', async () => {
+        const updatedName = `test_agentless-regular-updated-${Date.now()}`;
+        const { item } = await apiClient.updatePackagePolicy(regularPackagePolicyId, {
+          policy_ids: [regularAgentPolicyId],
+          name: updatedName,
+          description: '',
+          namespace: 'default',
+          package: {
+            name: 'test_agentless',
+            version: '1.0.0',
+          },
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: { api_key: 'TEST_VALUE_API_KEY' },
+              streams: {},
+            },
+          },
+        });
+
+        expect(item.name).to.be(updatedName);
+      });
+
+      it('should still allow copying regular agent policies', async () => {
+        const res = await supertest
+          .post(`/api/fleet/agent_policies/${regularAgentPolicyId}/copy`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `copied-regular-${uuidv4()}`,
+            description: '',
+          })
+          .expect(200);
+
+        expect(res.body.item.id).not.to.be(regularAgentPolicyId);
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/test_agentless_only/1.0.0/changelog.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/test_agentless_only/1.0.0/changelog.yml
@@ -1,0 +1,7 @@
+version: 1.0.0
+entries:
+  - version: 1.0.0
+    changes:
+      - description: Initial version
+        type: enhancement
+        link: https://github.com/elastic/kibana/pull/123456

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/test_agentless_only/1.0.0/docs/README.md
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/test_agentless_only/1.0.0/docs/README.md
@@ -1,0 +1,3 @@
+# Test Agentless Only
+
+Test package with a single policy template that only supports agentless deployment. Used to exercise the `disableAgentlessLegacyAPI` block for packages that require agentless.

--- a/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/test_agentless_only/1.0.0/manifest.yml
+++ b/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages/test_agentless_only/1.0.0/manifest.yml
@@ -1,0 +1,43 @@
+format_version: 3.0.0
+name: test_agentless_only
+title: 'Test Agentless Only'
+version: 1.0.0
+source:
+  license: 'Elastic-2.0'
+description: 'Test package that only supports agentless deployment'
+type: integration
+categories:
+  - custom
+conditions:
+  kibana:
+    version: '^9.0.0'
+  elastic:
+    subscription: 'basic'
+policy_templates:
+  - name: sample
+    title: Sample logs
+    description: Collect sample logs
+    deployment_modes:
+      default:
+        enabled: false
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
+    inputs:
+      - type: httpjson
+        title: Collect sample logs from instances
+        description: Collecting sample logs
+        vars:
+          - name: api_key
+            type: password
+            title: API Key
+            multi: false
+            required: true
+            show_user: true
+            description: A test API key secret
+            secret: true
+owner:
+  github: elastic/integrations
+  type: elastic

--- a/x-pack/platform/test/fleet_api_integration/config.agentless_legacy_disabled.ts
+++ b/x-pack/platform/test/fleet_api_integration/config.agentless_legacy_disabled.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+const EXPERIMENTAL_FEATURES_ARG_PREFIX = '--xpack.fleet.experimentalFeatures=';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseFleetApiConfig = await readConfigFile(require.resolve('./config.base.ts'));
+  const baseConfig = baseFleetApiConfig.getAll();
+  const baseServerArgs: string[] = baseConfig.kbnTestServer.serverArgs;
+
+  // The base config already passes --xpack.fleet.experimentalFeatures; passing the
+  // flag twice would make Kibana parse it as an array and fail config validation,
+  // so the base value is extended in place instead.
+  const baseExperimentalArg = baseServerArgs.find((arg) =>
+    arg.startsWith(EXPERIMENTAL_FEATURES_ARG_PREFIX)
+  );
+  const experimentalFeatures = {
+    ...(baseExperimentalArg
+      ? JSON.parse(baseExperimentalArg.slice(EXPERIMENTAL_FEATURES_ARG_PREFIX.length))
+      : {}),
+    disableAgentlessLegacyAPI: true,
+  };
+
+  return {
+    ...baseConfig,
+    testFiles: [require.resolve('./apis/agentless_legacy_disabled')],
+    junit: {
+      reportName: 'X-Pack Fleet Agentless Legacy API Disabled Integration Tests',
+    },
+    kbnTestServer: {
+      ...baseConfig.kbnTestServer,
+      serverArgs: [
+        ...baseServerArgs.filter((arg) => !arg.startsWith(EXPERIMENTAL_FEATURES_ARG_PREFIX)),
+        `${EXPERIMENTAL_FEATURES_ARG_PREFIX}${JSON.stringify(experimentalFeatures)}`,
+        // Cloud configuration needed for agentless functionality in ESS (same as config.agentless.ts)
+        `--xpack.cloud.id="ftr_fake_cloud_id:aGVsbG8uY29tOjQ0MyRFUzEyM2FiYyRrYm4xMjNhYmM="`,
+        `--xpack.cloud.base_url="https://cloud.elastic.co"`,
+        `--xpack.cloud.deployment_url="/deployments/deploymentId"`,
+      ],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

This PR extends the `disableAgentlessLegacyAPI` experimental flag so that, when enabled, the legacy agent/package policy APIs reject any remaining agentless write path with a `400` pointing callers to the agentless policies API.

The flag already gated agentless **create** on `POST /api/fleet/package_policies` and `POST /api/fleet/agent_policies` (#243407). With this PR, when the flag is enabled:

| Endpoint | Rejected when |
|---|---|
| `POST /api/fleet/package_policies` | `supports_agentless: true` in the body (existing), the package only supports agentless deployment, or a target agent policy is agentless |
| `PUT /api/fleet/package_policies/{id}` | the package policy is agentless (own flag, parent agent policy flag, or body flag) |
| `POST /api/fleet/package_policies/upgrade` and `/upgrade/dryrun` | any target package policy is agentless — whole request rejected before any upgrade |
| `POST /api/fleet/agent_policies/{id}/copy` | the source agent policy is agentless (copy previously cloned a full working agentless deployment, bypassing the create block) |

Notes:

- The flag defaults to `false` — no behavior change unless it is enabled.
- Blocks throw `FleetError` (→ `400`) with a consistent "…use the agentless policies API." message.
- `PUT /api/fleet/agent_policies/{id}` already rejects agentless unconditionally (#246439) and is unchanged apart from the message wording.
- DELETE and read endpoints stay open on purpose: reads are unaffected by the migration, and delete must keep working as a cleanup path (the service-layer cascade removes the paired agent policy and deployment).


Manual check with the flag enabled in `kibana.dev.yml`:

```yaml
xpack.fleet.experimentalFeatures:
  disableAgentlessLegacyAPI: true
```

## Release note

When the `disableAgentlessLegacyAPI` experimental feature flag is enabled, Fleet's legacy agent/package policy APIs reject agentless create, update, upgrade, and copy operations with a `400` error; agentless policies must be managed through the agentless policies API (`/api/fleet/agentless_policies`).


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



