### PR TITLE
[Docs] Document theme:darkMode default (system from 9.5)

### DIFF
--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -107,7 +107,7 @@ groups:
 
           The default value depends on your version:
 
-          * {applies_to}`stack: ga 9.5` Defaults to `system`.
+          * {applies_to}`stack: ga 9.5+` Defaults to `system`.
           * {applies_to}`stack: ga 9.0-9.4` Defaults to `disabled`.
         datatype: enum
         options:

--- a/docs/reference/advanced-settings-space.yml
+++ b/docs/reference/advanced-settings-space.yml
@@ -104,6 +104,11 @@ groups:
         id: theme-darkmode
         description: |
           The UI theme that the {{product.kibana}} UI should use. Set to `enabled` or `disabled` to enable or disable the dark theme. Set to `system` to have the {{product.kibana}} UI theme follow the system theme. You must refresh the page to apply the setting.
+
+          The default value depends on your version:
+
+          * {applies_to}`stack: ga 9.5` Defaults to `system`.
+          * {applies_to}`stack: ga 9.0-9.4` Defaults to `disabled`.
         datatype: enum
         options:
           - option: enabled


### PR DESCRIPTION
## Summary

The `theme:darkMode` advanced setting reference (in `docs/reference/advanced-settings-space.yml`) doesn't document a default value. As of 9.5 the registered default changed from `disabled` to `system` (see #273826 / #242973), so a user with no saved color-mode preference now follows their OS color scheme.

This PR adds the default to the setting description using the automated-settings per-version defaults idiom (inline `{applies_to}` badges in a bulleted list):

* `stack: ga 9.5` — defaults to `system`
* `stack: ga 9.0-9.4` — defaults to `disabled` (preserved cumulatively)

The companion user-facing how-to update is in elastic/docs-content#7278.

### Verification

Code: Default change verified against #273826 (`src/core/packages/ui-settings/server-internal/src/settings/theme.ts` → `getDefaultDarkModeValue` returns `'system'` for dist builds).

Rendered docs:
<img width="755" height="500" alt="image" src="https://github.com/user-attachments/assets/c81b79a9-2097-492d-8df5-832418041f84" />


---

> **AI-generated draft** — created with Claude Opus 4.8. Review for accuracy before merging.