### PR TITLE
[One Workflow] Exclude waitForApproval from parallel branches

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -1135,8 +1135,8 @@ function buildParallelBranchBody(
     .find((bodyNode) => isHitlWaitStepType(bodyNode?.type));
   if (unsupportedNode) {
     throw new GraphBuildError(
-      `Parallel step "${stepId}" has a branch body containing an unsupported step type "${unsupportedNode.stepType}". ` +
-        `"waitForInput" and "waitForApproval" steps are not supported inside a parallel branch yet.`,
+      `Parallel step "${stepId}" has a branch body containing an unsupported HITL wait step "${unsupportedNode.stepType}". ` +
+        `HITL wait steps are not supported inside a parallel branch yet.`,
       stepId
     );
   }

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -1122,11 +1122,11 @@ function buildParallelBranchBody(
 
   // The parallel executor drives each branch in-process. Timer-based `wait`
   // steps are supported: a waiting branch parks across ticks and the parallel
-  // re-ticks at the earliest branch `resumeAt`. `waitForInput`, however, is an
-  // indefinite, externally-resumed wait that has no per-branch resume signal,
-  // so it cannot run inside a branch yet — reject it at compile time instead of
-  // hanging the branch at runtime.
-  const UNSUPPORTED_BRANCH_NODE_TYPES = new Set(['waitForInput']);
+  // re-ticks at the earliest branch `resumeAt`. HITL waits, however, are
+  // indefinite, externally-resumed waits that have no per-branch resume signal,
+  // so they cannot run inside a branch yet — reject them at compile time instead
+  // of hanging or self-resuming the branch at runtime.
+  const UNSUPPORTED_BRANCH_NODE_TYPES = new Set(['waitForInput', 'waitForApproval']);
   const unsupportedNode = bodyGraph
     .nodes()
     .map((nodeId) => bodyGraph.node(nodeId))
@@ -1134,7 +1134,7 @@ function buildParallelBranchBody(
   if (unsupportedNode) {
     throw new GraphBuildError(
       `Parallel step "${stepId}" has a branch body containing an unsupported step type "${unsupportedNode.stepType}". ` +
-        `"waitForInput" steps are not supported inside a parallel branch yet.`,
+        `"waitForInput" and "waitForApproval" steps are not supported inside a parallel branch yet.`,
       stepId
     );
   }

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -10,7 +10,10 @@
 import { graphlib } from '@dagrejs/dagre';
 import { omit } from 'lodash';
 import { GraphBuildError } from './graph_build_error';
-import { DEFAULT_WAIT_FOR_APPROVAL_TIMEOUT } from '../../common/wait_for_approval';
+import {
+  DEFAULT_WAIT_FOR_APPROVAL_TIMEOUT,
+  isHitlWaitStepType,
+} from '../../common/wait_for_approval';
 import { DEFAULT_LOOP_MAX_ITERATIONS } from '../../spec/schema';
 import type {
   BaseStep,
@@ -1126,11 +1129,10 @@ function buildParallelBranchBody(
   // indefinite, externally-resumed waits that have no per-branch resume signal,
   // so they cannot run inside a branch yet — reject them at compile time instead
   // of hanging or self-resuming the branch at runtime.
-  const UNSUPPORTED_BRANCH_NODE_TYPES = new Set(['waitForInput', 'waitForApproval']);
   const unsupportedNode = bodyGraph
     .nodes()
     .map((nodeId) => bodyGraph.node(nodeId))
-    .find((bodyNode) => UNSUPPORTED_BRANCH_NODE_TYPES.has(bodyNode?.type as string));
+    .find((bodyNode) => isHitlWaitStepType(bodyNode?.type));
   if (unsupportedNode) {
     throw new GraphBuildError(
       `Parallel step "${stepId}" has a branch body containing an unsupported step type "${unsupportedNode.stepType}". ` +

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/parallel_step_graph.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/parallel_step_graph.test.ts
@@ -146,6 +146,21 @@ describe('convertToWorkflowGraph - parallel step', () => {
     ).toThrow(/not supported inside a parallel branch/);
   });
 
+  it('rejects a waitForApproval step inside a branch body', () => {
+    expect(() =>
+      buildGraph({
+        ...baseParallel,
+        steps: [
+          {
+            name: 'approve',
+            type: 'waitForApproval',
+            with: { message: 'approve?' },
+          } as unknown as ConnectorStep,
+        ],
+      })
+    ).toThrow(/not supported inside a parallel branch/);
+  });
+
   it('compiles a workflow.fail step inside a dynamic branch body', () => {
     // `workflow.output` / `workflow.fail` are allowed inside a branch body; the
     // terminator node is compiled into the branch chain like any other step.
@@ -295,6 +310,27 @@ describe('convertToWorkflowGraph - parallel step', () => {
         ],
       } as unknown as ParallelStep)
     ).toThrow(/unsupported flow-control|timeout/);
+  });
+
+  it('rejects a waitForApproval step inside a static branch body', () => {
+    expect(() =>
+      buildGraph({
+        name: 'fanOut',
+        type: 'parallel',
+        branches: [
+          {
+            name: 'approval',
+            steps: [
+              {
+                name: 'approve',
+                type: 'waitForApproval',
+                with: { message: 'approve?' },
+              },
+            ],
+          },
+        ],
+      } as unknown as ParallelStep)
+    ).toThrow(/not supported inside a parallel branch/);
   });
 
   it('compiles a workflow.fail step inside a static branch body', () => {


### PR DESCRIPTION
Reject waitForApproval in parallel branch bodies until HITL resume is step-scoped, preventing branch approvals from self-resuming on parent re-ticks.