### PR TITLE
[Security Solution][Flyout] toggle between legacy and new rule flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { AlertEvent } from './alert_event';
+import { TestProviders } from '../../../../common/mock';
+import { createExpandableFlyoutApiMock } from '../../../../common/mock/expandable_flyout';
+import { useFetchAlertData } from '../../../pages/use_fetch_alert_data';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { RulePanelKey } from '../../../../flyout/rule_details/right';
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../../pages/use_fetch_alert_data');
+jest.mock('../../../../common/components/user_privileges');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../../../flyout_v2/use_flyout_api');
+
+const savedObjectId = 'so1';
+const defaultProps = {
+  alertId: 'a1',
+  totalAlerts: 1,
+  savedObjectId,
+  rule: { id: 'rule-1', name: 'My rule' },
+};
+
+const ruleLinkTestId = `alert-rule-link-${savedObjectId}`;
+
+describe('AlertEvent', () => {
+  const flyoutApi = createFlyoutApiMock();
+  const mockOpenFlyout = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFetchAlertData as jest.Mock).mockReturnValue([false, {}]);
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      rulesPrivileges: { rules: { read: true } },
+    });
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
+    });
+  });
+
+  it('renders the rule link with the resolved rule name', () => {
+    render(
+      <TestProviders>
+        <AlertEvent {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId(ruleLinkTestId)).toHaveTextContent('My rule');
+  });
+
+  it('opens the legacy expandable flyout when the new flyout is disabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+
+    render(
+      <TestProviders>
+        <AlertEvent {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId(ruleLinkTestId));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: RulePanelKey,
+        params: { ruleId: 'rule-1' },
+      },
+    });
+    expect(flyoutApi.openRuleFlyout).not.toHaveBeenCalled();
+  });
+
+  it('opens the new rule flyout when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(
+      <TestProviders>
+        <AlertEvent {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId(ruleLinkTestId));
+
+    expect(flyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'rule-1' });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+  });
+
+  it('does not open any flyout when the user cannot read rules', () => {
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      rulesPrivileges: { rules: { read: false } },
+    });
+
+    render(
+      <TestProviders>
+        <AlertEvent {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId(ruleLinkTestId));
+
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openRuleFlyout).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/alert/components/alert_event.tsx
@@ -14,6 +14,8 @@ import { useFetchAlertData } from '../../../pages/use_fetch_alert_data';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import * as i18n from '../translations';
 import { RulePanelKey } from '../../../../flyout/rule_details/right';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
 
 /**
  * Security signals (`signal.*`) shipped before the ECS `kibana.alert.*` move,
@@ -41,6 +43,8 @@ export const AlertEvent: React.FC<AlertEventProps> = ({
   rule,
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openRuleFlyout } = useFlyoutApi();
   const {
     rulesPrivileges: {
       rules: { read: canReadRules },
@@ -73,9 +77,13 @@ export const AlertEvent: React.FC<AlertEventProps> = ({
 
   const onRuleClick = useCallback(() => {
     if (resolvedRuleId && canReadRules) {
-      openFlyout({ right: { id: RulePanelKey, params: { ruleId: resolvedRuleId } } });
+      if (enableNewFlyout) {
+        openRuleFlyout({ ruleId: resolvedRuleId });
+      } else {
+        openFlyout({ right: { id: RulePanelKey, params: { ruleId: resolvedRuleId } } });
+      }
     }
-  }, [openFlyout, canReadRules, resolvedRuleId]);
+  }, [openFlyout, canReadRules, resolvedRuleId, enableNewFlyout, openRuleFlyout]);
 
   if (loadingAlertData) {
     return <EuiLoadingSpinner size="m" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/about_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/about_section.test.tsx
@@ -10,34 +10,19 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { useExpandSection } from '../../../shared/hooks/use_expand_section';
+import { useFlyoutApi } from '../../../use_flyout_api';
+import { createFlyoutApiMock } from '../../../use_flyout_api.mock';
 import { ABOUT_SECTION_TEST_ID, ABOUT_SECTION_TITLE, AboutSection } from './about_section';
 
-jest.mock('../../../../common/lib/kibana', () => ({
-  useKibana: () => ({
-    services: {
-      overlays: {
-        openSystemFlyout: jest.fn(),
-      },
-    },
-  }),
-}));
+jest.mock('../../../use_flyout_api');
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useStore: () => ({}),
-}));
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({ push: jest.fn() }),
-}));
-
-jest.mock('../../../shared/hooks/use_default_flyout_properties', () => ({
-  useDefaultDocumentFlyoutProperties: () => ({ size: 'm' }),
-}));
-
+// Capture the `onShowRuleSummary` prop passed to AlertDescription so the test can invoke it.
+let capturedOnShowRuleSummary: (() => void) | undefined;
 jest.mock('./alert_description', () => ({
-  AlertDescription: () => <div>{'AlertDescription'}</div>,
+  AlertDescription: ({ onShowRuleSummary }: { onShowRuleSummary?: () => void }) => {
+    capturedOnShowRuleSummary = onShowRuleSummary;
+    return <div>{'AlertDescription'}</div>;
+  },
 }));
 
 jest.mock('./alert_reason', () => ({
@@ -77,13 +62,17 @@ const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord
 
 const alertHit = createMockHit({
   'event.kind': 'signal',
+  'kibana.alert.rule.uuid': 'rule-uuid-123',
 });
 
 describe('AboutSection', () => {
   const mockUseExpandSection = jest.mocked(useExpandSection);
+  const flyoutApi = createFlyoutApiMock();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedOnShowRuleSummary = undefined;
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
   });
 
   it('renders the About expandable section', () => {
@@ -128,6 +117,25 @@ describe('AboutSection', () => {
       expect(getByText('AlertStatus')).toBeInTheDocument();
       expect(getByText('MitreAttack')).toBeInTheDocument();
     });
+  });
+
+  it('opens the rule flyout with the alert rule id when onShowRuleSummary is invoked', () => {
+    mockUseExpandSection.mockReturnValue(true);
+
+    render(
+      <IntlProvider locale="en">
+        <AboutSection hit={alertHit} />
+      </IntlProvider>
+    );
+
+    expect(capturedOnShowRuleSummary).toBeDefined();
+
+    act(() => {
+      capturedOnShowRuleSummary?.();
+    });
+
+    expect(flyoutApi.openRuleFlyout).toHaveBeenCalledTimes(1);
+    expect(flyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'rule-uuid-123' });
   });
 
   it('renders EventCategoryDescription and EventRenderer for event.kind === event', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/about_section.tsx
@@ -10,18 +10,13 @@ import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 import React, { memo, useCallback, useMemo } from 'react';
 import { ALERT_RULE_UUID, EVENT_KIND } from '@kbn/rule-data-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { EventKind } from '../constants/event_kinds';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
 import { ExpandableSection } from '../../../shared/components/expandable_section';
 import { useExpandSection } from '../../../shared/hooks/use_expand_section';
 import { isEcsAllowedValue } from '../utils/event_utils';
-import { useKibana } from '../../../../common/lib/kibana';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
-import { RuleDetails } from '../../../rule/main';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { AlertDescription } from './alert_description';
 import { AlertReason } from './alert_reason';
 import { AlertStatus } from './alert_status';
@@ -55,11 +50,7 @@ export interface AboutSectionProps {
  * For all other events, it shows the event kind description, a list of event categories and event renderer.
  */
 export const AboutSection = memo(({ hit }: AboutSectionProps) => {
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const { openRuleFlyout } = useFlyoutApi();
 
   const eventKind = useMemo(() => getFieldValue(hit, EVENT_KIND) as string, [hit]);
   const isAlert = eventKind === EventKind.signal;
@@ -71,19 +62,10 @@ export const AboutSection = memo(({ hit }: AboutSectionProps) => {
   );
 
   const onShowRuleSummary = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <RuleDetails ruleId={ruleId} />,
-      }),
-      {
-        ...defaultDocumentFlyoutProperties,
-        session: 'inherit',
-      }
-    );
-  }, [defaultDocumentFlyoutProperties, history, overlays, ruleId, services, store]);
+    if (ruleId) {
+      openRuleFlyout({ ruleId });
+    }
+  }, [openRuleFlyout, ruleId]);
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.test.tsx
@@ -24,6 +24,10 @@ import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app'
 import { HighlightedFields } from './highlighted_fields';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
