### PR TITLE
[Security Solution][Flyout] toggle between legacy and new attack flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/kpis/attacks_list_panel/attacks_list_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/kpis/attacks_list_panel/attacks_list_panel.test.tsx
@@ -15,27 +15,16 @@ import { AttackDetailsRightPanelKey } from '../../../../../flyout/attack_details
 import { useKibana } from '../../../../../common/lib/kibana';
 import { AttacksEventTypes } from '../../../../../common/lib/telemetry';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('../../../../../common/lib/kibana');
-jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
-  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
-}));
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../../../../flyout_v2/use_flyout_api');
 jest.mock('./use_attacks_list_data');
 jest.mock('@kbn/expandable-flyout');
 jest.mock('../../../../../entity_analytics/components/severity/severity_bar', () => ({
   SeverityBar: () => <div data-test-subj="severity-bar" />,
-}));
-jest.mock('../../../../../flyout_v2/shared/hooks/use_default_flyout_properties');
-jest.mock('../../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: jest.fn(({ children }: { children: React.ReactNode }) => (
-    <div data-test-subj="flyout-providers">{children}</div>
-  )),
-}));
-jest.mock('../../../../../flyout_v2/attack/main/attack_flyout_wrapper', () => ({
-  AttackFlyoutWrapper: (props: unknown) => (
-    <div data-test-subj="attack-flyout-wrapper">{JSON.stringify(props)}</div>
-  ),
 }));
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -53,11 +42,14 @@ describe('AttacksListPanel', () => {
   } as unknown as DataView;
 
   const mockOpenFlyout = jest.fn();
-  const mockOpenSystemFlyout = jest.fn();
   const reportEvent = jest.fn();
+
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
       openFlyout: mockOpenFlyout,
@@ -67,18 +59,7 @@ describe('AttacksListPanel', () => {
         telemetry: {
           reportEvent,
         },
-        overlays: {
-          openSystemFlyout: mockOpenSystemFlyout,
-        },
       },
-    });
-    (useDefaultDocumentFlyoutProperties as jest.Mock).mockReturnValue({
-      maxWidth: 1200,
-      minWidth: 400,
-      ownFocus: false,
-      paddingSize: 'm',
-      resizable: true,
-      size: 's',
     });
   });
 
@@ -163,14 +144,14 @@ describe('AttacksListPanel', () => {
         },
       },
     });
-    expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openAttackFlyout).not.toHaveBeenCalled();
     expect(reportEvent).toHaveBeenCalledWith(AttacksEventTypes.DetailsFlyoutOpened, {
       id: 'attack-1',
       source: 'attacks_page_summary_kpi',
     });
   });
 
