### PR TITLE
[9.3] [Obs AI] Update max length for string schemas (#275484)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/ai_insight.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/ai_insight.ts
@@ -10,10 +10,11 @@ import dedent from 'dedent';
 import type { Attachment } from '@kbn/onechat-common/attachments';
 import type { AttachmentTypeDefinition } from '@kbn/onechat-server/attachments';
 import { OBSERVABILITY_AI_INSIGHT_ATTACHMENT_TYPE_ID } from '../../common';
+import { MAX_TEXT_LENGTH } from '../utils/schema_limits';
 
 const aiInsightAttachmentDataSchema = z.object({
-  context: z.string(),
-  summary: z.string(),
+  context: z.string().max(MAX_TEXT_LENGTH),
+  summary: z.string().max(MAX_TEXT_LENGTH),
   attachmentLabel: z.string().optional(),
 });
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/alert.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/alert.ts
@@ -16,9 +16,10 @@ import type {
   ObservabilityAgentBuilderPluginStart,
   ObservabilityAgentBuilderPluginStartDependencies,
 } from '../types';
+import { MAX_SHORT_STRING_LENGTH } from '../utils/schema_limits';
 
 const alertDataSchema = z.object({
-  alertId: z.string(),
+  alertId: z.string().max(MAX_SHORT_STRING_LENGTH),
   attachmentLabel: z.string().optional(),
 });
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/error.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/error.ts
@@ -17,15 +17,16 @@ import type {
   ObservabilityAgentBuilderPluginStartDependencies,
 } from '../types';
 import type { ObservabilityAgentBuilderDataRegistry } from '../data_registry/data_registry';
+import { MAX_SHORT_STRING_LENGTH } from '../utils/schema_limits';
 
 const GET_ERROR_DETAILS_TOOL_ID = 'get_error_details';
 
 const errorDataSchema = z.object({
-  errorId: z.string(),
-  serviceName: z.string().optional(),
-  environment: z.string().nullable().optional(),
-  start: z.string().optional(),
-  end: z.string().optional(),
+  errorId: z.string().max(MAX_SHORT_STRING_LENGTH),
+  serviceName: z.string().max(MAX_SHORT_STRING_LENGTH).optional(),
+  environment: z.string().max(MAX_SHORT_STRING_LENGTH).nullable().optional(),
+  start: z.string().max(MAX_SHORT_STRING_LENGTH).optional(),
+  end: z.string().max(MAX_SHORT_STRING_LENGTH).optional(),
 });
 
 export type ErrorAttachmentData = z.infer<typeof errorDataSchema>;

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/log.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/log.ts
@@ -18,12 +18,13 @@ import type {
 import type { ObservabilityAgentBuilderDataRegistry } from '../data_registry/data_registry';
 import { OBSERVABILITY_LOG_ATTACHMENT_TYPE_ID } from '../../common';
 import { getLogDocumentById } from '../routes/ai_insights/get_log_document_by_id';
+import { MAX_INDEX_PATTERN_LENGTH, MAX_SHORT_STRING_LENGTH } from '../utils/schema_limits';
 
 const GET_LOG_DOCUMENT_TOOL_ID = 'get_log_document';
 
 const logDataSchema = z.object({
-  id: z.string(),
-  index: z.string(),
+  id: z.string().max(MAX_SHORT_STRING_LENGTH),
+  index: z.string().max(MAX_INDEX_PATTERN_LENGTH),
 });
 
 export type LogAttachmentData = z.infer<typeof logDataSchema>;

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_alerts/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_alerts/tool.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../types';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { timeRangeSchemaOptional } from '../../utils/tool_schemas';
+import { MAX_KQL_FILTER_LENGTH, MAX_SHORT_STRING_LENGTH } from '../../utils/schema_limits';
 import { getToolHandler } from './handler';
 
 export const OBSERVABILITY_GET_ALERTS_TOOL_ID = 'observability.get_alerts';
@@ -58,6 +59,7 @@ const getAlertsSchema = z.object({
   ...timeRangeSchemaOptional(DEFAULT_TIME_RANGE),
   kqlFilter: z
     .string()
+    .max(MAX_KQL_FILTER_LENGTH)
     .optional()
     .describe(
       'Optional KQL (Kibana Query Language) filter to narrow down alerts. Examples: \'service.name: "frontend"\' (alerts for the frontend service), \'service.name: "checkout" AND host.name: "web-*"\', \'kibana.alert.rule.name: "High CPU"\'.'
@@ -69,7 +71,7 @@ const getAlertsSchema = z.object({
       'Whether to include recovered/closed alerts. Defaults to false, which means only active alerts will be returned.'
     ),
   fields: z
-    .array(z.string())
+    .array(z.string().max(MAX_SHORT_STRING_LENGTH))
     .optional()
     .describe(
       'Optional list of fields to include in the alert documents. If not specified, a default set of common alert fields is returned. Use this to request specific fields like "error.message", "url.full", or any custom alert fields.'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_anomaly_detection_jobs/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_anomaly_detection_jobs/tool.ts
@@ -18,6 +18,7 @@ import type {
   ObservabilityAgentBuilderPluginSetupDependencies,
 } from '../../types';
 import { timeRangeSchemaOptional } from '../../utils/tool_schemas';
+import { MAX_SHORT_STRING_LENGTH } from '../../utils/schema_limits';
 import { getToolHandler } from './handler';
 
 export const OBSERVABILITY_GET_ANOMALY_DETECTION_JOBS_TOOL_ID =
@@ -40,7 +41,7 @@ export interface GetAnomalyDetectionJobsToolResult {
 
 const getAnomalyDetectionJobsSchema = z.object({
   jobIds: z
-    .array(z.string().min(1))
+    .array(z.string().min(1).max(MAX_SHORT_STRING_LENGTH))
     .min(1)
     .max(20)
     .describe(

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_hosts/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_hosts/tool.ts
@@ -17,6 +17,7 @@ import type {
 import type { CoreSetup, Logger } from '@kbn/core/server';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { timeRangeSchemaOptional } from '../../utils/tool_schemas';
+import { MAX_KQL_FILTER_LENGTH } from '../../utils/schema_limits';
 import type {
   ObservabilityAgentBuilderPluginStart,
   ObservabilityAgentBuilderPluginStartDependencies,
@@ -56,6 +57,7 @@ const getHostsSchema = z.object({
     .optional(),
   kqlFilter: z
     .string()
+    .max(MAX_KQL_FILTER_LENGTH)
     .optional()
     .describe(
       'Optional KQL filter to narrow down results. Examples: "service.name: frontend" (show only hosts running the frontend service), "host.name: web-*", or "cloud.provider: aws".'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_index_info/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_index_info/tool.ts
@@ -13,6 +13,11 @@ import type { CoreSetup, Logger } from '@kbn/core/server';
 import dedent from 'dedent';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { timeRangeSchemaOptional } from '../../utils/tool_schemas';
+import {
+  MAX_INDEX_PATTERN_LENGTH,
+  MAX_KQL_FILTER_LENGTH,
+  MAX_SHORT_STRING_LENGTH,
+} from '../../utils/schema_limits';
 import type {
   ObservabilityAgentBuilderPluginSetupDependencies,
   ObservabilityAgentBuilderPluginStart,
@@ -33,12 +38,13 @@ const getIndexInfoSchema = z.object({
   ),
   index: z
     .string()
+    .max(MAX_INDEX_PATTERN_LENGTH)
     .optional()
     .describe(
       'Index pattern (e.g., "logs-*", "metrics-*"). Required for "list-fields" and "get-field-values".'
     ),
   fields: z
-    .array(z.string())
+    .array(z.string().max(MAX_SHORT_STRING_LENGTH))
     .max(10)
     .optional()
     .describe(
@@ -47,10 +53,12 @@ const getIndexInfoSchema = z.object({
   ...timeRangeSchemaOptional({ start: 'now-24h', end: 'now' }),
   kqlFilter: z
     .string()
+    .max(MAX_KQL_FILTER_LENGTH)
     .optional()
     .describe('KQL filter to scope field discovery (e.g., ["service.name: checkout"]).'),
   intent: z
     .string()
+    .max(MAX_SHORT_STRING_LENGTH)
     .optional()
     .describe(
       'Investigation focus to filter relevant fields (e.g., "memory issues", "high latency").'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_change_points/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_change_points/tool.ts
@@ -17,6 +17,11 @@ import type {
 } from '../../types';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { timeRangeSchemaRequired } from '../../utils/tool_schemas';
+import {
+  MAX_INDEX_PATTERN_LENGTH,
+  MAX_KQL_FILTER_LENGTH,
+  MAX_SHORT_STRING_LENGTH,
+} from '../../utils/schema_limits';
 import { getLogsIndices } from '../../utils/get_logs_indices';
 import { getToolHandler } from './handler';
 
@@ -24,15 +29,21 @@ export const OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID = 'observability.get_lo
 
 const getLogChangePointsSchema = z.object({
   ...timeRangeSchemaRequired,
-  index: z.string().describe('The index or index pattern to find the logs').optional(),
+  index: z
+    .string()
+    .max(MAX_INDEX_PATTERN_LENGTH)
+    .describe('The index or index pattern to find the logs')
+    .optional(),
   kqlFilter: z
     .string()
+    .max(MAX_KQL_FILTER_LENGTH)
     .describe(
       'A KQL query to filter the log documents. Examples: level:error, service.name:"my-service"'
     )
     .optional(),
   messageField: z
     .string()
+    .max(MAX_SHORT_STRING_LENGTH)
     .describe(
       'The unstructured text field to run the categorize_text aggregation on. This groups similar logs into patterns. Defaults to message'
     )

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_metric_change_points/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_metric_change_points/tool.ts
@@ -16,6 +16,11 @@ import type {
 } from '../../types';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { timeRangeSchemaRequired } from '../../utils/tool_schemas';
+import {
+  MAX_INDEX_PATTERN_LENGTH,
+  MAX_KQL_FILTER_LENGTH,
+  MAX_SHORT_STRING_LENGTH,
+} from '../../utils/schema_limits';
 import { getMetricsIndices } from '../../utils/get_metrics_indices';
 import { getToolHandler } from './handler';
 
@@ -24,15 +29,21 @@ export const OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID =
 
 const getMetricChangePointsSchema = z.object({
   ...timeRangeSchemaRequired,
-  index: z.string().describe('The index or index pattern to find the metrics').optional(),
+  index: z
+    .string()
+    .max(MAX_INDEX_PATTERN_LENGTH)
+    .describe('The index or index pattern to find the metrics')
+    .optional(),
   kqlFilter: z
     .string()
+    .max(MAX_KQL_FILTER_LENGTH)
     .describe('A KQL filter to filter the metric documents, e.g.: my_field:foo')
     .optional(),
   aggregation: z
     .object({
       field: z
         .string()
+        .max(MAX_SHORT_STRING_LENGTH)
         .describe(
           `Numeric field to aggregate and observe for changes (e.g., 'transaction.duration.us').`
         ),
@@ -42,7 +53,7 @@ const getMetricChangePointsSchema = z.object({
     })
     .optional(),
   groupBy: z
-    .array(z.string())
+    .array(z.string().max(MAX_SHORT_STRING_LENGTH))
     .describe(
       `Optional keyword fields to break down metrics by to identify which specific group experienced a change.
 Use only low-cardinality fields. Using many fields or high-cardinality fields can cause a large number of groups and severely impact performance.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_trace_metrics/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_trace_metrics/tool.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../types';
 import type { ObservabilityAgentBuilderDataRegistry } from '../../data_registry/data_registry';
 import { timeRangeSchemaRequired } from '../../utils/tool_schemas';
+import { MAX_KQL_FILTER_LENGTH, MAX_SHORT_STRING_LENGTH } from '../../utils/schema_limits';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { getToolHandler } from './handler';
 import { OBSERVABILITY_GET_HOSTS_TOOL_ID, OBSERVABILITY_GET_SERVICES_TOOL_ID } from '..';
@@ -26,12 +27,14 @@ const getTraceMetricsSchema = z.object({
   ...timeRangeSchemaRequired,
   kqlFilter: z
     .string()
+    .max(MAX_KQL_FILTER_LENGTH)
     .optional()
     .describe(
       'KQL filter to scope the data. Examples: \'service.name: "frontend"\', \'service.name: "checkout" AND transaction.name: "POST /api/cart"\', \'host.name: "web-*"\'.'
     ),
   groupBy: z
     .string()
+    .max(MAX_SHORT_STRING_LENGTH)
     .optional()
     .describe(
       'Field to group results by. Common fields: "service.name", "transaction.name", "host.name", "container.id". Use low-cardinality fields where possible for meaningful aggregations. If not specified, results are grouped by service.name.'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/run_log_rate_analysis/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/run_log_rate_analysis/tool.ts
@@ -17,14 +17,16 @@ import type {
   ObservabilityAgentBuilderPluginStartDependencies,
 } from '../../types';
 import { timeRangeSchemaRequired, indexDescription } from '../../utils/tool_schemas';
+import { MAX_INDEX_PATTERN_LENGTH, MAX_SHORT_STRING_LENGTH } from '../../utils/schema_limits';
 import { getToolHandler } from './handler';
 
 export const OBSERVABILITY_RUN_LOG_RATE_ANALYSIS_TOOL_ID = 'observability.run_log_rate_analysis';
 
 const logRateAnalysisSchema = z.object({
-  index: z.string().describe(indexDescription),
+  index: z.string().max(MAX_INDEX_PATTERN_LENGTH).describe(indexDescription),
   timeFieldName: z
     .string()
+    .max(MAX_SHORT_STRING_LENGTH)
     .describe(
       'Timestamp field used to build the baseline/deviation windows. Defaults to `@timestamp`.'
     )

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/schema_limits.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/schema_limits.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Upper bounds for free-form string inputs used in attachment and tool schemas.
+ *
+ * Unbounded `z.string()` validation lets a caller submit arbitrarily large values,
+ * which can exhaust memory/CPU (Denial of Service). These limits are safety guards
+ * rather than business validation, so they are intentionally generous while still
+ * rejecting pathological payloads (CodeQL rule `js/kibana/unbounded-string-in-schema`).
+ */
+
+/**
+ * Short single-line strings: identifiers (IDs, trace/transaction ids), entity and field
+ * names, environments, ML job ids/groups, Elasticsearch date math (e.g. "now-24h"),
+ * attachment labels, and short free-text intents. Matches the Elasticsearch keyword
+ * `ignore_above` default of 1024.
+ */
+export const MAX_SHORT_STRING_LENGTH = 1024;
+
+/** Index names and index patterns, which may be comma-separated lists of patterns. */
+export const MAX_INDEX_PATTERN_LENGTH = 4096;
+
+/** KQL filter expressions, which may chain several clauses. */
+export const MAX_KQL_FILTER_LENGTH = 4096;
+
+/** Large free-text payloads such as AI-generated summaries and prefetched context blobs. */
+export const MAX_TEXT_LENGTH = 500_000;

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/tool_schemas.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/tool_schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from '@kbn/zod';
+import { MAX_SHORT_STRING_LENGTH } from './schema_limits';
 
 const startDescription =
   'The start time of the query window using Elasticsearch date math (e.g., "now-24h", "now-15m").';
@@ -16,19 +17,21 @@ export const indexDescription =
   'Concrete index or index pattern to analyze (for example `logs-payments.api-default`).';
 
 export const timeRangeSchemaRequired = {
-  start: z.string().describe(startDescription),
-  end: z.string().describe(endDescription),
+  start: z.string().max(MAX_SHORT_STRING_LENGTH).describe(startDescription),
+  end: z.string().max(MAX_SHORT_STRING_LENGTH).describe(endDescription),
 };
 
 export function timeRangeSchemaOptional(defaultTimeRange: { start: string; end: string }) {
   return {
     start: z
       .string()
+      .max(MAX_SHORT_STRING_LENGTH)
       .describe(`${startDescription} Defaults to ${defaultTimeRange.start}.`)
       .default(defaultTimeRange.start),
 
     end: z
       .string()
+      .max(MAX_SHORT_STRING_LENGTH)
       .describe(`${endDescription} Defaults to ${defaultTimeRange.end}.`)
       .default(defaultTimeRange.end),
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Obs AI] Update max length for string schemas (#275484)](https://github.com/elastic/kibana/pull/275484)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2026-07-07T20:02:15Z","message":"[Obs AI] Update max length for string schemas (#275484)\n\nCloses https://github.com/elastic/kibana-team/issues/3629\n\n## Summary\n\nUpdates schemas of `observability_agent_builder` tools and attachments\nwith max length.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"92a9fc6f80ad0f84f2b226c2f190260f283396b1","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.4","Team:nightshift-context-and-research","v9.3.8"],"title":"[Obs AI] Update max length for string schemas","number":275484,"url":"https://github.com/elastic/kibana/pull/275484","mergeCommit":{"message":"[Obs AI] Update max length for string schemas (#275484)\n\nCloses https://github.com/elastic/kibana-team/issues/3629\n\n## Summary\n\nUpdates schemas of `observability_agent_builder` tools and attachments\nwith max length.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"92a9fc6f80ad0f84f2b226c2f190260f283396b1"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275484","number":275484,"mergeCommit":{"message":"[Obs AI] Update max length for string schemas (#275484)\n\nCloses https://github.com/elastic/kibana-team/issues/3629\n\n## Summary\n\nUpdates schemas of `observability_agent_builder` tools and attachments\nwith max length.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"92a9fc6f80ad0f84f2b226c2f190260f283396b1"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276824","number":276824,"state":"OPEN"},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->