### PR TITLE
[Security Solution][Flyout] toggle between legacy and new document/attack flyouts (main and tools)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -9,8 +9,17 @@ import { EuiBadge, EuiButtonEmpty, EuiToolTip, EuiLoadingSpinner, useEuiTheme } 
 import { css } from '@emotion/react';
 import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import { DraggableBadge } from '../../../../../common/components/draggables';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { Host } from '../../../../../flyout_v2/entity/host/main';
+import { User } from '../../../../../flyout_v2/entity/user/main';
+import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
+import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
 import { getFlyoutPanelProps, ENTITY_TYPE_BY_FIELD } from './helpers';
 import { useEntityEuidFromAlerts } from './use_entity_euid_from_alerts';
 import { useMarkdownFormatterContext } from '../context';
@@ -22,6 +31,12 @@ export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
   const { disableActions, scopeId, alertIds } = useMarkdownFormatterContext();
   const { openRightPanel } = useExpandableFlyoutApi();
   const { euiTheme } = useEuiTheme();
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
   const isEntityField = name in ENTITY_TYPE_BY_FIELD && typeof value === 'string';
 
@@ -38,10 +53,45 @@ export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
   );
 
   const onEntityClick = useCallback(() => {
-    if (flyoutPanelProps != null) {
+    if (flyoutPanelProps == null) {
+      return;
+    }
+
+    if (enableNewFlyout) {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children:
+            ENTITY_TYPE_BY_FIELD[name] === 'host' ? (
+              <Host hostName={value as string} entityId={euid} />
+            ) : (
+              <User userName={value as string} entityId={euid} />
+            ),
+        }),
+        {
+          ...defaultDocumentFlyoutProperties,
+          historyKey: documentFlyoutHistoryKey,
+          session: 'start',
+        }
+      );
+    } else {
       openRightPanel(flyoutPanelProps);
     }
-  }, [flyoutPanelProps, openRightPanel]);
+  }, [
+    flyoutPanelProps,
+    openRightPanel,
+    enableNewFlyout,
+    overlays,
+    services,
+    store,
+    history,
+    name,
+    value,
+    euid,
+    defaultDocumentFlyoutProperties,
+  ]);
 
   const entityButton: React.ReactElement | null = useMemo(
     () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.test.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TestProviders } from '../../../../common/mock';
+import { AlertEvent } from './alert_event';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useFetchAlertData } from '../../../pages/use_fetch_alert_data';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+
+const props = {
+  alertId: 'alert-id',
+  rule: { id: 'rule-id', name: 'Test Rule' },
+  savedObjectId: 'saved-object-id',
+  totalAlerts: 1,
+};
+
+const mockOpenFlyout = jest.fn();
+const mockOpenSystemFlyout = jest.fn();
+
+jest.mock('@kbn/expandable-flyout');
+
+jest.mock('../../../pages/use_fetch_alert_data');
+jest.mock('../../../../common/components/user_privileges');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
+
+jest.mock('../../../../common/lib/kibana', () => {
+  const original = jest.requireActual('../../../../common/lib/kibana');
+  return {
+    ...original,
+    useKibana: () => ({
+      ...original.useKibana(),
+      services: {
+        ...original.useKibana().services,
+        overlays: {
+          ...original.useKibana().services.overlays,
+          openSystemFlyout: mockOpenSystemFlyout,
+        },
+      },
+    }),
+  };
+});
+
+jest.mock('../../../../flyout_v2/shared/components/flyout_provider', () => ({
+  flyoutProviders: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
+const useFetchAlertDataMock = useFetchAlertData as jest.Mock;
+
+const clickRuleLink = () => {
+  fireEvent.click(screen.getByTestId(`alert-rule-link-${props.savedObjectId}`));
+};
+
+describe('AlertEvent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: mockOpenFlyout });
+    useFetchAlertDataMock.mockReturnValue([false, {}]);
+    useUserPrivilegesMock.mockReturnValue({
+      rulesPrivileges: {
+        rules: { read: true, edit: false },
+        exceptions: { read: false, crud: false },
+      },
+    });
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+  });
+
+  it('renders the rule link', () => {
+    render(
+      <TestProviders>
+        <AlertEvent {...props} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId(`alert-rule-link-${props.savedObjectId}`)).toBeInTheDocument();
+  });
+
+  it('opens the legacy rule flyout when the new flyout is disabled', () => {
+    render(
+      <TestProviders>
+        <AlertEvent {...props} />
+      </TestProviders>
+    );
+
+    clickRuleLink();
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: { id: 'rule-panel', params: { ruleId: 'rule-id' } },
+    });
+    expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+  });
+
+  it('opens the new rule flyout (system flyout) when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(
+      <TestProviders>
+        <AlertEvent {...props} />
+      </TestProviders>
+    );
+
+    clickRuleLink();
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalled();
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+  });
+
+  it('does not open any flyout when the user cannot read rules', () => {
+    useUserPrivilegesMock.mockReturnValue({
+      rulesPrivileges: {
+        rules: { read: false, edit: false },
+        exceptions: { read: false, crud: false },
+      },
+    });
+
+    render(
+      <TestProviders>
+        <AlertEvent {...props} />
+      </TestProviders>
+    );
+
+    clickRuleLink();
+
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.tsx
@@ -9,11 +9,19 @@ import { isEmpty } from 'lodash';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { UserActionTitle } from '@kbn/cases-components';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { getRuleInfo, type AlertAttachmentMetadata } from '@kbn/cases-plugin/common';
 import { useFetchAlertData } from '../../../pages/use_fetch_alert_data';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import * as i18n from '../translations';
 import { RulePanelKey } from '../../../../flyout/rule_details/right';
+import { RuleDetails } from '../../../../flyout_v2/rule/main';
+import { flyoutProviders } from '../../../../flyout_v2/shared/components/flyout_provider';
+import { useDefaultDocumentFlyoutProperties } from '../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../../../../flyout_v2/shared/constants/flyout_history';
 
 /**
  * Security signals (`signal.*`) shipped before the ECS `kibana.alert.*` move,
@@ -41,6 +49,12 @@ export const AlertEvent: React.FC<AlertEventProps> = ({
   rule,
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const {
     rulesPrivileges: {
       rules: { read: canReadRules },
@@ -72,10 +86,38 @@ export const AlertEvent: React.FC<AlertEventProps> = ({
   );
 
   const onRuleClick = useCallback(() => {
-    if (resolvedRuleId && canReadRules) {
+    if (!resolvedRuleId || !canReadRules) {
+      return;
+    }
+
+    if (enableNewFlyout) {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <RuleDetails ruleId={resolvedRuleId} />,
+        }),
+        {
+          ...defaultDocumentFlyoutProperties,
+          historyKey: documentFlyoutHistoryKey,
+          session: 'start',
+        }
+      );
+    } else {
       openFlyout({ right: { id: RulePanelKey, params: { ruleId: resolvedRuleId } } });
     }
-  }, [openFlyout, canReadRules, resolvedRuleId]);
+  }, [
+    openFlyout,
+    canReadRules,
+    resolvedRuleId,
+    enableNewFlyout,
+    overlays,
+    services,
+    store,
+    history,
+    defaultDocumentFlyoutProperties,
+  ]);
 
   if (loadingAlertData) {
     return <EuiLoadingSpinner size="m" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.test.tsx
@@ -7,17 +7,19 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ShowEventButton } from './show_event_button';
+import { ShowAlertButton } from './show_alert_button';
 import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
+import { useKibana } from '../../../../common/lib/kibana';
 import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
 import { createDocumentFlyoutApiMock } from '../../../../flyout_v2/document/use_document_flyout_api.mock';
 import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
 
 const props = {
   id: 'action-id',
-  eventId: 'event-id',
-  index: 'event-index',
+  alertId: 'alert-id',
+  index: 'alert-index',
 };
 
 const mockOpenFlyout = jest.fn();
@@ -27,11 +29,7 @@ jest.mock('@kbn/expandable-flyout', () => ({
   useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout }),
 }));
 
-jest.mock('../../../../common/lib/kibana', () => ({
-  useKibana: () => ({
-    services: { telemetry: { reportEvent: mockReportEvent } },
-  }),
-}));
+jest.mock('../../../../common/lib/kibana');
 
 jest.mock('@kbn/cases-plugin/public', () => ({
   useCaseViewNavigation: jest.fn(),
@@ -43,8 +41,22 @@ jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
 
 const useCaseViewParamsMock = useCaseViewParams as jest.Mock;
 const useCaseViewNavigationMock = useCaseViewNavigation as jest.Mock;
+const useKibanaMock = useKibana as jest.Mock;
 
-describe('ShowEventButton', () => {
+const setKibanaServices = (ease: boolean) => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      telemetry: { reportEvent: mockReportEvent },
+      application: {
+        capabilities: {
+          [SECURITY_FEATURE_ID]: { configurations: ease },
+        },
+      },
+    },
+  });
+};
+
+describe('ShowAlertButton', () => {
   const navigateToCaseView = jest.fn();
   let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
 
@@ -55,23 +67,24 @@ describe('ShowEventButton', () => {
     documentFlyoutApi = createDocumentFlyoutApiMock();
     jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    setKibanaServices(false);
   });
 
-  it('renders the show event button', () => {
-    render(<ShowEventButton {...props} />);
-    expect(screen.getByTestId('comment-action-show-event-action-id')).toBeInTheDocument();
+  it('renders the show alert button', () => {
+    render(<ShowAlertButton {...props} />);
+    expect(screen.getByTestId('comment-action-show-alert-action-id')).toBeInTheDocument();
   });
 
-  it('opens the legacy expandable flyout when the new flyout is disabled', () => {
-    render(<ShowEventButton {...props} />);
-    const button = screen.getByTestId('comment-action-show-event-action-id');
-    fireEvent.click(button);
+  it('opens the legacy expandable flyout when the new flyout is disabled (non-EASE)', () => {
+    render(<ShowAlertButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
     expect(mockOpenFlyout).toHaveBeenCalledWith({
       right: {
         id: 'document-details-right',
         params: {
-          id: 'event-id',
-          indexName: 'event-index',
+          id: 'alert-id',
+          indexName: 'alert-index',
           scopeId: 'timeline-case',
         },
       },
@@ -81,20 +94,53 @@ describe('ShowEventButton', () => {
     expect(navigateToCaseView).not.toHaveBeenCalled();
   });
 
-  it('opens the new document flyout (from index) when the new flyout is enabled', () => {
+  it('opens the new document flyout (from index) when the new flyout is enabled (non-EASE)', () => {
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
 
-    render(<ShowEventButton {...props} />);
-    const button = screen.getByTestId('comment-action-show-event-action-id');
-    fireEvent.click(button);
+    render(<ShowAlertButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
 
     expect(documentFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
-      documentId: 'event-id',
-      indexName: 'event-index',
+      documentId: 'alert-id',
+      indexName: 'alert-index',
       renderCellActions: casesCellActionRenderer,
     });
     expect(mockOpenFlyout).not.toHaveBeenCalled();
     expect(mockReportEvent).toHaveBeenCalled();
     expect(navigateToCaseView).not.toHaveBeenCalled();
+  });
+
+  it('opens the legacy EASE flyout when the EASE capability is on, regardless of the new flyout flag', () => {
+    setKibanaServices(true);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(<ShowAlertButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: 'ease-details',
+        params: {
+          id: 'alert-id',
+          indexName: 'alert-index',
+        },
+      },
+    });
+    expect(documentFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    // EASE path does not report the document flyout telemetry event
+    expect(mockReportEvent).not.toHaveBeenCalled();
+    expect(navigateToCaseView).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the case view when there is no valid index', () => {
+    render(<ShowAlertButton {...props} index="" />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
+    expect(navigateToCaseView).toHaveBeenCalledWith({
+      detailName: 'case-id',
+      tabId: 'alerts',
+    });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(documentFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.tsx
@@ -6,15 +6,18 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
 import { CASE_VIEW_PAGE_TABS } from '@kbn/cases-plugin/common';
 import { EasePanelKey } from '../../../../flyout/ease/constants/panel_keys';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
+import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
 import { SHOW_ALERT_TOOLTIP } from '../translations';
 
@@ -32,6 +35,8 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
   } = useKibana().services;
   const { navigateToCaseView } = useCaseViewNavigation();
   const { detailName } = useCaseViewParams();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openDocumentFlyoutFromIndex } = useDocumentFlyoutApi();
 
   // TODO We shouldn't have to check capabilities here, this should be done at a much higher level.
   //  https://github.com/elastic/kibana/issues/218741
@@ -41,6 +46,7 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
     const hasValidIndex = index && String(index).trim();
     if (hasValidIndex) {
       if (EASE) {
+        // EASE alert summary flyout has no new-flyout equivalent yet, so it stays on the legacy flyout.
         openFlyout({
           right: {
             id: EasePanelKey,
@@ -51,16 +57,24 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
           },
         });
       } else {
-        openFlyout({
-          right: {
-            id: DocumentDetailsRightPanelKey,
-            params: {
-              id: alertId,
-              indexName: index,
-              scopeId: TimelineId.casePage,
+        if (enableNewFlyout) {
+          openDocumentFlyoutFromIndex({
+            documentId: alertId,
+            indexName: index,
+            renderCellActions: casesCellActionRenderer,
+          });
+        } else {
+          openFlyout({
+            right: {
+              id: DocumentDetailsRightPanelKey,
+              params: {
+                id: alertId,
+                indexName: index,
+                scopeId: TimelineId.casePage,
+              },
             },
-          },
-        });
+          });
+        }
         telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
           location: TimelineId.casePage,
           panel: 'right',
@@ -69,7 +83,17 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
     } else {
       navigateToCaseView({ detailName, tabId: CASE_VIEW_PAGE_TABS.ALERTS });
     }
-  }, [EASE, alertId, index, openFlyout, telemetry, detailName, navigateToCaseView]);
+  }, [
+    EASE,
+    alertId,
+    index,
+    openFlyout,
+    telemetry,
+    detailName,
+    navigateToCaseView,
+    enableNewFlyout,
+    openDocumentFlyoutFromIndex,
+  ]);
 
   return (
     <EuiToolTip position="top" content={<p>{SHOW_ALERT_TOOLTIP}</p>}>

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/components/show_event_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/components/show_event_button.tsx
@@ -6,14 +6,17 @@
  */
 
 import React, { memo, useCallback } from 'react';
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
 import { CASE_VIEW_PAGE_TABS } from '@kbn/cases-plugin/common';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
+import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { SHOW_EVENT_TOOLTIP } from '../translations';
 
 export interface ShowEventButtonProps {
@@ -27,20 +30,30 @@ const ShowEventButtonComponent = ({ id, eventId, index }: ShowEventButtonProps) 
   const { telemetry } = useKibana().services;
   const { navigateToCaseView } = useCaseViewNavigation();
   const { detailName } = useCaseViewParams();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openDocumentFlyoutFromIndex } = useDocumentFlyoutApi();
 
   const onClick = useCallback(() => {
     const hasValidIndex = index && String(index).trim();
     if (hasValidIndex) {
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName: index,
-            scopeId: TimelineId.casePage,
+      if (enableNewFlyout) {
+        openDocumentFlyoutFromIndex({
+          documentId: eventId,
+          indexName: index,
+          renderCellActions: casesCellActionRenderer,
+        });
+      } else {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName: index,
+              scopeId: TimelineId.casePage,
+            },
           },
-        },
-      });
+        });
+      }
       telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
         location: TimelineId.casePage,
         panel: 'right',
