### PR TITLE
[APM] Migrate agent_keys and latency_distribution route params to zod, drop unused processorEventRt

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/agent_keys_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/agent_keys_params.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PrivilegeType } from '@kbn/apm-types';
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { createAgentKeyRoute } from './create_agent_key';
+import { invalidateAgentKeyRoute } from './invalidate_agent_key';
+
+describe('createAgentKeyRoute params', () => {
+  it('accepts a name and known privileges', () => {
+    const result = createAgentKeyRoute.params!.safeParse({
+      body: { name: 'my-key', privileges: [PrivilegeType.EVENT] },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an unknown privilege', () => {
+    const result = createAgentKeyRoute.params!.safeParse({
+      body: { name: 'my-key', privileges: ['manage_own_api_key'] },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('invalidateAgentKeyRoute params', () => {
+  it('accepts an id', () => {
+    const result = invalidateAgentKeyRoute.params!.safeParse({ body: { id: 'abc' } });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing id', () => {
+    const result = invalidateAgentKeyRoute.params!.safeParse({ body: {} });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/create_agent_key.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/create_agent_key.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { SecurityCreateApiKeyResponse } from '@elastic/elasticsearch/lib/api/types';
-import { privilegesTypeRt } from '@kbn/apm-types';
+import { privilegesTypeSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 
 export interface CreateAgentKeyResponse {
@@ -15,10 +15,10 @@ export interface CreateAgentKeyResponse {
 
 export const createAgentKeyRoute = defineRoute<CreateAgentKeyResponse>()({
   endpoint: 'POST /api/apm/agent_keys 2023-10-31',
-  params: t.type({
-    body: t.type({
-      name: t.string,
-      privileges: privilegesTypeRt,
+  params: z.object({
+    body: z.object({
+      name: z.string(),
+      privileges: privilegesTypeSchema,
     }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/invalidate_agent_key.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/invalidate_agent_key.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
 
 export interface InvalidateAgentKeyResponse {
@@ -13,7 +13,7 @@ export interface InvalidateAgentKeyResponse {
 
 export const invalidateAgentKeyRoute = defineRoute<InvalidateAgentKeyResponse>()({
   endpoint: 'POST /internal/apm/api_key/invalidate',
-  params: t.type({
-    body: t.type({ id: t.string }),
+  params: z.object({
+    body: z.object({ id: z.string() }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/latency_distribution_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/latency_distribution_params.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LatencyDistributionChartType } from '@kbn/apm-types';
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { latencyOverallSpanDistributionRoute } from './overall_span_distribution';
+import { latencyOverallTransactionDistributionRoute } from './overall_transaction_distribution';
+
+const baseBody = {
+  environment: 'production',
+  kuery: '',
+  start: '2023-01-01T00:00:00.000Z',
+  end: '2023-01-02T00:00:00.000Z',
+  percentileThreshold: '95',
+  chartType: LatencyDistributionChartType.spanLatency,
+};
+
+describe('latencyOverallSpanDistributionRoute params', () => {
+  it('accepts the minimal required body', () => {
+    const result = latencyOverallSpanDistributionRoute.params!.shape.body.safeParse(baseBody);
+
+    expectParseSuccess(result);
+    expect(result.data.percentileThreshold).toEqual(95);
+  });
+
+  it('accepts optional fields, including a mixed string/number termFilters value', () => {
+    const result = latencyOverallSpanDistributionRoute.params!.shape.body.safeParse({
+      ...baseBody,
+      serviceName: 'opbeans-java',
+      spanName: 'GET /api',
+      durationMin: '100',
+      durationMax: '2000',
+      isOtel: true,
+      termFilters: [
+        { fieldName: 'foo', fieldValue: 'bar' },
+        { fieldName: 'baz', fieldValue: 42 },
+      ],
+    });
+
+    expectParseSuccess(result);
+    expect(result.data.termFilters).toEqual([
+      { fieldName: 'foo', fieldValue: 'bar' },
+      { fieldName: 'baz', fieldValue: 42 },
+    ]);
+  });
+
+  it('rejects a missing percentileThreshold', () => {
+    const { percentileThreshold, ...withoutThreshold } = baseBody;
+
+    const result =
+      latencyOverallSpanDistributionRoute.params!.shape.body.safeParse(withoutThreshold);
+
+    expectParseError(result);
+  });
+
+  it('rejects an unknown chartType', () => {
+    const result = latencyOverallSpanDistributionRoute.params!.shape.body.safeParse({
+      ...baseBody,
+      chartType: 'not_a_real_chart',
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('latencyOverallTransactionDistributionRoute params', () => {
+  it('accepts the minimal required body', () => {
+    const result =
+      latencyOverallTransactionDistributionRoute.params!.shape.body.safeParse(baseBody);
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts optional transaction-specific fields', () => {
+    const result = latencyOverallTransactionDistributionRoute.params!.shape.body.safeParse({
+      ...baseBody,
+      serviceName: 'opbeans-java',
+      transactionName: 'GET /api',
+      transactionType: 'request',
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing required field', () => {
+    const { environment, ...withoutEnvironment } = baseBody;
+
+    const result =
+      latencyOverallTransactionDistributionRoute.params!.shape.body.safeParse(withoutEnvironment);
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_span_distribution.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_span_distribution.ts
@@ -4,42 +4,39 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { OverallLatencyDistributionResponse } from '@kbn/apm-types';
-import { latencyDistributionChartTypeRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { latencyDistributionChartTypeSchema, environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type LatencyOverallSpanDistributionResponse = OverallLatencyDistributionResponse;
 
 export const latencyOverallSpanDistributionRoute =
   defineRoute<LatencyOverallSpanDistributionResponse>()({
     endpoint: 'POST /internal/apm/latency/overall_distribution/spans',
-    params: t.type({
-      body: t.intersection([
-        t.partial({
-          serviceName: t.string,
-          spanName: t.string,
-          transactionId: t.string,
-          termFilters: t.array(
-            t.type({
-              fieldName: t.string,
-              fieldValue: t.union([t.string, toNumberRt]),
-            })
-          ),
-          durationMin: toNumberRt,
-          durationMax: toNumberRt,
-          isOtel: t.boolean,
-        }),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-        t.type({
-          percentileThreshold: toNumberRt,
-          chartType: latencyDistributionChartTypeRt,
-        }),
-      ]),
+    params: z.object({
+      body: z
+        .object({
+          serviceName: z.string().optional(),
+          spanName: z.string().optional(),
+          transactionId: z.string().optional(),
+          termFilters: z
+            .array(
+              z.object({
+                fieldName: z.string(),
+                fieldValue: z.union([z.string(), z.number()]),
+              })
+            )
+            .optional(),
+          durationMin: z.coerce.number().optional(),
+          durationMax: z.coerce.number().optional(),
+          isOtel: z.boolean().optional(),
+          percentileThreshold: z.coerce.number(),
+          chartType: latencyDistributionChartTypeSchema,
+        })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_transaction_distribution.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_transaction_distribution.ts
@@ -4,41 +4,38 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { OverallLatencyDistributionResponse } from '@kbn/apm-types';
-import { latencyDistributionChartTypeRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { latencyDistributionChartTypeSchema, environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type LatencyOverallTransactionDistributionResponse = OverallLatencyDistributionResponse;
 
 export const latencyOverallTransactionDistributionRoute =
   defineRoute<LatencyOverallTransactionDistributionResponse>()({
     endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
-    params: t.type({
-      body: t.intersection([
-        t.partial({
-          serviceName: t.string,
-          transactionName: t.string,
-          transactionType: t.string,
-          termFilters: t.array(
-            t.type({
-              fieldName: t.string,
-              fieldValue: t.union([t.string, toNumberRt]),
-            })
-          ),
-          durationMin: toNumberRt,
-          durationMax: toNumberRt,
-        }),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-        t.type({
-          percentileThreshold: toNumberRt,
-          chartType: latencyDistributionChartTypeRt,
-        }),
-      ]),
+    params: z.object({
+      body: z
+        .object({
+          serviceName: z.string().optional(),
+          transactionName: z.string().optional(),
+          transactionType: z.string().optional(),
+          termFilters: z
+            .array(
+              z.object({
+                fieldName: z.string(),
+                fieldValue: z.union([z.string(), z.number()]),
+              })
+            )
+            .optional(),
+          durationMin: z.coerce.number().optional(),
+          durationMax: z.coerce.number().optional(),
+          percentileThreshold: z.coerce.number(),
+          chartType: latencyDistributionChartTypeSchema,
+        })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/processor_event.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/processor_event.ts
@@ -5,20 +5,8 @@
  * 2.0.
  */
 import { ProcessorEvent } from '@kbn/apm-types-shared';
-import * as t from 'io-ts';
 import { z } from '@kbn/zod/v4';
 
-export const processorEventRt = t.union([
-  t.literal(ProcessorEvent.transaction),
-  t.literal(ProcessorEvent.error),
-  t.literal(ProcessorEvent.metric),
-  t.literal(ProcessorEvent.span),
-]);
-
-/**
- * zod equivalent, additive (see `default_api_types.ts` in `@kbn/apm-api-shared`
- * for why - elastic/kibana#243355).
- */
 export const processorEventSchema = z.union([
   z.literal(ProcessorEvent.transaction),
   z.literal(ProcessorEvent.error),

--- a/x-pack/solutions/observability/plugins/apm/common/processor_event.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/processor_event.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export { processorEventRt, type UIProcessorEvent } from '@kbn/apm-types';
+export { type UIProcessorEvent } from '@kbn/apm-types';
 export { ProcessorEvent } from '@kbn/apm-types-shared';


### PR DESCRIPTION
## Summary

Part of #243355 (migrate `io-ts` to `@kbn/zod` in APM).

Not stacked this time — #276617/#276618/#276634/#276637/#276642 have all
merged, so this branches directly off `main`.

Third route-group migration, same strategy as #276637/#276642: swap each
endpoint's io-ts composition for the matching additive zod schema from
#276634.

## Changes

- **`agent_keys`**: `create_agent_key.ts` (`privilegesTypeRt` →
  `privilegesTypeSchema`) and `invalidate_agent_key.ts` (plain
  `t.type`). This completes the group — the other two routes
  (`agent_keys`, `agent_keys/privileges`) have no params at all.
- **`latency_distribution`**: `overall_span_distribution.ts` and
  `overall_transaction_distribution.ts` swap their io-ts
  `t.intersection` (`environmentRt`/`kueryRt`/`rangeRt`/
  `latencyDistributionChartTypeRt` + inline `toNumberRt`/`t.partial`
  fields) for the equivalent zod `.merge()` composition.
  - `toNumberRt` has no shared codec counterpart (it's a
    `@kbn/io-ts-utils` primitive, not one of the `@kbn/apm-types`/
    `default_api_types.ts` exports), so standalone numeric fields
    (`durationMin`, `durationMax`, `percentileThreshold`) use
    `z.coerce.number()` directly.
  - `termFilters[].fieldValue` was `t.union([t.string, toNumberRt])`.
    Since io-ts unions resolve to the first successful member and
    `t.string` matches any string first, a numeric-looking *string*
    was never actually converted to a number in the original — only a
    genuine JSON number hit the `toNumberRt` branch. The zod port
    (`z.union([z.string(), z.number()])`) preserves that exactly (no
    coercion on the number branch, since it's only reached for
    non-string input already).

## Cleanup

`processorEventRt` (io-ts) has zero real consumers left now that
`event_metadata`/`span_links` migrated in #276642 — removed it from
`@kbn/apm-types` along with the now-dead re-export in
`apm/common/processor_event.ts`.

`indexLifecyclePhaseRt` is **not** cleaned up yet — it still has a real
consumer in APM's client-side routing (`public/components/routing/home/
storage_explorer.tsx`), which is Phase 4 scope, not done yet.

## Test plan

- [x] New `agent_keys_params.test.ts` and
      `latency_distribution_params.test.ts` (40/40 passing package-wide)
- [x] `kbn-apm-types` tests still green after removing `processorEventRt`
      (28/28)
- [x] `node x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/type_check.js`
      on `kbn-apm-api-shared`, `kbn-apm-types`, and the APM plugin — all
      clean
- [x] `node scripts/lint_ts_projects.js`
- [ ] No FTR/API-integration coverage for these groups specifically,
      same caveat as the prior route-group PRs in this migration.
- [x] Manual testing with kibana dev tools: 
- Agent keys
   1. createAgentKeyRoute — valid
  POST kbn:api/apm/agent_keys
  {
    "name": "test-key",
    "privileges": ["event:write"]
  }

  2. Invalid privilege — expect 400
  POST kbn:api/apm/agent_keys
  {
    "name": "test-key",
    "privileges": ["invalid:privilege"]
  }

  3. Missing name — expect 400
  POST kbn:api/apm/agent_keys
  {
    "privileges": ["event:write"]
  }

  4. invalidateAgentKeyRoute — valid shape (will likely fail at the security-layer since some-key-id won't exist, but that proves it passed schema validation and reached the handler)
  POST kbn:internal/apm/api_key/invalidate
  {
    "id": "some-key-id"
  }

  5. Missing id — expect 400
  POST kbn:internal/apm/api_key/invalidate
  {}

  - latency_distribution

  6. latencyOverallSpanDistributionRoute — valid, minimal
  POST kbn:internal/apm/latency/overall_distribution/spans
  {
    "environment": "production",
    "kuery": "",
    "start": "2026-07-09T14:00:00.000Z",
    "end": "2026-07-09T14:15:00.000Z",
    "percentileThreshold": 95,
    "chartType": "spanLatency"
  }

  7. Same, with optional fields + mixed string/number termFilters
  POST kbn:internal/apm/latency/overall_distribution/spans
  {
    "environment": "production",
    "kuery": "",
    "start": "2026-07-09T14:00:00.000Z",
    "end": "2026-07-09T14:15:00.000Z",
    "percentileThreshold": 95,
    "chartType": "spanLatency",
    "serviceName": "opbeans-java",
    "spanName": "GET /api",
    "durationMin": 100,
    "durationMax": 2000,
    "isOtel": true,
    "termFilters": [
      { "fieldName": "foo", "fieldValue": "bar" },
      { "fieldName": "baz", "fieldValue": 42 }
    ]
  }

  8. Missing percentileThreshold — expect 400
  POST kbn:internal/apm/latency/overall_distribution/spans
  {
    "environment": "production",
    "kuery": "",
    "start": "2026-07-09T14:00:00.000Z",
    "end": "2026-07-09T14:15:00.000Z",
    "chartType": "spanLatency"
  }

  9. Invalid chartType — expect 400
  POST kbn:internal/apm/latency/overall_distribution/spans
  {
    "environment": "production",
    "kuery": "",
    "start": "2026-07-09T14:00:00.000Z",
    "end": "2026-07-09T14:15:00.000Z",
    "percentileThreshold": 95,
    "chartType": "not_a_real_chart"
  }

  10. latencyOverallTransactionDistributionRoute — valid, with optional fields
  POST kbn:internal/apm/latency/overall_distribution/transactions
  {
    "environment": "production",
    "kuery": "",
    "start": "2026-07-09T14:00:00.000Z",
    "end": "2026-07-09T14:15:00.000Z",
    "percentileThreshold": 95,
    "chartType": "transactionLatency",
    "serviceName": "opbeans-java",
    "transactionName": "GET /api",
    "transactionType": "request"
  }

  11. Missing required environment — expect 400
  POST kbn:internal/apm/latency/overall_distribution/transactions
  {
    "kuery": "",
    "start": "2026-07-09T14:00:00.000Z",
    "end": "2026-07-09T14:15:00.000Z",
    "percentileThreshold": 95,
    "chartType": "transactionLatency"
  }



🤖 Generated with [Claude Code](https://claude.com/claude-code)