### PR TITLE
[One Workflow] Collapse foreach iterations in execution tree

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -92,6 +92,7 @@ function convertTreeToEuiTreeViewItems(
 
     return {
       id: item.stepExecutionId ?? `${item.stepId}-${item.executionIndex}-no-step-execution`,
+      isExpanded: item.children.length > 0 && item.stepType !== 'foreach-iteration',
       css: [
         getStatusCss({ status, selected }, euiTheme),
         // Don't allow selecting skeleton steps using css, as we don't have a 'disabled' prop on the tree view item
@@ -344,7 +345,6 @@ export const WorkflowStepExecutionTree = ({
             <EuiTreeView
               data-test-subj="workflowStepExecutionTree"
               showExpansionArrows
-              expandByDefault
               items={regularItems}
               aria-label={i18n.translate(
                 'workflows.WorkflowStepExecutionTree.workflowStepExecutionTreeAriaLabel',

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -55,6 +55,8 @@ import type { ChildWorkflowExecutionsMap } from '../model/use_child_workflow_exe
 const TRIGGER_BOLT_ICON_SVG =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="%23535966" d="M7.04 13.274a.5.5 0 1 0 .892.453l3.014-5.931a.5.5 0 0 0-.445-.727H5.316L8.03 1.727a.5.5 0 1 0-.892-.453L4.055 7.343a.5.5 0 0 0 .446.726h5.185L7.04 13.274Z"/></svg>';
 
+const COLLAPSED_BY_DEFAULT_STEP_TYPES = ['foreach-iteration', 'while', 'switch', 'parallel'];
+
 function convertTreeToEuiTreeViewItems(
   treeItems: StepExecutionTreeItem[],
   stepExecutionMap: Map<string, WorkflowStepExecutionDto>,
@@ -92,7 +94,8 @@ function convertTreeToEuiTreeViewItems(
 
     return {
       id: item.stepExecutionId ?? `${item.stepId}-${item.executionIndex}-no-step-execution`,
-      isExpanded: item.children.length > 0 && item.stepType !== 'foreach-iteration',
+      isExpanded:
+        item.children.length > 0 && !COLLAPSED_BY_DEFAULT_STEP_TYPES.includes(item.stepType),
       css: [
         getStatusCss({ status, selected }, euiTheme),
         // Don't allow selecting skeleton steps using css, as we don't have a 'disabled' prop on the tree view item

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -55,7 +55,13 @@ import type { ChildWorkflowExecutionsMap } from '../model/use_child_workflow_exe
 const TRIGGER_BOLT_ICON_SVG =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="%23535966" d="M7.04 13.274a.5.5 0 1 0 .892.453l3.014-5.931a.5.5 0 0 0-.445-.727H5.316L8.03 1.727a.5.5 0 1 0-.892-.453L4.055 7.343a.5.5 0 0 0 .446.726h5.185L7.04 13.274Z"/></svg>';
 
-const COLLAPSED_BY_DEFAULT_STEP_TYPES = ['foreach-iteration', 'while', 'switch', 'parallel'];
+const COLLAPSED_BY_DEFAULT_STEP_TYPES = [
+  'foreach-iteration',
+  'while-iteration',
+  'parallel-branch',
+  'enter-case-branch',
+  'enter-default-branch',
+];
 
 function convertTreeToEuiTreeViewItems(
   treeItems: StepExecutionTreeItem[],


### PR DESCRIPTION
## TL;DR

Collapse generated iteration and branch rows by default in the workflow execution tree so large executions render less content upfront while authored container steps stay expanded.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->