### PR TITLE
[Entity Analytics] Fixing test mocks for set asset criticality tool

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/set_asset_criticality_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/set_asset_criticality_tool.test.ts
@@ -507,10 +507,24 @@ describe('setAssetCriticalityTool', () => {
 
     it('reports success=false when the caller lacks write privilege', async () => {
       mockCheckPrivileges.mockResolvedValueOnce({
+        hasAllRequested: false,
         privileges: {
           elasticsearch: {
-            index: new Proxy({}, { get: () => [{ privilege: 'write', authorized: false }] }),
+            cluster: [],
+            index: new Proxy(
+              {},
+              {
+                get: () => [
+                  { privilege: 'read', authorized: true },
+                  { privilege: 'write', authorized: false },
+                ],
+              }
+            ),
           },
+          kibana: [
+            { privilege: 'api:securitySolution', authorized: true },
+            { privilege: 'api:securitySolution-entity-analytics', authorized: true },
+          ],
         },
       });
       const ctx = handlerContext();


### PR DESCRIPTION
## Summary

Two PRs (https://github.com/elastic/kibana/pull/276522) and (https://github.com/elastic/kibana/pull/276092) were merged close to each other that both touched the same jest tests. This updates the mocks for the jest test so that the test passes.