### PR TITLE
[Scout] Fix streams_app & snapshot_restore Scout tests on cloud-stateful-classic

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/fixtures/page_objects/snapshot_restore_page.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/fixtures/page_objects/snapshot_restore_page.ts
@@ -12,10 +12,25 @@ export class SnapshotRestorePage {
 
   async waitForSnapshotsTab({
     state = 'noRepos',
-  }: { state?: 'noRepos' | 'noSnapshots' | 'hasSnapshots' } = {}) {
-    // noRepos    → RepositoryEmptyPrompt renders registerRepositoryButton
+  }: { state?: 'noRepos' | 'noSnapshots' | 'hasSnapshots' | 'loaded' } = {}) {
+    // noRepos     → RepositoryEmptyPrompt renders registerRepositoryButton
     // noSnapshots → SnapshotEmptyPrompt renders emptyPrompt (repos exist, no snapshots yet)
     // hasSnapshots → snapshotList table
+    // loaded      → either emptyPrompt or snapshotList — a repository exists but the snapshot count
+    //               is irrelevant. Use this when the test only needs a repository present: the
+    //               empty-snapshots count is global across all repositories, and on ECH the managed
+    //               `found-snapshots` repository continuously accrues SLM snapshots, so `noSnapshots`
+    //               never resolves there.
+    if (state === 'loaded') {
+      // `emptyPrompt` and `snapshotList` are mutually exclusive in the DOM (snapshot_list.tsx
+      // renders one or the other), so the combined locator resolves to a single element.
+      await this.page.testSubj
+        .locator('emptyPrompt')
+        .or(this.page.testSubj.locator('snapshotList'))
+        .waitFor({ state: 'visible' });
+      return;
+    }
+
     const selectorMap = {
       noRepos: 'registerRepositoryButton',
       noSnapshots: 'emptyPrompt',

--- a/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/fixtures/snapshot_repository_helpers.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/fixtures/snapshot_repository_helpers.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsClient } from '@kbn/scout';
+
+/**
+ * The managed snapshot repository every Elastic Cloud (ECH) deployment ships with. Cloud has no
+ * node-local filesystem path (`path.repo` is empty), so tests must reuse this repository instead
+ * of registering an `fs` repository the way the local Scout cluster can.
+ */
+export const CLOUD_DEFAULT_SNAPSHOT_REPOSITORY = 'found-snapshots';
+const LOCAL_FS_SNAPSHOT_REPOSITORY_LOCATION = 'temp';
+
+export interface ManagedSnapshotRepository {
+  /** Name of the repository to use in the test. */
+  name: string;
+  /** Removes anything this helper created (never deletes the managed Cloud repository). */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Ensures a usable snapshot repository, branching on the deployment (pass `config.isCloud`):
+ *
+ * - Local Scout stateful cluster: registers an `fs` repository at `path.repo` (`temp`).
+ * - Elastic Cloud (ECH): has no node-local `path.repo`, so reuses the managed `found-snapshots`
+ *   repository that every deployment ships with (never creates or deletes it).
+ */
+export async function ensureSnapshotRepository(
+  esClient: EsClient,
+  isCloud: boolean,
+  fsRepositoryName: string
+): Promise<ManagedSnapshotRepository> {
+  const name = isCloud ? CLOUD_DEFAULT_SNAPSHOT_REPOSITORY : fsRepositoryName;
+
+  if (!isCloud) {
+    await esClient.snapshot.createRepository({
+      name: fsRepositoryName,
+      verify: true,
+      repository: { type: 'fs', settings: { location: LOCAL_FS_SNAPSHOT_REPOSITORY_LOCATION } },
+    });
+  }
+
+  return {
+    name,
+    cleanup: async () => {
+      // Only remove what we created; never delete the managed Cloud repository.
+      if (!isCloud) {
+        await esClient.snapshot.deleteRepository({ name: [fsRepositoryName] }).catch(() => {});
+      }
+    },
+  };
+}

--- a/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/tests/a11y.spec.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/tests/a11y.spec.ts
@@ -135,7 +135,9 @@ test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.class
 
     await browserAuth.loginAsAdmin();
     await page.gotoApp('management/data/snapshot_restore');
-    await snapshotRestore.waitForSnapshotsTab({ state: 'noSnapshots' });
+    // The wizard only needs a repository to select; the snapshot count is irrelevant (and non-zero
+    // on ECH, where the managed `found-snapshots` repository always holds SLM snapshots).
+    await snapshotRestore.waitForSnapshotsTab({ state: 'loaded' });
     await snapshotRestore.navToPolicies();
 
     await test.step('page one', async () => {

--- a/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/tests/a11y.spec.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/tests/a11y.spec.ts
@@ -9,19 +9,23 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
+import {
+  type ManagedSnapshotRepository,
+  ensureSnapshotRepository,
+} from '../fixtures/snapshot_repository_helpers';
 
 // Modals, flyouts, and context menus render in EUI portals outside .kbnAppWrapper.
 const A11Y_SELECTORS = ['.kbnAppWrapper', '[data-euiportal="true"]'];
 
 test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.classic }, () => {
-  let repoName: string | undefined;
+  let repository: ManagedSnapshotRepository | undefined;
   let snapshotName: string | undefined;
   let policyName: string | undefined;
 
   test.afterEach(async ({ esClient, kbnClient }) => {
-    if (snapshotName && repoName) {
+    if (snapshotName && repository) {
       await esClient.snapshot
-        .delete({ snapshot: snapshotName, repository: repoName })
+        .delete({ snapshot: snapshotName, repository: repository.name })
         .catch(() => {});
       snapshotName = undefined;
     }
@@ -29,9 +33,10 @@ test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.class
       await esClient.slm.deleteLifecycle({ policy_id: policyName }).catch(() => {});
       policyName = undefined;
     }
-    if (repoName) {
-      await esClient.snapshot.deleteRepository({ name: [repoName] }).catch(() => {});
-      repoName = undefined;
+    if (repository) {
+      // Only removes a locally created `fs` repository; the managed Cloud repository is left intact.
+      await repository.cleanup();
+      repository = undefined;
     }
     await kbnClient.savedObjects.cleanStandardList();
   });
@@ -40,7 +45,17 @@ test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.class
     page,
     browserAuth,
     pageObjects,
+    config,
   }) => {
+    // On ECH every deployment ships with the managed `found-snapshots` repository, so Snapshot &
+    // Restore always has a repository and the empty-state UI (registerRepositoryButton) never
+    // renders. The test is skipped on Cloud; it still exercises the empty-state a11y locally where
+    // no default repository exists.
+    test.skip(
+      config.isCloud === true,
+      'On ECH the managed `found-snapshots` repository always exists, so the empty-state UI is never rendered.'
+    );
+
     const { snapshotRestore } = pageObjects;
 
     await browserAuth.loginAsAdmin();
@@ -76,18 +91,14 @@ test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.class
     browserAuth,
     pageObjects,
     esClient,
+    config,
   }) => {
     const { snapshotRestore } = pageObjects;
-    repoName = `testrepo-${Date.now()}`;
+    repository = await ensureSnapshotRepository(esClient, config.isCloud, `testrepo-${Date.now()}`);
     snapshotName = `testsnapshot-${Date.now()}`;
 
-    await esClient.snapshot.createRepository({
-      name: repoName,
-      verify: true,
-      repository: { type: 'fs', settings: { location: 'temp' } },
-    });
     await esClient.snapshot.create({
-      repository: repoName,
+      repository: repository.name,
       snapshot: snapshotName,
       wait_for_completion: true,
     });
@@ -112,16 +123,15 @@ test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.class
     browserAuth,
     pageObjects,
     esClient,
+    config,
   }) => {
     const { snapshotRestore } = pageObjects;
-    repoName = `policyrepo-${Date.now()}`;
+    repository = await ensureSnapshotRepository(
+      esClient,
+      config.isCloud,
+      `policyrepo-${Date.now()}`
+    );
     policyName = `testpolicy-${Date.now()}`;
-
-    await esClient.snapshot.createRepository({
-      name: repoName,
-      verify: true,
-      repository: { type: 'fs', settings: { location: 'temp' } },
-    });
 
     await browserAuth.loginAsAdmin();
     await page.gotoApp('management/data/snapshot_restore');
@@ -132,7 +142,7 @@ test.describe('Snapshot & Restore — accessibility', { tag: tags.stateful.class
       await snapshotRestore.fillCreateNewPolicyPageOne(
         policyName!,
         '<daily-snap-{now/d}>',
-        repoName!
+        repository!.name
       );
       const { violations } = await page.checkA11y({ include: A11Y_SELECTORS });
       expect(violations).toStrictEqual([]);

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/data_lifecycle_helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/data_lifecycle_helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { type ApiServicesFixture, type Locator, type ScoutPage } from '@kbn/scout';
+import { type ApiServicesFixture, type EsClient, type Locator, type ScoutPage } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { omit } from 'lodash';
 
@@ -117,6 +117,61 @@ export async function setStreamDslLifecycle(
       lifecycle: { dsl },
     },
   });
+}
+
+/**
+ * The managed snapshot repository every Elastic Cloud (ECH) deployment ships with. Cloud has no
+ * node-local filesystem path (`path.repo` is empty), so a default repository must reuse this one
+ * instead of registering an `fs` repository the way the local Scout cluster can.
+ */
+export const CLOUD_DEFAULT_SNAPSHOT_REPOSITORY = 'found-snapshots';
+const LOCAL_FS_SNAPSHOT_REPOSITORY_LOCATION = '/tmp/repo';
+
+export interface ManagedDefaultSnapshotRepository {
+  /** Name of the repository set as the cluster's default. */
+  name: string;
+  /** Restores "no default repository" and removes anything this helper created. */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Registers a default snapshot repository so the frozen-phase gate is satisfied, branching on the
+ * deployment (pass `config.isCloud`):
+ *
+ * - Local Scout stateful cluster: registers an `fs` repository at `path.repo` (`/tmp/repo`).
+ * - Elastic Cloud (ECH): has no node-local `path.repo`, so reuses the managed `found-snapshots`
+ *   repository that every deployment ships with (never creates or deletes it).
+ */
+export async function setDefaultSnapshotRepository(
+  esClient: EsClient,
+  isCloud: boolean,
+  fsRepositoryName: string
+): Promise<ManagedDefaultSnapshotRepository> {
+  const name = isCloud ? CLOUD_DEFAULT_SNAPSHOT_REPOSITORY : fsRepositoryName;
+
+  if (!isCloud) {
+    await esClient.snapshot.createRepository({
+      name: fsRepositoryName,
+      repository: { type: 'fs', settings: { location: LOCAL_FS_SNAPSHOT_REPOSITORY_LOCATION } },
+    });
+  }
+
+  await esClient.cluster.putSettings({
+    persistent: { 'repositories.default_repository': name },
+  });
+
+  return {
+    name,
+    cleanup: async () => {
+      await esClient.cluster.putSettings({
+        persistent: { 'repositories.default_repository': null },
+      });
+      // Only remove what we created; never delete the managed Cloud repository.
+      if (!isCloud) {
+        await esClient.snapshot.deleteRepository({ name: fsRepositoryName }).catch(() => {});
+      }
+    },
+  };
 }
 
 /**

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/add_data_phase_flow.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/add_data_phase_flow.spec.ts
@@ -10,8 +10,10 @@ import { expect } from '@kbn/scout/ui';
 
 import { test } from '../../../fixtures';
 import {
+  type ManagedDefaultSnapshotRepository,
   RETENTION_TEST_IDS,
   closeToastsIfPresent,
+  setDefaultSnapshotRepository,
   setStreamDslLifecycle,
 } from '../../../fixtures/data_lifecycle_helpers';
 
@@ -133,20 +135,18 @@ test.describe(
       esClient,
       apiServices,
       pageObjects,
+      config,
     }) => {
       // The frozen phase is gated on a default snapshot repository (the suite's beforeAll cleared
-      // it). Register a real fs repository (the Scout stateful cluster sets `path.repo=/tmp/repo`)
-      // and set it as the cluster default so the gate passes and the flyout — not the gating modal —
+      // it). Register a default repository (an `fs` repository locally, the managed
+      // `found-snapshots` on Cloud) so the gate passes and the flyout — not the gating modal —
       // opens. The finally block restores the suite's "no default repository" invariant so sibling
       // tests are unaffected regardless of execution order.
-      const REPO_NAME = 'streams-frozen-phase-test-repo';
-      await esClient.snapshot.createRepository({
-        name: REPO_NAME,
-        repository: { type: 'fs', settings: { location: '/tmp/repo' } },
-      });
-      await esClient.cluster.putSettings({
-        persistent: { 'repositories.default_repository': REPO_NAME },
-      });
+      const repository = await setDefaultSnapshotRepository(
+        esClient,
+        config.isCloud,
+        'streams-frozen-phase-test-repo'
+      );
 
       try {
         // Reset to a clean DSL lifecycle and reload so the gating hook re-fetches the new default.
@@ -181,10 +181,7 @@ test.describe(
           await expect(page.getByTestId(FROZEN_PHASE_BUTTON)).toBeVisible();
         });
       } finally {
-        await esClient.cluster.putSettings({
-          persistent: { 'repositories.default_repository': null },
-        });
-        await esClient.snapshot.deleteRepository({ name: REPO_NAME }).catch(() => {});
+        await repository.cleanup();
       }
     });
 
@@ -207,22 +204,22 @@ test.describe(
     test('resumes adding the frozen phase when a default repository is created and the modal is refreshed', async ({
       page,
       esClient,
+      config,
     }) => {
       // No default repository yet (cleared in beforeAll), so selecting frozen opens the gating modal.
       await page.getByTestId(ADD_DATA_PHASE_BUTTON).click();
       await page.getByTestId(FROZEN_OPTION).click();
       await expect(page.getByTestId(DEFAULT_REPO_MODAL_TITLE)).toBeVisible();
 
-      const REPO_NAME = 'streams-frozen-resume-test-repo';
+      let repository: ManagedDefaultSnapshotRepository | undefined;
       try {
-        // Configure a default snapshot repository out of band while the modal is open.
-        await esClient.snapshot.createRepository({
-          name: REPO_NAME,
-          repository: { type: 'fs', settings: { location: '/tmp/repo' } },
-        });
-        await esClient.cluster.putSettings({
-          persistent: { 'repositories.default_repository': REPO_NAME },
-        });
+        // Configure a default snapshot repository out of band while the modal is open (an `fs`
+        // repository locally, the managed `found-snapshots` on Cloud).
+        repository = await setDefaultSnapshotRepository(
+          esClient,
+          config.isCloud,
+          'streams-frozen-resume-test-repo'
+        );
 
         // Refresh should detect the repository, close the modal, and resume the flow by opening the
         // data phases flyout on the frozen panel (rather than leaving the user stuck in the modal).
@@ -236,10 +233,7 @@ test.describe(
         await page.getByTestId(DATA_PHASES_FLYOUT_CANCEL).click();
         await page.getByTestId(DATA_PHASES_FLYOUT).waitFor({ state: 'hidden' });
       } finally {
-        await esClient.cluster.putSettings({
-          persistent: { 'repositories.default_repository': null },
-        });
-        await esClient.snapshot.deleteRepository({ name: REPO_NAME }).catch(() => {});
+        await repository?.cleanup();
       }
     });
 
@@ -276,27 +270,41 @@ test.describe(
       page,
       apiServices,
       pageObjects,
+      esClient,
+      config,
     }) => {
-      await setStreamDslLifecycle(apiServices.streams, STREAM, { frozen_after: '10d' });
-      await pageObjects.streams.gotoDataRetentionTab(STREAM);
+      // A working frozen phase requires a default snapshot repository. Register one (an `fs`
+      // repository locally, the managed `found-snapshots` on Cloud).
+      const repository = await setDefaultSnapshotRepository(
+        esClient,
+        config.isCloud,
+        'streams-frozen-edit-test-repo'
+      );
 
-      // The frozen phase's timeline label is the localized, capitalized "Frozen".
-      await test.step('edit opens the data phases flyout (no gating on an existing phase)', async () => {
-        await page.getByTestId(FROZEN_PHASE_BUTTON).click();
-        await page.getByTestId(FROZEN_PHASE_EDIT_BUTTON).click();
-        await expect(page.getByTestId(DATA_PHASES_FLYOUT)).toBeVisible();
-        await expect(page.getByTestId(DATA_PHASES_FLYOUT_FROZEN_PANEL)).toBeVisible();
-      });
+      try {
+        await setStreamDslLifecycle(apiServices.streams, STREAM, { frozen_after: '10d' });
+        await pageObjects.streams.gotoDataRetentionTab(STREAM);
 
-      await test.step('remove deletes the frozen phase from the timeline', async () => {
-        await page.getByTestId(DATA_PHASES_FLYOUT_CANCEL).click();
-        await page.getByTestId(DATA_PHASES_FLYOUT).waitFor({ state: 'hidden' });
+        // The frozen phase's timeline label is the localized, capitalized "Frozen".
+        await test.step('edit opens the data phases flyout (no gating on an existing phase)', async () => {
+          await page.getByTestId(FROZEN_PHASE_BUTTON).click();
+          await page.getByTestId(FROZEN_PHASE_EDIT_BUTTON).click();
+          await expect(page.getByTestId(DATA_PHASES_FLYOUT)).toBeVisible();
+          await expect(page.getByTestId(DATA_PHASES_FLYOUT_FROZEN_PANEL)).toBeVisible();
+        });
 
-        await page.getByTestId(FROZEN_PHASE_BUTTON).click();
-        await page.getByTestId(FROZEN_PHASE_REMOVE_BUTTON).click();
+        await test.step('remove deletes the frozen phase from the timeline', async () => {
+          await page.getByTestId(DATA_PHASES_FLYOUT_CANCEL).click();
+          await page.getByTestId(DATA_PHASES_FLYOUT).waitFor({ state: 'hidden' });
 
-        await expect(page.getByTestId(FROZEN_PHASE_BUTTON)).toBeHidden();
-      });
+          await page.getByTestId(FROZEN_PHASE_BUTTON).click();
+          await page.getByTestId(FROZEN_PHASE_REMOVE_BUTTON).click();
+
+          await expect(page.getByTestId(FROZEN_PHASE_BUTTON)).toBeHidden();
+        });
+      } finally {
+        await repository.cleanup();
+      }
     });
   }
 );


### PR DESCRIPTION
## Summary

Fixes a set of Scout tests that fail **deterministically** (not flaky) on the `cloud-stateful-classic` target of the scheduled `appex-qa-stateful-kibana-scout-tests` pipeline. They pass on the local target but were never Cloud (ECH) compatible.

### Tests fixed

**`streams_app`** — `x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/add_data_phase_flow.spec.ts`
- Fixes #276328 — *adds a frozen phase through the data phases flyout when a default repository exists*
- Fixes #276329 — *resumes adding the frozen phase when a default repository is created and the modal is refreshed*
- Fixes #276330 — *edits and removes the frozen phase from its timeline popover*

**`snapshot_restore`** — `x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/tests/a11y.spec.ts`
- Fixes #274871 — *empty state: all tabs have no a11y violations*
- Fixes #274872 — *table views with data: snapshots and repositories have no a11y violations*
- Fixes #274873 — *create policy wizard: all steps have no a11y violations*

## Why they were failing on Cloud

These suites are tagged for both `@local-stateful-classic` and `@cloud-stateful-classic`. Only the local variant runs on PR CI; the Cloud variant runs post-merge on the scheduled ECH pipeline — so the failures only surfaced there. Each assumed a local Scout cluster:

1. **Filesystem snapshot repository** (#276328, #276329, #274872, #274873) — the tests register an `fs` snapshot repository (`/tmp/repo`, `temp`), which only works because the local Scout cluster sets `path.repo`. ECH has no node-local `path.repo`, so `createRepository` fails with `repository_exception`.
2. **Empty-state assumption** (#274871) — the test waits for the Snapshot & Restore empty-state UI, but every ECH deployment ships with a managed `found-snapshots` repository, so the empty state never renders.
3. **Popover geometry** (#276330) — the frozen edit/remove test ran with no default repository, so the phase popover showed the tall *"default repository required"* callout. On ECH that makes the popover tall enough to push its Edit/Remove actions above the viewport, where Playwright can't click them.
4. **Ambient snapshots** (#274873) — the create-policy-wizard test waited for `state: 'noSnapshots'`, which only resolves when the global snapshot count is `0`. That count spans all repositories, and on ECH the managed `found-snapshots` repository continuously accrues SLM snapshots, so the empty prompt never renders and the wait times out. (This is a second Cloud-only failure mode in the same test, on top of cause #1.)

## Fixes

- Branch explicitly on `config.isCloud`: on Cloud reuse the managed `found-snapshots` repository; on local register the `fs` repository as before (helper added per plugin — no reliance on `createRepository` throwing).
- Skip the empty-state a11y test on Cloud, where the empty state is unreachable — same idiom as the existing `ingest_pipelines` GeoIP precedent.
- Register a default repository for the frozen edit/remove test so the popover renders its normal (short) content and the actions stay in the viewport.
- Add a `loaded` state to the snapshot_restore page object that resolves on either `emptyPrompt` or `snapshotList`, and use it in the create-policy-wizard test — it only needs a repository to select, not an empty snapshot list, so the wait now holds regardless of ambient snapshots.

## Testing

Both specs pass locally (`node scripts/scout run-tests --arch stateful --domain classic`):
- `streams_app` add_data_phase_flow — **10 passed**
- `snapshot_restore` a11y — **3 passed**

The Cloud branch (`config.isCloud === true`) can't be exercised on a local Scout cluster; it is validated by the scheduled `appex-qa-stateful-kibana-scout-tests` pipeline after merge.

### Checklist
- [x] Unit/Scout tests updated and passing locally

`release_note:skip` — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
