### PR TITLE
[Cases][AttachmentV2] Remove schema validator in unified attachments

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
@@ -135,12 +135,11 @@ export interface AttachmentType<Props> {
   getAttachmentTabViewObject?: (
     props?: CommonAttachmentTabViewProps
   ) => AttachmentTabViewObject<CommonAttachmentTabViewProps>;
-  schemaValidator?: (data: unknown) => void;
 }
 
 interface UnifiedAttachmentSchema {
-  /** Full-payload zod schema. Preferred over `schemaValidator`. */
-  schema?: z.ZodType;
+  /** Full-payload zod schema used for validation and renderer prop narrowing. */
+  schema: z.ZodType;
   /**
    * Schema exposed to workflow authors. When unset, workflow steps fall back to
    * `schema` if it is a Zod object; when `false`, the type is excluded.

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_type_filter.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/attachment_type_filter.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { z } from '@kbn/zod/v4';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
@@ -26,28 +27,28 @@ const buildRegistry = () => {
     displayName: 'Comment',
     icon: 'editorComment',
     getAttachmentViewObject: () => ({ event: 'added a comment' }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   registry.register({
     id: 'security.alert',
     displayName: 'Alert',
     icon: 'bell',
     getAttachmentViewObject: () => ({ event: 'added an alert' }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   registry.register({
     id: 'security.event',
     displayName: 'Event',
     icon: 'bell',
     getAttachmentViewObject: () => ({ event: 'added an event' }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   registry.register({
     id: 'observability.alert',
     displayName: 'Alert',
     icon: 'bell',
     getAttachmentViewObject: () => ({ event: 'added an alert' }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   return registry;
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { z } from '@kbn/zod/v4';
 import {
   basicCase,
   alertComment,
@@ -46,7 +47,7 @@ const buildRegistry = () => {
     getAttachmentTabViewObject: () => ({
       children: () => <div data-test-subj="test-alerts-table">{'Alerts table'}</div>,
     }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   registry.register({
     id: 'security.event',
@@ -56,7 +57,7 @@ const buildRegistry = () => {
     getAttachmentTabViewObject: () => ({
       children: () => <div data-test-subj="test-events-table">{'Events table'}</div>,
     }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   registry.register({
     id: 'file',
@@ -66,7 +67,7 @@ const buildRegistry = () => {
     getAttachmentTabViewObject: () => ({
       children: () => <div data-test-subj="test-files-table">{'Files table'}</div>,
     }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   // Comment is intentionally registered without `getAttachmentTabViewObject`
   // to mirror production: comments live in the activity tab, not here.
@@ -75,7 +76,7 @@ const buildRegistry = () => {
     displayName: 'Comment',
     icon: 'editorComment',
     getAttachmentViewObject: () => ({ event: 'added a comment' }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   return registry;
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { z } from '@kbn/zod/v4';
 import { renderHook } from '@testing-library/react';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 
@@ -36,7 +37,7 @@ const buildRegistry = () => {
     getAttachmentTabViewObject: () => ({
       children: () => <div data-test-subj="test-alerts-table">{'Alerts'}</div>,
     }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   // File type is intentionally registered: the hook must NOT count it from
   // comments — files are counted via the file stats API instead.
@@ -48,7 +49,7 @@ const buildRegistry = () => {
     getAttachmentTabViewObject: () => ({
       children: () => <div />,
     }),
-    schemaValidator: () => {},
+    schema: z.object({}),
   });
   return registry;
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { z } from '@kbn/zod/v4';
 import { EuiCommentList } from '@elastic/eui';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -239,7 +240,7 @@ describe('createCommentUserActionBuilder', () => {
         icon: 'bell',
         getAttachmentViewObject: () => ({ event: 'added an event' }),
         getAttachmentRemovalObject: () => ({ event: 'removed event' }),
-        schemaValidator: () => {},
+        schema: z.object({}),
       });
 
       const userAction = getEventUserAction({
@@ -579,7 +580,7 @@ describe('createCommentUserActionBuilder', () => {
           event: 'added an event',
           timelineAvatar: <span data-test-subj="event-timeline-avatar" />,
         }),
-        schemaValidator: () => {},
+        schema: z.object({}),
       });
 
       const userAction = getEventUserAction();
@@ -729,6 +730,7 @@ describe('createCommentUserActionBuilder', () => {
             timelineAvatar: 'lensApp',
             children: React.lazy(SpyLazyFactory),
           }),
+          schema: z.object({}),
         });
 
         const userAction = getPersistableStateUserAction();
@@ -821,6 +823,7 @@ describe('createCommentUserActionBuilder', () => {
             event: 'added an embeddable',
             timelineAvatar: 'lensApp',
           }),
+          schema: z.object({}),
         });
 
         const userAction = getPersistableStateUserAction();

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/types.ts
@@ -39,8 +39,7 @@ export interface ExternalReferenceAttachmentType {
   id: string;
   /**
    * A function to validate data stored with the attachment type. This function should throw an error
-   * if the data is not in the form it expects. For **unified reference** types registered on the
-   * unified registry, the full `UnifiedReferenceAttachmentPayload` is passed (not metadata alone).
+   * if the data is not in the form it expects.
    */
   schemaValidator?: (data: unknown) => void;
 }
