### PR TITLE
[Transforms] Add project routing information to expanded transform details

### DIFF
--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/expanded_row_details_pane.test.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/expanded_row_details_pane.test.tsx
@@ -69,6 +69,7 @@ describe('Transform: Transform List Expanded Row <ExpandedRowDetailsPane />', ()
     expect(screen.getAllByText(item.id).length).toBeGreaterThan(0);
     expect(screen.getByText('source_index')).toBeInTheDocument();
     expect(screen.getByText('farequote-2019')).toBeInTheDocument();
+    expect(screen.queryByText('Project routing')).not.toBeInTheDocument();
     expect(screen.getByText('destination_index')).toBeInTheDocument();
     expect(screen.getAllByText('fq_date_histogram_1m_1441').length).toBeGreaterThan(0);
 
@@ -101,6 +102,30 @@ describe('Transform: Transform List Expanded Row <ExpandedRowDetailsPane />', ()
 
     expect(screen.getByText('source_index')).toBeInTheDocument();
     expect(screen.getByText('source-index-1')).toBeInTheDocument();
+  });
+
+  test('displays project routing when configured', () => {
+    mockUseGetTransformStats.mockReturnValue({
+      data: undefined,
+      isError: false,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useGetTransformStats>);
+
+    const item = {
+      ...transformListRow,
+      config: {
+        ...transformListRow.config,
+        source: {
+          ...transformListRow.config.source,
+          project_routing: '_alias:*',
+        },
+      },
+    } as unknown as TransformListRow;
+
+    renderWithI18n(<ExpandedRowDetailsPane item={item} onAlertEdit={onAlertEdit} />);
+
+    expect(screen.getByText('Project routing')).toBeInTheDocument();
+    expect(screen.getByText('_alias:*')).toBeInTheDocument();
   });
 
   test('displays source_index when index is an array', () => {

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/expanded_row_details_pane.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/expanded_row_details_pane.tsx
@@ -143,6 +143,19 @@ export const ExpandedRowDetailsPane: FC<ExpandedRowDetailsPaneProps> = ({ item, 
         title: 'source_index',
         description: <SourceIndexDescription index={item.config.source.index} />,
       },
+      ...(isDefined(item.config.source.project_routing)
+        ? [
+            {
+              title: i18n.translate(
+                'xpack.transform.transformList.transformDetails.projectRoutingLabel',
+                {
+                  defaultMessage: 'Project routing',
+                }
+              ),
+              description: item.config.source.project_routing,
+            },
+          ]
+        : []),
       {
         title: 'destination_index',
         description: item.config.dest.index,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/276762

## Summary

This PR shows `source.project_routing` in the Transform expanded row Details pane when the field is present on a transform config.

The value is displayed in the existing General details section with the localized label `Project routing`. Transforms without `source.project_routing` continue to render unchanged

## Changes

- Adds a conditional `Project routing` item to the expanded row Details pane.
- Displays the raw `source.project_routing` value, for example `_alias:*`.
- Adds test coverage for both:
  - transforms with `source.project_routing`
  - transforms without `source.project_routing`


<img width="1920" height="961" alt="Screenshot 2026-07-08 at 18 41 21" src="https://github.com/user-attachments/assets/8fb9cdcd-c680-4404-bcda-1d9c6629ce64" />


## Testing

Start the local CPS serverless stack:

```node scripts/scout start-server --arch serverless --domain security_complete --serverConfigSet cps_local```


Open Kibana: `http://localhost:5620`
Navigate to Console and run these commands:
```
PUT cps-pr3-source-v2
{
  "mappings": {
    "properties": {
      "host_name": {
        "type": "keyword"
      },
      "bytes": {
        "type": "long"
      }
    }
  }
}

PUT cps-pr3-source-v2/_doc/1?refresh=true
{
  "host_name": "origin-host",
  "bytes": 10
}

PUT _transform/cps_pr3_project_routing_test
{
  "source": {
    "index": "cps-pr3-source-v2",
    "project_routing": "_alias:*"
  },
  "dest": {
    "index": "cps-pr3-dest-v2"
  },
  "pivot": {
    "group_by": {
      "host_name": {
        "terms": {
          "field": "host_name"
        }
      }
    },
    "aggregations": {
      "bytes.sum": {
        "sum": {
          "field": "bytes"
        }
      }
    }
  }
}

PUT _transform/cps_pr3_no_project_routing_test
{
  "source": {
    "index": "cps-pr3-source-v2"
  },
  "dest": {
    "index": "cps-pr3-dest-no-routing"
  },
  "pivot": {
    "group_by": {
      "host_name": {
        "terms": {
          "field": "host_name"
        }
      }
    },
    "aggregations": {
      "bytes.sum": {
        "sum": {
          "field": "bytes"
        }
      }
    }
  }
}
```


Navigate to Transforms and verify:
1. Expand cps_pr3_project_routing_test.
2. Open the Details tab.
3. Confirm the General section shows Project routing with value `_alias:*`.
4. Then expand cps_pr3_no_project_routing_test and confirm Project routing is not shown.



