### PR TITLE
[Alerting V2] [UI] Rule Details — Artifacts: Action policies section

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.test.ts
@@ -34,7 +34,7 @@ const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolic
     updatedBy: 'user',
     updatedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
-  }) as ActionPolicyResponse;
+  } as ActionPolicyResponse);
 
 describe('isExplicitlyLinkedToRule', () => {
   it('returns true for the simple-action rule.id matcher', () => {
@@ -43,15 +43,15 @@ describe('isExplicitlyLinkedToRule', () => {
 
   it('returns true for spaced KQL syntax and compound matchers', () => {
     expect(isExplicitlyLinkedToRule(`rule.id : "${RULE_ID}"`, RULE_ID)).toBe(true);
-    expect(
-      isExplicitlyLinkedToRule(`rule.id: "${RULE_ID}" and severity: "high"`, RULE_ID)
-    ).toBe(true);
+    expect(isExplicitlyLinkedToRule(`rule.id: "${RULE_ID}" and severity: "high"`, RULE_ID)).toBe(
+      true
+    );
   });
 
   it('returns true when the rule.id clause appears inside an OR branch', () => {
-    expect(
-      isExplicitlyLinkedToRule(`rule.id: "${RULE_ID}" or severity: "high"`, RULE_ID)
-    ).toBe(true);
+    expect(isExplicitlyLinkedToRule(`rule.id: "${RULE_ID}" or severity: "high"`, RULE_ID)).toBe(
+      true
+    );
   });
 
   it('returns false for null, empty, or malformed matchers', () => {
@@ -82,9 +82,9 @@ describe('isRuleScopedCatchAllMatcher', () => {
   });
 
   it('returns false when additional matching criteria are present', () => {
-    expect(
-      isRuleScopedCatchAllMatcher(`rule.id: "${RULE_ID}" and severity: "high"`, RULE_ID)
-    ).toBe(false);
+    expect(isRuleScopedCatchAllMatcher(`rule.id: "${RULE_ID}" and severity: "high"`, RULE_ID)).toBe(
+      false
+    );
   });
 
   it('returns false when the matcher is not explicitly linked', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
+import { buildRuleScopedMatcher } from './rule_scoped_action_policies';
+import {
+  isExplicitlyLinkedToRule,
+  isRuleScopedCatchAllMatcher,
+  summarizeExplicitlyLinkedActionPolicies,
+} from './explicitly_linked_action_policies';
+
+const RULE_ID = 'rule-abc-123';
+
+const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolicyResponse =>
+  ({
+    id: 'policy-1',
+    name: 'Policy Alpha',
+    description: '',
+    enabled: true,
+    destinations: [{ type: 'workflow', id: 'workflow-1' }],
+    matcher: buildRuleScopedMatcher(RULE_ID),
+    groupBy: null,
+    tags: null,
+    groupingMode: 'per_episode',
+    throttle: null,
+    snoozedUntil: null,
+    auth: { owner: 'user', createdByUser: true },
+    createdBy: 'user',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedBy: 'user',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }) as ActionPolicyResponse;
+
+describe('isExplicitlyLinkedToRule', () => {
+  it('returns true for the simple-action rule.id matcher', () => {
+    expect(isExplicitlyLinkedToRule(buildRuleScopedMatcher(RULE_ID), RULE_ID)).toBe(true);
+  });
+
+  it('returns true for spaced KQL syntax and compound matchers', () => {
+    expect(isExplicitlyLinkedToRule(`rule.id : "${RULE_ID}"`, RULE_ID)).toBe(true);
+    expect(
+      isExplicitlyLinkedToRule(`rule.id: "${RULE_ID}" and severity: "high"`, RULE_ID)
+    ).toBe(true);
+  });
+
+  it('returns true when the rule.id clause appears inside an OR branch', () => {
+    expect(
+      isExplicitlyLinkedToRule(`rule.id: "${RULE_ID}" or severity: "high"`, RULE_ID)
+    ).toBe(true);
+  });
+
+  it('returns false for null, empty, or malformed matchers', () => {
+    expect(isExplicitlyLinkedToRule(null, RULE_ID)).toBe(false);
+    expect(isExplicitlyLinkedToRule('', RULE_ID)).toBe(false);
+    expect(isExplicitlyLinkedToRule('rule.id:', RULE_ID)).toBe(false);
+    expect(isExplicitlyLinkedToRule('this is not kql (((', RULE_ID)).toBe(false);
+  });
+
+  it('returns false when the matcher references a different rule id', () => {
+    expect(isExplicitlyLinkedToRule(buildRuleScopedMatcher('other-rule'), RULE_ID)).toBe(false);
+  });
+
+  it('returns false for negated rule.id clauses', () => {
+    expect(isExplicitlyLinkedToRule(`not rule.id: "${RULE_ID}"`, RULE_ID)).toBe(false);
+  });
+
+  it('returns false for global catch-all matchers', () => {
+    expect(isExplicitlyLinkedToRule(null, RULE_ID)).toBe(false);
+    expect(isExplicitlyLinkedToRule('severity: "high"', RULE_ID)).toBe(false);
+  });
+});
+
+describe('isRuleScopedCatchAllMatcher', () => {
+  it('returns true for a matcher that only scopes to the rule id', () => {
+    expect(isRuleScopedCatchAllMatcher(buildRuleScopedMatcher(RULE_ID), RULE_ID)).toBe(true);
+    expect(isRuleScopedCatchAllMatcher(`rule.id : "${RULE_ID}"`, RULE_ID)).toBe(true);
+  });
+
+  it('returns false when additional matching criteria are present', () => {
+    expect(
+      isRuleScopedCatchAllMatcher(`rule.id: "${RULE_ID}" and severity: "high"`, RULE_ID)
+    ).toBe(false);
+  });
+
+  it('returns false when the matcher is not explicitly linked', () => {
+    expect(isRuleScopedCatchAllMatcher(`rule.id: "other-rule"`, RULE_ID)).toBe(false);
+  });
+});
+
+describe('summarizeExplicitlyLinkedActionPolicies', () => {
+  it('filters, sorts, and counts linked policies', () => {
+    const summary = summarizeExplicitlyLinkedActionPolicies(
+      [
+        buildPolicy({
+          id: 'policy-b',
+          name: 'Bravo',
+          matcher: `rule.id: "${RULE_ID}" and severity: "high"`,
+        }),
+        buildPolicy({ id: 'policy-a', name: 'Alpha' }),
+        buildPolicy({
+          id: 'policy-global',
+          name: 'Global',
+          matcher: null,
+        }),
+        buildPolicy({
+          id: 'policy-other',
+          name: 'Other rule',
+          matcher: buildRuleScopedMatcher('other-rule'),
+        }),
+      ],
+      RULE_ID
+    );
+
+    expect(summary.totalCount).toBe(2);
+    expect(summary.matchingCriteriaCount).toBe(1);
+    expect(summary.catchAllCount).toBe(1);
+    expect(summary.policies.map((policy) => policy.id)).toEqual(['policy-a', 'policy-b']);
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
+import { fromKueryExpression, type KueryNode } from '@kbn/es-query';
+
+const RULE_ID_FIELD = 'rule.id';
+
+const normalizeKueryValue = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+};
+
+const getIsFieldAndValue = (node: KueryNode): { field: string; value: string } | null => {
+  if (node.type !== 'function' || node.function !== 'is') {
+    return null;
+  }
+
+  const args = node.arguments as KueryNode[];
+  if (args.length < 2) {
+    return null;
+  }
+
+  const fieldArg = args[0];
+  const valueArg = args[1];
+  if (fieldArg?.type !== 'literal' || typeof fieldArg.value !== 'string') {
+    return null;
+  }
+  if (valueArg?.type !== 'literal' || typeof valueArg.value !== 'string') {
+    return null;
+  }
+
+  return {
+    field: fieldArg.value,
+    value: normalizeKueryValue(valueArg.value),
+  };
+};
+
+const isRuleIdEqualsNode = (node: KueryNode, ruleId: string): boolean => {
+  const parsed = getIsFieldAndValue(node);
+  return parsed?.field === RULE_ID_FIELD && parsed.value === ruleId;
+};
+
+const containsPositiveRuleIdMatch = (node: KueryNode, ruleId: string, negated: boolean): boolean => {
+  if (node.type !== 'function') {
+    return false;
+  }
+
+  switch (node.function) {
+    case 'is':
+      return !negated && isRuleIdEqualsNode(node, ruleId);
+    case 'and':
+    case 'or':
+      return (node.arguments as KueryNode[]).some((arg) =>
+        containsPositiveRuleIdMatch(arg, ruleId, negated)
+      );
+    case 'not':
+      return containsPositiveRuleIdMatch(node.arguments[0], ruleId, !negated);
+    case 'nested':
+      return containsPositiveRuleIdMatch(node.arguments[1], ruleId, negated);
+    default:
+      return false;
+  }
+};
+
+const unwrapSingleAndChain = (node: KueryNode): KueryNode => {
+  if (node.type !== 'function' || node.function !== 'and') {
+    return node;
+  }
+
+  const args = node.arguments as KueryNode[];
+  if (args.length !== 1) {
+    return node;
+  }
+
+  return unwrapSingleAndChain(args[0]);
+};
+
+const parseMatcherAst = (matcher: string): KueryNode | null => {
+  const trimmed = matcher.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return fromKueryExpression(trimmed);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns true when the matcher contains a positive `rule.id` clause equal to `ruleId`.
+ */
+export const isExplicitlyLinkedToRule = (
+  matcher: string | null | undefined,
+  ruleId: string
+): boolean => {
+  if (!matcher?.trim() || !ruleId) {
+    return false;
+  }
+
+  const ast = parseMatcherAst(matcher);
+  if (!ast) {
+    return false;
+  }
+
+  return containsPositiveRuleIdMatch(ast, ruleId, false);
+};
+
+/**
+ * True when the matcher is explicitly linked to the rule and contains no filters beyond `rule.id`.
+ */
+export const isRuleScopedCatchAllMatcher = (
+  matcher: string | null | undefined,
+  ruleId: string
+): boolean => {
+  if (!isExplicitlyLinkedToRule(matcher, ruleId) || !matcher?.trim()) {
+    return false;
+  }
+
+  const ast = parseMatcherAst(matcher);
+  if (!ast) {
+    return false;
+  }
+
+  return isRuleIdEqualsNode(unwrapSingleAndChain(ast), ruleId);
+};
+
+export interface LinkedActionPolicySummary {
+  policies: ActionPolicyResponse[];
+  totalCount: number;
+  catchAllCount: number;
+  matchingCriteriaCount: number;
+}
+
+/**
+ * Filters policies explicitly linked to `ruleId` and computes stat breakdowns for the rule details UI.
+ */
+export const summarizeExplicitlyLinkedActionPolicies = (
+  policies: ActionPolicyResponse[],
+  ruleId: string
+): LinkedActionPolicySummary => {
+  const linked = policies
+    .filter((policy) => isExplicitlyLinkedToRule(policy.matcher, ruleId))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  let catchAllCount = 0;
+  let matchingCriteriaCount = 0;
+
+  for (const policy of linked) {
+    if (isRuleScopedCatchAllMatcher(policy.matcher, ruleId)) {
+      catchAllCount++;
+    } else {
+      matchingCriteriaCount++;
+    }
+  }
+
+  return {
+    policies: linked,
+    totalCount: linked.length,
+    catchAllCount,
+    matchingCriteriaCount,
+  };
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.ts
@@ -48,7 +48,11 @@ const isRuleIdEqualsNode = (node: KueryNode, ruleId: string): boolean => {
   return parsed?.field === RULE_ID_FIELD && parsed.value === ruleId;
 };
 
-const containsPositiveRuleIdMatch = (node: KueryNode, ruleId: string, negated: boolean): boolean => {
+const containsPositiveRuleIdMatch = (
+  node: KueryNode,
+  ruleId: string,
+  negated: boolean
+): boolean => {
   if (node.type !== 'function') {
     return false;
   }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.ts
@@ -10,14 +10,6 @@ import { fromKueryExpression, type KueryNode } from '@kbn/es-query';
 
 const RULE_ID_FIELD = 'rule.id';
 
-const normalizeKueryValue = (raw: string): string => {
-  const trimmed = raw.trim();
-  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-};
-
 const getIsFieldAndValue = (node: KueryNode): { field: string; value: string } | null => {
   if (node.type !== 'function' || node.function !== 'is') {
     return null;
@@ -39,7 +31,7 @@ const getIsFieldAndValue = (node: KueryNode): { field: string; value: string } |
 
   return {
     field: fieldArg.value,
-    value: normalizeKueryValue(valueArg.value),
+    value: valueArg.value,
   };
 };
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/index.ts
@@ -18,6 +18,12 @@ export {
 } from './helpers/rule_scoped_action_policies';
 export type { RuleScopedSimpleActionPolicy } from './helpers/rule_scoped_action_policies';
 export {
+  isExplicitlyLinkedToRule,
+  isRuleScopedCatchAllMatcher,
+  summarizeExplicitlyLinkedActionPolicies,
+} from './helpers/explicitly_linked_action_policies';
+export type { LinkedActionPolicySummary } from './helpers/explicitly_linked_action_policies';
+export {
   DISPATCH_PAYLOAD_VARIABLES,
   INLINE_ACTION_STEP_DEFINITIONS,
   getDefaultInlineActionStepDefinition,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -68,11 +68,15 @@ export {
   isActionValid,
   buildRuleScopedMatcher,
   selectRuleSimpleActionPolicies,
+  isExplicitlyLinkedToRule,
+  isRuleScopedCatchAllMatcher,
+  summarizeExplicitlyLinkedActionPolicies,
 } from './actions_form';
 export type {
   ActionDraft,
   ActionDraftOrigin,
   RuleScopedSimpleActionPolicy,
+  LinkedActionPolicySummary,
   InlineActionStepDefinition,
   InlineActionStepType,
   InlineWorkflowActionDraft,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.test.tsx
@@ -6,9 +6,8 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
-import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { ActionPoliciesArtifactsSubsection } from './action_policies_artifacts_subsection';
 import { RuleProvider } from '../../rule_context';
 import type { RuleApiResponse } from '../../../../services/rules_api';
@@ -17,28 +16,6 @@ const mockUseLinkedActionPolicies = jest.fn();
 
 jest.mock('./use_linked_action_policies', () => ({
   useLinkedActionPolicies: (...args: unknown[]) => mockUseLinkedActionPolicies(...args),
-}));
-
-jest.mock('../../../action_policy/action_policy_destinations_summary', () => ({
-  ActionPolicyDestinationsSummary: () => (
-    <div data-test-subj="actionPolicyDestinationsSummaryMock">destinations</div>
-  ),
-}));
-
-jest.mock('../../../action_policy/details_flyout/action_policy_details_flyout_container', () => ({
-  ActionPolicyDetailsFlyoutContainer: ({
-    policyId,
-    onClose,
-  }: {
-    policyId: string;
-    onClose: () => void;
-  }) => (
-    <div data-test-subj={`actionPolicyDetailsFlyout-${policyId}`}>
-      <button type="button" onClick={onClose}>
-        Close flyout
-      </button>
-    </div>
-  ),
 }));
 
 const mockHttpService = {
@@ -71,27 +48,6 @@ const baseRule: RuleApiResponse = {
   updatedAt: '2026-03-04T12:00:00.000Z',
 };
 
-const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolicyResponse =>
-  ({
-    id: 'policy-1',
-    name: 'Notify on breach',
-    description: '',
-    enabled: true,
-    destinations: [{ type: 'workflow', id: 'workflow-1' }],
-    matcher: 'rule.id: "rule-1"',
-    groupBy: null,
-    tags: null,
-    groupingMode: 'per_episode',
-    throttle: null,
-    snoozedUntil: null,
-    auth: { owner: 'user', createdByUser: true },
-    createdBy: 'user',
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedBy: 'user',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-    ...overrides,
-  } as ActionPolicyResponse);
-
 const renderSubsection = (rule: RuleApiResponse = baseRule) =>
   render(
     <I18nProvider>
@@ -105,7 +61,6 @@ describe('ActionPoliciesArtifactsSubsection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseLinkedActionPolicies.mockReturnValue({
-      policies: [],
       totalCount: 0,
       catchAllCount: 0,
       matchingCriteriaCount: 0,
@@ -120,9 +75,8 @@ describe('ActionPoliciesArtifactsSubsection', () => {
     expect(mockUseLinkedActionPolicies).toHaveBeenCalledWith('rule-1');
   });
 
-  it('renders loading state', () => {
+  it('renders loading state on the stat', () => {
     mockUseLinkedActionPolicies.mockReturnValue({
-      policies: [],
       totalCount: 0,
       catchAllCount: 0,
       matchingCriteriaCount: 0,
@@ -132,12 +86,11 @@ describe('ActionPoliciesArtifactsSubsection', () => {
     });
 
     renderSubsection();
-    expect(screen.getByTestId('ruleActionPoliciesArtifactsLoading')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsStat')).toBeInTheDocument();
   });
 
-  it('renders error state', () => {
+  it('hides the stat when loading fails', () => {
     mockUseLinkedActionPolicies.mockReturnValue({
-      policies: [],
       totalCount: 0,
       catchAllCount: 0,
       matchingCriteriaCount: 0,
@@ -147,25 +100,19 @@ describe('ActionPoliciesArtifactsSubsection', () => {
     });
 
     renderSubsection();
+    expect(screen.queryByTestId('ruleActionPoliciesArtifactsStat')).not.toBeInTheDocument();
     expect(screen.getByTestId('ruleActionPoliciesArtifactsError')).toBeInTheDocument();
   });
 
-  it('renders empty state when no policies are linked', () => {
+  it('renders zero count without a separate empty prompt', () => {
     renderSubsection();
-    expect(screen.getByTestId('ruleActionPoliciesArtifactsEmpty')).toBeInTheDocument();
-    expect(screen.getByText('No action policies linked to this rule')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsStat')).toHaveTextContent('0');
+    expect(screen.queryByTestId('ruleActionPoliciesArtifactsEmpty')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ruleActionPoliciesArtifactsSummary')).not.toBeInTheDocument();
   });
 
-  it('renders stat, summary, manage link, and policy rows', () => {
+  it('renders stat, summary, and open link without listing individual policies', () => {
     mockUseLinkedActionPolicies.mockReturnValue({
-      policies: [
-        buildPolicy({ id: 'policy-1', name: 'Catch all policy' }),
-        buildPolicy({
-          id: 'policy-2',
-          name: 'Filtered policy',
-          enabled: false,
-        }),
-      ],
       totalCount: 2,
       catchAllCount: 1,
       matchingCriteriaCount: 1,
@@ -180,56 +127,19 @@ describe('ActionPoliciesArtifactsSubsection', () => {
     expect(screen.getByTestId('ruleActionPoliciesArtifactsSummary')).toHaveTextContent(
       '1 is matching criteria and 1 is catch-all'
     );
-    expect(screen.getByTestId('ruleActionPoliciesArtifactsManageLink')).toHaveAttribute(
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsOpenLink')).toHaveAttribute(
       'href',
       '/app/management/alertingV2/action_policies'
     );
-    expect(screen.getByTestId('ruleActionPolicyArtifactName-policy-1')).toHaveTextContent(
-      'Catch all policy'
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsOpenLink')).toHaveAttribute(
+      'target',
+      '_blank'
     );
-    expect(screen.getByTestId('ruleActionPolicyArtifactStatus-policy-2')).toHaveTextContent(
-      'Disabled'
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsOpenLink')).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
     );
-    expect(screen.getByTestId('ruleActionPoliciesArtifactsHelp')).toBeInTheDocument();
-  });
-
-  it('renders snoozed status for enabled snoozed policies', () => {
-    mockUseLinkedActionPolicies.mockReturnValue({
-      policies: [
-        buildPolicy({
-          id: 'policy-snoozed',
-          snoozedUntil: '2099-01-01T00:00:00.000Z',
-        }),
-      ],
-      totalCount: 1,
-      catchAllCount: 1,
-      matchingCriteriaCount: 0,
-      isLoading: false,
-      isError: false,
-      error: null,
-    });
-
-    renderSubsection();
-
-    expect(screen.getByTestId('ruleActionPolicyArtifactStatus-policy-snoozed')).toHaveTextContent(
-      'Snoozed'
-    );
-  });
-
-  it('opens the policy details flyout when a policy name is clicked', () => {
-    mockUseLinkedActionPolicies.mockReturnValue({
-      policies: [buildPolicy()],
-      totalCount: 1,
-      catchAllCount: 1,
-      matchingCriteriaCount: 0,
-      isLoading: false,
-      isError: false,
-      error: null,
-    });
-
-    renderSubsection();
-
-    fireEvent.click(screen.getByTestId('ruleActionPolicyArtifactName-policy-1'));
-    expect(screen.getByTestId('actionPolicyDetailsFlyout-policy-1')).toBeInTheDocument();
+    expect(screen.getByText('Open notification policies')).toBeInTheDocument();
+    expect(screen.queryByTestId('ruleActionPolicyArtifactRow-policy-1')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.test.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
+import { ActionPoliciesArtifactsSubsection } from './action_policies_artifacts_subsection';
+import { RuleProvider } from '../../rule_context';
+import type { RuleApiResponse } from '../../../../services/rules_api';
+
+const mockUseLinkedActionPolicies = jest.fn();
+
+jest.mock('./use_linked_action_policies', () => ({
+  useLinkedActionPolicies: (...args: unknown[]) => mockUseLinkedActionPolicies(...args),
+}));
+
+jest.mock('../../../action_policy/action_policy_destinations_summary', () => ({
+  ActionPolicyDestinationsSummary: () => (
+    <div data-test-subj="actionPolicyDestinationsSummaryMock">destinations</div>
+  ),
+}));
+
+jest.mock('../../../action_policy/details_flyout/action_policy_details_flyout_container', () => ({
+  ActionPolicyDetailsFlyoutContainer: ({
+    policyId,
+    onClose,
+  }: {
+    policyId: string;
+    onClose: () => void;
+  }) => (
+    <div data-test-subj={`actionPolicyDetailsFlyout-${policyId}`}>
+      <button type="button" onClick={onClose}>
+        Close flyout
+      </button>
+    </div>
+  ),
+}));
+
+const mockHttpService = {
+  basePath: {
+    prepend: (path: string) => path,
+  },
+};
+
+jest.mock('@kbn/core-di-browser', () => ({
+  useService: (token: unknown) => {
+    if (token === 'http') {
+      return mockHttpService;
+    }
+    return {};
+  },
+  CoreStart: (key: string) => key,
+}));
+
+const baseRule: RuleApiResponse = {
+  id: 'rule-1',
+  kind: 'alert',
+  enabled: true,
+  metadata: { name: 'Test Rule' },
+  time_field: '@timestamp',
+  schedule: { every: '5m', lookback: '10m' },
+  query: { format: 'composed' as const, base: 'FROM logs-*', breach: { segment: '' } },
+  createdBy: 'alice@example.com',
+  createdAt: '2026-03-01T12:00:00.000Z',
+  updatedBy: 'bob@example.com',
+  updatedAt: '2026-03-04T12:00:00.000Z',
+};
+
+const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolicyResponse =>
+  ({
+    id: 'policy-1',
+    name: 'Notify on breach',
+    description: '',
+    enabled: true,
+    destinations: [{ type: 'workflow', id: 'workflow-1' }],
+    matcher: 'rule.id: "rule-1"',
+    groupBy: null,
+    tags: null,
+    groupingMode: 'per_episode',
+    throttle: null,
+    snoozedUntil: null,
+    auth: { owner: 'user', createdByUser: true },
+    createdBy: 'user',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedBy: 'user',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as ActionPolicyResponse);
+
+const renderSubsection = (rule: RuleApiResponse = baseRule) =>
+  render(
+    <I18nProvider>
+      <RuleProvider rule={rule}>
+        <ActionPoliciesArtifactsSubsection />
+      </RuleProvider>
+    </I18nProvider>
+  );
+
+describe('ActionPoliciesArtifactsSubsection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLinkedActionPolicies.mockReturnValue({
+      policies: [],
+      totalCount: 0,
+      catchAllCount: 0,
+      matchingCriteriaCount: 0,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+  });
+
+  it('loads linked policies for the current rule', () => {
+    renderSubsection();
+    expect(mockUseLinkedActionPolicies).toHaveBeenCalledWith('rule-1');
+  });
+
+  it('renders loading state', () => {
+    mockUseLinkedActionPolicies.mockReturnValue({
+      policies: [],
+      totalCount: 0,
+      catchAllCount: 0,
+      matchingCriteriaCount: 0,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    renderSubsection();
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsLoading')).toBeInTheDocument();
+  });
+
+  it('renders error state', () => {
+    mockUseLinkedActionPolicies.mockReturnValue({
+      policies: [],
+      totalCount: 0,
+      catchAllCount: 0,
+      matchingCriteriaCount: 0,
+      isLoading: false,
+      isError: true,
+      error: new Error('boom'),
+    });
+
+    renderSubsection();
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsError')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no policies are linked', () => {
+    renderSubsection();
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsEmpty')).toBeInTheDocument();
+    expect(screen.getByText('No action policies linked to this rule')).toBeInTheDocument();
+  });
+
+  it('renders stat, summary, manage link, and policy rows', () => {
+    mockUseLinkedActionPolicies.mockReturnValue({
+      policies: [
+        buildPolicy({ id: 'policy-1', name: 'Catch all policy' }),
+        buildPolicy({
+          id: 'policy-2',
+          name: 'Filtered policy',
+          enabled: false,
+        }),
+      ],
+      totalCount: 2,
+      catchAllCount: 1,
+      matchingCriteriaCount: 1,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderSubsection();
+
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsStat')).toHaveTextContent('2');
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsSummary')).toHaveTextContent(
+      '1 is matching criteria and 1 is catch-all'
+    );
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsManageLink')).toHaveAttribute(
+      'href',
+      '/app/management/alertingV2/action_policies'
+    );
+    expect(screen.getByTestId('ruleActionPolicyArtifactName-policy-1')).toHaveTextContent(
+      'Catch all policy'
+    );
+    expect(screen.getByTestId('ruleActionPolicyArtifactStatus-policy-2')).toHaveTextContent(
+      'Disabled'
+    );
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsHelp')).toBeInTheDocument();
+  });
+
+  it('renders snoozed status for enabled snoozed policies', () => {
+    mockUseLinkedActionPolicies.mockReturnValue({
+      policies: [
+        buildPolicy({
+          id: 'policy-snoozed',
+          snoozedUntil: '2099-01-01T00:00:00.000Z',
+        }),
+      ],
+      totalCount: 1,
+      catchAllCount: 1,
+      matchingCriteriaCount: 0,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderSubsection();
+
+    expect(screen.getByTestId('ruleActionPolicyArtifactStatus-policy-snoozed')).toHaveTextContent(
+      'Snoozed'
+    );
+  });
+
+  it('opens the policy details flyout when a policy name is clicked', () => {
+    mockUseLinkedActionPolicies.mockReturnValue({
+      policies: [buildPolicy()],
+      totalCount: 1,
+      catchAllCount: 1,
+      matchingCriteriaCount: 0,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderSubsection();
+
+    fireEvent.click(screen.getByTestId('ruleActionPolicyArtifactName-policy-1'));
+    expect(screen.getByTestId('actionPolicyDetailsFlyout-policy-1')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.test.tsx
@@ -14,9 +14,16 @@ import type { RuleApiResponse } from '../../../../services/rules_api';
 
 const mockUseLinkedActionPolicies = jest.fn();
 
-jest.mock('./use_linked_action_policies', () => ({
-  useLinkedActionPolicies: (...args: unknown[]) => mockUseLinkedActionPolicies(...args),
-}));
+jest.mock('./use_linked_action_policies', () => {
+  const actual = jest.requireActual<typeof import('./use_linked_action_policies')>(
+    './use_linked_action_policies'
+  );
+
+  return {
+    ...actual,
+    useLinkedActionPolicies: (...args: unknown[]) => mockUseLinkedActionPolicies(...args),
+  };
+});
 
 const mockHttpService = {
   basePath: {
@@ -66,6 +73,7 @@ describe('ActionPoliciesArtifactsSubsection', () => {
       matchingCriteriaCount: 0,
       isLoading: false,
       isError: false,
+      isCountTruncated: false,
       error: null,
     });
   });
@@ -82,6 +90,7 @@ describe('ActionPoliciesArtifactsSubsection', () => {
       matchingCriteriaCount: 0,
       isLoading: true,
       isError: false,
+      isCountTruncated: false,
       error: null,
     });
 
@@ -96,6 +105,7 @@ describe('ActionPoliciesArtifactsSubsection', () => {
       matchingCriteriaCount: 0,
       isLoading: false,
       isError: true,
+      isCountTruncated: false,
       error: new Error('boom'),
     });
 
@@ -118,6 +128,7 @@ describe('ActionPoliciesArtifactsSubsection', () => {
       matchingCriteriaCount: 1,
       isLoading: false,
       isError: false,
+      isCountTruncated: false,
       error: null,
     });
 
@@ -141,5 +152,24 @@ describe('ActionPoliciesArtifactsSubsection', () => {
     );
     expect(screen.getByText('Open notification policies')).toBeInTheDocument();
     expect(screen.queryByTestId('ruleActionPolicyArtifactRow-policy-1')).not.toBeInTheDocument();
+  });
+
+  it('shows a truncated count indicator when linked policy counts may be incomplete', () => {
+    mockUseLinkedActionPolicies.mockReturnValue({
+      totalCount: 5,
+      catchAllCount: 2,
+      matchingCriteriaCount: 3,
+      isLoading: false,
+      isError: false,
+      isCountTruncated: true,
+      error: null,
+    });
+
+    renderSubsection();
+
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsStat')).toHaveTextContent('5+');
+    expect(screen.getByTestId('ruleActionPoliciesArtifactsTruncatedHint')).toHaveTextContent(
+      'This space has more than 100 action policies, so this count may be low.'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.tsx
@@ -21,7 +21,10 @@ import { CoreStart, useService } from '@kbn/core-di-browser';
 import { i18n } from '@kbn/i18n';
 import { paths } from '../../../../constants';
 import { useRule } from '../../rule_context';
-import { useLinkedActionPolicies } from './use_linked_action_policies';
+import {
+  useLinkedActionPolicies,
+  LINKED_ACTION_POLICIES_FETCH_LIMIT,
+} from './use_linked_action_policies';
 
 const openLinkLabel = i18n.translate(
   'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.openLink',
@@ -67,10 +70,12 @@ const ActionPoliciesSubsectionHeader = ({ openHref }: { openHref: string }) => (
 export const ActionPoliciesArtifactsSubsection: React.FC = () => {
   const rule = useRule();
   const http = useService(CoreStart('http'));
-  const { totalCount, catchAllCount, matchingCriteriaCount, isLoading, isError } =
+  const { totalCount, catchAllCount, matchingCriteriaCount, isCountTruncated, isLoading, isError } =
     useLinkedActionPolicies(rule.id);
 
   const openNotificationPoliciesHref = http.basePath.prepend(paths.actionPolicyList);
+
+  const statTitle = isCountTruncated ? `${totalCount}+` : totalCount;
 
   const summaryText =
     totalCount > 0
@@ -81,17 +86,28 @@ export const ActionPoliciesArtifactsSubsection: React.FC = () => {
         })
       : null;
 
-  const showStat = isLoading || !isError;
+  const truncatedCountHint = isCountTruncated
+    ? i18n.translate(
+        'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.truncatedCountHint',
+        {
+          defaultMessage:
+            'This space has more than {fetchLimit} action policies, so this count may be low.',
+          values: { fetchLimit: LINKED_ACTION_POLICIES_FETCH_LIMIT },
+        }
+      )
+    : null;
+
+  const shouldShowCounts = isLoading || !isError;
 
   return (
     <EuiPanel hasBorder paddingSize="m" data-test-subj="ruleActionPoliciesArtifactsSection">
       <ActionPoliciesSubsectionHeader openHref={openNotificationPoliciesHref} />
       <EuiSpacer size="m" />
 
-      {showStat ? (
+      {shouldShowCounts ? (
         <>
           <EuiStat
-            title={totalCount}
+            title={statTitle}
             description={i18n.translate(
               'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.statDescription',
               { defaultMessage: 'Notification policies' }
@@ -108,6 +124,19 @@ export const ActionPoliciesArtifactsSubsection: React.FC = () => {
               <EuiSpacer size="s" />
               <EuiText size="s" color="subdued" data-test-subj="ruleActionPoliciesArtifactsSummary">
                 {summaryText}
+              </EuiText>
+            </>
+          ) : null}
+
+          {truncatedCountHint ? (
+            <>
+              <EuiSpacer size="s" />
+              <EuiText
+                size="s"
+                color="subdued"
+                data-test-subj="ruleActionPoliciesArtifactsTruncatedHint"
+              >
+                {truncatedCountHint}
               </EuiText>
             </>
           ) : null}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.tsx
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiIconTip,
+  EuiLink,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  EuiStat,
+  EuiText,
+} from '@elastic/eui';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
+import { i18n } from '@kbn/i18n';
+import { ActionPolicyDestinationsSummary } from '../../../action_policy/action_policy_destinations_summary';
+import { ActionPolicyDetailsFlyoutContainer } from '../../../action_policy/details_flyout/action_policy_details_flyout_container';
+import { ActionPolicyStateBadge } from '../../../action_policy/action_policy_state_badge';
+import { isSnoozed } from '../../../action_policy/is_snoozed';
+import { paths } from '../../../../constants';
+import { useRule } from '../../rule_context';
+import { useLinkedActionPolicies } from './use_linked_action_policies';
+
+const LinkedActionPolicyStatusBadge = ({ policy }: { policy: ActionPolicyResponse }) => {
+  if (!policy.enabled) {
+    return <ActionPolicyStateBadge policy={policy} isLoading={false} />;
+  }
+
+  if (isSnoozed(policy.snoozedUntil)) {
+    return (
+      <EuiBadge color="hollow" iconType="bellSlash">
+        {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.statusSnoozed', {
+          defaultMessage: 'Snoozed',
+        })}
+      </EuiBadge>
+    );
+  }
+
+  return <ActionPolicyStateBadge policy={policy} isLoading={false} />;
+};
+
+const ActionPolicyRow = ({
+  policy,
+  onViewPolicy,
+}: {
+  policy: ActionPolicyResponse;
+  onViewPolicy: (policyId: string) => void;
+}) => (
+  <EuiPanel hasBorder paddingSize="s" data-test-subj={`ruleActionPolicyArtifactRow-${policy.id}`}>
+    <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+      <EuiFlexItem grow={2}>
+        <EuiLink
+          onClick={() => onViewPolicy(policy.id)}
+          data-test-subj={`ruleActionPolicyArtifactName-${policy.id}`}
+        >
+          {policy.name}
+        </EuiLink>
+      </EuiFlexItem>
+      <EuiFlexItem grow={2}>
+        <ActionPolicyDestinationsSummary destinations={policy.destinations} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <span data-test-subj={`ruleActionPolicyArtifactStatus-${policy.id}`}>
+          <LinkedActionPolicyStatusBadge policy={policy} />
+        </span>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+);
+
+const ActionPoliciesSubsectionHeader = () => (
+  <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="bell" size="m" aria-hidden={true} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <strong>
+              {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.title', {
+                defaultMessage: 'Action policies',
+              })}
+            </strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <span data-test-subj="ruleActionPoliciesArtifactsHelp">
+            <EuiIconTip
+              type="questionInCircle"
+              color="subdued"
+              content={i18n.translate(
+                'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.helpTooltip',
+                {
+                  defaultMessage:
+                    "Only action policies whose matcher explicitly filters on this rule's ID are shown. Policies that might match based on tags or other fields are not included.",
+                }
+              )}
+            />
+          </span>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        iconType="boxesHorizontal"
+        color="text"
+        aria-label={i18n.translate(
+          'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.overflowMenuAriaLabel',
+          { defaultMessage: 'Action policies section menu' }
+        )}
+        data-test-subj="ruleActionPoliciesArtifactsOverflowButton"
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
+export const ActionPoliciesArtifactsSubsection: React.FC = () => {
+  const rule = useRule();
+  const http = useService(CoreStart('http'));
+  const { policies, totalCount, catchAllCount, matchingCriteriaCount, isLoading, isError } =
+    useLinkedActionPolicies(rule.id);
+  const [policyToViewId, setPolicyToViewId] = useState<string | null>(null);
+
+  const manageActionPoliciesHref = useMemo(
+    () => http.basePath.prepend(paths.actionPolicyList),
+    [http.basePath]
+  );
+
+  const summaryText = useMemo(() => {
+    if (totalCount === 0) {
+      return null;
+    }
+
+    return i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.summary', {
+      defaultMessage:
+        '{matchingCriteriaCount, plural, one {# is matching criteria} other {# are matching criteria}} and {catchAllCount, plural, one {# is catch-all} other {# are catch-all}}',
+      values: { matchingCriteriaCount, catchAllCount },
+    });
+  }, [catchAllCount, matchingCriteriaCount, totalCount]);
+
+  return (
+    <>
+      <EuiPanel hasBorder paddingSize="m" data-test-subj="ruleActionPoliciesArtifactsSection">
+        <ActionPoliciesSubsectionHeader />
+        <EuiSpacer size="s" />
+        <EuiButtonEmpty
+          size="s"
+          iconType="popout"
+          iconSide="right"
+          href={manageActionPoliciesHref}
+          data-test-subj="ruleActionPoliciesArtifactsManageLink"
+        >
+          {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.manageLink', {
+            defaultMessage: 'Manage action policies',
+          })}
+        </EuiButtonEmpty>
+        <EuiSpacer size="m" />
+
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiStat
+              title={totalCount}
+              description={i18n.translate(
+                'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.statDescription',
+                { defaultMessage: 'Action policies' }
+              )}
+              titleSize="l"
+              textAlign="left"
+              reverse
+              isLoading={isLoading}
+              data-test-subj="ruleActionPoliciesArtifactsStat"
+            />
+          </EuiFlexItem>
+          {summaryText ? (
+            <EuiFlexItem grow>
+              <EuiText size="s" color="subdued" data-test-subj="ruleActionPoliciesArtifactsSummary">
+                {summaryText}
+              </EuiText>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+
+        <EuiSpacer size="m" />
+
+        {isLoading ? (
+          <EuiLoadingSpinner size="m" data-test-subj="ruleActionPoliciesArtifactsLoading" />
+        ) : null}
+
+        {!isLoading && isError ? (
+          <EuiEmptyPrompt
+            color="danger"
+            iconType="warning"
+            data-test-subj="ruleActionPoliciesArtifactsError"
+            title={
+              <h4>
+                {i18n.translate(
+                  'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.errorTitle',
+                  {
+                    defaultMessage: 'Could not load action policies',
+                  }
+                )}
+              </h4>
+            }
+            body={
+              <EuiText size="s">
+                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.errorBody', {
+                  defaultMessage: 'Try refreshing the page.',
+                })}
+              </EuiText>
+            }
+          />
+        ) : null}
+
+        {!isLoading && !isError && totalCount === 0 ? (
+          <EuiEmptyPrompt
+            iconType="bell"
+            data-test-subj="ruleActionPoliciesArtifactsEmpty"
+            title={
+              <h4>
+                {i18n.translate(
+                  'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.emptyTitle',
+                  {
+                    defaultMessage: 'No action policies linked to this rule',
+                  }
+                )}
+              </h4>
+            }
+            body={
+              <EuiText size="s">
+                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.emptyBody', {
+                  defaultMessage:
+                    "Create or edit an action policy with a matcher that filters on this rule's ID.",
+                })}
+              </EuiText>
+            }
+          />
+        ) : null}
+
+        {!isLoading && !isError && policies.length > 0 ? (
+          <>
+            {policies.map((policy) => (
+              <React.Fragment key={policy.id}>
+                <ActionPolicyRow policy={policy} onViewPolicy={setPolicyToViewId} />
+                <EuiSpacer size="s" />
+              </React.Fragment>
+            ))}
+          </>
+        ) : null}
+      </EuiPanel>
+
+      {policyToViewId ? (
+        <ActionPolicyDetailsFlyoutContainer
+          policyId={policyToViewId}
+          onClose={() => setPolicyToViewId(null)}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/action_policies_artifacts_subsection.tsx
@@ -5,124 +5,61 @@
  * 2.0.
  */
 
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import {
-  EuiBadge,
-  EuiButtonEmpty,
-  EuiButtonIcon,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiIconTip,
   EuiLink,
-  EuiLoadingSpinner,
   EuiPanel,
   EuiSpacer,
   EuiStat,
   EuiText,
 } from '@elastic/eui';
 import { CoreStart, useService } from '@kbn/core-di-browser';
-import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { i18n } from '@kbn/i18n';
-import { ActionPolicyDestinationsSummary } from '../../../action_policy/action_policy_destinations_summary';
-import { ActionPolicyDetailsFlyoutContainer } from '../../../action_policy/details_flyout/action_policy_details_flyout_container';
-import { ActionPolicyStateBadge } from '../../../action_policy/action_policy_state_badge';
-import { isSnoozed } from '../../../action_policy/is_snoozed';
 import { paths } from '../../../../constants';
 import { useRule } from '../../rule_context';
 import { useLinkedActionPolicies } from './use_linked_action_policies';
 
-const LinkedActionPolicyStatusBadge = ({ policy }: { policy: ActionPolicyResponse }) => {
-  if (!policy.enabled) {
-    return <ActionPolicyStateBadge policy={policy} isLoading={false} />;
-  }
-
-  if (isSnoozed(policy.snoozedUntil)) {
-    return (
-      <EuiBadge color="hollow" iconType="bellSlash">
-        {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.statusSnoozed', {
-          defaultMessage: 'Snoozed',
-        })}
-      </EuiBadge>
-    );
-  }
-
-  return <ActionPolicyStateBadge policy={policy} isLoading={false} />;
-};
-
-const ActionPolicyRow = ({
-  policy,
-  onViewPolicy,
-}: {
-  policy: ActionPolicyResponse;
-  onViewPolicy: (policyId: string) => void;
-}) => (
-  <EuiPanel hasBorder paddingSize="s" data-test-subj={`ruleActionPolicyArtifactRow-${policy.id}`}>
-    <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
-      <EuiFlexItem grow={2}>
-        <EuiLink
-          onClick={() => onViewPolicy(policy.id)}
-          data-test-subj={`ruleActionPolicyArtifactName-${policy.id}`}
-        >
-          {policy.name}
-        </EuiLink>
-      </EuiFlexItem>
-      <EuiFlexItem grow={2}>
-        <ActionPolicyDestinationsSummary destinations={policy.destinations} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <span data-test-subj={`ruleActionPolicyArtifactStatus-${policy.id}`}>
-          <LinkedActionPolicyStatusBadge policy={policy} />
-        </span>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiPanel>
+const openLinkLabel = i18n.translate(
+  'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.openLink',
+  { defaultMessage: 'Open notification policies' }
 );
 
-const ActionPoliciesSubsectionHeader = () => (
-  <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
-    <EuiFlexItem grow={false}>
+const ActionPoliciesSubsectionHeader = ({ openHref }: { openHref: string }) => (
+  <EuiFlexGroup alignItems="center" gutterSize="s" wrap responsive={false}>
+    <EuiFlexItem grow={false} style={{ minWidth: 0 }}>
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="bell" size="m" aria-hidden={true} />
+          <EuiIcon type="reporter" size="m" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">
             <strong>
-              {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.title', {
-                defaultMessage: 'Action policies',
+              {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.title', {
+                defaultMessage: 'Notification policies',
               })}
             </strong>
           </EuiText>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <span data-test-subj="ruleActionPoliciesArtifactsHelp">
-            <EuiIconTip
-              type="questionInCircle"
-              color="subdued"
-              content={i18n.translate(
-                'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.helpTooltip',
-                {
-                  defaultMessage:
-                    "Only action policies whose matcher explicitly filters on this rule's ID are shown. Policies that might match based on tags or other fields are not included.",
-                }
-              )}
-            />
-          </span>
-        </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="boxesHorizontal"
-        color="text"
-        aria-label={i18n.translate(
-          'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.overflowMenuAriaLabel',
-          { defaultMessage: 'Action policies section menu' }
-        )}
-        data-test-subj="ruleActionPoliciesArtifactsOverflowButton"
-      />
+    <EuiFlexItem grow={false} style={{ marginLeft: 'auto' }}>
+      <EuiText size="xs">
+        <EuiLink
+          color="text"
+          href={openHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          external={false}
+          style={{ fontWeight: 'normal', whiteSpace: 'nowrap' }}
+          data-test-subj="ruleActionPoliciesArtifactsOpenLink"
+        >
+          {openLinkLabel}
+        </EuiLink>
+      </EuiText>
     </EuiFlexItem>
   </EuiFlexGroup>
 );
@@ -130,76 +67,56 @@ const ActionPoliciesSubsectionHeader = () => (
 export const ActionPoliciesArtifactsSubsection: React.FC = () => {
   const rule = useRule();
   const http = useService(CoreStart('http'));
-  const { policies, totalCount, catchAllCount, matchingCriteriaCount, isLoading, isError } =
+  const { totalCount, catchAllCount, matchingCriteriaCount, isLoading, isError } =
     useLinkedActionPolicies(rule.id);
-  const [policyToViewId, setPolicyToViewId] = useState<string | null>(null);
 
-  const manageActionPoliciesHref = useMemo(
-    () => http.basePath.prepend(paths.actionPolicyList),
-    [http.basePath]
-  );
+  const openNotificationPoliciesHref = http.basePath.prepend(paths.actionPolicyList);
 
-  const summaryText = useMemo(() => {
-    if (totalCount === 0) {
-      return null;
-    }
+  const summaryText =
+    totalCount > 0
+      ? i18n.translate('xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.summary', {
+          defaultMessage:
+            '{matchingCriteriaCount, plural, one {# is matching criteria} other {# are matching criteria}} and {catchAllCount, plural, one {# is catch-all} other {# are catch-all}}',
+          values: { matchingCriteriaCount, catchAllCount },
+        })
+      : null;
 
-    return i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.summary', {
-      defaultMessage:
-        '{matchingCriteriaCount, plural, one {# is matching criteria} other {# are matching criteria}} and {catchAllCount, plural, one {# is catch-all} other {# are catch-all}}',
-      values: { matchingCriteriaCount, catchAllCount },
-    });
-  }, [catchAllCount, matchingCriteriaCount, totalCount]);
+  const showStat = isLoading || !isError;
 
   return (
-    <>
-      <EuiPanel hasBorder paddingSize="m" data-test-subj="ruleActionPoliciesArtifactsSection">
-        <ActionPoliciesSubsectionHeader />
-        <EuiSpacer size="s" />
-        <EuiButtonEmpty
-          size="s"
-          iconType="popout"
-          iconSide="right"
-          href={manageActionPoliciesHref}
-          data-test-subj="ruleActionPoliciesArtifactsManageLink"
-        >
-          {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.manageLink', {
-            defaultMessage: 'Manage action policies',
-          })}
-        </EuiButtonEmpty>
-        <EuiSpacer size="m" />
+    <EuiPanel hasBorder paddingSize="m" data-test-subj="ruleActionPoliciesArtifactsSection">
+      <ActionPoliciesSubsectionHeader openHref={openNotificationPoliciesHref} />
+      <EuiSpacer size="m" />
 
-        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiStat
-              title={totalCount}
-              description={i18n.translate(
-                'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.statDescription',
-                { defaultMessage: 'Action policies' }
-              )}
-              titleSize="l"
-              textAlign="left"
-              reverse
-              isLoading={isLoading}
-              data-test-subj="ruleActionPoliciesArtifactsStat"
-            />
-          </EuiFlexItem>
+      {showStat ? (
+        <>
+          <EuiStat
+            title={totalCount}
+            description={i18n.translate(
+              'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.statDescription',
+              { defaultMessage: 'Notification policies' }
+            )}
+            titleSize="l"
+            textAlign="left"
+            reverse
+            isLoading={isLoading}
+            data-test-subj="ruleActionPoliciesArtifactsStat"
+          />
+
           {summaryText ? (
-            <EuiFlexItem grow>
+            <>
+              <EuiSpacer size="s" />
               <EuiText size="s" color="subdued" data-test-subj="ruleActionPoliciesArtifactsSummary">
                 {summaryText}
               </EuiText>
-            </EuiFlexItem>
+            </>
           ) : null}
-        </EuiFlexGroup>
+        </>
+      ) : null}
 
-        <EuiSpacer size="m" />
-
-        {isLoading ? (
-          <EuiLoadingSpinner size="m" data-test-subj="ruleActionPoliciesArtifactsLoading" />
-        ) : null}
-
-        {!isLoading && isError ? (
+      {!isLoading && isError ? (
+        <>
+          <EuiSpacer size="m" />
           <EuiEmptyPrompt
             color="danger"
             iconType="warning"
@@ -207,66 +124,26 @@ export const ActionPoliciesArtifactsSubsection: React.FC = () => {
             title={
               <h4>
                 {i18n.translate(
-                  'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.errorTitle',
+                  'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.errorTitle',
                   {
-                    defaultMessage: 'Could not load action policies',
+                    defaultMessage: 'Could not load notification policies',
                   }
                 )}
               </h4>
             }
             body={
               <EuiText size="s">
-                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.errorBody', {
-                  defaultMessage: 'Try refreshing the page.',
-                })}
-              </EuiText>
-            }
-          />
-        ) : null}
-
-        {!isLoading && !isError && totalCount === 0 ? (
-          <EuiEmptyPrompt
-            iconType="bell"
-            data-test-subj="ruleActionPoliciesArtifactsEmpty"
-            title={
-              <h4>
                 {i18n.translate(
-                  'xpack.alertingV2.ruleDetails.artifacts.actionPolicies.emptyTitle',
+                  'xpack.alertingV2.ruleDetails.artifacts.notificationPolicies.errorBody',
                   {
-                    defaultMessage: 'No action policies linked to this rule',
+                    defaultMessage: 'Try refreshing the page.',
                   }
                 )}
-              </h4>
-            }
-            body={
-              <EuiText size="s">
-                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.actionPolicies.emptyBody', {
-                  defaultMessage:
-                    "Create or edit an action policy with a matcher that filters on this rule's ID.",
-                })}
               </EuiText>
             }
           />
-        ) : null}
-
-        {!isLoading && !isError && policies.length > 0 ? (
-          <>
-            {policies.map((policy) => (
-              <React.Fragment key={policy.id}>
-                <ActionPolicyRow policy={policy} onViewPolicy={setPolicyToViewId} />
-                <EuiSpacer size="s" />
-              </React.Fragment>
-            ))}
-          </>
-        ) : null}
-      </EuiPanel>
-
-      {policyToViewId ? (
-        <ActionPolicyDetailsFlyoutContainer
-          policyId={policyToViewId}
-          onClose={() => setPolicyToViewId(null)}
-        />
+        </>
       ) : null}
-    </>
+    </EuiPanel>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { ArtifactsSection } from './artifacts_section';
+
+jest.mock('./dashboard_artifacts_subsection', () => ({
+  DashboardArtifactsSubsection: () => (
+    <div data-test-subj="dashboardArtifactsSubsectionMock">dashboards</div>
+  ),
+}));
+
+describe('ArtifactsSection', () => {
+  it('renders the artifacts accordion with the dashboards subsection', () => {
+    render(
+      <I18nProvider>
+        <ArtifactsSection />
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('ruleArtifactsSection')).toBeInTheDocument();
+    expect(screen.getByText('Artifacts')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboardArtifactsSubsectionMock')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.test.tsx
@@ -16,8 +16,14 @@ jest.mock('./dashboard_artifacts_subsection', () => ({
   ),
 }));
 
+jest.mock('./action_policies_artifacts_subsection', () => ({
+  ActionPoliciesArtifactsSubsection: () => (
+    <div data-test-subj="actionPoliciesArtifactsSubsectionMock">action policies</div>
+  ),
+}));
+
 describe('ArtifactsSection', () => {
-  it('renders the artifacts accordion with the dashboards subsection', () => {
+  it('renders the artifacts accordion with dashboard and action policy subsections', () => {
     render(
       <I18nProvider>
         <ArtifactsSection />
@@ -26,6 +32,8 @@ describe('ArtifactsSection', () => {
 
     expect(screen.getByTestId('ruleArtifactsSection')).toBeInTheDocument();
     expect(screen.getByText('Artifacts')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleArtifactsSubsectionsRow')).toBeInTheDocument();
     expect(screen.getByTestId('dashboardArtifactsSubsectionMock')).toBeInTheDocument();
+    expect(screen.getByTestId('actionPoliciesArtifactsSubsectionMock')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.tsx
@@ -30,7 +30,7 @@ export const ArtifactsSection: React.FC = () => {
       paddingSize="m"
       initialIsOpen
     >
-      <EuiFlexGroup gutterSize="l" responsive={false} data-test-subj="ruleArtifactsSubsectionsRow">
+      <EuiFlexGroup gutterSize="l" responsive={true} data-test-subj="ruleArtifactsSubsectionsRow">
         <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
           <DashboardArtifactsSubsection />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiAccordion, EuiText, useGeneratedHtmlId } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { DashboardArtifactsSubsection } from './dashboard_artifacts_subsection';
+
+export const ArtifactsSection: React.FC = () => {
+  const artifactsAccordionId = useGeneratedHtmlId({ prefix: 'ruleArtifactsSection' });
+
+  return (
+    <EuiAccordion
+      id={artifactsAccordionId}
+      data-test-subj="ruleArtifactsSection"
+      buttonContent={
+        <EuiText size="s">
+          <strong>
+            {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.title', {
+              defaultMessage: 'Artifacts',
+            })}
+          </strong>
+        </EuiText>
+      }
+      paddingSize="m"
+      initialIsOpen
+    >
+      <DashboardArtifactsSubsection />
+    </EuiAccordion>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/artifacts_section.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { EuiAccordion, EuiText, useGeneratedHtmlId } from '@elastic/eui';
+import { EuiAccordion, EuiFlexGroup, EuiFlexItem, EuiText, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { ActionPoliciesArtifactsSubsection } from './action_policies_artifacts_subsection';
 import { DashboardArtifactsSubsection } from './dashboard_artifacts_subsection';
 
 export const ArtifactsSection: React.FC = () => {
@@ -29,7 +30,14 @@ export const ArtifactsSection: React.FC = () => {
       paddingSize="m"
       initialIsOpen
     >
-      <DashboardArtifactsSubsection />
+      <EuiFlexGroup gutterSize="l" responsive={false} data-test-subj="ruleArtifactsSubsectionsRow">
+        <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
+          <DashboardArtifactsSubsection />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
+          <ActionPoliciesArtifactsSubsection />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiAccordion>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/dashboard_artifacts_subsection.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/dashboard_artifacts_subsection.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { DASHBOARD_ARTIFACT_TYPE } from '@kbn/alerting-v2-constants';
-import { DashboardArtifactsSection } from './dashboard_artifacts_section';
+import { DashboardArtifactsSubsection } from './dashboard_artifacts_subsection';
 import { RuleProvider } from '../../rule_context';
 import type { RuleApiResponse } from '../../../../services/rules_api';
 
@@ -91,16 +91,16 @@ const baseRule: RuleApiResponse = {
   updatedAt: '2026-03-04T12:00:00.000Z',
 };
 
-const renderSection = (rule: RuleApiResponse) =>
+const renderSubsection = (rule: RuleApiResponse) =>
   render(
     <I18nProvider>
       <RuleProvider rule={rule}>
-        <DashboardArtifactsSection />
+        <DashboardArtifactsSubsection />
       </RuleProvider>
     </I18nProvider>
   );
 
-describe('DashboardArtifactsSection', () => {
+describe('DashboardArtifactsSubsection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDashboardServiceOverride = mockDashboardService;
@@ -112,7 +112,7 @@ describe('DashboardArtifactsSection', () => {
   });
 
   it('renders empty state when the rule has no dashboard artifacts', async () => {
-    renderSection(baseRule);
+    renderSubsection(baseRule);
 
     await waitFor(() => {
       expect(screen.getByTestId('ruleDashboardArtifactsEmpty')).toBeInTheDocument();
@@ -123,7 +123,7 @@ describe('DashboardArtifactsSection', () => {
   it('renders loading state while dashboards are being resolved', () => {
     mockResolveDashboardsByIds.mockReturnValue(new Promise(() => {}));
 
-    renderSection({
+    renderSubsection({
       ...baseRule,
       artifacts: [{ id: 'artifact-1', type: DASHBOARD_ARTIFACT_TYPE, value: 'dash-1' }],
     });
@@ -134,7 +134,7 @@ describe('DashboardArtifactsSection', () => {
   it('renders error state when dashboard resolution fails', async () => {
     mockResolveDashboardsByIds.mockRejectedValue(new Error('network error'));
 
-    renderSection({
+    renderSubsection({
       ...baseRule,
       artifacts: [{ id: 'artifact-1', type: DASHBOARD_ARTIFACT_TYPE, value: 'dash-1' }],
     });
@@ -150,7 +150,7 @@ describe('DashboardArtifactsSection', () => {
       missing: [],
     });
 
-    renderSection({
+    renderSubsection({
       ...baseRule,
       artifacts: [{ id: 'artifact-1', type: DASHBOARD_ARTIFACT_TYPE, value: 'dash-1' }],
     });
@@ -169,7 +169,7 @@ describe('DashboardArtifactsSection', () => {
   });
 
   it('opens the edit flyout when the add action is clicked', async () => {
-    renderSection(baseRule);
+    renderSubsection(baseRule);
 
     fireEvent.click(screen.getByTestId('ruleDashboardArtifactsAddButton'));
     expect(mockOpenEditFlyout).toHaveBeenCalledWith(baseRule);
@@ -189,7 +189,7 @@ describe('DashboardArtifactsSection', () => {
       ],
     };
 
-    renderSection(rule);
+    renderSubsection(rule);
 
     await waitFor(() => {
       expect(screen.getByTestId('ruleDashboardArtifactDeleteButton-dash-1')).toBeInTheDocument();
@@ -220,7 +220,7 @@ describe('DashboardArtifactsSection', () => {
       artifacts: [{ id: 'artifact-missing', type: DASHBOARD_ARTIFACT_TYPE, value: 'dash-missing' }],
     };
 
-    renderSection(rule);
+    renderSubsection(rule);
 
     await waitFor(() => {
       expect(
@@ -250,7 +250,7 @@ describe('DashboardArtifactsSection', () => {
 
   it('renders a subdued note when the dashboard plugin is unavailable', () => {
     mockDashboardServiceOverride = undefined;
-    renderSection(baseRule);
+    renderSubsection(baseRule);
 
     expect(screen.getByTestId('ruleDashboardArtifactsUnavailable')).toBeInTheDocument();
     expect(screen.getByText('Dashboards are unavailable in this environment.')).toBeInTheDocument();

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/dashboard_artifacts_subsection.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/dashboard_artifacts_subsection.tsx
@@ -7,7 +7,6 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import {
-  EuiAccordion,
   EuiBadge,
   EuiButtonIcon,
   EuiCode,
@@ -246,7 +245,7 @@ const DashboardsSubsectionHeader = ({
   </EuiFlexGroup>
 );
 
-export const DashboardArtifactsSection: React.FC = () => {
+export const DashboardArtifactsSubsection: React.FC = () => {
   const rule = useRule();
   const http = useService(CoreStart('http'));
   const share = useService(PluginStart('share')) as SharePluginStart;
@@ -260,7 +259,6 @@ export const DashboardArtifactsSection: React.FC = () => {
 
   const [artifactIdPendingDelete, setArtifactIdPendingDelete] = useState<string | null>(null);
   const confirmModalTitleId = useGeneratedHtmlId();
-  const artifactsAccordionId = useGeneratedHtmlId({ prefix: 'ruleArtifactsSection' });
 
   const handleEdit = useCallback(() => {
     openEditFlyout(rule);
@@ -313,113 +311,97 @@ export const DashboardArtifactsSection: React.FC = () => {
 
   return (
     <>
-      <EuiAccordion
-        id={artifactsAccordionId}
-        data-test-subj="ruleArtifactsSection"
-        buttonContent={
-          <EuiText size="s">
-            <strong>
-              {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.title', {
-                defaultMessage: 'Artifacts',
-              })}
-            </strong>
+      <EuiPanel hasBorder paddingSize="m" data-test-subj="ruleDashboardArtifactsSection">
+        <DashboardsSubsectionHeader onAdd={handleEdit} isAddDisabled={!dashboard} />
+        <EuiSpacer size="m" />
+
+        {!dashboard ? (
+          <EuiText size="s" color="subdued" data-test-subj="ruleDashboardArtifactsUnavailable">
+            {i18n.translate(
+              'xpack.alertingV2.ruleDetails.artifacts.dashboards.unavailableService',
+              {
+                defaultMessage: 'Dashboards are unavailable in this environment.',
+              }
+            )}
           </EuiText>
-        }
-        paddingSize="m"
-        initialIsOpen
-      >
-        <EuiPanel hasBorder paddingSize="m" data-test-subj="ruleDashboardArtifactsSection">
-          <DashboardsSubsectionHeader onAdd={handleEdit} isAddDisabled={!dashboard} />
-          <EuiSpacer size="m" />
+        ) : null}
 
-          {!dashboard ? (
-            <EuiText size="s" color="subdued" data-test-subj="ruleDashboardArtifactsUnavailable">
-              {i18n.translate(
-                'xpack.alertingV2.ruleDetails.artifacts.dashboards.unavailableService',
-                {
-                  defaultMessage: 'Dashboards are unavailable in this environment.',
-                }
-              )}
-            </EuiText>
-          ) : null}
+        {dashboard && isLoading ? (
+          <EuiLoadingSpinner size="m" data-test-subj="ruleDashboardArtifactsLoading" />
+        ) : null}
 
-          {dashboard && isLoading ? (
-            <EuiLoadingSpinner size="m" data-test-subj="ruleDashboardArtifactsLoading" />
-          ) : null}
+        {dashboard && !isLoading && isError ? (
+          <EuiEmptyPrompt
+            color="danger"
+            iconType="warning"
+            data-test-subj="ruleDashboardArtifactsError"
+            title={
+              <h4>
+                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.errorTitle', {
+                  defaultMessage: 'Could not load dashboards',
+                })}
+              </h4>
+            }
+            body={
+              <EuiText size="s">
+                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.errorBody', {
+                  defaultMessage: 'Try refreshing the page.',
+                })}
+              </EuiText>
+            }
+          />
+        ) : null}
 
-          {dashboard && !isLoading && isError ? (
-            <EuiEmptyPrompt
-              color="danger"
-              iconType="warning"
-              data-test-subj="ruleDashboardArtifactsError"
-              title={
-                <h4>
-                  {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.errorTitle', {
-                    defaultMessage: 'Could not load dashboards',
-                  })}
-                </h4>
-              }
-              body={
-                <EuiText size="s">
-                  {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.errorBody', {
-                    defaultMessage: 'Try refreshing the page.',
-                  })}
-                </EuiText>
-              }
-            />
-          ) : null}
+        {dashboard && !isLoading && !isError && !hasDashboardArtifacts ? (
+          <EuiEmptyPrompt
+            iconType="dashboardApp"
+            data-test-subj="ruleDashboardArtifactsEmpty"
+            title={
+              <h4>
+                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.emptyTitle', {
+                  defaultMessage: 'No dashboards linked',
+                })}
+              </h4>
+            }
+            body={
+              <EuiText size="s">
+                {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.emptyBody', {
+                  defaultMessage: 'Edit the rule to attach investigation dashboards.',
+                })}
+              </EuiText>
+            }
+          />
+        ) : null}
 
-          {dashboard && !isLoading && !isError && !hasDashboardArtifacts ? (
-            <EuiEmptyPrompt
-              iconType="dashboardApp"
-              data-test-subj="ruleDashboardArtifactsEmpty"
-              title={
-                <h4>
-                  {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.emptyTitle', {
-                    defaultMessage: 'No dashboards linked',
-                  })}
-                </h4>
-              }
-              body={
-                <EuiText size="s">
-                  {i18n.translate('xpack.alertingV2.ruleDetails.artifacts.dashboards.emptyBody', {
-                    defaultMessage: 'Edit the rule to attach investigation dashboards.',
-                  })}
-                </EuiText>
-              }
-            />
-          ) : null}
-
-          {dashboard && !isLoading && !isError && hasDashboardArtifacts ? (
-            <>
-              {dashboardLinks.map((entry) => (
-                <React.Fragment key={entry.id}>
-                  <ResolvedDashboardRow
-                    dashboardId={entry.id}
-                    title={entry.title}
-                    href={entry.href}
-                    artifactId={artifactIdByDashboardId.get(entry.id)}
-                    isDeleting={isDeleting}
-                    onDelete={handleDeleteRequest}
-                  />
-                  <EuiSpacer size="s" />
-                </React.Fragment>
-              ))}
-              {missing.map((missingDashboard) => (
-                <React.Fragment key={missingDashboard.id}>
-                  <MissingDashboardRow
-                    missingDashboard={missingDashboard}
-                    artifactId={artifactIdByDashboardId.get(missingDashboard.id)}
-                    isDeleting={isDeleting}
-                    onDelete={handleDeleteRequest}
-                  />
-                  <EuiSpacer size="s" />
-                </React.Fragment>
-              ))}
-            </>
-          ) : null}
-        </EuiPanel>
-      </EuiAccordion>
+        {dashboard && !isLoading && !isError && hasDashboardArtifacts ? (
+          <>
+            {dashboardLinks.map((entry) => (
+              <React.Fragment key={entry.id}>
+                <ResolvedDashboardRow
+                  dashboardId={entry.id}
+                  title={entry.title}
+                  href={entry.href}
+                  artifactId={artifactIdByDashboardId.get(entry.id)}
+                  isDeleting={isDeleting}
+                  onDelete={handleDeleteRequest}
+                />
+                <EuiSpacer size="s" />
+              </React.Fragment>
+            ))}
+            {missing.map((missingDashboard) => (
+              <React.Fragment key={missingDashboard.id}>
+                <MissingDashboardRow
+                  missingDashboard={missingDashboard}
+                  artifactId={artifactIdByDashboardId.get(missingDashboard.id)}
+                  isDeleting={isDeleting}
+                  onDelete={handleDeleteRequest}
+                />
+                <EuiSpacer size="s" />
+              </React.Fragment>
+            ))}
+          </>
+        ) : null}
+      </EuiPanel>
 
       {artifactIdPendingDelete ? (
         <EuiConfirmModal

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/index.ts
@@ -6,4 +6,3 @@
  */
 
 export { ArtifactsSection } from './artifacts_section';
-export { DashboardArtifactsSubsection } from './dashboard_artifacts_subsection';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/index.ts
@@ -5,4 +5,5 @@
  * 2.0.
  */
 
-export { DashboardArtifactsSection } from './dashboard_artifacts_section';
+export { ArtifactsSection } from './artifacts_section';
+export { DashboardArtifactsSubsection } from './dashboard_artifacts_subsection';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
+import { buildRuleScopedMatcher } from '@kbn/alerting-v2-rule-form';
+import { useLinkedActionPolicies } from './use_linked_action_policies';
+
+const mockListActionPolicies = jest.fn();
+
+jest.mock('../../../../services/action_policies_api', () => ({
+  ActionPoliciesApi: 'ActionPoliciesApi',
+}));
+
+jest.mock('@kbn/core-di-browser', () => ({
+  useService: (token: unknown) => {
+    if (token === 'ActionPoliciesApi') {
+      return { listActionPolicies: mockListActionPolicies };
+    }
+    return {};
+  },
+  CoreStart: (key: string) => key,
+}));
+
+const RULE_ID = 'rule-1';
+
+const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolicyResponse =>
+  ({
+    id: 'policy-1',
+    name: 'Alpha Policy',
+    description: '',
+    enabled: true,
+    destinations: [{ type: 'workflow', id: 'workflow-1' }],
+    matcher: buildRuleScopedMatcher(RULE_ID),
+    groupBy: null,
+    tags: null,
+    groupingMode: 'per_episode',
+    throttle: null,
+    snoozedUntil: null,
+    auth: { owner: 'user', createdByUser: true },
+    createdBy: 'user',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedBy: 'user',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }) as ActionPolicyResponse;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useLinkedActionPolicies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListActionPolicies.mockResolvedValue({ items: [], total: 0, page: 1, perPage: 100 });
+  });
+
+  it('does not fetch when ruleId is empty', () => {
+    const Wrapper = createWrapper();
+    renderHook(() => useLinkedActionPolicies(''), { wrapper: Wrapper });
+
+    expect(mockListActionPolicies).not.toHaveBeenCalled();
+  });
+
+  it('fetches policies and returns explicitly linked matches with counts', async () => {
+    mockListActionPolicies.mockResolvedValue({
+      items: [
+        buildPolicy({ id: 'linked-catch-all', name: 'Catch all' }),
+        buildPolicy({
+          id: 'linked-filtered',
+          name: 'Filtered',
+          matcher: `rule.id: "${RULE_ID}" and severity: "high"`,
+        }),
+        buildPolicy({
+          id: 'global',
+          name: 'Global',
+          matcher: null,
+        }),
+      ],
+      total: 3,
+      page: 1,
+      perPage: 100,
+    });
+
+    const Wrapper = createWrapper();
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockListActionPolicies).toHaveBeenCalledWith({
+      page: 1,
+      perPage: 100,
+    });
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.catchAllCount).toBe(1);
+    expect(result.current.matchingCriteriaCount).toBe(1);
+    expect(result.current.policies.map((policy) => policy.id)).toEqual([
+      'linked-catch-all',
+      'linked-filtered',
+    ]);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces API errors', async () => {
+    mockListActionPolicies.mockRejectedValue(new Error('network error'));
+
+    const Wrapper = createWrapper();
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('network error');
+    expect(result.current.policies).toEqual([]);
+    expect(result.current.totalCount).toBe(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
@@ -138,10 +138,6 @@ describe('useLinkedActionPolicies', () => {
     expect(result.current.totalCount).toBe(2);
     expect(result.current.catchAllCount).toBe(1);
     expect(result.current.matchingCriteriaCount).toBe(1);
-    expect(result.current.policies.map((policy) => policy.id)).toEqual([
-      'linked-catch-all',
-      'linked-filtered',
-    ]);
     expect(result.current.isError).toBe(false);
     expect(result.current.error).toBeNull();
   });
@@ -159,7 +155,6 @@ describe('useLinkedActionPolicies', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error?.message).toBe('network error');
-    expect(result.current.policies).toEqual([]);
     expect(result.current.totalCount).toBe(0);
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { buildRuleScopedMatcher } from '@kbn/alerting-v2-rule-form';
 import { useLinkedActionPolicies } from './use_linked_action_policies';
+import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
 
 const mockListActionPolicies = jest.fn();
 
@@ -49,15 +50,12 @@ const buildPolicy = (overrides: Partial<ActionPolicyResponse> = {}): ActionPolic
     updatedBy: 'user',
     updatedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
-  }) as ActionPolicyResponse;
+  } as ActionPolicyResponse);
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
+const createWrapper =
+  (queryClient: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
-};
 
 describe('useLinkedActionPolicies', () => {
   beforeEach(() => {
@@ -66,10 +64,42 @@ describe('useLinkedActionPolicies', () => {
   });
 
   it('does not fetch when ruleId is empty', () => {
-    const Wrapper = createWrapper();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const Wrapper = createWrapper(queryClient);
     renderHook(() => useLinkedActionPolicies(''), { wrapper: Wrapper });
 
     expect(mockListActionPolicies).not.toHaveBeenCalled();
+  });
+
+  it('uses a query key nested under action policy list keys', async () => {
+    mockListActionPolicies.mockResolvedValue({
+      items: [buildPolicy()],
+      total: 1,
+      page: 1,
+      perPage: 100,
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const Wrapper = createWrapper(queryClient);
+    renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryCache().getAll()).toHaveLength(1);
+    });
+
+    expect(queryClient.getQueryCache().getAll()[0]?.queryKey).toEqual(
+      actionPolicyKeys.linkedForRule(RULE_ID)
+    );
+    expect(actionPolicyKeys.linkedForRule(RULE_ID)).toEqual([
+      'actionPolicy',
+      'list',
+      'linkedForRule',
+      RULE_ID,
+    ]);
   });
 
   it('fetches policies and returns explicitly linked matches with counts', async () => {
@@ -92,7 +122,11 @@ describe('useLinkedActionPolicies', () => {
       perPage: 100,
     });
 
-    const Wrapper = createWrapper();
+    const Wrapper = createWrapper(
+      new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+    );
     const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -115,7 +149,11 @@ describe('useLinkedActionPolicies', () => {
   it('surfaces API errors', async () => {
     mockListActionPolicies.mockRejectedValue(new Error('network error'));
 
-    const Wrapper = createWrapper();
+    const Wrapper = createWrapper(
+      new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+    );
     const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.test.ts
@@ -10,7 +10,10 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { buildRuleScopedMatcher } from '@kbn/alerting-v2-rule-form';
-import { useLinkedActionPolicies } from './use_linked_action_policies';
+import {
+  useLinkedActionPolicies,
+  LINKED_ACTION_POLICIES_FETCH_LIMIT,
+} from './use_linked_action_policies';
 import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
 
 const mockListActionPolicies = jest.fn();
@@ -60,7 +63,12 @@ const createWrapper =
 describe('useLinkedActionPolicies', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockListActionPolicies.mockResolvedValue({ items: [], total: 0, page: 1, perPage: 100 });
+    mockListActionPolicies.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
+    });
   });
 
   it('does not fetch when ruleId is empty', () => {
@@ -78,7 +86,7 @@ describe('useLinkedActionPolicies', () => {
       items: [buildPolicy()],
       total: 1,
       page: 1,
-      perPage: 100,
+      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
     });
 
     const queryClient = new QueryClient({
@@ -119,7 +127,7 @@ describe('useLinkedActionPolicies', () => {
       ],
       total: 3,
       page: 1,
-      perPage: 100,
+      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
     });
 
     const Wrapper = createWrapper(
@@ -133,13 +141,35 @@ describe('useLinkedActionPolicies', () => {
 
     expect(mockListActionPolicies).toHaveBeenCalledWith({
       page: 1,
-      perPage: 100,
+      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
     });
     expect(result.current.totalCount).toBe(2);
     expect(result.current.catchAllCount).toBe(1);
     expect(result.current.matchingCriteriaCount).toBe(1);
+    expect(result.current.isCountTruncated).toBe(false);
     expect(result.current.isError).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+
+  it('flags truncated counts when the space has more policies than the fetch limit', async () => {
+    mockListActionPolicies.mockResolvedValue({
+      items: [buildPolicy({ id: 'linked-1' })],
+      total: LINKED_ACTION_POLICIES_FETCH_LIMIT + 1,
+      page: 1,
+      perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
+    });
+
+    const Wrapper = createWrapper(
+      new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+    );
+    const { result } = renderHook(() => useLinkedActionPolicies(RULE_ID), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.totalCount).toBe(1);
+    expect(result.current.isCountTruncated).toBe(true);
   });
 
   it('surfaces API errors', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
@@ -11,13 +11,15 @@ import { summarizeExplicitlyLinkedActionPolicies } from '@kbn/alerting-v2-rule-f
 import { ActionPoliciesApi } from '../../../../services/action_policies_api';
 import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
 
-/** List API max page size; client-side filter may miss policies beyond the first page. */
-const LINKED_ACTION_POLICIES_LIST_PER_PAGE = 100;
+/** Max policies fetched from the list API; linked counts may undercount when the space has more. */
+export const LINKED_ACTION_POLICIES_FETCH_LIMIT = 100;
 
 export interface UseLinkedActionPoliciesResult {
   totalCount: number;
   catchAllCount: number;
   matchingCriteriaCount: number;
+  /** True when the space has more policies than {@link LINKED_ACTION_POLICIES_FETCH_LIMIT} and the list response was truncated. */
+  isCountTruncated: boolean;
   isLoading: boolean;
   isError: boolean;
   error: Error | null;
@@ -32,17 +34,30 @@ export const useLinkedActionPolicies = (ruleId: string): UseLinkedActionPolicies
     queryFn: () =>
       actionPoliciesApi.listActionPolicies({
         page: 1,
-        perPage: LINKED_ACTION_POLICIES_LIST_PER_PAGE,
+        perPage: LINKED_ACTION_POLICIES_FETCH_LIMIT,
       }),
     enabled,
     refetchOnWindowFocus: false,
-    select: (response) => summarizeExplicitlyLinkedActionPolicies(response.items, ruleId),
+    /*
+     * Client-side filter for policies whose matcher explicitly includes rule.id.
+     * We do not use _match_for_rule here — that endpoint returns broader matches
+     * (global and global-filtered policies), not only explicit rule.id linkage.
+     */
+    select: (response) => {
+      const summary = summarizeExplicitlyLinkedActionPolicies(response.items, ruleId);
+
+      return {
+        ...summary,
+        isCountTruncated: response.total > LINKED_ACTION_POLICIES_FETCH_LIMIT,
+      };
+    },
   });
 
   return {
     totalCount: data?.totalCount ?? 0,
     catchAllCount: data?.catchAllCount ?? 0,
     matchingCriteriaCount: data?.matchingCriteriaCount ?? 0,
+    isCountTruncated: data?.isCountTruncated ?? false,
     isLoading: enabled && isLoading,
     isError: error != null,
     error: error instanceof Error ? error : error != null ? new Error(String(error)) : null,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useService } from '@kbn/core-di-browser';
+import { summarizeExplicitlyLinkedActionPolicies } from '@kbn/alerting-v2-rule-form';
+import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
+import { ActionPoliciesApi } from '../../../../services/action_policies_api';
+import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
+
+/** List API max page size; client-side filter may miss policies beyond the first page. */
+const LINKED_ACTION_POLICIES_LIST_PER_PAGE = 100;
+
+export interface UseLinkedActionPoliciesResult {
+  policies: ActionPolicyResponse[];
+  totalCount: number;
+  catchAllCount: number;
+  matchingCriteriaCount: number;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+}
+
+export const useLinkedActionPolicies = (ruleId: string): UseLinkedActionPoliciesResult => {
+  const actionPoliciesApi = useService(ActionPoliciesApi);
+  const enabled = Boolean(ruleId);
+
+  const { isLoading, error, data } = useQuery({
+    queryKey: actionPolicyKeys.linkedForRule(ruleId),
+    queryFn: () =>
+      actionPoliciesApi.listActionPolicies({
+        page: 1,
+        perPage: LINKED_ACTION_POLICIES_LIST_PER_PAGE,
+      }),
+    enabled,
+    refetchOnWindowFocus: false,
+    select: (response) => summarizeExplicitlyLinkedActionPolicies(response.items, ruleId),
+  });
+
+  return {
+    policies: data?.policies ?? [],
+    totalCount: data?.totalCount ?? 0,
+    catchAllCount: data?.catchAllCount ?? 0,
+    matchingCriteriaCount: data?.matchingCriteriaCount ?? 0,
+    isLoading: enabled && isLoading,
+    isError: error != null,
+    error: error instanceof Error ? error : error != null ? new Error(String(error)) : null,
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/use_linked_action_policies.ts
@@ -8,7 +8,6 @@
 import { useQuery } from '@kbn/react-query';
 import { useService } from '@kbn/core-di-browser';
 import { summarizeExplicitlyLinkedActionPolicies } from '@kbn/alerting-v2-rule-form';
-import type { ActionPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { ActionPoliciesApi } from '../../../../services/action_policies_api';
 import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
 
@@ -16,7 +15,6 @@ import { actionPolicyKeys } from '../../../../hooks/query_key_factory';
 const LINKED_ACTION_POLICIES_LIST_PER_PAGE = 100;
 
 export interface UseLinkedActionPoliciesResult {
-  policies: ActionPolicyResponse[];
   totalCount: number;
   catchAllCount: number;
   matchingCriteriaCount: number;
@@ -42,7 +40,6 @@ export const useLinkedActionPolicies = (ruleId: string): UseLinkedActionPolicies
   });
 
   return {
-    policies: data?.policies ?? [],
     totalCount: data?.totalCount ?? 0,
     catchAllCount: data?.catchAllCount ?? 0,
     matchingCriteriaCount: data?.matchingCriteriaCount ?? 0,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/rule_overview_section.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/rule_overview_section.test.tsx
@@ -21,9 +21,7 @@ jest.mock('./signal_rule_overview', () => ({
 }));
 
 jest.mock('./artifacts', () => ({
-  DashboardArtifactsSection: () => (
-    <div data-test-subj="dashboardArtifactsSectionMock">dashboards</div>
-  ),
+  ArtifactsSection: () => <div data-test-subj="artifactsSectionMock">artifacts</div>,
 }));
 
 const baseRule: RuleApiResponse = {
@@ -64,15 +62,15 @@ describe('RuleOverviewSection', () => {
     });
   });
 
-  describe('dashboard artifacts visibility', () => {
-    it('shows the dashboard artifacts section for alert rules', () => {
+  describe('artifacts visibility', () => {
+    it('shows the artifacts section for alert rules', () => {
       renderSection({ ...baseRule, kind: 'alert' });
-      expect(screen.getByTestId('dashboardArtifactsSectionMock')).toBeInTheDocument();
+      expect(screen.getByTestId('artifactsSectionMock')).toBeInTheDocument();
     });
 
-    it('does not show dashboard artifacts for signal rules', () => {
+    it('does not show artifacts for signal rules', () => {
       renderSection({ ...baseRule, kind: 'signal' });
-      expect(screen.queryByTestId('dashboardArtifactsSectionMock')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('artifactsSectionMock')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/rule_overview_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/rule_overview_section.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { EuiErrorBoundary, EuiSpacer } from '@elastic/eui';
 import { AlertTimelineSection } from './alert_timeline/alert_timeline_section';
-import { DashboardArtifactsSection } from './artifacts';
+import { ArtifactsSection } from './artifacts';
 import { SignalRuleOverview } from './signal_rule_overview';
 import { useRule } from '../rule_context';
 
@@ -29,7 +29,7 @@ export const RuleOverviewSection: React.FC = () => {
       {rule.kind === 'alert' ? (
         <>
           <EuiSpacer size="l" />
-          <DashboardArtifactsSection />
+          <ArtifactsSection />
         </>
       ) : null}
     </div>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
@@ -54,7 +54,8 @@ export const actionPolicyKeys = {
   }) => [...actionPolicyKeys.lists(), filters] as const,
   allTags: () => [...actionPolicyKeys.all, 'tags'] as const,
   tags: (search?: string) => [...actionPolicyKeys.allTags(), { search }] as const,
-  linkedForRule: (ruleId: string) => [...actionPolicyKeys.all, 'linkedForRule', ruleId] as const,
+  linkedForRule: (ruleId: string) =>
+    [...actionPolicyKeys.lists(), 'linkedForRule', ruleId] as const,
 };
 
 export const executionHistoryKeys = {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
@@ -54,6 +54,7 @@ export const actionPolicyKeys = {
   }) => [...actionPolicyKeys.lists(), filters] as const,
   allTags: () => [...actionPolicyKeys.all, 'tags'] as const,
   tags: (search?: string) => [...actionPolicyKeys.allTags(), { search }] as const,
+  linkedForRule: (ruleId: string) => [...actionPolicyKeys.all, 'linkedForRule', ruleId] as const,
 };
 
 export const executionHistoryKeys = {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_setup_rule_notifications.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_setup_rule_notifications.ts
@@ -20,6 +20,7 @@ import {
 } from '@kbn/alerting-v2-rule-form';
 import { ActionPoliciesApi } from '../services/action_policies_api';
 import type { RuleApiResponse } from '../services/rules_api';
+import { actionPolicyKeys } from './query_key_factory';
 
 export interface SetupRuleNotificationsParams {
   rule: RuleApiResponse;
@@ -203,6 +204,7 @@ export const useSetupRuleNotifications = () => {
       // Drop the caches unconditionally after any reconcile attempt
       queryClient.removeQueries({ queryKey: getRuleNotificationDraftsQueryKey(rule.id) });
       queryClient.removeQueries({ queryKey: ['matchedActionPolicies', rule.id] });
+      queryClient.invalidateQueries({ queryKey: actionPolicyKeys.lists(), exact: false });
     },
   });
 };


### PR DESCRIPTION
Closes #271324 

Adds a Notification policies card to the Artifacts section on the Alerting V2 rule details Overview tab (alert rules only), alongside the existing Dashboards card.

- Refactors Artifacts into a shared accordion with side-by-side subsections (stacked on narrow viewports).
- Introduces KQL-based explicitly linked detection for policies whose matcher includes rule.id: "<this-rule-id>" (distinct from _match_for_rule and from the simple-actions exact-matcher flow).
- Fetches policies via listActionPolicies and client-filters to linked policies; shows count, catch-all vs matching-criteria breakdown, and an Open notification policies link to management.
- Invalidates action policy list queries after simple-action policy setup on rule save so the card refreshes.
- Out of scope: policy CRUD in this panel, inferred/global matches, dispatcher activity, list UI for individual policies.

## Test plan
 1. Open an alert rule with no linked policies → Artifacts shows Dashboards + Notification policies; count is 0; Open notification policies opens management in a new tab.
 2. Create a rule-scoped policy (rule.id: "<ruleId>") → card shows count 1, catch-all summary, refreshes after save when created via rule flyout simple actions.
 3. Create a compound policy (rule.id: "<ruleId>" AND …) → counted as matching criteria, not catch-all.
 4. Create a global policy (no rule.id) → does not appear in the count.
 5. Signal rule → Artifacts section (including notification policies) is hidden.
 6. API failure → error prompt only (no stat).
 
**Automated:**
```
node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/artifacts/
node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/helpers/explicitly_linked_action_policies.test.ts
```

**Notes / limitations**
Client-side filter over the first 100 policies from the list API; spaces with more policies may not show accurate counts until a server-side filter exists.