### PR TITLE
[9.3] Expand zones for Kibana distribution build agents (#276895)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -38,7 +38,7 @@ steps:
       provider: gcp
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c
+      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       diskSizeGb: 200
     key: build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,7 +7,7 @@ steps:
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c
+      zones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       diskSizeGb: 200
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Expand zones for Kibana distribution build agents (#276895)](https://github.com/elastic/kibana/pull/276895)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tamerlan","email":"37669316+TamerlanG@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-08T09:25:21Z","message":"Expand zones for Kibana distribution build agents (#276895)\n\n## Summary\n\nExpands the GCP zones for the `build` step in the PR, on-merge, and\nrspack e2e pipeline from 3 zones (`us-central1-a/b/c`) to 9 zones across\n`us-central1`, `us-east1`, and `us-west1`.\n\nThis increases spot instance availability and reduces build failures\ncaused by zone-level capacity constraints.","sha":"e72bd20870a7458d18319cac4f9fdd11a4eb2ea8","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0"],"title":"Expand zones for Kibana distribution build agents","number":276895,"url":"https://github.com/elastic/kibana/pull/276895","mergeCommit":{"message":"Expand zones for Kibana distribution build agents (#276895)\n\n## Summary\n\nExpands the GCP zones for the `build` step in the PR, on-merge, and\nrspack e2e pipeline from 3 zones (`us-central1-a/b/c`) to 9 zones across\n`us-central1`, `us-east1`, and `us-west1`.\n\nThis increases spot instance availability and reduces build failures\ncaused by zone-level capacity constraints.","sha":"e72bd20870a7458d18319cac4f9fdd11a4eb2ea8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276895","number":276895,"mergeCommit":{"message":"Expand zones for Kibana distribution build agents (#276895)\n\n## Summary\n\nExpands the GCP zones for the `build` step in the PR, on-merge, and\nrspack e2e pipeline from 3 zones (`us-central1-a/b/c`) to 9 zones across\n`us-central1`, `us-east1`, and `us-west1`.\n\nThis increases spot instance availability and reduces build failures\ncaused by zone-level capacity constraints.","sha":"e72bd20870a7458d18319cac4f9fdd11a4eb2ea8"}}]}] BACKPORT-->