@@ -48,7 +61,16 @@ const ShowEventButtonComponent = ({ id, eventId, index }: ShowEventButtonProps) 
     } else {
       navigateToCaseView({ detailName, tabId: CASE_VIEW_PAGE_TABS.EVENTS });
     }
-  }, [eventId, index, openFlyout, telemetry, detailName, navigateToCaseView]);
+  }, [
+    eventId,
+    index,
+    openFlyout,
+    telemetry,
+    detailName,
+    navigateToCaseView,
+    enableNewFlyout,
+    openDocumentFlyoutFromIndex,
+  ]);
 
   return (
     <EuiToolTip position="top" content={<p>{SHOW_EVENT_TOOLTIP}</p>}>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
@@ -23,10 +23,11 @@ import { createExpandableFlyoutApiMock } from '../../../mock/expandable_flyout';
 import { useUserPrivileges } from '../../user_privileges';
 import { initialUserPrivilegesState } from '../../user_privileges/user_privileges_context';
 import { useIsNewFlyoutEnabled } from '../../../hooks/use_is_new_flyout_enabled';
+import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../../flyout_v2/document/use_document_flyout_api.mock';
 
-jest.mock('../../../hooks/use_is_new_flyout_enabled', () => ({
-  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
-}));
+jest.mock('../../../hooks/use_is_new_flyout_enabled');
+jest.mock('../../../../flyout_v2/document/use_document_flyout_api');
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
   const original = jest.requireActual('react-redux');
@@ -38,18 +39,11 @@ jest.mock('react-redux', () => {
 });
 
 jest.mock('../../../utils/route/use_route_spy');
-jest.mock('../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => children,
-}));
 
 const mockOpenFlyout = jest.fn();
 jest.mock('@kbn/expandable-flyout');
 
 const mockedTelemetry = createTelemetryServiceMock();
-const mockOpenSystemFlyout = jest.fn();
-const mockDocumentFlyoutWrapper = jest.fn((_props?: unknown) => (
-  <div>{'MockDocumentFlyoutWrapper'}</div>
-));
 jest.mock('../../../lib/kibana', () => {
   const original = jest.requireActual('../../../lib/kibana');
   return {
@@ -59,24 +53,8 @@ jest.mock('../../../lib/kibana', () => {
       services: {
         ...original.useKibana().services,
         telemetry: mockedTelemetry,
-        overlays: {
-          ...original.useKibana().services.overlays,
-          openSystemFlyout: mockOpenSystemFlyout,
-        },
       },
     }),
-  };
-});
-jest.mock('../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => children,
-}));
-jest.mock('../../../../flyout_v2/document/main/document_flyout_wrapper', () => ({
-  DocumentFlyoutWrapper: (props: unknown) => mockDocumentFlyoutWrapper(props),
-}));
-jest.mock('@kbn/kibana-react-plugin/public', () => {
-  const original = jest.requireActual('@kbn/kibana-react-plugin/public');
-  return {
-    ...original,
   };
 });
 
