### PR TITLE
[ML][AIOps] Log rate analysis: ensures 'Field name" shows up correctly

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
@@ -14,7 +14,6 @@ import {
   EuiIcon,
   EuiIconTip,
   EuiText,
-  EuiTextTruncate,
   EuiToolTip,
 } from '@elastic/eui';
 import type { estypes } from '@elastic/elasticsearch';
@@ -252,7 +251,7 @@ export const useColumns = (
                   },
                 ]);
           return (
-            <>
+            <div css={{ display: 'flex', alignItems: 'center', overflow: 'hidden' }}>
               {type === SIGNIFICANT_ITEM_TYPE.KEYWORD && (
                 <FieldStatsPopover
                   dataView={dataView}
@@ -269,6 +268,7 @@ export const useColumns = (
                   css={{
                     marginLeft: euiTheme.size.s,
                     marginRight: euiTheme.size.xs,
+                    flexShrink: 0,
                   }}
                 >
                   <EuiIconTip
@@ -286,8 +286,19 @@ export const useColumns = (
                 </span>
               )}
 
-              <EuiTextTruncate text={fieldName} />
-            </>
+              <span
+                title={fieldName}
+                css={{
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {fieldName}
+              </span>
+            </div>
           );
         },
         sortable: true,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/277054

This looks like an issue with this view not playing nice with `EuiTextTruncate` because the component depends on a set width to work. `EuiTextTruncate` was placed as a flex child inside a `div` with no explicit width — and because the column width is defined as a percentage, the `div` has no resolved width that the internal `ResizeObserver` can measure, so it always sees 0 and never renders the text. The `<span>` replacement avoids this by using pure CSS truncation, which the browser resolves directly from layout without any JavaScript measurement.

Before:
<img width="870" height="463" alt="image" src="https://github.com/user-attachments/assets/4ecc5201-bcbd-4998-98fb-34a2d99b565e" />

After:
<img width="1433" height="836" alt="image" src="https://github.com/user-attachments/assets/25ee1752-6906-410b-b907-0924541716f9" />

<img width="694" height="680" alt="image" src="https://github.com/user-attachments/assets/f181a94c-b919-4b0a-b0b9-a1e36a27afff" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->