### PR TITLE
[ES|QL] Propagates approximation flag to cascade

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.test.tsx
@@ -141,6 +141,7 @@ const createContextValue = ({
     esqlQuery,
     esqlVariables: undefined,
     timeRange: undefined,
+    isApproximate: false,
     viewModeToggle: undefined,
     expandedDoc$: new BehaviorSubject<DataTableRecord | undefined>(expandedDoc),
     expandedDocOwner$: new BehaviorSubject<string | undefined>(currentOwner),

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.test.tsx
@@ -124,6 +124,7 @@ const createWrapper = async (overrides?: Partial<CascadedDocumentsContext>) => {
     esqlQuery,
     esqlVariables: undefined,
     timeRange: undefined,
+    isApproximate: false,
     viewModeToggle: undefined,
     expandedDoc$: new BehaviorSubject<DataTableRecord | undefined>(undefined),
     expandedDocOwner$: new BehaviorSubject<string | undefined>(undefined),

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -36,6 +36,7 @@ export interface CascadedDocumentsContext
   esqlQuery: AggregateQuery;
   esqlVariables: ESQLControlVariable[] | undefined;
   timeRange: TimeRange | undefined;
+  isApproximate: boolean;
   viewModeToggle: ReactElement | undefined;
   expandedDoc$: BehaviorSubject<DataTableRecord | undefined>;
   expandedDocOwner$: BehaviorSubject<string | undefined>;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -281,6 +281,7 @@ describe('data_fetching related hooks', () => {
         esqlQuery,
         esqlVariables: undefined,
         timeRange: undefined,
+        isApproximate: false,
         viewModeToggle: undefined,
         expandedDoc$: new BehaviorSubject<DataTableRecord | undefined>(undefined),
         expandedDocOwner$: new BehaviorSubject<string | undefined>(undefined),
@@ -391,7 +392,30 @@ describe('data_fetching related hooks', () => {
           esqlVariables: contextValue.esqlVariables,
           timeRange: contextValue.timeRange,
           dataView,
+          isApproximate: contextValue.isApproximate,
         });
+      });
+
+      it('forwards isApproximate from the context so drill-downs match the active search mode', async () => {
+        const mockRow = createMockRowData();
+        const { Wrapper, contextValue } = createWrapper({ isApproximate: true });
+        const dataView = dataViewWithTimefieldMock;
+
+        const { result } = renderHook(() => useDataCascadeRowExpansionHandlers({ dataView }), {
+          wrapper: Wrapper,
+        });
+
+        await act(async () => {
+          await result.current.onCascadeLeafNodeExpanded({
+            row: mockRow,
+            nodePath: ['category'],
+            nodePathMap: { category: 'A' },
+          });
+        });
+
+        expect(contextValue.cascadedDocumentsFetcher.fetchCascadedDocuments).toHaveBeenCalledWith(
+          expect.objectContaining({ isApproximate: true })
+        );
       });
     });
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
@@ -165,7 +165,7 @@ export function useDataCascadeRowExpansionHandlers({
     DataCascadeRowCellProps<ESQLDataGroupNode, DataTableRecord>,
     'onCascadeLeafNodeExpanded' | 'onCascadeLeafNodeCollapsed'
   > {
-  const { cascadedDocumentsFetcher, esqlQuery, esqlVariables, timeRange } =
+  const { cascadedDocumentsFetcher, esqlQuery, esqlVariables, timeRange, isApproximate } =
     useCascadedDocumentsContext();
   const { trackCascadeExpanded, trackCascadeCollapsed } = useCascadedDocumentsTelemetry();
 
@@ -211,6 +211,7 @@ export function useDataCascadeRowExpansionHandlers({
       esqlVariables,
       timeRange,
       dataView,
+      isApproximate,
     });
   });
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -489,6 +489,7 @@ function DiscoverDocumentsComponent({
     internalStateActions.setCascadedDocumentsDataGridUiState
   );
   const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
+  const isApproximate = useAppStateSelector((state) => state.isApproximate ?? false);
   const cascadedDocumentsContext = useMemo<CascadedDocumentsContext | undefined>(() => {
     if (
       !isCascadedDocumentsVisible(availableCascadeGroups, query) ||
@@ -505,6 +506,7 @@ function DiscoverDocumentsComponent({
       esqlQuery: query,
       esqlVariables,
       timeRange: requestParams.timeRangeAbsolute,
+      isApproximate,
       viewModeToggle,
       expandedDoc$,
       expandedDocOwner$,
@@ -532,6 +534,7 @@ function DiscoverDocumentsComponent({
     expandedDocOwner$,
     getExpandedDocSetter,
     getRenderDocumentViewMetaSetter,
+    isApproximate,
     latestCascadedDocumentsDataGridsUiState,
     latestDataCascadeUiState,
     onUpdateESQLQuery,

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
@@ -99,6 +99,7 @@ const createFetchParams = (
     esqlVariables: undefined,
     dataView: dataViewWithTimefieldMock,
     timeRange: { from: 'now-15m', to: 'now' },
+    isApproximate: false,
     ...overrides,
   };
 };
@@ -166,6 +167,24 @@ describe('CascadedDocumentsFetcher', () => {
     );
     expect(stateManager.setColumnsMeta).toHaveBeenCalledWith(columnsMeta);
     expect(stateManager.setCascadedDocuments).toHaveBeenCalledWith(params.nodeId, records);
+  });
+
+  it('forwards isApproximate to fetchEsql so cascade drill-downs match the active search mode', async () => {
+    const { fetcher } = createFetcher();
+    const cascadeQuery: AggregateQuery = { esql: 'from logs' };
+
+    mockConstructCascadeQuery.mockReturnValueOnce(cascadeQuery);
+    mockFetchEsql.mockResolvedValue({ records: [], esqlQueryColumns: [] });
+
+    await fetcher.fetchCascadedDocuments(
+      createFetchParams({ nodeId: 'node-approx', isApproximate: true })
+    );
+
+    expect(mockFetchEsql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isApproximate: true,
+      })
+    );
   });
 
   it('skips updating columns meta when the fetched value is unchanged', async () => {

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -23,6 +23,7 @@ import type { ScopedProfilesManager } from '../../../context_awareness';
 export interface FetchCascadedDocumentsParams extends CascadeQueryArgs {
   nodeId: string;
   timeRange: TimeRange | undefined;
+  isApproximate: boolean;
 }
 
 export interface CascadedDocumentsStateManager {
@@ -56,6 +57,7 @@ export class CascadedDocumentsFetcher {
     esqlVariables,
     dataView,
     timeRange,
+    isApproximate,
   }: FetchCascadedDocumentsParams) {
     this.cancelFetch(nodeId);
 
@@ -97,6 +99,7 @@ export class CascadedDocumentsFetcher {
         timeRange,
         scopedProfilesManager: this.scopedProfilesManager,
         inspectorAdapters: { requests: this.requestAdapter },
+        isApproximate,
         inspectorConfig: {
           title: i18n.translate('discover.dataCascade.inspector.cascadeQueryTitle', {
             defaultMessage: 'Cascade Row Data Query',


### PR DESCRIPTION
## Summary

This follow up PR propagates the isApproximation to the cascade experience. 

I did it only for consistency, it doesnt really make any difference because the cascade experience is running queries like `from index | WHERE field =="value"` and at these queries the isApproximation is not making any difference



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