+import {
+  HOST_NAME_FIELD_NAME,
+  SIGNAL_RULE_NAME_FIELD_NAME,
+} from '../../../../timelines/components/timeline/body/renderers/constants';
 
 jest.mock('../../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
@@ -230,6 +234,86 @@ describe('InvestigationSection', () => {
       expect.objectContaining({ renderCellActions: localMockRenderCellActions }),
       expect.anything()
     );
+  });
+
+  it('renders a rule link keyed by the rule UUID and opening as a new parent flyout', () => {
+    mockUseExpandSection.mockReturnValue(true);
+    const ruleUuid = '28f4bc3f-5795-46e3-b5ca-d73cd4ab3e5c';
+    const ruleHit = createMockHit({
+      'event.kind': 'signal',
+      'kibana.alert.rule.uuid': ruleUuid,
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={ruleHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    const renderFlyoutLink = mockHighlightedFields.mock.calls[0][0].renderFlyoutLink;
+    const element = renderFlyoutLink!({
+      field: SIGNAL_RULE_NAME_FIELD_NAME,
+      value: 'Match All',
+      children: <span />,
+    }) as React.ReactElement;
+
+    // The link target is the UUID (not the displayed name), and it opens as a new main flyout.
+    expect(element.props.value).toBe(ruleUuid);
+    expect(element.props.asParent).toBe(true);
+  });
+
+  it('falls back to plain children for a rule field when the rule UUID is unavailable', () => {
+    mockUseExpandSection.mockReturnValue(true);
+
+    render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={mockHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    const renderFlyoutLink = mockHighlightedFields.mock.calls[0][0].renderFlyoutLink;
+    const element = renderFlyoutLink!({
+      field: SIGNAL_RULE_NAME_FIELD_NAME,
+      value: 'Match All',
+      children: <span data-test-subj="ruleChild" />,
+    }) as React.ReactElement;
+
+    // No UUID on the hit → no OpenFlyoutLink, just the passthrough children.
+    expect(element.props.value).toBeUndefined();
+    expect(element.props.children).toBeDefined();
+  });
+
+  it('opens a non-rule entity field (host) as a new parent flyout', () => {
+    mockUseExpandSection.mockReturnValue(true);
+
+    render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={mockHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    const renderFlyoutLink = mockHighlightedFields.mock.calls[0][0].renderFlyoutLink;
+    const element = renderFlyoutLink!({
+      field: HOST_NAME_FIELD_NAME,
+      value: 'host-1',
+      children: <span />,
+    }) as React.ReactElement;
+
+    // Host keeps its value as-is and opens as a parent.
+    expect(element.props.value).toBe('host-1');
+    expect(element.props.asParent).toBe(true);
   });
 
   it('uses Security history key when opening flyout inside Security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
@@ -33,6 +33,8 @@ import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
 import {
   HOST_NAME_FIELD_NAME,
+  LEGACY_SIGNAL_RULE_NAME_FIELD_NAME,
+  SIGNAL_RULE_NAME_FIELD_NAME,
   USER_NAME_FIELD_NAME,
 } from '../../../../timelines/components/timeline/body/renderers/constants';
 
@@ -120,13 +122,27 @@ export const InvestigationSection = memo(
     }, [history, historyKey, hit, overlays, services, store]);
 
     const renderFlyoutLink = useCallback(
-      (props: OpenFlyoutLinkProps) => (
-        <OpenFlyoutLink
-          {...props}
-          asParent={props.field === HOST_NAME_FIELD_NAME || props.field === USER_NAME_FIELD_NAME}
-        />
-      ),
-      []
+      (props: OpenFlyoutLinkProps) => {
+        // Rule name fields: substitute the rule UUID as the link target (the flyout is keyed by
+        // UUID) while keeping the rule name as the displayed text. When no UUID is available,
+        // render plain text to avoid opening the rule flyout with an invalid id.
+        if (
+          props.field === SIGNAL_RULE_NAME_FIELD_NAME ||
+          props.field === LEGACY_SIGNAL_RULE_NAME_FIELD_NAME
+        ) {
+          if (!ruleId) {
+            return <>{props.children}</>;
+          }
+          return <OpenFlyoutLink {...props} value={ruleId} asParent />;
+        }
+        return (
+          <OpenFlyoutLink
+            {...props}
+            asParent={props.field === HOST_NAME_FIELD_NAME || props.field === USER_NAME_FIELD_NAME}
+          />
+        );
+      },
+      [ruleId]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -149,7 +149,7 @@ export const DocumentFlyout = memo(
           if (!ruleId) {
             return <>{props.children}</>;
           }
-          return <OpenFlyoutLink {...props} value={ruleId} />;
+          return <OpenFlyoutLink {...props} value={ruleId} asParent />;
         }
         // Host and IP fields open as a new flyout (parent) rather than a child of the current one.
         const isIpField = getEcsField(props.field)?.type === IP_FIELD_TYPE;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.mock.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleFlyoutApi } from './use_rule_flyout_api';
+
+/**
+ * Returns a `useRuleFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useRuleFlyoutApi).mockReturnValue(createRuleFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createRuleFlyoutApiMock = (): jest.Mocked<RuleFlyoutApi> => ({
+  openRuleFlyout: jest.fn(),
+  openRuleFlyoutAsChild: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { useRuleFlyoutApi } from './use_rule_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+const ruleId = 'rule-1';
+
+describe('useRuleFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  it('openRuleFlyout opens a system flyout, defaulting to a new session', () => {
+    const { result } = renderHook(() => useRuleFlyoutApi());
+    result.current.openRuleFlyout({ ruleId });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openRuleFlyoutAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useRuleFlyoutApi());
+    result.current.openRuleFlyoutAsChild({ ruleId });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({
+        size: 's',
+        session: 'inherit',
+        historyKey: documentFlyoutHistoryKey,
+      })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useRuleFlyoutApi());
+    result.current.openRuleFlyout({ ruleId });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+// Lazy-loaded so consumers of this hook don't statically pull the rule flyout graph into their
+// bundle; the chunk only loads when the flyout is actually opened.
+const RuleDetails = lazy(() => import('./main').then((m) => ({ default: m.RuleDetails })));
+
+export interface OpenRuleFlyoutParams {
+  /** The unique identifier of the rule to display. */
+  ruleId: string;
+}
+
+export interface RuleFlyoutApi {
+  /**
+   * Opens the rule details flyout as a new, top-level flyout (starting a fresh session).
+   * Use this from outside any flyout — e.g. a case attachment, or a rule-name link that should
+   * open its own flyout.
+   */
+  openRuleFlyout: (params: OpenRuleFlyoutParams) => void;
+  /**
+   * Opens the rule details flyout as a child of the currently open flyout (nested in its history
+   * stack, so the back button returns to it). Use this from within an already-open flyout.
+   */
+  openRuleFlyoutAsChild: (params: OpenRuleFlyoutParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) rule flyout, in the same mindset as
+ * `useExpandableFlyoutApi`, `useDocumentFlyoutApi`, `useAttackFlyoutApi`, etc. It encapsulates the
+ * provider wiring (`flyoutProviders` + `overlays.openSystemFlyout`) and the flyout properties so
+ * call sites don't repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useRuleFlyoutApi = (): RuleFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  // `session` is the only thing that differs between a main and a child flyout. It is kept private
+  // here so callers never have to reason about it: they pick `openRuleFlyout` (main) or
+  // `openRuleFlyoutAsChild` (child) and this helper maps that to the right session.
+  const open = useCallback(
+    (children: ReactNode, session: OverlaySystemFlyoutOpenOptions['session']) => {
+      const properties: OverlaySystemFlyoutOpenOptions = {
+        ...defaultDocumentFlyoutProperties,
+        historyKey,
+        session,
+      };
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openRuleFlyout = useCallback(
+    ({ ruleId }: OpenRuleFlyoutParams) => {
+      open(<RuleDetails ruleId={ruleId} />, 'start');
+    },
+    [open]
+  );
+
+  const openRuleFlyoutAsChild = useCallback(
+    ({ ruleId }: OpenRuleFlyoutParams) => {
+      open(<RuleDetails ruleId={ruleId} />, 'inherit');
+    },
+    [open]
+  );
+
+  return useMemo(
+    () => ({ openRuleFlyout, openRuleFlyoutAsChild }),
+    [openRuleFlyout, openRuleFlyoutAsChild]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
@@ -8,6 +8,7 @@
 import type { FlyoutApi } from './use_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
 import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
+import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
 
 /**
  * Returns a `useFlyoutApi` return value with every method stubbed as a `jest.fn()`.
@@ -18,4 +19,5 @@ import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.moc
 export const createFlyoutApiMock = (): jest.Mocked<FlyoutApi> => ({
   ...createAttackFlyoutApiMock(),
   ...createNetworkFlyoutApiMock(),
+  ...createRuleFlyoutApiMock(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
@@ -11,36 +11,46 @@ import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
 import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
 import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
+import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
+import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
 import { useFlyoutApi } from './use_flyout_api';
 
 jest.mock('./attack/use_attack_flyout_api');
 jest.mock('./network/use_network_flyout_api');
+jest.mock('./rule/use_rule_flyout_api');
 
 describe('useFlyoutApi', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('exposes the attack and network flyout methods from the composed per-type hooks', () => {
+  it('exposes the attack, network, and rule flyout methods from composed per-type hooks', () => {
     const attackApi = createAttackFlyoutApiMock();
     const networkApi = createNetworkFlyoutApiMock();
+    const ruleApi = createRuleFlyoutApiMock();
     jest.mocked(useAttackFlyoutApi).mockReturnValue(attackApi);
     jest.mocked(useNetworkFlyoutApi).mockReturnValue(networkApi);
+    jest.mocked(useRuleFlyoutApi).mockReturnValue(ruleApi);
 
     const { result } = renderHook(() => useFlyoutApi());
 
     const attackParams = { attackId: 'attack-1', indexName: '.alerts-security' };
     const networkParams = { ip: '1.2.3.4', flowTarget: FlowTargetSourceDest.source };
+    const ruleParams = { ruleId: 'rule-1' };
 
     // The facade surfaces the composed methods, and calling one delegates to the per-type hook.
     result.current.openAttackFlyout(attackParams);
     result.current.openAttackFlyoutAsChild(attackParams);
     result.current.openNetworkFlyout(networkParams);
     result.current.openNetworkFlyoutAsChild(networkParams);
+    result.current.openRuleFlyout(ruleParams);
+    result.current.openRuleFlyoutAsChild(ruleParams);
 
     expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(attackParams);
     expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(attackParams);
     expect(networkApi.openNetworkFlyout).toHaveBeenCalledWith(networkParams);
     expect(networkApi.openNetworkFlyoutAsChild).toHaveBeenCalledWith(networkParams);
+    expect(ruleApi.openRuleFlyout).toHaveBeenCalledWith(ruleParams);
+    expect(ruleApi.openRuleFlyoutAsChild).toHaveBeenCalledWith(ruleParams);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
@@ -10,13 +10,16 @@ import type { AttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import type { NetworkFlyoutApi } from './network/use_network_flyout_api';
 import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
+import type { RuleFlyoutApi } from './rule/use_rule_flyout_api';
+import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
 
 /**
  * The single developer-facing API for opening any new (EUI-based) Security Solution flyout.
  *
- * Rather than importing a per-type hook (`useNetworkFlyoutApi`, `useDocumentFlyoutApi`, `useNetworkFlyoutApi`, …), call
+ * Rather than importing a per-type hook (`useDocumentFlyoutApi`, …), call
  * sites use this one hook and get every open method, namespaced by type
- * (`openDocumentFlyoutFromIndex`, `openNetworkFlyout`, `openAttackFlyout`, …). Each method comes in
+ * (`openDocumentFlyoutFromIndex`, …).
+ * Each method comes in
  * a main variant (opens a new, top-level flyout) and, where it makes sense, an `...AsChild` variant
  * (opens nested inside the currently open flyout). Callers never deal with the flyout `session`.
  *
@@ -30,17 +33,19 @@ import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
  *
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
-export type FlyoutApi = AttackFlyoutApi & NetworkFlyoutApi;
+export type FlyoutApi = AttackFlyoutApi & NetworkFlyoutApi & RuleFlyoutApi;
 
 export const useFlyoutApi = (): FlyoutApi => {
   const attack = useAttackFlyoutApi();
   const network = useNetworkFlyoutApi();
+  const rule = useRuleFlyoutApi();
 
   return useMemo(
     () => ({
       ...attack,
       ...network,
+      ...rule,
     }),
-    [attack, network]
+    [attack, network, rule]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.test.tsx
@@ -7,28 +7,48 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { RenderRuleName } from './formatted_field_helpers';
 import { TestProviders } from '../../../../../common/mock';
+import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../../flyout_v2/use_flyout_api.mock';
+import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
+import { RulePanelKey } from '../../../../../flyout/rule_details/right';
+import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
 
+jest.mock('@kbn/expandable-flyout');
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../../common/components/link_to');
 jest.mock('../../../../../common/components/user_privileges');
 jest.mock('../../../../../common/hooks/use_is_new_flyout_enabled', () => ({
   useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
 }));
+jest.mock('../../../../../flyout_v2/use_flyout_api');
 
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 const useKibanaMock = useKibana as jest.Mock;
 
 const mockNavigateToApp = jest.fn();
+const mockOpenFlyout = jest.fn();
+
+const inTimelineContext = {
+  enableHostDetailsFlyout: true,
+  enableIpDetailsFlyout: true,
+  timelineID: TimelineId.active,
+  tabType: TimelineTabs.query,
+};
 
 const defaultProps = {
   fieldName: 'kibana.alert.rule.name',
   linkValue: 'rule-id-123',
   value: 'Test Rule Name',
 };
+
+const flyoutApi = createFlyoutApiMock();
 
 describe('RenderRuleName', () => {
   beforeEach(() => {
@@ -40,6 +60,12 @@ describe('RenderRuleName', () => {
           getUrlForApp: jest.fn().mockReturnValue('/app/security/rules/id/rule-id-123'),
         },
       },
+    });
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
     });
   });
 
@@ -109,6 +135,55 @@ describe('RenderRuleName', () => {
 
         expect(mockNavigateToApp).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('when in a timeline context', () => {
+    beforeEach(() => {
+      useUserPrivilegesMock.mockReturnValue({
+        rulesPrivileges: {
+          rules: { read: true, edit: false },
+          exceptions: { read: false, crud: false },
+        },
+      });
+    });
+
+    const renderInTimelineContext = () =>
+      render(
+        <TestProviders>
+          <StatefulEventContext.Provider value={inTimelineContext}>
+            <RenderRuleName {...defaultProps} />
+          </StatefulEventContext.Provider>
+        </TestProviders>
+      );
+
+    it('opens the legacy expandable flyout when the new flyout is disabled', () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+
+      renderInTimelineContext();
+      fireEvent.click(screen.getByTestId('ruleName'));
+
+      expect(mockOpenFlyout).toHaveBeenCalledWith({
+        right: {
+          id: RulePanelKey,
+          params: {
+            ruleId: defaultProps.linkValue,
+          },
+        },
+      });
+      expect(flyoutApi.openRuleFlyout).not.toHaveBeenCalled();
+      expect(mockNavigateToApp).not.toHaveBeenCalled();
+    });
+
+    it('opens the new rule flyout when the new flyout is enabled', () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      renderInTimelineContext();
+      fireEvent.click(screen.getByTestId('ruleName'));
+
+      expect(flyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: defaultProps.linkValue });
+      expect(mockOpenFlyout).not.toHaveBeenCalled();
+      expect(mockNavigateToApp).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.tsx
@@ -11,8 +11,6 @@ import { isEmpty, isString } from 'lodash/fp';
 import type { SyntheticEvent } from 'react';
 import React, { useCallback, useContext, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { getEmptyTagValue } from '../../../../../common/components/empty_value';
 import { getRuleDetailsUrl } from '../../../../../common/components/link_to/redirect_to_detection_engine';
 import { TruncatableText } from '../../../../../common/components/truncatable_text';
@@ -28,9 +26,7 @@ import { GenericLinkButton } from '../../../../../common/components/links/helper
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
 import { RulePanelKey } from '../../../../../flyout/rule_details/right';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
-import { RuleDetails } from '../../../../../flyout_v2/rule/main';
-import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 
 interface RenderRuleNameProps {
@@ -60,12 +56,10 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
   const { services } = useKibana();
-  const { overlays, application } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { application } = services;
   const eventContext = useContext(StatefulEventContext);
   const enableNewFlyout = useIsNewFlyoutEnabled();
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const { openRuleFlyout } = useFlyoutApi();
 
   const ruleName = `${value}`;
   const ruleId = linkValue;
@@ -90,18 +84,7 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
       }
 
       if (enableNewFlyout && ruleId) {
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: <RuleDetails ruleId={ruleId} />,
-          }),
-          {
-            ...defaultDocumentFlyoutProperties,
-            session: 'inherit',
-          }
-        );
+        openRuleFlyout({ ruleId });
         return;
       }
 
@@ -123,11 +106,7 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
       eventContext,
       isInTimelineContext,
       enableNewFlyout,
-      overlays,
-      services,
-      store,
-      history,
-      defaultDocumentFlyoutProperties,
+      openRuleFlyout,
     ]
   );
 


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is only focusing on the rule flyout. A couple of follow up PRs will take care of the other flyouts.

The PR also introduces a single developer-facing API to open the new rule flyout, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:
- `useFlyoutApi()`: that is inernally calling the network flyout specific api:
  - `useRuleFlyoutApi()` which returns `openRuleFlyout` that opens the rule flyout

> [!TIP]
> Developers should use - unless not possible - the useFlyoutApi() to open all of their flyouts

Every external entry point that opened the legacy rule flyout now routes through the API when the new flyout is enabled (the cases alert attachment rule link, and the timeline `rule.name` field renderer). Inside the new document flyout itself, the About-section rule summary link now goes through the same API, and the Table tab's `rule.name` link now opens the rule flyout as a **new** flyout instead of a child.

> [!WARNING]
> No legacy flyout behavior change introduced! Only toggling between the legacy and new flyout based off the advanced setting.

#### Advanced setting off (default)

https://github.com/user-attachments/assets/57d6fccc-7922-476e-bca1-8cc9f56e84a7

#### Advanced setting on

https://github.com/user-attachments/assets/1c9fbb60-be9a-476b-98a3-6d886e433e30

### Notes

The Table tab `rule.name` link opens through the shared `OpenFlyoutLink` renderer (not the API hook). It was defaulting to `session: 'inherit'`, which opened the rule details **as a child** of the current flyout; it now passes `asParent` so it starts a new flyout, matching every other rule entry point.

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new rule flyout opens from each surface:
   - A case with an alert attachment → click the rule name link.
   - A timeline row → click a `rule.name` value (it opens the rule flyout).
   - Open an alert in the new document flyout → the About section "rule summary" link, and the **Table** tab → search `rule.name` and click the link (it should open as a new flyout, not a child).
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->