### PR TITLE
[8.19] Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments (#276742)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 
-import { agentPolicyService } from '../agent_policy';
-import { packagePolicyService } from '../package_policy';
+import { agentPolicyService, getAgentPolicySavedObjectType } from '../agent_policy';
+import { packagePolicyService, getPackagePolicySavedObjectType } from '../package_policy';
 import { PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE } from '../../constants';
 import { setupFleet } from '../setup';
 import { getAgentsByKuery, forceUnenrollAgent } from '../agents';
@@ -36,6 +37,11 @@ const mockedListEnrollmentApiKeys = listEnrollmentApiKeys as jest.MockedFunction
 
 const mockedAgentPolicyService = agentPolicyService as jest.Mocked<typeof agentPolicyService>;
 const mockedPackagePolicyService = packagePolicyService as jest.Mocked<typeof packagePolicyService>;
+const mockedGetAgentPolicySavedObjectType = getAgentPolicySavedObjectType as jest.MockedFunction<
+  typeof getAgentPolicySavedObjectType
+>;
+const mockedGetPackagePolicySavedObjectType =
+  getPackagePolicySavedObjectType as jest.MockedFunction<typeof getPackagePolicySavedObjectType>;
 
 jest.mock('../app_context', () => ({
   appContextService: {
@@ -104,5 +110,124 @@ describe('reset agent policies', () => {
     expect(mockedSetupFleet).toBeCalled();
     expect(mockedForceUnenrollAgent).toBeCalled();
     expect(mockedDeleteEnrollmentApiKey).toBeCalled();
+  });
+
+  describe('_deleteGhostPackagePolicies with legacy (non-space-aware) saved object types', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockedGetAgentPolicySavedObjectType.mockResolvedValue('ingest-agent-policies');
+      mockedGetPackagePolicySavedObjectType.mockResolvedValue('ingest-package-policies');
+      mockedAgentPolicyService.list.mockResolvedValueOnce({ items: [] } as any);
+    });
+
+    it('should resolve the legacy agent policy type and not delete a package policy whose parent agent policy exists', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [{ id: 'policy1', type: 'ingest-agent-policies', attributes: {} }],
+      } as any);
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await resetPreconfiguredAgentPolicies(soClient, esClient);
+
+      expect(soClient.bulkGet).toBeCalledWith([{ id: 'policy1', type: 'ingest-agent-policies' }]);
+      expect(soClient.delete).not.toBeCalled();
+      expect(mockedSetupFleet).toBeCalled();
+    });
+
+    it('should delete a ghost package policy using the resolved legacy package policy type', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'policy1',
+            type: 'ingest-agent-policies',
+            error: { statusCode: 404, message: 'Not found', error: 'Not Found' },
+          },
+        ],
+      } as any);
+      soClient.delete.mockResolvedValueOnce(undefined as any);
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await resetPreconfiguredAgentPolicies(soClient, esClient);
+
+      expect(soClient.delete).toBeCalledWith('ingest-package-policies', 'pkgPolicy1');
+      expect(mockedSetupFleet).toBeCalled();
+    });
+
+    it('should not abort the reset when deleting a ghost package policy 404s', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'policy1',
+            type: 'ingest-agent-policies',
+            error: { statusCode: 404, message: 'Not found', error: 'Not Found' },
+          },
+        ],
+      } as any);
+      soClient.delete.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError('ingest-package-policies', 'pkgPolicy1')
+      );
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await expect(resetPreconfiguredAgentPolicies(soClient, esClient)).resolves.not.toThrow();
+
+      expect(mockedSetupFleet).toBeCalled();
+    });
+
+    it('should propagate non-404 errors from deleting a ghost package policy', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedPackagePolicyService.list.mockResolvedValueOnce({
+        items: [{ id: 'pkgPolicy1', name: 'pkgPolicy1', policy_ids: ['policy1'] }],
+      } as any);
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'policy1',
+            type: 'ingest-agent-policies',
+            error: { statusCode: 404, message: 'Not found', error: 'Not Found' },
+          },
+        ],
+      } as any);
+      soClient.delete.mockRejectedValueOnce(new Error('boom'));
+      soClient.find.mockImplementation(async (option) => {
+        if (option.type === PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE) {
+          return { saved_objects: [] } as any;
+        }
+        throw new Error('not mocked');
+      });
+
+      await expect(resetPreconfiguredAgentPolicies(soClient, esClient)).rejects.toThrow('boom');
+
+      expect(mockedSetupFleet).not.toBeCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/reset_agent_policies.ts
@@ -15,11 +15,10 @@ import { setupFleet } from '../setup';
 import {
   LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
-  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE,
 } from '../../constants';
 import { agentPolicyService, getAgentPolicySavedObjectType } from '../agent_policy';
