### PR TITLE
[9.3] [Cloud Connect] Tighten up permissions (#276408)

### DIFF
--- a/x-pack/platform/plugins/shared/cloud_connect/moon.yml
+++ b/x-pack/platform/plugins/shared/cloud_connect/moon.yml
@@ -31,6 +31,8 @@ dependsOn:
   - '@kbn/licensing-types'
   - '@kbn/actions-plugin'
   - '@kbn/home-plugin'
+  - '@kbn/core-security-server'
+  - '@kbn/core-http-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/cloud_connect/server/features.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/features.ts
@@ -6,6 +6,7 @@
  */
 
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
+import { ApiPrivileges } from '@kbn/core-security-server';
 import type { KibanaFeatureConfig } from '@kbn/features-plugin/server';
 import { PLUGIN_NAME } from '../common';
 import { CLOUD_CONNECT_API_KEY_TYPE } from '../common/constants';
@@ -35,7 +36,10 @@ export const cloudConnectedFeature: KibanaFeatureConfig = {
         read: [CLOUD_CONNECT_API_KEY_TYPE],
       },
       ui: ['show', 'configure'],
-      api: [],
+      api: [
+        ApiPrivileges.manage(CLOUD_CONNECTED_FEATURE_ID),
+        ApiPrivileges.read(CLOUD_CONNECTED_FEATURE_ID),
+      ],
     },
     read: {
       app: [CLOUD_CONNECTED_APP_ID, 'kibana'],
@@ -48,7 +52,7 @@ export const cloudConnectedFeature: KibanaFeatureConfig = {
         read: [CLOUD_CONNECT_API_KEY_TYPE],
       },
       ui: ['show'],
-      api: [],
+      api: [ApiPrivileges.read(CLOUD_CONNECTED_FEATURE_ID)],
     },
   },
 };

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.test.ts
@@ -10,6 +10,7 @@ import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mo
 import { registerAuthenticateRoute } from './authenticate';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import type { CloudConnectApiKey } from '../types';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 jest.mock('../services/cloud_connect_client');
 jest.mock('../lib/create_storage_service');
@@ -114,6 +115,13 @@ describe('Authentication Routes', () => {
       routeHandler = getCall![1];
     });
 
