### PR TITLE
[WIP][One Workflow] Group Workflows nav under Automation panel in Security nav

### DIFF
--- a/src/platform/packages/shared/deeplinks/workflows/deep_links.ts
+++ b/src/platform/packages/shared/deeplinks/workflows/deep_links.ts
@@ -9,4 +9,5 @@
 
 export enum WorkflowsPageName {
   workflows = 'workflows',
+  library = 'library',
 }

--- a/x-pack/solutions/security/packages/navigation/index.ts
+++ b/x-pack/solutions/security/packages/navigation/index.ts
@@ -14,5 +14,6 @@ export {
   LinkCategoryType,
   SECURITY_UI_APP_ID,
   ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
+  WORKFLOWS_TEMPLATES_NAV_FLAG,
 } from './src/constants';
 export * from './src/types';

--- a/x-pack/solutions/security/packages/navigation/src/constants.ts
+++ b/x-pack/solutions/security/packages/navigation/src/constants.ts
@@ -40,3 +40,6 @@ export enum SecurityGroupName {
 /** This Kibana Advanced Setting allows users to enable/disable the Alerts and Attacks Alignment feature */
 export const ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING =
   'securitySolution:enableAlertsAndAttacksAlignment' as const;
+
+/** Feature flag gating the "Templates" entry in the Workflows side-nav panel. */
+export const WORKFLOWS_TEMPLATES_NAV_FLAG = 'securitySolution.workflowsTemplatesInNav' as const;

--- a/x-pack/solutions/security/packages/navigation/src/constants.ts
+++ b/x-pack/solutions/security/packages/navigation/src/constants.ts
@@ -30,6 +30,7 @@ export enum SecurityGroupName {
   entityAnalytics = 'securityGroup:entityAnalytics',
   machineLearning = 'securityGroup:machineLearning',
   launchpad = 'securityGroup:launchpad',
+  workflows = 'securityGroup:workflows',
 
   // TODO: https://github.com/elastic/kibana/issues/242434
   // Investigate possibility of using `detections` instead

--- a/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts
+++ b/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts
@@ -45,6 +45,11 @@ export const i18nStrings = {
         defaultMessage: 'Automation',
       }),
     },