@@ -56,10 +55,10 @@ export type UnifiedAttachmentState = Pick<UnifiedAttachmentPayload, 'type' | 'me
   );
 
 export interface UnifiedAttachmentType
-  extends ExternalReferenceAttachmentType,
-    Omit<PersistableState<UnifiedAttachmentState>, 'migrations' | 'inject' | 'extract'> {
-  /** Full-payload zod schema. Preferred over `schemaValidator` for new registrations. */
-  schema?: z.ZodType;
+  extends Omit<PersistableState<UnifiedAttachmentState>, 'migrations' | 'inject' | 'extract'> {
+  id: string;
+  /** Full-payload zod schema. Sole validation source for unified attachments. */
+  schema: z.ZodType;
   /**
    * Schema exposed to workflow authors. When unset, workflow steps fall back to
    * `schema` if it is a Zod object; when `false`, the type is excluded.
@@ -68,10 +67,13 @@ export interface UnifiedAttachmentType
 }
 
 export interface UnifiedAttachmentTypeSetup
-  extends ExternalReferenceAttachmentType,
-    Omit<PersistableStateDefinition<UnifiedAttachmentState>, 'migrations' | 'inject' | 'extract'> {
-  /** Full-payload zod schema. Preferred over `schemaValidator` for new registrations. */
-  schema?: z.ZodType;
+  extends Omit<
+    PersistableStateDefinition<UnifiedAttachmentState>,
+    'migrations' | 'inject' | 'extract'
+  > {
+  id: string;
+  /** Full-payload zod schema. Sole validation source for unified attachments. */
+  schema: z.ZodType;
   workflowSchema?: z.ZodObject | false;
 }
 

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/unified_attachment_registry.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/unified_attachment_registry.ts
@@ -17,7 +17,6 @@ export class UnifiedAttachmentTypeRegistry extends AttachmentTypeRegistry<Unifie
     const item: UnifiedAttachmentType = {
       id: attachmentType.id,
       schema: attachmentType.schema,
-      schemaValidator: attachmentType.schemaValidator,
       workflowSchema: attachmentType.workflowSchema,
       telemetry: attachmentType.telemetry || ((state, stats) => stats),
     };

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.test.ts
@@ -45,19 +45,7 @@ describe('validateUnifiedRegisteredAttachments', () => {
     ).toThrow(/is not registered in unified attachment type registry/);
   });
 
-  it('throws when neither `schema` nor `schemaValidator` is set', () => {
-    const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
-    unifiedAttachmentTypeRegistry.register({ id: COMMENT_ATTACHMENT_TYPE });
-
-    expect(() =>
-      validateUnifiedRegisteredAttachments({
-        query: { ...validCommentPayload },
-        unifiedAttachmentTypeRegistry,
-      })
-    ).toThrow(/does not define a schema validator/);
-  });
-
-  describe('when `schema` is set (preferred path)', () => {
+  describe('when `schema` is set', () => {
     it('accepts a valid payload', () => {
       const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
       unifiedAttachmentTypeRegistry.register({
@@ -101,78 +89,6 @@ describe('validateUnifiedRegisteredAttachments', () => {
           unifiedAttachmentTypeRegistry,
         })
       ).toThrow(/data\.content: Comment content must be a non-empty string/);
-    });
-
-    it('prefers `schema` over a (legacy) `schemaValidator` when both are set', () => {
-      const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
-      const legacyValidator = jest.fn();
-      unifiedAttachmentTypeRegistry.register({
-        id: COMMENT_ATTACHMENT_TYPE,
-        schema: CommentAttachmentPayloadSchema,
-        schemaValidator: legacyValidator,
-      });
-
-      validateUnifiedRegisteredAttachments({
-        query: { ...validCommentPayload },
-        unifiedAttachmentTypeRegistry,
-      });
-
-      expect(legacyValidator).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when only legacy `schemaValidator` is set (fallback path)', () => {
-    it('passes the `data` slice for unified value attachments', () => {
-      const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
-      const schemaValidator = jest.fn();
-      unifiedAttachmentTypeRegistry.register({
-        id: COMMENT_ATTACHMENT_TYPE,
-        schemaValidator,
-      });
-
-      validateUnifiedRegisteredAttachments({
-        query: { ...validCommentPayload },
-        unifiedAttachmentTypeRegistry,
-      });
-
-      expect(schemaValidator).toHaveBeenCalledWith(validCommentPayload.data);
-    });
-
-    it('passes the `metadata` slice (or null) for unified reference attachments', () => {
-      const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
-      const schemaValidator = jest.fn();
-      unifiedAttachmentTypeRegistry.register({
-        id: 'security.alert',
-        schemaValidator,
-      });
-
-      validateUnifiedRegisteredAttachments({
-        query: {
-          type: 'security.alert',
-          owner: 'securitySolution',
-          attachmentId: 'alert-1',
-        },
-        unifiedAttachmentTypeRegistry,
-      });
-
-      expect(schemaValidator).toHaveBeenCalledWith(null);
-    });
-
-    it('rejects when the legacy validator throws', () => {
-      const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
-      unifiedAttachmentTypeRegistry.register({
-        id: COMMENT_ATTACHMENT_TYPE,
-        schemaValidator: () => {
-          throw new Error('legacy boom');
-        },
-      });
-
-      expect(() =>
-        validateUnifiedRegisteredAttachments({
-          query: { ...validCommentPayload },
-          unifiedAttachmentTypeRegistry,
-        })
-      ).toThrow(/legacy boom/);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.test.ts
@@ -45,6 +45,19 @@ describe('validateUnifiedRegisteredAttachments', () => {
     ).toThrow(/is not registered in unified attachment type registry/);
   });
 
+  it('throws a Boom badRequest when a registered type has no schema (runtime misuse)', () => {
+    const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
+    // Simulate a type registered via `as any` that bypasses the required-schema type.
+    unifiedAttachmentTypeRegistry.register({ id: COMMENT_ATTACHMENT_TYPE } as never);
+
+    expect(() =>
+      validateUnifiedRegisteredAttachments({
+        query: { ...validCommentPayload },
+        unifiedAttachmentTypeRegistry,
+      })
+    ).toThrow(/Attachment type 'comment' does not define a schema/);
+  });
+
   describe('when `schema` is set', () => {
     it('accepts a valid payload', () => {
       const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.ts
@@ -13,8 +13,6 @@ import {
   isCommentRequestTypePersistableState,
   isLegacyAttachmentRequest,
   isUnifiedAttachmentRequest,
-  isUnifiedReferenceAttachmentRequest,
-  isUnifiedValueAttachmentRequest,
   isPersistableType,
   toUnifiedPersistableStateAttachmentType,
 } from '../../../common/utils/attachments';
@@ -122,24 +120,7 @@ export const validateUnifiedRegisteredAttachments = ({
     );
   }
 
-  // Prefer `schema`; fall back to the slice-based `schemaValidator` below.
-  if (attachmentType.schema) {
-    parseUnifiedAttachmentWithSchema(attachmentType.schema, query, query.type);
-    return;
-  }
-
-  if (!attachmentType.schemaValidator) {
-    throw Boom.badRequest(`Attachment type '${query.type}' does not define a schema validator.`);
-  }
-  if (isUnifiedValueAttachmentRequest(query)) {
-    attachmentType.schemaValidator(query.data);
-  } else if (isUnifiedReferenceAttachmentRequest(query)) {
-    attachmentType.schemaValidator(query.metadata ?? null);
-  } else {
-    throw Boom.badRequest(
-      `Invalid unified attachment request: expected value (data) or reference (attachmentId) shape.`
-    );
-  }
+  parseUnifiedAttachmentWithSchema(attachmentType.schema, query, query.type);
 };
 
 export const validateRegisteredAttachments = ({

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/validators.ts
@@ -120,6 +120,10 @@ export const validateUnifiedRegisteredAttachments = ({
     );
   }
 
+  if (!attachmentType.schema) {
+    throw Boom.badRequest(`Attachment type '${query.type}' does not define a schema.`);
+  }
+
   parseUnifiedAttachmentWithSchema(attachmentType.schema, query, query.type);
 };
 

--- a/x-pack/platform/plugins/shared/cases/server/client/decode_unified_comment_request.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/decode_unified_comment_request.test.ts
@@ -25,7 +25,7 @@ describe('decodeUnifiedCommentRequest', () => {
     );
   });
 
-  describe('when `schema` is set (preferred path)', () => {
+  describe('when `schema` is set', () => {
     it('accepts a valid payload', () => {
       const unifiedRegistry = new UnifiedAttachmentTypeRegistry();
       unifiedRegistry.register({
@@ -52,58 +52,5 @@ describe('decodeUnifiedCommentRequest', () => {
         )
       ).toThrow(/data\.content: Comment content must be a non-empty string/);
     });
-
-    it('prefers `schema` over a (legacy) `schemaValidator` when both are set', () => {
-      const unifiedRegistry = new UnifiedAttachmentTypeRegistry();
-      const legacyValidator = jest.fn();
-      unifiedRegistry.register({
-        id: COMMENT_ATTACHMENT_TYPE,
-        schema: CommentAttachmentPayloadSchema,
-        schemaValidator: legacyValidator,
-      });
-
-      decodeUnifiedCommentRequest({ ...validCommentPayload }, unifiedRegistry);
-
-      expect(legacyValidator).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when only legacy `schemaValidator` is set (fallback path)', () => {
-    it('passes the `data` slice for unified value attachments', () => {
-      const unifiedRegistry = new UnifiedAttachmentTypeRegistry();
-      const schemaValidator = jest.fn();
-      unifiedRegistry.register({ id: COMMENT_ATTACHMENT_TYPE, schemaValidator });
-
-      decodeUnifiedCommentRequest({ ...validCommentPayload }, unifiedRegistry);
-
-      expect(schemaValidator).toHaveBeenCalledWith(validCommentPayload.data);
-    });
-
-    it('passes the `metadata` slice (or null) for unified reference attachments', () => {
-      const unifiedRegistry = new UnifiedAttachmentTypeRegistry();
-      const schemaValidator = jest.fn();
-      unifiedRegistry.register({ id: 'security.alert', schemaValidator });
-
-      decodeUnifiedCommentRequest(
-        {
-          type: 'security.alert',
-          owner: 'securitySolution',
-          attachmentId: 'alert-1',
-        },
-        unifiedRegistry
-      );
-
-      expect(schemaValidator).toHaveBeenCalledWith(null);
-    });
-  });
-
-  it('silently no-ops when neither `schema` nor `schemaValidator` is set', () => {
-    // Pre-existing behavior; the API path (`validateUnifiedRegisteredAttachments`) throws instead.
-    const unifiedRegistry = new UnifiedAttachmentTypeRegistry();
-    unifiedRegistry.register({ id: COMMENT_ATTACHMENT_TYPE });
-
-    expect(() =>
-      decodeUnifiedCommentRequest({ ...validCommentPayload }, unifiedRegistry)
-    ).not.toThrow();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/decode_unified_comment_request.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/decode_unified_comment_request.test.ts
@@ -25,6 +25,16 @@ describe('decodeUnifiedCommentRequest', () => {
     );
   });
 
+  it('throws a Boom badRequest when a registered type has no schema (runtime misuse)', () => {
+    const unifiedRegistry = new UnifiedAttachmentTypeRegistry();
+    // Simulate a type registered via `as any` that bypasses the required-schema type.
+    unifiedRegistry.register({ id: COMMENT_ATTACHMENT_TYPE } as never);
+
+    expect(() => decodeUnifiedCommentRequest({ ...validCommentPayload }, unifiedRegistry)).toThrow(
+      /Attachment type 'comment' does not define a schema/
+    );
+  });
+
   describe('when `schema` is set', () => {
     it('accepts a valid payload', () => {
       const unifiedRegistry = new UnifiedAttachmentTypeRegistry();

--- a/x-pack/platform/plugins/shared/cases/server/client/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/utils.ts
@@ -167,8 +167,7 @@ const decodeExternalReferenceAttachment = (
   }
 };
 
-/** Validates a unified attachment via the registered `schema`
- * (preferred) or legacy `schemaValidator`. */
+/** Validates a unified attachment via the registered `schema`. */
 const decodeUnifiedAttachment = (
   attachment: UnifiedAttachmentPayload,
   unifiedRegistry: UnifiedAttachmentTypeRegistry
@@ -181,20 +180,7 @@ const decodeUnifiedAttachment = (
 
   const attachmentType = unifiedRegistry.get(attachment.type);
 
-  if (attachmentType.schema) {
-    parseUnifiedAttachmentWithSchema(attachmentType.schema, attachment, attachment.type);
-    return;
-  }
-
-  if (!attachmentType.schemaValidator) {
-    return;
-  }
-
-  if (isUnifiedValueAttachmentRequest(attachment)) {
-    attachmentType.schemaValidator(attachment.data);
-  } else if (isUnifiedReferenceAttachmentRequest(attachment)) {
-    attachmentType.schemaValidator(attachment.metadata ?? null);
-  }
+  parseUnifiedAttachmentWithSchema(attachmentType.schema, attachment, attachment.type);
 };
 
 export const decodeUnifiedCommentRequest = (

--- a/x-pack/platform/plugins/shared/cases/server/client/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/utils.ts
@@ -180,6 +180,10 @@ const decodeUnifiedAttachment = (
 
   const attachmentType = unifiedRegistry.get(attachment.type);
 
+  if (!attachmentType.schema) {
+    throw badRequest(`Attachment type '${attachment.type}' does not define a schema.`);
+  }
+
   parseUnifiedAttachmentWithSchema(attachmentType.schema, attachment, attachment.type);
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/endpoint/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/endpoint/index.tsx
@@ -7,10 +7,8 @@
 
 import React, { lazy, Suspense } from 'react';
 import { EuiAvatar } from '@elastic/eui';
-import type {
-  UnifiedReferenceAttachmentType,
-  UnifiedReferenceAttachmentViewProps,
-} from '@kbn/cases-plugin/public/client/attachment_framework/types';
+import type { UnifiedReferenceAttachmentViewProps } from '@kbn/cases-plugin/public/client/attachment_framework/types';
+import { defineAttachment } from '@kbn/cases-plugin/public';
 import { SECURITY_ENDPOINT_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
 import { EndpointAttachmentPayloadSchema } from '../../../../common/cases/attachments/endpoint';
 import type { EndpointMetadata } from './types';
@@ -25,21 +23,22 @@ const getEventContent = (props: UnifiedReferenceAttachmentViewProps) => (
   </Suspense>
 );
 
-export const getEndpointUnifiedAttachment = (): UnifiedReferenceAttachmentType => ({
-  id: SECURITY_ENDPOINT_ATTACHMENT_TYPE,
-  icon: 'lockOpen',
-  displayName: ENDPOINT_DISPLAY_NAME,
-  schema: EndpointAttachmentPayloadSchema,
-  getAttachmentViewObject: (props) => {
-    const metadata = props.metadata as EndpointMetadata | undefined;
-    const iconType = metadata?.command === 'isolate' ? 'lock' : 'lockOpen';
+export const getEndpointUnifiedAttachment = () =>
+  defineAttachment({
+    id: SECURITY_ENDPOINT_ATTACHMENT_TYPE,
+    icon: 'lockOpen',
+    displayName: ENDPOINT_DISPLAY_NAME,
+    schema: EndpointAttachmentPayloadSchema,
+    getAttachmentViewObject: (props) => {
+      const metadata = props.metadata as EndpointMetadata | undefined;
+      const iconType = metadata?.command === 'isolate' ? 'lock' : 'lockOpen';
 
-    return {
-      event: getEventContent(props),
-      timelineAvatar: (
-        <EuiAvatar name="endpoint" color="subdued" iconType={iconType} aria-label={iconType} />
-      ),
-      children: LazyChildren,
-    };
-  },
-});
+      return {
+        event: getEventContent(props),
+        timelineAvatar: (
+          <EuiAvatar name="endpoint" color="subdued" iconType={iconType} aria-label={iconType} />
+        ),
+        children: LazyChildren,
+      };
+    },
+  });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/index.tsx
@@ -7,11 +7,8 @@
 
 import React, { Suspense, lazy, type ComponentType } from 'react';
 import { EuiAvatar } from '@elastic/eui';
-import type {
-  CommonAttachmentTabViewProps,
-  UnifiedReferenceAttachmentType,
-} from '@kbn/cases-plugin/public';
-import { AttachmentActionType } from '@kbn/cases-plugin/public';
+import type { CommonAttachmentTabViewProps } from '@kbn/cases-plugin/public';
+import { AttachmentActionType, defineAttachment } from '@kbn/cases-plugin/public';
 import {
   SECURITY_EVENT_ATTACHMENT_TYPE,
   isIndexMetadata,
@@ -96,14 +93,15 @@ const getAttachmentRemovalObject = (props: UnifiedReferenceAttachmentViewProps) 
 /**
  * Returns the event attachment type for registration with the unified registry.
  */
-export const getEventType = (): UnifiedReferenceAttachmentType => ({
-  id: SECURITY_EVENT_ATTACHMENT_TYPE,
-  displayName: EVENT_DISPLAY_NAME,
-  icon: 'bell',
-  schema: SecurityEventAttachmentPayloadSchema,
-  getAttachmentViewObject: (props) => getAttachmentViewObject(props),
-  getAttachmentRemovalObject: (props) => getAttachmentRemovalObject(props),
-  getAttachmentTabViewObject: () => ({
-    children: EventTabContentWrapper,
-  }),
-});
+export const getEventType = () =>
+  defineAttachment({
+    id: SECURITY_EVENT_ATTACHMENT_TYPE,
+    displayName: EVENT_DISPLAY_NAME,
+    icon: 'bell',
+    schema: SecurityEventAttachmentPayloadSchema,
+    getAttachmentViewObject: (props) => getAttachmentViewObject(props),
+    getAttachmentRemovalObject: (props) => getAttachmentRemovalObject(props),
+    getAttachmentTabViewObject: () => ({
+      children: EventTabContentWrapper,
+    }),
+  });


### PR DESCRIPTION
## Summary

Removed the legacy `schemaValidator` in unified attachment registry and enforce zod `schema`. 

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.