### PR TITLE
Increase Node.js heap for Linting (with types) step to 16 GB

### DIFF
--- a/.buildkite/scripts/steps/lint_with_types.sh
+++ b/.buildkite/scripts/steps/lint_with_types.sh
@@ -7,5 +7,5 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Lint: eslint (with types)'
-export NODE_OPTIONS='--max-old-space-size=8192'
+export NODE_OPTIONS='--max-old-space-size=16384'
 node scripts/eslint_with_types


### PR DESCRIPTION
## Summary

Increases the Node.js heap limit for the **Linting (with types)** CI step from 8 GB to 16 GB, as we are hitting the current limit.

The `n4-standard-32` machine used for this step has 128 GB RAM, so this is well within available resources.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->