+    it('should require the cloudConnect read privilege', () => {
+      const getCall = mockRouter.get.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/config'
+      );
+      expect(getCall![0].security).toEqual(CLOUD_CONNECT_READ_SECURITY);
+    });
+
     it('should return config with license and cluster info on happy path', async () => {
       mockEsClient.license.get.mockResolvedValue({
         license: {
@@ -210,6 +218,13 @@ describe('Authentication Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/authenticate'
       );
       routeHandler = postCall![1];
+    });
+
+    it('should require the cloudConnect manage privilege', () => {
+      const postCall = mockRouter.post.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/authenticate'
+      );
+      expect(postCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
     });
 
     it('should authenticate with cluster-scoped key (happy path)', async () => {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/authenticate.ts
@@ -17,6 +17,7 @@ import type { OnboardClusterResponse } from '../types';
 import { getCurrentClusterData } from '../lib/cluster_info';
 import { createStorageService } from '../lib/create_storage_service';
 import { hasAnyDefaultLLMConnectors } from '../lib/update_default_llm_actions';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 const bodySchema = schema.object({
   apiKey: schema.string({ minLength: 1 }),
@@ -45,12 +46,7 @@ export const registerAuthenticateRoute = ({
   router.get(
     {
       path: `${API_BASE_PATH}/config`,
-      security: {
-        authz: {
-          enabled: false,
-          reason: 'This route returns public configuration information.',
-        },
-      },
+      security: CLOUD_CONNECT_READ_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -108,13 +104,7 @@ export const registerAuthenticateRoute = ({
   router.post(
     {
       path: `${API_BASE_PATH}/authenticate`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates authentication to the Cloud Connect API and handles authorization there.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: {
         body: bodySchema,
       },

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.test.ts
@@ -10,6 +10,7 @@ import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mo
 import { registerClustersRoute } from './clusters';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import type { CloudConnectApiKey } from '../types';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 jest.mock('../services/cloud_connect_client');
 jest.mock('../lib/create_storage_service');
@@ -109,6 +110,13 @@ describe('Clusters Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/cluster_details'
       );
       routeHandler = getCall![1];
+    });
+
+    it('should require the cloudConnect read privilege', () => {
+      const getCall = mockRouter.get.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster_details'
+      );
+      expect(getCall![0].security).toEqual(CLOUD_CONNECT_READ_SECURITY);
     });
 
     it('should return cluster details with subscription state on happy path', async () => {
@@ -465,6 +473,13 @@ describe('Clusters Routes', () => {
       routeHandler = deleteCall![1];
     });
 
+    it('should require the cloudConnect manage privilege', () => {
+      const deleteCall = mockRouter.delete.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster'
+      );
+      expect(deleteCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
+    });
+
     it('should disconnect cluster on happy path', async () => {
       mockStorageService.getApiKey.mockResolvedValue({
         apiKey: 'test-api-key-123',
@@ -581,6 +596,13 @@ describe('Clusters Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/cluster_details'
       );
       routeHandler = putCall![1];
+    });
+
+    it('should require the cloudConnect manage privilege', () => {
+      const putCall = mockRouter.put.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster_details'
+      );
+      expect(putCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
     });
 
     it('should update services on happy path', async () => {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/clusters.ts
@@ -17,6 +17,7 @@ import { createStorageService } from '../lib/create_storage_service';
 import { enableInferenceCCM, disableInferenceCCM } from '../services/inference_ccm';
 import { updateDefaultLLMActions } from '../lib/update_default_llm_actions';
 import { waitForInferenceEndpoint } from '../lib/wait_for_inference_endpoint';
+import { CLOUD_CONNECT_READ_SECURITY, CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 interface CloudConnectedStartDeps {
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
@@ -40,13 +41,7 @@ export const registerClustersRoute = ({
   router.get(
     {
       path: `${API_BASE_PATH}/cluster_details`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_READ_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -145,13 +140,7 @@ export const registerClustersRoute = ({
   router.delete(
     {
       path: `${API_BASE_PATH}/cluster`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -219,13 +208,7 @@ export const registerClustersRoute = ({
   router.put(
     {
       path: `${API_BASE_PATH}/cluster_details`,
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: {
         body: schema.object({
           services: schema.recordOf(

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.test.ts
@@ -9,6 +9,7 @@ import type { IRouter } from '@kbn/core/server';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { registerRotateApiKeyRoute } from './rotate_api_key';
 import { CloudConnectClient } from '../services/cloud_connect_client';
+import { CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 jest.mock('../services/cloud_connect_client');
 jest.mock('../lib/create_storage_service');
@@ -106,6 +107,13 @@ describe('Rotate API Key Routes', () => {
       routeHandler = rotateCall![1];
     });
 
+    it('should require the cloudConnect manage privilege', () => {
+      const rotateCall = mockRouter.post.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster/rotate_api_key'
+      );
+      expect(rotateCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
+    });
+
     it('should rotate cluster API key and save new key', async () => {
       mockCloudConnectInstance.rotateClusterApiKey.mockResolvedValue({
         key: 'new-rotated-api-key-789',
@@ -162,6 +170,13 @@ describe('Rotate API Key Routes', () => {
         (call) => call[0].path === '/internal/cloud_connect/cluster/{service_key}/rotate_api_key'
       );
       routeHandler = rotateCall![1];
+    });
+
+    it('should require the cloudConnect manage privilege', () => {
+      const rotateCall = mockRouter.post.mock.calls.find(
+        (call) => call[0].path === '/internal/cloud_connect/cluster/{service_key}/rotate_api_key'
+      );
+      expect(rotateCall![0].security).toEqual(CLOUD_CONNECT_MANAGE_SECURITY);
     });
 
     it('should rotate EIS service API key and update inference CCM', async () => {

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/rotate_api_key.ts
@@ -12,6 +12,7 @@ import axios from 'axios';
 import { CloudConnectClient } from '../services/cloud_connect_client';
 import { getApiKeyData, ApiKeyNotFoundError } from '../lib/create_storage_service';
 import { enableInferenceCCM } from '../services/inference_ccm';
+import { CLOUD_CONNECT_MANAGE_SECURITY } from './route_security';
 
 interface CloudConnectedStartDeps {
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
@@ -33,13 +34,7 @@ export const registerRotateApiKeyRoute = ({
   router.post(
     {
       path: '/internal/cloud_connect/cluster/rotate_api_key',
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: false,
       options: {
         access: 'internal',
@@ -112,13 +107,7 @@ export const registerRotateApiKeyRoute = ({
   router.post(
     {
       path: '/internal/cloud_connect/cluster/{service_key}/rotate_api_key',
-      security: {
-        authz: {
-          enabled: false,
-          reason:
-            'This route delegates to the Cloud Connect API for authentication and authorization.',
-        },
-      },
+      security: CLOUD_CONNECT_MANAGE_SECURITY,
       validate: {
         params: schema.object({
           // Only EIS is currently supported

--- a/x-pack/platform/plugins/shared/cloud_connect/server/routes/route_security.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/routes/route_security.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteSecurity } from '@kbn/core-http-server';
+import { ApiPrivileges } from '@kbn/core-security-server';
+import { CLOUD_CONNECTED_FEATURE_ID } from '../features';
+
+/**
+ * Applied to routes that only need to view Cloud Connect state, e.g. reading
+ * cluster/service details. Satisfied by either the `read` or `all` Kibana privilege.
+ */
+export const CLOUD_CONNECT_READ_SECURITY: RouteSecurity = {
+  authz: {
+    requiredPrivileges: [ApiPrivileges.read(CLOUD_CONNECTED_FEATURE_ID)],
+  },
+};
+
+/**
+ * Applied to routes that configure or mutate Cloud Connect state, e.g. onboarding,
+ * updating services, rotating keys, or disconnecting the cluster. Only satisfied by
+ * the `all` Kibana privilege.
+ */
+export const CLOUD_CONNECT_MANAGE_SECURITY: RouteSecurity = {
+  authz: {
+    requiredPrivileges: [ApiPrivileges.manage(CLOUD_CONNECTED_FEATURE_ID)],
+  },
+};

--- a/x-pack/platform/plugins/shared/cloud_connect/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cloud_connect/tsconfig.json
@@ -26,6 +26,8 @@
     "@kbn/licensing-plugin",
     "@kbn/licensing-types",
     "@kbn/actions-plugin",
-    "@kbn/home-plugin"
+    "@kbn/home-plugin",
+    "@kbn/core-security-server",
+    "@kbn/core-http-server"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Cloud Connect] Tighten up permissions (#276408)](https://github.com/elastic/kibana/pull/276408)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2026-07-08T10:20:53Z","message":"[Cloud Connect] Tighten up permissions (#276408)","sha":"8b4d327e96b72859b8a33a843178b7adc559cc07","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:version","Feature:Cloud Connect","v9.5.0","v9.4.4","v9.3.8"],"title":"[Cloud Connect] Tighten up permissions","number":276408,"url":"https://github.com/elastic/kibana/pull/276408","mergeCommit":{"message":"[Cloud Connect] Tighten up permissions (#276408)","sha":"8b4d327e96b72859b8a33a843178b7adc559cc07"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276408","number":276408,"mergeCommit":{"message":"[Cloud Connect] Tighten up permissions (#276408)","sha":"8b4d327e96b72859b8a33a843178b7adc559cc07"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276941","number":276941,"state":"OPEN"},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->