### PR TITLE
[Agent Builder] Reject empty structured agent output

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { processStructuredAnswerResponse } from './action_utils';
+import { AgentActionType, type StructuredAnswerAction, type AgentErrorAction } from './actions';
+
+describe('processStructuredAnswerResponse', () => {
+  it('returns a structured answer action for a populated object', () => {
+    const response = { classification: 'true_positive' };
+    expect(processStructuredAnswerResponse(response).type).toBe(AgentActionType.StructuredAnswer);
+  });
+
+  it('preserves the response data on the structured answer action', () => {
+    const response = { classification: 'true_positive', confidence_score: 0.9 };
+    const action = processStructuredAnswerResponse(response) as StructuredAnswerAction;
+    expect(action.data).toEqual(response);
+  });
+
+  it('returns an error action when the model returns an empty object', () => {
+    expect(processStructuredAnswerResponse({}).type).toBe(AgentActionType.Error);
+  });
+
+  it('reports an empty structured response error message for an empty object', () => {
+    const action = processStructuredAnswerResponse({}) as AgentErrorAction;
+    expect(action.error.message).toBe('agent returned an empty structured response');
+  });
+
+  describe.each([
+    ['a string', 'not an object'],
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+  ])('when the response is %s', (_label, response) => {
+    it('returns an error action', () => {
+      expect(processStructuredAnswerResponse(response).type).toBe(AgentActionType.Error);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.ts
@@ -123,6 +123,19 @@ export const processStructuredAnswerResponse = (
 ): StructuredAnswerAction | AgentErrorAction => {
   try {
     if (response && typeof response === 'object') {
+      // A structured response with no fields (e.g. the model emitted an empty
+      // tool call `{}`) is not a usable answer. Treat it as an empty response,
+      // mirroring processResearchResponse above, so the answer agent retries
+      // instead of surfacing a blank answer.
+      if (Object.keys(response).length === 0) {
+        return errorAction(
+          createAgentExecutionError(
+            'agent returned an empty structured response',
+            AgentExecutionErrorCode.emptyResponse,
+            {}
+          )
+        );
+      }
       return structuredAnswerAction(response);
     }
     return errorAction(


### PR DESCRIPTION
Adds a guard so the structured answer agent rejects an empty `{}` object from the model instead of accepting it as a real answer. Before this, an empty structured response surfaced as a blank alert note and a `{}` in the seeded conversation.

## Summary

`processStructuredAnswerResponse` accepted any object as a valid `structured_answer`, including `{}`. The non-structured path right above it (`processResearchResponse`) already treats an empty model response as an `emptyResponse` error, so the structured path was just missing the same guard. This adds it: an object with no fields becomes an `emptyResponse` error, which `answerAgentEdge` routes back into the existing bounded in-graph retry before it can become a blank answer.

Why it showed up now: structured output and the workflow `ai.agent` step are recent, and the security alert analysis workflow is the first heavy user, with large per-alert prompts at batch volume, which is where the model occasionally emits an empty tool call. Smaller structured-output callers (like title generation) basically never hit it.

I confirmed the root cause with runtime logging: the model returns `{}` straight out of `withStructuredOutput().invoke()`, and it was passed through unchanged into the round. In one verification run the model emitted `{}` 6 times out of 80 calls, all 6 were rejected and retried, and 0 blank verdicts reached the workflow across 75 runs.

Screenshot of the bug, the empty `{}` rendered in the conversation the workflow seeded:

<img width="1024" height="604" alt="bug-empty-structured-output" src="https://github.com/user-attachments/assets/f95162d8-a512-408c-a359-fd554c82b017" />

## To test

1. Run the unit tests:
   `node scripts/jest --config x-pack/platform/plugins/shared/agent_builder/jest.config.js x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.test.ts`
2. Before: `processStructuredAnswerResponse({})` returned a `structured_answer` action with empty `data`.
3. After: it returns an `error` action (`emptyResponse`), so the answer agent retries instead of surfacing a blank answer.

_PR developed with Cursor + Claude Opus 4.8_

Made with [Cursor](https://cursor.com)