@@ -90,6 +68,8 @@ const mockRouteSpy: RouteSpyState = {
   pathName: '/',
 };
 describe('RowAction', () => {
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
+
   const sampleData = {
     _id: '1',
     data: [],
@@ -132,11 +112,13 @@ describe('RowAction', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    documentFlyoutApi = createDocumentFlyoutApiMock();
     jest.mocked(useExpandableFlyoutApi).mockReturnValue({
       ...createExpandableFlyoutApiMock(),
       openFlyout: mockOpenFlyout,
     });
     jest.mocked(useExpandableFlyoutState).mockReturnValue({} as unknown as ExpandableFlyoutState);
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
     (useRouteSpy as jest.Mock).mockReturnValue([mockRouteSpy]);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
@@ -173,7 +155,7 @@ describe('RowAction', () => {
     });
   });
 
-  test('should open expandable flyout when enableNewFlyout setting is disabled', () => {
+  test('should open the legacy expandable flyout when enableNewFlyout setting is disabled', () => {
     const wrapper = render(
       <TestProviders>
         <RowAction {...defaultProps} />
@@ -183,10 +165,10 @@ describe('RowAction', () => {
     fireEvent.click(wrapper.getByTestId('expand-event'));
 
     expect(mockOpenFlyout).toHaveBeenCalled();
-    expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+    expect(documentFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
   });
 
-  test('should open system flyout when enableNewFlyout setting is enabled', () => {
+  test('should open the new document flyout when enableNewFlyout setting is enabled', () => {
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
     const refetch = jest.fn();
 
@@ -199,14 +181,58 @@ describe('RowAction', () => {
     fireEvent.click(wrapper.getByTestId('expand-event'));
 
     expect(mockOpenFlyout).not.toHaveBeenCalled();
-    expect(mockOpenSystemFlyout).toHaveBeenCalled();
-    const flyoutElement = mockOpenSystemFlyout.mock.calls[0][0];
-    expect(flyoutElement.props.documentId).toBe('1');
-    expect(flyoutElement.props.indexName).toBeUndefined();
-    expect(flyoutElement.props.renderCellActions).toBeDefined();
-    expect(flyoutElement.props.onAlertUpdated).toEqual(expect.any(Function));
-    flyoutElement.props.onAlertUpdated();
+    expect(documentFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: '1',
+        indexName: undefined,
+        renderCellActions: expect.any(Function),
+        onAlertUpdated: expect.any(Function),
+      })
+    );
+
+    const { onAlertUpdated } = documentFlyoutApi.openDocumentFlyoutFromIndex.mock.calls[0][0];
+    onAlertUpdated?.();
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('notes', () => {
+    beforeEach(() => {
+      (useUserPrivileges as jest.Mock).mockReturnValue({
+        ...initialUserPrivilegesState(),
+        notesPrivileges: { read: true, crud: true },
+        timelinePrivileges: { read: true },
+      });
+    });
+
+    test('should open the legacy expandable flyout when enableNewFlyout setting is disabled', () => {
+      const wrapper = render(
+        <TestProviders>
+          <RowAction {...defaultProps} />
+        </TestProviders>
+      );
+
+      fireEvent.click(wrapper.getByTestId('timeline-notes-button-small'));
+
+      expect(mockOpenFlyout).toHaveBeenCalled();
+      expect(documentFlyoutApi.openNotes).not.toHaveBeenCalled();
+    });
+
+    test('should open the new notes flyout when enableNewFlyout setting is enabled', () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      const wrapper = render(
+        <TestProviders>
+          <RowAction {...defaultProps} />
+        </TestProviders>
+      );
+
+      fireEvent.click(wrapper.getByTestId('timeline-notes-button-small'));
+
+      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      expect(documentFlyoutApi.openNotes).toHaveBeenCalledWith(
+        expect.objectContaining({ hit: expect.any(Object) })
+      );
+    });
   });
 
   describe('privileges', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -10,11 +10,12 @@ import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { documentFlyoutHistoryKey } from '../../../../flyout_v2/shared/constants/flyout_history';
-import { cellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
-import { DocumentFlyoutWrapper } from '../../../../flyout_v2/document/main/document_flyout_wrapper';
+import { TableId } from '@kbn/securitysolution-data-table';
+import {
+  casesCellActionRenderer,
+  cellActionRenderer,
+} from '../../../../flyout_v2/shared/components/cell_actions';
+import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useKibana } from '../../../lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../hooks/use_is_new_flyout_enabled';
@@ -32,8 +33,6 @@ import { type ColumnHeaderOptions, type OnRowSelected } from '../../../../../com
 import { DocumentEventTypes, NotesEventTypes } from '../../../lib/telemetry';
 import { getMappedNonEcsValue } from '../../../utils/get_mapped_non_ecs_value';
 import { useUserPrivileges } from '../../user_privileges';
-import { flyoutProviders } from '../../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 export type RowActionProps = EuiDataGridCellValueElementProps & {
   columnHeaders: ColumnHeaderOptions[];
@@ -85,14 +84,11 @@ const RowActionComponent = ({
     [esHitRecord]
   );
 
-  const { services } = useKibana();
-  const { telemetry, overlays } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { telemetry } = useKibana().services;
 
   const { openFlyout } = useExpandableFlyoutApi();
   const enableNewFlyout = useIsNewFlyoutEnabled();
-  const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const { openDocumentFlyoutFromIndex, openNotes } = useDocumentFlyoutApi();
 
   const columnValues = useMemo(
     () =>
@@ -121,26 +117,13 @@ const RowActionComponent = ({
 
   const handleOnEventDetailPanelOpened = useCallback(() => {
     if (enableNewFlyout && hit) {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: (
-            <DocumentFlyoutWrapper
-              documentId={eventId}
-              indexName={indexName ?? undefined}
-              renderCellActions={cellActionRenderer}
-              onAlertUpdated={handleAlertUpdated}
-            />
-          ),
-        }),
-        {
-          ...defaultFlyoutProperties,
-          historyKey: documentFlyoutHistoryKey,
-          session: 'start',
-        }
-      );
+      openDocumentFlyoutFromIndex({
+        documentId: eventId,
+        indexName: indexName ?? undefined,
+        renderCellActions:
+          tableId === TableId.alertsOnCasePage ? casesCellActionRenderer : cellActionRenderer,
+        onAlertUpdated: handleAlertUpdated,
+      });
     } else {
       openFlyout({
         right: {
@@ -158,13 +141,9 @@ const RowActionComponent = ({
       });
     }
   }, [
-    defaultFlyoutProperties,
     enableNewFlyout,
     hit,
-    overlays,
-    services,
-    store,
-    history,
+    openDocumentFlyoutFromIndex,
     eventId,
     indexName,
     handleAlertUpdated,
@@ -174,27 +153,31 @@ const RowActionComponent = ({
   ]);
 
   const toggleShowNotes = useCallback(() => {
-    openFlyout({
-      right: {
-        id: DocumentDetailsRightPanelKey,
-        params: {
-          id: eventId,
-          indexName,
-          scopeId: tableId,
+    if (enableNewFlyout && hit) {
+      openNotes({ hit });
+    } else {
+      openFlyout({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: tableId,
+          },
         },
-      },
-      left: {
-        id: DocumentDetailsLeftPanelKey,
-        path: {
-          tab: LeftPanelNotesTab,
+        left: {
+          id: DocumentDetailsLeftPanelKey,
+          path: {
+            tab: LeftPanelNotesTab,
+          },
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: tableId,
+          },
         },
-        params: {
-          id: eventId,
-          indexName,
-          scopeId: tableId,
-        },
-      },
-    });
+      });
+    }
     telemetry.reportEvent(NotesEventTypes.OpenNoteInExpandableFlyoutClicked, {
       location: tableId,
     });
@@ -202,7 +185,7 @@ const RowActionComponent = ({
       location: tableId,
       panel: 'left',
     });
-  }, [eventId, indexName, openFlyout, tableId, telemetry]);
+  }, [enableNewFlyout, hit, openNotes, openFlyout, eventId, indexName, tableId, telemetry]);
 
   const Action = controlColumn.rowCellRender;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { mockTimelineData, mockTimelineModel, TestProviders } from '../../mock';
 import { useShallowEqualSelector } from '../../hooks/use_selector';
 import { licenseService } from '../../hooks/use_license';
@@ -14,6 +14,11 @@ import type { ActionsComponentProps } from './actions';
 import { Actions } from './actions';
 import { useIsAnalyzerEnabled } from '../../../detections/hooks/use_is_analyzer_enabled';
 import { AlertContextMenu } from '../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
+import { useIsNewFlyoutEnabled } from '../../hooks/use_is_new_flyout_enabled';
+import { useDocumentFlyoutApi } from '../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../flyout_v2/document/use_document_flyout_api.mock';
+import { useNavigateToAnalyzer } from '../../../flyout/document_details/shared/hooks/use_navigate_to_analyzer';
+import { useNavigateToSessionView } from '../../../flyout/document_details/shared/hooks/use_navigate_to_session_view';
 
 jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/alert_context_menu',
@@ -23,6 +28,10 @@ jest.mock(
 );
 jest.mock('../../hooks/use_selector');
 jest.mock('../../../detections/hooks/use_is_analyzer_enabled');
+jest.mock('../../hooks/use_is_new_flyout_enabled');
+jest.mock('../../../flyout_v2/document/use_document_flyout_api');
+jest.mock('../../../flyout/document_details/shared/hooks/use_navigate_to_analyzer');
+jest.mock('../../../flyout/document_details/shared/hooks/use_navigate_to_session_view');
 jest.mock('../../hooks/use_license', () => {
   const licenseServiceInstance = {
     isPlatinumPlus: jest.fn(),
@@ -56,10 +65,24 @@ const defaultProps: ActionsComponentProps = {
   toggleShowNotes: jest.fn(),
 };
 
+const mockNavigateToAnalyzer = jest.fn();
+const mockNavigateToSessionView = jest.fn();
+
 describe('Actions', () => {
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useShallowEqualSelector as jest.Mock).mockReturnValue(mockTimelineModel);
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useNavigateToAnalyzer).mockReturnValue({
+      navigateToAnalyzer: mockNavigateToAnalyzer,
+    });
+    jest.mocked(useNavigateToSessionView).mockReturnValue({
+      navigateToSessionView: mockNavigateToSessionView,
+    });
   });
 
   describe('expand icon', () => {
@@ -273,6 +296,39 @@ describe('Actions', () => {
 
         expect(queryByTestId('view-in-analyzer')).not.toBeInTheDocument();
       });
+
+      it('should navigate to the legacy analyzer when enableNewFlyout setting is disabled', () => {
+        (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...defaultProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('view-in-analyzer'));
+
+        expect(mockNavigateToAnalyzer).toHaveBeenCalled();
+        expect(documentFlyoutApi.openAnalyzer).not.toHaveBeenCalled();
+      });
+
+      it('should open the new analyzer flyout when enableNewFlyout setting is enabled', () => {
+        (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...defaultProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('view-in-analyzer'));
+
+        expect(mockNavigateToAnalyzer).not.toHaveBeenCalled();
+        expect(documentFlyoutApi.openAnalyzer).toHaveBeenCalledWith(
+          expect.objectContaining({ hit: defaultProps.hit })
+        );
+      });
     });
 
     describe('session view icon', () => {
@@ -326,6 +382,54 @@ describe('Actions', () => {
         );
 
         expect(queryByTestId('session-view-button')).not.toBeInTheDocument();
+      });
+
+      const sessionViewProps = {
+        ...defaultProps,
+        ecsData: {
+          ...mockTimelineData[0].ecs,
+          event: { kind: ['alert'] },
+          agent: { type: ['endpoint'] },
+          process: {
+            entry_leader: { entity_id: ['test_id'], start: ['2022-05-08T13:44:00.13Z'] },
+          },
+          _index: '.ds-logs-endpoint.events.process-default',
+        },
+      };
+
+      it('should navigate to the legacy session view when enableNewFlyout setting is disabled', () => {
+        const licenseServiceMock = licenseService as jest.Mocked<typeof licenseService>;
+        licenseServiceMock.isEnterprise.mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...sessionViewProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('session-view-button'));
+
+        expect(mockNavigateToSessionView).toHaveBeenCalled();
+        expect(documentFlyoutApi.openSessionView).not.toHaveBeenCalled();
+      });
+
+      it('should open the new session view flyout when enableNewFlyout setting is enabled', () => {
+        const licenseServiceMock = licenseService as jest.Mocked<typeof licenseService>;
+        licenseServiceMock.isEnterprise.mockReturnValue(true);
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...sessionViewProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('session-view-button'));
+
+        expect(mockNavigateToSessionView).not.toHaveBeenCalled();
+        expect(documentFlyoutApi.openSessionView).toHaveBeenCalledWith(
+          expect.objectContaining({ hit: defaultProps.hit })
+        );
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -35,6 +35,8 @@ import * as i18n from './translations';
 import { DEFAULT_ACTION_BUTTON_WIDTH, isAlert } from './helpers';
 import { useNavigateToAnalyzer } from '../../../flyout/document_details/shared/hooks/use_navigate_to_analyzer';
 import { useNavigateToSessionView } from '../../../flyout/document_details/shared/hooks/use_navigate_to_session_view';
+import { useIsNewFlyoutEnabled } from '../../hooks/use_is_new_flyout_enabled';
+import { useDocumentFlyoutApi } from '../../../flyout_v2/document/use_document_flyout_api';
 
 const ActionsContainer = styled.div`
   align-items: center;
@@ -86,6 +88,8 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
   );
 
   const { startTransaction } = useStartTransaction();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openAnalyzer, openSessionView: openSessionViewFlyout } = useDocumentFlyoutApi();
 
   const eventType = getEventType(ecsData);
 
@@ -105,8 +109,12 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
 
   const handleClick = useCallback(() => {
     startTransaction({ name: ALERTS_ACTIONS.OPEN_ANALYZER });
-    navigateToAnalyzer();
-  }, [startTransaction, navigateToAnalyzer]);
+    if (enableNewFlyout && hit) {
+      openAnalyzer({ hit, onAlertUpdated: () => refetch?.() });
+    } else {
+      navigateToAnalyzer();
+    }
+  }, [startTransaction, navigateToAnalyzer, enableNewFlyout, hit, openAnalyzer, refetch]);
 
   const sessionViewConfig = useMemo(() => {
     const { process, _id, _index, timestamp, kibana } = ecsData;
@@ -135,8 +143,25 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
 
   const openSessionView = useCallback(() => {
     startTransaction({ name: ALERTS_ACTIONS.OPEN_SESSION_VIEW });
-    navigateToSessionView();
-  }, [navigateToSessionView, startTransaction]);
+    if (enableNewFlyout && hit) {
+      openSessionViewFlyout({
+        hit,
+        jumpToCursor: sessionViewConfig?.jumpToCursor,
+        jumpToEntityId: sessionViewConfig?.jumpToEntityId,
+        onAlertUpdated: () => refetch?.(),
+      });
+    } else {
+      navigateToSessionView();
+    }
+  }, [
+    startTransaction,
+    navigateToSessionView,
+    enableNewFlyout,
+    hit,
+    openSessionViewFlyout,
+    sessionViewConfig,
+    refetch,
+  ]);
 
   const onExpandEvent = useCallback(() => {
     onEventDetailsPanelOpened();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DocumentFlyoutWrapperFromPattern } from './document_flyout_wrapper_from_pattern';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useTimelineEventsDetails } from '../../../timelines/containers/details';
+import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
+
+jest.mock('../../../data_view_manager/hooks/use_data_view');
+jest.mock('../../../timelines/containers');
+jest.mock('../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
+jest.mock('@kbn/discover-utils', () => ({
+  ...jest.requireActual('@kbn/discover-utils'),
+  buildDataTableRecord: jest.fn(() => ({ id: '1', raw: { _id: '1' }, flattened: {} })),
+  getFieldValue: jest.fn(() => 'event'),
+}));
+// Stub the presentational flyout so we don't need its full provider tree.
+jest.mock('.', () => ({
+  DocumentFlyout: () => <div data-test-subj="document-flyout" />,
+}));
+
+const props = {
+  documentId: '1',
+  indexName: 'logs-*,.alerts-security.alerts-default',
+  renderCellActions: () => null,
+  onAlertUpdated: jest.fn(),
+};
+
+const setEventsDetails = (tuple: unknown[]) =>
+  (useTimelineEventsDetails as jest.Mock).mockReturnValue(tuple);
+
+describe('DocumentFlyoutWrapperFromPattern', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useDataView as jest.Mock).mockReturnValue({
+      dataView: { getRuntimeMappings: jest.fn(() => ({})), hasMatchedIndices: jest.fn(() => true) },
+      status: 'ready',
+    });
+    (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
+    // [loading, dataFormattedForFieldBrowser, searchHit, dataAsNestedObject, refetch]
+    setEventsDetails([false, [], { _id: '1', _index: 'x', fields: {} }, {}, jest.fn()]);
+  });
+
+  it('shows the loading state while the document is being fetched', () => {
+    setEventsDetails([true, [], undefined, null, jest.fn()]);
+    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    expect(getByTestId('document-from-pattern-wrapper-loading')).toBeInTheDocument();
+  });
+
+  it('renders the document flyout once the document is resolved', () => {
+    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    expect(getByTestId('document-flyout')).toBeInTheDocument();
+  });
+
+  it('shows a not-found callout when no document matches the id across the pattern', () => {
+    setEventsDetails([false, [], undefined, null, jest.fn()]);
+    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    expect(getByTestId('document-from-pattern-wrapper-not-found')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useMemo } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { buildDataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import type { EsHitRecord } from '@kbn/discover-utils/types';
+import { EVENT_KIND } from '@kbn/rule-data-utils';
+import type { RunTimeMappings } from '../../../../common/api/search_strategy';
+import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
+import { useTimelineEventsDetails } from '../../../timelines/containers/details';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+import { FlyoutLoading } from '../../shared/components/flyout_loading';
+import { FlyoutMissingAlertsPrivilege } from './components/flyout_missing_alerts_privilege';
+import { EventKind } from './constants/event_kinds';
+import { DocumentFlyout } from '.';
+import type { DocumentFlyoutWrapperProps } from './document_flyout_wrapper';
+
+const DATA_VIEW_ERROR = i18n.translate(
+  'xpack.securitySolution.flyout.document.fromPatternWrapper.dataViewError',
+  {
+    defaultMessage: 'Unable to retrieve the data view for analyzer.',
+  }
+);
+
+const DOCUMENT_NOT_FOUND = i18n.translate(
+  'xpack.securitySolution.flyout.document.fromPatternWrapper.documentNotFound',
+  {
+    defaultMessage: 'Cannot find document. No documents match that ID.',
+  }
+);
+
+/**
+ * Same purpose as {@link DocumentFlyoutWrapper}, but for callers that only know the document id and
+ * a broad index *pattern* (e.g. notes, where the document's concrete `_index` is not stored on the
+ * note). Rather than the single-document ES search (which pins `_index` and therefore needs the
+ * concrete index), it resolves the document from its id across the pattern using the timeline
+ * events-details search strategy, then renders the same presentational `DocumentFlyout`.
+ *
+ * Public props are identical to `DocumentFlyoutWrapper`, so call sites can swap one for the other;
+ * only the internal fetch strategy differs.
+ */
+export const DocumentFlyoutWrapperFromPattern = memo(
+  ({ documentId, indexName, renderCellActions, onAlertUpdated }: DocumentFlyoutWrapperProps) => {
+    const { dataView, status } = useDataView(PageScope.default);
+
+    const isDataViewLoading = status === 'loading' || status === 'pristine';
+    const isDataViewInvalid =
+      status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+
+    const shouldSkipSearch = useMemo(
+      () => isDataViewLoading || isDataViewInvalid || !documentId || !indexName || !dataView,
+      [dataView, documentId, indexName, isDataViewInvalid, isDataViewLoading]
+    );
+
+    const runtimeMappings = dataView?.getRuntimeMappings() as RunTimeMappings;
+
+    const [loading, , searchHit, , refetchDocument] = useTimelineEventsDetails({
+      indexName: indexName ?? '',
+      eventId: documentId ?? '',
+      runtimeMappings,
+      skip: shouldSkipSearch,
+    });
+
+    const hit = useMemo(
+      () => (searchHit ? buildDataTableRecord(searchHit as EsHitRecord) : undefined),
+      [searchHit]
+    );
+
+    const handleAlertUpdated = useCallback(() => {
+      onAlertUpdated();
+      refetchDocument();
+    }, [onAlertUpdated, refetchDocument]);
+
+    const isAlert = useMemo(
+      () => hit && (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+      [hit]
+    );
+
+    const { hasAlertsRead, loading: isAlertsPrivilegesLoading } = useAlertsPrivileges();
+    const missingAlertsPrivilege = isAlert && !isAlertsPrivilegesLoading && !hasAlertsRead;
+
+    if (isDataViewLoading || (isAlert && isAlertsPrivilegesLoading) || loading) {
+      return <FlyoutLoading data-test-subj="document-from-pattern-wrapper-loading" />;
+    }
+
+    if (missingAlertsPrivilege) {
+      return <FlyoutMissingAlertsPrivilege />;
+    }
+
+    if (isDataViewInvalid) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          color="danger"
+          iconType="warning"
+          title={DATA_VIEW_ERROR}
+          data-test-subj="document-from-pattern-wrapper-data-view-error"
+        />
+      );
+    }
+
+    if (hit) {
+      return (
+        <DocumentFlyout
+          hit={hit}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={handleAlertUpdated}
+        />
+      );
+    }
+
+    return (
+      <EuiCallOut
+        announceOnMount
+        color="danger"
+        iconType="warning"
+        title={DOCUMENT_NOT_FOUND}
+        data-test-subj="document-from-pattern-wrapper-not-found"
+      />
+    );
+  }
+);
+DocumentFlyoutWrapperFromPattern.displayName = 'DocumentFlyoutWrapperFromPattern';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.mock.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DocumentFlyoutApi } from './use_document_flyout_api';
+
+/**
+ * Returns a `useDocumentFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useDocumentFlyoutApi).mockReturnValue(createDocumentFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createDocumentFlyoutApiMock = (): jest.Mocked<DocumentFlyoutApi> => ({
+  openDocumentFlyoutFromIndex: jest.fn(),
+  openDocumentFlyoutFromPattern: jest.fn(),
+  openNotes: jest.fn(),
+  openAnalyzer: jest.fn(),
+  openSessionView: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { useDocumentFlyoutApi } from './use_document_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../../common/hooks/use_experimental_features');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+  defaultToolsFlyoutProperties: { size: 'm' },
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+
+describe('useDocumentFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  const getProperties = () => mockOpenSystemFlyout.mock.calls[0][1];
+
+  it('openDocumentFlyoutFromIndex opens a system flyout with the document properties', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentFlyoutFromIndex({ documentId: '1', indexName: 'index' });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openDocumentFlyoutFromPattern opens a system flyout with the document properties', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentFlyoutFromPattern({ documentId: '1', indexName: 'logs-*,alerts-*' });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start' })
+    );
+  });
+
+  it('openNotes opens a tools flyout without a session (inherits the parent)', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openNotes({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', historyKey: documentFlyoutHistoryKey })
+    );
+    expect(getProperties().session).toBeUndefined();
+  });
+
+  it('openAnalyzer opens a tools flyout as a new session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openAnalyzer({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('openSessionView opens a tools flyout as a new session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openSessionView({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openNotes({ hit });
+
+    expect(getProperties().historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { noop } from 'lodash/fp';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import type { CellActionRenderer } from '../shared/components/cell_actions';
+import { cellActionRenderer } from '../shared/components/cell_actions';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import {
+  defaultToolsFlyoutProperties,
+  useDefaultDocumentFlyoutProperties,
+} from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+// Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
+// tool graph into their bundle; the chunk only loads when a flyout is actually opened.
+const DocumentFlyoutWrapper = lazy(() =>
+  import('./main/document_flyout_wrapper').then((m) => ({ default: m.DocumentFlyoutWrapper }))
+);
+const DocumentFlyoutWrapperFromPattern = lazy(() =>
+  import('./main/document_flyout_wrapper_from_pattern').then((m) => ({
+    default: m.DocumentFlyoutWrapperFromPattern,
+  }))
+);
+const NotesDetails = lazy(() =>
+  import('../shared/tools/notes').then((m) => ({ default: m.NotesDetails }))
+);
+const AnalyzerGraph = lazy(() =>
+  import('./tools/analyzer').then((m) => ({ default: m.AnalyzerGraph }))
+);
+const SessionView = lazy(() =>
+  import('./tools/session_view').then((m) => ({ default: m.SessionView }))
+);
+
+export interface OpenDocumentFlyoutParams {
+  /** Elasticsearch `_id` of the document to open. */
+  documentId: string;
+  /**
+   * For `openDocumentFlyoutFromIndex`, the concrete `_index` of the document.
+   * For `openDocumentFlyoutFromPattern`, a (possibly comma-separated / wildcard) index pattern.
+   */
+  indexName: string | undefined;
+  /** Renderer for cell actions in the flyout. Defaults to the standard `cellActionRenderer`. */
+  renderCellActions?: CellActionRenderer;
+  /** Invoked after an alert is mutated inside the flyout, to let the caller refresh. Defaults to a no-op. */
+  onAlertUpdated?: () => void;
+}
+
+export interface OpenNotesParams {
+  /** The document record whose notes should be shown. */
+  hit: DataTableRecord;
+}
+
+export interface OpenAnalyzerParams {
+  /** The document record to analyze. */
+  hit: DataTableRecord;
+  renderCellActions?: CellActionRenderer;
+  onAlertUpdated?: () => void;
+}
+
+export interface OpenSessionViewParams {
+  /** The document record to open the session view for. */
+  hit: DataTableRecord;
+  jumpToCursor?: string;
+  jumpToEntityId?: string;
+  renderCellActions?: CellActionRenderer;
+  onAlertUpdated?: () => void;
+}
+
+export interface DocumentFlyoutApi {
+  /** Opens the document details flyout, resolving the document from its concrete `_index`. */
+  openDocumentFlyoutFromIndex: (params: OpenDocumentFlyoutParams) => void;
+  /**
+   * Opens the document details flyout, resolving the document from its id across an index pattern
+   * (for callers that don't know the concrete `_index`, e.g. notes).
+   */
+  openDocumentFlyoutFromPattern: (params: OpenDocumentFlyoutParams) => void;
+  /** Opens the notes tools flyout for a document. */
+  openNotes: (params: OpenNotesParams) => void;
+  /** Opens the analyzer tools flyout for a document. */
+  openAnalyzer: (params: OpenAnalyzerParams) => void;
+  /** Opens the session view tools flyout for a document. */
+  openSessionView: (params: OpenSessionViewParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) document flyout and its tool flyouts, in the
+ * same mindset as `useExpandableFlyoutApi`. It encapsulates the provider wiring
+ * (`flyoutProviders` + `overlays.openSystemFlyout`) and the per-tool flyout properties so call
+ * sites don't have to repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  const open = useCallback(
+    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history]
+  );
+
+  const openDocumentFlyoutFromIndex = useCallback(
+    ({
+      documentId,
+      indexName,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenDocumentFlyoutParams) => {
+      open(
+        <DocumentFlyoutWrapper
+          documentId={documentId}
+          indexName={indexName}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openDocumentFlyoutFromPattern = useCallback(
+    ({
+      documentId,
+      indexName,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenDocumentFlyoutParams) => {
+      open(
+        <DocumentFlyoutWrapperFromPattern
+          documentId={documentId}
+          indexName={indexName}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openNotes = useCallback(
+    ({ hit }: OpenNotesParams) => {
+      open(<NotesDetails hit={hit} />, { ...defaultToolsFlyoutProperties, historyKey });
+    },
+    [open, historyKey]
+  );
+
+  const openAnalyzer = useCallback(
+    ({
+      hit,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenAnalyzerParams) => {
+      open(
+        <AnalyzerGraph
+          hit={hit}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  const openSessionView = useCallback(
+    ({
+      hit,
+      jumpToCursor,
+      jumpToEntityId,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenSessionViewParams) => {
+      open(
+        <SessionView
+          hit={hit}
+          jumpToCursor={jumpToCursor}
+          jumpToEntityId={jumpToEntityId}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  return useMemo(
+    () => ({
+      openDocumentFlyoutFromIndex,
+      openDocumentFlyoutFromPattern,
+      openNotes,
+      openAnalyzer,
+      openSessionView,
+    }),
+    [
+      openDocumentFlyoutFromIndex,
+      openDocumentFlyoutFromPattern,
+      openNotes,
+      openAnalyzer,
+      openSessionView,
+    ]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
@@ -6,7 +6,10 @@
  */
 
 import React from 'react';
-import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import {
+  SECURITY_CELL_ACTIONS_CASE_EVENTS,
+  SECURITY_CELL_ACTIONS_DEFAULT,
+} from '@kbn/ui-actions-plugin/common/trigger_ids';
 import {
   type CellActionFieldValue,
   CellActionsMode,
@@ -46,6 +49,31 @@ export const cellActionRenderer: CellActionRenderer = ({
     triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
     mode={CellActionsMode.HOVER_DOWN}
     visibleCellActions={5}
+    sourcererScopeId={getSourcererScopeId(scopeId)}
+    metadata={{ scopeId }}
+  >
+    {children}
+  </SecurityCellActions>
+);
+
+/**
+ * Cell action renderer for Cases.
+ * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
+ */
+export const casesCellActionRenderer: CellActionRenderer = ({
+  field,
+  value,
+  children,
+  scopeId,
+}: CellActionRendererProps) => (
+  <SecurityCellActions
+    data={{
+      field,
+      value: value ?? [],
+    }}
+    triggerId={SECURITY_CELL_ACTIONS_CASE_EVENTS}
+    mode={CellActionsMode.HOVER_DOWN}
+    visibleCellActions={2}
     sourcererScopeId={getSourcererScopeId(scopeId)}
     metadata={{ scopeId }}
   >

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.test.tsx
@@ -15,16 +15,30 @@ import { DocumentDetailsRightPanelKey } from '../../flyout/document_details/shar
 import { TableId } from '@kbn/securitysolution-data-table';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { withIndices } from '../../data_view_manager/hooks/__mocks__/use_data_view';
+import { useDocumentFlyoutApi } from '../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../flyout_v2/document/use_document_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
 
 jest.mock('@kbn/expandable-flyout');
+jest.mock('../../flyout_v2/document/use_document_flyout_api');
+jest.mock('../../common/hooks/use_is_new_flyout_enabled');
 
 const mockEventId = 'eventId';
 const mockTimelineId = 'timelineId';
 
 describe('OpenFlyoutButtonIcon', () => {
-  it('should render the chevron icon', () => {
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useDataView).mockReturnValue(withIndices(['test1', 'test2']));
+  });
+
+  it('should render the chevron icon', () => {
     const { getByTestId } = render(
       <TestProviders>
         <OpenFlyoutButtonIcon
@@ -38,10 +52,9 @@ describe('OpenFlyoutButtonIcon', () => {
     expect(getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should call the expandable flyout api when the button is clicked', () => {
+  it('should open the legacy expandable flyout when the new flyout is disabled', () => {
     const openFlyout = jest.fn();
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout });
-    jest.mocked(useDataView).mockReturnValue(withIndices(['test1', 'test2']));
 
     const { getByTestId } = render(
       <TestProviders>
@@ -53,8 +66,7 @@ describe('OpenFlyoutButtonIcon', () => {
       </TestProviders>
     );
 
-    const button = getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID);
-    button.click();
+    getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID).click();
 
     expect(openFlyout).toHaveBeenCalledWith({
       right: {
@@ -65,6 +77,28 @@ describe('OpenFlyoutButtonIcon', () => {
           scopeId: TableId.alertsOnAlertsPage,
         },
       },
+    });
+    expect(documentFlyoutApi.openDocumentFlyoutFromPattern).not.toHaveBeenCalled();
+  });
+
+  it('should open the new document flyout (from pattern) when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <OpenFlyoutButtonIcon
+          eventId={mockEventId}
+          timelineId={mockTimelineId}
+          iconType="chevronSingleRight"
+        />
+      </TestProviders>
+    );
+
+    getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID).click();
+
+    expect(documentFlyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith({
+      documentId: mockEventId,
+      indexName: 'test1,test2',
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
@@ -14,7 +14,9 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { PageScope } from '../../data_view_manager/constants';
 import { OPEN_FLYOUT_BUTTON_TEST_ID } from './test_ids';
 import { useKibana } from '../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentDetailsRightPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
+import { useDocumentFlyoutApi } from '../../flyout_v2/document/use_document_flyout_api';
 import { DocumentEventTypes } from '../../common/lib/telemetry';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 
@@ -50,23 +52,38 @@ export const OpenFlyoutButtonIcon = memo(
 
     const { telemetry } = useKibana().services;
     const { openFlyout } = useExpandableFlyoutApi();
+    const enableNewFlyout = useIsNewFlyoutEnabled();
+    const { openDocumentFlyoutFromPattern } = useDocumentFlyoutApi();
 
     const handleClick = useCallback(() => {
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName: selectedPatterns.join(','),
-            scopeId: TableId.alertsOnAlertsPage, // TODO we should update the flyout's code to separate scopeId and preview
+      const indexName = selectedPatterns.join(',');
+      if (enableNewFlyout) {
+        openDocumentFlyoutFromPattern({ documentId: eventId, indexName });
+      } else {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: TableId.alertsOnAlertsPage, // TODO we should update the flyout's code to separate scopeId and preview
+            },
           },
-        },
-      });
+        });
+      }
       telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
         location: timelineId,
         panel: 'right',
       });
-    }, [eventId, openFlyout, selectedPatterns, telemetry, timelineId]);
+    }, [
+      eventId,
+      openFlyout,
+      selectedPatterns,
+      telemetry,
+      timelineId,
+      enableNewFlyout,
+      openDocumentFlyoutFromPattern,
+    ]);
 
     return (
       <EuiToolTip content={OPEN_FLYOUT_BUTTON} disableScreenReaderOutput>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
@@ -18,11 +18,21 @@ import type { OpenTimelineResult, TimelineResultNote } from '../types';
 import { NotePreviews } from '.';
 import { useDeleteNote } from './hooks/use_delete_note';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../../flyout_v2/document/use_document_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 
 const mockDispatch = jest.fn();
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/hooks/use_selector');
+jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../flyout_v2/document/use_document_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('react-redux', () => {
   const original = jest.requireActual('react-redux');
@@ -43,6 +53,7 @@ describe('NotePreviews', () => {
   let note1updated: number;
   let note2updated: number;
   let note3updated: number;
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
 
   beforeEach(() => {
     mockResults = cloneDeep(mockTimelineResults);
@@ -61,6 +72,11 @@ describe('NotePreviews', () => {
         crud: true,
       },
     });
+    (useSelectedPatterns as jest.Mock).mockReturnValue(['test1', 'test2']);
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   test('it renders a note preview for each note when isModal is false', () => {
@@ -304,6 +320,68 @@ describe('NotePreviews', () => {
     );
 
     expect(wrapper.find(`[data-test-subj="notes-toggle-event-details"]`).exists()).toBeFalsy();
+  });
+
+  describe('Toggle event details', () => {
+    const renderWithNote = () => {
+      const timeline = mockTimelineResults[0];
+      (useDeepEqualSelector as jest.Mock).mockReturnValue(timeline);
+
+      return render(
+        <TestProviders>
+          <NotePreviews
+            notes={[
+              {
+                noteId: 'noteId1',
+                note: 'a note',
+                savedObjectId: 'test-id',
+                updated: note2updated,
+                updatedBy: 'alice',
+              },
+            ]}
+            showTimelineDescription
+            timelineId="test-timeline-id"
+          />
+        </TestProviders>,
+        {
+          wrapper: createReactQueryWrapper(),
+        }
+      );
+    };
+
+    it('should open the legacy expandable flyout when the new flyout is disabled', () => {
+      const openFlyout = jest.fn();
+      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout });
+
+      const { getByTestId } = renderWithNote();
+
+      fireEvent.click(getByTestId('notes-toggle-event-details'));
+
+      expect(openFlyout).toHaveBeenCalledWith({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: 'event1',
+            indexName: 'test1,test2',
+            scopeId: 'test-timeline-id',
+          },
+        },
+      });
+      expect(documentFlyoutApi.openDocumentFlyoutFromPattern).not.toHaveBeenCalled();
+    });
+
+    it('should open the new document flyout (from pattern) when the new flyout is enabled', () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      const { getByTestId } = renderWithNote();
+
+      fireEvent.click(getByTestId('notes-toggle-event-details'));
+
+      expect(documentFlyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith({
+        documentId: 'event1',
+        indexName: 'test1,test2',
+      });
+    });
   });
 
   describe('Delete Notes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
@@ -23,7 +23,9 @@ import { userSelectedNotesForDeletion } from '../../../../notes';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useDocumentFlyoutApi } from '../../../../flyout_v2/document/use_document_flyout_api';
 import type { TimelineResultNote } from '../types';
 import { defaultToEmptyTag, getEmptyValue } from '../../../../common/components/empty_value';
 import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
@@ -56,23 +58,38 @@ const ToggleEventDetailsButtonComponent: React.FC<ToggleEventDetailsButtonProps>
 
   const { telemetry } = useKibana().services;
   const { openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openDocumentFlyoutFromPattern } = useDocumentFlyoutApi();
 
   const handleClick = useCallback(() => {
-    openFlyout({
-      right: {
-        id: DocumentDetailsRightPanelKey,
-        params: {
-          id: eventId,
-          indexName: selectedPatterns.join(','),
-          scopeId: timelineId,
+    const indexName = selectedPatterns.join(',');
+    if (enableNewFlyout) {
+      openDocumentFlyoutFromPattern({ documentId: eventId, indexName });
+    } else {
+      openFlyout({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: timelineId,
+          },
         },
-      },
-    });
+      });
+    }
     telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
       location: timelineId,
       panel: 'right',
     });
-  }, [eventId, openFlyout, selectedPatterns, telemetry, timelineId]);
+  }, [
+    eventId,
+    openFlyout,
+    selectedPatterns,
+    telemetry,
+    timelineId,
+    enableNewFlyout,
+    openDocumentFlyoutFromPattern,
+  ]);
 
   return (
     <EuiToolTip content={i18n.TOGGLE_EXPAND_EVENT_DETAILS} disableScreenReaderOutput>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -28,6 +28,11 @@ import { defaultRowRenderers } from '../../body/renderers';
 import { useDispatch } from 'react-redux';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { initialUserPrivilegesState } from '../../../../../common/components/user_privileges/user_privileges_context';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../../../flyout_v2/document/use_document_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 const SPECIAL_TEST_TIMEOUT = 30000;
 
@@ -55,6 +60,10 @@ mockUseResizeObserver.mockImplementation(() => ({}));
 jest.mock('../../../../../common/lib/kibana');
 
 jest.mock('../../../../../common/components/user_privileges');
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../flyout_v2/document/use_document_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 let useTimelineEventsMock = jest.fn();
 
@@ -93,6 +102,8 @@ const TestComponent = (props: Partial<ComponentProps<typeof EqlTabContentCompone
 
 describe('EQL Tab', () => {
   const props = {} as EqlTabContentComponentProps;
+  const mockOpenFlyout = jest.fn();
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
 
   beforeAll(() => {
     // https://github.com/atlassian/react-beautiful-dnd/blob/4721a518356f72f1dac45b5fd4ee9d466aa2996b/docs/guides/setup-problem-detection-and-error-recovery.md#disable-logging
@@ -128,6 +139,14 @@ describe('EQL Tab', () => {
       ...initialUserPrivilegesState(),
       notesPrivileges: { read: true },
     });
+
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
+    });
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
 
     HTMLElement.prototype.getBoundingClientRect = jest.fn(() => {
       return {
@@ -360,5 +379,88 @@ describe('EQL Tab', () => {
         SPECIAL_TEST_TIMEOUT
       );
     });
+  });
+
+  describe('Leading actions - notes', () => {
+    beforeEach(() => {
+      // The notes control column only renders when the corresponding rawEvent is present,
+      // so we provide a rawEvent that matches the first (and only) event.
+      (useTimelineEvents as jest.Mock).mockReturnValue([
+        false,
+        {
+          events: mockTimelineData.slice(0, 1),
+          rawEvents: [
+            {
+              _id: mockTimelineData[0]._id,
+              _index: 'test-index',
+              _source: {},
+            },
+          ],
+          pageInfo: {
+            activePage: 0,
+            totalPages: 10,
+          },
+        },
+      ]);
+    });
+
+    it(
+      'should open the legacy notes flyout when the new flyout is disabled',
+      async () => {
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(mockOpenFlyout).toHaveBeenCalledWith(
+            expect.objectContaining({
+              right: expect.objectContaining({ id: 'document-details-right' }),
+              left: expect.objectContaining({ id: 'document-details-left' }),
+            })
+          );
+        });
+        expect(documentFlyoutApi.openNotes).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the new notes flyout when the new flyout is enabled',
+      async () => {
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(documentFlyoutApi.openNotes).toHaveBeenCalledWith({
+            hit: expect.objectContaining({ _id: mockTimelineData[0]._id }),
+          });
+        });
+        expect(mockOpenFlyout).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -43,6 +43,8 @@ import { EqlTabHeader } from './header';
 import { useTimelineColumns } from '../shared/use_timeline_columns';
 import { useTimelineControlColumn } from '../shared/use_timeline_control_columns';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentEventTypes, NotesEventTypes } from '../../../../../common/lib/telemetry';
 import { TimelineRefetch } from '../../refetch_timeline';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
@@ -77,6 +79,8 @@ export const EqlTabContentComponent: React.FC<Props> = ({
    */
   const [pageIndex, setPageIndex] = useState(0);
   const { telemetry } = useKibana().services;
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNotes } = useDocumentFlyoutApi();
   const { query: eqlQuery = '', ...restEqlOption } = eqlOptions;
   const { portalNode: eqlEventsCountPortalNode } = useEqlEventsCountPortal();
   const { setTimelineFullScreen, timelineFullScreen } = useTimelineFullScreen();
@@ -164,7 +168,9 @@ export const EqlTabContentComponent: React.FC<Props> = ({
       const isAttackRow = eventData != null && isAttackDiscoveryRow(eventData);
       const indexName = selectedPatterns.join(',');
 
-      if (isAttackRow) {
+      if (enableNewFlyout && eventData) {
+        openNotes({ hit: eventData });
+      } else if (isAttackRow) {
         openFlyout({
           right: {
             id: AttackDetailsRightPanelKey,
@@ -215,7 +221,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
         panel: 'left',
       });
     },
-    [openFlyout, selectedPatterns, telemetry, timelineId]
+    [enableNewFlyout, openNotes, openFlyout, selectedPatterns, telemetry, timelineId]
   );
 
   const leadingControlColumns = useTimelineControlColumn({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 import type { Dispatch } from 'redux';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { DefaultCellRenderer } from '../../cell_rendering/default_cell_renderer';
 import { defaultHeaders, mockTimelineData } from '../../../../../common/mock';
@@ -26,6 +26,13 @@ import type { ExperimentalFeatures } from '../../../../../../common';
 import { allowedExperimentalValues } from '../../../../../../common';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { createStartServicesMock } from '../../../../../common/lib/kibana/kibana_react.mock';
+import { useUserPrivileges } from '../../../../../common/components/user_privileges';
+import { initialUserPrivilegesState } from '../../../../../common/components/user_privileges/user_privileges_context';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../../../flyout_v2/document/use_document_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 jest.mock('../../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -36,6 +43,12 @@ jest.mock('../../../../containers/details', () => ({
 jest.mock('../../../fields_browser', () => ({
   useFieldBrowserOptions: jest.fn(),
 }));
+
+jest.mock('../../../../../common/components/user_privileges');
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../flyout_v2/document/use_document_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('../../../../../common/hooks/use_experimental_features');
 const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
@@ -61,6 +74,8 @@ const useKibanaMock = useKibana as jest.Mock;
 
 describe('PinnedTabContent', () => {
   let props = {} as PinnedTabContentComponentProps;
+  const mockOpenFlyout = jest.fn();
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
   const sort: Sort[] = [
     {
       columnId: '@timestamp',
@@ -98,6 +113,20 @@ describe('PinnedTabContent', () => {
       }
     );
 
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      ...initialUserPrivilegesState(),
+      notesPrivileges: { read: true },
+      timelinePrivileges: { crud: true, read: true },
+    });
+
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
+    });
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+
     useKibanaMock.mockReturnValue(kibanaMockResult);
 
     props = {
@@ -123,6 +152,86 @@ describe('PinnedTabContent', () => {
       );
 
       expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+    });
+  });
+
+  describe('Leading actions - notes', () => {
+    beforeEach(() => {
+      // The notes control column only renders when the corresponding rawEvent is present,
+      // so we provide a rawEvent that matches the first (and only) event.
+      (useTimelineEvents as jest.Mock).mockReturnValue([
+        false,
+        {
+          events: mockTimelineData.slice(0, 1),
+          rawEvents: [
+            {
+              _id: mockTimelineData[0]._id,
+              _index: 'test-index',
+              _source: {},
+            },
+          ],
+          pageInfo: {
+            activePage: 0,
+            totalPages: 1,
+          },
+        },
+      ]);
+
+      props = {
+        ...props,
+        pinnedEventIds: { [mockTimelineData[0]._id]: true },
+      };
+    });
+
+    it('should open the legacy notes flyout when the new flyout is disabled', async () => {
+      render(
+        <TestProviders>
+          <PinnedTabContentComponent {...props} />
+        </TestProviders>
+      );
+
+      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+      await waitFor(() => {
+        expect(mockOpenFlyout).toHaveBeenCalledWith(
+          expect.objectContaining({
+            right: expect.objectContaining({ id: 'document-details-right' }),
+            left: expect.objectContaining({ id: 'document-details-left' }),
+          })
+        );
+      });
+      expect(documentFlyoutApi.openNotes).not.toHaveBeenCalled();
+    });
+
+    it('should open the new notes flyout when the new flyout is enabled', async () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      render(
+        <TestProviders>
+          <PinnedTabContentComponent {...props} />
+        </TestProviders>
+      );
+
+      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+      await waitFor(() => {
+        expect(documentFlyoutApi.openNotes).toHaveBeenCalledWith({
+          hit: expect.objectContaining({ _id: mockTimelineData[0]._id }),
+        });
+      });
+      expect(mockOpenFlyout).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -12,7 +12,8 @@ import { connect } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { RunTimeMappings, TimelineItem } from '@kbn/timelines-plugin/common/search_strategy';
 import { PageScope } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
@@ -35,6 +36,8 @@ import type { TimelineTabCommonProps } from '../shared/types';
 import { useTimelineColumns } from '../shared/use_timeline_columns';
 import { useTimelineControlColumn } from '../shared/use_timeline_control_columns';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentEventTypes, NotesEventTypes } from '../../../../../common/lib/telemetry';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
 
@@ -76,6 +79,8 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   const [pageIndex, setPageIndex] = useState(0);
 
   const { telemetry } = useKibana().services;
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNotes } = useDocumentFlyoutApi();
 
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const { dataView } = useDataView(PageScope.timeline);
@@ -185,33 +190,37 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   const { openFlyout } = useExpandableFlyoutApi();
 
   const onToggleShowNotes = useCallback(
-    (eventId?: string) => {
+    (eventId?: string, eventData?: DataTableRecord & TimelineItem) => {
       if (!eventId) {
         return;
       }
 
-      const indexName = selectedPatterns.join(',');
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
+      if (enableNewFlyout && eventData) {
+        openNotes({ hit: eventData });
+      } else {
+        const indexName = selectedPatterns.join(',');
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
           },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: LeftPanelNotesTab,
+          left: {
+            id: DocumentDetailsLeftPanelKey,
+            path: {
+              tab: LeftPanelNotesTab,
+            },
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
           },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
-          },
-        },
-      });
+        });
+      }
       telemetry.reportEvent(NotesEventTypes.OpenNoteInExpandableFlyoutClicked, {
         location: timelineId,
       });
@@ -220,7 +229,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
         panel: 'left',
       });
     },
-    [openFlyout, selectedPatterns, telemetry, timelineId]
+    [enableNewFlyout, openNotes, openFlyout, selectedPatterns, telemetry, timelineId]
   );
 
   const leadingControlColumns = useTimelineControlColumn({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -48,8 +48,13 @@ import { useDataView } from '../../../../../data_view_manager/hooks/use_data_vie
 import { useBrowserFields } from '../../../../../data_view_manager/hooks/use_browser_fields';
 import { mockBrowserFields } from '@kbn/timelines-plugin/public/mock/browser_fields';
 import { withIndices } from '../../../../../data_view_manager/hooks/__mocks__/use_data_view';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../../../flyout_v2/document/use_document_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 jest.mock('../../../../../data_view_manager/hooks/use_browser_fields');
+jest.mock('../../../../../flyout_v2/document/use_document_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('../../../../../common/utils/route/use_route_spy', () => {
   return {
@@ -188,6 +193,7 @@ const useTimelineEventsSpy = jest.spyOn(useTimelineEventsModule, 'useTimelineEve
 // Failing: See https://github.com/elastic/kibana/issues/224186
 describe.skip('query tab with unified timeline', () => {
   const fetchNotesSpy = jest.spyOn(notesApi, 'fetchNotesByDocumentIds');
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
   beforeAll(() => {
     fetchNotesSpy.mockImplementation(jest.fn());
     jest.mocked(useExpandableFlyoutApi).mockImplementation(() => ({
@@ -259,6 +265,10 @@ describe.skip('query tab with unified timeline', () => {
       endpointPrivileges: getEndpointPrivilegesInitialStateMock(),
       detectionEnginePrivileges: { loading: false, error: undefined, result: undefined },
     });
+
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   describe('render', () => {
@@ -1073,6 +1083,31 @@ describe.skip('query tab with unified timeline', () => {
             })
           );
         });
+        expect(documentFlyoutApi.openNotes).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the new notes flyout when the new flyout is enabled',
+      async () => {
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        renderTestComponents();
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(documentFlyoutApi.openNotes).toHaveBeenCalledWith({
+            hit: expect.objectContaining({ _id: mockTimelineData[0]._id }),
+          });
+        });
+        expect(mockOpenFlyout).not.toHaveBeenCalled();
       },
       SPECIAL_TEST_TIMEOUT
     );
@@ -1130,6 +1165,7 @@ describe.skip('query tab with unified timeline', () => {
             })
           );
         });
+        expect(documentFlyoutApi.openNotes).not.toHaveBeenCalled();
       },
       SPECIAL_TEST_TIMEOUT
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -27,6 +27,8 @@ import {
   DocumentDetailsRightPanelKey,
 } from '../../../../../flyout/document_details/shared/constants/panel_keys';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import {
   AttackDetailsLeftPanelKey,
   AttackDetailsRightPanelKey,
@@ -106,6 +108,9 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const {
     query: { filterManager: timelineFilterManager },
   } = timelineDataService;
+
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNotes } = useDocumentFlyoutApi();
 
   const getManageTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
 
@@ -232,7 +237,9 @@ export const QueryTabContentComponent: React.FC<Props> = ({
       const indexName =
         (isAttackRow ? eventData.ecs._index : undefined) ?? selectedPatterns.join(',');
 
-      if (isAttackRow) {
+      if (enableNewFlyout && eventData) {
+        openNotes({ hit: eventData });
+      } else if (isAttackRow) {
         openFlyout({
           right: {
             id: AttackDetailsRightPanelKey,
@@ -283,7 +290,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
         panel: 'left',
       });
     },
-    [openFlyout, selectedPatterns, telemetry, timelineId]
+    [enableNewFlyout, openNotes, openFlyout, selectedPatterns, telemetry, timelineId]
   );
 
   const leadingControlColumns = useTimelineControlColumn({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -20,10 +20,13 @@ import * as timelineActions from '../../../../store/actions';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from '../../../../../flyout_v2/document/use_document_flyout_api.mock';
 
 jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
   useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
 }));
+jest.mock('../../../../../flyout_v2/document/use_document_flyout_api');
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn(() => ({
@@ -153,6 +156,8 @@ const getTimelineFromStore = (
 };
 
 describe('unified data table', () => {
+  let documentFlyoutApi: ReturnType<typeof createDocumentFlyoutApiMock>;
+
   beforeEach(() => {
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
       openFlyout: openFlyoutMock,
@@ -160,6 +165,8 @@ describe('unified data table', () => {
     });
     mockUiSettingsGet.mockReturnValue(false);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    documentFlyoutApi = createDocumentFlyoutApiMock();
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentFlyoutApi);
   });
   afterEach(() => {
     updateSampleSizeSpy.mockClear();
@@ -199,7 +206,7 @@ describe('unified data table', () => {
   );
 
   it(
-    'opens DocumentFlyoutWrapper via system flyout when enableNewFlyout setting is enabled and row is not an attack',
+    'opens the new document flyout (from index) when enableNewFlyout setting is enabled and row is not an attack',
     async () => {
       jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
 
@@ -209,13 +216,16 @@ describe('unified data table', () => {
       fireEvent.click(screen.getAllByTestId('docTableExpandToggleColumn')[0]);
 
       await waitFor(() => {
-        expect(mockOpenSystemFlyout).toHaveBeenCalled();
+        expect(documentFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith(
+          expect.objectContaining({
+            documentId: mockTimelineData[0]._id,
+            indexName: mockTimelineData[0].ecs._index,
+          })
+        );
       });
 
-      const flyoutElement = mockOpenSystemFlyout.mock.calls[0][0];
-      expect(flyoutElement.props.documentId).toBe(mockTimelineData[0]._id);
-      expect(flyoutElement.props.indexName).toBe(mockTimelineData[0].ecs._index);
-      expect(flyoutElement.props.onAlertUpdated).toBe(refetchMock);
+      // the document (non-attack) new flyout no longer goes through the inline system flyout
+      expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
     },
     SPECIAL_TEST_TIMEOUT
   );
@@ -238,7 +248,8 @@ describe('unified data table', () => {
       expect(flyoutElement.props.attackId).toBe('attack-1');
       expect(flyoutElement.props.indexName).toBe('attack-index');
       expect(flyoutElement.props.onAttackUpdated).toBe(refetchMock);
-      expect(mockDocumentFlyoutWrapper).not.toHaveBeenCalled();
+      // attack rows keep using the inline system flyout, not the document flyout api
+      expect(documentFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
     },
     SPECIAL_TEST_TIMEOUT
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -23,7 +23,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useHistory } from 'react-router-dom';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
-import { cellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
+import { useDocumentFlyoutApi } from '../../../../../flyout_v2/document/use_document_flyout_api';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
 import { useOnExpandableFlyoutClose } from '../../../../../flyout/shared/hooks/use_on_expandable_flyout_close';
 import { DocumentDetailsRightPanelKey } from '../../../../../flyout/document_details/shared/constants/panel_keys';
@@ -57,7 +57,6 @@ import { TIMELINE_EVENT_DETAIL_ROW_ID } from '../../body/constants';
 import { DocumentEventTypes } from '../../../../../common/lib/telemetry/types';
 import { getTimelineRowTypeIndicator } from './get_row_indicator';
 import { isAttackDiscoveryRow } from './is_attack_discovery_row';
-import { DocumentFlyoutWrapper } from '../../../../../flyout_v2/document/main/document_flyout_wrapper';
 import { AttackFlyoutWrapper } from '../../../../../flyout_v2/attack/main/attack_flyout_wrapper';
 import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
@@ -150,6 +149,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     } = services;
 
     const enableNewFlyout = useIsNewFlyoutEnabled();
+    const { openDocumentFlyoutFromIndex } = useDocumentFlyoutApi();
 
     const [expandedDoc, setExpandedDoc] = useState<DataTableRecord & TimelineItem>();
 
@@ -191,32 +191,34 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       (eventData: DataTableRecord & TimelineItem) => {
         if (enableNewFlyout) {
           const isAttackRow = isAttackDiscoveryRow(eventData);
-          overlays.openSystemFlyout(
-            flyoutProviders({
-              services,
-              store,
-              history,
-              children: isAttackRow ? (
-                <AttackFlyoutWrapper
-                  attackId={eventData._id}
-                  indexName={eventData.ecs._index ?? ''}
-                  onAttackUpdated={refetch}
-                />
-              ) : (
-                <DocumentFlyoutWrapper
-                  documentId={eventData._id}
-                  indexName={eventData.ecs._index}
-                  renderCellActions={cellActionRenderer}
-                  onAlertUpdated={refetch}
-                />
-              ),
-            }),
-            {
-              ...defaultFlyoutProperties,
-              historyKey: documentFlyoutHistoryKey,
-              session: 'start',
-            }
-          );
+          if (isAttackRow) {
+            // The attack flyout is not part of `useDocumentFlyoutApi`, so it stays inline for now.
+            overlays.openSystemFlyout(
+              flyoutProviders({
+                services,
+                store,
+                history,
+                children: (
+                  <AttackFlyoutWrapper
+                    attackId={eventData._id}
+                    indexName={eventData.ecs._index ?? ''}
+                    onAttackUpdated={refetch}
+                  />
+                ),
+              }),
+              {
+                ...defaultFlyoutProperties,
+                historyKey: documentFlyoutHistoryKey,
+                session: 'start',
+              }
+            );
+          } else {
+            openDocumentFlyoutFromIndex({
+              documentId: eventData._id,
+              indexName: eventData.ecs._index,
+              onAlertUpdated: refetch,
+            });
+          }
         } else {
           const isAttackRow = isAttackDiscoveryRow(eventData);
           const indexName = eventData.ecs._index ?? '';
@@ -248,6 +250,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [
         defaultFlyoutProperties,
         enableNewFlyout,
+        openDocumentFlyoutFromIndex,
         overlays,
         services,
         store,


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is the first of 3 that ensures all the places will open the new flyout. It focuses on the flyouts owned by Threat Hunting: the **document** flyout (main + tools), the **attack** flyout, and the **IOC** (indicator) flyout. A couple of follow up PRs will take care of the other flyouts (user, host...).

This PR adds a new `DocumentFlyoutWrapperFromPattern` component. I realized that in some places (Timelines page and Notes management page) we do not have the index available, but only the list of indices from the dataView. The `DocumentFlyoutWrapper` component we had already can only fetch a document from a single index as we're using a Discover hook for that.

The PR also introduces single developer-facing APIs to open the new flyouts and their tools, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:

- `useDocumentFlyoutApi()`
  - `openDocumentFlyoutFromIndex`: opens the document main flyout from a document id and index
  - `openDocumentFlyoutFromPattern`: opens the document main flyout from a document id and index pattern
  - `openNotes`, `openAnalyzer`, `openSessionView`: open the document tools flyouts
- `useAttackFlyoutApi()`
  - `openAttackFlyout`: opens the attack main flyout from an attack id and index
- `useIocFlyoutApi()`
  - `openIocFlyout`: opens the IOC (indicator) flyout from an indicator

Every external entry point that opened one of these legacy flyouts now routes through the matching API when the new flyout is enabled (alerts/timeline tables, timeline tabs, notes management page + note previews, cases alert/event/indicator attachments, the attacks page list/table, and the threat intelligence indicators table). The `data_table` is now fully API-driven for both the document and attack rows.

> [!NOTE]
> No legacy flyout behavior introduced! Only toggling between the legacy and new flyout based off the advanced setting.

A few entry points are intentionally **not** migrated here because they have no new-flyout equivalent yet (left on the legacy flyout, to follow up once the target exists): the EASE alert-summary flyout, the `service_name` renderer, and the alert/attack **shared-link URL redirects** (which need new-flyout deep-link support).

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new flyout/tool opens from each surface:
   - Alerts table / timeline row → expand a row (document flyout), and the row's **Analyze event** / **Session view** actions (tool flyouts).
   - Timeline `query`/`eql`/`pinned` tabs → open notes on a row (notes tools flyout).
   - Notes management page + a saved timeline's note previews (Timelines page) → open event details.
   - A case with an alert and an event attachment → the show-alert / show-event buttons.
   - Attacks page → open an attack from the KPI list and from the attacks table; and a timeline row that is an attack discovery alert → the **attack** flyout.
   - Threat intelligence → **Indicators** table row action, and a case with an IOC (indicator) attachment → the **IOC** flyout.
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).
4. For notes specifically, confirm the document actually loads (this exercises `DocumentFlyoutWrapperFromPattern` resolving the id across the pattern rather than failing with "Cannot find document").

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
