### PR TITLE
[Security Solution][Flyout] toggle between legacy and new document flyout (main and tools)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShowAlertButton } from './show_alert_button';
+import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
+
+const props = {
+  id: 'action-id',
+  alertId: 'alert-id',
+  index: 'alert-index',
+};
+
+const mockOpenFlyout = jest.fn();
+const mockReportEvent = jest.fn();
+
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout }),
+}));
+
+jest.mock('../../../../common/lib/kibana');
+
+jest.mock('@kbn/cases-plugin/public', () => ({
+  useCaseViewNavigation: jest.fn(),
+  useCaseViewParams: jest.fn(),
+}));
+
+jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
+
+const useCaseViewParamsMock = useCaseViewParams as jest.Mock;
+const useCaseViewNavigationMock = useCaseViewNavigation as jest.Mock;
+const useKibanaMock = useKibana as jest.Mock;
+
+const setKibanaServices = (ease: boolean) => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      telemetry: { reportEvent: mockReportEvent },
+      application: {
+        capabilities: {
+          [SECURITY_FEATURE_ID]: { configurations: ease },
+        },
+      },
+    },
+  });
+};
+
+describe('ShowAlertButton', () => {
+  const navigateToCaseView = jest.fn();
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCaseViewParamsMock.mockReturnValue({ detailName: 'case-id' });
+    useCaseViewNavigationMock.mockReturnValue({ navigateToCaseView });
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    setKibanaServices(false);
+  });
+
+  it('renders the show alert button', () => {
+    render(<ShowAlertButton {...props} />);
+    expect(screen.getByTestId('comment-action-show-alert-action-id')).toBeInTheDocument();
+  });
+
+  it('opens the legacy expandable flyout when the new flyout is disabled (non-EASE)', () => {
+    render(<ShowAlertButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: 'document-details-right',
+        params: {
+          id: 'alert-id',
+          indexName: 'alert-index',
+          scopeId: 'timeline-case',
+        },
+      },
+    });
+    expect(flyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    expect(mockReportEvent).toHaveBeenCalled();
+    expect(navigateToCaseView).not.toHaveBeenCalled();
+  });
+
+  it('opens the new document flyout (from index) when the new flyout is enabled (non-EASE)', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(<ShowAlertButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
+    expect(flyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+      documentId: 'alert-id',
+      indexName: 'alert-index',
+      renderCellActions: casesCellActionRenderer,
+    });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(mockReportEvent).toHaveBeenCalled();
+    expect(navigateToCaseView).not.toHaveBeenCalled();
+  });
+
+  it('opens the legacy EASE flyout when the EASE capability is on, regardless of the new flyout flag', () => {
+    setKibanaServices(true);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(<ShowAlertButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: 'ease-details',
+        params: {
+          id: 'alert-id',
+          indexName: 'alert-index',
+        },
+      },
+    });
+    expect(flyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    // EASE path does not report the document flyout telemetry event
+    expect(mockReportEvent).not.toHaveBeenCalled();
+    expect(navigateToCaseView).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the case view when there is no valid index', () => {
+    render(<ShowAlertButton {...props} index="" />);
+    fireEvent.click(screen.getByTestId('comment-action-show-alert-action-id'));
+
+    expect(navigateToCaseView).toHaveBeenCalledWith({
+      detailName: 'case-id',
+      tabId: 'alerts',
+    });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/show_alert_button.tsx
@@ -6,15 +6,18 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
 import { CASE_VIEW_PAGE_TABS } from '@kbn/cases-plugin/common';
 import { EasePanelKey } from '../../../../flyout/ease/constants/panel_keys';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
 import { SHOW_ALERT_TOOLTIP } from '../translations';
 
@@ -32,6 +35,8 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
   } = useKibana().services;
   const { navigateToCaseView } = useCaseViewNavigation();
   const { detailName } = useCaseViewParams();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openDocumentFlyoutFromIndex } = useFlyoutApi();
 
   // TODO We shouldn't have to check capabilities here, this should be done at a much higher level.
   //  https://github.com/elastic/kibana/issues/218741
@@ -41,6 +46,7 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
     const hasValidIndex = index && String(index).trim();
     if (hasValidIndex) {
       if (EASE) {
+        // EASE alert summary flyout has no new-flyout equivalent yet, so it stays on the legacy flyout.
         openFlyout({
           right: {
             id: EasePanelKey,
@@ -51,16 +57,24 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
           },
         });
       } else {
-        openFlyout({
-          right: {
-            id: DocumentDetailsRightPanelKey,
-            params: {
-              id: alertId,
-              indexName: index,
-              scopeId: TimelineId.casePage,
+        if (enableNewFlyout) {
+          openDocumentFlyoutFromIndex({
+            documentId: alertId,
+            indexName: index,
+            renderCellActions: casesCellActionRenderer,
+          });
+        } else {
+          openFlyout({
+            right: {
+              id: DocumentDetailsRightPanelKey,
+              params: {
+                id: alertId,
+                indexName: index,
+                scopeId: TimelineId.casePage,
+              },
             },
-          },
-        });
+          });
+        }
         telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
           location: TimelineId.casePage,
           panel: 'right',
@@ -69,7 +83,17 @@ export const ShowAlertButton = ({ id, alertId, index }: ShowAlertButtonProps) =>
     } else {
       navigateToCaseView({ detailName, tabId: CASE_VIEW_PAGE_TABS.ALERTS });
     }
-  }, [EASE, alertId, index, openFlyout, telemetry, detailName, navigateToCaseView]);
+  }, [
+    EASE,
+    alertId,
+    index,
+    openFlyout,
+    telemetry,
+    detailName,
+    navigateToCaseView,
+    enableNewFlyout,
+    openDocumentFlyoutFromIndex,
+  ]);
 
   return (
     <EuiToolTip position="top" content={<p>{SHOW_ALERT_TOOLTIP}</p>}>

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/components/show_event_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/components/show_event_button.test.tsx
@@ -9,6 +9,10 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ShowEventButton } from './show_event_button';
 import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 
 const props = {
   id: 'action-id',
@@ -34,16 +38,23 @@ jest.mock('@kbn/cases-plugin/public', () => ({
   useCaseViewParams: jest.fn(),
 }));
 
+jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
+
 const useCaseViewParamsMock = useCaseViewParams as jest.Mock;
 const useCaseViewNavigationMock = useCaseViewNavigation as jest.Mock;
 
 describe('ShowEventButton', () => {
   const navigateToCaseView = jest.fn();
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     useCaseViewParamsMock.mockReturnValue({ detailName: 'case-id' });
     useCaseViewNavigationMock.mockReturnValue({ navigateToCaseView });
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   it('renders the show event button', () => {
@@ -51,7 +62,7 @@ describe('ShowEventButton', () => {
     expect(screen.getByTestId('comment-action-show-event-action-id')).toBeInTheDocument();
   });
 
-  it('opens flyout directly when index is valid (events use hook, not cases routing)', () => {
+  it('opens the legacy expandable flyout when the new flyout is disabled', () => {
     render(<ShowEventButton {...props} />);
     const button = screen.getByTestId('comment-action-show-event-action-id');
     fireEvent.click(button);
@@ -65,6 +76,24 @@ describe('ShowEventButton', () => {
         },
       },
     });
+    expect(flyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    expect(mockReportEvent).toHaveBeenCalled();
+    expect(navigateToCaseView).not.toHaveBeenCalled();
+  });
+
+  it('opens the new document flyout (from index) when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(<ShowEventButton {...props} />);
+    const button = screen.getByTestId('comment-action-show-event-action-id');
+    fireEvent.click(button);
+
+    expect(flyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+      documentId: 'event-id',
+      indexName: 'event-index',
+      renderCellActions: casesCellActionRenderer,
+    });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
     expect(mockReportEvent).toHaveBeenCalled();
     expect(navigateToCaseView).not.toHaveBeenCalled();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/components/show_event_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/components/show_event_button.tsx
@@ -6,14 +6,17 @@
  */
 
 import React, { memo, useCallback } from 'react';
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useCaseViewNavigation, useCaseViewParams } from '@kbn/cases-plugin/public';
 import { CASE_VIEW_PAGE_TABS } from '@kbn/cases-plugin/common';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { casesCellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { SHOW_EVENT_TOOLTIP } from '../translations';
 
 export interface ShowEventButtonProps {
@@ -27,20 +30,30 @@ const ShowEventButtonComponent = ({ id, eventId, index }: ShowEventButtonProps) 
   const { telemetry } = useKibana().services;
   const { navigateToCaseView } = useCaseViewNavigation();
   const { detailName } = useCaseViewParams();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openDocumentFlyoutFromIndex } = useFlyoutApi();
 
   const onClick = useCallback(() => {
     const hasValidIndex = index && String(index).trim();
     if (hasValidIndex) {
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName: index,
-            scopeId: TimelineId.casePage,
+      if (enableNewFlyout) {
+        openDocumentFlyoutFromIndex({
+          documentId: eventId,
+          indexName: index,
+          renderCellActions: casesCellActionRenderer,
+        });
+      } else {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName: index,
+              scopeId: TimelineId.casePage,
+            },
           },
-        },
-      });
+        });
+      }
       telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
         location: TimelineId.casePage,
         panel: 'right',
@@ -48,7 +61,16 @@ const ShowEventButtonComponent = ({ id, eventId, index }: ShowEventButtonProps) 
     } else {
       navigateToCaseView({ detailName, tabId: CASE_VIEW_PAGE_TABS.EVENTS });
     }
-  }, [eventId, index, openFlyout, telemetry, detailName, navigateToCaseView]);
+  }, [
+    eventId,
+    index,
+    openFlyout,
+    telemetry,
+    detailName,
+    navigateToCaseView,
+    enableNewFlyout,
+    openDocumentFlyoutFromIndex,
+  ]);
 
   return (
     <EuiToolTip position="top" content={<p>{SHOW_EVENT_TOOLTIP}</p>}>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.test.tsx
@@ -23,10 +23,11 @@ import { createExpandableFlyoutApiMock } from '../../../mock/expandable_flyout';
 import { useUserPrivileges } from '../../user_privileges';
 import { initialUserPrivilegesState } from '../../user_privileges/user_privileges_context';
 import { useIsNewFlyoutEnabled } from '../../../hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
 
-jest.mock('../../../hooks/use_is_new_flyout_enabled', () => ({
-  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
-}));
+jest.mock('../../../hooks/use_is_new_flyout_enabled');
+jest.mock('../../../../flyout_v2/use_flyout_api');
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
   const original = jest.requireActual('react-redux');
@@ -38,18 +39,11 @@ jest.mock('react-redux', () => {
 });
 
 jest.mock('../../../utils/route/use_route_spy');
-jest.mock('../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => children,
-}));
 
 const mockOpenFlyout = jest.fn();
 jest.mock('@kbn/expandable-flyout');
 
 const mockedTelemetry = createTelemetryServiceMock();
-const mockOpenSystemFlyout = jest.fn();
-const mockDocumentFlyoutWrapper = jest.fn((_props?: unknown) => (
-  <div>{'MockDocumentFlyoutWrapper'}</div>
-));
 jest.mock('../../../lib/kibana', () => {
   const original = jest.requireActual('../../../lib/kibana');
   return {
@@ -59,24 +53,8 @@ jest.mock('../../../lib/kibana', () => {
       services: {
         ...original.useKibana().services,
         telemetry: mockedTelemetry,
-        overlays: {
-          ...original.useKibana().services.overlays,
-          openSystemFlyout: mockOpenSystemFlyout,
-        },
       },
     }),
-  };
-});
-jest.mock('../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => children,
-}));
-jest.mock('../../../../flyout_v2/document/main/document_flyout_wrapper', () => ({
-  DocumentFlyoutWrapper: (props: unknown) => mockDocumentFlyoutWrapper(props),
-}));
-jest.mock('@kbn/kibana-react-plugin/public', () => {
-  const original = jest.requireActual('@kbn/kibana-react-plugin/public');
-  return {
-    ...original,
   };
 });
 
