### PR TITLE
[Cases][AttachmentV2] Enable cases attachment flag

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -25,7 +25,7 @@ describe('config validation', () => {
             "resetTaskTimeoutMinutes": 60,
           },
           "attachments": Object {
-            "enabled": false,
+            "enabled": true,
           },
           "casesRedesign": Object {
             "details": false,
@@ -146,9 +146,9 @@ describe('config validation', () => {
       `);
     });
 
-    it('sets attachments.enabled default to false', () => {
+    it('sets attachments.enabled default to true', () => {
       const config = ConfigSchema.validate({});
-      expect(config.attachments.enabled).toBe(false);
+      expect(config.attachments.enabled).toBe(true);
     });
 
     it('allows attachments.enabled to be set to true', () => {

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -114,7 +114,7 @@ export const ConfigSchema = schema.object({
     }),
   }),
   attachments: schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
+    enabled: schema.boolean({ defaultValue: true }),
   }),
   chat: schema.object({
     enabled: schema.boolean({ defaultValue: false }),


### PR DESCRIPTION
## Summary

Dependency: https://github.com/elastic/kibana/pull/278259 to be merged first, this PR is stacked on top of the FTR fixes 

Enable attachment v2 feature flag

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->