+    templates: {
+      title: i18n.translate('securitySolutionPackages.navLinks.workflows.templates', {
+        defaultMessage: 'Templates',
+      }),
+    },
   },
   explore: {
     title: i18n.translate('securitySolutionPackages.navLinks.explore', {

--- a/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts
+++ b/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts
@@ -36,6 +36,16 @@ export const i18nStrings = {
       defaultMessage: 'Investigations',
     }),
   },
+  workflows: {
+    title: i18n.translate('securitySolutionPackages.navLinks.workflows', {
+      defaultMessage: 'Workflows',
+    }),
+    automation: {
+      title: i18n.translate('securitySolutionPackages.navLinks.workflows.automation', {
+        defaultMessage: 'Automation',
+      }),
+    },
+  },
   explore: {
     title: i18n.translate('securitySolutionPackages.navLinks.explore', {
       defaultMessage: 'Explore',

--- a/x-pack/solutions/security/packages/navigation/src/link_groups.ts
+++ b/x-pack/solutions/security/packages/navigation/src/link_groups.ts
@@ -22,4 +22,5 @@ export const SecurityLinkGroup: Record<SecurityGroupName, SecurityLinkGroupDefin
     [SecurityGroupName.entityAnalytics]: { title: i18nStrings.entityAnalytics.title },
     [SecurityGroupName.machineLearning]: { title: i18nStrings.ml.title },
     [SecurityGroupName.launchpad]: { title: i18nStrings.launchPad.title },
+    [SecurityGroupName.workflows]: { title: i18nStrings.workflows.title },
   });

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/index.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/index.ts
@@ -14,6 +14,7 @@ import { createAssetsNavigationTree } from './assets_navigation_tree';
 import { createEntityAnalyticsNavigationTree } from './entity_analytics_navigation_tree';
 import { createMachineLearningNavigationTree } from './ml_navigation_tree';
 import { createAlertDetectionsNavigationTree } from './alert_detections_navigation_tree';
+import { createWorkflowsNavigationTree } from './workflows_navigation_tree';
 
 export const defaultNavigationTree = {
   alertDetections: createAlertDetectionsNavigationTree,
@@ -25,5 +26,6 @@ export const defaultNavigationTree = {
   assets: createAssetsNavigationTree,
   entityAnalytics: createEntityAnalyticsNavigationTree,
   ml: createMachineLearningNavigationTree,
+  workflows: createWorkflowsNavigationTree,
 };
 export type DefaultNavigationTree = typeof defaultNavigationTree;

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/workflows_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/workflows_navigation_tree.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import type { NodeDefinition } from '@kbn/core-chrome-browser';
+import type { AppDeepLinkId, NodeDefinition } from '@kbn/core-chrome-browser';
 import { SecurityGroupName } from '../constants';
 import { SecurityLinkGroup } from '../link_groups';
 import { i18nStrings } from '../i18n_strings';
 
-export const createWorkflowsNavigationTree = (): NodeDefinition => ({
+export const createWorkflowsNavigationTree = (templatesEnabled = false): NodeDefinition => ({
   id: SecurityGroupName.workflows,
   title: SecurityLinkGroup[SecurityGroupName.workflows].title,
   icon: 'branch',
@@ -23,6 +23,14 @@ export const createWorkflowsNavigationTree = (): NodeDefinition => ({
         {
           link: 'workflows',
         },
+        ...(templatesEnabled
+          ? [
+              {
+                title: i18nStrings.workflows.templates.title,
+                link: 'workflows-library' as AppDeepLinkId,
+              },
+            ]
+          : []),
       ],
     },
   ],

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/workflows_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/workflows_navigation_tree.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { AppDeepLinkId, NodeDefinition } from '@kbn/core-chrome-browser';
+import type { NodeDefinition } from '@kbn/core-chrome-browser';
 import { SecurityGroupName } from '../constants';
 import { SecurityLinkGroup } from '../link_groups';
 import { i18nStrings } from '../i18n_strings';
@@ -27,7 +27,7 @@ export const createWorkflowsNavigationTree = (templatesEnabled = false): NodeDef
           ? [
               {
                 title: i18nStrings.workflows.templates.title,
-                link: 'workflows-library' as AppDeepLinkId,
+                link: 'workflows:library' as const,
               },
             ]
           : []),

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/workflows_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/workflows_navigation_tree.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { NodeDefinition } from '@kbn/core-chrome-browser';
+import { SecurityGroupName } from '../constants';
+import { SecurityLinkGroup } from '../link_groups';
+import { i18nStrings } from '../i18n_strings';
+
+export const createWorkflowsNavigationTree = (): NodeDefinition => ({
+  id: SecurityGroupName.workflows,
+  title: SecurityLinkGroup[SecurityGroupName.workflows].title,
+  icon: 'branch',
+  renderAs: 'panelOpener',
+  children: [
+    {
+      title: i18nStrings.workflows.automation.title,
+      breadcrumbStatus: 'hidden',
+      children: [
+        {
+          link: 'workflows',
+        },
+      ],
+    },
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -61,9 +61,7 @@ export const createNavigationTree = (
             icon: 'warning',
             link: securityLink(SecurityPageName.alerts),
           },
-      {
-        link: 'workflows',
-      },
+      defaultNavigationTree.workflows(),
       // TODO: remove this item when agentBuilderNavAtTop is enabled by default and the Agent Builder link is always at the top of the nav
       ...(showAgentBuilder && !agentBuilderNavAtTop ? [agentBuilderLink] : []),
       {

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -10,6 +10,7 @@ import { AIChatExperience } from '@kbn/ai-assistant-common';
 import {
   ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
   SecurityPageName,
+  WORKFLOWS_TEMPLATES_NAV_FLAG,
 } from '@kbn/security-solution-navigation';
 import { i18nStrings, securityLink } from '@kbn/security-solution-navigation/links';
 import { defaultNavigationTree } from '@kbn/security-solution-navigation/navigation_tree';
@@ -26,6 +27,10 @@ export const createNavigationTree = (
   const showAgentBuilder = chatExperience === AIChatExperience.Agent;
   const agentBuilderNavAtTop = services.featureFlags.getBooleanValue(
     AGENT_BUILDER_NAV_AT_TOP_FLAG,
+    false
+  );
+  const workflowsTemplatesEnabled = services.featureFlags.getBooleanValue(
+    WORKFLOWS_TEMPLATES_NAV_FLAG,
     false
   );
 
@@ -61,7 +66,7 @@ export const createNavigationTree = (
             icon: 'warning',
             link: securityLink(SecurityPageName.alerts),
           },
-      defaultNavigationTree.workflows(),
+      defaultNavigationTree.workflows(workflowsTemplatesEnabled),
       // TODO: remove this item when agentBuilderNavAtTop is enabled by default and the Agent Builder link is always at the top of the nav
       ...(showAgentBuilder && !agentBuilderNavAtTop ? [agentBuilderLink] : []),
       {

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -12,6 +12,7 @@ import {
   ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
   SecurityGroupName,
   SecurityPageName,
+  WORKFLOWS_TEMPLATES_NAV_FLAG,
 } from '@kbn/security-solution-navigation';
 import { i18nStrings, securityLink } from '@kbn/security-solution-navigation/links';
 import { defaultNavigationTree } from '@kbn/security-solution-navigation/navigation_tree';
@@ -32,6 +33,10 @@ export const createNavigationTree = async (
   const showAgentBuilder = chatExperience === AIChatExperience.Agent;
   const agentBuilderNavAtTop = services.featureFlags.getBooleanValue(
     AGENT_BUILDER_NAV_AT_TOP_FLAG,
+    false
+  );
+  const workflowsTemplatesEnabled = services.featureFlags.getBooleanValue(
+    WORKFLOWS_TEMPLATES_NAV_FLAG,
     false
   );
   const agentBuilderLink = {
@@ -66,7 +71,7 @@ export const createNavigationTree = async (
             icon: 'warning',
             link: securityLink(SecurityPageName.alerts),
           },
-      defaultNavigationTree.workflows(),
+      defaultNavigationTree.workflows(workflowsTemplatesEnabled),
       // TODO: remove this item when agentBuilderNavAtTop is enabled by default and the Agent Builder link is always at the top of the nav
       ...(showAgentBuilder && !agentBuilderNavAtTop ? [agentBuilderLink] : []),
       {

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -66,9 +66,7 @@ export const createNavigationTree = async (
             icon: 'warning',
             link: securityLink(SecurityPageName.alerts),
           },
-      {
-        link: 'workflows',
-      },
+      defaultNavigationTree.workflows(),
       // TODO: remove this item when agentBuilderNavAtTop is enabled by default and the Agent Builder link is always at the top of the nav
       ...(showAgentBuilder && !agentBuilderNavAtTop ? [agentBuilderLink] : []),
       {


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/18149

## Summary

Converts the Workflows entry in the Security solution navigation from a flat link into a panel opener grouped under an "Automation" section, matching the pattern used by other grouped Security nav items (Investigations, Explore, etc.). Optionally adds a **Templates** entry under Automation, gated on the `securitySolution.workflowsTemplatesInNav` feature flag.

### Changes

- Add `securityGroup:workflows` to `SecurityGroupName` and register it in `SecurityLinkGroup`.
- Add `workflows` (with nested `automation` and `templates`) entries to `i18nStrings`.
- Add `createWorkflowsNavigationTree(templatesEnabled?)` — renders as `panelOpener` with an `Automation` child group containing the `workflows` link and, when the flag is on, a `workflows:library` link labelled "Templates".
- Add `library` to `WorkflowsPageName` (so `workflows:library` types cleanly).
- Wire the flag through ESS and Serverless navigation trees via `services.featureFlags.getBooleanValue(WORKFLOWS_TEMPLATES_NAV_FLAG, false)`.

### Screenshots

| Before | After (flag off) | After (flag on) |
|--------|------------------|-----------------|
| ![before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260707/6ke7ywnz-before-nav.png) | ![after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260707/wjr8g3ka-after-panel-open.png) | ![after-templates](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260707/c8m3ekdj-after-panel-templates.png) |