-  it('calls openSystemFlyout with AttackFlyoutWrapper when enableNewFlyout setting is on', () => {
+  it('calls openAttackFlyout when enableNewFlyout setting is on', () => {
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
     const mockRefetch = jest.fn();
     const mockItems = [{ id: 'attack-1', name: 'Attack 1', alertsCount: 5, severityCount: {} }];
@@ -191,7 +172,12 @@ describe('AttacksListPanel', () => {
     const link = screen.getByText('Attack 1');
     link.click();
 
-    expect(mockOpenSystemFlyout).toHaveBeenCalled();
+    expect(flyoutApi.openAttackFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attackId: 'attack-1',
+        indexName: 'test-index-pattern',
+      })
+    );
     expect(mockOpenFlyout).not.toHaveBeenCalled();
     expect(reportEvent).toHaveBeenCalledWith(AttacksEventTypes.DetailsFlyoutOpened, {
       id: 'attack-1',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/kpis/attacks_list_panel/attacks_list_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/kpis/attacks_list_panel/attacks_list_panel.tsx
@@ -22,8 +22,6 @@ import type { Filter, Query } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
-import { useStore } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import { AttackDetailsRightPanelKey } from '../../../../../flyout/attack_details/constants/panel_keys';
 import { SeverityBar } from '../../../../../entity_analytics/components/severity/severity_bar';
 import { useAttacksListData } from './use_attacks_list_data';
@@ -31,10 +29,7 @@ import type { AttacksListItem } from './types';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { AttacksEventTypes } from '../../../../../common/lib/telemetry';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
-import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
-import { AttackFlyoutWrapper } from '../../../../../flyout_v2/attack/main/attack_flyout_wrapper';
-import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 
 const PAGE_SIZE = 10;
 const TABLE_WIDTH = 385;
@@ -74,12 +69,9 @@ export interface AttacksListPanelProps {
 export const AttacksListPanel = React.memo<AttacksListPanelProps>(
   ({ filters, query, dataView }) => {
     const { openFlyout } = useExpandableFlyoutApi();
-    const { services } = useKibana();
-    const { telemetry, overlays } = services;
+    const { telemetry } = useKibana().services;
     const enableNewFlyout = useIsNewFlyoutEnabled();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-    const store = useStore();
-    const history = useHistory();
+    const { openAttackFlyout } = useFlyoutApi();
 
     const { items, isLoading, pageIndex, setPageIndex, pageSize, setPageSize, total, refetch } =
       useAttacksListData({
@@ -104,25 +96,11 @@ export const AttacksListPanel = React.memo<AttacksListPanelProps>(
               className="eui-textTruncate"
               onClick={() => {
                 if (enableNewFlyout) {
-                  overlays.openSystemFlyout(
-                    flyoutProviders({
-                      services,
-                      store,
-                      history,
-                      children: (
-                        <AttackFlyoutWrapper
-                          attackId={item.id}
-                          indexName={dataView.getIndexPattern()}
-                          onAttackUpdated={refetch}
-                        />
-                      ),
-                    }),
-                    {
-                      ...defaultFlyoutProperties,
-                      historyKey: documentFlyoutHistoryKey,
-                      session: 'start',
-                    }
-                  );
+                  openAttackFlyout({
+                    attackId: item.id,
+                    indexName: dataView.getIndexPattern(),
+                    onAttackUpdated: refetch,
+                  });
                 } else {
                   openFlyout({
                     right: {
@@ -168,18 +146,7 @@ export const AttacksListPanel = React.memo<AttacksListPanelProps>(
           ),
         },
       ],
-      [
-        dataView,
-        defaultFlyoutProperties,
-        enableNewFlyout,
-        history,
-        openFlyout,
-        overlays,
-        refetch,
-        services,
-        store,
-        telemetry,
-      ]
+      [dataView, enableNewFlyout, openAttackFlyout, openFlyout, refetch, telemetry]
     );
 
     const pagination = {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.test.tsx
@@ -32,15 +32,15 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { AttacksEventTypes } from '../../../../common/lib/telemetry';
 import { useLocalStorage } from '../../../../common/components/local_storage';
 import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
-import { useDefaultDocumentFlyoutProperties } from '../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('../../../../common/components/local_storage', () => ({
   useLocalStorage: jest.fn(),
 }));
 jest.mock('../../../../common/lib/kibana');
-jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
-  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
-}));
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../../../flyout_v2/use_flyout_api');
 jest.mock('@kbn/expandable-flyout');
 jest.mock('../../user_info');
 jest.mock('../../../containers/detection_engine/lists/use_lists_config');
@@ -80,17 +80,6 @@ jest.mock('./attacks_view_options_popover', () => ({
   ),
 }));
 jest.mock('./grouping_settings/use_group_stats');
-jest.mock('../../../../flyout_v2/shared/hooks/use_default_flyout_properties');
-jest.mock('../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: jest.fn(({ children }: { children: React.ReactNode }) => (
-    <div data-test-subj="flyout-providers">{children}</div>
-  )),
-}));
-jest.mock('../../../../flyout_v2/attack/main/attack_flyout_wrapper', () => ({
-  AttackFlyoutWrapper: (props: unknown) => (
-    <div data-test-subj="attack-flyout-wrapper">{JSON.stringify(props)}</div>
-  ),
-}));
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useStore: () => ({ getState: jest.fn(), dispatch: jest.fn(), subscribe: jest.fn() }),
@@ -112,7 +101,6 @@ const mockUseExpandableFlyoutApi = useExpandableFlyoutApi as jest.Mock;
 const mockUseGroupStats = useGroupStats as jest.Mock;
 
 const reportEvent = jest.fn();
-const mockOpenSystemFlyout = jest.fn();
 
 const defaultProps: Parameters<typeof TableSection>[0] = {
   assignees: [],
@@ -125,30 +113,23 @@ const defaultProps: Parameters<typeof TableSection>[0] = {
 };
 
 describe('<TableSection />', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
   beforeEach(() => {
     (useLocalStorage as jest.Mock).mockReturnValue([
       [{ latestTimestamp: { order: 'desc' } }],
       jest.fn(),
     ]);
 
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
     (useKibana as jest.Mock).mockReturnValue({
       services: {
         telemetry: {
           reportEvent,
         },
-        overlays: {
-          openSystemFlyout: mockOpenSystemFlyout,
-        },
       },
-    });
-    (useDefaultDocumentFlyoutProperties as jest.Mock).mockReturnValue({
-      maxWidth: 1200,
-      minWidth: 400,
-      ownFocus: false,
-      paddingSize: 'm',
-      resizable: true,
-      size: 's',
     });
     mockUseGetDefaultGroupTitleRenderers.mockReturnValue({
       defaultGroupTitleRenderers: jest.fn(),
@@ -275,10 +256,10 @@ describe('<TableSection />', () => {
         },
       },
     });
-    expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openAttackFlyout).not.toHaveBeenCalled();
   });
 
-  it('should call openSystemFlyout with AttackFlyoutWrapper when enableNewFlyout is true', async () => {
+  it('should call openAttackFlyout when enableNewFlyout is true', async () => {
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
     mockUseAttackGroupHandler.mockReturnValue({
       getAttack: jest.fn().mockReturnValue({ id: 'attack-1' }),
@@ -298,7 +279,12 @@ describe('<TableSection />', () => {
     const { openAttackDetailsFlyout } = mockUseGetDefaultGroupTitleRenderers.mock.calls[0][0];
     openAttackDetailsFlyout('group-1', {});
 
-    expect(mockOpenSystemFlyout).toHaveBeenCalled();
+    expect(flyoutApi.openAttackFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attackId: 'attack-1',
+        indexName: '.alerts-security.alerts-default',
+      })
+    );
     expect(reportEvent).toHaveBeenCalledWith(AttacksEventTypes.DetailsFlyoutOpened, {
       id: 'attack-1',
       source: 'attacks_page_table',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -6,8 +6,6 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { useStore } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import { isNonLocalIndexName } from '@kbn/es-query';
@@ -26,10 +24,7 @@ import { inputsSelectors } from '../../../../common/store/inputs';
 import { useKibana } from '../../../../common/lib/kibana';
 import { AttacksEventTypes } from '../../../../common/lib/telemetry';
 import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
-import { useDefaultDocumentFlyoutProperties } from '../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
-import { flyoutProviders } from '../../../../flyout_v2/shared/components/flyout_provider';
-import { AttackFlyoutWrapper } from '../../../../flyout_v2/attack/main/attack_flyout_wrapper';
-import { documentFlyoutHistoryKey } from '../../../../flyout_v2/shared/constants/flyout_history';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { useUserData } from '../../user_info';
 import { useListsConfig } from '../../../containers/detection_engine/lists/use_lists_config';
 import {
@@ -133,12 +128,9 @@ export const TableSection = React.memo(
 
     const { to, from } = useGlobalTime();
 
-    const { services } = useKibana();
-    const { telemetry, overlays } = services;
+    const { telemetry } = useKibana().services;
     const enableNewFlyout = useIsNewFlyoutEnabled();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-    const store = useStore();
-    const history = useHistory();
+    const { openAttackFlyout } = useFlyoutApi();
 
     const [{ loading: userInfoLoading }] = useUserData();
 
@@ -177,25 +169,7 @@ export const TableSection = React.memo(
         const attack = getAttack(selectedGroup, bucket);
         if (attack) {
           if (enableNewFlyout) {
-            overlays.openSystemFlyout(
-              flyoutProviders({
-                services,
-                store,
-                history,
-                children: (
-                  <AttackFlyoutWrapper
-                    attackId={attack.id}
-                    indexName={dataView.getIndexPattern()}
-                    onAttackUpdated={() => {}}
-                  />
-                ),
-              }),
-              {
-                ...defaultFlyoutProperties,
-                historyKey: documentFlyoutHistoryKey,
-                session: 'start',
-              }
-            );
+            openAttackFlyout({ attackId: attack.id, indexName: dataView.getIndexPattern() });
           } else {
             openFlyout({
               right: {
@@ -213,18 +187,7 @@ export const TableSection = React.memo(
           });
         }
       },
-      [
-        dataView,
-        defaultFlyoutProperties,
-        enableNewFlyout,
-        getAttack,
-        history,
-        openFlyout,
-        overlays,
-        services,
-        store,
-        telemetry,
-      ]
+      [dataView, enableNewFlyout, getAttack, openAttackFlyout, openFlyout, telemetry]
     );
 
     const { defaultGroupTitleRenderers } = useGetDefaultGroupTitleRenderers({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.tsx
@@ -13,16 +13,12 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../../../shared/hooks/use_default_flyout_properties';
+import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
 import { noopCellActionRenderer } from '../../../shared/components/cell_actions';
 import { DocumentFlyoutWrapper } from '../../../document/main/document_flyout_wrapper';
-import { CorrelationsDetails } from '../../tools/correlations';
-import { EntitiesDetails } from '../../tools/entities';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { AISummarySection } from '../components/ai_summary_section';
 import { VisualizationsSection } from '../components/visualizations_section';
 import { InsightsSection } from '../components/insights_section';
@@ -53,6 +49,7 @@ export const OverviewTab = memo(({ hit, onAttackUpdated }: OverviewTabProps) => 
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const { openAttackCorrelations, openAttackEntities } = useFlyoutApi();
 
   const alertIds = useAttackAlertIds(hit);
 
@@ -86,31 +83,13 @@ export const OverviewTab = memo(({ hit, onAttackUpdated }: OverviewTabProps) => 
   );
 
   const onShowCorrelations = useCallback(
-    () =>
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <CorrelationsDetails hit={hit} alertIds={alertIds} onShowAlert={onShowAlert} />,
-        }),
-        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
-      ),
-    [alertIds, history, historyKey, hit, onShowAlert, overlays, services, store]
+    () => openAttackCorrelations({ hit, alertIds, onShowAlert }),
+    [openAttackCorrelations, hit, alertIds, onShowAlert]
   );
 
   const onShowEntities = useCallback(
-    () =>
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <EntitiesDetails hit={hit} alertIds={alertIds} />,
-        }),
-        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
-      ),
-    [alertIds, history, historyKey, hit, overlays, services, store]
+    () => openAttackEntities({ hit, alertIds }),
+    [openAttackEntities, hit, alertIds]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.mock.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttackFlyoutApi } from './use_attack_flyout_api';
+
+/**
+ * Returns a `useAttackFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useAttackFlyoutApi).mockReturnValue(createAttackFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createAttackFlyoutApiMock = (): jest.Mocked<AttackFlyoutApi> => ({
+  openAttackFlyout: jest.fn(),
+  openAttackFlyoutAsChild: jest.fn(),
+  openAttackCorrelations: jest.fn(),
+  openAttackEntities: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { useAttackFlyoutApi } from './use_attack_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+  defaultToolsFlyoutProperties: { size: 'm' },
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+
+describe('useAttackFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  it('openAttackFlyout opens a system flyout as a new session with the document properties', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackFlyout({ attackId: 'attack-1', indexName: '.alerts-security' });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openAttackFlyoutAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackFlyoutAsChild({ attackId: 'attack-1', indexName: '.alerts-security' });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({
+        size: 's',
+        session: 'inherit',
+        historyKey: documentFlyoutHistoryKey,
+      })
+    );
+  });
+
+  it('openAttackCorrelations opens the correlations tool flyout with the tools properties', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackCorrelations({ hit, alertIds: ['alert-1'] });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openAttackEntities opens the entities tool flyout with the tools properties', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackEntities({ hit, alertIds: ['alert-1'] });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackFlyout({ attackId: 'attack-1', indexName: '.alerts-security' });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { noop } from 'lodash/fp';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import {
+  defaultToolsFlyoutProperties,
+  useDefaultDocumentFlyoutProperties,
+} from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+// Lazy-loaded so consumers of this hook don't statically pull the attack flyout graph into their
+// bundle; the chunk only loads when the flyout (or one of its tools) is actually opened.
+const AttackFlyoutWrapper = lazy(() =>
+  import('./main/attack_flyout_wrapper').then((m) => ({ default: m.AttackFlyoutWrapper }))
+);
+const CorrelationsDetails = lazy(() =>
+  import('./tools/correlations').then((m) => ({ default: m.CorrelationsDetails }))
+);
+const EntitiesDetails = lazy(() =>
+  import('./tools/entities').then((m) => ({ default: m.EntitiesDetails }))
+);
+
+export interface OpenAttackFlyoutParams {
+  /** Elasticsearch `_id` of the attack discovery alert. */
+  attackId: string;
+  /** Concrete `_index` the attack lives in. */
+  indexName: string;
+  /** Invoked after the attack is mutated inside the flyout, to let the caller refresh. Defaults to a no-op. */
+  onAttackUpdated?: () => void;
+}
+
+export interface OpenAttackCorrelationsParams {
+  /** The raw attack document hit. */
+  hit: DataTableRecord;
+  /** Ids of the alerts correlated to the attack. */
+  alertIds: string[];
+  /** Optional callback to open one of the correlated alerts. */
+  onShowAlert?: (id: string, indexName: string) => void;
+}
+
+export interface OpenAttackEntitiesParams {
+  /** The raw attack document hit. */
+  hit: DataTableRecord;
+  /** Ids of the alerts correlated to the attack. */
+  alertIds: string[];
+}
+
+export interface AttackFlyoutApi {
+  /**
+   * Opens the attack discovery details flyout as a new, top-level flyout (starting a fresh session).
+   * Use this from outside any flyout — e.g. a table row, a timeline row, a case attachment.
+   */
+  openAttackFlyout: (params: OpenAttackFlyoutParams) => void;
+  /**
+   * Opens the attack discovery details flyout as a child of the currently open flyout (nested in its
+   * history stack, so the back button returns to it). Use this from within an already-open flyout.
+   */
+  openAttackFlyoutAsChild: (params: OpenAttackFlyoutParams) => void;
+  /** Opens the attack's Correlations tool flyout (alerts correlated to the attack). */
+  openAttackCorrelations: (params: OpenAttackCorrelationsParams) => void;
+  /** Opens the attack's Entities tool flyout (hosts/users involved in the attack). */
+  openAttackEntities: (params: OpenAttackEntitiesParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) attack flyout and its tool flyouts, in the same
+ * mindset as `useExpandableFlyoutApi`, `useDocumentFlyoutApi`, etc. It encapsulates the provider
+ * wiring (`flyoutProviders` + `overlays.openSystemFlyout`) and the per-flyout properties so call
+ * sites don't repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useAttackFlyoutApi = (): AttackFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  // The main/child flyout and the tools differ only in their properties (base size + session). Both
+  // are kept private here so callers never reason about them: they pick the method they want and
+  // this helper opens the system flyout with the given properties.
+  const open = useCallback(
+    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history]
+  );
+
+  const openAttackFlyout = useCallback(
+    ({ attackId, indexName, onAttackUpdated = noop }: OpenAttackFlyoutParams) => {
+      open(
+        <AttackFlyoutWrapper
+          attackId={attackId}
+          indexName={indexName}
+          onAttackUpdated={onAttackUpdated}
+        />,
+        { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openAttackFlyoutAsChild = useCallback(
+    ({ attackId, indexName, onAttackUpdated = noop }: OpenAttackFlyoutParams) => {
+      open(
+        <AttackFlyoutWrapper
+          attackId={attackId}
+          indexName={indexName}
+          onAttackUpdated={onAttackUpdated}
+        />,
+        { ...defaultDocumentFlyoutProperties, historyKey, session: 'inherit' }
+      );
+    },
+    [open, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openAttackCorrelations = useCallback(
+    ({ hit, alertIds, onShowAlert }: OpenAttackCorrelationsParams) => {
+      open(<CorrelationsDetails hit={hit} alertIds={alertIds} onShowAlert={onShowAlert} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, historyKey]
+  );
+
+  const openAttackEntities = useCallback(
+    ({ hit, alertIds }: OpenAttackEntitiesParams) => {
+      open(<EntitiesDetails hit={hit} alertIds={alertIds} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, historyKey]
+  );
+
+  return useMemo(
+    () => ({
+      openAttackFlyout,
+      openAttackFlyoutAsChild,
+      openAttackCorrelations,
+      openAttackEntities,
+    }),
+    [openAttackFlyout, openAttackFlyoutAsChild, openAttackCorrelations, openAttackEntities]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FlyoutApi } from './use_flyout_api';
+import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+
+/**
+ * Returns a `useFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Composes the per-type mocks, mirroring how the real hook composes the per-type hooks.
+ * Use with `jest.mocked(useFlyoutApi).mockReturnValue(createFlyoutApiMock())` and assert against
+ * the individual method you care about.
+ */
+export const createFlyoutApiMock = (): jest.Mocked<FlyoutApi> => ({
+  ...createAttackFlyoutApiMock(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useFlyoutApi } from './use_flyout_api';
+import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
+import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+
+jest.mock('./attack/use_attack_flyout_api');
+
+describe('useFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exposes the attack flyout methods from the composed per-type hook', () => {
+    const attackApi = createAttackFlyoutApiMock();
+    jest.mocked(useAttackFlyoutApi).mockReturnValue(attackApi);
+
+    const { result } = renderHook(() => useFlyoutApi());
+
+    const params = { attackId: 'attack-1', indexName: '.alerts-security' };
+
+    // The facade surfaces the composed methods, and calling one delegates to the per-type hook.
+    result.current.openAttackFlyout(params);
+    result.current.openAttackFlyoutAsChild(params);
+
+    expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(params);
+    expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(params);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { AttackFlyoutApi } from './attack/use_attack_flyout_api';
+import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
+
+/**
+ * The single developer-facing API for opening any new (EUI-based) Security Solution flyout.
+ *
+ * Rather than importing a per-type hook (`useAttackFlyoutApi`, `useDocumentFlyoutApi`, …), call
+ * sites use this one hook and get every open method, namespaced by type
+ * (`openAttackFlyout`, `openDocumentFlyoutFromIndex`, `openNetworkFlyout`, …). Each method comes in
+ * a main variant (opens a new, top-level flyout) and, where it makes sense, an `...AsChild` variant
+ * (opens nested inside the currently open flyout). Callers never deal with the flyout `session`.
+ *
+ * This is a thin facade: the per-type hooks own the actual wiring (lazy-loading, provider setup,
+ * flyout properties) and remain the unit each team maintains. This file only composes them, so
+ * adding a new flyout type is a one-line change here.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export type FlyoutApi = AttackFlyoutApi;
+
+export const useFlyoutApi = (): FlyoutApi => {
+  const attack = useAttackFlyoutApi();
+
+  return useMemo(
+    () => ({
+      ...attack,
+    }),
+    [attack]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -20,10 +20,13 @@ import * as timelineActions from '../../../../store/actions';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
   useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
 }));
+jest.mock('../../../../../flyout_v2/use_flyout_api');
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn(() => ({
@@ -42,9 +45,6 @@ const mockUiSettingsGet = jest.fn().mockReturnValue(false);
 const mockDocumentFlyoutWrapper = jest.fn((_props?: unknown) => (
   <div>{'MockDocumentFlyoutWrapper'}</div>
 ));
-const mockAttackFlyoutWrapper = jest.fn((_props?: unknown) => (
-  <div>{'MockAttackFlyoutWrapper'}</div>
-));
 
 const updateSampleSizeSpy = jest.spyOn(timelineActions, 'updateSampleSize');
 
@@ -54,9 +54,6 @@ jest.mock('../../../../../flyout_v2/shared/components/flyout_provider', () => ({
 }));
 jest.mock('../../../../../flyout_v2/document/main/document_flyout_wrapper', () => ({
   DocumentFlyoutWrapper: (props: unknown) => mockDocumentFlyoutWrapper(props),
-}));
-jest.mock('../../../../../flyout_v2/attack/main/attack_flyout_wrapper', () => ({
-  AttackFlyoutWrapper: (props: unknown) => mockAttackFlyoutWrapper(props),
 }));
 jest.mock('../../../../../common/lib/kibana', () => {
   const original = jest.requireActual('../../../../../common/lib/kibana');
@@ -153,6 +150,8 @@ const getTimelineFromStore = (
 };
 
 describe('unified data table', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
   beforeEach(() => {
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
       openFlyout: openFlyoutMock,
@@ -160,6 +159,8 @@ describe('unified data table', () => {
     });
     mockUiSettingsGet.mockReturnValue(false);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
   });
   afterEach(() => {
     updateSampleSizeSpy.mockClear();
@@ -221,7 +222,7 @@ describe('unified data table', () => {
   );
 
   it(
-    'opens AttackFlyoutWrapper via system flyout when enableNewFlyout setting is enabled and row is an attack discovery alert',
+    'opens the new attack flyout when enableNewFlyout setting is enabled and row is an attack discovery alert',
     async () => {
       jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
 
@@ -231,13 +232,16 @@ describe('unified data table', () => {
       fireEvent.click(screen.getByTestId('docTableExpandToggleColumn'));
 
       await waitFor(() => {
-        expect(mockOpenSystemFlyout).toHaveBeenCalled();
+        expect(flyoutApi.openAttackFlyout).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attackId: 'attack-1',
+            indexName: 'attack-index',
+          })
+        );
       });
 
-      const flyoutElement = mockOpenSystemFlyout.mock.calls[0][0];
-      expect(flyoutElement.props.attackId).toBe('attack-1');
-      expect(flyoutElement.props.indexName).toBe('attack-index');
-      expect(flyoutElement.props.onAttackUpdated).toBe(refetchMock);
+      // attack rows no longer go through the inline system flyout or the document flyout api
+      expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
       expect(mockDocumentFlyoutWrapper).not.toHaveBeenCalled();
     },
     SPECIAL_TEST_TIMEOUT

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -24,6 +24,7 @@ import { useHistory } from 'react-router-dom';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
 import { cellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
 import { useOnExpandableFlyoutClose } from '../../../../../flyout/shared/hooks/use_on_expandable_flyout_close';
 import { DocumentDetailsRightPanelKey } from '../../../../../flyout/document_details/shared/constants/panel_keys';
@@ -58,7 +59,6 @@ import { DocumentEventTypes } from '../../../../../common/lib/telemetry/types';
 import { getTimelineRowTypeIndicator } from './get_row_indicator';
 import { isAttackDiscoveryRow } from './is_attack_discovery_row';
 import { DocumentFlyoutWrapper } from '../../../../../flyout_v2/document/main/document_flyout_wrapper';
-import { AttackFlyoutWrapper } from '../../../../../flyout_v2/attack/main/attack_flyout_wrapper';
 import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
@@ -150,6 +150,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     } = services;
 
     const enableNewFlyout = useIsNewFlyoutEnabled();
+    const { openAttackFlyout } = useFlyoutApi();
 
     const [expandedDoc, setExpandedDoc] = useState<DataTableRecord & TimelineItem>();
 
@@ -191,32 +192,34 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       (eventData: DataTableRecord & TimelineItem) => {
         if (enableNewFlyout) {
           const isAttackRow = isAttackDiscoveryRow(eventData);
-          overlays.openSystemFlyout(
-            flyoutProviders({
-              services,
-              store,
-              history,
-              children: isAttackRow ? (
-                <AttackFlyoutWrapper
-                  attackId={eventData._id}
-                  indexName={eventData.ecs._index ?? ''}
-                  onAttackUpdated={refetch}
-                />
-              ) : (
-                <DocumentFlyoutWrapper
-                  documentId={eventData._id}
-                  indexName={eventData.ecs._index}
-                  renderCellActions={cellActionRenderer}
-                  onAlertUpdated={refetch}
-                />
-              ),
-            }),
-            {
-              ...defaultFlyoutProperties,
-              historyKey: documentFlyoutHistoryKey,
-              session: 'start',
-            }
-          );
+          if (isAttackRow) {
+            openAttackFlyout({
+              attackId: eventData._id,
+              indexName: eventData.ecs._index ?? '',
+              onAttackUpdated: refetch,
+            });
+          } else {
+            overlays.openSystemFlyout(
+              flyoutProviders({
+                services,
+                store,
+                history,
+                children: (
+                  <DocumentFlyoutWrapper
+                    documentId={eventData._id}
+                    indexName={eventData.ecs._index}
+                    renderCellActions={cellActionRenderer}
+                    onAlertUpdated={refetch}
+                  />
+                ),
+              }),
+              {
+                ...defaultFlyoutProperties,
+                historyKey: documentFlyoutHistoryKey,
+                session: 'start',
+              }
+            );
+          }
         } else {
           const isAttackRow = isAttackDiscoveryRow(eventData);
           const indexName = eventData.ecs._index ?? '';
@@ -246,14 +249,15 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
         }
       },
       [
-        defaultFlyoutProperties,
         enableNewFlyout,
+        openAttackFlyout,
+        refetch,
         overlays,
         services,
         store,
         history,
+        defaultFlyoutProperties,
         timelineId,
-        refetch,
         openFlyout,
         telemetry,
       ]


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is only focusing on the attack flyout. A couple of follow up PRs will take care of the other flyouts.

The PR also introduces single developer-facing APIs to open the new ioc flyout, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:
- `useFlyoutApi()`: that is inernally calling the network flyout specific api:
  - `useAttackFlyoutApi()` which returns:
    - `openAttackFlyout` that opens the attack main flyout
    - `openAttackFlyoutAsChild` that opens the flyout as a child
    - `openAttackCorrelations()` that opens the correlations tools flyout
    - `openAttackEntities()` that opens the entities tools flyout

> [!TIP]
> Developers should use - unless not possible - the useFlyoutApi() to open all of their flyouts

Every external entry point that opened one of these legacy flyouts now routes through the matching API when the new flyout is enabled.

> [!WARNING]
> No legacy flyout behavior change introduced! Only toggling between the legacy and new flyout based off the advanced setting.

#### Advanced setting off (default)

https://github.com/user-attachments/assets/a2471c87-e2d1-47eb-bc42-722e89701331

#### Advanced setting on

https://github.com/user-attachments/assets/d4cbe584-4e27-4659-8a9c-7fa94085a89f

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new flyout/tool opens from each surface.
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->