### PR TITLE
[Alerting] Add rule save/create/engagement telemetry (#275023)

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/rule_form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/index.ts
@@ -31,3 +31,10 @@ export {
   RuleActionsAlertsFilterTimeframe,
   NOTIFY_WHEN_OPTIONS,
 } from './src/rule_actions';
+
+export {
+  RULE_CREATED_EVENT_TYPE,
+  registerRuleCreatedEventType,
+  reportRuleCreatedEvent,
+  type RuleCreatedEventData,
+} from './src/common/telemetry';

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/common/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/common/hooks/use_create_rule.ts
@@ -13,7 +13,12 @@ import type { Rule } from '../types';
 
 export interface UseCreateRuleProps {
   http: HttpStart;
-  onSuccess?: (rule: Rule) => void;
+  /**
+   * `variables` is the same object passed to `mutate` (i.e. `{ formData }`), so callers can
+   * access the request payload -- e.g. `ruleTypeId`, `params`, `artifacts` -- alongside the
+   * created rule returned by the API, without having to track it separately.
+   */
+  onSuccess?: (rule: Rule, variables: { formData: CreateRuleBody }) => void;
   onError?: (error: IHttpFetchError<{ message: string }>) => void;
 }
 

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  RULE_CREATED_EVENT_TYPE,
+  registerRuleCreatedEventType,
+  reportRuleCreatedEvent,
+  type RuleCreatedEventData,
+} from './rule_created_event';

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/rule_created_event.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/rule_created_event.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  RULE_CREATED_EVENT_TYPE,
+  registerRuleCreatedEventType,
+  reportRuleCreatedEvent,
+} from './rule_created_event';
+
+describe('rule_created_event', () => {
+  test('registerRuleCreatedEventType registers the rule_created event type', () => {
+    const registerEventType = jest.fn();
+
+    registerRuleCreatedEventType({ registerEventType } as never);
+
+    expect(registerEventType).toHaveBeenCalledTimes(1);
+    expect(registerEventType).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: RULE_CREATED_EVENT_TYPE })
+    );
+  });
+
+  test('reportRuleCreatedEvent reports the event with the given data', () => {
+    const reportEvent = jest.fn();
+
+    reportRuleCreatedEvent(
+      { reportEvent },
+      {
+        rule_id: 'rule-1',
+        rule_type_id: '.es-query',
+      }
+    );
+
+    expect(reportEvent).toHaveBeenCalledWith(RULE_CREATED_EVENT_TYPE, {
+      rule_id: 'rule-1',
+      rule_type_id: '.es-query',
+    });
+  });
+
+  test('reportRuleCreatedEvent forwards optional fields when provided', () => {
+    const reportEvent = jest.fn();
+
+    reportRuleCreatedEvent(
+      { reportEvent },
+      {
+        rule_id: 'rule-1',
+        rule_type_id: 'slo.rules.burnRate',
+        template_id: 'template-1',
+        slo_id: 'slo-1',
+        dashboard_ids: ['dash-1', 'dash-2'],
+      }
+    );
+
+    expect(reportEvent).toHaveBeenCalledWith(RULE_CREATED_EVENT_TYPE, {
+      rule_id: 'rule-1',
+      rule_type_id: 'slo.rules.burnRate',
+      template_id: 'template-1',
+      slo_id: 'slo-1',
+      dashboard_ids: ['dash-1', 'dash-2'],
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/rule_created_event.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/rule_created_event.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AnalyticsServiceSetup,
+  AnalyticsServiceStart,
+  EventTypeOpts,
+  RootSchema,
+} from '@kbn/core-analytics-browser';
+
+/**
+ * Fired once, right after a rule's create API call resolves successfully. Unlike the
+ * `data-ebt-*` click attributes on the save buttons (see `getRuleSaveEbtProps`), this is a
+ * bespoke EBT event rather than a click attribute, because the rule's id doesn't exist yet at
+ * click-time during the create flow -- it's only known once the API call resolves.
+ */
+export const RULE_CREATED_EVENT_TYPE = 'rule_created';
+
+export interface RuleCreatedEventData {
+  rule_id: string;
+  rule_type_id: string;
+  /** Parsed from the URL when the rule was created from a template, e.g. `/create/template/{template_id}`. */
+  template_id?: string;
+  /** Only present for SLO burn rate rules (`rule_type_id === 'slo.rules.burnRate'`). */
+  slo_id?: string;
+  /** Ids of the dashboards linked to the rule via `artifacts.dashboards`. */
+  dashboard_ids?: string[];
+}
+
+const schema: RootSchema<RuleCreatedEventData> = {
+  rule_id: {
+    type: 'keyword',
+    _meta: {
+      description: 'The id of the newly created rule.',
+    },
+  },
+  rule_type_id: {
+    type: 'keyword',
+    _meta: {
+      description: 'The rule type id of the newly created rule.',
+    },
+  },
+  template_id: {
+    type: 'keyword',
+    _meta: {
+      description:
+        'The id of the alert/SLO template the rule was created from, when applicable.',
+      optional: true,
+    },
+  },
+  slo_id: {
+    type: 'keyword',
+    _meta: {
+      description: "The linked SLO's id, only present for SLO burn rate rules.",
+      optional: true,
+    },
+  },
+  dashboard_ids: {
+    type: 'array',
+    items: {
+      type: 'keyword',
+      _meta: {
+        description: 'The id of a dashboard linked to the rule.',
+      },
+    },
+    _meta: {
+      description: 'Ids of the dashboards linked to the rule via artifacts.dashboards.',
+      optional: true,
+    },
+  },
+};
+
+const eventTypeOpts: EventTypeOpts<RuleCreatedEventData> = {
+  eventType: RULE_CREATED_EVENT_TYPE,
+  schema,
+};
+
+/** Call once, from a plugin's `setup()`, before any `reportRuleCreatedEvent` calls. */
+export function registerRuleCreatedEventType(analytics: AnalyticsServiceSetup) {
+  analytics.registerEventType(eventTypeOpts);
+}
+
+export function reportRuleCreatedEvent(
+  analytics: Pick<AnalyticsServiceStart, 'reportEvent'>,
+  data: RuleCreatedEventData
+) {
+  analytics.reportEvent(RULE_CREATED_EVENT_TYPE, data);
+}

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/rule_created_event.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/common/telemetry/rule_created_event.ts
@@ -47,8 +47,7 @@ const schema: RootSchema<RuleCreatedEventData> = {
   template_id: {
     type: 'keyword',
     _meta: {
-      description:
-        'The id of the alert/SLO template the rule was created from, when applicable.',
+      description: 'The id of the alert/SLO template the rule was created from, when applicable.',
       optional: true,
     },
   },

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/create_rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/create_rule_form.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CreateRuleForm } from './create_rule_form';
+import type { RuleFormPlugins } from './types';
+
+jest.mock('./rule_form_state', () => ({
+  RuleFormStateProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('./rule_page', () => ({
+  RulePage: () => <div data-test-subj="rulePageMock" />,
+}));
+
+jest.mock('./rule_flyout', () => ({
+  RuleFlyout: () => <div data-test-subj="ruleFlyoutMock" />,
+}));
+
+jest.mock('./hooks/use_load_dependencies', () => ({
+  useLoadDependencies: jest.fn(),
+}));
+
+const mutate = jest.fn();
+const useCreateRuleMock = jest.fn(() => ({ mutate, isLoading: false }));
+
+jest.mock('./common/hooks', () => ({
+  useCreateRule: (...args: unknown[]) => useCreateRuleMock(...args),
+}));
+
+const reportRuleCreatedEvent = jest.fn();
+jest.mock('./common/telemetry', () => ({
+  reportRuleCreatedEvent: (...args: unknown[]) => reportRuleCreatedEvent(...args),
+}));
+
+const { useLoadDependencies } = jest.requireMock('./hooks/use_load_dependencies');
+
+const addSuccess = jest.fn();
+const onSubmit = jest.fn();
+
+const basePlugins = {
+  http: {},
+  docLinks: {},
+  notifications: { toasts: { addSuccess, addDanger: jest.fn() } },
+  ruleTypeRegistry: {},
+  fieldsMetadata: {},
+  application: { capabilities: {} },
+} as unknown as RuleFormPlugins;
+
+describe('CreateRuleForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCreateRuleMock.mockReturnValue({ mutate, isLoading: false });
+    useLoadDependencies.mockReturnValue({
+      isInitialLoading: false,
+      ruleType: { id: '.es-query', authorizedConsumers: { alerts: { all: true } } },
+      ruleTypes: [],
+      ruleTypeModel: {},
+      uiConfig: {},
+      healthCheckError: null,
+      connectors: [],
+      connectorTypes: [],
+      alertFields: [],
+      flappingSettings: undefined,
+    });
+  });
+
+  const renderForm = (plugins: RuleFormPlugins = basePlugins) => {
+    render(
+      <CreateRuleForm ruleTypeId=".es-query" plugins={plugins} onSubmit={onSubmit} isFlyout />
+    );
+    return useCreateRuleMock.mock.calls[0][0] as {
+      onSuccess: (
+        rule: { id: string; name: string },
+        variables: { formData: Record<string, unknown> }
+      ) => void;
+    };
+  };
+
+  it('shows a success toast and calls onSubmit when the create call succeeds', () => {
+    const { onSuccess } = renderForm();
+
+    onSuccess(
+      { id: 'rule-1', name: 'my rule' },
+      { formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined } }
+    );
+
+    expect(addSuccess).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledWith('rule-1');
+  });
+
+  it('reports the rule_created event when plugins.analytics is provided', () => {
+    const reportEvent = jest.fn();
+    const { onSuccess } = renderForm({
+      ...basePlugins,
+      analytics: { reportEvent },
+    } as unknown as RuleFormPlugins);
+
+    onSuccess(
+      { id: 'rule-1', name: 'my rule' },
+      {
+        formData: {
+          ruleTypeId: 'slo.rules.burnRate',
+          params: { sloId: 'slo-1' },
+          artifacts: { dashboards: [{ id: 'dash-1' }] },
+        },
+      }
+    );
+
+    expect(reportRuleCreatedEvent).toHaveBeenCalledWith(
+      { reportEvent },
+      expect.objectContaining({
+        rule_id: 'rule-1',
+        rule_type_id: 'slo.rules.burnRate',
+        slo_id: 'slo-1',
+        dashboard_ids: ['dash-1'],
+      })
+    );
+  });
+
+  it('does not report the rule_created event when plugins.analytics is not provided', () => {
+    const { onSuccess } = renderForm();
+
+    onSuccess(
+      { id: 'rule-1', name: 'my rule' },
+      { formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined } }
+    );
+
+    expect(reportRuleCreatedEvent).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/create_rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/create_rule_form.test.tsx
@@ -27,15 +27,15 @@ jest.mock('./hooks/use_load_dependencies', () => ({
 }));
 
 const mutate = jest.fn();
-const useCreateRuleMock = jest.fn(() => ({ mutate, isLoading: false }));
+const mockUseCreateRule = jest.fn(() => ({ mutate, isLoading: false }));
 
 jest.mock('./common/hooks', () => ({
-  useCreateRule: (...args: unknown[]) => useCreateRuleMock(...args),
+  useCreateRule: (...args: unknown[]) => mockUseCreateRule(...args),
 }));
 
-const reportRuleCreatedEvent = jest.fn();
+const mockReportRuleCreatedEvent = jest.fn();
 jest.mock('./common/telemetry', () => ({
-  reportRuleCreatedEvent: (...args: unknown[]) => reportRuleCreatedEvent(...args),
+  reportRuleCreatedEvent: (...args: unknown[]) => mockReportRuleCreatedEvent(...args),
 }));
 
 const { useLoadDependencies } = jest.requireMock('./hooks/use_load_dependencies');
@@ -47,7 +47,7 @@ const basePlugins = {
   http: {},
   docLinks: {},
   notifications: { toasts: { addSuccess, addDanger: jest.fn() } },
-  ruleTypeRegistry: {},
+  ruleTypeRegistry: { list: jest.fn(() => []), has: jest.fn(() => true), get: jest.fn() },
   fieldsMetadata: {},
   application: { capabilities: {} },
 } as unknown as RuleFormPlugins;
@@ -55,7 +55,7 @@ const basePlugins = {
 describe('CreateRuleForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useCreateRuleMock.mockReturnValue({ mutate, isLoading: false });
+    mockUseCreateRule.mockReturnValue({ mutate, isLoading: false });
     useLoadDependencies.mockReturnValue({
       isInitialLoading: false,
       ruleType: { id: '.es-query', authorizedConsumers: { alerts: { all: true } } },
@@ -74,7 +74,7 @@ describe('CreateRuleForm', () => {
     render(
       <CreateRuleForm ruleTypeId=".es-query" plugins={plugins} onSubmit={onSubmit} isFlyout />
     );
-    return useCreateRuleMock.mock.calls[0][0] as {
+    return mockUseCreateRule.mock.calls[0][0] as {
       onSuccess: (
         rule: { id: string; name: string },
         variables: { formData: Record<string, unknown> }
@@ -112,7 +112,7 @@ describe('CreateRuleForm', () => {
       }
     );
 
-    expect(reportRuleCreatedEvent).toHaveBeenCalledWith(
+    expect(mockReportRuleCreatedEvent).toHaveBeenCalledWith(
       { reportEvent },
       expect.objectContaining({
         rule_id: 'rule-1',
@@ -131,6 +131,6 @@ describe('CreateRuleForm', () => {
       { formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined } }
     );
 
-    expect(reportRuleCreatedEvent).not.toHaveBeenCalled();
+    expect(mockReportRuleCreatedEvent).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/create_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/create_rule_form.tsx
@@ -14,6 +14,7 @@ import type { RuleFormData, RuleFormPlugins, RuleTypeMetaData } from './types';
 import { DEFAULT_VALID_CONSUMERS, getDefaultFormData } from './constants';
 import { RuleFormStateProvider } from './rule_form_state';
 import { useCreateRule } from './common/hooks';
+import { reportRuleCreatedEvent } from './common/telemetry';
 import { RulePage } from './rule_page';
 import { RuleFlyout } from './rule_flyout';
 import {
@@ -28,6 +29,7 @@ import {
   getInitialConsumer,
   getInitialMultiConsumer,
   getInitialSchedule,
+  getRuleCreatedEventData,
   parseRuleCircuitBreakerErrorMessage,
 } from './utils';
 import { RULE_CREATE_SUCCESS_TEXT, RULE_CREATE_ERROR_TEXT } from './translations';
@@ -78,9 +80,20 @@ export const CreateRuleForm = (props: CreateRuleFormProps) => {
 
   const { mutate, isLoading: isSaving } = useCreateRule({
     http,
-    onSuccess: ({ name, id }) => {
+    onSuccess: ({ name, id }, { formData: createdFormData }) => {
       toasts.addSuccess(RULE_CREATE_SUCCESS_TEXT(name));
       onSubmit?.(id);
+
+      if (plugins.analytics) {
+        reportRuleCreatedEvent(
+          plugins.analytics,
+          getRuleCreatedEventData({
+            ruleId: id,
+            pathname: window.location.pathname,
+            formData: createdFormData,
+          })
+        );
+      }
     },
     onError: (error) => {
       const message = parseRuleCircuitBreakerErrorMessage(

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout.test.tsx
@@ -209,4 +209,51 @@ describe('ruleFlyout', () => {
     fireEvent.click(screen.getByTestId('ruleFlyoutFooterCancelButton'));
     expect(screen.getByTestId('confirmRuleCloseModal')).toBeInTheDocument();
   });
+
+  test('should add ebt click attributes to the create footer save button', async () => {
+    render(<RuleFlyout onCancel={onCancel} onSave={onSave} />);
+
+    fireEvent.click(screen.getByTestId('ruleFlyoutFooterNextStepButton'));
+    expect(await screen.findByTestId('ruleFlyoutFooterPreviousStepButton')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('ruleFlyoutFooterNextStepButton'));
+
+    const saveButton = await screen.findByTestId('ruleFlyoutFooterSaveButton');
+    expect(saveButton).toHaveAttribute('data-ebt-action', 'ruleSave');
+    expect(saveButton).toHaveAttribute('data-ebt-element', 'ruleFlyoutCreateFooterSaveButton');
+    // formDataMock has no ruleTypeId/artifacts, so there's nothing to put in the detail
+    expect(saveButton).not.toHaveAttribute('data-ebt-detail');
+  });
+
+  test('should add ebt click attributes with the ruleId to the edit footer save button', () => {
+    useRuleFormState.mockReturnValue({
+      plugins: {
+        application: {
+          navigateToUrl,
+          capabilities: {
+            actions: {
+              show: true,
+              save: true,
+              execute: true,
+            },
+          },
+        },
+      },
+      baseErrors: {},
+      paramsErrors: {},
+      id: 'rule-1',
+      formData: formDataMock,
+      connectors: [],
+      connectorTypes: [],
+      aadTemplateFields: [],
+    });
+
+    render(<RuleFlyout isEdit onCancel={onCancel} onSave={onSave} />);
+
+    const saveButton = screen.getByTestId('ruleFlyoutFooterSaveButton');
+    expect(saveButton).toHaveAttribute('data-ebt-action', 'ruleSave');
+    expect(saveButton).toHaveAttribute('data-ebt-element', 'ruleFlyoutEditFooterSaveButton');
+    expect(JSON.parse(saveButton.getAttribute('data-ebt-detail')!)).toEqual({
+      ruleId: 'rule-1',
+    });
+  });
 });

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_create_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_create_footer.tsx
@@ -12,7 +12,7 @@ import {
   EuiFlexItem,
   EuiFlyoutFooter,
 } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   RULE_FLYOUT_FOOTER_BACK_TEXT,
   RULE_FLYOUT_FOOTER_CANCEL_TEXT,
@@ -20,6 +20,8 @@ import {
   RULE_FLYOUT_FOOTER_NEXT_TEXT,
   RULE_PAGE_FOOTER_SHOW_REQUEST_TEXT,
 } from '../translations';
+import { useRuleFormState } from '../hooks';
+import { getRuleSaveEbtProps } from '../utils';
 
 export interface RuleFlyoutCreateFooterProps {
   isSaving: boolean;
@@ -43,6 +45,13 @@ export const RuleFlyoutCreateFooter = ({
   goToNextStep,
   goToPreviousStep,
 }: RuleFlyoutCreateFooterProps) => {
+  const { formData } = useRuleFormState();
+
+  const saveButtonEbtProps = useMemo(
+    () => getRuleSaveEbtProps({ element: 'ruleFlyoutCreateFooterSaveButton', formData }),
+    [formData]
+  );
+
   return (
     <EuiFlyoutFooter>
       <EuiFlexGroup justifyContent="spaceBetween">
@@ -92,6 +101,7 @@ export const RuleFlyoutCreateFooter = ({
                   isDisabled={isSaving || hasErrors}
                   isLoading={isSaving}
                   onClick={onSave}
+                  {...saveButtonEbtProps}
                 >
                   {RULE_FLYOUT_FOOTER_CREATE_TEXT}
                 </EuiButton>

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_edit_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_edit_footer.tsx
@@ -12,12 +12,14 @@ import {
   EuiFlexItem,
   EuiFlyoutFooter,
 } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   RULE_FLYOUT_FOOTER_CANCEL_TEXT,
   RULE_FLYOUT_FOOTER_SAVE_TEXT,
   RULE_PAGE_FOOTER_SHOW_REQUEST_TEXT,
 } from '../translations';
+import { useRuleFormState } from '../hooks';
+import { getRuleSaveEbtProps } from '../utils';
 
 export interface RuleFlyoutEditFooterProps {
   isSaving: boolean;
@@ -33,6 +35,14 @@ export const RuleFlyoutEditFooter = ({
   hasErrors,
   isSaving,
 }: RuleFlyoutEditFooterProps) => {
+  const { formData, id } = useRuleFormState();
+
+  const saveButtonEbtProps = useMemo(
+    () =>
+      getRuleSaveEbtProps({ element: 'ruleFlyoutEditFooterSaveButton', ruleId: id, formData }),
+    [id, formData]
+  );
+
   return (
     <EuiFlyoutFooter>
       <EuiFlexGroup justifyContent="spaceBetween">
@@ -63,6 +73,7 @@ export const RuleFlyoutEditFooter = ({
                 isDisabled={isSaving || hasErrors}
                 isLoading={isSaving}
                 onClick={onSave}
+                {...saveButtonEbtProps}
               >
                 {RULE_FLYOUT_FOOTER_SAVE_TEXT}
               </EuiButton>

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_edit_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_edit_footer.tsx
@@ -38,8 +38,7 @@ export const RuleFlyoutEditFooter = ({
   const { formData, id } = useRuleFormState();
 
   const saveButtonEbtProps = useMemo(
-    () =>
-      getRuleSaveEbtProps({ element: 'ruleFlyoutEditFooterSaveButton', ruleId: id, formData }),
+    () => getRuleSaveEbtProps({ element: 'ruleFlyoutEditFooterSaveButton', ruleId: id, formData }),
     [id, formData]
   );
 

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.test.tsx
@@ -146,4 +146,70 @@ describe('rulePageFooter', () => {
     expect(screen.getByTestId('rulePageFooterSaveButton')).toBeDisabled();
     expect(screen.getByTestId('rulePageFooterCancelButton')).not.toBeDisabled();
   });
+
+  test('should add ebt click attributes to the save button without a ruleId in create mode', () => {
+    render(<RulePageFooter onSave={onSave} onCancel={onCancel} />);
+
+    const saveButton = screen.getByTestId('rulePageFooterSaveButton');
+    expect(saveButton).toHaveAttribute('data-ebt-action', 'ruleSave');
+    expect(saveButton).toHaveAttribute('data-ebt-element', 'rulePageFooterSaveButton');
+    expect(saveButton).not.toHaveAttribute('data-ebt-detail');
+  });
+
+  test('should include the ruleId in the ebt detail in edit mode', () => {
+    useRuleFormState.mockReturnValue({
+      plugins: {
+        application: {
+          capabilities: {
+            actions: {
+              show: true,
+            },
+          },
+        },
+      },
+      baseErrors: {},
+      paramsErrors: {},
+      id: 'rule-1',
+      formData: {
+        actions: [],
+      },
+    });
+
+    render(<RulePageFooter isEdit onSave={onSave} onCancel={onCancel} />);
+
+    const saveButton = screen.getByTestId('rulePageFooterSaveButton');
+    expect(JSON.parse(saveButton.getAttribute('data-ebt-detail')!)).toEqual({
+      ruleId: 'rule-1',
+    });
+  });
+
+  test('should include sloId and dashboardIds in the ebt detail when available', () => {
+    useRuleFormState.mockReturnValue({
+      plugins: {
+        application: {
+          capabilities: {
+            actions: {
+              show: true,
+            },
+          },
+        },
+      },
+      baseErrors: {},
+      paramsErrors: {},
+      formData: {
+        actions: [],
+        ruleTypeId: 'slo.rules.burnRate',
+        params: { sloId: 'slo-1' },
+        artifacts: { dashboards: [{ id: 'dash-1' }] },
+      },
+    });
+
+    render(<RulePageFooter onSave={onSave} onCancel={onCancel} />);
+
+    const saveButton = screen.getByTestId('rulePageFooterSaveButton');
+    expect(JSON.parse(saveButton.getAttribute('data-ebt-detail')!)).toEqual({
+      sloId: 'slo-1',
+      dashboardIds: ['dash-1'],
+    });
+  });
 });

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.tsx
@@ -16,6 +16,7 @@ import {
 import { useRuleFormScreenContext, useRuleFormState } from '../hooks';
 import { hasRuleErrors } from '../validation';
 import { ConfirmCreateRule } from '../components';
+import { getRuleSaveEbtProps } from '../utils';
 
 export interface RulePageFooterProps {
   isEdit?: boolean;
@@ -33,13 +34,26 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
 
   const {
     plugins: { application },
-    formData: { actions },
+    formData,
+    id,
     connectors,
     baseErrors = {},
     paramsErrors = {},
     actionsErrors = {},
     actionsParamsErrors = {},
   } = useRuleFormState();
+
+  const { actions } = formData;
+
+  const saveButtonEbtProps = useMemo(
+    () =>
+      getRuleSaveEbtProps({
+        element: 'rulePageFooterSaveButton',
+        ruleId: isEdit ? id : undefined,
+        formData,
+      }),
+    [isEdit, id, formData]
+  );
 
   const hasErrors = useMemo(() => {
     const hasBrokenConnectors = actions.some((action) => {
@@ -121,6 +135,7 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
                 onClick={onSaveClick}
                 disabled={isSaving || hasErrors}
                 isLoading={isSaving}
+                {...saveButtonEbtProps}
               >
                 {saveButtonText}
               </EuiButton>

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/types.ts
@@ -8,6 +8,7 @@
 import type { ActionType } from '@kbn/actions-types';
 import type { ActionVariable, RulesSettingsFlapping } from '@kbn/alerting-types';
 import type { ChartsPluginSetup } from '@kbn/charts-plugin/public';
+import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import type { HttpStart } from '@kbn/core-http-browser';
@@ -73,6 +74,12 @@ export interface RuleFormPlugins {
   fieldsMetadata: FieldsMetadataPublicStart;
   contentManagement?: ContentManagementPublicStart;
   uiActions?: UiActionsStart;
+  /**
+   * Used to report the `rule_created` EBT event on create-flow save success. Optional so that
+   * consumers who haven't registered the event type (see `registerRuleCreatedEventType`) don't
+   * have to pass it -- the event just won't be reported for them.
+   */
+  analytics?: Pick<AnalyticsServiceStart, 'reportEvent'>;
 }
 
 export interface RuleFormState<

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_created_event_data.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_created_event_data.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getRuleCreatedEventData } from './get_rule_created_event_data';
+import { SLO_BURN_RATE_RULE_TYPE_ID } from './get_rule_save_ebt_props';
+
+describe('getRuleCreatedEventData', () => {
+  it('returns the minimal payload when there is nothing else to report', () => {
+    const data = getRuleCreatedEventData({
+      ruleId: 'rule-1',
+      pathname: '/app/management/insightsAndAlerting/triggersActions/rule/create/.es-query',
+      formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined },
+    });
+
+    expect(data).toEqual({
+      rule_id: 'rule-1',
+      rule_type_id: '.es-query',
+      template_id: undefined,
+    });
+  });
+
+  it('includes the template_id when created from a template', () => {
+    const data = getRuleCreatedEventData({
+      ruleId: 'rule-1',
+      pathname: '/app/management/insightsAndAlerting/triggersActions/create/template/my-template',
+      formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined },
+    });
+
+    expect(data.template_id).toBe('my-template');
+  });
+
+  it('includes slo_id only for burn rate rules', () => {
+    const burnRateData = getRuleCreatedEventData({
+      ruleId: 'rule-1',
+      pathname: '/create/slo.rules.burnRate',
+      formData: {
+        ruleTypeId: SLO_BURN_RATE_RULE_TYPE_ID,
+        params: { sloId: 'slo-1' },
+        artifacts: undefined,
+      },
+    });
+    expect(burnRateData.slo_id).toBe('slo-1');
+
+    const otherRuleData = getRuleCreatedEventData({
+      ruleId: 'rule-1',
+      pathname: '/create/.es-query',
+      formData: {
+        ruleTypeId: '.es-query',
+        params: { sloId: 'slo-1' },
+        artifacts: undefined,
+      },
+    });
+    expect(otherRuleData.slo_id).toBeUndefined();
+  });
+
+  it('includes dashboard_ids when the rule has linked dashboards', () => {
+    const data = getRuleCreatedEventData({
+      ruleId: 'rule-1',
+      pathname: '/create/.es-query',
+      formData: {
+        ruleTypeId: '.es-query',
+        params: {},
+        artifacts: { dashboards: [{ id: 'dash-1' }, { id: 'dash-2' }] },
+      },
+    });
+
+    expect(data.dashboard_ids).toEqual(['dash-1', 'dash-2']);
+  });
+
+  it('omits dashboard_ids when there are none', () => {
+    const data = getRuleCreatedEventData({
+      ruleId: 'rule-1',
+      pathname: '/create/.es-query',
+      formData: { ruleTypeId: '.es-query', params: {}, artifacts: { dashboards: [] } },
+    });
+
+    expect(data.dashboard_ids).toBeUndefined();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_created_event_data.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_created_event_data.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleCreatedEventData } from '../common/telemetry';
+import type { RuleFormData } from '../types';
+import { SLO_BURN_RATE_RULE_TYPE_ID } from './get_rule_save_ebt_props';
+import { getTemplateIdFromPathname } from './get_template_id_from_pathname';
+
+export interface GetRuleCreatedEventDataParams {
+  ruleId: string;
+  /** Pass `window.location.pathname`; kept as a param so this stays a pure, testable function. */
+  pathname: string;
+  formData: Pick<RuleFormData, 'ruleTypeId' | 'params' | 'artifacts'>;
+}
+
+/**
+ * Builds the payload for the `rule_created` EBT event (see `reportRuleCreatedEvent`), fired once
+ * the create-flow's API call resolves successfully.
+ */
+export function getRuleCreatedEventData({
+  ruleId,
+  pathname,
+  formData,
+}: GetRuleCreatedEventDataParams): RuleCreatedEventData {
+  const sloId =
+    formData.ruleTypeId === SLO_BURN_RATE_RULE_TYPE_ID
+      ? (formData.params as { sloId?: string } | undefined)?.sloId
+      : undefined;
+
+  const dashboardIds = formData.artifacts?.dashboards?.map(({ id }) => id);
+
+  return {
+    rule_id: ruleId,
+    rule_type_id: formData.ruleTypeId!,
+    template_id: getTemplateIdFromPathname(pathname),
+    ...(sloId && { slo_id: sloId }),
+    ...(dashboardIds && dashboardIds.length > 0 && { dashboard_ids: dashboardIds }),
+  };
+}

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_save_ebt_props.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_save_ebt_props.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getRuleSaveEbtProps, SLO_BURN_RATE_RULE_TYPE_ID } from './get_rule_save_ebt_props';
+
+describe('getRuleSaveEbtProps', () => {
+  it('returns bare action/element props when there is nothing to include in the detail', () => {
+    const props = getRuleSaveEbtProps({
+      element: 'rulePageFooterSaveButton',
+      formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined },
+    });
+
+    expect(props).toEqual({
+      'data-ebt-action': 'ruleSave',
+      'data-ebt-element': 'rulePageFooterSaveButton',
+    });
+  });
+
+  it('includes ruleId when provided (edit flow)', () => {
+    const props = getRuleSaveEbtProps({
+      element: 'ruleFlyoutEditFooterSaveButton',
+      ruleId: 'rule-1',
+      formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined },
+    });
+
+    expect(props['data-ebt-detail']).toBeDefined();
+    expect(JSON.parse(props['data-ebt-detail']!)).toEqual({ ruleId: 'rule-1' });
+  });
+
+  it('does not include ruleId when not provided (create flow)', () => {
+    const props = getRuleSaveEbtProps({
+      element: 'ruleFlyoutCreateFooterSaveButton',
+      formData: { ruleTypeId: '.es-query', params: {}, artifacts: undefined },
+    });
+
+    expect(props['data-ebt-detail']).toBeUndefined();
+  });
+
+  it('includes sloId only for burn rate rules', () => {
+    const burnRateProps = getRuleSaveEbtProps({
+      element: 'rulePageFooterSaveButton',
+      formData: {
+        ruleTypeId: SLO_BURN_RATE_RULE_TYPE_ID,
+        params: { sloId: 'slo-1' },
+        artifacts: undefined,
+      },
+    });
+    expect(JSON.parse(burnRateProps['data-ebt-detail']!)).toEqual({ sloId: 'slo-1' });
+
+    const otherRuleProps = getRuleSaveEbtProps({
+      element: 'rulePageFooterSaveButton',
+      formData: {
+        ruleTypeId: '.es-query',
+        params: { sloId: 'slo-1' },
+        artifacts: undefined,
+      },
+    });
+    expect(otherRuleProps['data-ebt-detail']).toBeUndefined();
+  });
+
+  it('includes dashboardIds when the rule has linked dashboards', () => {
+    const props = getRuleSaveEbtProps({
+      element: 'rulePageFooterSaveButton',
+      formData: {
+        ruleTypeId: '.es-query',
+        params: {},
+        artifacts: { dashboards: [{ id: 'dash-1' }, { id: 'dash-2' }] },
+      },
+    });
+
+    expect(JSON.parse(props['data-ebt-detail']!)).toEqual({
+      dashboardIds: ['dash-1', 'dash-2'],
+    });
+  });
+
+  it('omits dashboardIds when the dashboards array is empty', () => {
+    const props = getRuleSaveEbtProps({
+      element: 'rulePageFooterSaveButton',
+      formData: {
+        ruleTypeId: '.es-query',
+        params: {},
+        artifacts: { dashboards: [] },
+      },
+    });
+
+    expect(props['data-ebt-detail']).toBeUndefined();
+  });
+
+  it('combines ruleId, sloId, and dashboardIds when all are present', () => {
+    const props = getRuleSaveEbtProps({
+      element: 'ruleFlyoutEditFooterSaveButton',
+      ruleId: 'rule-1',
+      formData: {
+        ruleTypeId: SLO_BURN_RATE_RULE_TYPE_ID,
+        params: { sloId: 'slo-1' },
+        artifacts: { dashboards: [{ id: 'dash-1' }] },
+      },
+    });
+
+    expect(JSON.parse(props['data-ebt-detail']!)).toEqual({
+      ruleId: 'rule-1',
+      sloId: 'slo-1',
+      dashboardIds: ['dash-1'],
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_save_ebt_props.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_rule_save_ebt_props.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getEbtProps } from '@kbn/ebt-click';
+import type { RuleFormData } from '../types';
+
+/**
+ * `data-ebt-action` value shared by every rule save button (page footer, create flyout
+ * footer, edit flyout footer). Kept consistent so the three surfaces are queryable together.
+ */
+export const RULE_SAVE_EBT_ACTION = 'ruleSave';
+
+/**
+ * Rule type id for the SLO burn rate rule. Hardcoded here (rather than imported from the SLO
+ * plugin) because `rule_form` is a rule-type-agnostic package and must not depend on any
+ * particular rule type's plugin.
+ */
+export const SLO_BURN_RATE_RULE_TYPE_ID = 'slo.rules.burnRate';
+
+export interface GetRuleSaveEbtPropsParams {
+  /** `data-ebt-element` value, unique per save button surface. */
+  element: string;
+  /** The rule's id, only known/relevant for the edit flow. */
+  ruleId?: string;
+  formData: Pick<RuleFormData, 'ruleTypeId' | 'params' | 'artifacts'>;
+}
+
+/**
+ * Builds the `data-ebt-*` props for a rule save button, so that clicking it is captured by
+ * core's generic `click` EBT tracker with useful, synchronously-available context:
+ * - `ruleId`, when editing an existing rule (not available yet at click-time when creating).
+ * - `sloId`, for SLO burn rate rules only (the rule type that requires it).
+ * - `dashboardIds`, when the rule has been linked to one or more dashboards via artifacts.
+ */
+export function getRuleSaveEbtProps({ element, ruleId, formData }: GetRuleSaveEbtPropsParams) {
+  const detail: Record<string, unknown> = {};
+
+  if (ruleId) {
+    detail.ruleId = ruleId;
+  }
+
+  if (formData.ruleTypeId === SLO_BURN_RATE_RULE_TYPE_ID) {
+    const sloId = (formData.params as { sloId?: string } | undefined)?.sloId;
+    if (typeof sloId === 'string' && sloId.length > 0) {
+      detail.sloId = sloId;
+    }
+  }
+
+  const dashboardIds = formData.artifacts?.dashboards?.map(({ id }) => id);
+  if (dashboardIds && dashboardIds.length > 0) {
+    detail.dashboardIds = dashboardIds;
+  }
+
+  return getEbtProps({
+    action: RULE_SAVE_EBT_ACTION,
+    element,
+    ...(Object.keys(detail).length > 0 ? { detail: JSON.stringify(detail) } : {}),
+  });
+}

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_template_id_from_pathname.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_template_id_from_pathname.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getTemplateIdFromPathname } from './get_template_id_from_pathname';
+
+describe('getTemplateIdFromPathname', () => {
+  it('extracts the template id from a create-from-template path', () => {
+    expect(
+      getTemplateIdFromPathname(
+        '/app/management/insightsAndAlerting/triggersActions/create/template/my-template-id'
+      )
+    ).toBe('my-template-id');
+  });
+
+  it('decodes url-encoded template ids', () => {
+    expect(getTemplateIdFromPathname('/create/template/my%20template')).toBe('my template');
+  });
+
+  it('returns undefined when the path has no template segment', () => {
+    expect(
+      getTemplateIdFromPathname(
+        '/app/management/insightsAndAlerting/triggersActions/create/.es-query'
+      )
+    ).toBeUndefined();
+  });
+
+  it('stops at query params or hash', () => {
+    expect(getTemplateIdFromPathname('/create/template/my-template-id?foo=bar')).toBe(
+      'my-template-id'
+    );
+    expect(getTemplateIdFromPathname('/create/template/my-template-id#section')).toBe(
+      'my-template-id'
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_template_id_from_pathname.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/get_template_id_from_pathname.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const CREATE_FROM_TEMPLATE_PATH_REGEX = /\/create\/template\/([^/?#]+)/;
+
+/**
+ * Parses the template id out of a rule creation pathname, e.g.
+ * `/app/management/insightsAndAlerting/triggersActions/create/template/my-template-id` ->
+ * `my-template-id`. Returns `undefined` when the rule wasn't created from a template.
+ */
+export function getTemplateIdFromPathname(pathname: string): string | undefined {
+  const match = pathname.match(CREATE_FROM_TEMPLATE_PATH_REGEX);
+  if (!match) {
+    return undefined;
+  }
+  return decodeURIComponent(match[1]);
+}

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/utils/index.ts
@@ -16,3 +16,6 @@ export * from './has_alerts_fields';
 export * from './get_selected_action_group';
 export * from './get_initial_consumer';
 export * from './get_default_params';
+export * from './get_rule_save_ebt_props';
+export * from './get_rule_created_event_data';
+export * from './get_template_id_from_pathname';

--- a/x-pack/platform/packages/shared/response-ops/rule_form/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/tsconfig.json
@@ -39,5 +39,7 @@
     "@kbn/react-hooks",
     "@kbn/response-ops-rules-apis",
     "@kbn/cps",
+    "@kbn/ebt-click",
+    "@kbn/core-analytics-browser",
   ]
 }

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/index.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  RULE_ENGAGEMENT_EVENT_TYPE,
+  registerRuleEngagementEventType,
+  reportRuleEngagementEvent,
+  type RuleEngagementAction,
+  type RuleEngagementEventData,
+} from './rule_engagement_event';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.test.ts
@@ -22,7 +22,7 @@ describe('rule_engagement_event', () => {
     );
   });
 
-  test.each(['edit', 'snooze', 'mute', 'disable', 'delete', 'clone'] as const)(
+  test.each(['edit', 'snooze', 'mute', 'disable', 'enable', 'delete', 'clone'] as const)(
     'reportRuleEngagementEvent reports a %s action',
     (action) => {
       const reportEvent = jest.fn();

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  RULE_ENGAGEMENT_EVENT_TYPE,
+  registerRuleEngagementEventType,
+  reportRuleEngagementEvent,
+} from './rule_engagement_event';
+
+describe('rule_engagement_event', () => {
+  test('registerRuleEngagementEventType registers the rule_engagement_action event type', () => {
+    const registerEventType = jest.fn();
+
+    registerRuleEngagementEventType({ registerEventType } as never);
+
+    expect(registerEventType).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: RULE_ENGAGEMENT_EVENT_TYPE })
+    );
+  });
+
+  test.each(['edit', 'snooze', 'mute', 'disable', 'delete', 'clone'] as const)(
+    'reportRuleEngagementEvent reports a %s action',
+    (action) => {
+      const reportEvent = jest.fn();
+
+      reportRuleEngagementEvent(
+        { reportEvent },
+        { action, rule_id: 'rule-1', rule_type_id: '.es-query' }
+      );
+
+      expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+        action,
+        rule_id: 'rule-1',
+        rule_type_id: '.es-query',
+      });
+    }
+  );
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AnalyticsServiceSetup,
+  AnalyticsServiceStart,
+  EventTypeOpts,
+  RootSchema,
+} from '@kbn/core-analytics-browser';
+
+/**
+ * A single shared EBT event for the rules list row actions (edit, snooze, mute, disable,
+ * delete, clone), distinguished by the `action` field. None of these currently have any
+ * telemetry -- there's a security audit log (`ruleAuditEvent` in the alerting plugin) but
+ * that's unrelated ECS audit logging, not EBT.
+ *
+ * These are click/intent signals, fired when the user triggers the action from the UI --
+ * not "the action definitely completed" signals (e.g. clicking "Delete" and then cancelling
+ * the confirmation modal still reports a `delete` engagement event). This mirrors how the
+ * generic core `click` EBT tracker already behaves for un-instrumented buttons.
+ */
+export const RULE_ENGAGEMENT_EVENT_TYPE = 'rule_engagement_action';
+
+export type RuleEngagementAction = 'edit' | 'snooze' | 'mute' | 'disable' | 'delete' | 'clone';
+
+export interface RuleEngagementEventData {
+  action: RuleEngagementAction;
+  rule_id: string;
+  rule_type_id: string;
+}
+
+const schema: RootSchema<RuleEngagementEventData> = {
+  action: {
+    type: 'keyword',
+    _meta: {
+      description: 'The rules list row action the user triggered.',
+    },
+  },
+  rule_id: {
+    type: 'keyword',
+    _meta: {
+      description: 'The id of the rule the action was triggered on.',
+    },
+  },
+  rule_type_id: {
+    type: 'keyword',
+    _meta: {
+      description: 'The rule type id of the rule the action was triggered on.',
+    },
+  },
+};
+
+const eventTypeOpts: EventTypeOpts<RuleEngagementEventData> = {
+  eventType: RULE_ENGAGEMENT_EVENT_TYPE,
+  schema,
+};
+
+/** Call once, from the plugin's `setup()`, before any `reportRuleEngagementEvent` calls. */
+export function registerRuleEngagementEventType(analytics: AnalyticsServiceSetup) {
+  analytics.registerEventType(eventTypeOpts);
+}
+
+export function reportRuleEngagementEvent(
+  analytics: Pick<AnalyticsServiceStart, 'reportEvent'>,
+  data: RuleEngagementEventData
+) {
+  analytics.reportEvent(RULE_ENGAGEMENT_EVENT_TYPE, data);
+}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/telemetry/rule_engagement_event.ts
@@ -25,7 +25,14 @@ import type {
  */
 export const RULE_ENGAGEMENT_EVENT_TYPE = 'rule_engagement_action';
 
-export type RuleEngagementAction = 'edit' | 'snooze' | 'mute' | 'disable' | 'delete' | 'clone';
+export type RuleEngagementAction =
+  | 'edit'
+  | 'snooze'
+  | 'mute'
+  | 'disable'
+  | 'enable'
+  | 'delete'
+  | 'clone';
 
 export interface RuleEngagementEventData {
   action: RuleEngagementAction;

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/with_bulk_rule_api_operations.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/with_bulk_rule_api_operations.test.tsx
@@ -14,6 +14,7 @@ import { withBulkRuleOperations } from './with_bulk_rule_api_operations';
 import type { SortField } from '../../../lib/rule_api/load_execution_log_aggregations';
 import type { Rule } from '../../../../types';
 import { useKibana } from '../../../../common/lib/kibana';
+import { RULE_ENGAGEMENT_EVENT_TYPE } from '../../../lib/telemetry';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../lib/rule_api/load_execution_log_aggregations', () => ({
@@ -128,6 +129,39 @@ describe('with_bulk_rule_api_operations', () => {
 
     expect(muteRule).toHaveBeenCalledTimes(1);
     expect(muteRule).toHaveBeenCalledWith({ id: rule.id, http });
+  });
+
+  it('muteRule reports a rule_engagement_action mute event when the rule is not already muted', async () => {
+    const { analytics } = useKibanaMock().services;
+    const user = userEvent.setup();
+    const ComponentToExtend = invoker('muteRule', (p) => p.rule);
+
+    const ExtendedComponent = withBulkRuleOperations(ComponentToExtend);
+    const rule = mockRule({ muteAll: false });
+    render(<ExtendedComponent rule={rule} />);
+    await user.click(screen.getByRole('button', { name: /call api/i }));
+
+    expect(analytics.reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+      action: 'mute',
+      rule_id: rule.id,
+      rule_type_id: rule.ruleTypeId,
+    });
+  });
+
+  it('muteRule does not report an event when the rule is already muted', async () => {
+    const { analytics } = useKibanaMock().services;
+    const user = userEvent.setup();
+    const ComponentToExtend = invoker('muteRule', (p) => p.rule);
+
+    const ExtendedComponent = withBulkRuleOperations(ComponentToExtend);
+    const rule = mockRule({ muteAll: true });
+    render(<ExtendedComponent rule={rule} />);
+    await user.click(screen.getByRole('button', { name: /call api/i }));
+
+    expect(analytics.reportEvent).not.toHaveBeenCalledWith(
+      RULE_ENGAGEMENT_EVENT_TYPE,
+      expect.anything()
+    );
   });
 
   it('unmuteRule calls the unmuteRule api', async () => {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/with_bulk_rule_api_operations.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/with_bulk_rule_api_operations.tsx
@@ -59,6 +59,7 @@ import { bulkEnableRules } from '../../../lib/rule_api/bulk_enable';
 import { bulkDisableRules } from '../../../lib/rule_api/bulk_disable';
 
 import { useKibana } from '../../../../common/lib/kibana';
+import { reportRuleEngagementEvent } from '../../../lib/telemetry';
 
 export interface ComponentOpts {
   muteRules: (rules: Rule[]) => Promise<void>;
@@ -102,7 +103,7 @@ export function withBulkRuleOperations<T>(
   WrappedComponent: React.ComponentType<T & ComponentOpts>
 ): React.FunctionComponent<PropsWithOptionalApiHandlers<T>> {
   return (props: PropsWithOptionalApiHandlers<T>) => {
-    const { http } = useKibana().services;
+    const { http, analytics } = useKibana().services;
     return (
       <WrappedComponent
         {...(props as T)}
@@ -117,6 +118,11 @@ export function withBulkRuleOperations<T>(
         }
         muteRule={async (rule: Rule) => {
           if (!isRuleMuted(rule)) {
+            reportRuleEngagementEvent(analytics, {
+              action: 'mute',
+              rule_id: rule.id,
+              rule_type_id: rule.ruleTypeId,
+            });
             return await muteRule({ http, id: rule.id });
           }
         }}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.test.tsx
@@ -8,7 +8,10 @@ import * as React from 'react';
 import moment from 'moment';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
+import {
+  waitForEuiPopoverOpen,
+  waitForEuiContextMenuPanelTransition,
+} from '@elastic/eui/lib/test/rtl';
 import { CollapsedItemActions } from './collapsed_item_actions';
 import { ruleTypeRegistryMock } from '../../../rule_type_registry.mock';
 import type { RuleTableItem, RuleTypeModel } from '../../../../types';
@@ -471,7 +474,6 @@ describe('CollapsedItemActions', () => {
     });
 
     describe('rule_engagement_action telemetry', () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       const reportEvent = useKibana().services.analytics.reportEvent as jest.Mock;
 
       afterEach(() => {
@@ -544,6 +546,7 @@ describe('CollapsedItemActions', () => {
         await waitForEuiPopoverOpen();
 
         await userEvent.click(screen.getByTestId('snoozeButton'));
+        await waitForEuiContextMenuPanelTransition();
 
         // One of the "commonly used" quick-snooze links; avoids depending on the default
         // value of the custom interval input.

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.test.tsx
@@ -539,6 +539,23 @@ describe('CollapsedItemActions', () => {
         });
       });
 
+      test('reports an enable action when enable is clicked', async () => {
+        render(<CollapsedItemActions {...getPropsWithRule({ enabled: false })} />);
+
+        await userEvent.click(screen.getByTestId('selectActionButton'));
+        await waitForEuiPopoverOpen();
+
+        await userEvent.click(screen.getByTestId('disableButton'));
+
+        await waitFor(() => {
+          expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+            action: 'enable',
+            rule_id: '1',
+            rule_type_id: 'test_rule_type',
+          });
+        });
+      });
+
       test('reports a snooze action when a snooze schedule is applied', async () => {
         render(<CollapsedItemActions {...getPropsWithRule()} />);
 

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.test.tsx
@@ -13,6 +13,7 @@ import { CollapsedItemActions } from './collapsed_item_actions';
 import { ruleTypeRegistryMock } from '../../../rule_type_registry.mock';
 import type { RuleTableItem, RuleTypeModel } from '../../../../types';
 import { useKibana } from '../../../../common/lib/kibana';
+import { RULE_ENGAGEMENT_EVENT_TYPE } from '../../../lib/telemetry';
 jest.mock('../../../../common/lib/kibana');
 
 const onRuleChanged = jest.fn();
@@ -467,6 +468,95 @@ describe('CollapsedItemActions', () => {
 
       await userEvent.click(screen.getByTestId('cloneRule'));
       expect(onCloneRule).toHaveBeenCalled();
+    });
+
+    describe('rule_engagement_action telemetry', () => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const reportEvent = useKibana().services.analytics.reportEvent as jest.Mock;
+
+      afterEach(() => {
+        reportEvent.mockClear();
+      });
+
+      test('reports an edit action when edit rule is clicked', async () => {
+        render(<CollapsedItemActions {...getPropsWithRule()} />);
+
+        await userEvent.click(screen.getByTestId('selectActionButton'));
+        await waitForEuiPopoverOpen();
+
+        await userEvent.click(screen.getByTestId('editRule'));
+        expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+          action: 'edit',
+          rule_id: '1',
+          rule_type_id: 'test_rule_type',
+        });
+      });
+
+      test('reports a delete action when delete rule is clicked', async () => {
+        render(<CollapsedItemActions {...getPropsWithRule()} />);
+
+        await userEvent.click(screen.getByTestId('selectActionButton'));
+        await waitForEuiPopoverOpen();
+
+        await userEvent.click(screen.getByTestId('deleteRule'));
+        expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+          action: 'delete',
+          rule_id: '1',
+          rule_type_id: 'test_rule_type',
+        });
+      });
+
+      test('reports a clone action when clone rule is clicked', async () => {
+        render(<CollapsedItemActions {...getPropsWithRule()} />);
+
+        await userEvent.click(screen.getByTestId('selectActionButton'));
+        await waitForEuiPopoverOpen();
+
+        await userEvent.click(screen.getByTestId('cloneRule'));
+        expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+          action: 'clone',
+          rule_id: '1',
+          rule_type_id: 'test_rule_type',
+        });
+      });
+
+      test('reports a disable action when disable is confirmed', async () => {
+        render(<CollapsedItemActions {...getPropsWithRule({ autoRecoverAlerts: false })} />);
+
+        await userEvent.click(screen.getByTestId('selectActionButton'));
+        await waitForEuiPopoverOpen();
+
+        await userEvent.click(screen.getByTestId('disableButton'));
+
+        await waitFor(() => {
+          expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+            action: 'disable',
+            rule_id: '1',
+            rule_type_id: 'test_rule_type',
+          });
+        });
+      });
+
+      test('reports a snooze action when a snooze schedule is applied', async () => {
+        render(<CollapsedItemActions {...getPropsWithRule()} />);
+
+        await userEvent.click(screen.getByTestId('selectActionButton'));
+        await waitForEuiPopoverOpen();
+
+        await userEvent.click(screen.getByTestId('snoozeButton'));
+
+        // One of the "commonly used" quick-snooze links; avoids depending on the default
+        // value of the custom interval input.
+        await userEvent.click(await screen.findByTestId('linkSnooze1h'));
+
+        await waitFor(() => {
+          expect(reportEvent).toHaveBeenCalledWith(RULE_ENGAGEMENT_EVENT_TYPE, {
+            action: 'snooze',
+            rule_id: '1',
+            rule_type_id: 'test_rule_type',
+          });
+        });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.tsx
@@ -192,13 +192,18 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
   }, []);
 
   const onEnable = useCallback(async () => {
+    reportRuleEngagementEvent(analytics, {
+      action: 'enable',
+      rule_id: item.id,
+      rule_type_id: item.ruleTypeId,
+    });
     asyncScheduler.schedule(async () => {
       await bulkEnableRules({ ids: [item.id] });
       onRuleChanged();
     }, 10);
     setIsDisabled(false);
     setIsPopoverOpen(false);
-  }, [bulkEnableRules, onRuleChanged, item.id]);
+  }, [bulkEnableRules, onRuleChanged, item.id, item.ruleTypeId, analytics]);
 
   const onDisable = useCallback(
     async (untrack: boolean) => {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/collapsed_item_actions.tsx
@@ -35,6 +35,7 @@ import {
   UNSNOOZE_SUCCESS_MESSAGE,
 } from './notify_badge';
 import { UntrackAlertsModal } from '../../common/components/untrack_alerts_modal';
+import { reportRuleEngagementEvent } from '../../../lib/telemetry';
 
 export type ComponentOpts = {
   item: RuleTableItem;
@@ -67,6 +68,7 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
   const {
     ruleTypeRegistry,
     notifications: { toasts },
+    analytics,
   } = useKibana().services;
 
   const { euiTheme } = useEuiTheme();
@@ -91,6 +93,11 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
 
   const snoozeRuleInternal = useCallback(
     async (snoozeSchedule: SnoozeSchedule) => {
+      reportRuleEngagementEvent(analytics, {
+        action: 'snooze',
+        rule_id: item.id,
+        rule_type_id: item.ruleTypeId,
+      });
       try {
         onLoading(true);
         await snoozeRule(item, snoozeSchedule);
@@ -104,7 +111,7 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
       }
       await snoozeRule(item, snoozeSchedule);
     },
-    [onLoading, snoozeRule, item, onRuleChanged, toasts, onClose]
+    [onLoading, snoozeRule, item, onRuleChanged, toasts, onClose, analytics]
   );
 
   const unsnoozeRuleInternal = useCallback(
@@ -195,13 +202,18 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
 
   const onDisable = useCallback(
     async (untrack: boolean) => {
+      reportRuleEngagementEvent(analytics, {
+        action: 'disable',
+        rule_id: item.id,
+        rule_type_id: item.ruleTypeId,
+      });
       onDisableModalClose();
       await bulkDisableRules({ ids: [item.id], untrack });
       onRuleChanged();
       setIsDisabled(true);
       setIsPopoverOpen(false);
     },
-    [onDisableModalClose, bulkDisableRules, onRuleChanged, item.id]
+    [onDisableModalClose, bulkDisableRules, onRuleChanged, item.id, item.ruleTypeId, analytics]
   );
 
   const onDisableClick = useCallback(() => {
@@ -268,6 +280,11 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
               'data-test-subj': 'cloneRule',
               onClick: async () => {
                 setIsPopoverOpen(!isPopoverOpen);
+                reportRuleEngagementEvent(analytics, {
+                  action: 'clone',
+                  rule_id: item.id,
+                  rule_type_id: item.ruleTypeId,
+                });
                 onCloneRule(item.id);
               },
               name: i18n.translate(
@@ -280,6 +297,11 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
               'data-test-subj': 'editRule',
               onClick: () => {
                 setIsPopoverOpen(!isPopoverOpen);
+                reportRuleEngagementEvent(analytics, {
+                  action: 'edit',
+                  rule_id: item.id,
+                  rule_type_id: item.ruleTypeId,
+                });
                 onEditRule(item);
               },
               name: i18n.translate(
@@ -306,6 +328,11 @@ export const CollapsedItemActions: React.FunctionComponent<ComponentOpts> = ({
               'data-test-subj': 'deleteRule',
               onClick: () => {
                 setIsPopoverOpen(!isPopoverOpen);
+                reportRuleEngagementEvent(analytics, {
+                  action: 'delete',
+                  rule_id: item.id,
+                  rule_type_id: item.ruleTypeId,
+                });
                 onDeleteRule(item);
               },
               name: i18n.translate(

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
@@ -47,10 +47,12 @@ import { ON_OPEN_PANEL_MENU, ALERT_RULE_TRIGGER } from '@kbn/ui-actions-plugin/c
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { CPSPluginStart } from '@kbn/cps/public';
 import type { Start as InspectorStart } from '@kbn/inspector-plugin/public';
+import { registerRuleCreatedEventType } from '@kbn/response-ops-rule-form';
 import { RuleDetailsLocatorDefinition } from './locators/rule_details';
 import { RulesLocatorDefinition } from './locators/rules';
 import type { Rule, RuleUiAction } from './types';
 import type { AlertsSearchBarProps } from './application/sections/alerts_search_bar';
+import { registerRuleEngagementEventType } from './application/lib/telemetry';
 
 import { getAddConnectorFlyoutLazy } from './common/get_add_connector_flyout';
 import { getAddConnectorFormLazy } from './common/get_add_connector_form';
@@ -237,6 +239,14 @@ export class Plugin
     };
 
     ExperimentalFeaturesService.init({ experimentalFeatures: this.experimentalFeatures });
+
+    // Rule save/creation click attributes are reported via the core `click` EBT tracker
+    // (see `@kbn/ebt-click`'s `getEbtProps`) and need no registration. These two are bespoke
+    // events that do need it: `rule_created` (fired on create-flow save success, once the new
+    // rule's id is known) and `rule_engagement_action` (fired for the rules list row actions --
+    // edit, snooze, mute, disable, delete, clone).
+    registerRuleCreatedEventType(core.analytics);
+    registerRuleEngagementEventType(core.analytics);
 
     plugins.share.url.locators.create(new RulesLocatorDefinition());
     plugins.share.url.locators.create(new RuleDetailsLocatorDefinition());

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
@@ -13,6 +13,7 @@
   ],
   "kbn_references": [
     "@kbn/core",
+    "@kbn/core-analytics-browser",
     "@kbn/human-readable-id",
     "@kbn/alerting-plugin",
     "@kbn/features-plugin",


### PR DESCRIPTION
## Summary

Resolves the response-ops half of #275023, which asks for telemetry to measure alert/SLO template adoption by linking rule saves back to the template they came from, plus engagement signals on existing rules. This is 1 of 2 companion PRs -- the actionable-obs team is covering the SLO-specific side separately (#276779).

There was no existing "save-confirm" EBT event for rules to extend: the save buttons (`rulePageFooterSaveButton` / `ruleFlyoutFooterSaveButton`) are plain EUI buttons picked up only by core's generic `click` EBT tracker, which just records whatever `data-*` attributes are present on the clicked element and its ancestors. This PR adds real instrumentation on top of that, using the already-merged `@kbn/ebt-click` package (`getEbtProps()`) plus two new bespoke EBT events. No core code is modified.

### 1. Save-time click attributes

Spread `getEbtProps({ action: 'ruleSave', element, detail })` onto the three rule save buttons (`rule_page_footer.tsx`, `rule_flyout_create_footer.tsx`, `rule_flyout_edit_footer.tsx`). `detail` is a JSON string containing whatever of the following is synchronously available at click time:
- `ruleId` -- edit flow only (not available yet during create).
- `sloId` -- both flows, only for `slo.rules.burnRate` rules, from `params.sloId`.
- `dashboardIds` -- both flows, from `artifacts.dashboards[].id`.

### 2. New `rule_created` event

**Deliberately promoted to a real event instead of a plain click attribute.** During create, the rule's id doesn't exist yet at click-time -- it's only returned once the create API call resolves. So this is a genuine `core.analytics.registerEventType` + `reportEvent` event, fired once from `CreateRuleForm`'s mutation `onSuccess`, after the POST resolves:
- `rule_id`, `rule_type_id` (required)
- `template_id` -- parsed from `window.location.pathname` (`/create/template/{template_id}`), when created from a template
- `slo_id`, `dashboard_ids` -- same conditions as above

Registered in `triggers_actions_ui`'s `plugin.ts#setup()`, the primary place `CreateRuleForm` is mounted (`/app/rules` create/edit route). The event schema/report helper live in `@kbn/response-ops-rule-form` so other consuming plugins can register it too if they want create-flow telemetry from their own entry point.

### 3. New `rule_engagement_action` event

None of the rules list row actions had any telemetry (the audit log via `ruleAuditEvent` is unrelated ECS audit logging, not EBT). Added a single shared event, distinguished by an `action` field, covering **7** actions: edit, snooze, mute, disable, **enable**, delete, clone. These are click/intent signals (fired when the user triggers the action), not "definitely completed" signals -- e.g. clicking delete and then cancelling the confirmation still reports the event, mirroring how the generic click tracker already behaves.

Wired at `collapsed_item_actions.tsx` (edit/snooze/disable/enable/delete/clone, where the full rule item with `ruleTypeId` is in scope) and in `with_bulk_rule_api_operations.tsx`'s `muteRule` wrapper (mute -- currently unused by any live UI trigger in this plugin, but instrumented at the API-wrapper level so it's covered wherever/whenever it's wired up).

**Why "enable" was added (not in the original issue ask):** Fleet's package installer auto-creates rules from `alerting_rule_template` assets server-side, **disabled**, with zero UI/telemetry signal, whenever an integration package is installed. For that path -- likely the dominant way customers get template-driven rules -- creation already happened invisibly; the real adoption signal is someone going to the rules list and enabling it. Flagging this explicitly since it's outside the issue's literal scope but was decided necessary while scoping.

## Open questions carried over from scoping (not blocking this PR)

- **Backport target**: the issue asks for "as far back as possible, from 9.2 is okay." Main is on 9.5.0 -- 3 already-released minors back. New telemetry doesn't typically backport the way bug fixes do; flagging for discussion with the issue author rather than assuming a 9.2 floor.
- A separate, larger follow-up is being proposed (not in this PR): persisting `template_id` as a durable field on the rule saved object for the interactive create-from-template flow. Fleet-installed rules already get this for free via their deterministic id (`fleet-{spaceId}-{pkgName}-{templateId}`) -- no code needed there.

## Verification

Ran locally (bootstrapped this worktree, node 24 + `yarn kbn bootstrap`):
- `node scripts/eslint` on all touched files -- clean.
- `node scripts/jest` for all touched/new test files across `@kbn/response-ops-rule-form` and `triggers_actions_ui` -- all passing.
- Did **not** run the full repo-wide type-check or test suite given time constraints; relying on CI for full coverage.

## Test plan
- [ ] CI green (lint, type-check, full jest)
- [ ] Manually verify `data-ebt-action`/`data-ebt-element`/`data-ebt-detail` attributes render on the three save buttons
- [ ] Manually verify `rule_created` and `rule_engagement_action` fire (e.g. via `ebt-kibana-browser` local telemetry log) for create, edit, snooze, disable, enable, delete, clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
