### PR TITLE
[Agent Builder][Visualizations] Vega authoring follow-ups

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/converters/vega_panel.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/converters/vega_panel.test.ts
@@ -12,7 +12,12 @@ import type { DashboardAttachmentData } from '../types';
 import { attachmentDataToDashboardState } from './from_attachment';
 import { dashboardStateToAttachmentData } from './to_attachment';
 
-const SPEC = '{"$schema":"https://vega.github.io/schema/vega-lite/v6.json","mark":"bar"}';
+const SPEC = JSON.stringify(
+  { $schema: 'https://vega.github.io/schema/vega-lite/v6.json', mark: 'bar' },
+  null,
+  2
+);
+const MINIFIED_SPEC = '{"$schema":"https://vega.github.io/schema/vega-lite/v6.json","mark":"bar"}';
 const grid = { x: 0, y: 0, w: 24, h: 15 };
 
 describe('Vega dashboard panel conversion (temporary legacy-vis bridge)', () => {
@@ -43,7 +48,7 @@ describe('Vega dashboard panel conversion (temporary legacy-vis bridge)', () => 
     ]);
   });
 
-  it('to_attachment normalizes a by-value legacy-vis Vega panel to the `vega` API shape', () => {
+  it('to_attachment normalizes a by-value legacy-vis Vega panel to the `vega` API shape, re-indenting a compact spec', () => {
     const state = {
       panels: [
         {
@@ -51,7 +56,11 @@ describe('Vega dashboard panel conversion (temporary legacy-vis bridge)', () => 
           id: 'p1',
           grid,
           config: {
-            savedVis: buildVegaSavedVis({ spec: SPEC, title: 'Chart', description: 'Desc' }),
+            savedVis: buildVegaSavedVis({
+              spec: MINIFIED_SPEC,
+              title: 'Chart',
+              description: 'Desc',
+            }),
           },
         },
       ],

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-common/index.ts
@@ -13,6 +13,7 @@ export {
   buildVegaSavedVis,
   extractVegaSpecFromSavedVis,
   normalizeVegaConfig,
+  prettyPrintVegaSpec,
   VEGA_VIS_TYPE,
   type VegaConfig,
   type VegaSavedVis,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-common/vega_saved_vis.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-common/vega_saved_vis.test.ts
@@ -9,6 +9,7 @@ import {
   buildVegaSavedVis,
   extractVegaSpecFromSavedVis,
   normalizeVegaConfig,
+  prettyPrintVegaSpec,
   VEGA_VIS_TYPE,
 } from './vega_saved_vis';
 
@@ -33,20 +34,35 @@ describe('buildVegaSavedVis', () => {
   });
 });
 
+describe('prettyPrintVegaSpec', () => {
+  it('re-indents a minified JSON spec with two spaces', () => {
+    expect(prettyPrintVegaSpec('{"mark":"bar"}')).toBe('{\n  "mark": "bar"\n}');
+  });
+
+  it('is idempotent for an already-indented spec', () => {
+    const pretty = '{\n  "mark": "bar"\n}';
+    expect(prettyPrintVegaSpec(pretty)).toBe(pretty);
+  });
+
+  it('returns the original text when the spec is not valid JSON', () => {
+    const hjson = '{mark: bar}';
+    expect(prettyPrintVegaSpec(hjson)).toBe(hjson);
+  });
+});
+
 describe('extractVegaSpecFromSavedVis', () => {
-  it('reads the spec, title, and description from a Vega legacy-vis config', () => {
-    const spec = '{"mark":"bar"}';
+  it('reads the spec, title, and description from a Vega legacy-vis config, pretty-printing the spec', () => {
     const config = {
       savedVis: {
         type: 'vega',
         title: 'Title',
         description: 'Desc',
-        params: { spec },
+        params: { spec: '{"mark":"bar"}' },
       },
     };
 
     expect(extractVegaSpecFromSavedVis(config)).toEqual({
-      spec,
+      spec: '{\n  "mark": "bar"\n}',
       title: 'Title',
       description: 'Desc',
     });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-common/vega_saved_vis.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-common/vega_saved_vis.ts
@@ -83,6 +83,18 @@ export const normalizeVegaConfig = (input: unknown): VegaConfig | undefined => {
   return config;
 };
 
+export const prettyPrintVegaSpec = (spec: string): string => {
+  try {
+    const parsed = JSON.parse(spec);
+    if (parsed && typeof parsed === 'object') {
+      return JSON.stringify(parsed, null, 2);
+    }
+  } catch {
+    // fall through
+  }
+  return spec;
+};
+
 /**
  * Read the serialized Vega spec out of a legacy-vis (`visualization`) panel's
  * by-value `config`, i.e. `config.savedVis.params.spec`. Returns `undefined` when
@@ -102,7 +114,7 @@ export const extractVegaSpecFromSavedVis = (
     return undefined;
   }
   return {
-    spec,
+    spec: prettyPrintVegaSpec(spec),
     title: typeof savedVis.title === 'string' ? savedVis.title : '',
     description: typeof savedVis.description === 'string' ? savedVis.description : '',
   };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/actions.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/actions.ts
@@ -33,6 +33,7 @@ export interface ValidateSpecAction {
   spec?: string;
   attempt: number;
   error?: string;
+  warnings?: string[];
 }
 
 export type VegaAction = GenerateEsqlAction | AuthorSpecAction | ValidateSpecAction;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -105,7 +105,9 @@ describe('createVegaGraph', () => {
     expect(state.error).toBeNull();
     const spec = JSON.parse(state.spec!);
     expect(spec.$schema).toBe(VEGA_LITE_SCHEMA);
-    expect(spec.data).toEqual({ url: { '%type%': 'esql', query: GENERATED_ESQL } });
+    expect(spec.data).toEqual({
+      url: { '%type%': 'esql', '%context%': true, query: GENERATED_ESQL },
+    });
     expect(spec.mark).toBe('bar');
     expect(state.esqlQuery).toBe(GENERATED_ESQL);
   });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -136,7 +136,7 @@ describe('createVegaGraph', () => {
     expect(selectInvoke).toHaveBeenCalledTimes(1);
   });
 
-  it('does not select reference examples when ES|QL resolution fails', async () => {
+  it('does not author a spec when ES|QL resolution fails, despite selecting examples in parallel', async () => {
     mockedGenerateEsql.mockResolvedValue({
       query: 'FROM logs-*',
       error: 'verification_exception: boom',
@@ -144,7 +144,7 @@ describe('createVegaGraph', () => {
 
     await run();
 
-    expect(selectInvoke).not.toHaveBeenCalled();
+    expect(selectInvoke).toHaveBeenCalledTimes(1);
     expect(invoke).not.toHaveBeenCalled();
   });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -337,4 +337,47 @@ describe('createVegaGraph', () => {
     expect(state.error).toEqual(expect.any(String));
     expect(invoke).toHaveBeenCalledTimes(3);
   });
+
+  describe('render warnings', () => {
+    it('hands every warning to the agent for one review pass, then finalizes its result', async () => {
+      invoke
+        .mockResolvedValueOnce(asCodeBlock({ mark: 'text', encoding: { x2: { value: 1 } } }))
+        .mockResolvedValueOnce(asCodeBlock({ mark: 'text', encoding: { x: { value: 1 } } }));
+      mockedValidateVegaSpec
+        .mockResolvedValueOnce({
+          warnings: [
+            'x2 dropped as it is incompatible with "text".',
+            'Infinite extent for field "count": [Infinity, -Infinity]',
+          ],
+        })
+        .mockResolvedValueOnce({ warnings: [] });
+
+      const state = await run({ esqlQuery: PROVIDED_ESQL });
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(state.error).toBeNull();
+      // Every warning — not a pre-filtered subset — is fed back, and the model is
+      // told to judge each one for itself.
+      const secondPrompt = JSON.stringify(invoke.mock.calls[1][0]);
+      expect(secondPrompt).toContain('x2 dropped as it is incompatible');
+      expect(secondPrompt).toContain('Infinite extent for field');
+      expect(secondPrompt).toContain('decide for yourself');
+    });
+
+    it('makes a single review pass and accepts the spec when the agent keeps its warnings', async () => {
+      // The model returns the same warning-bearing spec every time (it judged the
+      // warnings harmless / unavoidable). We must not loop the whole budget.
+      invoke.mockResolvedValue(asCodeBlock({ mark: 'text', encoding: { x2: { value: 1 } } }));
+      mockedValidateVegaSpec.mockResolvedValue({
+        warnings: ['Infinite extent for field "count": [Infinity, -Infinity]'],
+      });
+
+      const state = await run({ esqlQuery: PROVIDED_ESQL });
+
+      // One initial authoring pass + one warning-review pass, then we accept.
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(state.error).toBeNull();
+      expect(state.spec).not.toBeNull();
+    });
+  });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -360,7 +360,7 @@ export const createVegaGraph = async (
       logger.warn('ES|QL resolution failed; finalizing without authoring a Vega spec');
       return FINALIZE_NODE;
     }
-    return SELECT_EXAMPLES_NODE;
+    return AUTHOR_SPEC_NODE;
   };
 
   const shouldRetryRouter = (state: VegaState): string => {
@@ -382,23 +382,25 @@ export const createVegaGraph = async (
     return AUTHOR_SPEC_NODE;
   };
 
-  return new StateGraph(VegaStateAnnotation)
-    .addNode(GENERATE_ESQL_NODE, generateESQLNode)
-    .addNode(SELECT_EXAMPLES_NODE, selectExamplesNode)
-    .addNode(AUTHOR_SPEC_NODE, authorSpecNode)
-    .addNode(VALIDATE_SPEC_NODE, validateSpecNode)
-    .addNode(FINALIZE_NODE, finalizeNode)
-    .addEdge('__start__', GENERATE_ESQL_NODE)
-    .addConditionalEdges(GENERATE_ESQL_NODE, afterGenerateEsqlRouter, {
-      [SELECT_EXAMPLES_NODE]: SELECT_EXAMPLES_NODE,
-      [FINALIZE_NODE]: FINALIZE_NODE,
-    })
-    .addEdge(SELECT_EXAMPLES_NODE, AUTHOR_SPEC_NODE)
-    .addEdge(AUTHOR_SPEC_NODE, VALIDATE_SPEC_NODE)
-    .addConditionalEdges(VALIDATE_SPEC_NODE, shouldRetryRouter, {
-      [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
-      [FINALIZE_NODE]: FINALIZE_NODE,
-    })
-    .addEdge(FINALIZE_NODE, '__end__')
-    .compile();
+  return (
+    new StateGraph(VegaStateAnnotation)
+      .addNode(GENERATE_ESQL_NODE, generateESQLNode)
+      .addNode(SELECT_EXAMPLES_NODE, selectExamplesNode)
+      .addNode(AUTHOR_SPEC_NODE, authorSpecNode)
+      .addNode(VALIDATE_SPEC_NODE, validateSpecNode)
+      .addNode(FINALIZE_NODE, finalizeNode)
+      .addEdge('__start__', GENERATE_ESQL_NODE)
+      .addEdge('__start__', SELECT_EXAMPLES_NODE)
+      .addConditionalEdges(GENERATE_ESQL_NODE, afterGenerateEsqlRouter, {
+        [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
+        [FINALIZE_NODE]: FINALIZE_NODE,
+      })
+      .addEdge(AUTHOR_SPEC_NODE, VALIDATE_SPEC_NODE)
+      .addConditionalEdges(VALIDATE_SPEC_NODE, shouldRetryRouter, {
+        [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
+        [FINALIZE_NODE]: FINALIZE_NODE,
+      })
+      .addEdge(FINALIZE_NODE, '__end__')
+      .compile()
+  );
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -79,6 +79,15 @@ const VegaStateAnnotation = Annotation.Root({
   existingEsql: Annotation<string | undefined>(),
   chartType: Annotation<SupportedChartType | undefined>(),
   // internal
+  /**
+   * Whether the model has already been given one authoring pass with the Vega
+   * warnings in hand. After that pass we accept its judgment (fix or keep) and
+   * stop retrying on warnings, so benign/unavoidable warnings never loop.
+   */
+  warningsReviewed: Annotation<boolean>({
+    reducer: (_, newValue) => newValue,
+    default: () => false,
+  }),
   esqlQuery: Annotation<string>(),
   columns: Annotation<EsqlEsqlColumnInfo[] | undefined>(),
   currentAttempt: Annotation<number>({ reducer: (_, newValue) => newValue, default: () => 0 }),
@@ -219,8 +228,15 @@ export const createVegaGraph = async (
     const attempt = state.currentAttempt + 1;
     logger.debug(`Authoring Vega-Lite spec (attempt ${attempt}/${MAX_RETRY_ATTEMPTS})`);
 
-    // Feed back authoring and structural-check failures so the next attempt can
-    // fix them, not just malformed JSON.
+    // This authoring pass reviews warnings if any prior validation rendered the
+    // spec but Vega emitted warnings. We hand the model every warning and let it
+    // judge each one, rather than pre-filtering to a curated list.
+    const reviewingWarnings = state.actions.some(
+      (action) => isValidateSpecAction(action) && action.success && (action.warnings?.length ?? 0) > 0
+    );
+
+    // Feed back authoring and structural-check failures, plus every Vega warning,
+    // so the next attempt can fix genuine problems (or consciously keep the spec).
     const previousContext = state.actions
       .filter((action) => isAuthorSpecAction(action) || isValidateSpecAction(action))
       .map((action) => {
@@ -229,12 +245,22 @@ export const createVegaGraph = async (
             ? undefined
             : `Authoring attempt ${action.attempt} failed: ${action.error}`;
         }
-        return action.success
-          ? undefined
-          : `Validation attempt ${action.attempt} failed: ${action.error}`;
+        if (!action.success) {
+          return `Validation attempt ${action.attempt} failed: ${action.error}`;
+        }
+        if (action.warnings && action.warnings.length > 0) {
+          return `Validation attempt ${action.attempt} rendered, but Vega emitted these warnings:\n${action.warnings
+            .map((warning) => `- ${warning}`)
+            .join('\n')}`;
+        }
+        return undefined;
       })
       .filter(Boolean)
       .join('\n');
+
+    const additionalContext = previousContext
+      ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object. Fix any error above. For each warning, decide for yourself whether it signals a real authoring mistake (e.g. an encoding or property Vega dropped or ignored) and fix it, or whether it is harmless or unavoidable and can be left as-is (validation runs against empty sample data, so warnings about empty/infinite extents or disabled external data loading are expected). If a warning needs no change, keep that part of the spec unchanged.`
+      : undefined;
 
     const prompt = createAuthorVegaSpecPrompt({
       nlQuery: state.nlQuery,
@@ -243,9 +269,7 @@ export const createVegaGraph = async (
       existingSpec: state.existingSpec,
       chartType: state.chartType,
       referenceExamples: state.referenceExamples,
-      additionalContext: previousContext
-        ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object that fixes the issues above.`
-        : undefined,
+      additionalContext,
     });
 
     let action: AuthorSpecAction;
@@ -261,7 +285,13 @@ export const createVegaGraph = async (
       action = { type: 'author_spec', success: false, attempt, error: message };
     }
 
-    return { currentAttempt: attempt, actions: [action] };
+    return {
+      currentAttempt: attempt,
+      actions: [action],
+      // Mark warnings reviewed once this pass carried them as feedback, so the
+      // retry router accepts the model's decision instead of looping.
+      warningsReviewed: state.warningsReviewed || reviewingWarnings,
+    };
   };
 
   // Structurally check the authored spec (it must declare a renderable view),
@@ -305,12 +335,16 @@ export const createVegaGraph = async (
         logger.debug(`Vega spec validated with warnings: ${warnings.join('; ')}`);
       }
 
+      // Carry every warning so the model can read them all and decide, on one
+      // authoring pass, which to fix and which to keep. The spec is still a
+      // success, so a warning it chooses to keep never blocks finalizing.
       action = {
         type: 'validate_spec',
         success: true,
         // Pretty-print so the stored/displayed spec stays human-readable.
         spec: JSON.stringify(normalized, null, 2),
         attempt,
+        warnings,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -322,15 +356,21 @@ export const createVegaGraph = async (
   };
 
   const finalizeNode = async (state: VegaState) => {
-    // Use the most recent spec that passed the structural check + normalization.
-    const lastRendered = [...state.actions]
+    // Specs that passed the structural check + normalization, most recent first.
+    const rendered = [...state.actions]
       .reverse()
-      .find((action) => isValidateSpecAction(action) && action.success && !!action.spec) as
-      | ValidateSpecAction
-      | undefined;
+      .filter(
+        (action): action is ValidateSpecAction =>
+          isValidateSpecAction(action) && action.success && !!action.spec
+      );
 
-    if (lastRendered?.spec) {
-      return { spec: lastRendered.spec, error: null };
+    // Prefer the most recent warning-free spec; otherwise fall back to the most
+    // recent rendered spec (retries could not clear every warning, but a
+    // warning still renders, so return the best we have rather than nothing).
+    const chosen = rendered.find((action) => !action.warnings?.length) ?? rendered[0];
+
+    if (chosen?.spec) {
+      return { spec: chosen.spec, error: null };
     }
 
     // Surface an ES|QL resolution failure (an unexecutable query that was never
@@ -366,9 +406,13 @@ export const createVegaGraph = async (
   const shouldRetryRouter = (state: VegaState): string => {
     const lastValidate = [...state.actions].reverse().find(isValidateSpecAction);
 
-    // Retry authoring when the spec failed the structural check or normalization,
-    // bounded by the attempt budget.
-    const needsRepair = !lastValidate?.success;
+    // Retry authoring when the spec failed the structural check / render. When it
+    // rendered with warnings, retry once to hand the model every warning and let
+    // it decide (fix or keep) — but only until that review pass has happened, so
+    // warnings the model chooses to keep never loop. All bounded by the budget.
+    const hasWarnings = (lastValidate?.warnings?.length ?? 0) > 0;
+    const needsRepair =
+      !lastValidate?.success || (hasWarnings && !state.warningsReviewed);
 
     if (!needsRepair) {
       return FINALIZE_NODE;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -232,7 +232,8 @@ export const createVegaGraph = async (
     // spec but Vega emitted warnings. We hand the model every warning and let it
     // judge each one, rather than pre-filtering to a curated list.
     const reviewingWarnings = state.actions.some(
-      (action) => isValidateSpecAction(action) && action.success && (action.warnings?.length ?? 0) > 0
+      (action) =>
+        isValidateSpecAction(action) && action.success && (action.warnings?.length ?? 0) > 0
     );
 
     // Feed back authoring and structural-check failures, plus every Vega warning,
@@ -249,7 +250,9 @@ export const createVegaGraph = async (
           return `Validation attempt ${action.attempt} failed: ${action.error}`;
         }
         if (action.warnings && action.warnings.length > 0) {
-          return `Validation attempt ${action.attempt} rendered, but Vega emitted these warnings:\n${action.warnings
+          return `Validation attempt ${
+            action.attempt
+          } rendered, but Vega emitted these warnings:\n${action.warnings
             .map((warning) => `- ${warning}`)
             .join('\n')}`;
         }
@@ -411,8 +414,7 @@ export const createVegaGraph = async (
     // it decide (fix or keep) — but only until that review pass has happened, so
     // warnings the model chooses to keep never loop. All bounded by the budget.
     const hasWarnings = (lastValidate?.warnings?.length ?? 0) > 0;
-    const needsRepair =
-      !lastValidate?.success || (hasWarnings && !state.warningsReviewed);
+    const needsRepair = !lastValidate?.success || (hasWarnings && !state.warningsReviewed);
 
     if (!needsRepair) {
       return FINALIZE_NODE;
@@ -426,25 +428,23 @@ export const createVegaGraph = async (
     return AUTHOR_SPEC_NODE;
   };
 
-  return (
-    new StateGraph(VegaStateAnnotation)
-      .addNode(GENERATE_ESQL_NODE, generateESQLNode)
-      .addNode(SELECT_EXAMPLES_NODE, selectExamplesNode)
-      .addNode(AUTHOR_SPEC_NODE, authorSpecNode)
-      .addNode(VALIDATE_SPEC_NODE, validateSpecNode)
-      .addNode(FINALIZE_NODE, finalizeNode)
-      .addEdge('__start__', GENERATE_ESQL_NODE)
-      .addEdge('__start__', SELECT_EXAMPLES_NODE)
-      .addConditionalEdges(GENERATE_ESQL_NODE, afterGenerateEsqlRouter, {
-        [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
-        [FINALIZE_NODE]: FINALIZE_NODE,
-      })
-      .addEdge(AUTHOR_SPEC_NODE, VALIDATE_SPEC_NODE)
-      .addConditionalEdges(VALIDATE_SPEC_NODE, shouldRetryRouter, {
-        [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
-        [FINALIZE_NODE]: FINALIZE_NODE,
-      })
-      .addEdge(FINALIZE_NODE, '__end__')
-      .compile()
-  );
+  return new StateGraph(VegaStateAnnotation)
+    .addNode(GENERATE_ESQL_NODE, generateESQLNode)
+    .addNode(SELECT_EXAMPLES_NODE, selectExamplesNode)
+    .addNode(AUTHOR_SPEC_NODE, authorSpecNode)
+    .addNode(VALIDATE_SPEC_NODE, validateSpecNode)
+    .addNode(FINALIZE_NODE, finalizeNode)
+    .addEdge('__start__', GENERATE_ESQL_NODE)
+    .addEdge('__start__', SELECT_EXAMPLES_NODE)
+    .addConditionalEdges(GENERATE_ESQL_NODE, afterGenerateEsqlRouter, {
+      [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
+      [FINALIZE_NODE]: FINALIZE_NODE,
+    })
+    .addEdge(AUTHOR_SPEC_NODE, VALIDATE_SPEC_NODE)
+    .addConditionalEdges(VALIDATE_SPEC_NODE, shouldRetryRouter, {
+      [AUTHOR_SPEC_NODE]: AUTHOR_SPEC_NODE,
+      [FINALIZE_NODE]: FINALIZE_NODE,
+    })
+    .addEdge(FINALIZE_NODE, '__end__')
+    .compile();
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/normalize_spec.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/normalize_spec.test.ts
@@ -22,7 +22,7 @@ describe('normalizeVegaSpec', () => {
   it('injects the ES|QL query as the data source', () => {
     const result = normalizeVegaSpec({ spec: { mark: 'bar' }, esqlQuery: ESQL });
 
-    expect(result.data).toEqual({ url: { '%type%': 'esql', query: ESQL } });
+    expect(result.data).toEqual({ url: { '%type%': 'esql', '%context%': true, query: ESQL } });
   });
 
   it('adds the timefield binding when provided', () => {
@@ -33,7 +33,7 @@ describe('normalizeVegaSpec', () => {
     });
 
     expect(result.data).toEqual({
-      url: { '%type%': 'esql', query: ESQL, '%timefield%': '@timestamp' },
+      url: { '%type%': 'esql', '%context%': true, query: ESQL, '%timefield%': '@timestamp' },
     });
   });
 
@@ -52,7 +52,12 @@ describe('normalizeVegaSpec', () => {
     });
 
     expect(result.data).toEqual({
-      url: { '%type%': 'esql', query: timeAwareEsql, '%timefield%': 'event.created' },
+      url: {
+        '%type%': 'esql',
+        '%context%': true,
+        query: timeAwareEsql,
+        '%timefield%': 'event.created',
+      },
     });
   });
 
@@ -73,7 +78,12 @@ describe('normalizeVegaSpec', () => {
     });
 
     expect(result.data).toEqual({
-      url: { '%type%': 'esql', query: timeSeriesEsql, '%timefield%': '@timestamp' },
+      url: {
+        '%type%': 'esql',
+        '%context%': true,
+        query: timeSeriesEsql,
+        '%timefield%': '@timestamp',
+      },
     });
   });
 
@@ -92,7 +102,7 @@ describe('normalizeVegaSpec', () => {
     });
 
     expect(result.data).toEqual({
-      url: { '%type%': 'esql', query: tbucketEsql, '%timefield%': 'created_at' },
+      url: { '%type%': 'esql', '%context%': true, query: tbucketEsql, '%timefield%': 'created_at' },
     });
   });
 
@@ -112,7 +122,12 @@ describe('normalizeVegaSpec', () => {
     });
 
     expect(result.data).toEqual({
-      url: { '%type%': 'esql', query: timeAwareEsql, '%timefield%': '@timestamp' },
+      url: {
+        '%type%': 'esql',
+        '%context%': true,
+        query: timeAwareEsql,
+        '%timefield%': '@timestamp',
+      },
     });
   });
 
@@ -123,7 +138,7 @@ describe('normalizeVegaSpec', () => {
       columns: [{ name: 'status', type: 'keyword' }],
     });
 
-    expect(result.data).toEqual({ url: { '%type%': 'esql', query: ESQL } });
+    expect(result.data).toEqual({ url: { '%type%': 'esql', '%context%': true, query: ESQL } });
   });
 
   it('replaces any data source the model may have authored', () => {
@@ -132,7 +147,7 @@ describe('normalizeVegaSpec', () => {
       esqlQuery: ESQL,
     });
 
-    expect(result.data).toEqual({ url: { '%type%': 'esql', query: ESQL } });
+    expect(result.data).toEqual({ url: { '%type%': 'esql', '%context%': true, query: ESQL } });
   });
 
   describe('nested data sources', () => {
@@ -148,7 +163,7 @@ describe('normalizeVegaSpec', () => {
       const result = normalizeVegaSpec({ spec, esqlQuery: ESQL });
       const layer = result.layer as Array<Record<string, unknown>>;
 
-      expect(result.data).toEqual({ url: { '%type%': 'esql', query: ESQL } });
+      expect(result.data).toEqual({ url: { '%type%': 'esql', '%context%': true, query: ESQL } });
       expect(layer[1]).not.toHaveProperty('data');
       expect(layer[1]).toEqual({ mark: 'rule' });
       expect(spec).toEqual(snapshot);
@@ -162,7 +177,7 @@ describe('normalizeVegaSpec', () => {
 
       const result = normalizeVegaSpec({ spec, esqlQuery: ESQL });
 
-      expect(result.data).toEqual({ url: { '%type%': 'esql', query: ESQL } });
+      expect(result.data).toEqual({ url: { '%type%': 'esql', '%context%': true, query: ESQL } });
       expect(result.spec).toEqual({ mark: 'line' });
     });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/normalize_spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/normalize_spec.ts
@@ -28,6 +28,7 @@ const isCompositeView = (spec: Record<string, unknown>): boolean =>
 /** Inline ES|QL data source understood by Kibana's Vega renderer. */
 interface EsqlDataUrl {
   '%type%': 'esql';
+  '%context%': true;
   query: string;
   '%timefield%'?: string;
 }
@@ -84,6 +85,9 @@ const buildEsqlDataUrl = ({
 
   return {
     '%type%': 'esql',
+    // Always apply the dashboard context (time range + filters) so the panel
+    // stays in sync with the dashboard the chart is embedded in.
+    '%context%': true,
     query: esqlQuery,
     ...(effectiveTimefield ? { '%timefield%': effectiveTimefield } : {}),
   };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/recover_esql.integration.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/recover_esql.integration.test.ts
@@ -109,7 +109,7 @@ describe('recover_esql end-to-end (real build_config + real graph)', () => {
     // into the output and bound back into the normalized spec's data source.
     expect(result.esqlQuery).toBe(RECOVERED_ESQL);
     expect(JSON.parse(result.spec).data).toEqual({
-      url: { '%type%': 'esql', query: RECOVERED_ESQL },
+      url: { '%type%': 'esql', '%context%': true, query: RECOVERED_ESQL },
     });
   });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples.test.ts
@@ -40,6 +40,29 @@ const mockModel = (
 
 const mockLogger = (): Logger => ({ warn: jest.fn() } as unknown as Logger);
 
+const fixedColorPaths = (node: unknown, path = '$'): string[] => {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, index) => fixedColorPaths(item, `${path}[${index}]`));
+  }
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+  const entries = Object.entries(node as Record<string, unknown>);
+  const here: string[] = [];
+  const mark = (node as Record<string, unknown>).mark;
+  if (
+    mark &&
+    typeof mark === 'object' &&
+    typeof (mark as Record<string, unknown>).color === 'string'
+  ) {
+    here.push(`${path}.mark.color`);
+  }
+  if ('config' in (node as Record<string, unknown>)) {
+    here.push(`${path}.config`);
+  }
+  return here.concat(entries.flatMap(([key, value]) => fixedColorPaths(value, `${path}.${key}`)));
+};
+
 const idsFor = async (result: { exampleIds?: string[] }): Promise<string[]> => {
   const { model } = mockModel(result);
   const selected = await selectReferenceExamples({ nlQuery: 'any request', model });
@@ -187,6 +210,16 @@ describe('reference example specs (loaded on demand)', () => {
         expect(spec.height).toBeUndefined();
         expect(spec.autosize).toEqual({ type: 'fit', contains: 'padding' });
       }
+    }
+  });
+
+  it('never hardcodes colors, so every example stays theme-aware in dark mode', async () => {
+    for (const example of VEGA_REFERENCE_EXAMPLES) {
+      const spec = await example.load();
+      const serialized = JSON.stringify(spec);
+
+      expect(serialized).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+      expect(fixedColorPaths(spec)).toEqual([]);
     }
   });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/reference_examples/index.ts
@@ -39,35 +39,35 @@ export const VEGA_REFERENCE_EXAMPLES: readonly VegaReferenceExample[] = [
     id: 'faceted_small_multiples',
     title: 'Faceted small multiples (one panel per category)',
     description:
-      'Split one chart into a grid of small multiples: a top-level `facet` (the splitting field) plus a per-cell `spec`, with `columns` as a SIBLING of `facet`/`spec` (never inside `facet`). Auto-sizing does not apply to facets, so set explicit `width`/`height` on the inner `spec`. Keep the facet field low-cardinality (pre-limit in ES|QL).',
+      'Split one chart into a grid of small multiples: a top-level `facet` (the splitting field) plus a per-cell `spec`, with `columns` as a SIBLING of `facet`/`spec` (never inside `facet`). Auto-sizing does not apply to facets, so set explicit `width`/`height` on the inner `spec`. Keep the facet field low-cardinality so the grid stays readable.',
     load: () => import('./faceted_small_multiples').then((module) => module.spec),
   },
   {
     id: 'scatter_bubble',
     title: 'Scatter / bubble plot (encoded size)',
     description:
-      'Relate two measures per entity with a `point` mark: quantitative `x` and `y`, a third measure as `size` (bubble), and a category as `color`. Disable zero baselines (`scale.zero = false`) when comparing magnitudes. Still filter by the time picker even without a temporal axis.',
+      'Relate two measures per entity with a `point` mark: quantitative `x` and `y`, a third measure as `size` (bubble), and a category as `color`. Disable zero baselines (`scale.zero = false`) when comparing magnitudes.',
     load: () => import('./scatter_bubble').then((module) => module.spec),
   },
   {
     id: 'heatmap',
     title: 'Heatmap (two categories + color measure)',
     description:
-      'Density across two dimensions with a `rect` mark: an ordinal/nominal `x` and `y`, and a sequential `color` scheme for the measure. Extract categorical buckets with `EVAL`, but keep the time-picker filter on the raw source field.',
+      'Density across two dimensions with a `rect` mark: an ordinal/nominal `x` and `y`, and a sequential `color` scheme for the measure.',
     load: () => import('./heatmap').then((module) => module.spec),
   },
   {
     id: 'timeline_gantt',
     title: 'Timeline / Gantt (ranged bars)',
     description:
-      'Show the start-to-end span of each item as a horizontal ranged bar: a `bar` mark with a temporal `x` (start) and `x2` (end) against a nominal `y` (the item). Produce the start/end columns in ES|QL (e.g. `MIN`/`MAX` of the time field per item), pre-sort by start and set `sort: null` on `y`. Keep the time-picker filter on the raw source field.',
+      'Show the start-to-end span of each item as a horizontal ranged bar: a `bar` mark with a temporal `x` (start) and `x2` (end) against a nominal `y` (the item). Pre-sort by start and set `sort: null` on `y`.',
     load: () => import('./timeline_gantt').then((module) => module.spec),
   },
   {
     id: 'calendar_heatmap',
     title: 'Calendar heatmap (week × weekday grid)',
     description:
-      'GitHub-style calendar heatmap: a `rect` mark with an ordinal `x` for the week and an ordinal `y` for the weekday (explicitly sorted Mon→Sun via `sort`), colored by a sequential `scheme`. Derive the week/weekday buckets with `EVAL DATE_FORMAT(...)` and keep the time-picker filter on the raw source field.',
+      'GitHub-style calendar heatmap: a `rect` mark with an ordinal `x` for the week and an ordinal `y` for the weekday (explicitly sorted Mon→Sun via `sort`), colored by a sequential `scheme`.',
     load: () => import('./calendar_heatmap').then((module) => module.spec),
   },
 ];
@@ -219,5 +219,11 @@ export const buildReferenceExamplesBlock = async ({
   if (selected.length === 0) {
     return '';
   }
-  return formatReferenceExamples(await loadReferenceExamples(selected));
+  try {
+    return formatReferenceExamples(await loadReferenceExamples(selected));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger?.warn(`Reference-example loading failed; authoring without examples: ${message}`);
+    return '';
+  }
 };

--- a/x-pack/platform/plugins/shared/agent_builder_visualizations/server/skills/visualization_creation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_visualizations/server/skills/visualization_creation_skill.ts
@@ -129,6 +129,8 @@ ${
 - Otherwise pass \`renderer: "lens"\` (the default when omitted) with the best-fitting \`chartType\`.
 - When updating an existing attachment, \`renderer\` is ignored — edits keep the existing renderer.
 
+**Scope — "Vega" here means Vega-Lite, not full Vega.** The Vega renderer only supports the Vega-Lite grammar. It cannot do full Vega features such as custom signals / imperative interactivity, arbitrary data transforms or expressions, or bespoke rendering. If a request fits neither a Lens chart type nor the Vega-Lite grammar, do **not** force a broken or misleading chart. Be honest with the user: explain that the requested chart is not supported in Vega-Lite and that full Vega is not available yet, then offer alternatives — the closest Vega-Lite approximation, a standard Lens chart, or splitting the request into multiple charts — and ask how they would like to proceed.
+
 ## Chart Type Guidance
 
 Supported values for \`chartType\`: ${Object.values(SupportedChartType).join(', ')}.
@@ -144,6 +146,7 @@ When uncertain, omit \`chartType\` and let ${
 - **Requested field missing:** suggest nearest valid fields from the index mapping.
 - **ES|QL returns no data:** explain and suggest broader time range/filters.
 - **Unsupported chart request:** pick closest supported type and explain the substitution.
+- **Needs full Vega (beyond Vega-Lite):** do not fake it or ship a broken chart. State plainly that the requested chart is not supported in Vega-Lite yet and that full Vega is not available, then offer alternatives (closest Vega-Lite approximation, a Lens chart, or multiple charts) and let the user choose.
 `,
   referencedContent: [
     {

--- a/x-pack/platform/plugins/shared/agent_builder_visualizations/server/tools/create_visualization/create_visualization.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_visualizations/server/tools/create_visualization/create_visualization.ts
@@ -90,7 +90,7 @@ export const createVisualizationTool = (): BuiltinToolDefinition<
   return {
     id: platformCoreTools.createVisualization,
     type: ToolType.builtin,
-    description: `Create or update a visualization from a natural language description. Supports BOTH standard Lens charts AND custom Vega-Lite visualizations, so prefer this tool over telling the user a chart cannot be built — you do not author Vega specs by hand or ask the user to paste anything.
+    description: `Create or update a visualization from a natural language description. Supports BOTH standard Lens charts AND custom Vega-Lite visualizations (the Vega-Lite grammar only — NOT full Vega). Prefer this tool over telling the user a chart cannot be built whenever the request fits Lens or Vega-Lite; you do not author Vega specs by hand or ask the user to paste anything. If a request genuinely needs full Vega (custom signals/interactivity, imperative transforms, or bespoke rendering), it is not supported yet — be honest with the user and offer alternatives instead of producing a broken chart.
 
 You choose how to render the request via the "renderer" parameter:
 - "lens" (the default when omitted) for a standard Lens chart (${Object.values(


### PR DESCRIPTION
## Summary

Small, independent follow-ups to the Vega authoring work in #276415 (already merged, so these land separately):

- **Reference examples fail open** — a broken example no longer crashes the authoring graph; it logs and proceeds without examples.
- **Parallelize example selection with ES|QL generation** — the two run concurrently from `__start__`, removing a model round-trip from the critical path (the ES|QL-failure short-circuit is preserved).
- **Trim ES|QL hints from example descriptions** — those descriptions are used after ES|QL is generated, so query-construction hints were noise; structural Vega guidance is kept.
- **Pretty-print stored Vega specs** — specs read from a dashboard panel stay human-readable in the attachment.
- **Self-correct on Vega warnings** — every render warning is fed back to the model for one review pass so it can fix genuine issues or consciously keep them, without looping the retry budget.
- **Be honest about Vega-Lite scope** — when a request needs full Vega (not just Vega-Lite), the skill offers alternatives instead of shipping a broken chart.

## Test plan

- [x] `node scripts/jest` on the affected `vega/` package and visualization tools
- [x] `node scripts/type_check` on the affected projects
- [x] `node scripts/eslint` on changed files


<!--ONMERGE {"backportTargets":["9.6"]} ONMERGE-->