### PR TITLE
[AlertingV2] Add context to query sandbox flyout title

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -128,6 +128,15 @@ const EDIT_MODE_OPTIONS = [
   { id: 'yaml', label: YAML_VIEW_LABEL, iconType: 'editorCodeBlock' },
 ];
 
+const getQuerySandboxTitle = (isBuilderMode: boolean) =>
+  isBuilderMode
+    ? i18n.translate('xpack.alertingV2.composeDiscover.querySandbox.builderContextualTitle', {
+        defaultMessage: 'Query sandbox: Preview results',
+      })
+    : i18n.translate('xpack.alertingV2.composeDiscover.querySandbox.editorContextualTitle', {
+        defaultMessage: 'Query sandbox: Edit queries',
+      });
+
 const getFlyoutTitle = (mode: ComposeDiscoverMode): string => {
   if (mode === 'clone') return CLONE_TITLE;
   if (mode === 'edit') return EDIT_TITLE;
@@ -1303,6 +1312,7 @@ export function ComposeDiscoverFlyout({
                 helpText={sandboxHelpText}
                 headerActions={sandboxHeaderActions}
                 onApply={isBuilderMode ? undefined : handleSandboxApply}
+                title={getQuerySandboxTitle(isBuilderMode)}
               />
             )}
           </EuiFlyout>


### PR DESCRIPTION
## Summary

Adds more descriptive titles to query sandbox flyout (varies by mode)

Closes https://github.com/elastic/rna-program/issues/553

<img width="1557" height="789" alt="Screenshot 2026-07-08 at 10 42 29 AM" src="https://github.com/user-attachments/assets/9408e130-199a-440c-8683-ffb1ffa35dcb" />

<img width="1554" height="782" alt="Screenshot 2026-07-08 at 10 41 35 AM" src="https://github.com/user-attachments/assets/82595744-a95c-4ed3-9d5b-7daa430ab5fb" />


