### PR TITLE
[One Workflow] feat: add Workday stack connector

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/index.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/index.ts
@@ -37,5 +37,6 @@ export { CONNECTOR_ID as TheHiveConnectorTypeId } from './thehive';
 export { CONNECTOR_ID as TinesConnectorTypeId } from './tines';
 export { CONNECTOR_ID as TorqConnectorTypeId } from './torq';
 export { CONNECTOR_ID as WebhookConnectorTypeId } from './webhook';
+export { CONNECTOR_ID as WorkdayConnectorTypeId } from './workday';
 export { CONNECTOR_ID as XmattersConnectorTypeId } from './xmatters';
 export { CONNECTOR_ID as XsoarConnectorTypeId } from './xsoar';

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/constants.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { i18n } from '@kbn/i18n';
+
+export const CONNECTOR_NAME = i18n.translate('connectors.workday.title', {
+  defaultMessage: 'Workday',
+});
+export const CONNECTOR_ID = '.workday';
+
+export enum SUB_ACTION {
+  GET_WORKER = 'getWorker',
+  SEARCH_WORKERS = 'searchWorkers',
+}

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/index.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+export * from './constants';
+
+export {
+  WorkdayActionParamsSchema,
+  WorkdayApiDoNotValidateResponsesSchema,
+  WorkdayConfigSchema,
+  WorkdayGetTokenResponseSchema,
+  WorkdayGetWorkerParamsSchema,
+  WorkdayGetWorkerResponseSchema,
+  WorkdaySearchWorkersParamsSchema,
+  WorkdaySearchWorkersResponseSchema,
+  WorkdaySecretsSchema,
+} from './schemas/latest';
+
+export type {
+  WorkdayActionParams,
+  WorkdayConfig,
+  WorkdayGetTokenResponse,
+  WorkdayGetWorkerParams,
+  WorkdayGetWorkerResponse,
+  WorkdaySearchWorkersParams,
+  WorkdaySearchWorkersResponse,
+  WorkdaySecrets,
+} from './types/latest';

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/latest.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/latest.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+export * from './v1';

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/v1.test.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/v1.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import {
+  WorkdayActionParamsSchema,
+  WorkdayConfigSchema,
+  WorkdayGetWorkerParamsSchema,
+  WorkdaySearchWorkersParamsSchema,
+  WorkdaySecretsSchema,
+} from './v1';
+import { SUB_ACTION } from '../constants';
+
+describe('workday schemas', () => {
+  describe('WorkdayConfigSchema', () => {
+    it('accepts apiUrl + tokenUrl', () => {
+      expect(() =>
+        WorkdayConfigSchema.parse({ apiUrl: 'https://a', tokenUrl: 'https://b' })
+      ).not.toThrow();
+    });
+    it('rejects unknown fields', () => {
+      expect(() =>
+        WorkdayConfigSchema.parse({
+          apiUrl: 'https://a',
+          tokenUrl: 'https://b',
+          extra: 'nope',
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('WorkdaySecretsSchema', () => {
+    it('accepts clientId + clientSecret', () => {
+      expect(() =>
+        WorkdaySecretsSchema.parse({ clientId: 'a', clientSecret: 'b' })
+      ).not.toThrow();
+    });
+  });
+
+  describe('WorkdayGetWorkerParamsSchema', () => {
+    it('requires workerId', () => {
+      expect(() => WorkdayGetWorkerParamsSchema.parse({ workerId: 'abc' })).not.toThrow();
+      expect(() => WorkdayGetWorkerParamsSchema.parse({ workerId: '' })).toThrow();
+    });
+  });
+
+  describe('WorkdaySearchWorkersParamsSchema', () => {
+    it('requires search of 3+ chars', () => {
+      expect(() => WorkdaySearchWorkersParamsSchema.parse({ search: 'jan' })).not.toThrow();
+      expect(() => WorkdaySearchWorkersParamsSchema.parse({ search: 'ja' })).toThrow();
+    });
+    it('rejects out-of-range limit', () => {
+      expect(() =>
+        WorkdaySearchWorkersParamsSchema.parse({ search: 'jane', limit: 0 })
+      ).toThrow();
+      expect(() =>
+        WorkdaySearchWorkersParamsSchema.parse({ search: 'jane', limit: 101 })
+      ).toThrow();
+    });
+  });
+
+  describe('WorkdayActionParamsSchema', () => {
+    it('accepts a getWorker action', () => {
+      expect(() =>
+        WorkdayActionParamsSchema.parse({
+          subAction: SUB_ACTION.GET_WORKER,
+          subActionParams: { workerId: 'abc' },
+        })
+      ).not.toThrow();
+    });
+    it('accepts a searchWorkers action', () => {
+      expect(() =>
+        WorkdayActionParamsSchema.parse({
+          subAction: SUB_ACTION.SEARCH_WORKERS,
+          subActionParams: { search: 'jane' },
+        })
+      ).not.toThrow();
+    });
+    it('rejects an unknown subAction', () => {
+      expect(() =>
+        WorkdayActionParamsSchema.parse({
+          subAction: 'nope',
+          subActionParams: {},
+        })
+      ).toThrow();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/v1.test.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/v1.test.ts
@@ -35,9 +35,7 @@ describe('workday schemas', () => {
 
   describe('WorkdaySecretsSchema', () => {
     it('accepts clientId + clientSecret', () => {
-      expect(() =>
-        WorkdaySecretsSchema.parse({ clientId: 'a', clientSecret: 'b' })
-      ).not.toThrow();
+      expect(() => WorkdaySecretsSchema.parse({ clientId: 'a', clientSecret: 'b' })).not.toThrow();
     });
   });
 
@@ -54,9 +52,7 @@ describe('workday schemas', () => {
       expect(() => WorkdaySearchWorkersParamsSchema.parse({ search: 'ja' })).toThrow();
     });
     it('rejects out-of-range limit', () => {
-      expect(() =>
-        WorkdaySearchWorkersParamsSchema.parse({ search: 'jane', limit: 0 })
-      ).toThrow();
+      expect(() => WorkdaySearchWorkersParamsSchema.parse({ search: 'jane', limit: 0 })).toThrow();
       expect(() =>
         WorkdaySearchWorkersParamsSchema.parse({ search: 'jane', limit: 101 })
       ).toThrow();

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/schemas/v1.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { z, lazySchema } from '@kbn/zod/v4';
+import { SUB_ACTION } from '../constants';
+
+export const WorkdayConfigSchema = lazySchema(() =>
+  z
+    .object({
+      apiUrl: z.string(),
+      tokenUrl: z.string(),
+    })
+    .strict()
+);
+
+export const WorkdaySecretsSchema = lazySchema(() =>
+  z
+    .object({
+      clientId: z.string(),
+      clientSecret: z.string(),
+    })
+    .strict()
+);
+
+export const WorkdayApiDoNotValidateResponsesSchema = lazySchema(() => z.any());
+
+export const WorkdayGetTokenResponseSchema = lazySchema(() =>
+  z
+    .object({
+      access_token: z.string(),
+      expires_in: z.coerce.number(),
+      token_type: z.string(),
+      scope: z.string().optional(),
+      refresh_token: z.string().optional(),
+    })
+    .passthrough()
+);
+
+export const WorkdayGetWorkerParamsSchema = lazySchema(() =>
+  z
+    .object({
+      workerId: z.string().min(1),
+    })
+    .strict()
+);
+
+export const WorkdaySearchWorkersParamsSchema = lazySchema(() =>
+  z
+    .object({
+      search: z.string().min(3),
+      limit: z.coerce.number().int().min(1).max(100).optional(),
+      offset: z.coerce.number().int().min(0).optional(),
+    })
+    .strict()
+);
+
+const WorkerRefSchema = z
+  .object({
+    id: z.string().optional(),
+    descriptor: z.string().optional(),
+    href: z.string().optional(),
+  })
+  .passthrough();
+
+const WorkerSchema = z
+  .object({
+    id: z.string().optional(),
+    descriptor: z.string().optional(),
+    href: z.string().optional(),
+    primaryWorkEmail: z.string().optional(),
+    businessTitle: z.string().optional(),
+    primarySupervisoryOrganization: WorkerRefSchema.optional(),
+    primaryJob: WorkerRefSchema.optional(),
+  })
+  .passthrough();
+
+export const WorkdayGetWorkerResponseSchema = lazySchema(() => WorkerSchema);
+
+export const WorkdaySearchWorkersResponseSchema = lazySchema(() =>
+  z
+    .object({
+      total: z.coerce.number().optional(),
+      data: z.array(WorkerSchema).optional(),
+    })
+    .passthrough()
+);
+
+export const WorkdayActionParamsSchema = lazySchema(() =>
+  z.discriminatedUnion('subAction', [
+    z
+      .object({
+        subAction: z.literal(SUB_ACTION.GET_WORKER),
+        subActionParams: WorkdayGetWorkerParamsSchema,
+      })
+      .strict(),
+    z
+      .object({
+        subAction: z.literal(SUB_ACTION.SEARCH_WORKERS),
+        subActionParams: WorkdaySearchWorkersParamsSchema,
+      })
+      .strict(),
+  ])
+);

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/types/latest.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/types/latest.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+export * from './v1';

--- a/src/platform/packages/shared/kbn-connector-schemas/workday/types/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/workday/types/v1.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { z } from '@kbn/zod/v4';
+import type {
+  WorkdayActionParamsSchema,
+  WorkdayConfigSchema,
+  WorkdayGetTokenResponseSchema,
+  WorkdayGetWorkerParamsSchema,
+  WorkdayGetWorkerResponseSchema,
+  WorkdaySearchWorkersParamsSchema,
+  WorkdaySearchWorkersResponseSchema,
+  WorkdaySecretsSchema,
+} from '../schemas/v1';
+
+export type WorkdayConfig = z.infer<typeof WorkdayConfigSchema>;
+export type WorkdaySecrets = z.infer<typeof WorkdaySecretsSchema>;
+
+export type WorkdayGetTokenResponse = z.infer<typeof WorkdayGetTokenResponseSchema>;
+
+export type WorkdayGetWorkerParams = z.infer<typeof WorkdayGetWorkerParamsSchema>;
+export type WorkdayGetWorkerResponse = z.infer<typeof WorkdayGetWorkerResponseSchema>;
+
+export type WorkdaySearchWorkersParams = z.infer<typeof WorkdaySearchWorkersParamsSchema>;
+export type WorkdaySearchWorkersResponse = z.infer<typeof WorkdaySearchWorkersResponseSchema>;
+
+export type WorkdayActionParams = z.infer<typeof WorkdayActionParamsSchema>;

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/index.ts
@@ -40,6 +40,7 @@ import { getCrowdStrikeConnectorType } from './crowdstrike';
 import { getXSOARConnectorType } from './xsoar';
 import { getJiraServiceManagementConnectorType } from './jira-service-management';
 import { getMcpConnectorType } from './mcp';
+import { getWorkdayConnectorType } from './workday';
 
 export interface RegistrationServices {
   validateEmailAddresses: (
@@ -83,6 +84,7 @@ export function registerConnectorTypes({
   connectorTypeRegistry.register(getTheHiveConnectorType());
   connectorTypeRegistry.register(getXSOARConnectorType());
   connectorTypeRegistry.register(getMcpConnectorType());
+  connectorTypeRegistry.register(getWorkdayConnectorType());
 
   if (ExperimentalFeaturesService.get().sentinelOneConnectorOn) {
     connectorTypeRegistry.register(getSentinelOneConnectorType());

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/connector.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/connector.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import type {
+  ActionConnectorFieldsProps,
+  ConfigFieldSchema,
+  SecretsFieldSchema,
+} from '@kbn/triggers-actions-ui-plugin/public';
+import { SimpleConnectorForm } from '@kbn/triggers-actions-ui-plugin/public';
+import * as i18n from './translations';
+
+const configFormSchema: ConfigFieldSchema[] = [
+  {
+    id: 'apiUrl',
+    label: i18n.API_URL_LABEL,
+    helpText: i18n.API_URL_HELP,
+    isUrlField: true,
+  },
+  {
+    id: 'tokenUrl',
+    label: i18n.TOKEN_URL_LABEL,
+    helpText: i18n.TOKEN_URL_HELP,
+    isUrlField: true,
+  },
+];
+
+const secretsFormSchema: SecretsFieldSchema[] = [
+  {
+    id: 'clientId',
+    label: i18n.CLIENT_ID_LABEL,
+    isPasswordField: false,
+    isRequired: true,
+  },
+  {
+    id: 'clientSecret',
+    label: i18n.CLIENT_SECRET_LABEL,
+    isPasswordField: true,
+    isRequired: true,
+  },
+];
+
+const WorkdayActionConnectorFields: React.FunctionComponent<ActionConnectorFieldsProps> = ({
+  readOnly,
+  isEdit,
+}) => (
+  <SimpleConnectorForm
+    isEdit={isEdit}
+    readOnly={readOnly}
+    configFormSchema={configFormSchema}
+    secretsFormSchema={secretsFormSchema}
+  />
+);
+
+// eslint-disable-next-line import/no-default-export
+export { WorkdayActionConnectorFields as default };

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getConnectorType as getWorkdayConnectorType } from './workday';

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/logo.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/logo.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+const Logo: React.FC = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 32 32"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="Workday"
+  >
+    <circle cx="16" cy="16" r="16" fill="#F38B00" />
+    <path
+      d="M6 10.5h3.6l1.9 8.3h.05l2.05-8.3h3.1l2.05 8.3h.05l1.9-8.3H24l-3.5 11h-3.3l-2.15-8.55h-.05L12.85 21.5H9.5z"
+      fill="#ffffff"
+    />
+  </svg>
+);
+
+// eslint-disable-next-line import/no-default-export
+export default Logo;

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/params.tsx
@@ -23,8 +23,14 @@ const actionOptions = [
   { value: SUB_ACTION.SEARCH_WORKERS, inputDisplay: i18n.SEARCH_WORKERS_LABEL },
 ];
 
-type GetWorkerParams = { workerId?: string };
-type SearchWorkersParams = { search?: string; limit?: number; offset?: number };
+interface GetWorkerParams {
+  workerId?: string;
+}
+interface SearchWorkersParams {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
 
 const WorkdayParamsFields: React.FunctionComponent<ActionParamsProps<WorkdayActionParams>> = ({
   actionParams,
@@ -99,6 +105,7 @@ const WorkdayParamsFields: React.FunctionComponent<ActionParamsProps<WorkdayActi
             error={errors['subActionParams.workerId'] as string[]}
           >
             <EuiFieldText
+              isInvalid={(errors['subActionParams.workerId'] as string[])?.length > 0}
               fullWidth
               value={getWorkerParams.workerId ?? ''}
               onChange={(e) => setGetWorker({ workerId: e.target.value })}
@@ -119,6 +126,7 @@ const WorkdayParamsFields: React.FunctionComponent<ActionParamsProps<WorkdayActi
               error={errors['subActionParams.search'] as string[]}
             >
               <EuiFieldText
+                isInvalid={(errors['subActionParams.search'] as string[])?.length > 0}
                 fullWidth
                 value={searchWorkersParams.search ?? ''}
                 onChange={(e) => setSearch({ search: e.target.value })}

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/params.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo } from 'react';
+import {
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSuperSelect,
+} from '@elastic/eui';
+import type { ActionParamsProps } from '@kbn/triggers-actions-ui-plugin/public';
+import { SUB_ACTION, type WorkdayActionParams } from '@kbn/connector-schemas/workday';
+import * as i18n from './translations';
+
+const actionOptions = [
+  { value: SUB_ACTION.GET_WORKER, inputDisplay: i18n.GET_WORKER_LABEL },
+  { value: SUB_ACTION.SEARCH_WORKERS, inputDisplay: i18n.SEARCH_WORKERS_LABEL },
+];
+
+type GetWorkerParams = { workerId?: string };
+type SearchWorkersParams = { search?: string; limit?: number; offset?: number };
+
+const WorkdayParamsFields: React.FunctionComponent<ActionParamsProps<WorkdayActionParams>> = ({
+  actionParams,
+  editAction,
+  index,
+  errors,
+}) => {
+  const subAction = actionParams.subAction ?? SUB_ACTION.GET_WORKER;
+
+  useEffect(() => {
+    if (!actionParams.subAction) {
+      editAction('subAction', SUB_ACTION.GET_WORKER, index);
+    }
+    if (!actionParams.subActionParams) {
+      editAction('subActionParams', { workerId: '' } as GetWorkerParams, index);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [actionParams]);
+
+  const onActionChange = useCallback(
+    (value: SUB_ACTION) => {
+      editAction('subAction', value, index);
+      editAction(
+        'subActionParams',
+        value === SUB_ACTION.GET_WORKER
+          ? ({ workerId: '' } as GetWorkerParams)
+          : ({ search: '' } as SearchWorkersParams),
+        index
+      );
+    },
+    [editAction, index]
+  );
+
+  const getWorkerParams = useMemo(
+    () => (actionParams.subActionParams as GetWorkerParams | undefined) ?? { workerId: '' },
+    [actionParams.subActionParams]
+  );
+
+  const searchWorkersParams = useMemo(
+    () =>
+      (actionParams.subActionParams as SearchWorkersParams | undefined) ?? {
+        search: '',
+      },
+    [actionParams.subActionParams]
+  );
+
+  const setGetWorker = (patch: Partial<GetWorkerParams>) =>
+    editAction('subActionParams', { ...getWorkerParams, ...patch }, index);
+  const setSearch = (patch: Partial<SearchWorkersParams>) =>
+    editAction('subActionParams', { ...searchWorkersParams, ...patch }, index);
+
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <EuiFormRow fullWidth label={i18n.ACTION_TYPE_LABEL}>
+          <EuiSuperSelect
+            fullWidth
+            options={actionOptions}
+            valueOfSelected={subAction}
+            onChange={onActionChange}
+            data-test-subj="workdayActionTypeSelect"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+
+      {subAction === SUB_ACTION.GET_WORKER && (
+        <EuiFlexItem>
+          <EuiFormRow
+            fullWidth
+            label={i18n.WORKER_ID_LABEL}
+            isInvalid={(errors['subActionParams.workerId'] as string[])?.length > 0}
+            error={errors['subActionParams.workerId'] as string[]}
+          >
+            <EuiFieldText
+              fullWidth
+              value={getWorkerParams.workerId ?? ''}
+              onChange={(e) => setGetWorker({ workerId: e.target.value })}
+              data-test-subj="workdayWorkerIdInput"
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      )}
+
+      {subAction === SUB_ACTION.SEARCH_WORKERS && (
+        <>
+          <EuiFlexItem>
+            <EuiFormRow
+              fullWidth
+              label={i18n.SEARCH_LABEL}
+              helpText={i18n.SEARCH_HELP}
+              isInvalid={(errors['subActionParams.search'] as string[])?.length > 0}
+              error={errors['subActionParams.search'] as string[]}
+            >
+              <EuiFieldText
+                fullWidth
+                value={searchWorkersParams.search ?? ''}
+                onChange={(e) => setSearch({ search: e.target.value })}
+                data-test-subj="workdaySearchInput"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiFormRow label={i18n.LIMIT_LABEL}>
+                  <EuiFieldNumber
+                    min={1}
+                    max={100}
+                    value={searchWorkersParams.limit ?? ''}
+                    onChange={(e) =>
+                      setSearch({
+                        limit: e.target.value === '' ? undefined : Number(e.target.value),
+                      })
+                    }
+                    data-test-subj="workdayLimitInput"
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow label={i18n.OFFSET_LABEL}>
+                  <EuiFieldNumber
+                    min={0}
+                    value={searchWorkersParams.offset ?? ''}
+                    onChange={(e) =>
+                      setSearch({
+                        offset: e.target.value === '' ? undefined : Number(e.target.value),
+                      })
+                    }
+                    data-test-subj="workdayOffsetInput"
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </>
+      )}
+    </EuiFlexGroup>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export { WorkdayParamsFields as default };

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/translations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/translations.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SELECT_MESSAGE = i18n.translate(
+  'xpack.stackConnectors.components.workday.selectMessageText',
+  {
+    defaultMessage: 'Look up worker data from Workday',
+  }
+);
+
+export const API_URL_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.config.apiUrlLabel',
+  {
+    defaultMessage: 'Workday REST API base URL',
+  }
+);
+
+export const API_URL_HELP = i18n.translate(
+  'xpack.stackConnectors.components.workday.config.apiUrlHelp',
+  {
+    defaultMessage:
+      'Fully-qualified base URL including tenant, e.g. https://wd2-impl-services1.workday.com/ccx/api/v1/mytenant',
+  }
+);
+
+export const TOKEN_URL_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.config.tokenUrlLabel',
+  {
+    defaultMessage: 'OAuth2 token URL',
+  }
+);
+
+export const TOKEN_URL_HELP = i18n.translate(
+  'xpack.stackConnectors.components.workday.config.tokenUrlHelp',
+  {
+    defaultMessage:
+      'Workday OAuth2 token endpoint, e.g. https://wd2-impl-services1.workday.com/ccx/oauth2/mytenant/token',
+  }
+);
+
+export const CLIENT_ID_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.config.clientIdLabel',
+  {
+    defaultMessage: 'Client ID',
+  }
+);
+
+export const CLIENT_SECRET_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.config.clientSecretLabel',
+  {
+    defaultMessage: 'Client secret',
+  }
+);
+
+export const ACTION_TYPE_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.actionTypeLabel',
+  {
+    defaultMessage: 'Action',
+  }
+);
+
+export const GET_WORKER_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.getWorkerLabel',
+  {
+    defaultMessage: 'Get worker by ID',
+  }
+);
+
+export const SEARCH_WORKERS_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.searchWorkersLabel',
+  {
+    defaultMessage: 'Search workers',
+  }
+);
+
+export const WORKER_ID_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.workerIdLabel',
+  {
+    defaultMessage: 'Worker ID',
+  }
+);
+
+export const SEARCH_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.searchLabel',
+  {
+    defaultMessage: 'Search query',
+  }
+);
+
+export const SEARCH_HELP = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.searchHelp',
+  {
+    defaultMessage: 'Matches on name; must be at least 3 characters.',
+  }
+);
+
+export const LIMIT_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.limitLabel',
+  {
+    defaultMessage: 'Limit',
+  }
+);
+
+export const OFFSET_LABEL = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.offsetLabel',
+  {
+    defaultMessage: 'Offset',
+  }
+);
+
+export const ACTION_REQUIRED = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.error.requiredAction',
+  {
+    defaultMessage: 'Action is required.',
+  }
+);
+
+export const INVALID_ACTION = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.error.invalidAction',
+  {
+    defaultMessage: 'Invalid action.',
+  }
+);
+
+export const WORKER_ID_REQUIRED = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.error.workerIdRequired',
+  {
+    defaultMessage: 'Worker ID is required.',
+  }
+);
+
+export const SEARCH_REQUIRED = i18n.translate(
+  'xpack.stackConnectors.components.workday.params.error.searchRequired',
+  {
+    defaultMessage: 'Search query must be at least 3 characters.',
+  }
+);

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/workday.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/workday.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TypeRegistry } from '@kbn/triggers-actions-ui-plugin/public/application/type_registry';
+import { registerConnectorTypes } from '..';
+import type { ActionTypeModel as ConnectorTypeModel } from '@kbn/triggers-actions-ui-plugin/public/types';
+import { experimentalFeaturesMock, registrationServicesMock } from '../../mocks';
+import { CONNECTOR_ID, SUB_ACTION } from '@kbn/connector-schemas/workday';
+import { ExperimentalFeaturesService } from '../../common/experimental_features_service';
+
+let connectorTypeModel: ConnectorTypeModel;
+
+beforeAll(() => {
+  const connectorTypeRegistry = new TypeRegistry<ConnectorTypeModel>();
+  ExperimentalFeaturesService.init({ experimentalFeatures: experimentalFeaturesMock });
+  registerConnectorTypes({ connectorTypeRegistry, services: registrationServicesMock });
+  const got = connectorTypeRegistry.get(CONNECTOR_ID);
+  if (got !== null) {
+    connectorTypeModel = got;
+  }
+});
+
+describe('workday connector type registration', () => {
+  it('is registered under .workday', () => {
+    expect(connectorTypeModel.id).toEqual(CONNECTOR_ID);
+  });
+});
+
+describe('workday validateParams', () => {
+  it('accepts a valid getWorker payload', async () => {
+    const errors = (await connectorTypeModel.validateParams(
+      {
+        subAction: SUB_ACTION.GET_WORKER,
+        subActionParams: { workerId: 'abc' },
+      },
+      null
+    )) as { errors: Record<string, string[]> };
+    expect(errors.errors.subAction).toEqual([]);
+    expect(errors.errors['subActionParams.workerId']).toEqual([]);
+  });
+
+  it('flags an empty workerId', async () => {
+    const errors = (await connectorTypeModel.validateParams(
+      {
+        subAction: SUB_ACTION.GET_WORKER,
+        subActionParams: { workerId: '' },
+      },
+      null
+    )) as { errors: Record<string, string[]> };
+    expect(errors.errors['subActionParams.workerId'].length).toBeGreaterThan(0);
+  });
+
+  it('accepts a valid searchWorkers payload', async () => {
+    const errors = (await connectorTypeModel.validateParams(
+      {
+        subAction: SUB_ACTION.SEARCH_WORKERS,
+        subActionParams: { search: 'jane' },
+      },
+      null
+    )) as { errors: Record<string, string[]> };
+    expect(errors.errors['subActionParams.search']).toEqual([]);
+  });
+
+  it('flags a too-short search query', async () => {
+    const errors = (await connectorTypeModel.validateParams(
+      {
+        subAction: SUB_ACTION.SEARCH_WORKERS,
+        subActionParams: { search: 'ja' },
+      },
+      null
+    )) as { errors: Record<string, string[]> };
+    expect(errors.errors['subActionParams.search'].length).toBeGreaterThan(0);
+  });
+
+  it('rejects an unknown subAction', async () => {
+    const errors = (await connectorTypeModel.validateParams(
+      { subAction: 'nope', subActionParams: {} } as never,
+      null
+    )) as { errors: Record<string, string[]> };
+    expect(errors.errors.subAction.length).toBeGreaterThan(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/workday.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/workday.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lazy } from 'react';
+import type {
+  ActionTypeModel as ConnectorTypeModel,
+  GenericValidationResult,
+} from '@kbn/triggers-actions-ui-plugin/public';
+import {
+  CONNECTOR_ID,
+  CONNECTOR_NAME,
+  SUB_ACTION,
+  type WorkdayActionParams,
+  type WorkdayConfig,
+  type WorkdaySecrets,
+} from '@kbn/connector-schemas/workday';
+import { SELECT_MESSAGE } from './translations';
+
+interface ValidationErrors {
+  subAction: string[];
+  'subActionParams.workerId': string[];
+  'subActionParams.search': string[];
+}
+
+export function getConnectorType(): ConnectorTypeModel<
+  WorkdayConfig,
+  WorkdaySecrets,
+  WorkdayActionParams
+> {
+  return {
+    id: CONNECTOR_ID,
+    actionTypeTitle: CONNECTOR_NAME,
+    iconClass: lazy(() => import('./logo')),
+    isExperimental: false,
+    selectMessage: SELECT_MESSAGE,
+    async validateParams(
+      actionParams
+    ): Promise<GenericValidationResult<ValidationErrors>> {
+      const translations = await import('./translations');
+      const errors: ValidationErrors = {
+        subAction: [],
+        'subActionParams.workerId': [],
+        'subActionParams.search': [],
+      };
+      const { subAction, subActionParams } = actionParams;
+
+      if (!subAction) {
+        errors.subAction.push(translations.ACTION_REQUIRED);
+      } else if (!Object.values(SUB_ACTION).includes(subAction)) {
+        errors.subAction.push(translations.INVALID_ACTION);
+      }
+
+      if (subAction === SUB_ACTION.GET_WORKER) {
+        const workerId = (subActionParams as { workerId?: string } | undefined)?.workerId;
+        if (!workerId || !workerId.trim()) {
+          errors['subActionParams.workerId'].push(translations.WORKER_ID_REQUIRED);
+        }
+      }
+
+      if (subAction === SUB_ACTION.SEARCH_WORKERS) {
+        const search = (subActionParams as { search?: string } | undefined)?.search;
+        if (!search || search.length < 3) {
+          errors['subActionParams.search'].push(translations.SEARCH_REQUIRED);
+        }
+      }
+
+      return { errors };
+    },
+    actionConnectorFields: lazy(() => import('./connector')),
+    actionParamsFields: lazy(() => import('./params')),
+  };
+}

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/workday.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/workday.ts
@@ -37,9 +37,7 @@ export function getConnectorType(): ConnectorTypeModel<
     iconClass: lazy(() => import('./logo')),
     isExperimental: false,
     selectMessage: SELECT_MESSAGE,
-    async validateParams(
-      actionParams
-    ): Promise<GenericValidationResult<ValidationErrors>> {
+    async validateParams(actionParams): Promise<GenericValidationResult<ValidationErrors>> {
       const translations = await import('./translations');
       const errors: ValidationErrors = {
         subAction: [],

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
@@ -42,6 +42,7 @@ import { getOpsgenieConnectorType } from './opsgenie';
 import { getSentinelOneConnectorType } from './sentinelone';
 import { getCrowdstrikeConnectorType } from './crowdstrike';
 import { getMcpConnectorType } from './mcp';
+import { getWorkdayConnectorType } from './workday';
 import type { ExperimentalFeatures } from '../../common/experimental_features';
 
 export { getConnectorType as getSwimlaneConnectorType } from './swimlane';
@@ -85,6 +86,7 @@ export function registerConnectorTypes({
   actions.registerSubActionConnectorType(getTheHiveConnectorType());
   actions.registerSubActionConnectorType(getXSOARConnectorType());
   actions.registerSubActionConnectorType(getMcpConnectorType());
+  actions.registerSubActionConnectorType(getWorkdayConnectorType());
 
   if (experimentalFeatures.sentinelOneConnectorOn) {
     actions.registerSubActionConnectorType(getSentinelOneConnectorType());

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/error.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/error.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const parseStatusMessage = (message: string): { code: number; message: string } => {
+  const regex = /Status code: (\d+). Message: (.+)/;
+  const match = message.match(regex);
+  if (match) {
+    return {
+      code: parseInt(match[1], 10),
+      message: match[2],
+    };
+  }
+  return {
+    code: 500,
+    message,
+  };
+};
+
+export class WorkdayError extends Error {
+  public code: number;
+  constructor(message: string) {
+    super(message);
+    const parsed = parseStatusMessage(message);
+    this.code = parsed.code;
+    this.message = parsed.message || 'Unknown Workday error';
+  }
+}

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/index.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getWorkdayConnectorType } from '.';
+
+describe('getWorkdayConnectorType', () => {
+  const t = getWorkdayConnectorType();
+  it('has the .workday connector id', () => {
+    expect(t.id).toBe('.workday');
+  });
+  it('advertises alerting, cases, workflows and agentBuilder feature ids', () => {
+    expect(t.supportedFeatureIds).toEqual(
+      expect.arrayContaining(['alerting', 'cases', 'workflows', 'agentBuilder'])
+    );
+  });
+  it('requires at least platinum license', () => {
+    expect(t.minimumLicenseRequired).toBe('platinum');
+  });
+  it('has config + secrets validators wired to the URL allow-list', () => {
+    expect(t.validators?.length).toBe(2);
+  });
+});

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/index.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SubActionConnectorType } from '@kbn/actions-plugin/server/sub_action_framework/types';
+import { ValidatorType } from '@kbn/actions-plugin/server/sub_action_framework/types';
+import {
+  AgentBuilderConnectorFeatureId,
+  AlertingConnectorFeatureId,
+  CasesConnectorFeatureId,
+  WorkflowsConnectorFeatureId,
+} from '@kbn/actions-plugin/common';
+import { urlAllowListValidator } from '@kbn/actions-plugin/server';
+import {
+  CONNECTOR_ID,
+  CONNECTOR_NAME,
+  WorkdayConfigSchema,
+  WorkdaySecretsSchema,
+  type WorkdayConfig,
+  type WorkdaySecrets,
+} from '@kbn/connector-schemas/workday';
+
+import { WorkdayConnector } from './workday';
+
+export const getWorkdayConnectorType = (): SubActionConnectorType<
+  WorkdayConfig,
+  WorkdaySecrets
+> => ({
+  id: CONNECTOR_ID,
+  name: CONNECTOR_NAME,
+  getService: (params) => new WorkdayConnector(params),
+  schema: {
+    config: WorkdayConfigSchema,
+    secrets: WorkdaySecretsSchema,
+  },
+  validators: [
+    { type: ValidatorType.CONFIG, validator: urlAllowListValidator('apiUrl') },
+    { type: ValidatorType.CONFIG, validator: urlAllowListValidator('tokenUrl') },
+  ],
+  supportedFeatureIds: [
+    AlertingConnectorFeatureId,
+    CasesConnectorFeatureId,
+    WorkflowsConnectorFeatureId,
+    AgentBuilderConnectorFeatureId,
+  ],
+  minimumLicenseRequired: 'platinum' as const,
+});

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/token_manager.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/token_manager.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ServiceParams, SubActionConnector } from '@kbn/actions-plugin/server';
+import type { ConnectorUsageCollector } from '@kbn/actions-plugin/server/usage';
+import type { ConnectorToken } from '@kbn/actions-plugin/server/types';
+import type { Logger } from '@kbn/logging';
+import {
+  WorkdayApiDoNotValidateResponsesSchema,
+  type WorkdayConfig,
+  type WorkdayGetTokenResponse,
+  type WorkdaySecrets,
+} from '@kbn/connector-schemas/workday';
+
+// Workday's OAuth2 token endpoint uses the Client Credentials grant with an
+// integration-registered API Client. Credentials are sent as HTTP Basic
+// (base64(clientId:clientSecret)) and the grant type is passed in the body.
+export class WorkdayTokenManager {
+  private connectorToken: ConnectorToken | null = null;
+  private readonly tokenUrl: string;
+  // Must be 'access_token' — ConnectorTokenClient.updateOrReplace hardcodes it.
+  private readonly tokenType = 'access_token';
+  private generatingNewTokenPromise: Promise<void> | null = null;
+  private reGenerateNewTokenPromise: Promise<void> | null = null;
+  private readonly base64encodedToken: string;
+  protected logger: Logger;
+
+  constructor(
+    private readonly params: ServiceParams<WorkdayConfig, WorkdaySecrets> & {
+      apiRequest: SubActionConnector<WorkdayConfig, WorkdaySecrets>['request'];
+    }
+  ) {
+    this.logger = params.logger.get('workdayTokenManager');
+    this.tokenUrl = params.config.tokenUrl;
+    this.base64encodedToken = Buffer.from(
+      params.secrets.clientId + ':' + params.secrets.clientSecret
+    ).toString('base64');
+  }
+
+  private isTokenExpired(token: ConnectorToken): boolean {
+    const now = new Date();
+    now.setSeconds(now.getSeconds() - 5);
+    const isExpired = token.expiresAt ? token.expiresAt < now.toISOString() : true;
+    if (isExpired) {
+      this.logger.debug(`Cached Workday access token expired at [${token.expiresAt}]`);
+    }
+    return isExpired;
+  }
+
+  private async fetchAndStoreNewToken(
+    connectorUsageCollector: ConnectorUsageCollector
+  ): Promise<WorkdayGetTokenResponse> {
+    const {
+      connector: { id: connectorId },
+    } = this.params;
+    const connectorTokenClient = this.params.services.connectorTokenClient;
+
+    this.logger.debug(`Requesting new Workday access token for connector [${connectorId}]`);
+
+    const tokenRequestDate = Date.now();
+    const newToken = await this.params.apiRequest<WorkdayGetTokenResponse>(
+      {
+        url: this.tokenUrl,
+        method: 'post',
+        headers: {
+          accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          authorization: 'Basic ' + this.base64encodedToken,
+        },
+        data: 'grant_type=client_credentials',
+        responseSchema:
+          WorkdayApiDoNotValidateResponsesSchema as unknown as typeof WorkdayApiDoNotValidateResponsesSchema,
+      },
+      connectorUsageCollector
+    );
+
+    await connectorTokenClient.updateOrReplace({
+      connectorId,
+      tokenRequestDate,
+      deleteExisting: true,
+      token: this.connectorToken,
+      newToken: newToken.data.access_token,
+      expiresInSec: newToken.data.expires_in,
+    });
+
+    return newToken.data;
+  }
+
+  private async retrieveOrGenerateNewTokenIfNeeded(
+    connectorUsageCollector: ConnectorUsageCollector
+  ): Promise<void> {
+    if (this.generatingNewTokenPromise) {
+      return await this.generatingNewTokenPromise;
+    }
+
+    this.generatingNewTokenPromise = new Promise(async (resolve, reject) => {
+      try {
+        const {
+          connector: { id: connectorId },
+        } = this.params;
+        const connectorTokenClient = this.params.services.connectorTokenClient;
+
+        if (!this.connectorToken) {
+          const cachedToken = await connectorTokenClient.get({
+            connectorId,
+            tokenType: this.tokenType,
+          });
+
+          if (cachedToken.connectorToken) {
+            this.connectorToken = cachedToken.connectorToken;
+          }
+        }
+
+        if (this.connectorToken && !this.isTokenExpired(this.connectorToken)) {
+          resolve();
+          return;
+        }
+
+        await this.fetchAndStoreNewToken(connectorUsageCollector);
+
+        const updatedCachedToken = await connectorTokenClient.get({
+          connectorId,
+          tokenType: this.tokenType,
+        });
+
+        if (!updatedCachedToken.connectorToken) {
+          throw new Error(`Failed to retrieve cached [${this.tokenType}] after it was updated.`);
+        }
+
+        this.connectorToken = updatedCachedToken.connectorToken;
+        resolve(undefined);
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    return await this.generatingNewTokenPromise.then(() => {
+      this.generatingNewTokenPromise = null;
+    });
+  }
+
+  public async get(connectorUsageCollector: ConnectorUsageCollector): Promise<string> {
+    if (this.reGenerateNewTokenPromise) {
+      await this.reGenerateNewTokenPromise;
+    }
+    await this.retrieveOrGenerateNewTokenIfNeeded(connectorUsageCollector);
+    if (!this.connectorToken) {
+      throw new Error('Access token for Workday not available!');
+    }
+    return this.connectorToken.token;
+  }
+
+  public async generateNew(connectorUsageCollector: ConnectorUsageCollector): Promise<void> {
+    if (this.reGenerateNewTokenPromise) {
+      return await this.reGenerateNewTokenPromise;
+    }
+
+    this.reGenerateNewTokenPromise = new Promise(async (resolve, reject) => {
+      try {
+        const connectorTokenClient = this.params.services.connectorTokenClient;
+        if (this.generatingNewTokenPromise) {
+          await this.generatingNewTokenPromise;
+        }
+
+        // A peer instance may have already refreshed the token.
+        if (this.connectorToken) {
+          const currentToken = this.connectorToken.token;
+          const latest = await connectorTokenClient.get({
+            connectorId: this.params.connector.id,
+            tokenType: this.tokenType,
+          });
+          if (latest.connectorToken && latest.connectorToken.token !== currentToken) {
+            this.connectorToken = latest.connectorToken;
+            return resolve(undefined);
+          }
+        }
+
+        await this.fetchAndStoreNewToken(connectorUsageCollector);
+        this.connectorToken = null;
+        resolve(undefined);
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    await this.reGenerateNewTokenPromise;
+  }
+}

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/types.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface NodeSystemError extends Error {
+  hostname?: string;
+  address?: string;
+  code: string;
+  dest: string;
+  errno: number;
+  info?: object;
+  message: string;
+  path?: string;
+  port?: number;
+  syscall: string;
+}
+
+export function isAggregateError(cause: unknown): cause is AggregateError {
+  return cause instanceof AggregateError;
+}

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/workday.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/workday.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { WorkdayConnector } from './workday';
+import { actionsConfigMock } from '@kbn/actions-plugin/server/actions_config.mock';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { actionsMock } from '@kbn/actions-plugin/server/mocks';
+import { CONNECTOR_ID as WORKDAY_CONNECTOR_ID } from '@kbn/connector-schemas/workday';
+import { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
+import { WorkdayError } from './error';
+
+const apiUrl = 'https://wd2-impl-services1.workday.com/ccx/api/v1/mytenant';
+const tokenUrl = 'https://wd2-impl-services1.workday.com/ccx/oauth2/mytenant/token';
+
+describe('WorkdayConnector', () => {
+  const logger = loggingSystemMock.createLogger();
+  let connector: WorkdayConnector;
+  let mockedRequest: jest.Mock;
+  let connectorUsageCollector: ConnectorUsageCollector;
+  let services: ReturnType<typeof actionsMock.createServices>;
+
+  const mockToken = {
+    id: 'token-id',
+    connectorId: 'connector-id',
+    tokenType: 'access_token',
+    token: 'wd-access-token',
+    expiresAt: new Date(Date.now() + 1800 * 1000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    services = actionsMock.createServices();
+
+    jest.spyOn(services.connectorTokenClient, 'get');
+    jest
+      .spyOn(services.connectorTokenClient, 'updateOrReplace')
+      .mockResolvedValue(undefined as unknown as void);
+
+    connector = new WorkdayConnector({
+      configurationUtilities: actionsConfigMock.create(),
+      connector: { id: '1', type: WORKDAY_CONNECTOR_ID },
+      config: { apiUrl, tokenUrl },
+      secrets: { clientId: 'cid', clientSecret: 'csecret' },
+      logger,
+      services,
+    });
+
+    // @ts-expect-error swap out the underlying HTTP layer
+    mockedRequest = connector.request = jest.fn() as jest.Mock;
+
+    connectorUsageCollector = new ConnectorUsageCollector({
+      logger,
+      connectorId: 'test-connector-id',
+    });
+
+    jest.mocked(services.connectorTokenClient.get).mockResolvedValue({
+      hasErrors: false,
+      connectorToken: mockToken,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getWorker', () => {
+    it('GETs the worker resource with a Bearer token', async () => {
+      const worker = { id: 'abc123', primaryWorkEmail: 'a@b.com' };
+      mockedRequest.mockResolvedValueOnce({ data: worker });
+
+      const result = await connector.getWorker({ workerId: 'abc123' }, connectorUsageCollector);
+
+      expect(services.connectorTokenClient.get).toHaveBeenCalledWith({
+        connectorId: '1',
+        tokenType: 'access_token',
+      });
+
+      expect(mockedRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          url: `${apiUrl}/workers/abc123`,
+          headers: expect.objectContaining({
+            Authorization: 'Bearer wd-access-token',
+            Accept: 'application/json',
+          }),
+        }),
+        connectorUsageCollector
+      );
+      expect(result).toEqual(worker);
+    });
+
+    it('percent-encodes the worker ID in the URL', async () => {
+      mockedRequest.mockResolvedValueOnce({ data: {} });
+      await connector.getWorker({ workerId: 'a b/c' }, connectorUsageCollector);
+      expect(mockedRequest.mock.calls[0][0].url).toBe(`${apiUrl}/workers/a%20b%2Fc`);
+    });
+  });
+
+  describe('searchWorkers', () => {
+    it('GETs /workers with a search param and optional pagination', async () => {
+      const body = { total: 1, data: [{ id: 'x' }] };
+      mockedRequest.mockResolvedValueOnce({ data: body });
+
+      const result = await connector.searchWorkers(
+        { search: 'jane', limit: 10, offset: 20 },
+        connectorUsageCollector
+      );
+
+      expect(mockedRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          url: `${apiUrl}/workers`,
+          params: { search: 'jane', limit: 10, offset: 20 },
+          headers: expect.objectContaining({ Authorization: 'Bearer wd-access-token' }),
+        }),
+        connectorUsageCollector
+      );
+      expect(result).toEqual(body);
+    });
+
+    it('omits limit/offset when not provided', async () => {
+      mockedRequest.mockResolvedValueOnce({ data: {} });
+      await connector.searchWorkers({ search: 'jane' }, connectorUsageCollector);
+      expect(mockedRequest.mock.calls[0][0].params).toEqual({ search: 'jane' });
+    });
+  });
+
+  describe('401 refresh-and-retry', () => {
+    it('refreshes the token and retries once on 401', async () => {
+      mockedRequest
+        // First call: the API request fails with 401
+        .mockImplementationOnce(async () => {
+          const err = new Error('unauthorized');
+          (err as unknown as { response: { status: number } }).response = { status: 401 };
+          throw err;
+        })
+        // Refresh call: token endpoint returns a new token
+        .mockResolvedValueOnce({
+          data: {
+            access_token: 'wd-new-token',
+            expires_in: 3600,
+            token_type: 'bearer',
+          },
+        })
+        // Retry of the original API request succeeds
+        .mockResolvedValueOnce({ data: { id: 'x' } });
+
+      const result = await connector.getWorker({ workerId: 'x' }, connectorUsageCollector);
+
+      expect(services.connectorTokenClient.updateOrReplace).toHaveBeenCalled();
+      expect(mockedRequest).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ id: 'x' });
+    });
+
+    it('throws WorkdayError when the request fails without 401', async () => {
+      mockedRequest.mockImplementationOnce(async () => {
+        throw new Error('Status code: 500. Message: boom');
+      });
+
+      await expect(
+        connector.getWorker({ workerId: 'x' }, connectorUsageCollector)
+      ).rejects.toBeInstanceOf(WorkdayError);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/workday.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/workday.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AxiosError } from 'axios';
+import type { ServiceParams } from '@kbn/actions-plugin/server';
+import { SubActionConnector } from '@kbn/actions-plugin/server';
+import type { SubActionRequestParams } from '@kbn/actions-plugin/server/sub_action_framework/types';
+import type { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
+import {
+  SUB_ACTION,
+  WorkdayApiDoNotValidateResponsesSchema,
+  WorkdayGetWorkerParamsSchema,
+  WorkdayGetWorkerResponseSchema,
+  WorkdaySearchWorkersParamsSchema,
+  WorkdaySearchWorkersResponseSchema,
+  type WorkdayConfig,
+  type WorkdayGetWorkerParams,
+  type WorkdayGetWorkerResponse,
+  type WorkdaySearchWorkersParams,
+  type WorkdaySearchWorkersResponse,
+  type WorkdaySecrets,
+} from '@kbn/connector-schemas/workday';
+
+import { WorkdayError } from './error';
+import { WorkdayTokenManager } from './token_manager';
+import { isAggregateError, type NodeSystemError } from './types';
+
+// Trim trailing slash so path joining is predictable.
+const stripTrailingSlash = (u: string): string => (u.endsWith('/') ? u.slice(0, -1) : u);
+
+export class WorkdayConnector extends SubActionConnector<WorkdayConfig, WorkdaySecrets> {
+  private readonly apiBase: string;
+  private tokenManager: WorkdayTokenManager;
+
+  constructor(params: ServiceParams<WorkdayConfig, WorkdaySecrets>) {
+    super(params);
+    this.apiBase = stripTrailingSlash(this.config.apiUrl);
+    this.tokenManager = new WorkdayTokenManager({
+      ...params,
+      apiRequest: (req, collector) => this.request(req, collector),
+    });
+    this.registerSubActions();
+  }
+
+  private registerSubActions() {
+    this.registerSubAction({
+      name: SUB_ACTION.GET_WORKER,
+      method: 'getWorker',
+      schema: WorkdayGetWorkerParamsSchema,
+    });
+    this.registerSubAction({
+      name: SUB_ACTION.SEARCH_WORKERS,
+      method: 'searchWorkers',
+      schema: WorkdaySearchWorkersParamsSchema,
+    });
+  }
+
+  public async getWorker(
+    { workerId }: WorkdayGetWorkerParams,
+    connectorUsageCollector: ConnectorUsageCollector
+  ): Promise<WorkdayGetWorkerResponse> {
+    return this.workdayApiRequest<WorkdayGetWorkerResponse>(
+      {
+        url: `${this.apiBase}/workers/${encodeURIComponent(workerId)}`,
+        method: 'GET',
+        responseSchema:
+          WorkdayGetWorkerResponseSchema as unknown as SubActionRequestParams<WorkdayGetWorkerResponse>['responseSchema'],
+      },
+      connectorUsageCollector
+    );
+  }
+
+  public async searchWorkers(
+    { search, limit, offset }: WorkdaySearchWorkersParams,
+    connectorUsageCollector: ConnectorUsageCollector
+  ): Promise<WorkdaySearchWorkersResponse> {
+    return this.workdayApiRequest<WorkdaySearchWorkersResponse>(
+      {
+        url: `${this.apiBase}/workers`,
+        method: 'GET',
+        params: {
+          search,
+          ...(limit !== undefined ? { limit } : {}),
+          ...(offset !== undefined ? { offset } : {}),
+        },
+        responseSchema:
+          WorkdaySearchWorkersResponseSchema as unknown as SubActionRequestParams<WorkdaySearchWorkersResponse>['responseSchema'],
+      },
+      connectorUsageCollector
+    );
+  }
+
+  private workdayApiRequest = async <R>(
+    req: SubActionRequestParams<R>,
+    connectorUsageCollector: ConnectorUsageCollector,
+    retried?: boolean
+  ): Promise<R> => {
+    try {
+      const token = await this.tokenManager.get(connectorUsageCollector);
+      const response = await this.request<R>(
+        {
+          ...req,
+          // Workday's REST resource shapes vary by tenant and version — do not
+          // enforce strict response validation for functional API calls.
+          responseSchema:
+            WorkdayApiDoNotValidateResponsesSchema as unknown as SubActionRequestParams<R>['responseSchema'],
+          headers: {
+            ...req.headers,
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+        connectorUsageCollector
+      );
+      return response.data;
+    } catch (error) {
+      const status = error?.response?.status ?? error?.status;
+      if (status === 401 && !retried) {
+        await this.tokenManager.generateNew(connectorUsageCollector);
+        return this.workdayApiRequest<R>(req, connectorUsageCollector, true);
+      }
+      throw new WorkdayError(error.message);
+    }
+  };
+
+  protected getResponseErrorMessage(
+    error: AxiosError<{ error?: string; error_description?: string; message?: string }>
+  ): string {
+    const body = error.response?.data;
+    if (body) {
+      // OAuth2 token errors: { error, error_description }
+      if (body.error_description) return body.error_description;
+      if (body.error) return body.error;
+      if (body.message) return body.message;
+    }
+
+    const cause: NodeSystemError | undefined = isAggregateError(error.cause)
+      ? (error.cause.errors[0] as NodeSystemError)
+      : (error.cause as NodeSystemError | undefined);
+    if (cause) {
+      if (cause.code === 'ENOTFOUND') return `URL not found: ${cause.hostname}`;
+      if (cause.code === 'ECONNREFUSED') return `Connection refused: ${cause.address}:${cause.port}`;
+    }
+
+    if (!error.response?.status) {
+      return `Unknown API Error: ${JSON.stringify(error.response?.data ?? {})}`;
+    }
+    return `API Error: ${JSON.stringify(error.response.data ?? {})}`;
+  }
+}

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/workday.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/workday.ts
@@ -143,7 +143,8 @@ export class WorkdayConnector extends SubActionConnector<WorkdayConfig, WorkdayS
       : (error.cause as NodeSystemError | undefined);
     if (cause) {
       if (cause.code === 'ENOTFOUND') return `URL not found: ${cause.hostname}`;
-      if (cause.code === 'ECONNREFUSED') return `Connection refused: ${cause.address}:${cause.port}`;
+      if (cause.code === 'ECONNREFUSED')
+        return `Connection refused: ${cause.address}:${cause.port}`;
     }
 
     if (!error.response?.status) {


### PR DESCRIPTION
Closes elastic/security-team#18169

## Summary

Adds a new Kibana stack connector for **Workday** (`connector_type_id: .workday`) built on the `SubActionConnector` v2 framework. Two sub-actions: `getWorker` (lookup by worker ID) and `searchWorkers` (search by name with pagination). OAuth 2.0 client credentials against Workday's REST API, with token caching + refresh-on-401 via `ConnectorTokenClient` — same pattern as the `crowdstrike` connector.

Origin: [Slack thread](https://elastic.slack.com/archives/C08U04SUN49/p1783504129102329) where a joking-serious follow-up ("wire Workday into Kiriver") turned into a real ask for an HR-system connector any team can pull into Cases / Alerting / Agent Builder / Workflows.

### What's included

**Schema package** (`@kbn/connector-schemas/workday`):
- `constants.ts` — `CONNECTOR_ID = '.workday'`, `SUB_ACTION` enum.
- Zod schemas: config (`apiUrl`, `tokenUrl`), secrets (`clientId`, `clientSecret`), per-subAction params + responses, `WorkdayActionParamsSchema` discriminated union.
- Types generated from schemas + inferred by consumers.

**Server** (`x-pack/platform/plugins/shared/stack_connectors/server/connector_types/workday/`):
- `workday.ts` — `WorkdayConnector extends SubActionConnector<Config, Secrets>` with `getWorker` and `searchWorkers` methods.
- `token_manager.ts` — OAuth2 token manager (client credentials, base64(id:secret) Basic auth, `grant_type=client_credentials` form body). Caches tokens via `ConnectorTokenClient`, dedupes concurrent fetches, refreshes on 401, honors 5s expiry safety margin.
- `error.ts` — `WorkdayError` that parses `"Status code: N. Message: ..."` into `.code` for 401-detection.
- `index.ts` — `getWorkdayConnectorType()` with `supportedFeatureIds: [alerting, cases, workflows, agentBuilder]`, `minimumLicenseRequired: platinum`, URL allow-list validators on both config URLs.
- Registered in `server/connector_types/index.ts`.

**Public UI** (`x-pack/platform/plugins/shared/stack_connectors/public/connector_types/workday/`):
- `connector.tsx` — `SimpleConnectorForm` with config (apiUrl + tokenUrl, isUrlField) and secrets (clientId, clientSecret as password) schemas.
- `params.tsx` — action selector (`getWorker` / `searchWorkers`) with the matching input fields (workerId text; or search + limit + offset).
- `workday.ts` — `ConnectorTypeModel` with `validateParams` (checks subAction, workerId presence, search-length ≥ 3).
- `logo.tsx`, `translations.ts` — inline SVG mark, i18n strings.
- Registered in `public/connector_types/index.ts`.

### Tests

25/25 jest tests pass:
- Schema (9): config/secrets validation, param bounds, discriminated union.
- Server (10): `getWorker` / `searchWorkers` URL + params + Bearer header + response shape; percent-encoding of worker ID; 401 refresh-and-retry path; error wrapping.
- Public (6): connector-type registers under `.workday`; `validateParams` accepts valid payloads and flags empty workerId, short search, unknown subAction.

Type-check clean on both `@kbn/connector-schemas` and `stack_connectors` (`node scripts/type_check --project …`).

### Screenshots

The Kibana bundle failed to compile on the sandbox devbox this PR was authored in (8 GB RAM was too tight for the kbn/optimizer even with `KBN_OPTIMIZER_MAX_WORKERS=1` and a 5 GB heap). Screenshots of the "Create connector" flyout and params UI will be added on top of this PR once a beefier machine is available — the code paths that render both forms are exercised by the public jest tests above.

### Out of scope for this PR (follow-ups)

- Docs page at `docs/reference/connectors-kibana/workday-action-type.md`.
- FTR + Workday simulator under `x-pack/platform/test/alerting_api_integration/`.
- Additional subActions (e.g. `getManager`, org-tree traversal) if usage warrants.
- Optional JWT Bearer grant support — Workday documents both Refresh Token and JWT Bearer as M2M grants; `client_credentials` (used here) is well-supported in real deployments but not the most prominent in Workday's own docs. Adding JWT is a small extension of the token manager.

## Test plan

- [ ] Reviewer bootstraps and runs `node scripts/jest x-pack/platform/plugins/shared/stack_connectors/{server,public}/connector_types/workday src/platform/packages/shared/kbn-connector-schemas/workday` — expects 25 passing.
- [ ] Reviewer runs `node scripts/type_check --project x-pack/platform/plugins/shared/stack_connectors/tsconfig.json` and `--project src/platform/packages/shared/kbn-connector-schemas/tsconfig.json` — expects clean.
- [ ] Reviewer boots Kibana + ES locally, opens **Stack Management → Connectors → Create connector**, confirms "Workday" appears in the picker, opens the flyout, fills the config + secrets, saves. Screenshot goes on the PR.
- [ ] Reviewer creates a rule / case action / workflow step using the connector, picks `getWorker` and `searchWorkers`, confirms the params UI renders and validates.
- [ ] Reviewer points the connector at a real (or mocked) Workday tenant and confirms the request/response wire format matches expectations.

---
_Created by @1workflow bot on behalf of U08SUNTMWTD_