### PR TITLE
[Metrics] [Discover] Add `temporality` to excluded field names for breakdowns

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/utils/parse_metrics_response_with_telemetry.test.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/utils/parse_metrics_response_with_telemetry.test.ts
@@ -367,6 +367,22 @@ describe('parseMetricsWithTelemetry', () => {
       expect(result.allDimensions).toEqual([{ name: 'host.name' }]);
     });
 
+    it('filters out internal dimension temporality', () => {
+      const response: MetricsESQLResponse[] = [
+        {
+          metric_name: 'cpu.usage',
+          index_name: 'my-index',
+          unit: ['percent'],
+          metric_type: 'counter',
+          field_type: ES_FIELD_TYPES.DOUBLE,
+          dimension_fields: ['host.name', 'temporality'],
+        },
+      ];
+      const result = parseMetricsWithTelemetry(response);
+      expect(result.metricItems[0].dimensionFields).toEqual([{ name: 'host.name' }]);
+      expect(result.allDimensions).toEqual([{ name: 'host.name' }]);
+    });
+
     it('filters out internal dimensions with labels._ prefix', () => {
       const response: MetricsESQLResponse[] = [
         {
@@ -395,6 +411,7 @@ describe('parseMetricsWithTelemetry', () => {
             'host.name',
             '_metric_names_hash',
             'unit',
+            'temporality',
             'labels._internal_',
             'pod.name',
           ],

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/utils/parse_metrics_response_with_telemetry.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/utils/parse_metrics_response_with_telemetry.ts
@@ -32,8 +32,15 @@ export const createInitialMetricsTelemetry = (): MetricsTelemetry => ({
 /**
  * Dimension names that are internal metadata and should not be exposed to users.
  * See: https://github.com/elastic/observability-dev/issues/5412
+ *
+ * These are genuine time-series dimensions in Elasticsearch (part of the TSID),
+ * so `METRICS_INFO` legitimately returns them and they can only be hidden here,
+ * at the presentation layer. `temporality` in particular originates from OTLP
+ * data (delta vs. cumulative aggregation) rather than being injected by
+ * Elastic, so it carries no `_` prefix and must be excluded by exact name.
+ * See: https://github.com/elastic/kibana/issues/273563
  */
-const INTERNAL_DIMENSION_EXACT_NAMES = new Set(['_metric_names_hash', 'unit']);
+const INTERNAL_DIMENSION_EXACT_NAMES = new Set(['_metric_names_hash', 'unit', 'temporality']);
 
 /**
  * Dimension name prefixes that indicate internal metadata fields.


### PR DESCRIPTION
## Summary

Resolves #273563.

As noted in the parent issue, part of Elasticsearch's OTLP intake procedure [interprets temporality input and writes](https://github.com/elastic/elasticsearch/blob/2c3ccf90b0a28367b4a5080e4d36b3200817d4f3/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java#L70) a `temporality` field. This field describes how a metric's measurements aggregate over time. It is an important ES-level field that participates in the TSID that keeps delta/cumulative series separate, in the Metrics UI we should treat it as internal. This field surfaces in the breakdown dropdown in our Metrics profile, and it doesn't provide utility for end users.

As part of https://github.com/elastic/kibana/pull/259905/, we already introduced a solution for excluding fields. In the case we handled there, we handled direct matches like `_metric_names_hash` and the prefix `labels._`, which catches Elastic-injected label fields while leaving user-defined `labels.*` fields untouched. This field does not adhere to these patterns, so we will explicitly filter it on the client side.

### Testing this PR

You can easily repro this using the `telemetrygen` utility.

0. Install the utility: `go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest`
1. Run the command (assumes a local Elasticsearch with `elastic:changeme`, you can modify this to suit your chosen setup:

```bash
telemetrygen metrics \
  --otlp-http --otlp-insecure \
  --otlp-endpoint localhost:9200 \
  --otlp-http-url-path /_otlp/v1/metrics \
  --otlp-header 'Authorization="Basic ZWxhc3RpYzpjaGFuZ2VtZQ=="' \
  --metric-type Sum \
  --aggregation-temporality cumulative \
  --metrics 50
```

When this command finishes, hit your targeted cluster with Kibana on `main`, you'll see the field show up as a breakdown option, just as it is reported in the parent issue. Then, check this code out. You should no longer see this field show up as a breakdown choice.

### Caveats

#### Custom field erasure

If our users create a custom TSDS that has a `temporality` field that they intend to use for their own purposes, this change could conceivably eliminate it from their dimensions dropdown. We already accepted this caveat with `unit`, which is also excluded, so this isn't a new risk.

#### Minor telemetry drift

We compute the number of dimensions after filtering is applied, so this will cause any users who are seeing this to have their telemetry log lower numbers. Again, we faced this issue with the `unit` filtering we already merged.

### Screenshots

#### Before

<img width="900" height="1138" alt="20260707151510" src="https://github.com/user-attachments/assets/bd810cec-c1cb-47f9-a0c9-db3518269d40" />

#### After

<img width="900" height="1138" alt="20260707150751" src="https://github.com/user-attachments/assets/95160967-a646-43c2-bdca-b828ef80203d" />
