### PR TITLE
[8.19] [ML] Hardening checks in the clear audit messages api (#276419)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/server/models/job_audit_messages/job_audit_messages.ts
+++ b/x-pack/platform/plugins/shared/ml/server/models/job_audit_messages/job_audit_messages.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import moment from 'moment';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
@@ -17,6 +18,7 @@ import type { JobMessage } from '../../../common/types/audit_message';
 import type { AuditMessage } from '../../../common/types/anomaly_detection_jobs';
 
 const SIZE = 1000;
+const ML_NOTIFICATIONS_INDEX_PREFIX = '.ml-notifications-';
 const LEVEL = { system_info: -1, info: 0, warning: 1, error: 2 } as const;
 
 type LevelName = keyof typeof LEVEL;
@@ -190,6 +192,9 @@ export function jobAuditMessagesProvider(
    * @param jobIds
    */
   async function getAuditMessagesSummary(jobIds: string[]): Promise<AuditMessage[]> {
+    // check that the jobs exist and the user has permission to access them
+    await mlClient.getJobs({ job_id: jobIds.join(',') });
+
     // TODO This is the current default value of the cluster setting `search.max_buckets`.
     // This should possibly consider the real settings in a future update.
     const maxBuckets = 10000;
@@ -367,6 +372,15 @@ export function jobAuditMessagesProvider(
     jobId: string,
     notificationIndices: string[]
   ): Promise<{ success: boolean; last_cleared: number }> {
+    notificationIndices.forEach((index) => {
+      if (!index.startsWith(ML_NOTIFICATIONS_INDEX_PREFIX) || index.includes(',')) {
+        throw Boom.badRequest(`Invalid notification index: ${index}`);
+      }
+    });
+
+    // check that the job exists and the user has permission to access it
+    await mlClient.getJobs({ job_id: jobId });
+
     const newClearedMessage = {
       job_id: jobId,
       job_type: 'anomaly_detection',
@@ -440,6 +454,9 @@ export function jobAuditMessagesProvider(
     jobIds: string[],
     earliestMs?: number
   ): Promise<JobsErrorsResponse> {
+    // check that the jobs exist and the user has permission to access them
+    await mlClient.getJobs({ job_id: jobIds.join(',') });
+
     const body = await asInternalUser.search(
       {
         index: ML_NOTIFICATION_INDEX_PATTERN,

--- a/x-pack/platform/plugins/shared/ml/server/routes/schemas/job_audit_messages_schema.ts
+++ b/x-pack/platform/plugins/shared/ml/server/routes/schemas/job_audit_messages_schema.ts
@@ -18,6 +18,6 @@ export const jobAuditMessagesQuerySchema = schema.object({
 });
 
 export const clearJobAuditMessagesBodySchema = schema.object({
-  jobId: schema.string(),
-  notificationIndices: schema.arrayOf(schema.string()),
+  jobId: schema.string({ maxLength: 1000 }),
+  notificationIndices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 100 }),
 });

--- a/x-pack/platform/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -123,5 +123,20 @@ export default ({ getService }: FtrProviderContext) => {
 
       expect(getBody.messages[0].cleared).to.not.eql(true);
     });
+
+    it('should reject invalid notification indices', async () => {
+      const { body, status } = await supertest
+        .put(`/internal/ml/job_audit_messages/clear_messages`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'))
+        .send({
+          jobId: 'test_get_job_audit_messages_1',
+          notificationIndices: ['not-a-notification-index'],
+        });
+      ml.api.assertResponseStatusCode(400, status, body);
+
+      expect(body.error).to.eql('Bad Request');
+      expect(body.message).to.eql('Invalid notification index: not-a-notification-index');
+    });
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Hardening checks in the clear audit messages api (#276419)](https://github.com/elastic/kibana/pull/276419)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"James Gowdy","email":"jgowdy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-08T10:26:29Z","message":"[ML] Hardening checks in the clear audit messages api (#276419)\n\nAdds a check to ensure all indices passed to the api are notifications\nindices.\nAdds a check to ensure the user has access to the specified job.\n\n---------\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"278f67718c876716f1ac84054451abf4b274f8e7","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:Anomaly Detection","backport:version","v9.5.0","v9.4.4","v8.19.19","v9.3.8"],"title":"[ML] Hardening checks in the clear audit messages api","number":276419,"url":"https://github.com/elastic/kibana/pull/276419","mergeCommit":{"message":"[ML] Hardening checks in the clear audit messages api (#276419)\n\nAdds a check to ensure all indices passed to the api are notifications\nindices.\nAdds a check to ensure the user has access to the specified job.\n\n---------\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"278f67718c876716f1ac84054451abf4b274f8e7"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276419","number":276419,"mergeCommit":{"message":"[ML] Hardening checks in the clear audit messages api (#276419)\n\nAdds a check to ensure all indices passed to the api are notifications\nindices.\nAdds a check to ensure the user has access to the specified job.\n\n---------\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"278f67718c876716f1ac84054451abf4b274f8e7"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276945","number":276945,"state":"OPEN"},{"branch":"8.19","label":"v8.19.19","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276953","number":276953,"state":"OPEN"}]}] BACKPORT-->