### PR TITLE
[Security Solution][Flyout] toggle between legacy and new ioc flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/indicator/components/comment_children.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/indicator/components/comment_children.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import {
   CommentChildren,
   INDICATOR_FEED_NAME_TEST_ID,
@@ -19,10 +19,30 @@ import { useIndicatorById } from '../hooks/use_indicator_by_id';
 import type { Indicator } from '../../../../../common/threat_intelligence/types/indicator';
 import { generateMockFileIndicator } from '../../../../../common/threat_intelligence/types/indicator';
 import { LOADING_LOGO_TEST_ID } from './test_ids';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+
+const mockOpenFlyout = jest.fn();
+
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout }),
+}));
 
 jest.mock('../hooks/use_indicator_by_id');
+jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
 
 describe('attachment_children initComponent', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+  });
+
   it('should render the basic values', () => {
     const id: string = 'abc123';
     const metadata: IndicatorAttachmentMetadata = {
@@ -65,5 +85,66 @@ describe('attachment_children initComponent', () => {
       </TestProvidersComponent>
     );
     expect(getByTestId(LOADING_LOGO_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should open the legacy expandable flyout when the new flyout is disabled', () => {
+    const id: string = 'abc123';
+    const metadata: IndicatorAttachmentMetadata = {
+      indicatorName: 'indicatorName',
+      indicatorFeedName: 'indicatorFeedName',
+      indicatorType: 'indicatorType',
+    };
+    const indicator = generateMockFileIndicator();
+
+    (useIndicatorById as jest.MockedFunction<typeof useIndicatorById>).mockReturnValue({
+      indicator,
+      isLoading: false,
+    });
+
+    const { getByTestId } = render(
+      <TestProvidersComponent>
+        <CommentChildren id={id} metadata={metadata} />
+      </TestProvidersComponent>
+    );
+
+    fireEvent.click(getByTestId(INDICATOR_NAME_TEST_ID));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: 'ioc-details-right',
+        params: {
+          id: indicator._id,
+        },
+      },
+    });
+    expect(flyoutApi.openIocFlyout).not.toHaveBeenCalled();
+  });
+
+  it('should open the new IOC flyout when the new flyout is enabled and the indicator is defined', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    const id: string = 'abc123';
+    const metadata: IndicatorAttachmentMetadata = {
+      indicatorName: 'indicatorName',
+      indicatorFeedName: 'indicatorFeedName',
+      indicatorType: 'indicatorType',
+    };
+    const indicator = generateMockFileIndicator();
+
+    (useIndicatorById as jest.MockedFunction<typeof useIndicatorById>).mockReturnValue({
+      indicator,
+      isLoading: false,
+    });
+
+    const { getByTestId } = render(
+      <TestProvidersComponent>
+        <CommentChildren id={id} metadata={metadata} />
+      </TestProvidersComponent>
+    );
+
+    fireEvent.click(getByTestId(INDICATOR_NAME_TEST_ID));
+
+    expect(flyoutApi.openIocFlyout).toHaveBeenCalledWith({ indicator });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/indicator/components/comment_children.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/indicator/components/comment_children.tsx
@@ -10,9 +10,12 @@ import React, { useCallback } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiLoadingLogo, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { IOCRightPanelKey } from '../../../../flyout/ioc_details/constants/panel_keys';
 import { LOADING_LOGO_TEST_ID } from './test_ids';
 import { useStyles } from './styles';
 import { useIndicatorById } from '../hooks/use_indicator_by_id';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import type { IndicatorAttachmentMetadata } from '..';
 
 export const INDICATOR_NAME_TEST_ID = 'tiCasesIndicatorName';
@@ -42,19 +45,25 @@ export const CommentChildren: FC<CommentChildrenProps> = ({ id, metadata }) => {
   const { indicatorName, indicatorType, indicatorFeedName } = metadata;
 
   const { openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openIocFlyout } = useFlyoutApi();
 
-  const open = useCallback(
-    () =>
+  const open = useCallback(() => {
+    if (enableNewFlyout) {
+      if (indicator) {
+        openIocFlyout({ indicator });
+      }
+    } else {
       openFlyout({
         right: {
-          id: 'ioc-details-right',
+          id: IOCRightPanelKey,
           params: {
             id: indicator?._id,
           },
         },
-      }),
-    [indicator?._id, openFlyout]
-  );
+      });
+    }
+  }, [enableNewFlyout, indicator, openIocFlyout, openFlyout]);
 
   if (isLoading) {
     return <EuiLoadingLogo data-test-subj={LOADING_LOGO_TEST_ID} logo="logoSecurity" size="xl" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.mock.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IocFlyoutApi } from './use_ioc_flyout_api';
+
+/**
+ * Returns a `useIocFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useIocFlyoutApi).mockReturnValue(createIocFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createIocFlyoutApiMock = (): jest.Mocked<IocFlyoutApi> => ({
+  openIocFlyout: jest.fn(),
+  openIocFlyoutAsChild: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { Indicator } from '../../../common/threat_intelligence/types/indicator';
+import { useIocFlyoutApi } from './use_ioc_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+  defaultToolsFlyoutProperties: { size: 'm' },
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+const indicator = {
+  _id: 'ioc-1',
+  fields: { 'threat.indicator.type': ['url'] },
+} as unknown as Indicator;
+
+describe('useIocFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  it('openIocFlyout opens a system flyout as a new session with the document properties', () => {
+    const { result } = renderHook(() => useIocFlyoutApi());
+    result.current.openIocFlyout({ indicator });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openIocFlyoutAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useIocFlyoutApi());
+    result.current.openIocFlyoutAsChild({ indicator });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({
+        size: 's',
+        session: 'inherit',
+        historyKey: documentFlyoutHistoryKey,
+      })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useIocFlyoutApi());
+    result.current.openIocFlyout({ indicator });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { Indicator } from '../../../common/threat_intelligence/types/indicator';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import type { CellActionRenderer } from '../shared/components/cell_actions';
+import { cellActionRenderer } from '../shared/components/cell_actions';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+// Lazy-loaded so consumers of this hook don't statically pull the IOC flyout graph into their
+// bundle; the chunk only loads when the flyout is actually opened.
+const IOCDetails = lazy(() => import('./main').then((m) => ({ default: m.IOCDetails })));
+
+export interface OpenIocFlyoutParams {
+  /** The indicator to render in the flyout. Its `_id`/`fields` are used to build the flyout's record. */
+  indicator: Indicator;
+  /** Renderer for cell actions in the flyout. Defaults to the standard `cellActionRenderer`. */
+  renderCellActions?: CellActionRenderer;
+}
+
+export interface IocFlyoutApi {
+  /**
+   * Opens the indicator (IOC) details flyout as a new, top-level flyout (starting a fresh session).
+   * Use this from outside any flyout — e.g. a table row, a case attachment.
+   */
+  openIocFlyout: (params: OpenIocFlyoutParams) => void;
+  /**
+   * Opens the indicator (IOC) details flyout as a child of the currently open flyout (nested in its
+   * history stack, so the back button returns to it). Use this from within an already-open flyout.
+   */
+  openIocFlyoutAsChild: (params: OpenIocFlyoutParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) IOC flyout, in the same mindset as
+ * `useExpandableFlyoutApi`, `useDocumentFlyoutApi`, etc. It encapsulates the provider wiring
+ * (`flyoutProviders` + `overlays.openSystemFlyout`), the flyout properties, and building the
+ * `IOCDetails` record from the indicator, so call sites don't repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useIocFlyoutApi = (): IocFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  // `session` is the only thing that differs between a main and a child flyout. It is kept private
+  // here so callers never have to reason about it: they pick `openIocFlyout` (main) or
+  // `openIocFlyoutAsChild` (child) and this helper maps that to the right session.
+  const open = useCallback(
+    (children: ReactNode, session: OverlaySystemFlyoutOpenOptions['session']) => {
+      const properties: OverlaySystemFlyoutOpenOptions = {
+        ...defaultDocumentFlyoutProperties,
+        historyKey,
+        session,
+      };
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  // Builds the flyout content (an `IOCDetails` element with a record derived from the indicator),
+  // shared by both the main and child open methods.
+  const buildContent = useCallback(
+    ({ indicator, renderCellActions = cellActionRenderer }: OpenIocFlyoutParams): ReactNode => {
+      const hit: DataTableRecord = {
+        id: indicator._id as string,
+        raw: { _id: indicator._id as string, fields: indicator.fields },
+        flattened: indicator.fields as Record<string, unknown>,
+      };
+      return <IOCDetails hit={hit} renderCellActions={renderCellActions} />;
+    },
+    []
+  );
+
+  const openIocFlyout = useCallback(
+    (params: OpenIocFlyoutParams) => open(buildContent(params), 'start'),
+    [open, buildContent]
+  );
+
+  const openIocFlyoutAsChild = useCallback(
+    (params: OpenIocFlyoutParams) => open(buildContent(params), 'inherit'),
+    [open, buildContent]
+  );
+
+  return useMemo(
+    () => ({ openIocFlyout, openIocFlyoutAsChild }),
+    [openIocFlyout, openIocFlyoutAsChild]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
@@ -7,6 +7,7 @@
 
 import type { FlyoutApi } from './use_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+import { createIocFlyoutApiMock } from './ioc/use_ioc_flyout_api.mock';
 import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
 import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
 
@@ -18,6 +19,7 @@ import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
  */
 export const createFlyoutApiMock = (): jest.Mocked<FlyoutApi> => ({
   ...createAttackFlyoutApiMock(),
+  ...createIocFlyoutApiMock(),
   ...createNetworkFlyoutApiMock(),
   ...createRuleFlyoutApiMock(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
@@ -7,8 +7,11 @@
 
 import { renderHook } from '@testing-library/react';
 import { FlowTargetSourceDest } from '../../common/search_strategy/security_solution/network';
+import type { Indicator } from '../../common/threat_intelligence/types/indicator';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+import { useIocFlyoutApi } from './ioc/use_ioc_flyout_api';
+import { createIocFlyoutApiMock } from './ioc/use_ioc_flyout_api.mock';
 import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
 import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
 import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
@@ -16,6 +19,7 @@ import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
 import { useFlyoutApi } from './use_flyout_api';
 
 jest.mock('./attack/use_attack_flyout_api');
+jest.mock('./ioc/use_ioc_flyout_api');
 jest.mock('./network/use_network_flyout_api');
 jest.mock('./rule/use_rule_flyout_api');
 
@@ -24,11 +28,13 @@ describe('useFlyoutApi', () => {
     jest.clearAllMocks();
   });
 
-  it('exposes the attack, network, and rule flyout methods from composed per-type hooks', () => {
+  it('exposes the attack, IOC, network, and rule methods from composed per-type hooks', () => {
     const attackApi = createAttackFlyoutApiMock();
+    const iocApi = createIocFlyoutApiMock();
     const networkApi = createNetworkFlyoutApiMock();
     const ruleApi = createRuleFlyoutApiMock();
     jest.mocked(useAttackFlyoutApi).mockReturnValue(attackApi);
+    jest.mocked(useIocFlyoutApi).mockReturnValue(iocApi);
     jest.mocked(useNetworkFlyoutApi).mockReturnValue(networkApi);
     jest.mocked(useRuleFlyoutApi).mockReturnValue(ruleApi);
 
@@ -37,10 +43,13 @@ describe('useFlyoutApi', () => {
     const attackParams = { attackId: 'attack-1', indexName: '.alerts-security' };
     const networkParams = { ip: '1.2.3.4', flowTarget: FlowTargetSourceDest.source };
     const ruleParams = { ruleId: 'rule-1' };
+    const iocParams = { indicator: { _id: 'ioc-1', fields: {} } as unknown as Indicator };
 
     // The facade surfaces the composed methods, and calling one delegates to the per-type hook.
     result.current.openAttackFlyout(attackParams);
     result.current.openAttackFlyoutAsChild(attackParams);
+    result.current.openIocFlyout(iocParams);
+    result.current.openIocFlyoutAsChild(iocParams);
     result.current.openNetworkFlyout(networkParams);
     result.current.openNetworkFlyoutAsChild(networkParams);
     result.current.openRuleFlyout(ruleParams);
@@ -48,6 +57,8 @@ describe('useFlyoutApi', () => {
 
     expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(attackParams);
     expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(attackParams);
+    expect(iocApi.openIocFlyout).toHaveBeenCalledWith(iocParams);
+    expect(iocApi.openIocFlyoutAsChild).toHaveBeenCalledWith(iocParams);
     expect(networkApi.openNetworkFlyout).toHaveBeenCalledWith(networkParams);
     expect(networkApi.openNetworkFlyoutAsChild).toHaveBeenCalledWith(networkParams);
     expect(ruleApi.openRuleFlyout).toHaveBeenCalledWith(ruleParams);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
@@ -8,6 +8,8 @@
 import { useMemo } from 'react';
 import type { AttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
+import type { IocFlyoutApi } from './ioc/use_ioc_flyout_api';
+import { useIocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import type { NetworkFlyoutApi } from './network/use_network_flyout_api';
 import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
 import type { RuleFlyoutApi } from './rule/use_rule_flyout_api';
@@ -33,19 +35,21 @@ import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
  *
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
-export type FlyoutApi = AttackFlyoutApi & NetworkFlyoutApi & RuleFlyoutApi;
+export type FlyoutApi = AttackFlyoutApi & IocFlyoutApi & NetworkFlyoutApi & RuleFlyoutApi;
 
 export const useFlyoutApi = (): FlyoutApi => {
   const attack = useAttackFlyoutApi();
+  const ioc = useIocFlyoutApi();
   const network = useNetworkFlyoutApi();
   const rule = useRuleFlyoutApi();
 
   return useMemo(
     () => ({
       ...attack,
+      ...ioc,
       ...network,
       ...rule,
     }),
-    [attack, network, rule]
+    [attack, ioc, network, rule]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.test.tsx
@@ -6,19 +6,37 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { OpenIndicatorFlyoutButton } from './open_flyout_button';
 import { generateMockIndicator } from '../../../../../../common/threat_intelligence/types/indicator';
 import { TestProvidersComponent } from '../../../../mocks/test_providers';
 import { BUTTON_TEST_ID } from './test_ids';
+import { IOCRightPanelKey } from '../../../../../flyout/ioc_details/constants/panel_keys';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
-jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
-  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
+const mockOpenFlyout = jest.fn();
+
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout }),
 }));
+
+jest.mock('../../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 const mockIndicator = generateMockIndicator();
 
-describe('<IndicatorsFlyout />', () => {
+describe('<OpenIndicatorFlyoutButton />', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+  });
+
   it('should render expand button', () => {
     const { getByTestId } = render(
       <TestProvidersComponent>
@@ -27,5 +45,40 @@ describe('<IndicatorsFlyout />', () => {
     );
 
     expect(getByTestId(BUTTON_TEST_ID).innerHTML).toContain('maximize');
+  });
+
+  it('should open the legacy expandable flyout when the new flyout is disabled', () => {
+    const { getByTestId } = render(
+      <TestProvidersComponent>
+        <OpenIndicatorFlyoutButton indicator={mockIndicator} />
+      </TestProvidersComponent>
+    );
+
+    fireEvent.click(getByTestId(BUTTON_TEST_ID));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: IOCRightPanelKey,
+        params: {
+          id: mockIndicator._id,
+        },
+      },
+    });
+    expect(flyoutApi.openIocFlyout).not.toHaveBeenCalled();
+  });
+
+  it('should open the new IOC flyout when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    const { getByTestId } = render(
+      <TestProvidersComponent>
+        <OpenIndicatorFlyoutButton indicator={mockIndicator} />
+      </TestProvidersComponent>
+    );
+
+    fireEvent.click(getByTestId(BUTTON_TEST_ID));
+
+    expect(flyoutApi.openIocFlyout).toHaveBeenCalledWith({ indicator: mockIndicator });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/open_flyout_button.tsx
@@ -5,21 +5,13 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import type { DataTableRecord } from '@kbn/discover-utils';
 import type { Indicator } from '../../../../../../common/threat_intelligence/types/indicator';
 import { IOCRightPanelKey } from '../../../../../flyout/ioc_details/constants/panel_keys';
-import { useKibana } from '../../../../../common/lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
-import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
-import { IOCDetails } from '../../../../../flyout_v2/ioc/main';
-import { cellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
-import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { BUTTON_TEST_ID } from './test_ids';
 import { VIEW_DETAILS_BUTTON_LABEL } from './translations';
 
@@ -35,37 +27,12 @@ export interface OpenIndicatorFlyoutButtonProps {
  */
 export const OpenIndicatorFlyoutButton = memo(({ indicator }: OpenIndicatorFlyoutButtonProps) => {
   const { openFlyout } = useExpandableFlyoutApi();
-  const { services } = useKibana();
-  const { overlays } = services;
   const enableNewFlyout = useIsNewFlyoutEnabled();
-  const store = useStore();
-  const history = useHistory();
-  const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-
-  const hit = useMemo<DataTableRecord>(
-    () => ({
-      id: indicator._id as string,
-      raw: { _id: indicator._id as string, fields: indicator.fields },
-      flattened: indicator.fields as Record<string, unknown>,
-    }),
-    [indicator]
-  );
+  const { openIocFlyout } = useFlyoutApi();
 
   const open = useCallback(() => {
     if (enableNewFlyout) {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <IOCDetails hit={hit} renderCellActions={cellActionRenderer} />,
-        }),
-        {
-          ...defaultFlyoutProperties,
-          historyKey: documentFlyoutHistoryKey,
-          session: 'start',
-        }
-      );
+      openIocFlyout({ indicator });
     } else {
       openFlyout({
         right: {
@@ -76,17 +43,7 @@ export const OpenIndicatorFlyoutButton = memo(({ indicator }: OpenIndicatorFlyou
         },
       });
     }
-  }, [
-    enableNewFlyout,
-    overlays,
-    services,
-    store,
-    history,
-    hit,
-    indicator._id,
-    defaultFlyoutProperties,
-    openFlyout,
-  ]);
+  }, [enableNewFlyout, openIocFlyout, indicator, openFlyout]);
 
   return (
     <EuiToolTip content={VIEW_DETAILS_BUTTON_LABEL} disableScreenReaderOutput>


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is only focusing on the ioc flyout. A couple of follow up PRs will take care of the other flyouts.

The PR also introduces single developer-facing APIs to open the new ioc flyout, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:
- `useFlyoutApi()`: that is inernally calling the network flyout specific api:
  - `useIocFlyoutApi()`: which returns `openIocFlyout` that opens the IOC flyout

> [!TIP]
> Developers should use - unless not possible - the `useFlyoutApi()` to open all of their flyouts

Every external entry point that opened one of these legacy flyouts now routes through the matching API when the new flyout is enabled.

> [!WARNING]
> No legacy flyout behavior change introduced! Only toggling between the legacy and new flyout based off the advanced setting.

#### Advanced setting off (default)

https://github.com/user-attachments/assets/799d9cf3-e7ef-41a0-b5db-599a73b23ace

#### Advanced setting on

https://github.com/user-attachments/assets/bc6049df-e5a8-4b93-aae4-c74cdd8471d2

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new flyout/tool opens from each surface.
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->