### PR TITLE
[One Workflow](bug): Hide historical input for unsaved workflow tests

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx
@@ -161,6 +161,7 @@ describe('WorkflowExecuteModal', () => {
         <WorkflowExecuteModal
           isTestRun={false}
           definition={null}
+          workflowId="wf-1"
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
         />
@@ -181,6 +182,7 @@ describe('WorkflowExecuteModal', () => {
             ...baseWorkflowDefinition,
             triggers: [{ type: 'alert' }],
           }}
+          workflowId="wf-1"
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
         />
@@ -193,8 +195,8 @@ describe('WorkflowExecuteModal', () => {
       expect(queryByText('Event')).not.toBeInTheDocument();
     });
 
-    it('uses the test run title and still exposes the full trigger tab set', () => {
-      const { getByText } = renderWithProviders(
+    it('uses the test run title and hides historical without a workflow id', () => {
+      const { getByText, queryByText } = renderWithProviders(
         <WorkflowExecuteModal
           isTestRun={true}
           definition={null}
@@ -208,7 +210,7 @@ describe('WorkflowExecuteModal', () => {
       expect(getByText('Document')).toBeInTheDocument();
       expect(getByText('Event')).toBeInTheDocument();
       expect(getByText('Manual')).toBeInTheDocument();
-      expect(getByText('Historical')).toBeInTheDocument();
+      expect(queryByText('Historical')).not.toBeInTheDocument();
     });
 
     it('keeps the alert trigger enabled when RAC prefetch succeeds (no capability pre-check)', () => {
@@ -334,6 +336,7 @@ describe('WorkflowExecuteModal', () => {
         <WorkflowExecuteModal
           isTestRun={false}
           definition={null}
+          workflowId="wf-1"
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
         />
@@ -365,6 +368,7 @@ describe('WorkflowExecuteModal', () => {
         <WorkflowExecuteModal
           isTestRun={false}
           definition={null}
+          workflowId="wf-1"
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
         />
@@ -981,6 +985,30 @@ describe('WorkflowExecuteModal', () => {
   });
 
   describe('Historical trigger', () => {
+    it('does not render historical for unsaved test workflows', () => {
+      const { queryByText } = renderWithProviders(
+        <WorkflowExecuteModal
+          isTestRun={true}
+          definition={
+            {
+              ...baseWorkflowDefinition,
+              triggers: [
+                {
+                  type: 'manual',
+                  inputs: [{ name: 'test-input', type: 'string', required: true }],
+                },
+              ],
+            } as WorkflowYaml
+          }
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(queryByText('Historical')).not.toBeInTheDocument();
+      expect(mockWorkflowExecuteHistoricalForm).not.toHaveBeenCalled();
+    });
+
     it('defaults to historical tab when initialExecutionId is provided', () => {
       const { getByText } = renderWithProviders(
         <WorkflowExecuteModal
@@ -1023,6 +1051,7 @@ describe('WorkflowExecuteModal', () => {
         <WorkflowExecuteModal
           isTestRun={false}
           definition={null}
+          workflowId="wf-1"
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
         />

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -98,9 +98,14 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
       [definition, yamlString]
     );
 
+    const includeHistoricalTrigger = Boolean(workflowId ?? initialExecutionId);
+
     const visibleTriggerTabs = useMemo(
-      () => getVisibleWorkflowTriggerTabs(definition),
-      [definition]
+      () =>
+        getVisibleWorkflowTriggerTabs(definition, {
+          includeHistorical: includeHistoricalTrigger,
+        }),
+      [definition, includeHistoricalTrigger]
     );
 
     const triggerTabAvailability = useMemo<WorkflowTriggerTabAvailability>(
@@ -119,7 +124,8 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
         hasAlertRacAccess,
         canReadWorkflowExecution,
         normalizedInputs,
-        eventDrivenExecutionEnabled
+        eventDrivenExecutionEnabled,
+        { includeHistorical: includeHistoricalTrigger }
       )
     );
 

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
@@ -169,6 +169,15 @@ describe('getVisibleWorkflowTriggerTabs', () => {
     ]);
   });
 
+  it('omits historical when previous executions are not available', () => {
+    expect(getVisibleWorkflowTriggerTabs(null, { includeHistorical: false })).toEqual([
+      'alert',
+      'index',
+      'event',
+      'manual',
+    ]);
+  });
+
   it('returns alert, manual, and historical for alert-only workflows', () => {
     expect(
       getVisibleWorkflowTriggerTabs({ ...baseDefinition, triggers: [{ type: 'alert' }] })

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
@@ -62,10 +62,13 @@ export function workflowDefinitionHasTriggerType(
 
 /** Run-modal tabs to show based on triggers declared in the workflow definition. */
 export function getVisibleWorkflowTriggerTabs(
-  definition: WorkflowYaml | null
+  definition: WorkflowYaml | null,
+  { includeHistorical = true }: { includeHistorical?: boolean } = {}
 ): readonly WorkflowTriggerTab[] {
   if (!definition?.triggers?.length) {
-    return ENABLED_TRIGGER_TABS;
+    return includeHistorical
+      ? ENABLED_TRIGGER_TABS
+      : ENABLED_TRIGGER_TABS.filter((tab) => tab !== 'historical');
   }
 
   const visible: WorkflowTriggerTab[] = [];
@@ -79,7 +82,10 @@ export function getVisibleWorkflowTriggerTabs(
   if (workflowDefinitionHasTriggerType(definition, 'manual')) {
     visible.push('index');
   }
-  visible.push('manual', 'historical');
+  visible.push('manual');
+  if (includeHistorical) {
+    visible.push('historical');
+  }
 
   return visible;
 }
@@ -234,9 +240,10 @@ export function resolveInitialSelectedTrigger(
   hasAlertRacAccess: boolean,
   canReadWorkflowExecution: boolean,
   normalizedInputs: NormalizedWorkflowInputs | undefined,
-  eventDrivenExecutionEnabled = true
+  eventDrivenExecutionEnabled = true,
+  { includeHistorical = true }: { includeHistorical?: boolean } = {}
 ): WorkflowTriggerTab {
-  const visibleTabs = getVisibleWorkflowTriggerTabs(definition);
+  const visibleTabs = getVisibleWorkflowTriggerTabs(definition, { includeHistorical });
 
   let selected: WorkflowTriggerTab;
 


### PR DESCRIPTION
## Summary

- Hide the Historical test input option when the workflow test modal has no saved workflow id or replay execution.
- Keep Historical available for saved workflows and explicit replay flows.
- Add regression coverage for unsaved workflow test runs and helper tab visibility.

# Before

<img width="1067" height="865" alt="Before" src="https://github.com/user-attachments/assets/c552a625-a372-477d-b074-bac31f9ea617" />

### After 

<img width="1067" height="865" alt="After" src="https://github.com/user-attachments/assets/0b885161-9444-4247-bff5-b0aa2204b7d0" />