### PR TITLE
[9.3] Fix AB workflow read permissions (#275623)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/kibana.jsonc
@@ -11,7 +11,7 @@
     "configPath": ["xpack", "agentBuilderPlatform"],
     "requiredPlugins": ["onechat"],
     "requiredBundles": [],
-    "optionalPlugins": ["cases", "llmTasks", "workflowsManagement"],
+    "optionalPlugins": ["cases", "llmTasks", "workflowsManagement", "security"],
     "extraPublicDirs": []
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
@@ -40,6 +40,8 @@ dependsOn:
   - '@kbn/spaces-plugin'
   - '@kbn/core-http-server-mocks'
   - '@kbn/core-ui-settings-server-mocks'
+  - '@kbn/security-plugin-types-server'
+  - '@kbn/workflows'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
@@ -7,6 +7,7 @@
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 import type { PluginConfig } from './config';
 import type {
   PluginSetupDependencies,
@@ -30,6 +31,7 @@ export class AgentBuilderPlatformPlugin
   private logger: Logger;
   // @ts-expect-error unused for now
   private config: OnechatConfig;
+  private security?: SecurityPluginStart;
 
   constructor(context: PluginInitializerContext<PluginConfig>) {
     this.logger = context.logger.get();
@@ -43,6 +45,7 @@ export class AgentBuilderPlatformPlugin
     registerTools({
       coreSetup,
       setupDeps,
+      getSecurity: () => this.security,
     });
     registerAttachmentTypes({
       coreSetup,
@@ -53,6 +56,7 @@ export class AgentBuilderPlatformPlugin
   }
 
   start(coreStart: CoreStart, startDeps: PluginStartDependencies): AgentBuilderPlatformPluginStart {
+    this.security = startDeps.security;
     return {};
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_workflow_execution_status.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_workflow_execution_status.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import { ExecutionStatus } from '@kbn/workflows';
+import { platformCoreTools } from '@kbn/onechat-common';
+import { getWorkflowExecutionStatusTool } from './get_workflow_execution_status';
+
+jest.mock('@kbn/onechat-genai-utils/tools/utils/workflows', () => ({
+  getExecutionState: jest.fn(),
+}));
+
+const { getExecutionState } = jest.requireMock('@kbn/onechat-genai-utils/tools/utils/workflows');
+
+const createWorkflowsManagement = () => ({
+  management: {
+    getWorkflowExecution: jest.fn(),
+  },
+});
+
+const createSecurity = (hasAllRequested = true) => ({
+  authz: {
+    actions: { api: { get: jest.fn((priv: string) => `api:${priv}`) } },
+    checkPrivilegesWithRequest: jest.fn().mockReturnValue({
+      atSpace: jest.fn().mockResolvedValue({ hasAllRequested }),
+    }),
+  },
+});
+
+const buildTool = (wm: ReturnType<typeof createWorkflowsManagement>, hasAllRequested = true) =>
+  getWorkflowExecutionStatusTool({
+    workflowsManagement: wm as any,
+    getSecurity: () => createSecurity(hasAllRequested) as any,
+  });
+
+const mockContext = {
+  spaceId: 'default',
+  request: {} as KibanaRequest,
+};
+
+describe('getWorkflowExecutionStatusTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should have the correct tool id', () => {
+    const tool = buildTool(createWorkflowsManagement());
+    expect(tool.id).toBe(platformCoreTools.getWorkflowExecutionStatus);
+  });
+
+  it('should return the execution state when the caller has readExecution', async () => {
+    const tool = buildTool(createWorkflowsManagement());
+    const execution = {
+      execution_id: 'exec-1',
+      status: ExecutionStatus.COMPLETED,
+      output: { secret_value: 'CANARY' },
+    };
+    getExecutionState.mockResolvedValue(execution);
+
+    const result = await tool.handler({ executionId: 'exec-1' }, mockContext as any);
+
+    expect(result).toEqual({ results: [{ type: 'other', data: { execution } }] });
+  });
+
+  it('should not read the execution and return not-found when the caller lacks readExecution', async () => {
+    const tool = buildTool(createWorkflowsManagement(), false);
+
+    const result = await tool.handler({ executionId: 'exec-1' }, mockContext as any);
+
+    expect(getExecutionState).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      results: [
+        {
+          type: 'error',
+          data: { message: "Workflow execution with ID 'exec-1' not found." },
+        },
+      ],
+    });
+  });
+
+  it('should return not-found when the execution does not exist', async () => {
+    const tool = buildTool(createWorkflowsManagement());
+    getExecutionState.mockResolvedValue(null);
+
+    const result = await tool.handler({ executionId: 'missing' }, mockContext as any);
+
+    expect(result).toEqual({
+      results: [
+        {
+          type: 'error',
+          data: { message: "Workflow execution with ID 'missing' not found." },
+        },
+      ],
+    });
+  });
+
+  it('should return an error result when the API throws', async () => {
+    const tool = buildTool(createWorkflowsManagement());
+    getExecutionState.mockRejectedValue(new Error('ES unavailable'));
+
+    const result = await tool.handler({ executionId: 'exec-1' }, mockContext as any);
+
+    expect(result).toEqual({
+      results: [
+        {
+          type: 'error',
+          data: { message: 'Failed to retrieve workflow execution status: ES unavailable' },
+        },
+      ],
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_workflow_execution_status.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_workflow_execution_status.ts
@@ -7,11 +7,13 @@
 
 import { z } from '@kbn/zod';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 import { platformCoreTools, ToolType } from '@kbn/onechat-common';
 import type { BuiltinToolDefinition } from '@kbn/onechat-server';
 import { cleanPrompt } from '@kbn/onechat-genai-utils/prompts';
 import { getExecutionState } from '@kbn/onechat-genai-utils/tools/utils/workflows';
 import { errorResult, otherResult } from '@kbn/onechat-genai-utils/tools/utils/results';
+import { hasWorkflowExecutionReadPrivilege } from './utils/check_execution_read_privilege';
 
 const getWorkflowExecutionStatusSchema = z.object({
   executionId: z
@@ -21,8 +23,10 @@ const getWorkflowExecutionStatusSchema = z.object({
 
 export const getWorkflowExecutionStatusTool = ({
   workflowsManagement,
+  getSecurity,
 }: {
   workflowsManagement: WorkflowsServerPluginSetup;
+  getSecurity: () => SecurityPluginStart | undefined;
 }): BuiltinToolDefinition<typeof getWorkflowExecutionStatusSchema> => {
   const { management: workflowApi } = workflowsManagement;
 
@@ -37,20 +41,38 @@ export const getWorkflowExecutionStatusTool = ({
     Instead, if the workflow didn't complete, tell the user they can ask you to check the execution.
     `),
     schema: getWorkflowExecutionStatusSchema,
-    handler: async ({ executionId }, { spaceId }) => {
-      const execution = await getExecutionState({
-        executionId,
-        spaceId,
-        workflowApi,
-      });
+    handler: async ({ executionId }, { spaceId, request }) => {
+      try {
+        const authorized = await hasWorkflowExecutionReadPrivilege({
+          getSecurity,
+          request,
+          spaceId,
+        });
+        if (!authorized) {
+          return {
+            results: [errorResult(`Workflow execution with ID '${executionId}' not found.`)],
+          };
+        }
 
-      if (execution) {
+        const execution = await getExecutionState({
+          executionId,
+          spaceId,
+          workflowApi,
+        });
+
+        if (execution) {
+          return {
+            results: [otherResult({ execution })],
+          };
+        } else {
+          return {
+            results: [errorResult(`Workflow execution with ID '${executionId}' not found.`)],
+          };
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
         return {
-          results: [otherResult({ execution })],
-        };
-      } else {
-        return {
-          results: [errorResult(`Workflow execution with ID '${executionId}' not found.`)],
+          results: [errorResult(`Failed to retrieve workflow execution status: ${message}`)],
         };
       }
     },

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/index.ts
@@ -7,6 +7,7 @@
 
 import type { CoreSetup } from '@kbn/core-lifecycle-server';
 import type { BuiltinToolDefinition } from '@kbn/onechat-server';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 import { productDocumentationTool } from './product_documentation';
 import { integrationKnowledgeTool } from './integration_knowledge';
 import type {
@@ -28,9 +29,11 @@ import { getWorkflowExecutionStatusTool } from './get_workflow_execution_status'
 export const registerTools = ({
   coreSetup,
   setupDeps,
+  getSecurity,
 }: {
   coreSetup: CoreSetup<PluginStartDependencies, AgentBuilderPlatformPluginStart>;
   setupDeps: PluginSetupDependencies;
+  getSecurity: () => SecurityPluginStart | undefined;
 }) => {
   const { onechat } = setupDeps;
 
@@ -50,7 +53,10 @@ export const registerTools = ({
 
   if (setupDeps.workflowsManagement) {
     tools.push(
-      getWorkflowExecutionStatusTool({ workflowsManagement: setupDeps.workflowsManagement })
+      getWorkflowExecutionStatusTool({
+        workflowsManagement: setupDeps.workflowsManagement,
+        getSecurity,
+      })
     );
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/utils/check_execution_read_privilege.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/utils/check_execution_read_privilege.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import { WorkflowsManagementApiActions } from '@kbn/workflows';
+
+/**
+ * Verifies the caller holds the `workflowsManagement:readExecution` Kibana
+ * privilege before workflow execution data is returned through an Agent Builder
+ * tool.
+ *
+ * Returns `true` when access is allowed. When the security plugin is disabled
+ * there is no privilege model to enforce, so access is allowed.
+ */
+export const hasWorkflowExecutionReadPrivilege = async ({
+  getSecurity,
+  request,
+  spaceId,
+}: {
+  getSecurity: () => SecurityPluginStart | undefined;
+  request: KibanaRequest;
+  spaceId: string;
+}): Promise<boolean> => {
+  const security = getSecurity();
+  if (!security) {
+    return true;
+  }
+
+  const requiredPrivilege = security.authz.actions.api.get(
+    WorkflowsManagementApiActions.readExecution
+  );
+  const { hasAllRequested } = await security.authz
+    .checkPrivilegesWithRequest(request)
+    .atSpace(spaceId, { kibana: [requiredPrivilege] });
+
+  return hasAllRequested;
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/types.ts
@@ -10,6 +10,7 @@ import type { OnechatPluginSetup, OnechatPluginStart } from '@kbn/onechat-plugin
 import type { LlmTasksPluginStart } from '@kbn/llm-tasks-plugin/server';
 import type { CasesServerStart } from '@kbn/cases-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 
 export interface PluginSetupDependencies {
   workflowsManagement?: WorkflowsServerPluginSetup;
@@ -21,6 +22,7 @@ export interface PluginStartDependencies {
   llmTasks?: LlmTasksPluginStart;
   cases?: CasesServerStart;
   spaces?: SpacesPluginStart;
+  security?: SecurityPluginStart;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
@@ -37,5 +37,7 @@
     "@kbn/spaces-plugin",
     "@kbn/core-http-server-mocks",
     "@kbn/core-ui-settings-server-mocks",
+    "@kbn/security-plugin-types-server",
+    "@kbn/workflows",
   ]
 }


### PR DESCRIPTION
## Summary

This is a manual backport of https://github.com/elastic/kibana/pull/275623 to `9.3`.

It could not be auto-backported because on `9.3` the workflow execution status tool lives in the `agent_builder_platform` plugin (which predates the onechat -> agent-builder rename) rather than `agent_builder_workflows`, so the fix was adapted to that plugin and its `@kbn/onechat-*` package imports.

Note: the `list_workflow_executions` tool does not exist on `9.3`, so only the `get_workflow_execution_status` tool is gated by the `workflowsManagement:readExecution` privilege check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
