### PR TITLE
[Security Solution] Add agent override for alert analysis workflow

### DIFF
--- a/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
+++ b/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
@@ -243,6 +243,8 @@ export const SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCO
   'securitySolution:alertAnalysisWorkflowAutoCloseConfidenceScoreMaxThreshold' as const;
 export const SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CONNECTOR_ID =
   'securitySolution:alertAnalysisWorkflowConnectorId' as const;
+export const SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID =
+  'securitySolution:alertAnalysisWorkflowAgentId' as const;
 export const SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CREATE_CONVERSATION =
   'securitySolution:alertAnalysisWorkflowCreateConversation' as const;
 export const SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_ENABLED =

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.yaml
@@ -106,9 +106,10 @@ steps:
   - name: set_runtime_config_variables
     type: data.set
     with:
-      # `${{ }}` preserves booleans/numbers; `{{ }}` is used for the connector id and tag prefix strings.
+      # `${{ }}` preserves booleans/numbers; `{{ }}` is used for the connector id, agent id, and tag prefix strings.
       workflow_enabled: "${{ steps.fetch_runtime_config.output.workflowEnabled }}"
       connector_id: "{{ steps.fetch_runtime_config.output.connectorId }}"
+      agent_id: "{{ steps.fetch_runtime_config.output.agentId }}"
       create_conversation: "${{ steps.fetch_runtime_config.output.createConversation }}"
       auto_close_enabled: "${{ steps.fetch_runtime_config.output.autoCloseEnabled }}"
       auto_close_confidence_score_min_threshold: "${{ steps.fetch_runtime_config.output.autoCloseConfidenceScoreMinThreshold }}"
@@ -941,7 +942,7 @@ steps:
 
           - name: onechat_runAgent_step
             type: ai.agent
-            agent-id: "elastic-ai-agent"
+            agent-id: "{{ variables.agent_id }}"
             connector-id: "{{ variables.connector_id }}"
             create-conversation: "${{ variables.create_conversation }}"
             on-failure:

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -908,6 +908,13 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'keyword',
     _meta: { description: 'AI connector used by the alert analysis workflow' },
   },
