### PR TITLE
[One Workflow] Expose workflow executions as a hidden index

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/common/create_index.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/create_index.test.ts
@@ -14,6 +14,7 @@ const createEsClientMock = () => ({
     exists: jest.fn(),
     create: jest.fn(),
     putMapping: jest.fn(),
+    putSettings: jest.fn(),
   },
 });
 
@@ -77,6 +78,27 @@ describe('createIndexWithMappings', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('creates the index with settings when provided', async () => {
+    const esClient = createEsClientMock();
+    esClient.indices.exists.mockResolvedValue(false);
+    esClient.indices.create.mockResolvedValue({});
+    const logger = createLoggerMock();
+
+    await createIndexWithMappings({
+      esClient: esClient as any,
+      indexName: '.test-index',
+      mappings: { properties: {} },
+      settings: { index: { hidden: true } },
+      logger: logger as any,
+    });
+
+    expect(esClient.indices.create).toHaveBeenCalledWith({
+      index: '.test-index',
+      mappings: { properties: {} },
+      settings: { index: { hidden: true } },
+    });
+  });
+
   it('rethrows non-resource-exists errors', async () => {
     const esClient = createEsClientMock();
     esClient.indices.exists.mockResolvedValue(false);
@@ -129,7 +151,29 @@ describe('createOrUpdateIndex', () => {
       index: '.test-index',
       properties: { id: { type: 'keyword' } },
     });
+    expect(esClient.indices.putSettings).not.toHaveBeenCalled();
     expect(esClient.indices.create).not.toHaveBeenCalled();
+  });
+
+  it('updates settings when index already exists and settings are provided', async () => {
+    const esClient = createEsClientMock();
+    esClient.indices.exists.mockResolvedValue(true);
+    esClient.indices.putMapping.mockResolvedValue({});
+    esClient.indices.putSettings.mockResolvedValue({});
+    const logger = createLoggerMock();
+
+    await createOrUpdateIndex({
+      esClient: esClient as any,
+      indexName: '.test-index',
+      mappings: { properties: {} },
+      settings: { index: { hidden: true } },
+      logger: logger as any,
+    });
+
+    expect(esClient.indices.putSettings).toHaveBeenCalledWith({
+      index: '.test-index',
+      settings: { index: { hidden: true } },
+    });
   });
 
   it('continues if putMapping fails', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/common/create_index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/create_index.ts
@@ -7,13 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  IndicesIndexSettings,
+  MappingTypeMapping,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 
 interface CreateIndexOptions {
   esClient: ElasticsearchClient;
   indexName: string;
   mappings: MappingTypeMapping;
+  settings?: IndicesIndexSettings;
   logger?: Logger;
 }
 
@@ -21,6 +25,7 @@ export const createIndexWithMappings = async ({
   esClient,
   indexName,
   mappings,
+  settings,
   logger,
 }: CreateIndexOptions): Promise<void> => {
   try {
@@ -40,6 +45,7 @@ export const createIndexWithMappings = async ({
     await esClient.indices.create({
       index: indexName,
       mappings,
+      ...(settings ? { settings } : {}),
     });
 
     logger?.debug(`Successfully created index ${indexName}`);
@@ -59,6 +65,7 @@ export const createOrUpdateIndex = async ({
   esClient,
   indexName,
   mappings,
+  settings,
   logger,
 }: CreateIndexOptions): Promise<void> => {
   try {
@@ -72,6 +79,7 @@ export const createOrUpdateIndex = async ({
         esClient,
         indexName,
         mappings,
+        settings,
         logger,
       });
     } else {
@@ -85,6 +93,14 @@ export const createOrUpdateIndex = async ({
       } catch (mappingError) {
         logger?.warn(`Failed to update mappings for index ${indexName}: ${mappingError.message}`);
         // Continue - the index exists and can be used
+      }
+
+      if (settings) {
+        await esClient.indices.putSettings({
+          index: indexName,
+          settings,
+        });
+        logger?.debug(`Updated settings for existing index ${indexName}`);
       }
     }
   } catch (error) {

--- a/src/platform/plugins/shared/workflows_execution_engine/common/create_indexes.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/create_indexes.test.ts
@@ -37,7 +37,10 @@ describe('createIndexes', () => {
     expect(createIndexWithMappings).not.toHaveBeenCalled();
 
     expect(createOrUpdateIndex).toHaveBeenCalledWith(
-      expect.objectContaining({ indexName: WORKFLOWS_EXECUTIONS_INDEX })
+      expect.objectContaining({
+        indexName: WORKFLOWS_EXECUTIONS_INDEX,
+        settings: { index: { hidden: true } },
+      })
     );
     expect(createOrUpdateIndex).toHaveBeenCalledWith(
       expect.objectContaining({ indexName: WORKFLOWS_STEP_EXECUTIONS_INDEX })

--- a/src/platform/plugins/shared/workflows_execution_engine/common/create_indexes.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/create_indexes.ts
@@ -28,6 +28,11 @@ export async function createIndexes(options: CreateIndexesOptions): Promise<void
       esClient,
       indexName: WORKFLOWS_EXECUTIONS_INDEX,
       mappings: WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS,
+      settings: {
+        index: {
+          hidden: true,
+        },
+      },
       logger,
     }),
     createOrUpdateIndex({

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_data_view.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_data_view.ts
@@ -67,6 +67,7 @@ export const WORKFLOW_EXECUTIONS_FIELD_SPECS: Record<string, FieldSpec> = {
 export const WORKFLOW_EXECUTIONS_DATA_VIEW_CREATE_SPEC: DataViewSpec = {
   ...WORKFLOW_EXECUTIONS_DATA_VIEW_SPEC,
   allowNoIndex: true,
+  allowHidden: true,
   fields: WORKFLOW_EXECUTIONS_FIELD_SPECS,
 };
 

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/internal/execution_fields.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/internal/execution_fields.ts
@@ -99,7 +99,7 @@ export function registerExecutionFieldsRoute({ router }: RouteDependencies) {
               ? {}
               : { indexFilter: buildUnmanagedWorkflowExecutionsFilter() }),
             fieldTypes: parseFields(request.query.field_types),
-            allowHidden: request.query.allow_hidden,
+            allowHidden: request.query.allow_hidden ?? true,
             ...(parseFields(request.query.fields).length > 0
               ? { fields: parseFields(request.query.fields) }
               : {}),

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/internal/internal.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/internal/internal.test.ts
@@ -267,6 +267,7 @@ describe('Internal Routes', () => {
       expect.objectContaining({
         pattern: WORKFLOWS_EXECUTIONS_INDEX,
         indexFilter: { bool: { must_not: [{ term: { managed: true } }] } },
+        allowHidden: true,
       })
     );
   });


### PR DESCRIPTION
## Summary
- Creates `.workflows-executions` as a hidden index and updates existing indices to `index.hidden: true` on Kibana startup.
- Allows Workflows execution data views and field discovery to resolve hidden execution indices.
- Keeps `.workflows-step-executions` unchanged so only workflow-level executions are exposed for analytics/dashboard use.

## Test plan
- `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/common/create_index.test.ts src/platform/plugins/shared/workflows_execution_engine/common/create_indexes.test.ts`
- `node scripts/jest --config=src/platform/plugins/shared/workflows_management/server/jest.config.js src/platform/plugins/shared/workflows_management/server/api/routes/internal/internal.test.ts`
- `node scripts/check`

## Companion PR
- Requires elastic/elasticsearch#153211 for `.workflows-executions` to stop being restricted and to receive implicit DLS-scoped read privileges from Kibana Workflows app privileges.

Made with [Cursor](https://cursor.com)