### PR TITLE
[SLO] Add telemetry for save-confirm, engagement events, related dashboards, and embeddables (#275023)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards.tsx
@@ -68,6 +68,7 @@ export function RelatedDashboards({
         dashboards={linkedDashboards}
         dataTestSubj="linked-dashboards"
         timeRange={timeRange}
+        ruleId={rule.id}
       />
       <DashboardTiles
         title={i18n.translate('xpack.observability.alertDetails.suggestedDashboards', {
@@ -77,6 +78,7 @@ export function RelatedDashboards({
         dashboards={suggestedDashboardsWithButton}
         dataTestSubj="suggested-dashboards"
         timeRange={timeRange}
+        ruleId={rule.id}
       />
     </div>
   );

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards/dashboard_tile.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards/dashboard_tile.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import type { LinkedDashboard } from '@kbn/observability-schema';
+import { render } from '../../../../utils/test_helper';
+import { useKibana } from '../../../../utils/kibana_react';
+import { createTelemetryClientMock } from '../../../../services/telemetry/telemetry_client.mock';
+import { DashboardTile } from './dashboard_tile';
+
+jest.mock('../../../../utils/kibana_react');
+
+const useKibanaMock = useKibana as jest.Mock;
+const telemetryClientMock = createTelemetryClientMock();
+
+const dashboard: LinkedDashboard = {
+  id: 'dashboard-1',
+  title: 'My dashboard',
+  matchedBy: {},
+};
+
+const mockKibana = () => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      telemetryClient: telemetryClientMock,
+      share: {
+        url: {
+          locators: {
+            get: () => ({
+              getRedirectUrl: () => 'http://localhost/app/dashboards#/view/dashboard-1',
+            }),
+          },
+        },
+      },
+      savedObjectsTagging: {
+        ui: {
+          convertNameToReference: jest.fn(),
+          components: {
+            TagList: () => <div />,
+          },
+        },
+      },
+    },
+  });
+};
+
+describe('DashboardTile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockKibana();
+  });
+
+  it('reports linked dashboard view with rule id and dashboard id', () => {
+    const { getByTestId } = render(
+      <DashboardTile
+        dashboard={dashboard}
+        timeRange={{ from: 'now-15m', to: 'now' }}
+        ruleId="rule-1"
+      />
+    );
+
+    fireEvent.click(getByTestId('alertDetails_viewLinkedDashboard_undefined'));
+
+    expect(telemetryClientMock.reportLinkedDashboardViewed).toHaveBeenCalledWith(
+      'unknown',
+      'rule-1',
+      'dashboard-1'
+    );
+  });
+
+  it('reports suggested dashboard added with rule id and dashboard id', () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <DashboardTile
+        dashboard={dashboard}
+        timeRange={{ from: 'now-15m', to: 'now' }}
+        ruleId="rule-1"
+        actionButtonProps={{
+          onClick,
+          label: 'Add to linked dashboards',
+          isLoading: false,
+          isDisabled: false,
+          ruleType: 'logs.alert.document.count',
+        }}
+      />
+    );
+
+    fireEvent.click(
+      getByTestId('addSuggestedDashboard_alertDetailsPage_logs.alert.document.count')
+    );
+
+    expect(onClick).toHaveBeenCalledWith(dashboard);
+    expect(telemetryClientMock.reportSuggestedDashboardAdded).toHaveBeenCalledWith(
+      'logs.alert.document.count',
+      'rule-1',
+      'dashboard-1'
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards/dashboard_tile.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards/dashboard_tile.tsx
@@ -32,10 +32,12 @@ export function DashboardTile({
   dashboard,
   actionButtonProps,
   timeRange,
+  ruleId,
 }: {
   dashboard: RelatedDashboard;
   actionButtonProps?: ActionButtonProps;
   timeRange: NonNullable<DashboardLocatorParams['time_range']>;
+  ruleId: string;
 }) {
   const {
     services: {
@@ -65,7 +67,9 @@ export function DashboardTile({
             onClick={() => {
               if (telemetryClient) {
                 telemetryClient.reportLinkedDashboardViewed(
-                  actionButtonProps?.ruleType || 'unknown'
+                  actionButtonProps?.ruleType || 'unknown',
+                  ruleId,
+                  dashboard.id
                 );
               }
             }}
@@ -89,7 +93,11 @@ export function DashboardTile({
               data-test-subj={`addSuggestedDashboard_alertDetailsPage_${actionButtonProps.ruleType}`}
               onClick={() => {
                 actionButtonProps.onClick(dashboard);
-                telemetryClient.reportSuggestedDashboardAdded(actionButtonProps.ruleType);
+                telemetryClient.reportSuggestedDashboardAdded(
+                  actionButtonProps.ruleType,
+                  ruleId,
+                  dashboard.id
+                );
               }}
               isLoading={actionButtonProps.isLoading}
               isDisabled={actionButtonProps.isDisabled}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards/dashboard_tiles.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_dashboards/dashboard_tiles.tsx
@@ -27,12 +27,14 @@ export function DashboardTiles({
   dashboards,
   dataTestSubj,
   timeRange,
+  ruleId,
 }: {
   title: string;
   isLoadingDashboards: boolean;
   dashboards?: Array<RelatedDashboard & { actionButtonProps?: ActionButtonProps }>;
   dataTestSubj: string;
   timeRange: NonNullable<DashboardLocatorParams['time_range']>;
+  ruleId: string;
 }) {
   const wrapWithHeader = (component: React.ReactNode) => {
     return (
@@ -70,6 +72,7 @@ export function DashboardTiles({
         dashboard={rest}
         actionButtonProps={actionButtonProps}
         timeRange={timeRange}
+        ruleId={ruleId}
       />
     ))
   );

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_client.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_client.ts
@@ -32,15 +32,19 @@ export class TelemetryClient implements ITelemetryClient {
     });
   }
 
-  reportLinkedDashboardViewed(ruleTypeId: string): void {
+  reportLinkedDashboardViewed(ruleTypeId: string, ruleId: string, dashboardId: string): void {
     this.analytics.reportEvent(TelemetryEventTypes.LINKED_DASHBOARD_VIEW, {
       rule_type_id: ruleTypeId,
+      rule_id: ruleId,
+      dashboard_id: dashboardId,
     });
   }
 
-  reportSuggestedDashboardAdded(ruleTypeId: string): void {
+  reportSuggestedDashboardAdded(ruleTypeId: string, ruleId: string, dashboardId: string): void {
     this.analytics.reportEvent(TelemetryEventTypes.SUGGESTED_DASHBOARD_ADDED, {
       rule_type_id: ruleTypeId,
+      rule_id: ruleId,
+      dashboard_id: dashboardId,
     });
   }
 }

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_events.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_events.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { events } from './telemetry_events';
+import { TelemetryEventTypes } from './types';
+
+describe('telemetry events', () => {
+  it('registers a schema entry for the linked dashboard view event', () => {
+    const event = events.find((e) => e.eventType === TelemetryEventTypes.LINKED_DASHBOARD_VIEW);
+
+    expect(event).toBeDefined();
+    expect(event?.schema).toMatchObject({
+      rule_type_id: { type: 'keyword' },
+      rule_id: { type: 'keyword' },
+      dashboard_id: { type: 'keyword' },
+    });
+  });
+
+  it('registers a schema entry for the suggested dashboard added event', () => {
+    const event = events.find((e) => e.eventType === TelemetryEventTypes.SUGGESTED_DASHBOARD_ADDED);
+
+    expect(event).toBeDefined();
+    expect(event?.schema).toMatchObject({
+      rule_type_id: { type: 'keyword' },
+      rule_id: { type: 'keyword' },
+      dashboard_id: { type: 'keyword' },
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_events.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_events.ts
@@ -69,6 +69,47 @@ const linkedDashboardView: TelemetryEvent = {
         optional: false,
       },
     },
+    rule_id: {
+      type: 'keyword' as const,
+      _meta: {
+        description: 'The ID of the rule backing the alert whose linked dashboard was viewed',
+        optional: false,
+      },
+    },
+    dashboard_id: {
+      type: 'keyword' as const,
+      _meta: {
+        description: 'The ID of the linked dashboard that was viewed',
+        optional: false,
+      },
+    },
+  },
+};
+
+const suggestedDashboardAdded: TelemetryEvent = {
+  eventType: TelemetryEventTypes.SUGGESTED_DASHBOARD_ADDED,
+  schema: {
+    rule_type_id: {
+      type: 'keyword' as const,
+      _meta: {
+        description: 'Rule type id',
+        optional: false,
+      },
+    },
+    rule_id: {
+      type: 'keyword' as const,
+      _meta: {
+        description: 'The ID of the rule backing the alert the suggested dashboard was added from',
+        optional: false,
+      },
+    },
+    dashboard_id: {
+      type: 'keyword' as const,
+      _meta: {
+        description: 'The ID of the suggested dashboard that was added to linked dashboards',
+        optional: false,
+      },
+    },
   },
 };
 
@@ -77,4 +118,5 @@ export const events: TelemetryEvent[] = [
   alertDetailsPageView,
   alertAddedToCase,
   linkedDashboardView,
+  suggestedDashboardAdded,
 ];

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/types.ts
@@ -13,8 +13,8 @@ export interface ITelemetryClient {
   reportRelatedAlertsLoaded(count: number): void;
   reportAlertDetailsPageView(ruleType: string): void;
   reportAlertAddedToCase(newCaseCreated: boolean, from: string, ruleTypeId: string): void;
-  reportLinkedDashboardViewed(ruleTypeId: string): void;
-  reportSuggestedDashboardAdded(ruleTypeId: string): void;
+  reportLinkedDashboardViewed(ruleTypeId: string, ruleId: string, dashboardId: string): void;
+  reportSuggestedDashboardAdded(ruleTypeId: string, ruleId: string, dashboardId: string): void;
 }
 
 export enum TelemetryEventTypes {
@@ -54,6 +54,8 @@ interface AlertAddedToCaseEvent {
 }
 interface LinkedDashboardViewParams {
   rule_type_id: string;
+  rule_id: string;
+  dashboard_id: string;
 }
 
 interface LinkedDashboardViewEvent {
@@ -62,6 +64,8 @@ interface LinkedDashboardViewEvent {
 }
 interface SuggestedDashboardAddedParams {
   rule_type_id: string;
+  rule_id: string;
+  dashboard_id: string;
 }
 
 interface SuggestedDashboardAddedEvent {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -24,6 +24,7 @@ export interface Props {
   slo?: GetSLOResponse;
   onFlyoutClose?: () => void;
   formSettings?: FormSettings;
+  templateId?: string;
 }
 
 const DEFAULT_FORM_SETTINGS: FormSettings = {
@@ -36,6 +37,7 @@ export function SloEditForm({
   initialValues,
   onFlyoutClose,
   formSettings = DEFAULT_FORM_SETTINGS,
+  templateId,
 }: Props) {
   const { isEditMode = false } = formSettings;
   assertValidProps({ isEditMode, slo, onFlyoutClose });
@@ -92,7 +94,12 @@ export function SloEditForm({
           ]}
         />
 
-        <SloEditFormFooter slo={slo} onFlyoutClose={onFlyoutClose} isEditMode={isEditMode} />
+        <SloEditFormFooter
+          slo={slo}
+          onFlyoutClose={onFlyoutClose}
+          isEditMode={isEditMode}
+          templateId={templateId}
+        />
       </EuiFlexGroup>
     </FormProvider>
   );

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form_footer.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form_footer.tsx
@@ -15,6 +15,7 @@ import { InPortal } from 'react-reverse-portal';
 import { useCreateRule } from '../../../hooks/use_create_burn_rate_rule';
 import { useCreateSlo } from '../../../hooks/use_create_slo';
 import { useKibana } from '../../../hooks/use_kibana';
+import { usePluginContext } from '../../../hooks/use_plugin_context';
 import { useUpdateSlo } from '../../../hooks/use_update_slo';
 import type { BurnRateRuleParams } from '../../../typings';
 import { createBurnRateRuleRequestBody } from '../helpers/create_burn_rate_rule_request_body';
@@ -31,13 +32,15 @@ export interface Props {
   slo?: GetSLOResponse;
   onFlyoutClose?: () => void;
   isEditMode: boolean;
+  templateId?: string;
 }
 
-export function SloEditFormFooter({ slo, onFlyoutClose, isEditMode }: Props) {
+export function SloEditFormFooter({ slo, onFlyoutClose, isEditMode, templateId }: Props) {
   const {
     application: { navigateToUrl },
     http: { basePath },
   } = useKibana().services;
+  const { telemetry } = usePluginContext();
 
   const isFlyout = Boolean(onFlyoutClose);
   const { getValues, trigger } = useFormContext<CreateSLOForm>();
@@ -62,6 +65,7 @@ export function SloEditFormFooter({ slo, onFlyoutClose, isEditMode }: Props) {
     } else {
       const processedValues = transformCreateSLOFormToCreateSLOInput(values);
       const resp = await createSlo({ slo: processedValues });
+      telemetry?.reportSloCreated({ slo_id: resp.id, template_id: templateId });
       createBurnRateRule({
         rule: createBurnRateRuleRequestBody({ ...processedValues, id: resp.id }),
       });

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/hooks/use_parse_template_id.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/hooks/use_parse_template_id.ts
@@ -26,5 +26,5 @@ export function useParseTemplateId() {
 
   const { data: template, isInitialLoading } = useFetchSloTemplate(templateId);
 
-  return { isInitialLoading, data: transformPartialSLODataToFormState(template) };
+  return { isInitialLoading, data: transformPartialSLODataToFormState(template), templateId };
 }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/hooks/use_slo_form_values.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/hooks/use_slo_form_values.ts
@@ -17,6 +17,7 @@ export interface UseSloFormValuesResponse {
   isLoading: boolean;
   isEditMode: boolean;
   slo: GetSLOResponse | undefined;
+  templateId: string | undefined;
 }
 
 export function useSloFormValues(sloId?: string): UseSloFormValuesResponse {
@@ -26,8 +27,11 @@ export function useSloFormValues(sloId?: string): UseSloFormValuesResponse {
   const sloFormValuesFromSloResponse = transformSloResponseToFormState(slo);
 
   const sloFormValuesFromUrlState = useParseUrlState();
-  const { isInitialLoading: isTemplateLoading, data: sloFormValuesFromTemplateId } =
-    useParseTemplateId();
+  const {
+    isInitialLoading: isTemplateLoading,
+    data: sloFormValuesFromTemplateId,
+    templateId,
+  } = useParseTemplateId();
 
   const initialValues = isEditMode
     ? sloFormValuesFromSloResponse
@@ -38,5 +42,7 @@ export function useSloFormValues(sloId?: string): UseSloFormValuesResponse {
     isLoading: isSloLoading || isTemplateLoading,
     isEditMode,
     slo,
+    // an SLO created from a template can only happen when creating (not editing) via ?fromTemplateId
+    templateId: isEditMode ? undefined : templateId,
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.test.tsx
@@ -31,7 +31,7 @@ import { usePermissions } from '../../hooks/use_permissions';
 import { useUpdateSlo } from '../../hooks/use_update_slo';
 import { PluginContext } from '../../context/plugin_context';
 import { kibanaStartMock } from '../../utils/kibana_react.mock';
-import { render, pluginContextDefaultValue } from '../../utils/test_helper';
+import { render, pluginContextDefaultValue, telemetryClientMock } from '../../utils/test_helper';
 import { SloEditPage } from './slo_edit';
 
 jest.mock('react-router-dom', () => ({
@@ -320,6 +320,10 @@ describe('SLO Edit Page', () => {
       });
 
       expect(mockCreate).toHaveBeenCalled();
+      expect(telemetryClientMock.reportSloCreated).toHaveBeenCalledWith({
+        slo_id: SLO_ID,
+        template_id: undefined,
+      });
     });
 
     it('renders the SLO Edit Form with prefilled values from a template', async () => {
@@ -364,6 +368,11 @@ describe('SLO Edit Page', () => {
       await waitFor(() => {
         fireEvent.click(getByTestId('sloFormSubmitButton'));
         expect(mockCreate).toHaveBeenCalled();
+      });
+
+      expect(telemetryClientMock.reportSloCreated).toHaveBeenCalledWith({
+        slo_id: SLO_ID,
+        template_id: 'template-1234',
       });
     });
   });

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.tsx
@@ -26,7 +26,7 @@ export function SloEditPage() {
     serverless,
   } = useKibana().services;
   const { sloId } = useParams<{ sloId: string | undefined }>();
-  const { initialValues, isLoading, isEditMode, slo } = useSloFormValues(sloId);
+  const { initialValues, isLoading, isEditMode, slo, templateId } = useSloFormValues(sloId);
 
   const { data: permissions } = usePermissions();
   const { ObservabilityPageTemplate } = usePluginContext();
@@ -91,7 +91,12 @@ export function SloEditPage() {
       {isLoading ? (
         <EuiLoadingSpinner size="xl" data-test-subj="sloEditLoadingSpinner" />
       ) : (
-        <SloEditForm slo={slo} formSettings={{ isEditMode }} initialValues={initialValues} />
+        <SloEditForm
+          slo={slo}
+          formSettings={{ isEditMode }}
+          initialValues={initialValues}
+          templateId={templateId}
+        />
       )}
     </ObservabilityPageTemplate>
   );

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { buildSlo } from '../../../data/slo/slo';
+import { useKibana } from '../../../hooks/use_kibana';
+import { usePermissions } from '../../../hooks/use_permissions';
+import { usePluginContext } from '../../../hooks/use_plugin_context';
+import { useActionModal } from '../../../context/action_modal';
+import { SloItemActions } from './slo_item_actions';
+
+jest.mock('../../../hooks/use_kibana');
+jest.mock('../../../hooks/use_permissions');
+jest.mock('../../../hooks/use_plugin_context');
+jest.mock('../../../context/action_modal');
+
+const useKibanaMock = useKibana as jest.Mock;
+const usePermissionsMock = usePermissions as jest.Mock;
+const usePluginContextMock = usePluginContext as jest.Mock;
+const useActionModalMock = useActionModal as jest.Mock;
+
+const mockTriggerAction = jest.fn();
+const mockNavigateToUrl = jest.fn();
+const telemetryMock = {
+  reportSloEdited: jest.fn(),
+  reportSloDeleted: jest.fn(),
+  reportSloCloned: jest.fn(),
+  reportSloReset: jest.fn(),
+};
+
+function renderWithIntl(children: React.ReactNode) {
+  return render(<IntlProvider locale="en">{children}</IntlProvider>);
+}
+
+describe('SloItemActions', () => {
+  const slo = buildSlo({ id: 'slo-1234' });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useKibanaMock.mockReturnValue({
+      services: {
+        application: { navigateToUrl: mockNavigateToUrl },
+        executionContext: { get: () => ({ name: 'not-dashboards' }) },
+        share: { url: { locators: { get: () => undefined } } },
+        http: { basePath: { prepend: (path: string) => path, get: () => '' } },
+      },
+    });
+
+    usePermissionsMock.mockReturnValue({
+      data: { hasAllWriteRequested: true, hasAllReadRequested: true },
+    });
+
+    usePluginContextMock.mockReturnValue({ telemetry: telemetryMock });
+
+    useActionModalMock.mockReturnValue({ triggerAction: mockTriggerAction });
+  });
+
+  function openActionsMenu() {
+    const { getByTestId } = renderWithIntl(
+      <SloItemActions
+        slo={slo}
+        isActionsPopoverOpen={true}
+        setIsActionsPopoverOpen={() => {}}
+        setIsAddRuleFlyoutOpen={() => {}}
+        setIsEditRuleFlyoutOpen={() => {}}
+      />
+    );
+    return { getByTestId };
+  }
+
+  it('reports slo_edited when the edit action is clicked', () => {
+    const { getByTestId } = openActionsMenu();
+
+    fireEvent.click(getByTestId('sloActionsEdit'));
+
+    expect(telemetryMock.reportSloEdited).toHaveBeenCalledWith({ slo_id: 'slo-1234' });
+  });
+
+  it('reports slo_cloned when the clone action is clicked', () => {
+    const { getByTestId } = openActionsMenu();
+
+    fireEvent.click(getByTestId('sloActionsClone'));
+
+    expect(telemetryMock.reportSloCloned).toHaveBeenCalledWith({ slo_id: 'slo-1234' });
+    expect(mockTriggerAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'clone', item: slo })
+    );
+  });
+
+  it('reports slo_deleted when the delete action is clicked', () => {
+    const { getByTestId } = openActionsMenu();
+
+    fireEvent.click(getByTestId('sloActionsDelete'));
+
+    expect(telemetryMock.reportSloDeleted).toHaveBeenCalledWith({ slo_id: 'slo-1234' });
+    expect(mockTriggerAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'delete', item: slo })
+    );
+  });
+
+  it('reports slo_reset when the reset action is clicked', () => {
+    const { getByTestId } = openActionsMenu();
+
+    fireEvent.click(getByTestId('sloActionsReset'));
+
+    expect(telemetryMock.reportSloReset).toHaveBeenCalledWith({ slo_id: 'slo-1234' });
+    expect(mockTriggerAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'reset', item: slo })
+    );
+  });
+
+  it('does not throw when telemetry client is unavailable', () => {
+    usePluginContextMock.mockReturnValue({ telemetry: undefined });
+    const { getByTestId } = openActionsMenu();
+
+    expect(() => fireEvent.click(getByTestId('sloActionsEdit'))).not.toThrow();
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.tsx
@@ -21,6 +21,7 @@ import type { Rule } from '@kbn/triggers-actions-ui-plugin/public';
 import React from 'react';
 import { useKibana } from '../../../hooks/use_kibana';
 import { usePermissions } from '../../../hooks/use_permissions';
+import { usePluginContext } from '../../../hooks/use_plugin_context';
 import type { BurnRateRuleParams } from '../../../typings';
 import { useSloActions } from '../../slo_details/hooks/use_slo_actions';
 import { useActionModal } from '../../../context/action_modal';
@@ -72,6 +73,7 @@ export function SloItemActions({
   const isDashboardContext = executionContextName === 'dashboards';
   const { data: permissions } = usePermissions();
   const { triggerAction } = useActionModal();
+  const { telemetry } = usePluginContext();
 
   const {
     handleNavigateToRules,
@@ -96,11 +98,17 @@ export function SloItemActions({
     navigateToUrl(sloDetailsUrl);
   };
 
+  const handleEdit = () => {
+    telemetry?.reportSloEdited({ slo_id: slo.id });
+  };
+
   const handleClone = () => {
+    telemetry?.reportSloCloned({ slo_id: slo.id });
     triggerAction({ type: 'clone', item: slo, onConfirm: () => setIsActionsPopoverOpen(false) });
   };
 
   const handleDelete = () => {
+    telemetry?.reportSloDeleted({ slo_id: slo.id });
     if (!!remoteDeleteUrl) {
       window.open(remoteDeleteUrl, '_blank');
     } else {
@@ -109,6 +117,7 @@ export function SloItemActions({
   };
 
   const handleReset = () => {
+    telemetry?.reportSloReset({ slo_id: slo.id });
     if (!!remoteResetUrl) {
       window.open(remoteResetUrl, '_blank');
     } else {
@@ -206,6 +215,7 @@ export function SloItemActions({
             icon="pencil"
             disabled={!permissions?.hasAllWriteRequested || hasUndefinedRemoteKibanaUrl}
             href={sloEditUrl}
+            onClick={handleEdit}
             target={isRemote ? '_blank' : undefined}
             toolTipContent={
               hasUndefinedRemoteKibanaUrl ? NOT_AVAILABLE_FOR_UNDEFINED_REMOTE_KIBANA_URL : ''

--- a/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_client.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
+import { SloTelemetryClient } from './telemetry_client';
+import { SloTelemetryEventTypes } from './types';
+
+describe('SloTelemetryClient', () => {
+  let reportEvent: jest.Mock;
+  let analytics: AnalyticsServiceStart;
+  let client: SloTelemetryClient;
+
+  beforeEach(() => {
+    reportEvent = jest.fn();
+    analytics = { reportEvent } as unknown as AnalyticsServiceStart;
+    client = new SloTelemetryClient(analytics);
+  });
+
+  it('reports slo_details_flyout_viewed with no params', () => {
+    client.reportSloDetailsFlyoutViewed();
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_DETAILS_FLYOUT_VIEWED, {});
+  });
+
+  it('reports slo_details_flyout_tab_changed with the tab id', () => {
+    client.reportSloDetailsFlyoutTabChanged({ tabId: 'overview' });
+
+    expect(reportEvent).toHaveBeenCalledWith(
+      SloTelemetryEventTypes.SLO_DETAILS_FLYOUT_TAB_CHANGED,
+      { tabId: 'overview' }
+    );
+  });
+
+  it('reports slo_create_flyout_viewed with the slo type', () => {
+    client.reportSloCreateFlyoutViewed({ sloType: 'sli.kql.custom' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_CREATE_FLYOUT_VIEWED, {
+      sloType: 'sli.kql.custom',
+    });
+  });
+
+  it('reports slo_created with slo_id and template_id', () => {
+    client.reportSloCreated({ slo_id: 'slo-1', template_id: 'template-1' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_CREATED, {
+      slo_id: 'slo-1',
+      template_id: 'template-1',
+    });
+  });
+
+  it('reports slo_created without a template_id when the SLO was not created from a template', () => {
+    client.reportSloCreated({ slo_id: 'slo-1' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_CREATED, {
+      slo_id: 'slo-1',
+    });
+  });
+
+  it('reports slo_edited with slo_id', () => {
+    client.reportSloEdited({ slo_id: 'slo-1' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_EDITED, {
+      slo_id: 'slo-1',
+    });
+  });
+
+  it('reports slo_deleted with slo_id', () => {
+    client.reportSloDeleted({ slo_id: 'slo-1' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_DELETED, {
+      slo_id: 'slo-1',
+    });
+  });
+
+  it('reports slo_cloned with slo_id', () => {
+    client.reportSloCloned({ slo_id: 'slo-1' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_CLONED, {
+      slo_id: 'slo-1',
+    });
+  });
+
+  it('reports slo_reset with slo_id', () => {
+    client.reportSloReset({ slo_id: 'slo-1' });
+
+    expect(reportEvent).toHaveBeenCalledWith(SloTelemetryEventTypes.SLO_RESET, {
+      slo_id: 'slo-1',
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_client.ts
@@ -10,6 +10,11 @@ import type {
   ISloTelemetryClient,
   SloDetailsFlyoutTabChangedParams,
   SloCreateFlyoutViewedParams,
+  SloCreatedParams,
+  SloEditedParams,
+  SloDeletedParams,
+  SloClonedParams,
+  SloResetParams,
 } from './types';
 import { SloTelemetryEventTypes } from './types';
 
@@ -26,5 +31,25 @@ export class SloTelemetryClient implements ISloTelemetryClient {
 
   public reportSloCreateFlyoutViewed = (params: SloCreateFlyoutViewedParams) => {
     this.analytics.reportEvent(SloTelemetryEventTypes.SLO_CREATE_FLYOUT_VIEWED, params);
+  };
+
+  public reportSloCreated = (params: SloCreatedParams) => {
+    this.analytics.reportEvent(SloTelemetryEventTypes.SLO_CREATED, params);
+  };
+
+  public reportSloEdited = (params: SloEditedParams) => {
+    this.analytics.reportEvent(SloTelemetryEventTypes.SLO_EDITED, params);
+  };
+
+  public reportSloDeleted = (params: SloDeletedParams) => {
+    this.analytics.reportEvent(SloTelemetryEventTypes.SLO_DELETED, params);
+  };
+
+  public reportSloCloned = (params: SloClonedParams) => {
+    this.analytics.reportEvent(SloTelemetryEventTypes.SLO_CLONED, params);
+  };
+
+  public reportSloReset = (params: SloResetParams) => {
+    this.analytics.reportEvent(SloTelemetryEventTypes.SLO_RESET, params);
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_events.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_events.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sloTelemetryEventBasedTypes } from './telemetry_events';
+import { SloTelemetryEventTypes } from './types';
+
+describe('sloTelemetryEventBasedTypes', () => {
+  it('registers a schema entry for every SloTelemetryEventTypes value', () => {
+    const registeredEventTypes = sloTelemetryEventBasedTypes.map((event) => event.eventType);
+
+    expect(registeredEventTypes).toEqual(Object.values(SloTelemetryEventTypes));
+  });
+
+  it('registers slo_id in the schema for each engagement event', () => {
+    const engagementEvents = [
+      SloTelemetryEventTypes.SLO_CREATED,
+      SloTelemetryEventTypes.SLO_EDITED,
+      SloTelemetryEventTypes.SLO_DELETED,
+      SloTelemetryEventTypes.SLO_CLONED,
+      SloTelemetryEventTypes.SLO_RESET,
+    ];
+
+    engagementEvents.forEach((eventType) => {
+      const event = sloTelemetryEventBasedTypes.find((e) => e.eventType === eventType);
+      expect(event?.schema).toHaveProperty('slo_id');
+    });
+  });
+
+  it('registers template_id as optional in the slo_created schema', () => {
+    const event = sloTelemetryEventBasedTypes.find(
+      (e) => e.eventType === SloTelemetryEventTypes.SLO_CREATED
+    );
+
+    expect(event?.schema).toMatchObject({
+      template_id: { _meta: { optional: true } },
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_events.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/services/telemetry/telemetry_events.ts
@@ -33,8 +33,70 @@ const sloCreateFlyoutViewedEventType: SloTelemetryEvent = {
   },
 };
 
+const sloCreatedEventType: SloTelemetryEvent = {
+  eventType: SloTelemetryEventTypes.SLO_CREATED,
+  schema: {
+    slo_id: {
+      type: 'keyword',
+      _meta: { description: 'The ID of the SLO that was created' },
+    },
+    template_id: {
+      type: 'keyword',
+      _meta: {
+        description: 'The ID of the SLO template the SLO was created from, if any',
+        optional: true,
+      },
+    },
+  },
+};
+
+const sloEditedEventType: SloTelemetryEvent = {
+  eventType: SloTelemetryEventTypes.SLO_EDITED,
+  schema: {
+    slo_id: {
+      type: 'keyword',
+      _meta: { description: 'The ID of the SLO that was edited' },
+    },
+  },
+};
+
+const sloDeletedEventType: SloTelemetryEvent = {
+  eventType: SloTelemetryEventTypes.SLO_DELETED,
+  schema: {
+    slo_id: {
+      type: 'keyword',
+      _meta: { description: 'The ID of the SLO that was deleted' },
+    },
+  },
+};
+
+const sloClonedEventType: SloTelemetryEvent = {
+  eventType: SloTelemetryEventTypes.SLO_CLONED,
+  schema: {
+    slo_id: {
+      type: 'keyword',
+      _meta: { description: 'The ID of the SLO that was cloned' },
+    },
+  },
+};
+
+const sloResetEventType: SloTelemetryEvent = {
+  eventType: SloTelemetryEventTypes.SLO_RESET,
+  schema: {
+    slo_id: {
+      type: 'keyword',
+      _meta: { description: 'The ID of the SLO that was reset' },
+    },
+  },
+};
+
 export const sloTelemetryEventBasedTypes = [
   sloDetailsFlyoutViewedEventType,
   sloDetailsFlyoutTabChangedEventType,
   sloCreateFlyoutViewedEventType,
+  sloCreatedEventType,
+  sloEditedEventType,
+  sloDeletedEventType,
+  sloClonedEventType,
+  sloResetEventType,
 ];

--- a/x-pack/solutions/observability/plugins/slo/public/services/telemetry/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/services/telemetry/types.ts
@@ -16,21 +16,57 @@ export interface SloCreateFlyoutViewedParams {
   sloType?: IndicatorType;
 }
 
+export interface SloCreatedParams {
+  slo_id: string;
+  template_id?: string;
+}
+
+export interface SloEditedParams {
+  slo_id: string;
+}
+
+export interface SloDeletedParams {
+  slo_id: string;
+}
+
+export interface SloClonedParams {
+  slo_id: string;
+}
+
+export interface SloResetParams {
+  slo_id: string;
+}
+
 export type SloTelemetryEventParams =
   | SloDetailsFlyoutTabChangedParams
   | SloCreateFlyoutViewedParams
+  | SloCreatedParams
+  | SloEditedParams
+  | SloDeletedParams
+  | SloClonedParams
+  | SloResetParams
   | Record<string, never>;
 
 export interface ISloTelemetryClient {
   reportSloDetailsFlyoutViewed(): void;
   reportSloDetailsFlyoutTabChanged(params: SloDetailsFlyoutTabChangedParams): void;
   reportSloCreateFlyoutViewed(params: SloCreateFlyoutViewedParams): void;
+  reportSloCreated(params: SloCreatedParams): void;
+  reportSloEdited(params: SloEditedParams): void;
+  reportSloDeleted(params: SloDeletedParams): void;
+  reportSloCloned(params: SloClonedParams): void;
+  reportSloReset(params: SloResetParams): void;
 }
 
 export enum SloTelemetryEventTypes {
   SLO_DETAILS_FLYOUT_VIEWED = 'slo_details_flyout_viewed',
   SLO_DETAILS_FLYOUT_TAB_CHANGED = 'slo_details_flyout_tab_changed',
   SLO_CREATE_FLYOUT_VIEWED = 'slo_create_flyout_viewed',
+  SLO_CREATED = 'slo_created',
+  SLO_EDITED = 'slo_edited',
+  SLO_DELETED = 'slo_deleted',
+  SLO_CLONED = 'slo_cloned',
+  SLO_RESET = 'slo_reset',
 }
 
 export interface SloTelemetryEvent {

--- a/x-pack/solutions/observability/plugins/slo/public/utils/test_helper.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/utils/test_helper.tsx
@@ -45,11 +45,23 @@ const queryClient = new QueryClient({
 
 const sloClient = createRepositoryClient<SLORouteRepository, DefaultClientOptions>(core);
 
+export const telemetryClientMock = {
+  reportSloDetailsFlyoutViewed: jest.fn(),
+  reportSloDetailsFlyoutTabChanged: jest.fn(),
+  reportSloCreateFlyoutViewed: jest.fn(),
+  reportSloCreated: jest.fn(),
+  reportSloEdited: jest.fn(),
+  reportSloDeleted: jest.fn(),
+  reportSloCloned: jest.fn(),
+  reportSloReset: jest.fn(),
+};
+
 export const pluginContextDefaultValue = {
   appMountParameters,
   observabilityRuleTypeRegistry,
   ObservabilityPageTemplate: KibanaPageTemplate,
   sloClient,
+  telemetry: telemetryClientMock,
 };
 
 export const render = (component: React.ReactNode) => {

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_alerts_embeddable.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_alerts_embeddable.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createEmbeddableSetupMock } from '@kbn/embeddable-plugin/server/mocks';
+import type { EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
+import { SLO_ALERTS_EMBEDDABLE_ID } from '../../../common/embeddables/alerts/constants';
+import {
+  getAlertsEmbeddableTelemetry,
+  registerAlertsEmbeddable,
+} from './register_alerts_embeddable';
+
+describe('registerAlertsEmbeddable', () => {
+  it('registers the schema/transforms definition and the telemetry factory', () => {
+    const embeddable = createEmbeddableSetupMock();
+
+    registerAlertsEmbeddable(embeddable);
+
+    expect(embeddable.registerEmbeddableServerDefinition).toHaveBeenCalledWith(
+      SLO_ALERTS_EMBEDDABLE_ID,
+      expect.objectContaining({ title: 'SLO alerts' })
+    );
+    expect(embeddable.registerEmbeddableFactory).toHaveBeenCalledWith({
+      id: SLO_ALERTS_EMBEDDABLE_ID,
+      telemetry: getAlertsEmbeddableTelemetry,
+    });
+  });
+});
+
+describe('getAlertsEmbeddableTelemetry', () => {
+  const state = (sloIds: string[]): EmbeddableStateWithType =>
+    ({
+      type: SLO_ALERTS_EMBEDDABLE_ID,
+      slos: sloIds.map((sloId) => ({ slo_id: sloId, slo_instance_id: '*' })),
+    } as unknown as EmbeddableStateWithType);
+
+  it('counts the panel once and each referenced slo_id', () => {
+    const stats = getAlertsEmbeddableTelemetry(state(['slo-1', 'slo-2']), {});
+
+    expect(stats).toEqual({ total: 1, 'slo_id.slo-1': 1, 'slo_id.slo-2': 1 });
+  });
+
+  it('handles a panel with no slos configured yet', () => {
+    const stats = getAlertsEmbeddableTelemetry(state([]), {});
+
+    expect(stats).toEqual({ total: 1 });
+  });
+
+  it('accumulates the same slo_id across multiple panels', () => {
+    let stats = {};
+    stats = getAlertsEmbeddableTelemetry(state(['slo-1']), stats);
+    stats = getAlertsEmbeddableTelemetry(state(['slo-1', 'slo-2']), stats);
+
+    expect(stats).toEqual({ total: 2, 'slo_id.slo-1': 2, 'slo_id.slo-2': 1 });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_alerts_embeddable.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_alerts_embeddable.ts
@@ -5,18 +5,51 @@
  * 2.0.
  */
 
-import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
+import type { EmbeddableSetup, EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
 import { SLO_ALERTS_EMBEDDABLE_ID } from '../../../common/embeddables/alerts/constants';
 import { getAlertsEmbeddableSchema } from './alerts_schema';
 import { getTransforms } from '../../../common/embeddables/alerts/transforms/transforms';
 
 /**
- * Registers the schema and transforms for the SLO Alerts embeddable
+ * Reports SLO alerts panel usage (panel count and each referenced slo_id) into the dashboard
+ * panel-usage collector's per-type `details` bucket. Called by the dashboard plugin's usage
+ * collector via `factory.telemetry(state, stats)` once per saved panel of this embeddable type,
+ * across every dashboard in the cluster. Unlike the other SLO embeddables, a single Alerts panel
+ * can reference multiple SLOs, so each one is counted.
+ */
+export const getAlertsEmbeddableTelemetry = (
+  state: EmbeddableStateWithType,
+  stats: Record<string, number>
+): Record<string, number> => {
+  const outputStats = { ...stats };
+  outputStats.total = (outputStats.total ?? 0) + 1;
+
+  const slos = (state as { slos?: unknown }).slos;
+  if (Array.isArray(slos)) {
+    for (const sloItem of slos) {
+      const sloId = (sloItem as { slo_id?: unknown } | undefined)?.slo_id;
+      if (typeof sloId === 'string') {
+        const key = `slo_id.${sloId}`;
+        outputStats[key] = (outputStats[key] ?? 0) + 1;
+      }
+    }
+  }
+
+  return outputStats;
+};
+
+/**
+ * Registers the schema, transforms, and telemetry hook for the SLO Alerts embeddable
  */
 export const registerAlertsEmbeddable = (embeddable: EmbeddableSetup): void => {
   embeddable.registerEmbeddableServerDefinition(SLO_ALERTS_EMBEDDABLE_ID, {
     title: 'SLO alerts',
     getSchema: getAlertsEmbeddableSchema,
     getTransforms,
+  });
+
+  embeddable.registerEmbeddableFactory({
+    id: SLO_ALERTS_EMBEDDABLE_ID,
+    telemetry: getAlertsEmbeddableTelemetry,
   });
 };

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_burn_rate_embeddable.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_burn_rate_embeddable.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createEmbeddableSetupMock } from '@kbn/embeddable-plugin/server/mocks';
+import type { EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
+import { SLO_BURN_RATE_EMBEDDABLE_ID } from '../../../common/embeddables/burn_rate/constants';
+import {
+  getBurnRateEmbeddableTelemetry,
+  registerBurnRateEmbeddable,
+} from './register_burn_rate_embeddable';
+
+describe('registerBurnRateEmbeddable', () => {
+  it('registers the schema/transforms definition and the telemetry factory', () => {
+    const embeddable = createEmbeddableSetupMock();
+
+    registerBurnRateEmbeddable(embeddable);
+
+    expect(embeddable.registerEmbeddableServerDefinition).toHaveBeenCalledWith(
+      SLO_BURN_RATE_EMBEDDABLE_ID,
+      expect.objectContaining({ title: 'SLO burn rate' })
+    );
+    expect(embeddable.registerEmbeddableFactory).toHaveBeenCalledWith({
+      id: SLO_BURN_RATE_EMBEDDABLE_ID,
+      telemetry: getBurnRateEmbeddableTelemetry,
+    });
+  });
+});
+
+describe('getBurnRateEmbeddableTelemetry', () => {
+  const state = (sloId: string): EmbeddableStateWithType =>
+    ({
+      type: SLO_BURN_RATE_EMBEDDABLE_ID,
+      slo_id: sloId,
+      slo_instance_id: '*',
+      duration: '1h',
+    } as unknown as EmbeddableStateWithType);
+
+  it('counts the panel and its slo_id', () => {
+    const stats = getBurnRateEmbeddableTelemetry(state('slo-1'), {});
+
+    expect(stats).toEqual({ total: 1, 'slo_id.slo-1': 1 });
+  });
+
+  it('accumulates counts across multiple panels for the same slo_id', () => {
+    let stats = {};
+    stats = getBurnRateEmbeddableTelemetry(state('slo-1'), stats);
+    stats = getBurnRateEmbeddableTelemetry(state('slo-1'), stats);
+
+    expect(stats).toEqual({ total: 2, 'slo_id.slo-1': 2 });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_burn_rate_embeddable.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_burn_rate_embeddable.ts
@@ -5,18 +5,45 @@
  * 2.0.
  */
 
-import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
+import type { EmbeddableSetup, EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
 import { SLO_BURN_RATE_EMBEDDABLE_ID } from '../../../common/embeddables/burn_rate/constants';
 import { getBurnRateEmbeddableSchema } from './burn_rate_schema';
 import { getTransforms } from '../../../common/embeddables/burn_rate/transforms/transforms';
 
 /**
- * Registers the schema and transforms for the SLO Burn Rate embeddable
+ * Reports SLO burn rate panel usage (panel count and referenced slo_id) into the dashboard
+ * panel-usage collector's per-type `details` bucket. Called by the dashboard plugin's usage
+ * collector via `factory.telemetry(state, stats)` once per saved panel of this embeddable type,
+ * across every dashboard in the cluster.
+ */
+export const getBurnRateEmbeddableTelemetry = (
+  state: EmbeddableStateWithType,
+  stats: Record<string, number>
+): Record<string, number> => {
+  const outputStats = { ...stats };
+  outputStats.total = (outputStats.total ?? 0) + 1;
+
+  const sloId = (state as { slo_id?: unknown }).slo_id;
+  if (typeof sloId === 'string') {
+    const key = `slo_id.${sloId}`;
+    outputStats[key] = (outputStats[key] ?? 0) + 1;
+  }
+
+  return outputStats;
+};
+
+/**
+ * Registers the schema, transforms, and telemetry hook for the SLO Burn Rate embeddable
  */
 export const registerBurnRateEmbeddable = (embeddable: EmbeddableSetup): void => {
   embeddable.registerEmbeddableServerDefinition(SLO_BURN_RATE_EMBEDDABLE_ID, {
     title: 'SLO burn rate',
     getSchema: getBurnRateEmbeddableSchema,
     getTransforms,
+  });
+
+  embeddable.registerEmbeddableFactory({
+    id: SLO_BURN_RATE_EMBEDDABLE_ID,
+    telemetry: getBurnRateEmbeddableTelemetry,
   });
 };

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_error_budget_embeddable.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_error_budget_embeddable.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createEmbeddableSetupMock } from '@kbn/embeddable-plugin/server/mocks';
+import type { EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
+import { SLO_ERROR_BUDGET_ID } from '../../../common/embeddables/error_budget/constants';
+import {
+  getErrorBudgetEmbeddableTelemetry,
+  registerErrorBudgetEmbeddable,
+} from './register_error_budget_embeddable';
+
+describe('registerErrorBudgetEmbeddable', () => {
+  it('registers the schema/transforms definition and the telemetry factory', () => {
+    const embeddable = createEmbeddableSetupMock();
+
+    registerErrorBudgetEmbeddable(embeddable);
+
+    expect(embeddable.registerEmbeddableServerDefinition).toHaveBeenCalledWith(
+      SLO_ERROR_BUDGET_ID,
+      expect.objectContaining({ title: 'SLO error budget' })
+    );
+    expect(embeddable.registerEmbeddableFactory).toHaveBeenCalledWith({
+      id: SLO_ERROR_BUDGET_ID,
+      telemetry: getErrorBudgetEmbeddableTelemetry,
+    });
+  });
+});
+
+describe('getErrorBudgetEmbeddableTelemetry', () => {
+  const state = (sloId: string): EmbeddableStateWithType =>
+    ({
+      type: SLO_ERROR_BUDGET_ID,
+      slo_id: sloId,
+      slo_instance_id: '*',
+    } as unknown as EmbeddableStateWithType);
+
+  it('counts the panel and its slo_id', () => {
+    const stats = getErrorBudgetEmbeddableTelemetry(state('slo-1'), {});
+
+    expect(stats).toEqual({ total: 1, 'slo_id.slo-1': 1 });
+  });
+
+  it('ignores state missing a slo_id without throwing', () => {
+    const stats = getErrorBudgetEmbeddableTelemetry(
+      { type: SLO_ERROR_BUDGET_ID } as EmbeddableStateWithType,
+      {}
+    );
+
+    expect(stats).toEqual({ total: 1 });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_error_budget_embeddable.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_error_budget_embeddable.ts
@@ -5,18 +5,45 @@
  * 2.0.
  */
 
-import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
+import type { EmbeddableSetup, EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
 import { SLO_ERROR_BUDGET_ID } from '../../../common/embeddables/error_budget/constants';
 import { getErrorBudgetEmbeddableSchema } from './error_budget_schema';
 import { getTransforms } from '../../../common/embeddables/error_budget/transforms/transforms';
 
 /**
- * Registers the schema and transforms for the SLO Error Budget embeddable
+ * Reports SLO error budget panel usage (panel count and referenced slo_id) into the dashboard
+ * panel-usage collector's per-type `details` bucket. Called by the dashboard plugin's usage
+ * collector via `factory.telemetry(state, stats)` once per saved panel of this embeddable type,
+ * across every dashboard in the cluster.
+ */
+export const getErrorBudgetEmbeddableTelemetry = (
+  state: EmbeddableStateWithType,
+  stats: Record<string, number>
+): Record<string, number> => {
+  const outputStats = { ...stats };
+  outputStats.total = (outputStats.total ?? 0) + 1;
+
+  const sloId = (state as { slo_id?: unknown }).slo_id;
+  if (typeof sloId === 'string') {
+    const key = `slo_id.${sloId}`;
+    outputStats[key] = (outputStats[key] ?? 0) + 1;
+  }
+
+  return outputStats;
+};
+
+/**
+ * Registers the schema, transforms, and telemetry hook for the SLO Error Budget embeddable
  */
 export const registerErrorBudgetEmbeddable = (embeddable: EmbeddableSetup): void => {
   embeddable.registerEmbeddableServerDefinition(SLO_ERROR_BUDGET_ID, {
     title: 'SLO error budget',
     getSchema: getErrorBudgetEmbeddableSchema,
     getTransforms,
+  });
+
+  embeddable.registerEmbeddableFactory({
+    id: SLO_ERROR_BUDGET_ID,
+    telemetry: getErrorBudgetEmbeddableTelemetry,
   });
 };

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_overview_embeddable.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_overview_embeddable.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createEmbeddableSetupMock } from '@kbn/embeddable-plugin/server/mocks';
+import type { EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
+import { SLO_OVERVIEW_EMBEDDABLE_ID } from '../../../common/embeddables/overview/constants';
+import {
+  getOverviewEmbeddableTelemetry,
+  registerOverviewEmbeddable,
+} from './register_overview_embeddable';
+
+describe('registerOverviewEmbeddable', () => {
+  it('registers the schema/transforms definition and the telemetry factory', () => {
+    const embeddable = createEmbeddableSetupMock();
+
+    registerOverviewEmbeddable(embeddable);
+
+    expect(embeddable.registerEmbeddableServerDefinition).toHaveBeenCalledWith(
+      SLO_OVERVIEW_EMBEDDABLE_ID,
+      expect.objectContaining({ title: 'SLO overview' })
+    );
+    expect(embeddable.registerEmbeddableFactory).toHaveBeenCalledWith({
+      id: SLO_OVERVIEW_EMBEDDABLE_ID,
+      telemetry: getOverviewEmbeddableTelemetry,
+    });
+  });
+});
+
+describe('getOverviewEmbeddableTelemetry', () => {
+  const singleState = (sloId: string): EmbeddableStateWithType =>
+    ({
+      type: SLO_OVERVIEW_EMBEDDABLE_ID,
+      overview_mode: 'single',
+      slo_id: sloId,
+    } as unknown as EmbeddableStateWithType);
+
+  const groupState = (): EmbeddableStateWithType =>
+    ({
+      type: SLO_OVERVIEW_EMBEDDABLE_ID,
+      overview_mode: 'groups',
+    } as unknown as EmbeddableStateWithType);
+
+  it('counts a single-SLO panel and its slo_id', () => {
+    const stats = getOverviewEmbeddableTelemetry(singleState('slo-1'), {});
+
+    expect(stats).toEqual({ total: 1, 'slo_id.slo-1': 1 });
+  });
+
+  it('counts a group-mode panel without a slo_id breakdown', () => {
+    const stats = getOverviewEmbeddableTelemetry(groupState(), {});
+
+    expect(stats).toEqual({ total: 1, groups: 1 });
+  });
+
+  it('accumulates across multiple panels, matching the reference reducer pattern', () => {
+    let stats = {};
+    stats = getOverviewEmbeddableTelemetry(singleState('slo-1'), stats);
+    stats = getOverviewEmbeddableTelemetry(singleState('slo-1'), stats);
+    stats = getOverviewEmbeddableTelemetry(singleState('slo-2'), stats);
+    stats = getOverviewEmbeddableTelemetry(groupState(), stats);
+
+    expect(stats).toEqual({
+      total: 4,
+      'slo_id.slo-1': 2,
+      'slo_id.slo-2': 1,
+      groups: 1,
+    });
+  });
+
+  it('does not mutate the incoming stats object', () => {
+    const initialStats = { total: 1 };
+
+    getOverviewEmbeddableTelemetry(singleState('slo-1'), initialStats);
+
+    expect(initialStats).toEqual({ total: 1 });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_overview_embeddable.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/register_overview_embeddable.ts
@@ -5,18 +5,49 @@
  * 2.0.
  */
 
-import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
+import type { EmbeddableSetup, EmbeddableStateWithType } from '@kbn/embeddable-plugin/server';
 import { SLO_OVERVIEW_EMBEDDABLE_ID } from '../../../common/embeddables/overview/constants';
 import { getOverviewEmbeddableSchema } from './schema';
 import { getTransforms } from '../../../common/embeddables/overview/transforms/transforms';
 
 /**
- * Registers the schema and transforms for the SLO Overview embeddable
+ * Reports SLO overview panel usage (panel count and, for single-SLO panels, the referenced
+ * slo_id) into the dashboard panel-usage collector's per-type `details` bucket. Called by the
+ * dashboard plugin's usage collector via `factory.telemetry(state, stats)` once per saved panel
+ * of this embeddable type, across every dashboard in the cluster.
+ */
+export const getOverviewEmbeddableTelemetry = (
+  state: EmbeddableStateWithType,
+  stats: Record<string, number>
+): Record<string, number> => {
+  const outputStats = { ...stats };
+  outputStats.total = (outputStats.total ?? 0) + 1;
+
+  const overviewMode = (state as { overview_mode?: unknown }).overview_mode;
+  const sloId = (state as { slo_id?: unknown }).slo_id;
+
+  if (overviewMode === 'single' && typeof sloId === 'string') {
+    const key = `slo_id.${sloId}`;
+    outputStats[key] = (outputStats[key] ?? 0) + 1;
+  } else if (overviewMode === 'groups') {
+    outputStats.groups = (outputStats.groups ?? 0) + 1;
+  }
+
+  return outputStats;
+};
+
+/**
+ * Registers the schema, transforms, and telemetry hook for the SLO Overview embeddable
  */
 export const registerOverviewEmbeddable = (embeddable: EmbeddableSetup): void => {
   embeddable.registerEmbeddableServerDefinition(SLO_OVERVIEW_EMBEDDABLE_ID, {
     title: 'SLO overview',
     getSchema: getOverviewEmbeddableSchema,
     getTransforms,
+  });
+
+  embeddable.registerEmbeddableFactory({
+    id: SLO_OVERVIEW_EMBEDDABLE_ID,
+    telemetry: getOverviewEmbeddableTelemetry,
   });
 };


### PR DESCRIPTION
## Summary

Actionable-obs (SLO / `alert_details`) half of the telemetry ask in #275023. A companion response-ops PR (rule save-confirm, rule engagement events, from the `jasonrhodes/issue-275023-rule-telemetry` branch — not yet opened) covers the alerting-side asks in the same issue.

This PR adds:

- **New SLO save-confirm event** (`slo_created`): fires on successful SLO creation with `slo_id` and, when the SLO was created from an integration template, `template_id`.
- **Four net-new SLO engagement events**: `slo_edited`, `slo_deleted`, `slo_cloned`, `slo_reset`, each carrying `slo_id`.
- **`rule_id` + `dashboard_id`** added to the existing `Linked Dashboard View` / `Suggested Dashboard Added` events on the alert details page's related-dashboards tiles.
- **SLO embeddable telemetry**: implements the optional `telemetry()` hook on the SLO Alerts / Burn Rate / Error Budget / Overview embeddable server factories, so panel counts (and referenced `slo_id`s) flow into the existing dashboard panel-usage collector.

## Open questions (flagging for data office / issue author)

1. **"Health-check" engagement event dropped from scope.** The issue asks for an SLO `health-check` engagement event, but no per-SLO action by that name exists in the code — the closest match (`useFetchSloGlobalDiagnosis`) is a global, non-SLO-scoped page-load call, not a user action on an individual SLO. Happy to add something here once there's a concrete UI action to instrument.
2. **Embeddable telemetry gives aggregate, not per-save, granularity.** The `telemetry()` hook this PR implements feeds the existing periodic dashboard panel-usage collector, which reports a per-cluster aggregate inventory (count of panels + which `slo_id`s appear), not a per-save-event stream. A true per-dashboard-save event would require a small change in the (cross-team-owned) `dashboard` plugin. Is the aggregate granularity sufficient for the "is this SLO template providing value" question, or do you need per-save resolution?

## Test plan

- [x] Added/updated unit tests for every touched module (telemetry clients/events, SLO edit page, SLO item actions, all four embeddable registration files, dashboard tile component) — all passing locally.
- [x] `node scripts/eslint` clean on all touched files.
- [x] `node scripts/type_check` clean (exit 0, no errors) for both the `slo` and `observability` plugin projects.
- [ ] Full CI suite — pending.