+  'securitySolution:alertAnalysisWorkflowAgentId': {
+    type: 'keyword',
+    _meta: {
+      description:
+        'Agent used by the alert analysis workflow (value is redacted; the setting is sensitive)',
+    },
+  },
   'securitySolution:alertAnalysisWorkflowCreateConversation': {
     type: 'boolean',
     _meta: {

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -214,6 +214,7 @@ export interface UsageStats {
   'securitySolution:alertAnalysisWorkflowAutoCloseConfidenceScoreMinThreshold': number;
   'securitySolution:alertAnalysisWorkflowAutoCloseConfidenceScoreMaxThreshold': number;
   'securitySolution:alertAnalysisWorkflowConnectorId': string;
+  'securitySolution:alertAnalysisWorkflowAgentId': string;
   'securitySolution:alertAnalysisWorkflowCreateConversation': boolean;
   'securitySolution:alertAnalysisWorkflowTagPrefix': string;
   'elasticRamen:enabled': boolean;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -12188,6 +12188,12 @@
             "description": "AI connector used by the alert analysis workflow"
           }
         },
+        "securitySolution:alertAnalysisWorkflowAgentId": {
+          "type": "keyword",
+          "_meta": {
+            "description": "Agent used by the alert analysis workflow (value is redacted; the setting is sensitive)"
+          }
+        },
         "securitySolution:alertAnalysisWorkflowCreateConversation": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/alert_analysis_workflow.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/alert_analysis_workflow.ts
@@ -30,6 +30,10 @@ export const AlertAnalysisWorkflowSettings = z.object({
   autoCloseEnabled: z.boolean(),
   autoCloseConfidenceScoreMinThreshold: z.number().min(0).max(1),
   autoCloseConfidenceScoreMaxThreshold: z.number().min(0).max(1),
+  // Agent Builder agent id the workflow's ai.agent step runs with. Non-empty (defaults to the
+  // platform default agent) so the workflow step always has a real agent to invoke. Max length
+  // matches Agent Builder's `agentIdMaxLength`.
+  agentId: z.string().min(1).max(64),
   // Prefix for the workflow tags written to (and matched on) each analyzed alert. Non-empty so the
   // dedup gate and tag replacement always have a real namespace to match against.
   tagPrefix: z.string().min(1).max(256),

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.test.tsx
@@ -31,6 +31,8 @@ const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 describe('AlertAnalysisWorkflowPage', () => {
   const coreStart = coreMock.createStart();
 
+  const listAgentsMock = jest.fn();
+
   const settingsGetResponse = (
     settings: Record<string, unknown> = {
       autoCloseEnabled: true,
@@ -75,9 +77,17 @@ describe('AlertAnalysisWorkflowPage', () => {
       };
     });
 
+    const startServices = createStartServicesMock(coreStart);
     return render(
       <MemoryRouter>
-        <TestProviders startServices={createStartServicesMock(coreStart)}>
+        <TestProviders
+          startServices={
+            {
+              ...startServices,
+              agentBuilder: { agents: { list: listAgentsMock } },
+            } as unknown as typeof startServices
+          }
+        >
           <AlertAnalysisWorkflowPage />
         </TestProviders>
       </MemoryRouter>
@@ -86,6 +96,28 @@ describe('AlertAnalysisWorkflowPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    listAgentsMock.mockResolvedValue([
+      { id: 'elastic-ai-agent', name: 'Elastic AI Agent', readonly: false },
+      { id: 'my-custom-agent', name: 'My Custom Agent', readonly: false },
+      { id: 'platform.builtin', name: 'Built-in Agent', readonly: true },
+    ]);
+  });
+
+  it('lists the user selectable agents excluding platform built-ins', async () => {
+    renderComponent();
+
+    fireEvent.click(await screen.findByTestId('alertAnalysisWorkflowAgentSelector'));
+
+    expect(await screen.findByText('My Custom Agent')).toBeInTheDocument();
+  });
+
+  it('excludes readonly built-in agents from the agent selector', async () => {
+    renderComponent();
+
+    fireEvent.click(await screen.findByTestId('alertAnalysisWorkflowAgentSelector'));
+
+    await screen.findByText('My Custom Agent');
+    expect(screen.queryByText('Built-in Agent')).not.toBeInTheDocument();
   });
 
   it('saves changed settings through the Security route', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   EuiButton,
   EuiDescribedFormGroup,
@@ -17,14 +17,17 @@ import {
   EuiLink,
   EuiLoadingSpinner,
   EuiSpacer,
+  EuiSuperSelect,
   EuiSwitch,
   EuiTitle,
 } from '@elastic/eui';
+import type { EuiSuperSelectOption } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isEqual } from 'lodash';
 import { useMutation, useQuery, useQueryClient } from '@kbn/react-query';
 import { ConnectorSelector } from '@kbn/security-solution-connectors';
 import { AiIcon } from '@kbn/shared-ux-ai-components';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { WorkflowsManagementUiActions } from '@kbn/workflows';
 import { SecuritySolutionPageWrapper } from '../../../../common/components/page_wrapper';
 import { HeaderPage } from '../../../../common/components/header_page';
@@ -42,6 +45,7 @@ import {
   type AlertAnalysisWorkflowSettingsWithConnector,
 } from './api';
 import { AlertAnalysisWorkflowRuleAttachmentSection } from './rule_attachment_section';
+import { useAlertAnalysisWorkflowAgents } from './use_alert_analysis_workflow_agents';
 import * as translations from './translations';
 
 const ALERT_ANALYSIS_WORKFLOW_SETTINGS_QUERY_KEY = [
@@ -65,6 +69,7 @@ export const AlertAnalysisWorkflowPage: React.FC = () => {
   );
   const canAccessPage = isEnterprise && canEditAdvancedSettings;
   const { aiConnectors, isLoading: isLoadingConnectors } = useAIConnectors();
+  const { agents, isLoading: isLoadingAgents } = useAlertAnalysisWorkflowAgents(canAccessPage);
   const { data: savedSettingsResponse, isLoading } = useQuery({
     queryKey: ALERT_ANALYSIS_WORKFLOW_SETTINGS_QUERY_KEY,
     enabled: canAccessPage,
@@ -89,6 +94,16 @@ export const AlertAnalysisWorkflowPage: React.FC = () => {
     );
   const isTagPrefixInvalid =
     pageSettings !== undefined && (pageSettings.tagPrefix ?? '').trim() === '';
+  const selectedAgentId = pageSettings?.agentId ?? agentBuilderDefaultAgentId;
+  const agentOptions = useMemo<Array<EuiSuperSelectOption<string>>>(() => {
+    const options = agents.map((agent) => ({ value: agent.id, inputDisplay: agent.name }));
+    // Keep the currently selected agent visible even if it is missing from the fetched list (for
+    // example a custom agent that was deleted), so the selection is never silently lost.
+    if (selectedAgentId && !options.some((option) => option.value === selectedAgentId)) {
+      options.push({ value: selectedAgentId, inputDisplay: selectedAgentId });
+    }
+    return options;
+  }, [agents, selectedAgentId]);
   const saveSettingsMutation = useMutation({
     mutationFn: async (settingsToSave: AlertAnalysisWorkflowSettingsWithConnector) => {
       return saveAlertAnalysisWorkflowSettings({ http, settings: settingsToSave });
@@ -228,6 +243,39 @@ export const AlertAnalysisWorkflowPage: React.FC = () => {
                   settings={settings}
                   onChange={(connectorId) =>
                     setPageSettings((prev) => (prev ? { ...prev, connectorId } : prev))
+                  }
+                />
+              </EuiFormRow>
+            </EuiDescribedFormGroup>
+            <EuiDescribedFormGroup
+              fullWidth
+              title={
+                <h4>
+                  <FormattedMessage
+                    id="xpack.securitySolution.alertAnalysisWorkflow.agentSectionTitle"
+                    defaultMessage="Agent"
+                  />
+                </h4>
+              }
+              description={
+                <p>
+                  <FormattedMessage
+                    id="xpack.securitySolution.alertAnalysisWorkflow.agentSectionDescription"
+                    defaultMessage="Select the Agent Builder agent used to analyze alerts. Choose the default agent or one of your custom agents."
+                  />
+                </p>
+              }
+            >
+              <EuiFormRow fullWidth label={translations.AGENT_LABEL}>
+                <EuiSuperSelect
+                  data-test-subj="alertAnalysisWorkflowAgentSelector"
+                  options={agentOptions}
+                  valueOfSelected={selectedAgentId}
+                  isLoading={isLoadingAgents}
+                  disabled={!canEditAdvancedSettings || !isWorkflowEnabled}
+                  aria-label={translations.AGENT_ARIA_LABEL}
+                  onChange={(agentId) =>
+                    setPageSettings((prev) => (prev ? { ...prev, agentId } : prev))
                   }
                 />
               </EuiFormRow>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/translations.ts
@@ -63,6 +63,20 @@ export const CONNECTOR_LABEL = i18n.translate(
   }
 );
 
+export const AGENT_LABEL = i18n.translate(
+  'xpack.securitySolution.alertAnalysisWorkflow.agentLabel',
+  {
+    defaultMessage: 'Agent',
+  }
+);
+
+export const AGENT_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.alertAnalysisWorkflow.agentAriaLabel',
+  {
+    defaultMessage: 'Agent used by the alert analysis workflow',
+  }
+);
+
 export const CREATE_CONVERSATION_ARIA_LABEL = i18n.translate(
   'xpack.securitySolution.alertAnalysisWorkflow.createConversationAriaLabel',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/use_alert_analysis_workflow_agents.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/use_alert_analysis_workflow_agents.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { coreMock } from '@kbn/core/public/mocks';
+import { TestProviders } from '../../../../common/mock';
+import { createStartServicesMock } from '../../../../common/lib/kibana/kibana_react.mock';
+import { useAlertAnalysisWorkflowAgents } from './use_alert_analysis_workflow_agents';
+
+describe('useAlertAnalysisWorkflowAgents', () => {
+  const coreStart = coreMock.createStart();
+  const listAgentsMock = jest.fn();
+
+  const wrapperWith = (agentBuilder?: unknown) => {
+    const startServices = createStartServicesMock(coreStart);
+    const services = { ...startServices, agentBuilder } as unknown as typeof startServices;
+    const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <TestProviders startServices={services}>{children}</TestProviders>
+    );
+    return Wrapper;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listAgentsMock.mockResolvedValue([
+      { id: 'elastic-ai-agent', name: 'Elastic AI Agent', readonly: false },
+      { id: 'my-custom-agent', name: 'My Custom Agent', readonly: false },
+      { id: 'platform.builtin', name: 'Built-in Agent', readonly: true },
+    ]);
+  });
+
+  it('reports not loading when Agent Builder is unavailable', () => {
+    const { result } = renderHook(() => useAlertAnalysisWorkflowAgents(true), {
+      wrapper: wrapperWith(undefined),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports not loading when the hook is disabled', () => {
+    const { result } = renderHook(() => useAlertAnalysisWorkflowAgents(false), {
+      wrapper: wrapperWith({ agents: { list: listAgentsMock } }),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('returns non-readonly agents when enabled', async () => {
+    const { result } = renderHook(() => useAlertAnalysisWorkflowAgents(true), {
+      wrapper: wrapperWith({ agents: { list: listAgentsMock } }),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agents).toEqual([
+        { id: 'elastic-ai-agent', name: 'Elastic AI Agent' },
+        { id: 'my-custom-agent', name: 'My Custom Agent' },
+      ])
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/use_alert_analysis_workflow_agents.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/use_alert_analysis_workflow_agents.ts
@@ -45,8 +45,11 @@ export const useAlertAnalysisWorkflowAgents = (
   return useMemo(
     () => ({
       agents: data ?? [],
-      isLoading,
+      // react-query v4 keeps `isLoading` true for a disabled query, which would otherwise leave the
+      // agent selector spinning forever when Agent Builder is unavailable. Gate it on the same
+      // condition as the query's `enabled`.
+      isLoading: isLoading && enabled && Boolean(agentBuilder),
     }),
-    [data, isLoading]
+    [data, isLoading, enabled, agentBuilder]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/use_alert_analysis_workflow_agents.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/alert_analysis_workflow/use_alert_analysis_workflow_agents.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useQuery } from '@kbn/react-query';
+import { useKibana } from '../../../../common/lib/kibana';
+
+const ALERT_ANALYSIS_WORKFLOW_AGENTS_QUERY_KEY = [
+  'alertAnalysisWorkflow',
+  'alertAnalysisWorkflowAgents',
+] as const;
+
+export interface AlertAnalysisWorkflowAgentOption {
+  id: string;
+  name: string;
+}
+
+/**
+ * Lists the Agent Builder agents selectable as the alert analysis workflow agent. Only the default
+ * agent and user-created (custom) agents are returned; platform built-in agents (`readonly`) are
+ * excluded because they are not meant to be picked here.
+ */
+export const useAlertAnalysisWorkflowAgents = (
+  enabled: boolean
+): { agents: AlertAnalysisWorkflowAgentOption[]; isLoading: boolean } => {
+  const {
+    services: { agentBuilder },
+  } = useKibana();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ALERT_ANALYSIS_WORKFLOW_AGENTS_QUERY_KEY,
+    enabled: enabled && Boolean(agentBuilder),
+    queryFn: async () => {
+      const allAgents = (await agentBuilder?.agents.list()) ?? [];
+      return allAgents
+        .filter((agent) => !agent.readonly)
+        .map((agent) => ({ id: agent.id, name: agent.name }));
+    },
+  });
+
+  return useMemo(
+    () => ({
+      agents: data ?? [],
+      isLoading,
+    }),
+    [data, isLoading]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -2219,6 +2219,7 @@ export const ALERT_ANALYSIS_WORKFLOW_SETTINGS_UPDATED_EVENT: EventTypeOpts<{
   autoCloseEnabled: boolean;
   createConversation: boolean;
   connectorConfigured: boolean;
+  customAgent: boolean;
   autoCloseConfidenceScoreMinThreshold: number;
   autoCloseConfidenceScoreMaxThreshold: number;
 }> = {
@@ -2243,6 +2244,12 @@ export const ALERT_ANALYSIS_WORKFLOW_SETTINGS_UPDATED_EVENT: EventTypeOpts<{
     connectorConfigured: {
       type: 'boolean',
       _meta: { description: 'Whether an AI connector is configured for the workflow' },
+    },
+    customAgent: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether a non-default (custom) agent is configured for the workflow',
+      },
     },
     autoCloseConfidenceScoreMinThreshold: {
       type: 'float',

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -7,10 +7,12 @@
 
 import { coreMock } from '@kbn/core/server/mocks';
 import {
+  SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MIN_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_ENABLED,
 } from '@kbn/management-settings-ids';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { initUiSettings } from './ui_settings';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import {
@@ -82,6 +84,20 @@ describe('initUiSettings', () => {
             type: 'number',
             technicalPreview: true,
           }),
+      })
+    );
+  });
+
+  it('registers the alert analysis workflow agent setting defaulting to the default agent', () => {
+    initUiSettings(mockUiSettings, mockExperimentalFeatures, false);
+
+    const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
+    expect(registeredSettings[SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID]).toEqual(
+      expect.objectContaining({
+        value: agentBuilderDefaultAgentId,
+        type: 'string',
+        sensitive: true,
+        technicalPreview: true,
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -8,9 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import { schema } from '@kbn/config-schema';
 import { DEFAULT_EXCLUDED_GAP_REASONS, gapReasonType } from '@kbn/alerting-plugin/common';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 
 import type { CoreSetup, UiSettingsParams } from '@kbn/core/server';
 import {
+  SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MIN_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_ENABLED,
@@ -825,6 +827,29 @@ export const getAlertAnalysisWorkflowSettings = (): SettingsConfig => ({
     category: [APP_ID],
     requiresPageReload: false,
     schema: schema.string(),
+    solutionViews: ['classic', 'security'],
+    technicalPreview: true,
+    readonly: true,
+  },
+  [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID]: {
+    name: i18n.translate('xpack.securitySolution.uiSettings.alertAnalysisWorkflowAgentIdLabel', {
+      defaultMessage: 'Alert analysis workflow agent',
+    }),
+    // The agent id is redacted from telemetry (see `sensitive` below); we only report whether a
+    // non-default agent is configured, never which one.
+    sensitive: true,
+    value: agentBuilderDefaultAgentId,
+    description: i18n.translate(
+      'xpack.securitySolution.uiSettings.alertAnalysisWorkflowAgentIdDescription',
+      {
+        defaultMessage:
+          'The Agent Builder agent used by the alert analysis workflow to classify alerts.',
+      }
+    ),
+    type: 'string',
+    category: [APP_ID],
+    requiresPageReload: false,
+    schema: schema.string({ minLength: 1 }),
     solutionViews: ['classic', 'security'],
     technicalPreview: true,
     readonly: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -849,7 +849,7 @@ export const getAlertAnalysisWorkflowSettings = (): SettingsConfig => ({
     type: 'string',
     category: [APP_ID],
     requiresPageReload: false,
-    schema: schema.string({ minLength: 1 }),
+    schema: schema.string({ minLength: 1, maxLength: 64 }),
     solutionViews: ['classic', 'security'],
     technicalPreview: true,
     readonly: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/install.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/install.test.ts
@@ -44,6 +44,7 @@ describe('alert analysis workflow install', () => {
           .mockResolvedValueOnce(0.8)
           .mockResolvedValueOnce(0.95)
           .mockResolvedValueOnce('connector-abc')
+          .mockResolvedValueOnce('elastic-ai-agent')
           .mockResolvedValueOnce(false)
           .mockResolvedValueOnce('alert-analysis'),
       };
@@ -56,6 +57,7 @@ describe('alert analysis workflow install', () => {
         autoCloseConfidenceScoreMinThreshold: 0.8,
         autoCloseConfidenceScoreMaxThreshold: 0.95,
         connectorId: 'connector-abc',
+        agentId: 'elastic-ai-agent',
         createConversation: false,
         tagPrefix: 'alert-analysis',
       });

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/install.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/install.ts
@@ -10,6 +10,7 @@ import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
 import type { IUiSettingsClient, Logger } from '@kbn/core/server';
 import type { WorkflowsExtensionsServerPluginStart } from '@kbn/workflows-extensions/server';
 import {
+  SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MIN_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_ENABLED,
@@ -34,6 +35,7 @@ export interface SecurityAlertAnalysisWorkflowSettings {
   autoCloseConfidenceScoreMinThreshold: number;
   autoCloseConfidenceScoreMaxThreshold: number;
   connectorId: string;
+  agentId: string;
   createConversation: boolean;
   tagPrefix: string;
 }
@@ -60,6 +62,7 @@ export const readSecurityAlertAnalysisWorkflowSettings = async (
   connectorId: await uiSettingsClient.get<string>(
     SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CONNECTOR_ID
   ),
+  agentId: await uiSettingsClient.get<string>(SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID),
   createConversation: await uiSettingsClient.get<boolean>(
     SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CREATE_CONVERSATION
   ),

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/settings_routes.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/settings_routes.test.ts
@@ -12,6 +12,7 @@ import { loggerMock } from '@kbn/logging-mocks';
 import { SECURITY_ALERT_ANALYSIS_WORKFLOW_ID } from '@kbn/workflows/managed';
 import { workflowsExtensionsMock } from '@kbn/workflows-extensions/server/mocks';
 import {
+  SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MIN_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_ENABLED,
@@ -116,6 +117,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
         .mockResolvedValueOnce(0.7) // autoCloseConfidenceScoreMinThreshold
         .mockResolvedValueOnce(0.9) // autoCloseConfidenceScoreMaxThreshold
         .mockResolvedValueOnce('connector-abc') // connectorId
+        .mockResolvedValueOnce('elastic-ai-agent') // agentId
         .mockResolvedValueOnce(true) // createConversation
         .mockResolvedValueOnce('alert-analysis'); // tagPrefix
     };
@@ -136,6 +138,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
             autoCloseConfidenceScoreMinThreshold: 0.7,
             autoCloseConfidenceScoreMaxThreshold: 0.9,
             connectorId: 'connector-abc',
+            agentId: 'elastic-ai-agent',
             createConversation: true,
             tagPrefix: 'alert-analysis',
           },
@@ -175,6 +178,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
       autoCloseConfidenceScoreMinThreshold: 0.75,
       autoCloseConfidenceScoreMaxThreshold: 0.95,
       connectorId: 'connector-xyz',
+      agentId: 'my-custom-agent',
       createConversation: false,
       tagPrefix: 'alert-analysis',
     };
@@ -194,6 +198,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
         [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD]:
           settings.autoCloseConfidenceScoreMaxThreshold,
         [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CONNECTOR_ID]: settings.connectorId,
+        [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID]: settings.agentId,
         [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CREATE_CONVERSATION]:
           settings.createConversation,
         [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_TAG_PREFIX]: settings.tagPrefix,
@@ -226,6 +231,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
           autoCloseEnabled: settings.autoCloseEnabled,
           createConversation: settings.createConversation,
           connectorConfigured: true,
+          customAgent: true,
         })
       );
     });
@@ -267,6 +273,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
         .mockResolvedValueOnce(0.85) // autoCloseConfidenceScoreMinThreshold
         .mockResolvedValueOnce(1) // autoCloseConfidenceScoreMaxThreshold
         .mockResolvedValueOnce('connector-abc') // connectorId
+        .mockResolvedValueOnce('elastic-ai-agent') // agentId
         .mockResolvedValueOnce(true) // createConversation
         .mockResolvedValueOnce('alert-analysis'); // tagPrefix
     };
@@ -289,6 +296,7 @@ describe('registerAlertAnalysisWorkflowSettingsRoutes', () => {
           autoCloseConfidenceScoreMinThreshold: 0.85,
           autoCloseConfidenceScoreMaxThreshold: 1,
           connectorId: 'connector-abc',
+          agentId: 'elastic-ai-agent',
           createConversation: true,
           tagPrefix: 'alert-analysis',
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/settings_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/settings_routes.ts
@@ -13,6 +13,7 @@ import { RULES_API_ALL, RULES_API_READ } from '@kbn/security-solution-features/c
 import { WorkflowsManagementApiActions } from '@kbn/workflows';
 import { SECURITY_ALERT_ANALYSIS_WORKFLOW_ID } from '@kbn/workflows/managed';
 import {
+  SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MIN_THRESHOLD,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_ENABLED,
@@ -21,6 +22,7 @@ import {
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_ENABLED,
   SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_TAG_PREFIX,
 } from '@kbn/management-settings-ids';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import {
   ALERT_ANALYSIS_WORKFLOW_API_VERSION,
   ALERT_ANALYSIS_WORKFLOW_RUNTIME_CONFIG_ROUTE,
@@ -76,6 +78,7 @@ const toWorkflowSettings = ({
   autoCloseConfidenceScoreMinThreshold,
   autoCloseConfidenceScoreMaxThreshold,
   connectorId,
+  agentId,
   workflowEnabled,
   createConversation,
   tagPrefix,
@@ -84,6 +87,7 @@ const toWorkflowSettings = ({
   autoCloseConfidenceScoreMinThreshold,
   autoCloseConfidenceScoreMaxThreshold,
   connectorId: connectorId ?? '',
+  agentId,
   workflowEnabled,
   createConversation,
   tagPrefix,
@@ -208,6 +212,8 @@ export const registerAlertAnalysisWorkflowSettingsRoutes = (
                 autoCloseEnabled: settings.autoCloseEnabled,
                 createConversation: settings.createConversation,
                 connectorConfigured: Boolean(settings.connectorId),
+                // Report only whether a non-default (custom) agent is used, never the agent id.
+                customAgent: settings.agentId !== agentBuilderDefaultAgentId,
                 autoCloseConfidenceScoreMinThreshold: settings.autoCloseConfidenceScoreMinThreshold,
                 autoCloseConfidenceScoreMaxThreshold: settings.autoCloseConfidenceScoreMaxThreshold,
               }
@@ -236,6 +242,7 @@ export const registerAlertAnalysisWorkflowSettingsRoutes = (
             [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AUTO_CLOSE_CONFIDENCE_SCORE_MAX_THRESHOLD]:
               settings.autoCloseConfidenceScoreMaxThreshold,
             [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CONNECTOR_ID]: settings.connectorId,
+            [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_AGENT_ID]: settings.agentId,
             [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_CREATE_CONVERSATION]:
               settings.createConversation,
             [SECURITY_SOLUTION_ALERT_ANALYSIS_WORKFLOW_TAG_PREFIX]: settings.tagPrefix,


### PR DESCRIPTION
## Summary

Adds a `securitySolution:alertAnalysisWorkflowAgentId` uiSetting so users can override the agent the managed alert analysis workflow runs with. Before, the workflow hardcoded `elastic-ai-agent`. Now the alert analysis workflow settings page shows an Agent dropdown listing the default agent and the user's custom Agent Builder agents, and the choice is threaded into the workflow's `ai.agent` step at run time. The setting defaults to the platform default agent (`elastic-ai-agent`), so behavior is unchanged until someone picks a different agent.

<img width="817" height="114" alt="Screenshot 2026-07-07 at 5 28 37 PM" src="https://github.com/user-attachments/assets/fb72274c-9257-46d1-a88f-e150e1df00ba" />


@nastasha-solomon again this should be documented as part of #269743. I updated the screenshot there.


The agent id is registered as `sensitive`, so telemetry redacts it. A `customAgent` boolean on the `alert_analysis_workflow_settings_updated` event records only whether a non-default agent is configured, never which one.

## To test

1. Run Kibana and ES locally with the alert analysis workflow enabled and configured (Enterprise license, an AI connector set).
2. Create a custom agent in Agent Builder.
3. Go to the alert analysis workflow settings page (Rules, then alert analysis workflow).
4. Open the Agent dropdown. It lists the default agent plus your custom agents, and excludes platform built-in agents.
5. Select a custom agent and save.
6. Confirm the setting persists on reload, and that the workflow's `ai.agent` step runs with the selected agent.

_PR developed with Cursor + Claude Opus 4.8_
