### PR TITLE
[Security Solution] Re-assert canWriteWorkflowInsights authz in generateInsightTool

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.test.ts
@@ -218,6 +218,7 @@ describe('automaticTroubleshootingGenerateInsightTool', () => {
 
     const createHandlerContext = () =>
       ({
+        request: {},
         modelProvider: mockModelProvider,
         spaceId: 'space-1',
         logger: {
@@ -231,6 +232,9 @@ describe('automaticTroubleshootingGenerateInsightTool', () => {
       mockEnsureInCurrentSpace = fleetServices.ensureInCurrentSpace as jest.Mock;
       mockEnsureInCurrentSpace.mockResolvedValue(undefined);
       mockEndpointAppContextService.getInternalFleetServices.mockClear();
+      // createMockEndpointAppContextService() defaults getEndpointAuthz to all-true
+      // (see security_solution/common/endpoint/service/authz/mocks.ts), so
+      // canWriteWorkflowInsights is authorized by default in these tests.
 
       tool = generateInsightTool(mockEndpointAppContextService);
 
@@ -296,6 +300,38 @@ describe('automaticTroubleshootingGenerateInsightTool', () => {
       });
       expect(mockGraph.invoke).toHaveBeenCalledWith({});
       expect(result).toEqual({ results: mockResults });
+    });
+
+    it('returns an error and skips graph execution when the user lacks canWriteWorkflowInsights privileges', async () => {
+      (mockEndpointAppContextService.getEndpointAuthz as jest.Mock).mockResolvedValueOnce({
+        canWriteWorkflowInsights: false,
+      });
+
+      const result = await tool.handler(
+        {
+          problemDescription: 'configuration issue detected',
+          remediation: 'fix the thing',
+          endpointIds: ['endpoint-1', 'endpoint-2'],
+          data: [{ event: { type: 'process' } }],
+        },
+        createHandlerContext()
+      );
+
+      expect(mockEndpointAppContextService.getEndpointAuthz).toHaveBeenCalled();
+      expect(mockEnsureInCurrentSpace).not.toHaveBeenCalled();
+      expect(mockModelProvider.getDefaultModel).not.toHaveBeenCalled();
+      expect(mockCreateGenerateInsightGraph).not.toHaveBeenCalled();
+      expect(mockGraph.invoke).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: 'Not authorized to write workflow insights',
+            },
+          },
+        ],
+      });
     });
 
     it('returns an error and skips graph execution when endpoint space validation fails', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.ts
@@ -58,9 +58,20 @@ This tool creates structured insights for persisting the results of the troubles
     schema: generateInsightSchema,
     handler: async (
       { problemDescription, remediation, endpointIds, data },
-      { spaceId, modelProvider, logger }
+      { request, spaceId, modelProvider, logger }
     ) => {
       try {
+        // securityWorkflowInsightsService.createFromDefendInsights (invoked further down via
+        // createGenerateInsightGraph) runs with an internal-user ES client and bypasses
+        // route-level authz. Re-assert the same `canWriteWorkflowInsights` gate the HTTP
+        // create_insights route enforces, since this tool is dispatched without that route.
+        const { canWriteWorkflowInsights } = await endpointAppContextService.getEndpointAuthz(
+          request
+        );
+        if (!canWriteWorkflowInsights) {
+          return errorResult('Not authorized to write workflow insights');
+        }
+
         await endpointAppContextService
           .getInternalFleetServices(spaceId)
           .ensureInCurrentSpace({ agentIds: endpointIds });


### PR DESCRIPTION
## Summary

`generateInsightTool` (the `automatic_troubleshooting` Agent Builder skill's insight-generation tool) calls `securityWorkflowInsightsService.createFromDefendInsights` to persist a workflow insight. That service is constructed in `plugin.ts` with `core.elasticsearch.client.asInternalUser` — an internal-user Elasticsearch client that bypasses per-user authorization.

The equivalent HTTP route, `create_insights.ts`, gates this same write with `withEndpointAuthz({ all: ['canWriteWorkflowInsights'] })`. The agent tool had no equivalent check: it validated the endpoint ids' space membership, but never asserted the calling user actually had `canWriteWorkflowInsights` privilege before writing through the internal-user client. Any chat user who could reach this tool could therefore create/update workflow insights regardless of their actual endpoint privileges — a privilege-escalation gap of the same shape as the one fixed in #272111 for the response-actions tools (isolate/unisolate/scan/get_running_processes).

## Fix

- Destructure `request` from the tool's `ToolHandlerContext`.
- Before dispatching to the insight-generation graph, call `endpointAppContextService.getEndpointAuthz(request)` and require `canWriteWorkflowInsights`; return an error result (skipping the space check, model load, and graph invocation) when the caller lacks it.
- Added a denial-path unit test asserting the graph/model provider are never invoked when the privilege check fails.

## Test plan

- [x] `node scripts/jest --config x-pack/solutions/security/plugins/security_solution/server/agent_builder/jest.config.js .../generate_insight/index.test.ts` — 25/25 passing, including the new denial-path test.
- [x] `node scripts/type_check.js --project x-pack/solutions/security/plugins/security_solution/tsconfig.json` — clean, no new errors.
- [x] Pre-push hook (eslint --fix, type_check, jest) passed clean.