### PR TITLE
[Console] Fix Windows CRLF editor corruption

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
@@ -260,6 +260,78 @@ describe('react monaco editor onChange performance', () => {
     cleanup();
   });
 
+  describe('WHEN the Monaco model uses CRLF and the controlled value uses LF', () => {
+    it('SHOULD apply Monaco change offsets to a CRLF-normalized shadow value', async () => {
+      let createdModel: monaco.editor.ITextModel | undefined;
+
+      const editorPushUndoStop = jest.fn();
+      const { cleanup } = setupMonacoEditorHarness({
+        onDidChangeModelContent: (cb) => {
+          lastOnDidChangeModelContentCb = cb;
+        },
+        onPushUndoStop: editorPushUndoStop,
+        onCreateModel: (model) => {
+          createdModel = model;
+        },
+      });
+
+      const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+      const { rerender } = render(<MonacoEditor value="" onChange={onChange} options={{}} />);
+
+      await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID);
+      expect(createdModel).toBeDefined();
+      expect(typeof lastOnDidChangeModelContentCb).toBe('function');
+
+      createdModel!.setEOL(monaco.editor.EndOfLineSequence.CRLF);
+      rerender(<MonacoEditor value={'A\nB'} onChange={onChange} options={{}} />);
+      onChange.mockClear();
+
+      const range = createRange();
+      const event = createEvent([{ range, rangeOffset: 3, rangeLength: 1, text: 'X' }]);
+      lastOnDidChangeModelContentCb!(event);
+
+      expect(onChange).toHaveBeenCalledWith('A\r\nX', event);
+
+      cleanup();
+    });
+  });
+
+  describe('WHEN the Monaco model uses LF and the controlled value uses CRLF', () => {
+    it('SHOULD apply Monaco change offsets to an LF-normalized shadow value', async () => {
+      let createdModel: monaco.editor.ITextModel | undefined;
+
+      const editorPushUndoStop = jest.fn();
+      const { cleanup } = setupMonacoEditorHarness({
+        onDidChangeModelContent: (cb) => {
+          lastOnDidChangeModelContentCb = cb;
+        },
+        onPushUndoStop: editorPushUndoStop,
+        onCreateModel: (model) => {
+          createdModel = model;
+        },
+      });
+
+      const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+      const { rerender } = render(<MonacoEditor value="" onChange={onChange} options={{}} />);
+
+      await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID);
+      expect(createdModel).toBeDefined();
+      expect(typeof lastOnDidChangeModelContentCb).toBe('function');
+
+      createdModel!.setEOL(monaco.editor.EndOfLineSequence.LF);
+      rerender(<MonacoEditor value={'A\r\nB'} onChange={onChange} options={{}} />);
+      onChange.mockClear();
+
+      const range = createRange();
+      const event = createEvent([{ range, rangeOffset: 2, rangeLength: 1, text: 'X' }]);
+      lastOnDidChangeModelContentCb!(event);
+
+      expect(onChange).toHaveBeenCalledWith('A\nX', event);
+
+      cleanup();
+    });
+  });
+
   it('pushes a full replace when controlled value changes externally', async () => {
     const originalCreateModel = monaco.editor.createModel.bind(monaco.editor);
     let pushEditOperationsSpy: jest.SpyInstance | undefined;

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
@@ -26,10 +26,11 @@ const defaultProps: Partial<ComponentProps<typeof MonacoEditor>> = {
 };
 
 const createEvent = (
-  changes: monaco.editor.IModelContentChange[]
+  changes: monaco.editor.IModelContentChange[],
+  eol = '\n'
 ): monaco.editor.IModelContentChangedEvent => ({
   changes,
-  eol: '\n',
+  eol,
   versionId: 1,
   isUndoing: false,
   isRedoing: false,
@@ -287,7 +288,10 @@ describe('react monaco editor onChange performance', () => {
       onChange.mockClear();
 
       const range = createRange();
-      const event = createEvent([{ range, rangeOffset: 3, rangeLength: 1, text: 'X' }]);
+      const event = createEvent(
+        [{ range, rangeOffset: 3, rangeLength: 1, text: 'X' }],
+        createdModel!.getEOL()
+      );
       lastOnDidChangeModelContentCb!(event);
 
       expect(onChange).toHaveBeenCalledWith('A\r\nX', event);
@@ -323,7 +327,10 @@ describe('react monaco editor onChange performance', () => {
       onChange.mockClear();
 
       const range = createRange();
-      const event = createEvent([{ range, rangeOffset: 2, rangeLength: 1, text: 'X' }]);
+      const event = createEvent(
+        [{ range, rangeOffset: 2, rangeLength: 1, text: 'X' }],
+        createdModel!.getEOL()
+      );
       lastOnDidChangeModelContentCb!(event);
 
       expect(onChange).toHaveBeenCalledWith('A\nX', event);

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
@@ -218,7 +218,7 @@ describe('react monaco editor onChange performance', () => {
     cleanup();
   });
 
-  it('does not pushEditOperations for controlled rerenders when value matches last known value', async () => {
+  it('does not normalize or push edits when a controlled rerender matches the shadow value', async () => {
     const originalCreateModel = monaco.editor.createModel.bind(monaco.editor);
     let pushEditOperationsSpy: jest.SpyInstance | undefined;
     const createModelSpy = jest
@@ -251,14 +251,19 @@ describe('react monaco editor onChange performance', () => {
 
     expect(onChange).toHaveBeenCalledWith('abXXXXefghij', event);
 
-    rerender(<MonacoEditor value="abXXXXefghij" onChange={onChange} options={{}} />);
+    const stringIncludesSpy = jest.spyOn(String.prototype, 'includes');
+    try {
+      rerender(<MonacoEditor value="abXXXXefghij" onChange={onChange} options={{}} />);
 
-    expect(pushEditOperationsSpy).toBeDefined();
-    expect(pushEditOperationsSpy!).not.toHaveBeenCalled();
-    expect(editorPushUndoStop).not.toHaveBeenCalled();
-
-    createModelSpy.mockRestore();
-    cleanup();
+      expect(stringIncludesSpy).not.toHaveBeenCalledWith('\r');
+      expect(pushEditOperationsSpy).toBeDefined();
+      expect(pushEditOperationsSpy!).not.toHaveBeenCalled();
+      expect(editorPushUndoStop).not.toHaveBeenCalled();
+    } finally {
+      stringIncludesSpy.mockRestore();
+      createModelSpy.mockRestore();
+      cleanup();
+    }
   });
 
   describe('WHEN the Monaco model uses CRLF and the controlled value uses LF', () => {

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -145,6 +145,10 @@ const applyModelContentChanges = (
   }, prevValue);
 };
 
+const normalizeEndOfLine = (value: string, eol: string): string => {
+  return value.replace(/\r\n|\r|\n/g, eol);
+};
+
 // initialize supported languages
 initializeSupportedLanguages();
 
@@ -197,7 +201,8 @@ export function MonacoEditor({
   const lastKnownValueRef = useRef<string>(value ?? defaultValue);
   useEffect(() => {
     if (typeof value === 'string') {
-      lastKnownValueRef.current = value;
+      const modelEol = editor.current?.getModel()?.getEOL();
+      lastKnownValueRef.current = modelEol ? normalizeEndOfLine(value, modelEol) : value;
     }
   }, [value]);
 
@@ -281,6 +286,7 @@ export function MonacoEditor({
       const finalOptions = { ...options, ...handleEditorWillMount() };
 
       const model = monaco.editor.createModel(finalValue!, language);
+      lastKnownValueRef.current = normalizeEndOfLine(finalValue!, model.getEOL());
 
       editor.current = monaco.editor.create(containerElement.current, {
         model,
@@ -331,20 +337,29 @@ export function MonacoEditor({
     if (editor.current) {
       // In controlled mode, `value` changes on every keystroke. Avoid calling `editor.getValue()`
       // (which materializes the full model) by comparing against our shadow copy first.
-      if (typeof value !== 'string' || value === lastKnownValueRef.current) {
+      if (typeof value !== 'string') {
         return;
       }
 
       const model = editor.current.getModel();
+      if (!model) {
+        return;
+      }
+
+      const valueInModelEol = normalizeEndOfLine(value, model.getEOL());
+      if (valueInModelEol === lastKnownValueRef.current) {
+        return;
+      }
+
       __preventTriggerChangeEvent.current = true;
       editor.current.pushUndoStop();
       // pushEditOperations says it expects a cursorComputer, but doesn't seem to need one.
-      model!.pushEditOperations(
+      model.pushEditOperations(
         [],
         [
           {
-            range: model!.getFullModelRange(),
-            text: value!,
+            range: model.getFullModelRange(),
+            text: valueInModelEol,
           },
         ],
         // @ts-expect-error
@@ -354,7 +369,7 @@ export function MonacoEditor({
       __preventTriggerChangeEvent.current = false;
 
       // Keep shadow state in sync for programmatic updates where we suppress onDidChangeModelContent.
-      lastKnownValueRef.current = value;
+      lastKnownValueRef.current = valueInModelEol;
     }
   }, [value]);
 

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -159,8 +159,8 @@ const HAS_NON_CRLF_LINE_ENDING = /(^|[^\r])\n|\r(?!\n)/;
  * EOL, then records `rangeOffset` / `rangeLength` from that same buffer:
  * https://github.com/microsoft/vscode/blob/e7e037083ff4455cf320e344325dacb480062c3c/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts#L276-L290
  *
- * Without this, CRLF shadow values and LF-based Monaco offsets drift by one extra `\r`
- * per preceding line break, replacing the wrong character.
+ * Without this, an LF shadow is one `\r` shorter per preceding line break than a CRLF
+ * Monaco model, so model offsets replace the wrong character.
  */
 const normalizeEndOfLine = (value: string, eol: string): string => {
   if (eol === '\n' && !value.includes('\r')) {

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -145,8 +145,33 @@ const applyModelContentChanges = (
   }, prevValue);
 };
 
+const ALL_LINE_ENDINGS = /\r\n|\r|\n/g;
+// For CRLF models, this separates values that are already safe to leave untouched
+// (`foo\r\nbar`) from values whose offsets would not line up with Monaco's CRLF model
+// text (`foo\nbar`, `foo\rbar`).
+const HAS_NON_CRLF_LINE_ENDING = /(^|[^\r])\n|\r(?!\n)/;
+
+/**
+ * Keep the shadow value's line endings aligned with Monaco before applying
+ * `IModelContentChangedEvent.changes`.
+ *
+ * Monaco applies edits against its text buffer: it normalizes edit text to the buffer
+ * EOL, then records `rangeOffset` / `rangeLength` from that same buffer:
+ * https://github.com/microsoft/vscode/blob/e7e037083ff4455cf320e344325dacb480062c3c/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts#L276-L290
+ *
+ * Without this, CRLF shadow values and LF-based Monaco offsets drift by one extra `\r`
+ * per preceding line break, replacing the wrong character.
+ */
 const normalizeEndOfLine = (value: string, eol: string): string => {
-  return value.replace(/\r\n|\r|\n/g, eol);
+  if (eol === '\n' && !value.includes('\r')) {
+    return value;
+  }
+
+  if (eol === '\r\n' && !HAS_NON_CRLF_LINE_ENDING.test(value)) {
+    return value;
+  }
+
+  return value.replace(ALL_LINE_ENDINGS, eol);
 };
 
 // initialize supported languages

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -225,7 +225,7 @@ export function MonacoEditor({
    */
   const lastKnownValueRef = useRef<string>(value ?? defaultValue);
   useEffect(() => {
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && value !== lastKnownValueRef.current) {
       const modelEol = editor.current?.getModel()?.getEOL();
       lastKnownValueRef.current = modelEol ? normalizeEndOfLine(value, modelEol) : value;
     }
@@ -362,7 +362,7 @@ export function MonacoEditor({
     if (editor.current) {
       // In controlled mode, `value` changes on every keystroke. Avoid calling `editor.getValue()`
       // (which materializes the full model) by comparing against our shadow copy first.
-      if (typeof value !== 'string') {
+      if (typeof value !== 'string' || value === lastKnownValueRef.current) {
         return;
       }
 


### PR DESCRIPTION
Closes #276552

## Summary

- Keeps the React-side CodeEditor shadow value in the same end-of-line representation as the Monaco model.
- Prevents Monaco change offsets from being applied to the wrong string coordinate space when the model uses CRLF and the controlled value uses LF.
- Skips EOL normalization and edit operations when a controlled rerender already matches the shadow value, preserving the large-buffer hot path.
- Adds regression coverage for both LF/CRLF mismatch directions, with test events using the model EOL.

## Root Cause

The CodeEditor performance optimization in #251173 avoided per-keystroke `editor.getValue()` calls by applying Monaco `event.changes` to a React-side shadow string.

On Windows, Monaco can use CRLF model coordinates while the controlled React value uses LF. Monaco reports `rangeOffset` and `rangeLength` in the model's string coordinate space, so applying those offsets to an LF shadow shifts edits after preceding newlines and can corrupt persisted editor content.

## Fix

- Normalize controlled values to the current Monaco model EOL before storing or comparing the shadow value.
- Return the original string when normalization is not needed, including the CRLF case where every line break is already a CRLF pair.
- Check the controlled value against the shadow before inspecting line endings, avoiding repeated full-buffer scans on matching controlled rerenders.
- Keep the existing incremental change path so the performance optimization remains in place.
- Make the EOL-mismatch tests construct change events with the Monaco model's current EOL.

## Before/After Screenshots (or Video)

Not included. The regression affects persisted editor text after refresh rather than a distinct visual presentation.

## Test Plan

Manual reproduction/verification:

1. Use a Windows browser, or simulate a Windows user agent before Monaco loads.
2. Open Dev Tools Console with the default multi-line sample text.
3. Edit a request after several preceding newlines, for example change `GET /my-index/_search?q="rocky mountain"` to `GET /my-index-2/_search?q="rocky mountain"`.
4. Wait for Console autosave, then refresh the page.
5. Before this fix, the restored buffer can contain duplicated/truncated text around the edited range. After this fix, the edited request is preserved exactly.

Automated checks:

- `node scripts/eslint src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx` passed.
- `node scripts/jest src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx` passed with 9 tests.
- `node scripts/type_check --project src/platform/packages/shared/shared-ux/code_editor/impl/tsconfig.type_check.json` passed.

## Release Note

Fixed a Windows-specific code editor issue that could corrupt multi-line edited text after refresh.

Assisted with Copilot using GPT-5.5 and GPT-5.6 Sol


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->