@@ -90,6 +68,8 @@ const mockRouteSpy: RouteSpyState = {
   pathName: '/',
 };
 describe('RowAction', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
   const sampleData = {
     _id: '1',
     data: [],
@@ -132,11 +112,13 @@ describe('RowAction', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    flyoutApi = createFlyoutApiMock();
     jest.mocked(useExpandableFlyoutApi).mockReturnValue({
       ...createExpandableFlyoutApiMock(),
       openFlyout: mockOpenFlyout,
     });
     jest.mocked(useExpandableFlyoutState).mockReturnValue({} as unknown as ExpandableFlyoutState);
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
     (useRouteSpy as jest.Mock).mockReturnValue([mockRouteSpy]);
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
@@ -173,7 +155,7 @@ describe('RowAction', () => {
     });
   });
 
-  test('should open expandable flyout when enableNewFlyout setting is disabled', () => {
+  test('should open the legacy expandable flyout when enableNewFlyout setting is disabled', () => {
     const wrapper = render(
       <TestProviders>
         <RowAction {...defaultProps} />
@@ -183,10 +165,10 @@ describe('RowAction', () => {
     fireEvent.click(wrapper.getByTestId('expand-event'));
 
     expect(mockOpenFlyout).toHaveBeenCalled();
-    expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
   });
 
-  test('should open system flyout when enableNewFlyout setting is enabled', () => {
+  test('should open the new document flyout when enableNewFlyout setting is enabled', () => {
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
     const refetch = jest.fn();
 
@@ -199,14 +181,58 @@ describe('RowAction', () => {
     fireEvent.click(wrapper.getByTestId('expand-event'));
 
     expect(mockOpenFlyout).not.toHaveBeenCalled();
-    expect(mockOpenSystemFlyout).toHaveBeenCalled();
-    const flyoutElement = mockOpenSystemFlyout.mock.calls[0][0];
-    expect(flyoutElement.props.documentId).toBe('1');
-    expect(flyoutElement.props.indexName).toBeUndefined();
-    expect(flyoutElement.props.renderCellActions).toBeDefined();
-    expect(flyoutElement.props.onAlertUpdated).toEqual(expect.any(Function));
-    flyoutElement.props.onAlertUpdated();
+    expect(flyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: '1',
+        indexName: undefined,
+        renderCellActions: expect.any(Function),
+        onAlertUpdated: expect.any(Function),
+      })
+    );
+
+    const { onAlertUpdated } = flyoutApi.openDocumentFlyoutFromIndex.mock.calls[0][0];
+    onAlertUpdated?.();
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('notes', () => {
+    beforeEach(() => {
+      (useUserPrivileges as jest.Mock).mockReturnValue({
+        ...initialUserPrivilegesState(),
+        notesPrivileges: { read: true, crud: true },
+        timelinePrivileges: { read: true },
+      });
+    });
+
+    test('should open the legacy expandable flyout when enableNewFlyout setting is disabled', () => {
+      const wrapper = render(
+        <TestProviders>
+          <RowAction {...defaultProps} />
+        </TestProviders>
+      );
+
+      fireEvent.click(wrapper.getByTestId('timeline-notes-button-small'));
+
+      expect(mockOpenFlyout).toHaveBeenCalled();
+      expect(flyoutApi.openNotes).not.toHaveBeenCalled();
+    });
+
+    test('should open the new notes flyout when enableNewFlyout setting is enabled', () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      const wrapper = render(
+        <TestProviders>
+          <RowAction {...defaultProps} />
+        </TestProviders>
+      );
+
+      fireEvent.click(wrapper.getByTestId('timeline-notes-button-small'));
+
+      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      expect(flyoutApi.openNotes).toHaveBeenCalledWith(
+        expect.objectContaining({ hit: expect.any(Object) })
+      );
+    });
   });
 
   describe('privileges', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -10,11 +10,12 @@ import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { documentFlyoutHistoryKey } from '../../../../flyout_v2/shared/constants/flyout_history';
-import { cellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
-import { DocumentFlyoutWrapper } from '../../../../flyout_v2/document/main/document_flyout_wrapper';
+import { TableId } from '@kbn/securitysolution-data-table';
+import {
+  casesCellActionRenderer,
+  cellActionRenderer,
+} from '../../../../flyout_v2/shared/components/cell_actions';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useKibana } from '../../../lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../hooks/use_is_new_flyout_enabled';
@@ -32,8 +33,6 @@ import { type ColumnHeaderOptions, type OnRowSelected } from '../../../../../com
 import { DocumentEventTypes, NotesEventTypes } from '../../../lib/telemetry';
 import { getMappedNonEcsValue } from '../../../utils/get_mapped_non_ecs_value';
 import { useUserPrivileges } from '../../user_privileges';
-import { flyoutProviders } from '../../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 export type RowActionProps = EuiDataGridCellValueElementProps & {
   columnHeaders: ColumnHeaderOptions[];
@@ -85,14 +84,11 @@ const RowActionComponent = ({
     [esHitRecord]
   );
 
-  const { services } = useKibana();
-  const { telemetry, overlays } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { telemetry } = useKibana().services;
 
   const { openFlyout } = useExpandableFlyoutApi();
   const enableNewFlyout = useIsNewFlyoutEnabled();
-  const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const { openDocumentFlyoutFromIndex, openNotes } = useFlyoutApi();
 
   const columnValues = useMemo(
     () =>
@@ -121,26 +117,13 @@ const RowActionComponent = ({
 
   const handleOnEventDetailPanelOpened = useCallback(() => {
     if (enableNewFlyout && hit) {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: (
-            <DocumentFlyoutWrapper
-              documentId={eventId}
-              indexName={indexName ?? undefined}
-              renderCellActions={cellActionRenderer}
-              onAlertUpdated={handleAlertUpdated}
-            />
-          ),
-        }),
-        {
-          ...defaultFlyoutProperties,
-          historyKey: documentFlyoutHistoryKey,
-          session: 'start',
-        }
-      );
+      openDocumentFlyoutFromIndex({
+        documentId: eventId,
+        indexName: indexName ?? undefined,
+        renderCellActions:
+          tableId === TableId.alertsOnCasePage ? casesCellActionRenderer : cellActionRenderer,
+        onAlertUpdated: handleAlertUpdated,
+      });
     } else {
       openFlyout({
         right: {
@@ -158,13 +141,9 @@ const RowActionComponent = ({
       });
     }
   }, [
-    defaultFlyoutProperties,
     enableNewFlyout,
     hit,
-    overlays,
-    services,
-    store,
-    history,
+    openDocumentFlyoutFromIndex,
     eventId,
     indexName,
     handleAlertUpdated,
@@ -174,27 +153,31 @@ const RowActionComponent = ({
   ]);
 
   const toggleShowNotes = useCallback(() => {
-    openFlyout({
-      right: {
-        id: DocumentDetailsRightPanelKey,
-        params: {
-          id: eventId,
-          indexName,
-          scopeId: tableId,
+    if (enableNewFlyout && hit) {
+      openNotes({ hit });
+    } else {
+      openFlyout({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: tableId,
+          },
         },
-      },
-      left: {
-        id: DocumentDetailsLeftPanelKey,
-        path: {
-          tab: LeftPanelNotesTab,
+        left: {
+          id: DocumentDetailsLeftPanelKey,
+          path: {
+            tab: LeftPanelNotesTab,
+          },
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: tableId,
+          },
         },
-        params: {
-          id: eventId,
-          indexName,
-          scopeId: tableId,
-        },
-      },
-    });
+      });
+    }
     telemetry.reportEvent(NotesEventTypes.OpenNoteInExpandableFlyoutClicked, {
       location: tableId,
     });
@@ -202,7 +185,7 @@ const RowActionComponent = ({
       location: tableId,
       panel: 'left',
     });
-  }, [eventId, indexName, openFlyout, tableId, telemetry]);
+  }, [enableNewFlyout, hit, openNotes, openFlyout, eventId, indexName, tableId, telemetry]);
 
   const Action = controlColumn.rowCellRender;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { mockTimelineData, mockTimelineModel, TestProviders } from '../../mock';
 import { useShallowEqualSelector } from '../../hooks/use_selector';
 import { licenseService } from '../../hooks/use_license';
@@ -14,6 +14,11 @@ import type { ActionsComponentProps } from './actions';
 import { Actions } from './actions';
 import { useIsAnalyzerEnabled } from '../../../detections/hooks/use_is_analyzer_enabled';
 import { AlertContextMenu } from '../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
+import { useIsNewFlyoutEnabled } from '../../hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../flyout_v2/use_flyout_api.mock';
+import { useNavigateToAnalyzer } from '../../../flyout/document_details/shared/hooks/use_navigate_to_analyzer';
+import { useNavigateToSessionView } from '../../../flyout/document_details/shared/hooks/use_navigate_to_session_view';
 
 jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/alert_context_menu',
@@ -23,6 +28,10 @@ jest.mock(
 );
 jest.mock('../../hooks/use_selector');
 jest.mock('../../../detections/hooks/use_is_analyzer_enabled');
+jest.mock('../../hooks/use_is_new_flyout_enabled');
+jest.mock('../../../flyout_v2/use_flyout_api');
+jest.mock('../../../flyout/document_details/shared/hooks/use_navigate_to_analyzer');
+jest.mock('../../../flyout/document_details/shared/hooks/use_navigate_to_session_view');
 jest.mock('../../hooks/use_license', () => {
   const licenseServiceInstance = {
     isPlatinumPlus: jest.fn(),
@@ -56,10 +65,24 @@ const defaultProps: ActionsComponentProps = {
   toggleShowNotes: jest.fn(),
 };
 
+const mockNavigateToAnalyzer = jest.fn();
+const mockNavigateToSessionView = jest.fn();
+
 describe('Actions', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useShallowEqualSelector as jest.Mock).mockReturnValue(mockTimelineModel);
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useNavigateToAnalyzer).mockReturnValue({
+      navigateToAnalyzer: mockNavigateToAnalyzer,
+    });
+    jest.mocked(useNavigateToSessionView).mockReturnValue({
+      navigateToSessionView: mockNavigateToSessionView,
+    });
   });
 
   describe('expand icon', () => {
@@ -273,6 +296,39 @@ describe('Actions', () => {
 
         expect(queryByTestId('view-in-analyzer')).not.toBeInTheDocument();
       });
+
+      it('should navigate to the legacy analyzer when enableNewFlyout setting is disabled', () => {
+        (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...defaultProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('view-in-analyzer'));
+
+        expect(mockNavigateToAnalyzer).toHaveBeenCalled();
+        expect(flyoutApi.openAnalyzer).not.toHaveBeenCalled();
+      });
+
+      it('should open the new analyzer flyout when enableNewFlyout setting is enabled', () => {
+        (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...defaultProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('view-in-analyzer'));
+
+        expect(mockNavigateToAnalyzer).not.toHaveBeenCalled();
+        expect(flyoutApi.openAnalyzer).toHaveBeenCalledWith(
+          expect.objectContaining({ hit: defaultProps.hit })
+        );
+      });
     });
 
     describe('session view icon', () => {
@@ -326,6 +382,54 @@ describe('Actions', () => {
         );
 
         expect(queryByTestId('session-view-button')).not.toBeInTheDocument();
+      });
+
+      const sessionViewProps = {
+        ...defaultProps,
+        ecsData: {
+          ...mockTimelineData[0].ecs,
+          event: { kind: ['alert'] },
+          agent: { type: ['endpoint'] },
+          process: {
+            entry_leader: { entity_id: ['test_id'], start: ['2022-05-08T13:44:00.13Z'] },
+          },
+          _index: '.ds-logs-endpoint.events.process-default',
+        },
+      };
+
+      it('should navigate to the legacy session view when enableNewFlyout setting is disabled', () => {
+        const licenseServiceMock = licenseService as jest.Mocked<typeof licenseService>;
+        licenseServiceMock.isEnterprise.mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...sessionViewProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('session-view-button'));
+
+        expect(mockNavigateToSessionView).toHaveBeenCalled();
+        expect(flyoutApi.openSessionView).not.toHaveBeenCalled();
+      });
+
+      it('should open the new session view flyout when enableNewFlyout setting is enabled', () => {
+        const licenseServiceMock = licenseService as jest.Mocked<typeof licenseService>;
+        licenseServiceMock.isEnterprise.mockReturnValue(true);
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        const { getByTestId } = render(
+          <TestProviders>
+            <Actions {...sessionViewProps} />
+          </TestProviders>
+        );
+
+        fireEvent.click(getByTestId('session-view-button'));
+
+        expect(mockNavigateToSessionView).not.toHaveBeenCalled();
+        expect(flyoutApi.openSessionView).toHaveBeenCalledWith(
+          expect.objectContaining({ hit: defaultProps.hit })
+        );
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -35,6 +35,8 @@ import * as i18n from './translations';
 import { DEFAULT_ACTION_BUTTON_WIDTH, isAlert } from './helpers';
 import { useNavigateToAnalyzer } from '../../../flyout/document_details/shared/hooks/use_navigate_to_analyzer';
 import { useNavigateToSessionView } from '../../../flyout/document_details/shared/hooks/use_navigate_to_session_view';
+import { useIsNewFlyoutEnabled } from '../../hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 
 const ActionsContainer = styled.div`
   align-items: center;
@@ -86,6 +88,8 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
   );
 
   const { startTransaction } = useStartTransaction();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openAnalyzer, openSessionView: openSessionViewFlyout } = useFlyoutApi();
 
   const eventType = getEventType(ecsData);
 
@@ -105,8 +109,12 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
 
   const handleClick = useCallback(() => {
     startTransaction({ name: ALERTS_ACTIONS.OPEN_ANALYZER });
-    navigateToAnalyzer();
-  }, [startTransaction, navigateToAnalyzer]);
+    if (enableNewFlyout && hit) {
+      openAnalyzer({ hit, onAlertUpdated: () => refetch?.() });
+    } else {
+      navigateToAnalyzer();
+    }
+  }, [startTransaction, navigateToAnalyzer, enableNewFlyout, hit, openAnalyzer, refetch]);
 
   const sessionViewConfig = useMemo(() => {
     const { process, _id, _index, timestamp, kibana } = ecsData;
@@ -135,8 +143,25 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
 
   const openSessionView = useCallback(() => {
     startTransaction({ name: ALERTS_ACTIONS.OPEN_SESSION_VIEW });
-    navigateToSessionView();
-  }, [navigateToSessionView, startTransaction]);
+    if (enableNewFlyout && hit) {
+      openSessionViewFlyout({
+        hit,
+        jumpToCursor: sessionViewConfig?.jumpToCursor,
+        jumpToEntityId: sessionViewConfig?.jumpToEntityId,
+        onAlertUpdated: () => refetch?.(),
+      });
+    } else {
+      navigateToSessionView();
+    }
+  }, [
+    startTransaction,
+    navigateToSessionView,
+    enableNewFlyout,
+    hit,
+    openSessionViewFlyout,
+    sessionViewConfig,
+    refetch,
+  ]);
 
   const onExpandEvent = useCallback(() => {
     onEventDetailsPanelOpened();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
@@ -33,17 +33,22 @@ import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 import { ANALYZER_PREVIEW_BANNER } from '../../../../resolver/view/resolver_without_providers';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
 });
-jest.mock('@kbn/expandable-flyout');
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: jest.fn(),
+}));
 jest.mock('../../../../resolver/view/use_resolver_query_params_cleaner');
 jest.mock('../../shared/hooks/use_which_flyout');
 jest.mock('../../../../detections/hooks/use_is_analyzer_enabled');
 jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('../../../../flyout_v2/use_flyout_api');
 
 const mockUiSettingsGet = jest.fn();
 let mockServerless: unknown;
@@ -63,6 +68,7 @@ jest.mock('../../../../common/lib/kibana', () => {
 });
 
 const mockUseWhichFlyout = useWhichFlyout as jest.Mock;
+const mockUseFlyoutApi = jest.mocked(useFlyoutApi);
 const FLYOUT_KEY = 'securitySolution';
 const mockExperimentalFeatureFlags = (flags: Record<string, boolean>) => {
   (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
@@ -115,6 +121,7 @@ describe('<AnalyzeGraph />', () => {
     mockServerless = undefined;
     mockUiSettingsGet.mockReturnValue(true);
     mockUseWhichFlyout.mockReturnValue(FLYOUT_KEY);
+    mockUseFlyoutApi.mockReturnValue(createFlyoutApiMock());
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
     mockExperimentalFeatureFlags({});
     (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.tsx
@@ -7,17 +7,8 @@
 
 import React, { memo, useCallback } from 'react';
 import { EuiHorizontalRule } from '@elastic/eui';
-import { useStore } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
-import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
 import { noopCellActionRenderer } from '../../../shared/components/cell_actions';
-import { DocumentFlyoutWrapper } from '../../../document/main/document_flyout_wrapper';
 import { useFlyoutApi } from '../../../use_flyout_api';
 import { AISummarySection } from '../components/ai_summary_section';
 import { VisualizationsSection } from '../components/visualizations_section';
@@ -42,44 +33,20 @@ export interface OverviewTabProps {
  * (and, from Correlations, an alert) as child flyouts via the new flyout system.
  */
 export const OverviewTab = memo(({ hit, onAttackUpdated }: OverviewTabProps) => {
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const { openAttackCorrelations, openAttackEntities } = useFlyoutApi();
+  const { openAttackCorrelations, openAttackEntities, openDocumentFlyoutFromIndexAsChild } =
+    useFlyoutApi();
 
   const alertIds = useAttackAlertIds(hit);
 
   const onShowAlert = useCallback(
     (id: string, indexName: string) =>
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: (
-            <DocumentFlyoutWrapper
-              documentId={id}
-              indexName={indexName}
-              renderCellActions={noopCellActionRenderer}
-              onAlertUpdated={onAttackUpdated}
-            />
-          ),
-        }),
-        { ...defaultDocumentFlyoutProperties, historyKey, session: 'inherit' }
-      ),
-    [
-      defaultDocumentFlyoutProperties,
-      history,
-      historyKey,
-      onAttackUpdated,
-      overlays,
-      services,
-      store,
-    ]
+      openDocumentFlyoutFromIndexAsChild({
+        documentId: id,
+        indexName,
+        renderCellActions: noopCellActionRenderer,
+        onAlertUpdated: onAttackUpdated,
+      }),
+    [openDocumentFlyoutFromIndexAsChild, onAttackUpdated]
   );
 
   const onShowCorrelations = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
@@ -9,34 +9,20 @@ import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 import React, { memo, useCallback, useMemo } from 'react';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { DocumentFlyoutWrapper } from '../document_flyout_wrapper';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { type CellActionRenderer } from '../../../shared/components/cell_actions';
 import { EventKind } from '../constants/event_kinds';
 import { getColumns } from '../../tools/prevalence/utils/get_columns';
 import { useRuleWithFallback } from '../../../../detection_engine/rule_management/logic/use_rule_with_fallback';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
-import { useKibana } from '../../../../common/lib/kibana';
 import { ExpandableSection } from '../../../shared/components/expandable_section';
 import { useExpandSection } from '../../../shared/hooks/use_expand_section';
 import { ThreatIntelligenceOverview } from './threat_intelligence_overview';
 import { CorrelationsOverview } from './correlations_overview';
 import { PrevalenceOverview } from './prevalence_overview';
 import { EntitiesOverview } from './entities_overview';
-import { PrevalenceDetails } from '../../tools/prevalence';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
-import { CorrelationsDetails } from '../../tools/correlations';
-import { ThreatIntelligenceDetails } from '../../tools/threat_intelligence';
-import { EntityDetails as EntitiesDetails } from '../../tools/entities';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../../../shared/hooks/use_default_flyout_properties';
 import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
 import { HOST_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
@@ -73,13 +59,14 @@ export interface InsightsSectionProps {
  */
 export const InsightsSection = memo(
   ({ hit, renderCellActions, onAlertUpdated }: InsightsSectionProps) => {
-    const { services } = useKibana();
-    const { overlays } = services;
-    const store = useStore();
-    const history = useHistory();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
     const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+    const {
+      openDocumentFlyoutFromIndexAsChild,
+      openDocumentEntities,
+      openDocumentCorrelations,
+      openDocumentThreatIntelligence,
+      openDocumentPrevalence,
+    } = useFlyoutApi();
 
     const expanded = useExpandSection({
       storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -105,91 +92,29 @@ export const InsightsSection = memo(
     );
 
     const onShowThreatIntelligenceDetails = useCallback(() => {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <ThreatIntelligenceDetails hit={hit} />,
-        }),
-        {
-          ...defaultToolsFlyoutProperties,
-          historyKey,
-          session: 'start',
-        }
-      );
-    }, [history, historyKey, hit, overlays, services, store]);
+      openDocumentThreatIntelligence({ hit });
+    }, [openDocumentThreatIntelligence, hit]);
 
     const onShowAlert = useCallback(
       (id: string, indexName: string) =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={id}
-                indexName={indexName}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultFlyoutProperties,
-            session: 'inherit',
-          }
-        ),
-      [
-        defaultFlyoutProperties,
-        renderCellActions,
-        history,
-        onAlertUpdated,
-        overlays,
-        services,
-        store,
-      ]
+        openDocumentFlyoutFromIndexAsChild({
+          documentId: id,
+          indexName,
+          renderCellActions,
+          onAlertUpdated,
+        }),
+      [openDocumentFlyoutFromIndexAsChild, renderCellActions, onAlertUpdated]
     );
 
-    const onShowEntitiesDetails = useCallback(() => {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <EntitiesDetails hit={hit} />,
-        }),
-        {
-          ...defaultToolsFlyoutProperties,
-          historyKey,
-          session: 'start',
-        }
-      );
-    }, [history, historyKey, hit, overlays, services, store]);
+    const onShowEntitiesDetails = useCallback(
+      () => openDocumentEntities({ hit }),
+      [openDocumentEntities, hit]
+    );
 
-    const onShowCorrelationsDetails = useCallback(() => {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: (
-            <CorrelationsDetails
-              hit={hit}
-              scopeId=""
-              isRulePreview={false}
-              onShowAlert={onShowAlert}
-            />
-          ),
-        }),
-        {
-          ...defaultToolsFlyoutProperties,
-          historyKey,
-          session: 'start',
-        }
-      );
-    }, [history, historyKey, hit, onShowAlert, overlays, services, store]);
+    const onShowCorrelationsDetails = useCallback(
+      () => openDocumentCorrelations({ hit, scopeId: '', isRulePreview: false, onShowAlert }),
+      [openDocumentCorrelations, hit, onShowAlert]
+    );
 
     const renderFlyoutLink = useCallback(
       (props: OpenFlyoutLinkProps) => (
@@ -199,36 +124,18 @@ export const InsightsSection = memo(
     );
 
     const onShowPrevalenceDetails = useCallback(() => {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: (
-            <PrevalenceDetails
-              hit={hit}
-              investigationFields={investigationFields}
-              scopeId={''}
-              columns={getColumns(renderCellActions, isInSecurityApp, '', renderFlyoutLink)}
-            />
-          ),
-        }),
-        {
-          ...defaultToolsFlyoutProperties,
-          historyKey,
-          session: 'start',
-        }
-      );
+      openDocumentPrevalence({
+        hit,
+        investigationFields,
+        scopeId: '',
+        columns: getColumns(renderCellActions, isInSecurityApp, '', renderFlyoutLink),
+      });
     }, [
+      openDocumentPrevalence,
       renderCellActions,
-      history,
-      historyKey,
       hit,
       investigationFields,
       isInSecurityApp,
-      overlays,
-      services,
-      store,
       renderFlyoutLink,
     ]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
@@ -11,24 +11,16 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { isNonLocalIndexName } from '@kbn/es-query';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { defaultToolsFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { EventKind } from '../constants/event_kinds';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
-import { useKibana } from '../../../../common/lib/kibana';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 import { useExpandSection } from '../../../shared/hooks/use_expand_section';
 import { ExpandableSection } from '../../../shared/components/expandable_section';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
 import { InvestigationGuide } from './investigation_guide';
-import { InvestigationGuide as InvestigationGuideToolsFlyout } from '../../tools/investigation_guide';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { HighlightedFields } from './highlighted_fields';
 import { useRuleWithFallback } from '../../../../detection_engine/rule_management/logic/use_rule_with_fallback';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
 import {
@@ -67,12 +59,7 @@ export interface InvestigationSectionProps {
  */
 export const InvestigationSection = memo(
   ({ hit, renderCellActions }: InvestigationSectionProps) => {
-    const { services } = useKibana();
-    const { overlays } = services;
-    const store = useStore();
-    const history = useHistory();
-    const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+    const { openDocumentInvestigationGuide } = useFlyoutApi();
 
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -106,20 +93,8 @@ export const InvestigationSection = memo(
     });
 
     const onShowInvestigationGuide = useCallback(() => {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <InvestigationGuideToolsFlyout hit={hit} />,
-        }),
-        {
-          ...defaultToolsFlyoutProperties,
-          historyKey,
-          session: 'start',
-        }
-      );
-    }, [history, historyKey, hit, overlays, services, store]);
+      openDocumentInvestigationGuide({ hit });
+    }, [openDocumentInvestigationGuide, hit]);
 
     const renderFlyoutLink = useCallback(
       (props: OpenFlyoutLinkProps) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/response_section.tsx
@@ -7,15 +7,7 @@
 
 import React, { memo, useCallback } from 'react';
 import { type DataTableRecord } from '@kbn/discover-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { defaultToolsFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import { ResponseDetails } from '../../tools/response';
-import { useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { ResponseSectionContent } from './response_section_content';
 
 export interface ResponseSectionProps {
@@ -34,28 +26,11 @@ export interface ResponseSectionProps {
  * Constructs the v2 tools flyout callback and forwards rendering to {@link ResponseSectionContent}.
  */
 export const ResponseSection = memo<ResponseSectionProps>(({ hit, isRulePreview = false }) => {
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { openDocumentResponse } = useFlyoutApi();
 
   const onShowResponseDetails = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <ResponseDetails hit={hit} />,
-      }),
-      {
-        ...defaultToolsFlyoutProperties,
-        historyKey,
-        session: 'start',
-      }
-    );
-  }, [history, historyKey, hit, overlays, services, store]);
+    openDocumentResponse({ hit });
+  }, [openDocumentResponse, hit]);
 
   return (
     <ResponseSectionContent

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/visualizations_section.tsx
@@ -8,13 +8,9 @@
 import React, { memo, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
-import { useKibana } from '../../../../common/lib/kibana';
 import { useExpandSection } from '../../../shared/hooks/use_expand_section';
 import { ExpandableSection } from '../../../shared/components/expandable_section';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
@@ -22,13 +18,7 @@ import { AnalyzerPreviewContainer } from './analyzer_preview_container';
 import { SessionPreviewContainer } from './session_preview_container';
 import { GraphPreviewContainer } from './graph_preview_container';
 import { useGraphPreview } from '../hooks/use_graph_preview';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import { AnalyzerGraph } from '../../tools/analyzer';
 import { useSessionViewConfig } from '../../tools/session_view/hooks/use_session_view_config';
-import { SessionView } from '../../tools/session_view';
-import { GraphDetails } from '../../tools/graph';
-import { defaultToolsFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 
 export const VISUALIZATION_SECTION_TEST_ID = `${PREFIX}Visualizations` as const;
 
@@ -62,14 +52,9 @@ export interface VisualizationsSectionProps {
  */
 export const VisualizationsSection = memo(
   ({ hit, renderCellActions, onAlertUpdated }: VisualizationsSectionProps) => {
-    const { services } = useKibana();
-    const { overlays } = services;
-    const store = useStore();
-    const history = useHistory();
+    const { openAnalyzer, openSessionView, openDocumentGraph } = useFlyoutApi();
     const sessionViewConfig = useSessionViewConfig(hit);
     const { hasGraphData } = useGraphPreview({ hit });
-    const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
     const expanded = useExpandSection({
       storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -78,88 +63,32 @@ export const VisualizationsSection = memo(
     });
 
     const onShowAnalyzer = useCallback(
-      () =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <AnalyzerGraph
-                hit={hit}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultToolsFlyoutProperties,
-            historyKey,
-            session: 'start',
-          }
-        ),
-      [history, historyKey, hit, onAlertUpdated, overlays, renderCellActions, services, store]
+      () => openAnalyzer({ hit, renderCellActions, onAlertUpdated }),
+      [openAnalyzer, hit, renderCellActions, onAlertUpdated]
     );
 
     const onShowSessionView = useCallback(
       () =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <SessionView
-                hit={hit}
-                jumpToCursor={sessionViewConfig?.jumpToCursor}
-                jumpToEntityId={sessionViewConfig?.jumpToEntityId}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultToolsFlyoutProperties,
-            historyKey,
-            session: 'start',
-          }
-        ),
+        openSessionView({
+          hit,
+          jumpToCursor: sessionViewConfig?.jumpToCursor,
+          jumpToEntityId: sessionViewConfig?.jumpToEntityId,
+          renderCellActions,
+          onAlertUpdated,
+        }),
       [
-        history,
-        historyKey,
+        openSessionView,
         hit,
         onAlertUpdated,
-        overlays,
         renderCellActions,
-        services,
         sessionViewConfig?.jumpToCursor,
         sessionViewConfig?.jumpToEntityId,
-        store,
       ]
     );
 
     const onShowGraph = useCallback(
-      () =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <GraphDetails
-                hit={hit}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultToolsFlyoutProperties,
-            historyKey,
-            session: 'start',
-          }
-        ),
-      [history, historyKey, hit, onAlertUpdated, overlays, renderCellActions, services, store]
+      () => openDocumentGraph({ hit, renderCellActions, onAlertUpdated }),
+      [openDocumentGraph, hit, renderCellActions, onAlertUpdated]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DocumentFlyoutWrapperFromPattern } from './document_flyout_wrapper_from_pattern';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useTimelineEventsDetails } from '../../../timelines/containers/details';
+import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
+
+jest.mock('../../../data_view_manager/hooks/use_data_view');
+jest.mock('../../../timelines/containers/details');
+jest.mock('../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
+jest.mock('@kbn/discover-utils', () => ({
+  buildDataTableRecord: jest.fn(() => ({ id: '1', raw: { _id: '1' }, flattened: {} })),
+  getFieldValue: jest.fn(() => 'event'),
+}));
+// Stub the presentational flyout so we don't need its full provider tree.
+jest.mock('.', () => ({
+  DocumentFlyout: () => <div data-test-subj="document-flyout" />,
+}));
+
+const props = {
+  documentId: '1',
+  indexName: 'logs-*,.alerts-security.alerts-default',
+  renderCellActions: () => null,
+  onAlertUpdated: jest.fn(),
+};
+
+const setEventsDetails = (tuple: unknown[]) =>
+  (useTimelineEventsDetails as jest.Mock).mockReturnValue(tuple);
+
+describe('DocumentFlyoutWrapperFromPattern', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useDataView as jest.Mock).mockReturnValue({
+      dataView: { getRuntimeMappings: jest.fn(() => ({})), hasMatchedIndices: jest.fn(() => true) },
+      status: 'ready',
+    });
+    (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
+    // [loading, dataFormattedForFieldBrowser, searchHit, dataAsNestedObject, refetch]
+    setEventsDetails([false, [], { _id: '1', _index: 'x', fields: {} }, {}, jest.fn()]);
+  });
+
+  it('shows the loading state while the document is being fetched', () => {
+    setEventsDetails([true, [], undefined, null, jest.fn()]);
+    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    expect(getByTestId('document-from-pattern-wrapper-loading')).toBeInTheDocument();
+  });
+
+  it('renders the document flyout once the document is resolved', () => {
+    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    expect(getByTestId('document-flyout')).toBeInTheDocument();
+  });
+
+  it('shows a not-found callout when no document matches the id across the pattern', () => {
+    setEventsDetails([false, [], undefined, null, jest.fn()]);
+    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    expect(getByTestId('document-from-pattern-wrapper-not-found')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useMemo } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { buildDataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import type { EsHitRecord } from '@kbn/discover-utils/types';
+import { EVENT_KIND } from '@kbn/rule-data-utils';
+import type { RunTimeMappings } from '../../../../common/api/search_strategy';
+import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
+import { useTimelineEventsDetails } from '../../../timelines/containers/details';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+import { FlyoutLoading } from '../../shared/components/flyout_loading';
+import { FlyoutMissingAlertsPrivilege } from './components/flyout_missing_alerts_privilege';
+import { EventKind } from './constants/event_kinds';
+import { DocumentFlyout } from '.';
+import type { DocumentFlyoutWrapperProps } from './document_flyout_wrapper';
+
+const DATA_VIEW_ERROR = i18n.translate(
+  'xpack.securitySolution.flyout.document.fromPatternWrapper.dataViewError',
+  {
+    defaultMessage: 'Unable to retrieve the data view for analyzer.',
+  }
+);
+
+const DOCUMENT_NOT_FOUND = i18n.translate(
+  'xpack.securitySolution.flyout.document.fromPatternWrapper.documentNotFound',
+  {
+    defaultMessage: 'Cannot find document. No documents match that ID.',
+  }
+);
+
+/**
+ * Same purpose as {@link DocumentFlyoutWrapper}, but for callers that only know the document id and
+ * a broad index *pattern* (e.g. notes, where the document's concrete `_index` is not stored on the
+ * note). Rather than the single-document ES search (which pins `_index` and therefore needs the
+ * concrete index), it resolves the document from its id across the pattern using the timeline
+ * events-details search strategy, then renders the same presentational `DocumentFlyout`.
+ *
+ * Public props are identical to `DocumentFlyoutWrapper`, so call sites can swap one for the other;
+ * only the internal fetch strategy differs.
+ */
+export const DocumentFlyoutWrapperFromPattern = memo(
+  ({ documentId, indexName, renderCellActions, onAlertUpdated }: DocumentFlyoutWrapperProps) => {
+    const { dataView, status } = useDataView(PageScope.default);
+
+    const isDataViewLoading = status === 'loading' || status === 'pristine';
+    const isDataViewInvalid =
+      status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+
+    const shouldSkipSearch = useMemo(
+      () => isDataViewLoading || isDataViewInvalid || !documentId || !indexName || !dataView,
+      [dataView, documentId, indexName, isDataViewInvalid, isDataViewLoading]
+    );
+
+    const runtimeMappings = dataView?.getRuntimeMappings() as RunTimeMappings;
+
+    const [loading, , searchHit, , refetchDocument] = useTimelineEventsDetails({
+      indexName: indexName ?? '',
+      eventId: documentId ?? '',
+      runtimeMappings,
+      skip: shouldSkipSearch,
+    });
+
+    const hit = useMemo(
+      () => (searchHit ? buildDataTableRecord(searchHit as EsHitRecord) : undefined),
+      [searchHit]
+    );
+
+    const handleAlertUpdated = useCallback(() => {
+      onAlertUpdated();
+      refetchDocument();
+    }, [onAlertUpdated, refetchDocument]);
+
+    const isAlert = useMemo(
+      () => hit && (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+      [hit]
+    );
+
+    const { hasAlertsRead, loading: isAlertsPrivilegesLoading } = useAlertsPrivileges();
+    const missingAlertsPrivilege = isAlert && !isAlertsPrivilegesLoading && !hasAlertsRead;
+
+    if (isDataViewLoading || (isAlert && isAlertsPrivilegesLoading) || loading) {
+      return <FlyoutLoading data-test-subj="document-from-pattern-wrapper-loading" />;
+    }
+
+    if (missingAlertsPrivilege) {
+      return <FlyoutMissingAlertsPrivilege />;
+    }
+
+    if (isDataViewInvalid) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          color="danger"
+          iconType="warning"
+          title={DATA_VIEW_ERROR}
+          data-test-subj="document-from-pattern-wrapper-data-view-error"
+        />
+      );
+    }
+
+    if (hit) {
+      return (
+        <DocumentFlyout
+          hit={hit}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={handleAlertUpdated}
+        />
+      );
+    }
+
+    return (
+      <EuiCallOut
+        announceOnMount
+        color="danger"
+        iconType="warning"
+        title={DOCUMENT_NOT_FOUND}
+        data-test-subj="document-from-pattern-wrapper-not-found"
+      />
+    );
+  }
+);
+DocumentFlyoutWrapperFromPattern.displayName = 'DocumentFlyoutWrapperFromPattern';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -19,10 +19,6 @@ import { css } from '@emotion/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
-import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { FlyoutLoading } from '../../shared/components/flyout_loading';
@@ -34,14 +30,11 @@ import { OverviewTab } from './tabs/overview_tab';
 import { JsonTab } from './tabs/json_tab';
 import { TableTab } from './tabs/table_tab';
 import { FLYOUT_STORAGE_KEYS } from './constants/local_storage';
-import { NotesDetails } from '../../shared/tools/notes';
 import { useTabs } from '../../shared/hooks/use_tabs';
-import { useKibana } from '../../../common/lib/kibana';
-import { flyoutProviders } from '../../shared/components/flyout_provider';
+import { useFlyoutApi } from '../../use_flyout_api';
 import type { OpenFlyoutLinkProps } from '../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../shared/components/open_flyout_link';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../../shared/constants/flyout_history';
 import { getEcsField } from '../../shared/components/table_field_name_cell';
 import {
   HOST_NAME_FIELD_NAME,
@@ -104,16 +97,12 @@ export interface DocumentFlyoutProps {
  */
 export const DocumentFlyout = memo(
   ({ hit, onAlertUpdated, renderCellActions }: DocumentFlyoutProps) => {
-    const { services } = useKibana();
-    const { overlays } = services;
-    const store = useStore();
-    const history = useHistory();
+    const { openNotes } = useFlyoutApi();
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
     );
     const isSecurityApp = useIsInSecurityApp();
-    const historyKey = isSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
     const { hasAlertsRead, loading } = useAlertsPrivileges();
     const missingAlertsPrivilege = !loading && !hasAlertsRead && isAlert;
 
@@ -161,19 +150,8 @@ export const DocumentFlyout = memo(
     );
 
     const onShowNotes = useCallback(() => {
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: <NotesDetails hit={hit} />,
-        }),
-        {
-          ...defaultToolsFlyoutProperties,
-          historyKey,
-        }
-      );
-    }, [history, historyKey, hit, overlays, services, store]);
+      openNotes({ hit });
+    }, [openNotes, hit]);
 
     if (isAlert && loading) {
       return <FlyoutLoading data-test-subj="document-overview-loading" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
@@ -29,9 +29,8 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
 import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import { DocumentFlyoutWrapper } from '../../main/document_flyout_wrapper';
-import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { useFlyoutApi } from '../../../use_flyout_api';
+import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
 import { renderEntityDetails } from '../../../entity/shared/render_entity_details';
 
@@ -61,40 +60,17 @@ export const GraphDetails = memo(
     const isInSecurityApp = useIsInSecurityApp();
     const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-    const { openNetworkFlyoutAsChild } = useFlyoutApi();
+    const { openDocumentFlyoutFromIndexAsChild, openNetworkFlyoutAsChild } = useFlyoutApi();
 
     const onShowDocument = useCallback(
       (documentId: string, indexName?: string) =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={documentId}
-                indexName={indexName}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultFlyoutProperties,
-            historyKey,
-            session: 'inherit',
-          }
-        ),
-      [
-        defaultFlyoutProperties,
-        history,
-        historyKey,
-        onAlertUpdated,
-        overlays,
-        renderCellActions,
-        services,
-        store,
-      ]
+        openDocumentFlyoutFromIndexAsChild({
+          documentId,
+          indexName,
+          renderCellActions,
+          onAlertUpdated,
+        }),
+      [openDocumentFlyoutFromIndexAsChild, renderCellActions, onAlertUpdated]
     );
 
     const onShowNetwork = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/components/session_view_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/components/session_view_details.test.tsx
@@ -14,7 +14,8 @@ import { Router } from '@kbn/shared-ux-router';
 import { createMemoryHistory } from 'history';
 import type { Process, ProcessEvent } from '@kbn/session-view-plugin/common';
 import { SessionViewDetails } from './session_view_details';
-import { useKibana } from '../../../../../common/lib/kibana';
+import { useFlyoutApi } from '../../../../use_flyout_api';
+import { createFlyoutApiMock } from '../../../../use_flyout_api.mock';
 
 let lastOnJumpToEvent: ((event: ProcessEvent) => void) | undefined;
 
@@ -32,7 +33,7 @@ jest.mock('@elastic/eui', () => {
   };
 });
 
-jest.mock('../../../../../common/lib/kibana');
+jest.mock('../../../../use_flyout_api');
 jest.mock('./process_tab', () => ({
   ProcessTab: () => <div data-test-subj="processTabMock" />,
 }));
@@ -47,8 +48,8 @@ jest.mock('./alerts_tab', () => ({
 }));
 
 describe('SessionViewDetails', () => {
-  const mockUseKibana = jest.mocked(useKibana);
-  const openSystemFlyout = jest.fn();
+  const mockUseFlyoutApi = jest.mocked(useFlyoutApi);
+  const flyoutApi = createFlyoutApiMock();
   const store = createStore(() => ({}));
   const history = createMemoryHistory();
 
@@ -75,13 +76,7 @@ describe('SessionViewDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     lastOnJumpToEvent = undefined;
-    mockUseKibana.mockReturnValue({
-      services: {
-        overlays: {
-          openSystemFlyout,
-        },
-      },
-    } as unknown as ReturnType<typeof useKibana>);
+    mockUseFlyoutApi.mockReturnValue(flyoutApi);
   });
 
   it('delegates jump to event handling to the parent', () => {
@@ -97,6 +92,6 @@ describe('SessionViewDetails', () => {
     lastOnJumpToEvent?.(event);
 
     expect(onJumpToEvent).toHaveBeenCalledWith(event);
-    expect(openSystemFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openDocumentFlyoutFromIndexAsChild).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/components/session_view_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/components/session_view_details.tsx
@@ -9,18 +9,13 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { EuiPanel, EuiTabbedContent } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { Process, ProcessEvent } from '@kbn/session-view-plugin/common';
-import { useStore } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import type { CellActionRenderer } from '../../../../shared/components/cell_actions';
-import { DocumentFlyoutWrapper } from '../../../main/document_flyout_wrapper';
-import { flyoutProviders } from '../../../../shared/components/flyout_provider';
+import { useFlyoutApi } from '../../../../use_flyout_api';
 import { PREFIX } from '../../../../../flyout/shared/test_ids';
 import { type CustomProcess } from '../../../../../flyout/document_details/session_view/context';
 import { AlertsTab } from './alerts_tab';
 import { MetadataTab } from './metadata_tab';
 import { ProcessTab } from './process_tab';
-import { useKibana } from '../../../../../common/lib/kibana';
-import { useDefaultDocumentFlyoutProperties } from '../../../../shared/hooks/use_default_flyout_properties';
 
 export const SESSION_VIEW_DETAILS_TEST_ID = `${PREFIX}SessionViewDetails` as const;
 
@@ -73,43 +68,18 @@ export const SessionViewDetails = memo(
     onJumpToEvent,
     onAlertUpdated,
   }: SessionViewDetailsProps) => {
-    const { services } = useKibana();
-    const { overlays } = services;
-    const store = useStore();
-    const history = useHistory();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+    const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
     const onShowAlertDetails = useCallback(
       (alertId: string, alertIndex: string) => {
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={alertId}
-                indexName={alertIndex}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultFlyoutProperties,
-            session: 'inherit',
-          }
-        );
+        openDocumentFlyoutFromIndexAsChild({
+          documentId: alertId,
+          indexName: alertIndex,
+          renderCellActions,
+          onAlertUpdated,
+        });
       },
-      [
-        defaultFlyoutProperties,
-        history,
-        onAlertUpdated,
-        overlays,
-        renderCellActions,
-        services,
-        store,
-      ]
+      [openDocumentFlyoutFromIndexAsChild, renderCellActions, onAlertUpdated]
     );
 
     const handleJumpToEvent = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/index.tsx
@@ -17,7 +17,7 @@ import { useStore } from 'react-redux';
 import { DocumentToolsFlyoutHeader } from '../../../shared/components/document_tools_flyout_header';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 import type { SessionViewConfig } from '../../../../../common/types/session_view';
-import { DocumentFlyoutWrapper } from '../../main/document_flyout_wrapper';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -73,6 +73,7 @@ export const SessionView: FC<SessionViewProps> = memo(
     const store = useStore();
     const history = useHistory();
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+    const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
     const { canReadPolicyManagement } = useUserPrivileges().endpointPrivileges;
 
@@ -88,34 +89,13 @@ export const SessionView: FC<SessionViewProps> = memo(
 
     const openAlertDetails = useCallback(
       (alertId: string, alertIndex: string, onClose?: () => void) =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={alertId}
-                indexName={alertIndex}
-                renderCellActions={renderCellActions}
-                onAlertUpdated={onAlertUpdated}
-              />
-            ),
-          }),
-          {
-            ...defaultFlyoutProperties,
-            session: 'inherit',
-          }
-        ),
-      [
-        defaultFlyoutProperties,
-        history,
-        onAlertUpdated,
-        overlays,
-        renderCellActions,
-        services,
-        store,
-      ]
+        openDocumentFlyoutFromIndexAsChild({
+          documentId: alertId,
+          indexName: alertIndex,
+          renderCellActions,
+          onAlertUpdated,
+        }),
+      [openDocumentFlyoutFromIndexAsChild, renderCellActions, onAlertUpdated]
     );
 
     const handleJumpToEvent = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.mock.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DocumentFlyoutApi } from './use_document_flyout_api';
+
+/**
+ * Returns a `useDocumentFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useDocumentFlyoutApi).mockReturnValue(createDocumentFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createDocumentFlyoutApiMock = (): jest.Mocked<DocumentFlyoutApi> => ({
+  openDocumentFlyoutFromIndex: jest.fn(),
+  openDocumentFlyoutFromIndexAsChild: jest.fn(),
+  openDocumentFlyoutFromPattern: jest.fn(),
+  openNotes: jest.fn(),
+  openAnalyzer: jest.fn(),
+  openSessionView: jest.fn(),
+  openDocumentEntities: jest.fn(),
+  openDocumentCorrelations: jest.fn(),
+  openDocumentResponse: jest.fn(),
+  openDocumentThreatIntelligence: jest.fn(),
+  openDocumentPrevalence: jest.fn(),
+  openDocumentInvestigationGuide: jest.fn(),
+  openDocumentGraph: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { useDocumentFlyoutApi } from './use_document_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../../common/hooks/use_experimental_features');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+  defaultToolsFlyoutProperties: { size: 'm' },
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+
+describe('useDocumentFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  const getProperties = () => mockOpenSystemFlyout.mock.calls[0][1];
+
+  it('openDocumentFlyoutFromIndex opens a system flyout with the document properties', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentFlyoutFromIndex({ documentId: '1', indexName: 'index' });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openDocumentFlyoutFromIndexAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentFlyoutFromIndexAsChild({ documentId: '1', indexName: 'index' });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({
+        size: 's',
+        session: 'inherit',
+        historyKey: documentFlyoutHistoryKey,
+      })
+    );
+  });
+
+  it('openDocumentFlyoutFromPattern opens a system flyout with the document properties', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentFlyoutFromPattern({ documentId: '1', indexName: 'logs-*,alerts-*' });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start' })
+    );
+  });
+
+  it('openNotes opens a tools flyout without a session (inherits the parent)', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openNotes({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', historyKey: documentFlyoutHistoryKey })
+    );
+    expect(getProperties().session).toBeUndefined();
+  });
+
+  it('openAnalyzer opens a tools flyout as a new session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openAnalyzer({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('openSessionView opens a tools flyout as a new session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openSessionView({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('openDocumentEntities opens a tools flyout as a new session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentEntities({ hit });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('openDocumentCorrelations opens a tools flyout as a new session', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentCorrelations({
+      hit,
+      scopeId: '',
+      isRulePreview: false,
+      onShowAlert: jest.fn(),
+    });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it.each([
+    ['openDocumentResponse', () => ({ hit })],
+    ['openDocumentThreatIntelligence', () => ({ hit })],
+    ['openDocumentInvestigationGuide', () => ({ hit })],
+    ['openDocumentGraph', () => ({ hit })],
+    ['openDocumentPrevalence', () => ({ hit, investigationFields: [], scopeId: '', columns: [] })],
+  ] as const)('%s opens a tools flyout as a new session', (method, buildParams) => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result.current[method] as (params: any) => void)(buildParams());
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openNotes({ hit });
+
+    expect(getProperties().historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -1,0 +1,463 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { noop } from 'lodash/fp';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { PrevalenceDetailsProps } from './tools/prevalence';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import type { CellActionRenderer } from '../shared/components/cell_actions';
+import { cellActionRenderer } from '../shared/components/cell_actions';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import {
+  defaultToolsFlyoutProperties,
+  useDefaultDocumentFlyoutProperties,
+} from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+// Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
+// tool graph into their bundle; the chunk only loads when a flyout is actually opened.
+const DocumentFlyoutWrapper = lazy(() =>
+  import('./main/document_flyout_wrapper').then((m) => ({ default: m.DocumentFlyoutWrapper }))
+);
+const DocumentFlyoutWrapperFromPattern = lazy(() =>
+  import('./main/document_flyout_wrapper_from_pattern').then((m) => ({
+    default: m.DocumentFlyoutWrapperFromPattern,
+  }))
+);
+const NotesDetails = lazy(() =>
+  import('../shared/tools/notes').then((m) => ({ default: m.NotesDetails }))
+);
+const AnalyzerGraph = lazy(() =>
+  import('./tools/analyzer').then((m) => ({ default: m.AnalyzerGraph }))
+);
+const SessionView = lazy(() =>
+  import('./tools/session_view').then((m) => ({ default: m.SessionView }))
+);
+const EntityDetails = lazy(() =>
+  import('./tools/entities').then((m) => ({ default: m.EntityDetails }))
+);
+const CorrelationsDetails = lazy(() =>
+  import('./tools/correlations').then((m) => ({ default: m.CorrelationsDetails }))
+);
+const ResponseDetails = lazy(() =>
+  import('./tools/response').then((m) => ({ default: m.ResponseDetails }))
+);
+const PrevalenceDetails = lazy(() =>
+  import('./tools/prevalence').then((m) => ({ default: m.PrevalenceDetails }))
+);
+const ThreatIntelligenceDetails = lazy(() =>
+  import('./tools/threat_intelligence').then((m) => ({ default: m.ThreatIntelligenceDetails }))
+);
+const InvestigationGuide = lazy(() =>
+  import('./tools/investigation_guide').then((m) => ({ default: m.InvestigationGuide }))
+);
+const GraphDetails = lazy(() => import('./tools/graph').then((m) => ({ default: m.GraphDetails })));
+
+export interface OpenDocumentFlyoutParams {
+  /** Elasticsearch `_id` of the document to open. */
+  documentId: string;
+  /**
+   * For `openDocumentFlyoutFromIndex`, the concrete `_index` of the document.
+   * For `openDocumentFlyoutFromPattern`, a (possibly comma-separated / wildcard) index pattern.
+   */
+  indexName: string | undefined;
+  /** Renderer for cell actions in the flyout. Defaults to the standard `cellActionRenderer`. */
+  renderCellActions?: CellActionRenderer;
+  /** Invoked after an alert is mutated inside the flyout, to let the caller refresh. Defaults to a no-op. */
+  onAlertUpdated?: () => void;
+}
+
+export interface OpenNotesParams {
+  /** The document record whose notes should be shown. */
+  hit: DataTableRecord;
+}
+
+export interface OpenAnalyzerParams {
+  /** The document record to analyze. */
+  hit: DataTableRecord;
+  renderCellActions?: CellActionRenderer;
+  onAlertUpdated?: () => void;
+}
+
+export interface OpenSessionViewParams {
+  /** The document record to open the session view for. */
+  hit: DataTableRecord;
+  jumpToCursor?: string;
+  jumpToEntityId?: string;
+  renderCellActions?: CellActionRenderer;
+  onAlertUpdated?: () => void;
+}
+
+export interface OpenDocumentEntitiesParams {
+  /** The document record whose related entities should be shown. */
+  hit: DataTableRecord;
+  /** Scope id for the entity links opened from the tool. */
+  scopeId?: string;
+}
+
+export interface OpenDocumentCorrelationsParams {
+  /** The document record whose correlations should be shown. */
+  hit: DataTableRecord;
+  /** Scope id for the document. */
+  scopeId: string;
+  /** Whether the document is being displayed in a rule preview. */
+  isRulePreview: boolean;
+  /** Callback to open one of the correlated alerts. */
+  onShowAlert: (id: string, indexName: string) => void;
+  /** Optional callback to open a correlated attack; when omitted the attack column is hidden. */
+  onShowAttack?: (id: string, indexName: string) => void;
+}
+
+export interface OpenDocumentResponseParams {
+  /** The alert document whose response actions should be shown. */
+  hit: DataTableRecord;
+}
+
+export interface OpenDocumentThreatIntelligenceParams {
+  /** The document whose threat intelligence matches should be shown. */
+  hit: DataTableRecord;
+}
+
+export interface OpenDocumentInvestigationGuideParams {
+  /** The alert document whose investigation guide should be shown. */
+  hit: DataTableRecord;
+}
+
+/** Parameters for the prevalence tool. Mirrors the tool's own props (the caller builds `columns`). */
+export type OpenDocumentPrevalenceParams = PrevalenceDetailsProps;
+
+export interface OpenDocumentGraphParams {
+  /** The document to render the graph for. */
+  hit: DataTableRecord;
+  renderCellActions?: CellActionRenderer;
+  onAlertUpdated?: () => void;
+}
+
+export interface DocumentFlyoutApi {
+  /**
+   * Opens the document details flyout (resolving the document from its concrete `_index`) as a new,
+   * top-level flyout (starting a fresh session). Use this from outside any flyout — e.g. a table row.
+   */
+  openDocumentFlyoutFromIndex: (params: OpenDocumentFlyoutParams) => void;
+  /**
+   * Opens the document details flyout (resolving from its concrete `_index`) as a child of the
+   * currently open flyout (nested in its history stack, so the back button returns to it). Use this
+   * from within an already-open flyout — e.g. a node click in the graph tool.
+   */
+  openDocumentFlyoutFromIndexAsChild: (params: OpenDocumentFlyoutParams) => void;
+  /**
+   * Opens the document details flyout, resolving the document from its id across an index pattern
+   * (for callers that don't know the concrete `_index`, e.g. notes).
+   */
+  openDocumentFlyoutFromPattern: (params: OpenDocumentFlyoutParams) => void;
+  /** Opens the notes tools flyout for a document. */
+  openNotes: (params: OpenNotesParams) => void;
+  /** Opens the analyzer tools flyout for a document. */
+  openAnalyzer: (params: OpenAnalyzerParams) => void;
+  /** Opens the session view tools flyout for a document. */
+  openSessionView: (params: OpenSessionViewParams) => void;
+  /** Opens the document's Entities tool flyout (hosts/users involved in the document). */
+  openDocumentEntities: (params: OpenDocumentEntitiesParams) => void;
+  /** Opens the document's Correlations tool flyout (related alerts/events/attacks). */
+  openDocumentCorrelations: (params: OpenDocumentCorrelationsParams) => void;
+  /** Opens the document's Response actions tool flyout. */
+  openDocumentResponse: (params: OpenDocumentResponseParams) => void;
+  /** Opens the document's Threat Intelligence tool flyout. */
+  openDocumentThreatIntelligence: (params: OpenDocumentThreatIntelligenceParams) => void;
+  /** Opens the document's Prevalence tool flyout. */
+  openDocumentPrevalence: (params: OpenDocumentPrevalenceParams) => void;
+  /** Opens the document's Investigation Guide tool flyout. */
+  openDocumentInvestigationGuide: (params: OpenDocumentInvestigationGuideParams) => void;
+  /** Opens the document's Graph tool flyout. */
+  openDocumentGraph: (params: OpenDocumentGraphParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) document flyout and its tool flyouts, in the
+ * same mindset as `useExpandableFlyoutApi`. It encapsulates the provider wiring
+ * (`flyoutProviders` + `overlays.openSystemFlyout`) and the per-tool flyout properties so call
+ * sites don't have to repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  const open = useCallback(
+    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history]
+  );
+
+  // Builds the document flyout content (resolved from a concrete `_index`), shared by both the main
+  // and child open methods. Only the `session` differs between them, so it is kept private here and
+  // callers pick `openDocumentFlyoutFromIndex` (main) or `openDocumentFlyoutFromIndexAsChild` (child).
+  const buildFromIndexContent = useCallback(
+    ({
+      documentId,
+      indexName,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenDocumentFlyoutParams): ReactNode => (
+      <DocumentFlyoutWrapper
+        documentId={documentId}
+        indexName={indexName}
+        renderCellActions={renderCellActions}
+        onAlertUpdated={onAlertUpdated}
+      />
+    ),
+    []
+  );
+
+  const openDocumentFlyoutFromIndex = useCallback(
+    (params: OpenDocumentFlyoutParams) => {
+      open(buildFromIndexContent(params), {
+        ...defaultDocumentFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openDocumentFlyoutFromIndexAsChild = useCallback(
+    (params: OpenDocumentFlyoutParams) => {
+      open(buildFromIndexContent(params), {
+        ...defaultDocumentFlyoutProperties,
+        historyKey,
+        session: 'inherit',
+      });
+    },
+    [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openDocumentFlyoutFromPattern = useCallback(
+    ({
+      documentId,
+      indexName,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenDocumentFlyoutParams) => {
+      open(
+        <DocumentFlyoutWrapperFromPattern
+          documentId={documentId}
+          indexName={indexName}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openNotes = useCallback(
+    ({ hit }: OpenNotesParams) => {
+      open(<NotesDetails hit={hit} />, { ...defaultToolsFlyoutProperties, historyKey });
+    },
+    [open, historyKey]
+  );
+
+  const openAnalyzer = useCallback(
+    ({
+      hit,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenAnalyzerParams) => {
+      open(
+        <AnalyzerGraph
+          hit={hit}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  const openSessionView = useCallback(
+    ({
+      hit,
+      jumpToCursor,
+      jumpToEntityId,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenSessionViewParams) => {
+      open(
+        <SessionView
+          hit={hit}
+          jumpToCursor={jumpToCursor}
+          jumpToEntityId={jumpToEntityId}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentEntities = useCallback(
+    ({ hit, scopeId }: OpenDocumentEntitiesParams) => {
+      open(<EntityDetails hit={hit} scopeId={scopeId} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentCorrelations = useCallback(
+    ({
+      hit,
+      scopeId,
+      isRulePreview,
+      onShowAlert,
+      onShowAttack,
+    }: OpenDocumentCorrelationsParams) => {
+      open(
+        <CorrelationsDetails
+          hit={hit}
+          scopeId={scopeId}
+          isRulePreview={isRulePreview}
+          onShowAlert={onShowAlert}
+          onShowAttack={onShowAttack}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentResponse = useCallback(
+    ({ hit }: OpenDocumentResponseParams) => {
+      open(<ResponseDetails hit={hit} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentThreatIntelligence = useCallback(
+    ({ hit }: OpenDocumentThreatIntelligenceParams) => {
+      open(<ThreatIntelligenceDetails hit={hit} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentPrevalence = useCallback(
+    ({ hit, investigationFields, scopeId, columns }: OpenDocumentPrevalenceParams) => {
+      open(
+        <PrevalenceDetails
+          hit={hit}
+          investigationFields={investigationFields}
+          scopeId={scopeId}
+          columns={columns}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentInvestigationGuide = useCallback(
+    ({ hit }: OpenDocumentInvestigationGuideParams) => {
+      open(<InvestigationGuide hit={hit} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
+    },
+    [open, historyKey]
+  );
+
+  const openDocumentGraph = useCallback(
+    ({
+      hit,
+      renderCellActions = cellActionRenderer,
+      onAlertUpdated = noop,
+    }: OpenDocumentGraphParams) => {
+      open(
+        <GraphDetails
+          hit={hit}
+          renderCellActions={renderCellActions}
+          onAlertUpdated={onAlertUpdated}
+        />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    },
+    [open, historyKey]
+  );
+
+  return useMemo(
+    () => ({
+      openDocumentFlyoutFromIndex,
+      openDocumentFlyoutFromIndexAsChild,
+      openDocumentFlyoutFromPattern,
+      openNotes,
+      openAnalyzer,
+      openSessionView,
+      openDocumentEntities,
+      openDocumentCorrelations,
+      openDocumentResponse,
+      openDocumentThreatIntelligence,
+      openDocumentPrevalence,
+      openDocumentInvestigationGuide,
+      openDocumentGraph,
+    }),
+    [
+      openDocumentFlyoutFromIndex,
+      openDocumentFlyoutFromIndexAsChild,
+      openDocumentFlyoutFromPattern,
+      openNotes,
+      openAnalyzer,
+      openSessionView,
+      openDocumentEntities,
+      openDocumentCorrelations,
+      openDocumentResponse,
+      openDocumentThreatIntelligence,
+      openDocumentPrevalence,
+      openDocumentInvestigationGuide,
+      openDocumentGraph,
+    ]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/alerts_insights/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/alerts_insights/index.tsx
@@ -8,10 +8,7 @@
 import React, { memo, useCallback } from 'react';
 import { EuiFlyoutHeader } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { noop } from 'lodash/fp';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import {
   EntityIdentifierFields,
   EntityType,
@@ -20,13 +17,8 @@ import { ToolsFlyoutHeader } from '../../../../shared/components/tools_flyout_he
 import { EntityIconByType } from '../../../../../entity_analytics/components/entity_store/entity_icon_by_type';
 import { AlertsDetailsTable } from '../../../../../cloud_security_posture/components/csp_details/alerts_findings_details_table';
 import type { CloudPostureEntityIdentifier } from '../../../../../cloud_security_posture/components/entity_insight';
-import { useKibana } from '../../../../../common/lib/kibana';
-import { flyoutProviders } from '../../../../shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../shared/hooks/use_default_flyout_properties';
-import { DocumentFlyoutWrapper } from '../../../../document/main/document_flyout_wrapper';
+import { useFlyoutApi } from '../../../../use_flyout_api';
 import { cellActionRenderer } from '../../../../shared/components/cell_actions';
-import { useIsInSecurityApp } from '../../../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../../../../shared/constants/flyout_history';
 import { ALERTS_INSIGHTS_TOOL_TEST_ID } from './test_ids';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.entityDetails.alertsInsights.title', {
@@ -57,37 +49,18 @@ export interface AlertsInsightsProps {
 
 export const AlertsInsights = memo(
   ({ entityType, value, entityId, onShowEntity }: AlertsInsightsProps) => {
-    const { services } = useKibana();
-    const store = useStore();
-    const history = useHistory();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-    const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+    const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
     const onExpandAlert = useCallback(
       (eventId: string, indexName: string) => {
-        services.overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={eventId}
-                indexName={indexName}
-                renderCellActions={cellActionRenderer}
-                onAlertUpdated={noop}
-              />
-            ),
-          }),
-          {
-            ...defaultFlyoutProperties,
-            historyKey,
-            session: 'inherit',
-          }
-        );
+        openDocumentFlyoutFromIndexAsChild({
+          documentId: eventId,
+          indexName,
+          renderCellActions: cellActionRenderer,
+          onAlertUpdated: noop,
+        });
       },
-      [services, store, history, defaultFlyoutProperties, historyKey]
+      [openDocumentFlyoutFromIndexAsChild]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
@@ -22,11 +22,10 @@ import { useIsInSecurityApp } from '../../../../../common/hooks/is_in_security_a
 import { flyoutProviders } from '../../../../shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../../../../shared/constants/flyout_history';
-import { DocumentFlyoutWrapper } from '../../../../document/main/document_flyout_wrapper';
+import { useFlyoutApi } from '../../../../use_flyout_api';
 import { cellActionRenderer } from '../../../../shared/components/cell_actions';
 import { ToolsFlyoutHeader } from '../../../../shared/components/tools_flyout_header';
 import { GraphVisualization } from '../../../../document/tools/graph/components/graph_visualization';
-import { useFlyoutApi } from '../../../../use_flyout_api';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.entityDetails.graphView.title', {
   defaultMessage: 'Graph',
@@ -63,27 +62,17 @@ export const GraphView = memo(
     const isInSecurityApp = useIsInSecurityApp();
     const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-    const { openNetworkFlyoutAsChild } = useFlyoutApi();
+    const { openDocumentFlyoutFromIndexAsChild, openNetworkFlyoutAsChild } = useFlyoutApi();
 
     const onShowDocument = useCallback(
       (documentId: string, indexName?: string) =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={documentId}
-                indexName={indexName}
-                renderCellActions={cellActionRenderer}
-                onAlertUpdated={noop}
-              />
-            ),
-          }),
-          { ...defaultFlyoutProperties, historyKey, session: 'inherit' }
-        ),
-      [overlays, services, store, history, defaultFlyoutProperties, historyKey]
+        openDocumentFlyoutFromIndexAsChild({
+          documentId,
+          indexName,
+          renderCellActions: cellActionRenderer,
+          onAlertUpdated: noop,
+        }),
+      [openDocumentFlyoutFromIndexAsChild]
     );
 
     const onShowNetwork = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/risk_inputs/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/risk_inputs/index.tsx
@@ -8,21 +8,13 @@
 import React, { memo, useCallback } from 'react';
 import { EuiFlyoutBody, EuiFlyoutHeader } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { noop } from 'lodash/fp';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { EntityType } from '../../../../../../common/entity_analytics/types';
 import { EntityIconByType } from '../../../../../entity_analytics/components/entity_store/entity_icon_by_type';
 import { RiskInputsTab } from '../../../../../entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab';
 import { ToolsFlyoutHeader } from '../../../../shared/components/tools_flyout_header';
-import { useKibana } from '../../../../../common/lib/kibana';
-import { flyoutProviders } from '../../../../shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../shared/hooks/use_default_flyout_properties';
-import { DocumentFlyoutWrapper } from '../../../../document/main/document_flyout_wrapper';
+import { useFlyoutApi } from '../../../../use_flyout_api';
 import { cellActionRenderer } from '../../../../shared/components/cell_actions';
-import { useIsInSecurityApp } from '../../../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../../../../shared/constants/flyout_history';
 import { RISK_INPUTS_TOOL_TEST_ID } from './test_ids';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.entityDetails.riskInputs.title', {
@@ -44,37 +36,18 @@ export interface RiskInputsProps {
 
 export const RiskInputs = memo(
   ({ entityType, entityName, entityId, onShowEntity }: RiskInputsProps) => {
-    const { services } = useKibana();
-    const store = useStore();
-    const history = useHistory();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-    const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+    const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
     const onShowAlert = useCallback(
       (id: string, indexName: string) => {
-        services.overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <DocumentFlyoutWrapper
-                documentId={id}
-                indexName={indexName}
-                renderCellActions={cellActionRenderer}
-                onAlertUpdated={noop}
-              />
-            ),
-          }),
-          {
-            ...defaultFlyoutProperties,
-            historyKey,
-            session: 'inherit',
-          }
-        );
+        openDocumentFlyoutFromIndexAsChild({
+          documentId: id,
+          indexName,
+          renderCellActions: cellActionRenderer,
+          onAlertUpdated: noop,
+        });
       },
-      [services, store, history, defaultFlyoutProperties, historyKey]
+      [openDocumentFlyoutFromIndexAsChild]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/cell_actions.tsx
@@ -6,7 +6,10 @@
  */
 
 import React from 'react';
-import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import {
+  SECURITY_CELL_ACTIONS_CASE_EVENTS,
+  SECURITY_CELL_ACTIONS_DEFAULT,
+} from '@kbn/ui-actions-plugin/common/trigger_ids';
 import {
   type CellActionFieldValue,
   CellActionsMode,
@@ -46,6 +49,31 @@ export const cellActionRenderer: CellActionRenderer = ({
     triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
     mode={CellActionsMode.HOVER_DOWN}
     visibleCellActions={5}
+    sourcererScopeId={getSourcererScopeId(scopeId)}
+    metadata={{ scopeId }}
+  >
+    {children}
+  </SecurityCellActions>
+);
+
+/**
+ * Cell action renderer for Cases.
+ * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
+ */
+export const casesCellActionRenderer: CellActionRenderer = ({
+  field,
+  value,
+  children,
+  scopeId,
+}: CellActionRendererProps) => (
+  <SecurityCellActions
+    data={{
+      field,
+      value: value ?? [],
+    }}
+    triggerId={SECURITY_CELL_ACTIONS_CASE_EVENTS}
+    mode={CellActionsMode.HOVER_DOWN}
+    visibleCellActions={2}
     sourcererScopeId={getSourcererScopeId(scopeId)}
     metadata={{ scopeId }}
   >

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
@@ -7,6 +7,7 @@
 
 import type { FlyoutApi } from './use_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+import { createDocumentFlyoutApiMock } from './document/use_document_flyout_api.mock';
 import { createIocFlyoutApiMock } from './ioc/use_ioc_flyout_api.mock';
 import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
 import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
@@ -18,6 +19,7 @@ import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
  * the individual method you care about.
  */
 export const createFlyoutApiMock = (): jest.Mocked<FlyoutApi> => ({
+  ...createDocumentFlyoutApiMock(),
   ...createAttackFlyoutApiMock(),
   ...createIocFlyoutApiMock(),
   ...createNetworkFlyoutApiMock(),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
@@ -6,10 +6,13 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import { FlowTargetSourceDest } from '../../common/search_strategy/security_solution/network';
 import type { Indicator } from '../../common/threat_intelligence/types/indicator';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+import { useDocumentFlyoutApi } from './document/use_document_flyout_api';
+import { createDocumentFlyoutApiMock } from './document/use_document_flyout_api.mock';
 import { useIocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import { createIocFlyoutApiMock } from './ioc/use_ioc_flyout_api.mock';
 import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
@@ -19,6 +22,7 @@ import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
 import { useFlyoutApi } from './use_flyout_api';
 
 jest.mock('./attack/use_attack_flyout_api');
+jest.mock('./document/use_document_flyout_api');
 jest.mock('./ioc/use_ioc_flyout_api');
 jest.mock('./network/use_network_flyout_api');
 jest.mock('./rule/use_rule_flyout_api');
@@ -28,11 +32,13 @@ describe('useFlyoutApi', () => {
     jest.clearAllMocks();
   });
 
-  it('exposes the attack, IOC, network, and rule methods from composed per-type hooks', () => {
+  it('exposes document, attack, IOC, network, and rule methods from composed hooks', () => {
+    const documentApi = createDocumentFlyoutApiMock();
     const attackApi = createAttackFlyoutApiMock();
     const iocApi = createIocFlyoutApiMock();
     const networkApi = createNetworkFlyoutApiMock();
     const ruleApi = createRuleFlyoutApiMock();
+    jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentApi);
     jest.mocked(useAttackFlyoutApi).mockReturnValue(attackApi);
     jest.mocked(useIocFlyoutApi).mockReturnValue(iocApi);
     jest.mocked(useNetworkFlyoutApi).mockReturnValue(networkApi);
@@ -40,12 +46,16 @@ describe('useFlyoutApi', () => {
 
     const { result } = renderHook(() => useFlyoutApi());
 
+    const fromIndexParams = { documentId: '1', indexName: 'index' };
     const attackParams = { attackId: 'attack-1', indexName: '.alerts-security' };
+    const iocParams = { indicator: { _id: 'ioc-1', fields: {} } as unknown as Indicator };
     const networkParams = { ip: '1.2.3.4', flowTarget: FlowTargetSourceDest.source };
     const ruleParams = { ruleId: 'rule-1' };
-    const iocParams = { indicator: { _id: 'ioc-1', fields: {} } as unknown as Indicator };
+    const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
 
-    // The facade surfaces the composed methods, and calling one delegates to the per-type hook.
+    result.current.openDocumentFlyoutFromIndex(fromIndexParams);
+    result.current.openDocumentFlyoutFromIndexAsChild(fromIndexParams);
+    result.current.openNotes({ hit });
     result.current.openAttackFlyout(attackParams);
     result.current.openAttackFlyoutAsChild(attackParams);
     result.current.openIocFlyout(iocParams);
@@ -55,6 +65,9 @@ describe('useFlyoutApi', () => {
     result.current.openRuleFlyout(ruleParams);
     result.current.openRuleFlyoutAsChild(ruleParams);
 
+    expect(documentApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith(fromIndexParams);
+    expect(documentApi.openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledWith(fromIndexParams);
+    expect(documentApi.openNotes).toHaveBeenCalledWith({ hit });
     expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(attackParams);
     expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(attackParams);
     expect(iocApi.openIocFlyout).toHaveBeenCalledWith(iocParams);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
@@ -8,6 +8,8 @@
 import { useMemo } from 'react';
 import type { AttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
+import type { DocumentFlyoutApi } from './document/use_document_flyout_api';
+import { useDocumentFlyoutApi } from './document/use_document_flyout_api';
 import type { IocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import { useIocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import type { NetworkFlyoutApi } from './network/use_network_flyout_api';
@@ -18,9 +20,9 @@ import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
 /**
  * The single developer-facing API for opening any new (EUI-based) Security Solution flyout.
  *
- * Rather than importing a per-type hook (`useDocumentFlyoutApi`, …), call
+ * Rather than importing a per-type hook (`useDocumentFlyoutApi`, ...), call
  * sites use this one hook and get every open method, namespaced by type
- * (`openDocumentFlyoutFromIndex`, …).
+ * (`openDocumentFlyoutFromIndex`, ...).
  * Each method comes in
  * a main variant (opens a new, top-level flyout) and, where it makes sense, an `...AsChild` variant
  * (opens nested inside the currently open flyout). Callers never deal with the flyout `session`.
@@ -35,9 +37,14 @@ import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
  *
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
-export type FlyoutApi = AttackFlyoutApi & IocFlyoutApi & NetworkFlyoutApi & RuleFlyoutApi;
+export type FlyoutApi = DocumentFlyoutApi &
+  AttackFlyoutApi &
+  IocFlyoutApi &
+  NetworkFlyoutApi &
+  RuleFlyoutApi;
 
 export const useFlyoutApi = (): FlyoutApi => {
+  const documentApi = useDocumentFlyoutApi();
   const attack = useAttackFlyoutApi();
   const ioc = useIocFlyoutApi();
   const network = useNetworkFlyoutApi();
@@ -45,11 +52,12 @@ export const useFlyoutApi = (): FlyoutApi => {
 
   return useMemo(
     () => ({
+      ...documentApi,
       ...attack,
       ...ioc,
       ...network,
       ...rule,
     }),
-    [attack, ioc, network, rule]
+    [documentApi, attack, ioc, network, rule]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.test.tsx
@@ -15,16 +15,30 @@ import { DocumentDetailsRightPanelKey } from '../../flyout/document_details/shar
 import { TableId } from '@kbn/securitysolution-data-table';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { withIndices } from '../../data_view_manager/hooks/__mocks__/use_data_view';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
 
 jest.mock('@kbn/expandable-flyout');
+jest.mock('../../flyout_v2/use_flyout_api');
+jest.mock('../../common/hooks/use_is_new_flyout_enabled');
 
 const mockEventId = 'eventId';
 const mockTimelineId = 'timelineId';
 
 describe('OpenFlyoutButtonIcon', () => {
-  it('should render the chevron icon', () => {
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    flyoutApi = createFlyoutApiMock();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useDataView).mockReturnValue(withIndices(['test1', 'test2']));
+  });
+
+  it('should render the chevron icon', () => {
     const { getByTestId } = render(
       <TestProviders>
         <OpenFlyoutButtonIcon
@@ -38,10 +52,9 @@ describe('OpenFlyoutButtonIcon', () => {
     expect(getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should call the expandable flyout api when the button is clicked', () => {
+  it('should open the legacy expandable flyout when the new flyout is disabled', () => {
     const openFlyout = jest.fn();
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout });
-    jest.mocked(useDataView).mockReturnValue(withIndices(['test1', 'test2']));
 
     const { getByTestId } = render(
       <TestProviders>
@@ -53,8 +66,7 @@ describe('OpenFlyoutButtonIcon', () => {
       </TestProviders>
     );
 
-    const button = getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID);
-    button.click();
+    getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID).click();
 
     expect(openFlyout).toHaveBeenCalledWith({
       right: {
@@ -65,6 +77,28 @@ describe('OpenFlyoutButtonIcon', () => {
           scopeId: TableId.alertsOnAlertsPage,
         },
       },
+    });
+    expect(flyoutApi.openDocumentFlyoutFromPattern).not.toHaveBeenCalled();
+  });
+
+  it('should open the new document flyout (from pattern) when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <OpenFlyoutButtonIcon
+          eventId={mockEventId}
+          timelineId={mockTimelineId}
+          iconType="chevronSingleRight"
+        />
+      </TestProviders>
+    );
+
+    getByTestId(OPEN_FLYOUT_BUTTON_TEST_ID).click();
+
+    expect(flyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith({
+      documentId: mockEventId,
+      indexName: 'test1,test2',
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
@@ -14,7 +14,9 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { PageScope } from '../../data_view_manager/constants';
 import { OPEN_FLYOUT_BUTTON_TEST_ID } from './test_ids';
 import { useKibana } from '../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentDetailsRightPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 import { DocumentEventTypes } from '../../common/lib/telemetry';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 
@@ -50,23 +52,38 @@ export const OpenFlyoutButtonIcon = memo(
 
     const { telemetry } = useKibana().services;
     const { openFlyout } = useExpandableFlyoutApi();
+    const enableNewFlyout = useIsNewFlyoutEnabled();
+    const { openDocumentFlyoutFromPattern } = useFlyoutApi();
 
     const handleClick = useCallback(() => {
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName: selectedPatterns.join(','),
-            scopeId: TableId.alertsOnAlertsPage, // TODO we should update the flyout's code to separate scopeId and preview
+      const indexName = selectedPatterns.join(',');
+      if (enableNewFlyout) {
+        openDocumentFlyoutFromPattern({ documentId: eventId, indexName });
+      } else {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: TableId.alertsOnAlertsPage, // TODO we should update the flyout's code to separate scopeId and preview
+            },
           },
-        },
-      });
+        });
+      }
       telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
         location: timelineId,
         panel: 'right',
       });
-    }, [eventId, openFlyout, selectedPatterns, telemetry, timelineId]);
+    }, [
+      eventId,
+      openFlyout,
+      selectedPatterns,
+      telemetry,
+      timelineId,
+      enableNewFlyout,
+      openDocumentFlyoutFromPattern,
+    ]);
 
     return (
       <EuiToolTip content={OPEN_FLYOUT_BUTTON} disableScreenReaderOutput>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -34,7 +34,7 @@ import { useAutotuneTimerange } from './use_autotune_timerange';
 import type { State } from '../../common/store/types';
 import { DocumentDetailsAnalyzerPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
-import { DocumentFlyoutWrapper } from '../../flyout_v2/document/main/document_flyout_wrapper';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 import { useDefaultDocumentFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 export const ANALYZER_PREVIEW_BANNER = {
@@ -75,6 +75,7 @@ export const ResolverWithoutProviders = React.memo(
     const history = useHistory();
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
     const { openPreviewPanel } = useExpandableFlyoutApi();
+    const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
     useResolverQueryParamCleaner(resolverComponentInstanceID);
     /**
@@ -143,34 +144,13 @@ export const ResolverWithoutProviders = React.memo(
     const onShowEvent = useCallback<NodeEventOnClick>(
       ({ documentId, indexName }) =>
         () =>
-          overlays.openSystemFlyout(
-            flyoutProviders({
-              services,
-              store,
-              history,
-              children: (
-                <DocumentFlyoutWrapper
-                  documentId={documentId}
-                  indexName={indexName}
-                  renderCellActions={renderCellActions}
-                  onAlertUpdated={handleAlertUpdated}
-                />
-              ),
-            }),
-            {
-              ...defaultFlyoutProperties,
-              session: 'inherit',
-            }
-          ),
-      [
-        defaultFlyoutProperties,
-        handleAlertUpdated,
-        history,
-        overlays,
-        renderCellActions,
-        services,
-        store,
-      ]
+          openDocumentFlyoutFromIndexAsChild({
+            documentId: documentId ?? '',
+            indexName,
+            renderCellActions,
+            onAlertUpdated: handleAlertUpdated,
+          }),
+      [openDocumentFlyoutFromIndexAsChild, renderCellActions, handleAlertUpdated]
     );
 
     const onShowPanel = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
@@ -18,11 +18,21 @@ import type { OpenTimelineResult, TimelineResultNote } from '../types';
 import { NotePreviews } from '.';
 import { useDeleteNote } from './hooks/use_delete_note';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 
 const mockDispatch = jest.fn();
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/hooks/use_selector');
+jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('react-redux', () => {
   const original = jest.requireActual('react-redux');
@@ -43,6 +53,7 @@ describe('NotePreviews', () => {
   let note1updated: number;
   let note2updated: number;
   let note3updated: number;
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
 
   beforeEach(() => {
     mockResults = cloneDeep(mockTimelineResults);
@@ -61,6 +72,11 @@ describe('NotePreviews', () => {
         crud: true,
       },
     });
+    (useSelectedPatterns as jest.Mock).mockReturnValue(['test1', 'test2']);
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout: jest.fn() });
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   test('it renders a note preview for each note when isModal is false', () => {
@@ -304,6 +320,68 @@ describe('NotePreviews', () => {
     );
 
     expect(wrapper.find(`[data-test-subj="notes-toggle-event-details"]`).exists()).toBeFalsy();
+  });
+
+  describe('Toggle event details', () => {
+    const renderWithNote = () => {
+      const timeline = mockTimelineResults[0];
+      (useDeepEqualSelector as jest.Mock).mockReturnValue(timeline);
+
+      return render(
+        <TestProviders>
+          <NotePreviews
+            notes={[
+              {
+                noteId: 'noteId1',
+                note: 'a note',
+                savedObjectId: 'test-id',
+                updated: note2updated,
+                updatedBy: 'alice',
+              },
+            ]}
+            showTimelineDescription
+            timelineId="test-timeline-id"
+          />
+        </TestProviders>,
+        {
+          wrapper: createReactQueryWrapper(),
+        }
+      );
+    };
+
+    it('should open the legacy expandable flyout when the new flyout is disabled', () => {
+      const openFlyout = jest.fn();
+      (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openFlyout });
+
+      const { getByTestId } = renderWithNote();
+
+      fireEvent.click(getByTestId('notes-toggle-event-details'));
+
+      expect(openFlyout).toHaveBeenCalledWith({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: 'event1',
+            indexName: 'test1,test2',
+            scopeId: 'test-timeline-id',
+          },
+        },
+      });
+      expect(flyoutApi.openDocumentFlyoutFromPattern).not.toHaveBeenCalled();
+    });
+
+    it('should open the new document flyout (from pattern) when the new flyout is enabled', () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      const { getByTestId } = renderWithNote();
+
+      fireEvent.click(getByTestId('notes-toggle-event-details'));
+
+      expect(flyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith({
+        documentId: 'event1',
+        indexName: 'test1,test2',
+      });
+    });
   });
 
   describe('Delete Notes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
@@ -23,7 +23,9 @@ import { userSelectedNotesForDeletion } from '../../../../notes';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 import type { TimelineResultNote } from '../types';
 import { defaultToEmptyTag, getEmptyValue } from '../../../../common/components/empty_value';
 import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
@@ -56,23 +58,38 @@ const ToggleEventDetailsButtonComponent: React.FC<ToggleEventDetailsButtonProps>
 
   const { telemetry } = useKibana().services;
   const { openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openDocumentFlyoutFromPattern } = useFlyoutApi();
 
   const handleClick = useCallback(() => {
-    openFlyout({
-      right: {
-        id: DocumentDetailsRightPanelKey,
-        params: {
-          id: eventId,
-          indexName: selectedPatterns.join(','),
-          scopeId: timelineId,
+    const indexName = selectedPatterns.join(',');
+    if (enableNewFlyout) {
+      openDocumentFlyoutFromPattern({ documentId: eventId, indexName });
+    } else {
+      openFlyout({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: timelineId,
+          },
         },
-      },
-    });
+      });
+    }
     telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
       location: timelineId,
       panel: 'right',
     });
-  }, [eventId, openFlyout, selectedPatterns, telemetry, timelineId]);
+  }, [
+    eventId,
+    openFlyout,
+    selectedPatterns,
+    telemetry,
+    timelineId,
+    enableNewFlyout,
+    openDocumentFlyoutFromPattern,
+  ]);
 
   return (
     <EuiToolTip content={i18n.TOGGLE_EXPAND_EVENT_DETAILS} disableScreenReaderOutput>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -28,6 +28,11 @@ import { defaultRowRenderers } from '../../body/renderers';
 import { useDispatch } from 'react-redux';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { initialUserPrivilegesState } from '../../../../../common/components/user_privileges/user_privileges_context';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 const SPECIAL_TEST_TIMEOUT = 30000;
 
@@ -55,6 +60,10 @@ mockUseResizeObserver.mockImplementation(() => ({}));
 jest.mock('../../../../../common/lib/kibana');
 
 jest.mock('../../../../../common/components/user_privileges');
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 let useTimelineEventsMock = jest.fn();
 
@@ -93,6 +102,8 @@ const TestComponent = (props: Partial<ComponentProps<typeof EqlTabContentCompone
 
 describe('EQL Tab', () => {
   const props = {} as EqlTabContentComponentProps;
+  const mockOpenFlyout = jest.fn();
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
 
   beforeAll(() => {
     // https://github.com/atlassian/react-beautiful-dnd/blob/4721a518356f72f1dac45b5fd4ee9d466aa2996b/docs/guides/setup-problem-detection-and-error-recovery.md#disable-logging
@@ -104,6 +115,10 @@ describe('EQL Tab', () => {
   });
 
   beforeEach(() => {
+    // Clear call history between tests. `mockOpenFlyout` is declared once at describe scope, so
+    // without this a legacy `openFlyout` call from one test leaks into the next and trips the
+    // `expect(mockOpenFlyout).not.toHaveBeenCalled()` assertions.
+    jest.clearAllMocks();
     useTimelineEventsMock = jest.fn(() => [
       false,
       {
@@ -128,6 +143,14 @@ describe('EQL Tab', () => {
       ...initialUserPrivilegesState(),
       notesPrivileges: { read: true },
     });
+
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
+    });
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
 
     HTMLElement.prototype.getBoundingClientRect = jest.fn(() => {
       return {
@@ -360,5 +383,88 @@ describe('EQL Tab', () => {
         SPECIAL_TEST_TIMEOUT
       );
     });
+  });
+
+  describe('Leading actions - notes', () => {
+    beforeEach(() => {
+      // The notes control column only renders when the corresponding rawEvent is present,
+      // so we provide a rawEvent that matches the first (and only) event.
+      (useTimelineEvents as jest.Mock).mockReturnValue([
+        false,
+        {
+          events: mockTimelineData.slice(0, 1),
+          rawEvents: [
+            {
+              _id: mockTimelineData[0]._id,
+              _index: 'test-index',
+              _source: {},
+            },
+          ],
+          pageInfo: {
+            activePage: 0,
+            totalPages: 10,
+          },
+        },
+      ]);
+    });
+
+    it(
+      'should open the legacy notes flyout when the new flyout is disabled',
+      async () => {
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(mockOpenFlyout).toHaveBeenCalledWith(
+            expect.objectContaining({
+              right: expect.objectContaining({ id: 'document-details-right' }),
+              left: expect.objectContaining({ id: 'document-details-left' }),
+            })
+          );
+        });
+        expect(flyoutApi.openNotes).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the new notes flyout when the new flyout is enabled',
+      async () => {
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(flyoutApi.openNotes).toHaveBeenCalledWith({
+            hit: expect.objectContaining({ _id: mockTimelineData[0]._id }),
+          });
+        });
+        expect(mockOpenFlyout).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -43,6 +43,8 @@ import { EqlTabHeader } from './header';
 import { useTimelineColumns } from '../shared/use_timeline_columns';
 import { useTimelineControlColumn } from '../shared/use_timeline_control_columns';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentEventTypes, NotesEventTypes } from '../../../../../common/lib/telemetry';
 import { TimelineRefetch } from '../../refetch_timeline';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
@@ -77,6 +79,8 @@ export const EqlTabContentComponent: React.FC<Props> = ({
    */
   const [pageIndex, setPageIndex] = useState(0);
   const { telemetry } = useKibana().services;
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNotes } = useFlyoutApi();
   const { query: eqlQuery = '', ...restEqlOption } = eqlOptions;
   const { portalNode: eqlEventsCountPortalNode } = useEqlEventsCountPortal();
   const { setTimelineFullScreen, timelineFullScreen } = useTimelineFullScreen();
@@ -164,7 +168,9 @@ export const EqlTabContentComponent: React.FC<Props> = ({
       const isAttackRow = eventData != null && isAttackDiscoveryRow(eventData);
       const indexName = selectedPatterns.join(',');
 
-      if (isAttackRow) {
+      if (enableNewFlyout && eventData) {
+        openNotes({ hit: eventData });
+      } else if (isAttackRow) {
         openFlyout({
           right: {
             id: AttackDetailsRightPanelKey,
@@ -215,7 +221,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
         panel: 'left',
       });
     },
-    [openFlyout, selectedPatterns, telemetry, timelineId]
+    [enableNewFlyout, openNotes, openFlyout, selectedPatterns, telemetry, timelineId]
   );
 
   const leadingControlColumns = useTimelineControlColumn({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 import type { Dispatch } from 'redux';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { DefaultCellRenderer } from '../../cell_rendering/default_cell_renderer';
 import { defaultHeaders, mockTimelineData } from '../../../../../common/mock';
@@ -26,6 +26,13 @@ import type { ExperimentalFeatures } from '../../../../../../common';
 import { allowedExperimentalValues } from '../../../../../../common';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { createStartServicesMock } from '../../../../../common/lib/kibana/kibana_react.mock';
+import { useUserPrivileges } from '../../../../../common/components/user_privileges';
+import { initialUserPrivilegesState } from '../../../../../common/components/user_privileges/user_privileges_context';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 jest.mock('../../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -36,6 +43,12 @@ jest.mock('../../../../containers/details', () => ({
 jest.mock('../../../fields_browser', () => ({
   useFieldBrowserOptions: jest.fn(),
 }));
+
+jest.mock('../../../../../common/components/user_privileges');
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('../../../../../common/hooks/use_experimental_features');
 const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
@@ -58,9 +71,12 @@ const kibanaMockResult = {
 };
 
 const useKibanaMock = useKibana as jest.Mock;
+const SPECIAL_TEST_TIMEOUT = 30000;
 
 describe('PinnedTabContent', () => {
   let props = {} as PinnedTabContentComponentProps;
+  const mockOpenFlyout = jest.fn();
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
   const sort: Sort[] = [
     {
       columnId: '@timestamp',
@@ -80,10 +96,22 @@ describe('PinnedTabContent', () => {
   });
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
+    HTMLElement.prototype.getBoundingClientRect = jest.fn(() => {
+      return {
+        width: 1000,
+        height: 1000,
+        x: 0,
+        y: 0,
+      } as DOMRect;
+    });
+
     (useTimelineEvents as jest.Mock).mockReturnValue([
       false,
       {
         events: mockTimelineData.slice(0, 1),
+        rawEvents: [],
         pageInfo: {
           activePage: 0,
           totalPages: 1,
@@ -97,6 +125,20 @@ describe('PinnedTabContent', () => {
         return allowedExperimentalValues[feature];
       }
     );
+
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      ...initialUserPrivilegesState(),
+      notesPrivileges: { read: true },
+      timelinePrivileges: { crud: true, read: true },
+    });
+
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
+    });
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
 
     useKibanaMock.mockReturnValue(kibanaMockResult);
 
@@ -124,5 +166,93 @@ describe('PinnedTabContent', () => {
 
       expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
     });
+  });
+
+  describe('Leading actions - notes', () => {
+    beforeEach(() => {
+      // The notes control column only renders when the corresponding rawEvent is present,
+      // so we provide a rawEvent that matches the first (and only) event.
+      (useTimelineEvents as jest.Mock).mockReturnValue([
+        false,
+        {
+          events: mockTimelineData.slice(0, 1),
+          rawEvents: [
+            {
+              _id: mockTimelineData[0]._id,
+              _index: 'test-index',
+              _source: {},
+            },
+          ],
+          pageInfo: {
+            activePage: 0,
+            totalPages: 1,
+          },
+        },
+      ]);
+
+      props = {
+        ...props,
+        pinnedEventIds: { [mockTimelineData[0]._id]: true },
+      };
+    });
+
+    it(
+      'should open the legacy notes flyout when the new flyout is disabled',
+      async () => {
+        render(
+          <TestProviders>
+            <PinnedTabContentComponent {...props} />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(mockOpenFlyout).toHaveBeenCalledWith(
+            expect.objectContaining({
+              right: expect.objectContaining({ id: 'document-details-right' }),
+              left: expect.objectContaining({ id: 'document-details-left' }),
+            })
+          );
+        });
+        expect(flyoutApi.openNotes).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the new notes flyout when the new flyout is enabled',
+      async () => {
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        render(
+          <TestProviders>
+            <PinnedTabContentComponent {...props} />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(flyoutApi.openNotes).toHaveBeenCalledWith({
+            hit: expect.objectContaining({ _id: mockTimelineData[0]._id }),
+          });
+        });
+        expect(mockOpenFlyout).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -12,7 +12,8 @@ import { connect } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { RunTimeMappings, TimelineItem } from '@kbn/timelines-plugin/common/search_strategy';
 import { PageScope } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
@@ -35,6 +36,8 @@ import type { TimelineTabCommonProps } from '../shared/types';
 import { useTimelineColumns } from '../shared/use_timeline_columns';
 import { useTimelineControlColumn } from '../shared/use_timeline_control_columns';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import { DocumentEventTypes, NotesEventTypes } from '../../../../../common/lib/telemetry';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
 
@@ -76,6 +79,8 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   const [pageIndex, setPageIndex] = useState(0);
 
   const { telemetry } = useKibana().services;
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNotes } = useFlyoutApi();
 
   const selectedPatterns = useSelectedPatterns(PageScope.timeline);
   const { dataView } = useDataView(PageScope.timeline);
@@ -185,33 +190,37 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   const { openFlyout } = useExpandableFlyoutApi();
 
   const onToggleShowNotes = useCallback(
-    (eventId?: string) => {
+    (eventId?: string, eventData?: DataTableRecord & TimelineItem) => {
       if (!eventId) {
         return;
       }
 
-      const indexName = selectedPatterns.join(',');
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
+      if (enableNewFlyout && eventData) {
+        openNotes({ hit: eventData });
+      } else {
+        const indexName = selectedPatterns.join(',');
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
           },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: LeftPanelNotesTab,
+          left: {
+            id: DocumentDetailsLeftPanelKey,
+            path: {
+              tab: LeftPanelNotesTab,
+            },
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
           },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
-          },
-        },
-      });
+        });
+      }
       telemetry.reportEvent(NotesEventTypes.OpenNoteInExpandableFlyoutClicked, {
         location: timelineId,
       });
@@ -220,7 +229,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
         panel: 'left',
       });
     },
-    [openFlyout, selectedPatterns, telemetry, timelineId]
+    [enableNewFlyout, openNotes, openFlyout, selectedPatterns, telemetry, timelineId]
   );
 
   const leadingControlColumns = useTimelineControlColumn({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -48,8 +48,13 @@ import { useDataView } from '../../../../../data_view_manager/hooks/use_data_vie
 import { useBrowserFields } from '../../../../../data_view_manager/hooks/use_browser_fields';
 import { mockBrowserFields } from '@kbn/timelines-plugin/public/mock/browser_fields';
 import { withIndices } from '../../../../../data_view_manager/hooks/__mocks__/use_data_view';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 jest.mock('../../../../../data_view_manager/hooks/use_browser_fields');
+jest.mock('../../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('../../../../../common/utils/route/use_route_spy', () => {
   return {
@@ -188,6 +193,7 @@ const useTimelineEventsSpy = jest.spyOn(useTimelineEventsModule, 'useTimelineEve
 // Failing: See https://github.com/elastic/kibana/issues/224186
 describe.skip('query tab with unified timeline', () => {
   const fetchNotesSpy = jest.spyOn(notesApi, 'fetchNotesByDocumentIds');
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
   beforeAll(() => {
     fetchNotesSpy.mockImplementation(jest.fn());
     jest.mocked(useExpandableFlyoutApi).mockImplementation(() => ({
@@ -259,6 +265,10 @@ describe.skip('query tab with unified timeline', () => {
       endpointPrivileges: getEndpointPrivilegesInitialStateMock(),
       detectionEnginePrivileges: { loading: false, error: undefined, result: undefined },
     });
+
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   describe('render', () => {
@@ -1073,6 +1083,31 @@ describe.skip('query tab with unified timeline', () => {
             })
           );
         });
+        expect(flyoutApi.openNotes).not.toHaveBeenCalled();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the new notes flyout when the new flyout is enabled',
+      async () => {
+        jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+        renderTestComponents();
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(flyoutApi.openNotes).toHaveBeenCalledWith({
+            hit: expect.objectContaining({ _id: mockTimelineData[0]._id }),
+          });
+        });
+        expect(mockOpenFlyout).not.toHaveBeenCalled();
       },
       SPECIAL_TEST_TIMEOUT
     );
@@ -1130,6 +1165,7 @@ describe.skip('query tab with unified timeline', () => {
             })
           );
         });
+        expect(flyoutApi.openNotes).not.toHaveBeenCalled();
       },
       SPECIAL_TEST_TIMEOUT
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -27,6 +27,8 @@ import {
   DocumentDetailsRightPanelKey,
 } from '../../../../../flyout/document_details/shared/constants/panel_keys';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import {
   AttackDetailsLeftPanelKey,
   AttackDetailsRightPanelKey,
@@ -106,6 +108,9 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const {
     query: { filterManager: timelineFilterManager },
   } = timelineDataService;
+
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNotes } = useFlyoutApi();
 
   const getManageTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
 
@@ -232,7 +237,9 @@ export const QueryTabContentComponent: React.FC<Props> = ({
       const indexName =
         (isAttackRow ? eventData.ecs._index : undefined) ?? selectedPatterns.join(',');
 
-      if (isAttackRow) {
+      if (enableNewFlyout && eventData) {
+        openNotes({ hit: eventData });
+      } else if (isAttackRow) {
         openFlyout({
           right: {
             id: AttackDetailsRightPanelKey,
@@ -283,7 +290,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
         panel: 'left',
       });
     },
-    [openFlyout, selectedPatterns, telemetry, timelineId]
+    [enableNewFlyout, openNotes, openFlyout, selectedPatterns, telemetry, timelineId]
   );
 
   const leadingControlColumns = useTimelineControlColumn({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -200,7 +200,7 @@ describe('unified data table', () => {
   );
 
   it(
-    'opens DocumentFlyoutWrapper via system flyout when enableNewFlyout setting is enabled and row is not an attack',
+    'opens the new document flyout (from index) when enableNewFlyout setting is enabled and row is not an attack',
     async () => {
       jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
 
@@ -210,13 +210,16 @@ describe('unified data table', () => {
       fireEvent.click(screen.getAllByTestId('docTableExpandToggleColumn')[0]);
 
       await waitFor(() => {
-        expect(mockOpenSystemFlyout).toHaveBeenCalled();
+        expect(flyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith(
+          expect.objectContaining({
+            documentId: mockTimelineData[0]._id,
+            indexName: mockTimelineData[0].ecs._index,
+          })
+        );
       });
 
-      const flyoutElement = mockOpenSystemFlyout.mock.calls[0][0];
-      expect(flyoutElement.props.documentId).toBe(mockTimelineData[0]._id);
-      expect(flyoutElement.props.indexName).toBe(mockTimelineData[0].ecs._index);
-      expect(flyoutElement.props.onAlertUpdated).toBe(refetchMock);
+      // the document (non-attack) new flyout no longer goes through the inline system flyout
+      expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
     },
     SPECIAL_TEST_TIMEOUT
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { useDispatch, useSelector, useStore } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type {
   UnifiedDataTableProps,
@@ -20,9 +20,7 @@ import type {
   EuiDataGridProps,
 } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useHistory } from 'react-router-dom';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
-import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
 import { cellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
 import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
@@ -58,8 +56,6 @@ import { TIMELINE_EVENT_DETAIL_ROW_ID } from '../../body/constants';
 import { DocumentEventTypes } from '../../../../../common/lib/telemetry/types';
 import { getTimelineRowTypeIndicator } from './get_row_indicator';
 import { isAttackDiscoveryRow } from './is_attack_discovery_row';
-import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 const DataGridMemoized = React.memo(UnifiedDataTable);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -58,7 +58,6 @@ import { TIMELINE_EVENT_DETAIL_ROW_ID } from '../../body/constants';
 import { DocumentEventTypes } from '../../../../../common/lib/telemetry/types';
 import { getTimelineRowTypeIndicator } from './get_row_indicator';
 import { isAttackDiscoveryRow } from './is_attack_discovery_row';
-import { DocumentFlyoutWrapper } from '../../../../../flyout_v2/document/main/document_flyout_wrapper';
 import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
@@ -124,9 +123,6 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     onUpdatePageIndex,
   }) {
     const dispatch = useDispatch();
-    const store = useStore();
-    const history = useHistory();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
     // Store context in state rather than creating object in provider value={} to prevent re-renders caused by a new object being created
     const [activeStatefulEventContext] = useState({
@@ -146,11 +142,10 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       telemetry,
       theme,
       data: dataPluginContract,
-      overlays,
     } = services;
 
     const enableNewFlyout = useIsNewFlyoutEnabled();
-    const { openAttackFlyout } = useFlyoutApi();
+    const { openAttackFlyout, openDocumentFlyoutFromIndex } = useFlyoutApi();
 
     const [expandedDoc, setExpandedDoc] = useState<DataTableRecord & TimelineItem>();
 
@@ -199,26 +194,12 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
               onAttackUpdated: refetch,
             });
           } else {
-            overlays.openSystemFlyout(
-              flyoutProviders({
-                services,
-                store,
-                history,
-                children: (
-                  <DocumentFlyoutWrapper
-                    documentId={eventData._id}
-                    indexName={eventData.ecs._index}
-                    renderCellActions={cellActionRenderer}
-                    onAlertUpdated={refetch}
-                  />
-                ),
-              }),
-              {
-                ...defaultFlyoutProperties,
-                historyKey: documentFlyoutHistoryKey,
-                session: 'start',
-              }
-            );
+            openDocumentFlyoutFromIndex({
+              documentId: eventData._id,
+              indexName: eventData.ecs._index,
+              renderCellActions: cellActionRenderer,
+              onAlertUpdated: refetch,
+            });
           }
         } else {
           const isAttackRow = isAttackDiscoveryRow(eventData);
@@ -251,12 +232,8 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [
         enableNewFlyout,
         openAttackFlyout,
+        openDocumentFlyoutFromIndex,
         refetch,
-        overlays,
-        services,
-        store,
-        history,
-        defaultFlyoutProperties,
         timelineId,
         openFlyout,
         telemetry,


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is only focusing on the documemt flyout (the main and all the tools). A couple of follow up PRs will take care of the other flyouts.

This PR adds a new `DocumentFlyoutWrapperFromPattern` component. I realized that in some places (Timelines page and Notes management page) we do not have the index available, but only the list of indices from the dataView. The `DocumentFlyoutWrapper` component we had already can only fetch a document from a single index as we're using a Discover hook for that.

The PR also introduces single developer-facing APIs to open the new flyouts and their tools, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:
- `useFlyoutApi()`: that is inernally calling the network flyout specific api:
  - `useDocumentFlyoutApi()` which returns:
    - `openDocumentFlyoutFromIndex`: opens the document main flyout from a document id and index
    - `openDocumentFlyoutFromPattern`: opens the document main flyout from a document id and index pattern
    - `openNotes`, `openAnalyzer`, `openSessionView`, `openDocumentEntities`, `openDocumentCorrelations`, `openDocumentResponse`, `openDocumentThreatIntelligence`, `openDocumentPrevalence`, `openDocumentInvestigationGuide`, `openDocumentGraph`: open the document tools flyouts

> [!TIP]
> Developers should use - unless not possible - the useFlyoutApi() to open all of their flyouts

Every external entry point that opened one of these legacy flyouts now routes through the matching API when the new flyout is enabled.

> [!WARNING]
> No legacy flyout behavior introduced! Only toggling between the legacy and new flyout based off the advanced setting.

#### Advanced setting off (default)

https://github.com/user-attachments/assets/756ede8f-0c1e-46c9-9fcb-41e82f588e2a

#### Advanced setting on

https://github.com/user-attachments/assets/6788ce58-dae0-4190-867f-2c8edae345cd

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new flyout/tool opens from each surface.
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->