### PR TITLE
[Security Solution][OneDiscover] Fix host drop & flyout v2 chevron display

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.tsx
@@ -41,6 +41,8 @@ interface ResolutionSectionProps {
     entityId: string;
     entityName: string | undefined;
   }) => void;
+  /** When true, hides the chevron icon in the resolution group header. Used by the v2 flyout. */
+  hideHeaderIcons?: boolean;
 }
 
 export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
@@ -49,6 +51,7 @@ export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
   scopeId,
   openDetailsPanel,
   onShowEntity,
+  hideHeaderIcons = false,
 }) => {
   const {
     data: group,
@@ -116,13 +119,13 @@ export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
       <ExpandablePanel
         header={{
           title: RESOLUTION_GROUP_LINK_TITLE,
-          // link + arrow only when navigation is wired up
+          // link only when navigation is wired up; arrow icon hidden for the v2 flyout
           ...(openDetailsPanel && {
             link: {
               callback: handleOpenResolutionTab,
               tooltip: RESOLUTION_GROUP_LINK_TOOLTIP,
             },
-            iconType: 'arrowStart',
+            iconType: hideHeaderIcons ? undefined : 'arrowStart',
           }),
         }}
         expand={{ expandable: false }}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/entities_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/entities_details.test.tsx
@@ -253,4 +253,23 @@ describe('<EntitiesDetails />', () => {
     expect(getByTestId(USER_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(HOST_TEST_ID)).toBeInTheDocument();
   });
+
+  it('renders host panel from document fields when EUID host identifiers are unavailable (mirrors the user fallback)', () => {
+    // dataAsNestedObject is what EUID identifier extraction reads from. Emptying `host` here
+    // means getEntityIdentifiersFromDocument('host', ...) returns nothing, even though the
+    // fields API (getFieldsData, via mockGetFieldsData) still resolves host.name. This
+    // reproduces the flyout_v2 Entities tool bug where the host was dropped because its
+    // visibility gate incorrectly required EUID identifiers while the user gate did not.
+    const contextValue = {
+      ...mockContextValue,
+      dataAsNestedObject: {
+        ...mockContextValue.dataAsNestedObject,
+        host: {},
+      },
+    } as DocumentDetailsContext;
+    const { queryByText, getByTestId } = renderEntitiesDetails(contextValue);
+    expect(queryByText(NO_DATA_MESSAGE)).not.toBeInTheDocument();
+    expect(getByTestId(USER_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(HOST_TEST_ID)).toBeInTheDocument();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/entities_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/entities_details.tsx
@@ -46,15 +46,6 @@ const resolveUserDisplayForEntities = (
 ): string | undefined =>
   resolveUserNameForEntityInsightsWithFallback(identityFields, getFieldsData);
 
-const resolveHostDisplayForEntities = (
-  identityFields: IdentityFields | undefined,
-  getFieldsData: GetFieldsData,
-  hostNameFromStore: string | undefined
-): string | undefined => {
-  const fromDocument = resolveHostNameForEntityInsightsWithFallback(identityFields, getFieldsData);
-  return fromDocument ?? hostNameFromStore;
-};
-
 /**
  * Entities displayed in the document details expandable flyout left section under the Insights tab
  */
@@ -94,23 +85,34 @@ export const EntitiesDetails: React.FC<EntitySectionOverrideBuilders> = ({
     skip: userEntityIdentifiers == null && legacyUserIdentityForStore == null,
   });
 
+  /**
+   * Host EUID extraction can return nothing when the entity store EUID API is still loading
+   * (it is imported lazily) or when the document is not fully populated. Mirror the user
+   * handling: resolve the display name from the document and use it for store lookup when
+   * EUID returns nothing.
+   */
+  const resolvedHostNameFromDocument = resolveHostNameForEntityInsightsWithFallback(
+    hostEntityIdentifiers,
+    getFieldsData
+  );
+  const legacyHostIdentityForStore =
+    resolvedHostNameFromDocument != null && resolvedHostNameFromDocument !== ''
+      ? ({ 'host.name': resolvedHostNameFromDocument } as IdentityFields)
+      : undefined;
+
   const hostEntityId = euidApi?.euid.getEuidFromObject('host', dataAsNestedObject);
   const hostEntityFromStore = useEntityFromStore({
     entityId: hostEntityId,
-    identityFields: hostEntityIdentifiers ?? undefined,
+    identityFields: hostEntityIdentifiers ?? legacyHostIdentityForStore,
     entityType: 'host',
-    skip: !hostEntityIdentifiers,
+    skip: hostEntityIdentifiers == null && legacyHostIdentityForStore == null,
   });
 
   const hostRecord = hostEntityFromStore.entityRecord;
   const hostNameFromStore =
     hostRecord != null && 'host' in hostRecord ? hostRecord.host?.name : undefined;
 
-  const resolvedHostName = resolveHostDisplayForEntities(
-    hostEntityIdentifiers,
-    getFieldsData,
-    hostNameFromStore
-  );
+  const resolvedHostName = resolvedHostNameFromDocument ?? hostNameFromStore;
 
   const userDisplayName = userEntityFromStore.entityRecord?.entity?.name ?? resolvedUserName;
   const hostDisplayName = hostEntityFromStore.entityRecord?.entity?.name ?? resolvedHostName;
@@ -135,8 +137,7 @@ export const EntitiesDetails: React.FC<EntitySectionOverrideBuilders> = ({
   );
 
   const showUserDetails = timestamp != null && userDisplayName != null;
-  const showHostDetails =
-    hostEntityIdentifiers != null && timestamp != null && hostDisplayName != null;
+  const showHostDetails = timestamp != null && hostDisplayName != null;
   const showDetails = showUserDetails || showHostDetails;
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/right/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/right/visualizations_section.tsx
@@ -29,11 +29,14 @@ export const VisualizationsSection = memo(
     isPreviewMode,
     scopeId,
     openDetailsPanel,
+    hideHeaderIcons = false,
   }: {
     entityId: string;
     isPreviewMode: boolean;
     scopeId: string;
     openDetailsPanel?: (path: EntityDetailsPath) => void;
+    /** When true, hides the chevron icon in the graph preview header. Used by the v2 flyout. */
+    hideHeaderIcons?: boolean;
   }) => {
     const expanded = useExpandSection({
       storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -59,7 +62,7 @@ export const VisualizationsSection = memo(
             <EntityGraphPreviewContainer
               entityId={entityId}
               // header link + arrow only shown when navigation is wired up (onShowGraph set)
-              showIcon={!isPreviewMode && openDetailsPanel != null}
+              showIcon={!isPreviewMode && openDetailsPanel != null && !hideHeaderIcons}
               onShowGraph={
                 isPreviewMode || scopeId === TableId.rulePreview
                   ? undefined

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.tsx
@@ -168,6 +168,7 @@ export const Content = ({
             isPreviewMode={isPreviewMode}
             scopeId={scopeId}
             openDetailsPanel={enableGraphAndResolutionNavigation ? openDetailsPanel : undefined}
+            hideHeaderIcons={hideHeaderIcons}
           />
           <EuiHorizontalRule margin="m" />
         </>
@@ -180,6 +181,7 @@ export const Content = ({
             scopeId={scopeId}
             openDetailsPanel={enableGraphAndResolutionNavigation ? openDetailsPanel : undefined}
             onShowEntity={onShowEntity}
+            hideHeaderIcons={hideHeaderIcons}
           />
           <EuiHorizontalRule />
         </>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/content.tsx
@@ -170,6 +170,7 @@ export const Content = ({
             isPreviewMode={isPreviewMode}
             scopeId={scopeId}
             openDetailsPanel={enableGraphAndResolutionNavigation ? openDetailsPanel : undefined}
+            hideHeaderIcons={hideHeaderIcons}
           />
           <EuiHorizontalRule margin="m" />
         </>
@@ -182,6 +183,7 @@ export const Content = ({
             scopeId={scopeId}
             openDetailsPanel={enableGraphAndResolutionNavigation ? openDetailsPanel : undefined}
             onShowEntity={onShowEntity}
+            hideHeaderIcons={hideHeaderIcons}
           />
           <EuiHorizontalRule />
         </>


### PR DESCRIPTION
## Summary

This PR fixes two small display bugs in the new expandable flyout system ("flyout_v2", behind the `newFlyoutSystemEnabled` experimental feature flag), which is a rewrite of the document/entity details flyouts on top of EUI's native flyout stacking rather than our bespoke implementation. Both were found while testing flyout_v2 directly — no tracking issue exists for either yet.

### 1. Host silently dropped from the flyout_v2 "Entities" tool

**Problem:** Opening an alert in the flyout_v2 flyout and expanding the *Entities* tool (`document/tools/entities`, rendered via the shared `EntitiesDetails` component) would sometimes show the user panel but omit the host panel entirely, even though `host.name` was present on the document and the entity preview elsewhere on the same alert displayed the host correctly.

**Root cause:** `EntitiesDetails` gates host visibility with `showHostDetails = hostEntityIdentifiers != null && ...`, requiring an Entity Store EUID identifier for the host to be resolved before showing anything. The equivalent user gate has no such requirement — it already falls back to resolving the display name from document fields (via `getFieldsData`) when EUID identifiers aren't available. EUID extraction can legitimately return nothing (the Entity Store EUID API is loaded lazily, or the document isn't fully populated yet), so the host gate could fail even when we had enough information (`host.name`) to render the panel.

**Fix:** Mirror the user's fallback behavior for the host: resolve the display name from document fields whenever EUID identifiers are unavailable, and use that resolved name (rather than the raw EUID identifiers) to decide whether to show the host panel and to look up the host in the Entity Store. Added a regression test that reproduces the bug (EUID identifiers empty, but `host.name` resolvable from fields) and asserts the host panel now renders.

**How to test:**
1. Enable the `newFlyoutSystemEnabled` experimental feature flag.
2. Open an alert flyout, expand the *Insights → Entities* tool (or the top-level *Entities* tool in flyout_v2, depending on entry point).
3. Pick a document where the host's Entity Store EUID hasn't resolved yet (e.g. right after the alert is generated, before the Entity Store has indexed it) but `host.name` is present on the document.
4. Before this fix: only the user panel renders, host is missing. After: both user and host panels render.

Video: 


https://github.com/user-attachments/assets/17995280-fbd6-42d4-b48b-afbd0e7997ed



### 2. Chevron on "Graph preview" / "Resolution" headers doesn't match the v2 interaction model

**Problem:** In the flyout_v2 host/user entity flyouts, the *Graph preview* and *Resolution group* section headers showed a chevron/arrow icon (`arrowStart`) next to the title link. Clicking the title does work in v2 (it drills down into a separate tool flyout, e.g. `GraphView`/`Resolution` opened via `openDetailsPanel`) — this is a purely visual fix, not a "navigation isn't ready" gate. The chevron is the wrong affordance for that interaction: it reads as an "expand in place" indicator (like an accordion arrow), but in v2 the click drills down into a new tool panel rather than expanding the current one. The other tool preview headers (risk summary, anomalies, alerts/misconfiguration/vulnerabilities) already hide this same icon in v2 for the same reason, via an existing `hideHeaderIcons`/`hideHeaderIcon` prop — Graph preview and Resolution were just missed when that was added.

**Fix:** Threaded the existing `hideHeaderIcons` prop into `VisualizationsSection` (graph preview) and `ResolutionSection` as well, so flyout_v2 hides the chevron there too, consistent with the other sections. The title-text link and its click-through behavior are unchanged — only the decorative icon is removed.

**How to test:**
1. Enable the `newFlyoutSystemEnabled` experimental feature flag.
2. Open a host or user entity flyout, look at the *Graph preview* and *Resolution* section headers.
3. Before this fix: chevron/arrow icon shown next to the title. After: no chevron, but the title is still clickable and still drills down into the Graph/Resolution tool panel.
4. Sanity check the legacy (non-v2) flyout is unaffected — those sections still show the chevron there.


https://github.com/user-attachments/assets/e4097041-c22f-4f4d-bf39-ba43574ac647



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->