### PR TITLE
siem: p1 integrations graph evaluation fixes

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.ts
@@ -413,7 +413,7 @@ FROM ${indexPatterns
     OR service.target.id IS NOT NULL OR service.target.name IS NOT NULL
     OR entity.target.id IS NOT NULL OR entity.target.name IS NOT NULL
 | EVAL  __action_exists = event.action IS NOT NULL
-| EVAL data_stream.dataset = COALESCE(event.dataset, MV_FIRST(SPLIT(_index, "-")))
+| EVAL data_stream.dataset = COALESCE(event.dataset, data_stream.dataset)
 ${buildEnrichmentQuery({ skipColumns: ['host.ip', 'host.target.ip', 'host.target.port'] })}
 ${buildV2ActorResolution()}
 | WHERE event.action IS NOT NULL AND actorEntityId IS NOT NULL
@@ -423,16 +423,18 @@ ${buildSaveSourceFieldsEsql()}
 | MV_EXPAND actorEntityId
 | MV_EXPAND targetEntityId
 ${buildPinnedEsql(pinnedIds)}
-// Create actor and target data - entity object built by TypeScript enrichment
+// sourceFields is nested inside "entity" so these strings are schema-valid as-is.
+// rebuildDocData rewrites doc.entity with enrichment data (reading sourceFields from entity.sourceFields),
+// but if JSON parsing fails it returns the raw string unchanged — which must already pass validation.
 | EVAL actorDocData = CONCAT(${JSON_OBJECT_START},
     ${concatJsonObjectPropertyEsqlExprAsString('id', 'actorEntityId')},
     ${JSON_OBJECT_SEPARATOR}, ${concatJsonObjectPropertyString('type', DOCUMENT_TYPE_ENTITY)},
-    ${JSON_OBJECT_SEPARATOR}, ${buildActorSourceFieldsEsql()},
+    ${JSON_OBJECT_SEPARATOR}, "\\"entity\\":{", ${buildActorSourceFieldsEsql()}, "}",
   ${JSON_OBJECT_END})
 | EVAL targetDocData = CONCAT(${JSON_OBJECT_START},
     ${concatJsonObjectPropertyEsqlExprAsString('id', 'COALESCE(targetEntityId, "")')},
     ${JSON_OBJECT_SEPARATOR}, ${concatJsonObjectPropertyString('type', DOCUMENT_TYPE_ENTITY)},
-    ${JSON_OBJECT_SEPARATOR}, ${buildTargetSourceFieldsEsql()},
+    ${JSON_OBJECT_SEPARATOR}, "\\"entity\\":{", ${buildTargetSourceFieldsEsql()}, "}",
   ${JSON_OBJECT_END})
 // Map host and source values to enriched contextual data
 | EVAL sourceIps = source.ip

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/azure_ai_foundry.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/azure_ai_foundry.ts
@@ -32,13 +32,13 @@ export const azure_ai_foundryEvaluations = {
       esql: `| EVAL
   user.id = CASE(
     user.id IS NOT NULL, user.id,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.ai_foundry.properties.object_id,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.ai_foundry.properties.object_id,
     null
   ),
   host.ip = CASE(
     host.ip IS NOT NULL, host.ip,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", source.ip,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.caller_ip_address,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", source.ip,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.caller_ip_address,
     null
   )`,
     },
@@ -48,9 +48,9 @@ export const azure_ai_foundryEvaluations = {
       esql: `| EVAL
   event.action = CASE(
     event.action IS NOT NULL, event.action,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.ai_foundry.operation_name,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.operation_name,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.operation_id,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.ai_foundry.operation_name,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.operation_name,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.operation_id,
     null
   )`,
     },
@@ -60,21 +60,21 @@ export const azure_ai_foundryEvaluations = {
       esql: `| EVAL
   service.target.id = CASE(
     service.target.id IS NOT NULL, service.target.id,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.resource.id,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.properties.model_deployment_name,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.backend_request_body.model,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.resource.id,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.properties.model_deployment_name,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.backend_request_body.model,
     null
   ),
   service.target.name = CASE(
     service.target.name IS NOT NULL, service.target.name,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.resource.name,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.properties.model_deployment_name,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.backend_request_body.model,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "Audit", azure.resource.name,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "RequestResponse", azure.ai_foundry.properties.model_deployment_name,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.backend_request_body.model,
     null
   ),
   entity.target.id = CASE(
     entity.target.id IS NOT NULL, entity.target.id,
-    data_stream.dataset == "azure.ai_foundry" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.backend_response_body.id,
+    data_stream.dataset == "azure_ai_foundry.logs" AND data_stream.type == "logs" AND azure.ai_foundry.category == "GatewayLogs", azure.ai_foundry.properties.backend_response_body.id,
     null
   )`,
     },

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/azure_openai.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/azure_openai.ts
@@ -32,13 +32,13 @@ export const azure_openaiEvaluations = {
       esql: `| EVAL
   user.id = CASE(
     user.id IS NOT NULL, user.id,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "Audit", azure.open_ai.properties.object_id,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "Audit", azure.open_ai.properties.object_id,
     null
   ),
   host.ip = CASE(
     host.ip IS NOT NULL, host.ip,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "GatewayLogs", source.ip,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "RequestResponse", azure.open_ai.caller_ip_address,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "GatewayLogs", source.ip,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "RequestResponse", azure.open_ai.caller_ip_address,
     null
   )`,
     },
@@ -48,8 +48,8 @@ export const azure_openaiEvaluations = {
       esql: `| EVAL
   event.action = CASE(
     event.action IS NOT NULL, event.action,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category IN ("Audit", "RequestResponse"), azure.open_ai.operation_name,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "GatewayLogs", azure.open_ai.properties.operation_id,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category IN ("Audit", "RequestResponse"), azure.open_ai.operation_name,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "GatewayLogs", azure.open_ai.properties.operation_id,
     null
   )`,
     },
@@ -59,16 +59,16 @@ export const azure_openaiEvaluations = {
       esql: `| EVAL
   service.target.id = CASE(
     service.target.id IS NOT NULL, service.target.id,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "Audit", azure.resource.id,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "RequestResponse", azure.open_ai.properties.model_deployment_name,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "GatewayLogs", azure.open_ai.properties.backend_request_body.model,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "Audit", azure.resource.id,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "RequestResponse", azure.open_ai.properties.model_deployment_name,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "GatewayLogs", azure.open_ai.properties.backend_request_body.model,
     null
   ),
   service.target.name = CASE(
     service.target.name IS NOT NULL, service.target.name,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "Audit", azure.resource.name,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "RequestResponse", azure.open_ai.properties.model_name,
-    data_stream.dataset == "azure.open_ai" AND azure.open_ai.category == "GatewayLogs", azure.open_ai.properties.backend_response_body.model,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "Audit", azure.resource.name,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "RequestResponse", azure.open_ai.properties.model_name,
+    data_stream.dataset == "azure_openai.logs" AND azure.open_ai.category == "GatewayLogs", azure.open_ai.properties.backend_response_body.model,
     null
   )`,
     },

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/m365_defender.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/m365_defender.ts
@@ -55,6 +55,7 @@ export const m365_defenderEvaluations = {
   user.name = CASE(
     user.name IS NOT NULL, user.name,
     data_stream.dataset == "m365_defender.event" AND m365_defender.event.initiating_process.account_name IS NOT NULL, m365_defender.event.initiating_process.account_name,
+    data_stream.dataset == "m365_defender.event" AND process.user.name IS NOT NULL, process.user.name,
     data_stream.dataset IN ("m365_defender.alert", "m365_defender.incident") AND process.user.name IS NOT NULL, process.user.name,
     null
   ),
@@ -69,6 +70,7 @@ export const m365_defenderEvaluations = {
       section: "Combined ES|QL \u2014 event action",
       esql: `| EVAL
   event.action = CASE(
+    data_stream.dataset == "m365_defender.alert" AND m365_defender.alert.title IS NOT NULL, m365_defender.alert.title,
     event.action IS NOT NULL, event.action,
     data_stream.dataset == "m365_defender.event" AND m365_defender.event.action.type IS NOT NULL, m365_defender.event.action.type,
     null
@@ -82,14 +84,14 @@ export const m365_defenderEvaluations = {
     host.target.id IS NOT NULL, host.target.id,
     data_stream.dataset == "m365_defender.event" AND event.action IN ("samr-query", "dns-query") AND m365_defender.event.additional_fields.DestinationComputerObjectGuid IS NOT NULL, m365_defender.event.additional_fields.DestinationComputerObjectGuid,
     data_stream.dataset IN ("m365_defender.alert", "m365_defender.incident") AND host.id IS NOT NULL, host.id,
-    data_stream.dataset == "m365_defender.event" AND event.action NOT IN ("samr-query", "dns-query", "logonsuccess", "logonfailed") AND host.id IS NOT NULL, host.id,
+    data_stream.dataset == "m365_defender.event" AND user.name IS NOT NULL AND event.action NOT IN ("samr-query", "dns-query", "logonsuccess", "logonfailed") AND host.id IS NOT NULL, host.id,
     null
   ),
   host.target.name = CASE(
     host.target.name IS NOT NULL, host.target.name,
     data_stream.dataset == "m365_defender.event" AND m365_defender.event.destination.device_name IS NOT NULL, m365_defender.event.destination.device_name,
     data_stream.dataset IN ("m365_defender.alert", "m365_defender.incident") AND host.name IS NOT NULL, host.name,
-    data_stream.dataset == "m365_defender.event" AND event.action NOT IN ("samr-query", "dns-query", "logonsuccess", "logonfailed") AND host.name IS NOT NULL, host.name,
+    data_stream.dataset == "m365_defender.event" AND user.name IS NOT NULL AND event.action NOT IN ("samr-query", "dns-query", "logonsuccess", "logonfailed") AND host.name IS NOT NULL, host.name,
     null
   ),
   host.target.ip = CASE(

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/m365_defender.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/m365_defender.ts
@@ -70,7 +70,6 @@ export const m365_defenderEvaluations = {
       section: "Combined ES|QL \u2014 event action",
       esql: `| EVAL
   event.action = CASE(
-    data_stream.dataset == "m365_defender.alert" AND m365_defender.alert.title IS NOT NULL, m365_defender.alert.title,
     event.action IS NOT NULL, event.action,
     data_stream.dataset == "m365_defender.event" AND m365_defender.event.action.type IS NOT NULL, m365_defender.event.action.type,
     null

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/tanium.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/runtime_evaluations/integrations/tanium.ts
@@ -6,7 +6,7 @@
  */
 
 /* eslint-disable prettier/prettier */
- 
+
 
 import type { IntegrationEvaluations } from "../types";
 
@@ -77,7 +77,6 @@ export const taniumEvaluations = {
   host.target.name = CASE(
     host.target.name IS NOT NULL, host.target.name,
     data_stream.dataset == "tanium.threat_response" AND tanium.threat_response.state.target.hostname IS NOT NULL, tanium.threat_response.state.target.hostname,
-    data_stream.dataset == "tanium.threat_response" AND tanium.threat_response.event.name IS NOT NULL AND tanium.threat_response.state.target.hostname IS NULL, host.name,
     null
   ),
   host.target.ip = CASE(


### PR DESCRIPTION
## Summary

- Fix `data_stream.dataset` fallback to use the `data_stream.dataset` field instead of splitting `_index` — more reliable for logsdb and aliased indices
- Fix dataset names in `azure_openai` and `azure_ai_foundry` evaluations (were matching `azure.open_ai` / `azure.ai_foundry`; actual datasets are `azure_openai.logs` / `azure_ai_foundry.logs`)
- Remove `alert.title` override for `event.action` in `m365_defender` (reverted — caused incorrect action labels)
- Fix tanium `host.target.name` self-loop: remove fallback to `host.name` when target hostname is null, which produced actor==target edges and crashed the graph layout with `CycleException` on long time ranges

## Test plan

- [ ] Verify `azure_openai` and `azure_ai_foundry` graph nodes appear with correct dataset matching
- [ ] Verify tanium graph works over long time ranges (e.g. 20 years) without crashing
- [ ] Verify `data_stream.dataset` fallback works correctly for logsdb-indexed integrations