-import { packagePolicyService } from '../package_policy';
+import { packagePolicyService, getPackagePolicySavedObjectType } from '../package_policy';
 import { getAgentsByKuery, forceUnenrollAgent } from '../agents';
 import { listEnrollmentApiKeys, deleteEnrollmentApiKey } from '../api_keys';
 import type { AgentPolicy } from '../../types';
@@ -73,6 +72,7 @@ async function _deleteGhostPackagePolicies(
     return acc;
   }, new Map<string, boolean>());
 
+  const packagePolicySavedObjectType = await getPackagePolicySavedObjectType();
   await pMap(
     packagePolicies,
     (packagePolicy) => {
@@ -80,7 +80,12 @@ async function _deleteGhostPackagePolicies(
         packagePolicy.policy_ids.every((policyId) => agentPolicyExistsMap.get(policyId) === false)
       ) {
         logger.info(`Deleting ghost package policy ${packagePolicy.name} (${packagePolicy.id})`);
-        return soClient.delete(PACKAGE_POLICY_SAVED_OBJECT_TYPE, packagePolicy.id);
+        return soClient.delete(packagePolicySavedObjectType, packagePolicy.id).catch((err) => {
+          if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
+            return undefined;
+          }
+          throw err;
+        });
       }
     },
     {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments (#276742)](https://github.com/elastic/kibana/pull/276742)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-07-08T06:45:46Z","message":"Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments (#276742)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/273838\n\nOn deployments with space awareness disabled, agent/package policies\nlive under `ingest-agent-policies`/`ingest-package-policies` rather than\nthe `fleet-*` types. Currently, the code always queries/deletes using\nthe `fleet-*` types, so `bulkGet` throws 404 which aborts the whole\nreset before `setupFleet` can rebuild the preconfigured policy.\n\nChanges made in `_deleteGhostPackagePolicies`:\n* Replace the hardcoded `AGENT_POLICY_SAVED_OBJECT_TYPE` used for the\n`bulkGet` parent-policy check with `await\ngetAgentPolicySavedObjectType()`\n* Replace the hardcoded `PACKAGE_POLICY_SAVED_OBJECT_TYP used for the\nghost-policy delete with `await getPackagePolicySavedObjectType()`\n* Add a `.catch` guard on the delete that swallows `isNotFoundError`\n(matching the existing pattern in `_deletePreconfigurationDeleteRecord`\nin the same file) and rethrows anything else\n\nUnit tests added for:\n* the legacy type being used for the existence check\n* ghost deletion using the resolved legacy type\n* 404-on-delete no longer aborting the reset\n* non-404 errors still propagating correctly\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk, narrowly scoped:\n* Only `_deleteGhostPackagePolicies is touched`: `_deleteExistingData`\nand `_deletePreconfigurationDeleteRecord` are unchanged\n* On space-aware deployments,\n`getAgentPolicySavedObjectType()`/`getPackagePolicySavedObjectType()`\nresolve to the same `fleet-*` constants that were hardcoded before\n* The new 404 guard only widens tolerance (a previously-fatal 404 is now\na no-op), it doesn't suppress other error types\n\n## Release note\n\nFixes a bug where `POST\n/internal/fleet/reset_preconfigured_agent_policies/{id}` always aborts\nbefore `setupFleet` runs on deployments where space awareness is\ndisabled.","sha":"befb50e4617f85218c6bc159e1976ba7dff720a7","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.5.0","v9.4.4","v8.19.19","v9.3.8"],"title":"Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments","number":276742,"url":"https://github.com/elastic/kibana/pull/276742","mergeCommit":{"message":"Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments (#276742)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/273838\n\nOn deployments with space awareness disabled, agent/package policies\nlive under `ingest-agent-policies`/`ingest-package-policies` rather than\nthe `fleet-*` types. Currently, the code always queries/deletes using\nthe `fleet-*` types, so `bulkGet` throws 404 which aborts the whole\nreset before `setupFleet` can rebuild the preconfigured policy.\n\nChanges made in `_deleteGhostPackagePolicies`:\n* Replace the hardcoded `AGENT_POLICY_SAVED_OBJECT_TYPE` used for the\n`bulkGet` parent-policy check with `await\ngetAgentPolicySavedObjectType()`\n* Replace the hardcoded `PACKAGE_POLICY_SAVED_OBJECT_TYP used for the\nghost-policy delete with `await getPackagePolicySavedObjectType()`\n* Add a `.catch` guard on the delete that swallows `isNotFoundError`\n(matching the existing pattern in `_deletePreconfigurationDeleteRecord`\nin the same file) and rethrows anything else\n\nUnit tests added for:\n* the legacy type being used for the existence check\n* ghost deletion using the resolved legacy type\n* 404-on-delete no longer aborting the reset\n* non-404 errors still propagating correctly\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk, narrowly scoped:\n* Only `_deleteGhostPackagePolicies is touched`: `_deleteExistingData`\nand `_deletePreconfigurationDeleteRecord` are unchanged\n* On space-aware deployments,\n`getAgentPolicySavedObjectType()`/`getPackagePolicySavedObjectType()`\nresolve to the same `fleet-*` constants that were hardcoded before\n* The new 404 guard only widens tolerance (a previously-fatal 404 is now\na no-op), it doesn't suppress other error types\n\n## Release note\n\nFixes a bug where `POST\n/internal/fleet/reset_preconfigured_agent_policies/{id}` always aborts\nbefore `setupFleet` runs on deployments where space awareness is\ndisabled.","sha":"befb50e4617f85218c6bc159e1976ba7dff720a7"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276742","number":276742,"mergeCommit":{"message":"Fix resetPreconfiguredAgentPolicies aborting with a 404 on legacy-SO-type deployments (#276742)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/273838\n\nOn deployments with space awareness disabled, agent/package policies\nlive under `ingest-agent-policies`/`ingest-package-policies` rather than\nthe `fleet-*` types. Currently, the code always queries/deletes using\nthe `fleet-*` types, so `bulkGet` throws 404 which aborts the whole\nreset before `setupFleet` can rebuild the preconfigured policy.\n\nChanges made in `_deleteGhostPackagePolicies`:\n* Replace the hardcoded `AGENT_POLICY_SAVED_OBJECT_TYPE` used for the\n`bulkGet` parent-policy check with `await\ngetAgentPolicySavedObjectType()`\n* Replace the hardcoded `PACKAGE_POLICY_SAVED_OBJECT_TYP used for the\nghost-policy delete with `await getPackagePolicySavedObjectType()`\n* Add a `.catch` guard on the delete that swallows `isNotFoundError`\n(matching the existing pattern in `_deletePreconfigurationDeleteRecord`\nin the same file) and rethrows anything else\n\nUnit tests added for:\n* the legacy type being used for the existence check\n* ghost deletion using the resolved legacy type\n* 404-on-delete no longer aborting the reset\n* non-404 errors still propagating correctly\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk, narrowly scoped:\n* Only `_deleteGhostPackagePolicies is touched`: `_deleteExistingData`\nand `_deletePreconfigurationDeleteRecord` are unchanged\n* On space-aware deployments,\n`getAgentPolicySavedObjectType()`/`getPackagePolicySavedObjectType()`\nresolve to the same `fleet-*` constants that were hardcoded before\n* The new 404 guard only widens tolerance (a previously-fatal 404 is now\na no-op), it doesn't suppress other error types\n\n## Release note\n\nFixes a bug where `POST\n/internal/fleet/reset_preconfigured_agent_policies/{id}` always aborts\nbefore `setupFleet` runs on deployments where space awareness is\ndisabled.","sha":"befb50e4617f85218c6bc159e1976ba7dff720a7"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276870","number":276870,"state":"OPEN"},{"branch":"8.19","label":"v8.19.19","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276869","number":276869,"state":"OPEN"}]}] BACKPORT-->