### PR TITLE
[Security Solution][Flyout] toggle between legacy and new network flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/network_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/network_details.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { NetworkDetails } from './network_details';
+import { TestProviders } from '../../common/mock';
+import { FlowTargetSourceDest } from '../../../common/search_strategy/security_solution/network';
+import { NetworkPanelKey } from '../../flyout/network_details';
+import { createExpandableFlyoutApiMock } from '../../common/mock/expandable_flyout';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../flyout_v2/use_flyout_api.mock';
+
+jest.mock('../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../flyout_v2/use_flyout_api');
+
+const mockOpenFlyout = jest.fn();
+jest.mock('@kbn/expandable-flyout');
+
+describe('NetworkDetails', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openFlyout: mockOpenFlyout,
+    });
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+  });
+
+  it('renders the ip address', () => {
+    render(
+      <TestProviders>
+        <NetworkDetails ip="1.2.3.4" />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('1.2.3.4')).toBeInTheDocument();
+  });
+
+  it('when new flyout is disabled, opens the legacy network expandable flyout', async () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+
+    render(
+      <TestProviders>
+        <NetworkDetails ip="1.2.3.4" />
+      </TestProviders>
+    );
+
+    await userEvent.click(screen.getByTestId('network-details'));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: NetworkPanelKey,
+        params: {
+          ip: '1.2.3.4',
+          flowTarget: FlowTargetSourceDest.source,
+        },
+      },
+    });
+    expect(flyoutApi.openNetworkFlyout).not.toHaveBeenCalled();
+  });
+
+  it('when new flyout is enabled, opens the new network flyout', async () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(
+      <TestProviders>
+        <NetworkDetails ip="1.2.3.4" />
+      </TestProviders>
+    );
+
+    await userEvent.click(screen.getByTestId('network-details'));
+
+    expect(flyoutApi.openNetworkFlyout).toHaveBeenCalledWith({
+      ip: '1.2.3.4',
+      flowTarget: FlowTargetSourceDest.source,
+    });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+  });
+
+  it('renders the empty tag and opens no flyout when ip is not provided', () => {
+    render(
+      <TestProviders>
+        <NetworkDetails ip={null} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByTestId('network-details')).not.toBeInTheDocument();
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openNetworkFlyout).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/network_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/network_details.tsx
@@ -13,6 +13,8 @@ import { NetworkDetailsLink } from '../../common/components/links';
 import { TruncatableText } from '../../common/components/truncatable_text';
 import { getEmptyTagValue } from '../../common/components/empty_value';
 import { NetworkPanelKey } from '../../flyout/network_details';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../flyout_v2/use_flyout_api';
 
 interface Props {
   ip: string | undefined | null;
@@ -20,17 +22,25 @@ interface Props {
 
 const NetworkDetailsComponent: React.FC<Props> = ({ ip }) => {
   const { openFlyout } = useExpandableFlyoutApi();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openNetworkFlyout } = useFlyoutApi();
   const openNetworkDetailsSidePanel = useCallback(() => {
-    openFlyout({
-      right: {
-        id: NetworkPanelKey,
-        params: {
-          ip,
-          flowTarget: FlowTargetSourceDest.source,
+    if (enableNewFlyout) {
+      if (ip) {
+        openNetworkFlyout({ ip, flowTarget: FlowTargetSourceDest.source });
+      }
+    } else {
+      openFlyout({
+        right: {
+          id: NetworkPanelKey,
+          params: {
+            ip,
+            flowTarget: FlowTargetSourceDest.source,
+          },
         },
-      },
-    });
-  }, [ip, openFlyout]);
+      });
+    }
+  }, [ip, openFlyout, enableNewFlyout, openNetworkFlyout]);
 
   if (!ip) {
     return getEmptyTagValue();

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/ip/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/ip/index.test.tsx
@@ -14,6 +14,9 @@ import { mockFlyoutApi } from '../../../../flyout/document_details/shared/mocks/
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useWhichFlyout } from '../../../../flyout/document_details/shared/hooks/use_which_flyout';
 import { NetworkPanelKey } from '../../../../flyout/network_details';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 
 const mockedTelemetry = createTelemetryServiceMock();
 jest.mock('../../../../common/lib/kibana', () => {
@@ -50,6 +53,8 @@ jest.mock('@kbn/expandable-flyout', () => ({
 jest.mock('../../../../flyout/document_details/shared/hooks/use_which_flyout', () => ({
   useWhichFlyout: jest.fn(),
 }));
+jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
 
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
@@ -65,6 +70,8 @@ describe('Port', () => {
   beforeEach(() => {
     jest.mocked(useWhichFlyout).mockReturnValue(null);
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
+    jest.mocked(useFlyoutApi).mockReturnValue(createFlyoutApiMock());
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
 
   test('renders correctly against snapshot', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -42,8 +42,10 @@ import type { OpenFlyoutLinkProps } from '../../shared/components/open_flyout_li
 import { OpenFlyoutLink } from '../../shared/components/open_flyout_link';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { documentFlyoutHistoryKey } from '../../shared/constants/flyout_history';
+import { getEcsField } from '../../shared/components/table_field_name_cell';
 import {
   HOST_NAME_FIELD_NAME,
+  IP_FIELD_TYPE,
   LEGACY_SIGNAL_RULE_NAME_FIELD_NAME,
   SIGNAL_RULE_NAME_FIELD_NAME,
 } from '../../../timelines/components/timeline/body/renderers/constants';
@@ -149,7 +151,11 @@ export const DocumentFlyout = memo(
           }
           return <OpenFlyoutLink {...props} value={ruleId} />;
         }
-        return <OpenFlyoutLink {...props} asParent={props.field === HOST_NAME_FIELD_NAME} />;
+        // Host and IP fields open as a new flyout (parent) rather than a child of the current one.
+        const isIpField = getEcsField(props.field)?.type === IP_FIELD_TYPE;
+        return (
+          <OpenFlyoutLink {...props} asParent={props.field === HOST_NAME_FIELD_NAME || isIpField} />
+        );
       },
       [ruleId]
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
@@ -31,7 +31,7 @@ import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_histo
 import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { DocumentFlyoutWrapper } from '../../main/document_flyout_wrapper';
 import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
-import { Network } from '../../../network/main';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
 import { renderEntityDetails } from '../../../entity/shared/render_entity_details';
 
@@ -61,6 +61,7 @@ export const GraphDetails = memo(
     const isInSecurityApp = useIsInSecurityApp();
     const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+    const { openNetworkFlyoutAsChild } = useFlyoutApi();
 
     const onShowDocument = useCallback(
       (documentId: string, indexName?: string) =>
@@ -97,17 +98,8 @@ export const GraphDetails = memo(
     );
 
     const onShowNetwork = useCallback(
-      (ip: string) =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: <Network ip={ip} flowTarget={FlowTargetSourceDest.source} />,
-          }),
-          { ...defaultFlyoutProperties, historyKey, session: 'inherit' }
-        ),
-      [defaultFlyoutProperties, history, historyKey, overlays, services, store]
+      (ip: string) => openNetworkFlyoutAsChild({ ip, flowTarget: FlowTargetSourceDest.source }),
+      [openNetworkFlyoutAsChild]
     );
 
     const onShowEntity = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
@@ -26,7 +26,7 @@ import { DocumentFlyoutWrapper } from '../../../../document/main/document_flyout
 import { cellActionRenderer } from '../../../../shared/components/cell_actions';
 import { ToolsFlyoutHeader } from '../../../../shared/components/tools_flyout_header';
 import { GraphVisualization } from '../../../../document/tools/graph/components/graph_visualization';
-import { Network } from '../../../../network/main';
+import { useFlyoutApi } from '../../../../use_flyout_api';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.entityDetails.graphView.title', {
   defaultMessage: 'Graph',
@@ -63,6 +63,7 @@ export const GraphView = memo(
     const isInSecurityApp = useIsInSecurityApp();
     const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+    const { openNetworkFlyoutAsChild } = useFlyoutApi();
 
     const onShowDocument = useCallback(
       (documentId: string, indexName?: string) =>
@@ -86,17 +87,8 @@ export const GraphView = memo(
     );
 
     const onShowNetwork = useCallback(
-      (ip: string) =>
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: <Network ip={ip} flowTarget={FlowTargetSourceDest.source} />,
-          }),
-          { ...defaultFlyoutProperties, historyKey, session: 'inherit' }
-        ),
-      [overlays, services, store, history, defaultFlyoutProperties, historyKey]
+      (ip: string) => openNetworkFlyoutAsChild({ ip, flowTarget: FlowTargetSourceDest.source }),
+      [openNetworkFlyoutAsChild]
     );
 
     const onShowGrouped = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.mock.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { NetworkFlyoutApi } from './use_network_flyout_api';
+
+/**
+ * Returns a `useNetworkFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useNetworkFlyoutApi).mockReturnValue(createNetworkFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createNetworkFlyoutApiMock = (): jest.Mocked<NetworkFlyoutApi> => ({
+  openNetworkFlyout: jest.fn(),
+  openNetworkFlyoutAsChild: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { FlowTargetSourceDest } from '../../../common/search_strategy/security_solution/network';
+import { useNetworkFlyoutApi } from './use_network_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+const ip = '1.2.3.4';
+
+describe('useNetworkFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  it('openNetworkFlyout opens a system flyout as a new session with the document properties', () => {
+    const { result } = renderHook(() => useNetworkFlyoutApi());
+    result.current.openNetworkFlyout({ ip, flowTarget: FlowTargetSourceDest.source });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openNetworkFlyoutAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useNetworkFlyoutApi());
+    result.current.openNetworkFlyoutAsChild({ ip, flowTarget: FlowTargetSourceDest.source });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({
+        size: 's',
+        session: 'inherit',
+        historyKey: documentFlyoutHistoryKey,
+      })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useNetworkFlyoutApi());
+    result.current.openNetworkFlyout({ ip, flowTarget: FlowTargetSourceDest.destination });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import type { FlowTargetSourceDest } from '../../../common/search_strategy/security_solution/network';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+// Lazy-loaded so consumers of this hook don't statically pull the network flyout graph into their
+// bundle; the chunk only loads when the flyout is actually opened.
+const Network = lazy(() => import('./main').then((m) => ({ default: m.Network })));
+
+export interface OpenNetworkFlyoutParams {
+  /** The IP address to render in the flyout. */
+  ip: string;
+  /** Whether the IP is the source or destination of the flow. */
+  flowTarget: FlowTargetSourceDest;
+}
+
+export interface NetworkFlyoutApi {
+  /**
+   * Opens the network (IP) details flyout as a new, top-level flyout (starting a fresh session).
+   * Use this from outside any flyout — e.g. a table row, a field link, a case attachment.
+   */
+  openNetworkFlyout: (params: OpenNetworkFlyoutParams) => void;
+  /**
+   * Opens the network (IP) details flyout as a child of the currently open flyout (nested in its
+   * history stack, so the back button returns to it). Use this from within an already-open flyout
+   * — e.g. a node click in the graph tool, or a link inside another flyout.
+   */
+  openNetworkFlyoutAsChild: (params: OpenNetworkFlyoutParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) network flyout, in the same mindset as
+ * `useExpandableFlyoutApi`, `useAttackFlyoutApi`, `useRuleFlyoutApi`, etc. It encapsulates the
+ * provider wiring (`flyoutProviders` + `overlays.openSystemFlyout`) and the flyout properties so
+ * call sites don't repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  // `session` is the only thing that differs between a main and a child flyout. It is kept private
+  // here so callers never have to reason about it: they pick `openNetworkFlyout` (main) or
+  // `openNetworkFlyoutAsChild` (child) and this helper maps that to the right session.
+  const open = useCallback(
+    (children: ReactNode, session: OverlaySystemFlyoutOpenOptions['session']) => {
+      const properties: OverlaySystemFlyoutOpenOptions = {
+        ...defaultDocumentFlyoutProperties,
+        historyKey,
+        session,
+      };
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const openNetworkFlyout = useCallback(
+    ({ ip, flowTarget }: OpenNetworkFlyoutParams) => {
+      open(<Network ip={ip} flowTarget={flowTarget} />, 'start');
+    },
+    [open]
+  );
+
+  const openNetworkFlyoutAsChild = useCallback(
+    ({ ip, flowTarget }: OpenNetworkFlyoutParams) => {
+      open(<Network ip={ip} flowTarget={flowTarget} />, 'inherit');
+    },
+    [open]
+  );
+
+  return useMemo(
+    () => ({ openNetworkFlyout, openNetworkFlyoutAsChild }),
+    [openNetworkFlyout, openNetworkFlyoutAsChild]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
@@ -7,6 +7,7 @@
 
 import type { FlyoutApi } from './use_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
 
 /**
  * Returns a `useFlyoutApi` return value with every method stubbed as a `jest.fn()`.
@@ -16,4 +17,5 @@ import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
  */
 export const createFlyoutApiMock = (): jest.Mocked<FlyoutApi> => ({
   ...createAttackFlyoutApiMock(),
+  ...createNetworkFlyoutApiMock(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
@@ -6,30 +6,41 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useFlyoutApi } from './use_flyout_api';
+import { FlowTargetSourceDest } from '../../common/search_strategy/security_solution/network';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
+import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
+import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
+import { useFlyoutApi } from './use_flyout_api';
 
 jest.mock('./attack/use_attack_flyout_api');
+jest.mock('./network/use_network_flyout_api');
 
 describe('useFlyoutApi', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('exposes the attack flyout methods from the composed per-type hook', () => {
+  it('exposes the attack and network flyout methods from the composed per-type hooks', () => {
     const attackApi = createAttackFlyoutApiMock();
+    const networkApi = createNetworkFlyoutApiMock();
     jest.mocked(useAttackFlyoutApi).mockReturnValue(attackApi);
+    jest.mocked(useNetworkFlyoutApi).mockReturnValue(networkApi);
 
     const { result } = renderHook(() => useFlyoutApi());
 
-    const params = { attackId: 'attack-1', indexName: '.alerts-security' };
+    const attackParams = { attackId: 'attack-1', indexName: '.alerts-security' };
+    const networkParams = { ip: '1.2.3.4', flowTarget: FlowTargetSourceDest.source };
 
     // The facade surfaces the composed methods, and calling one delegates to the per-type hook.
-    result.current.openAttackFlyout(params);
-    result.current.openAttackFlyoutAsChild(params);
+    result.current.openAttackFlyout(attackParams);
+    result.current.openAttackFlyoutAsChild(attackParams);
+    result.current.openNetworkFlyout(networkParams);
+    result.current.openNetworkFlyoutAsChild(networkParams);
 
-    expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(params);
-    expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(params);
+    expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(attackParams);
+    expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(attackParams);
+    expect(networkApi.openNetworkFlyout).toHaveBeenCalledWith(networkParams);
+    expect(networkApi.openNetworkFlyoutAsChild).toHaveBeenCalledWith(networkParams);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
@@ -8,13 +8,15 @@
 import { useMemo } from 'react';
 import type { AttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
+import type { NetworkFlyoutApi } from './network/use_network_flyout_api';
+import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
 
 /**
  * The single developer-facing API for opening any new (EUI-based) Security Solution flyout.
  *
- * Rather than importing a per-type hook (`useAttackFlyoutApi`, `useDocumentFlyoutApi`, …), call
+ * Rather than importing a per-type hook (`useNetworkFlyoutApi`, `useDocumentFlyoutApi`, `useNetworkFlyoutApi`, …), call
  * sites use this one hook and get every open method, namespaced by type
- * (`openAttackFlyout`, `openDocumentFlyoutFromIndex`, `openNetworkFlyout`, …). Each method comes in
+ * (`openDocumentFlyoutFromIndex`, `openNetworkFlyout`, `openAttackFlyout`, …). Each method comes in
  * a main variant (opens a new, top-level flyout) and, where it makes sense, an `...AsChild` variant
  * (opens nested inside the currently open flyout). Callers never deal with the flyout `session`.
  *
@@ -28,15 +30,17 @@ import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
  *
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
-export type FlyoutApi = AttackFlyoutApi;
+export type FlyoutApi = AttackFlyoutApi & NetworkFlyoutApi;
 
 export const useFlyoutApi = (): FlyoutApi => {
   const attack = useAttackFlyoutApi();
+  const network = useNetworkFlyoutApi();
 
   return useMemo(
     () => ({
       ...attack,
+      ...network,
     }),
-    [attack]
+    [attack, network]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/formatted_ip/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/formatted_ip/index.test.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+import { EuiButtonEmpty } from '@elastic/eui';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -13,12 +14,15 @@ import { TestProviders } from '../../../common/mock';
 import { TimelineId, TimelineTabs } from '../../../../common/types/timeline';
 import { StatefulEventContext } from '../../../common/components/events_viewer/stateful_event_context';
 import { NetworkPanelKey } from '../../../flyout/network_details';
+import { FlowTargetSourceDest } from '../../../../common/search_strategy/security_solution/network';
 import { createExpandableFlyoutApiMock } from '../../../common/mock/expandable_flyout';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../flyout_v2/use_flyout_api.mock';
 
-jest.mock('../../../common/hooks/use_is_new_flyout_enabled', () => ({
-  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
-}));
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('../../../flyout_v2/use_flyout_api');
 
 jest.mock('react-redux', () => {
   const origin = jest.requireActual('react-redux');
@@ -46,12 +50,19 @@ const mockOpenFlyout = jest.fn();
 jest.mock('@kbn/expandable-flyout');
 
 describe('FormattedIp', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.mocked(useExpandableFlyoutApi).mockReturnValue({
       ...createExpandableFlyoutApiMock(),
       openFlyout: mockOpenFlyout,
     });
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
   });
+
   const props = {
     value: '192.168.1.1',
     contextId: 'test-context-id',
@@ -71,31 +82,58 @@ describe('FormattedIp', () => {
     expect(screen.getByText(props.value)).toBeInTheDocument();
   });
 
-  test('if enableIpDetailsFlyout, should open NetworkDetails expandable flyout', async () => {
+  describe('button variant (Component prop set)', () => {
     const context = {
       enableHostDetailsFlyout: true,
       enableIpDetailsFlyout: true,
       timelineID: TimelineId.active,
       tabType: TimelineTabs.query,
     };
-    render(
-      <TestProviders>
-        <StatefulEventContext.Provider value={context}>
-          <FormattedIp {...props} />
-        </StatefulEventContext.Provider>
-      </TestProviders>
-    );
 
-    await userEvent.click(screen.getByTestId('network-details'));
-    expect(mockOpenFlyout).toHaveBeenCalledWith({
-      right: {
-        id: NetworkPanelKey,
-        params: {
-          ip: props.value,
-          flowTarget: 'source',
-          scopeId: TimelineId.active,
+    test('when new flyout is disabled, should open the legacy NetworkDetails expandable flyout', async () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+
+      render(
+        <TestProviders>
+          <StatefulEventContext.Provider value={context}>
+            <FormattedIp {...props} Component={EuiButtonEmpty} isButton />
+          </StatefulEventContext.Provider>
+        </TestProviders>
+      );
+
+      await userEvent.click(screen.getByTestId('data-grid-network-details'));
+
+      expect(mockOpenFlyout).toHaveBeenCalledWith({
+        right: {
+          id: NetworkPanelKey,
+          params: {
+            ip: props.value,
+            scopeId: TimelineId.active,
+            flowTarget: FlowTargetSourceDest.source,
+          },
         },
-      },
+      });
+      expect(flyoutApi.openNetworkFlyout).not.toHaveBeenCalled();
+    });
+
+    test('when new flyout is enabled, should open the new network flyout', async () => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+      render(
+        <TestProviders>
+          <StatefulEventContext.Provider value={context}>
+            <FormattedIp {...props} Component={EuiButtonEmpty} isButton />
+          </StatefulEventContext.Provider>
+        </TestProviders>
+      );
+
+      await userEvent.click(screen.getByTestId('data-grid-network-details'));
+
+      expect(flyoutApi.openNetworkFlyout).toHaveBeenCalledWith({
+        ip: props.value,
+        flowTarget: FlowTargetSourceDest.source,
+      });
+      expect(mockOpenFlyout).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/formatted_ip/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/formatted_ip/index.tsx
@@ -10,19 +10,14 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import deepEqual from 'fast-deep-equal';
 import type { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { StatefulEventContext } from '../../../common/components/events_viewer/stateful_event_context';
 import { FlowTargetSourceDest } from '../../../../common/search_strategy/security_solution/network';
 import { getOrEmptyTagFromValue } from '../../../common/components/empty_value';
-import { useKibana } from '../../../common/lib/kibana';
 import { NetworkDetailsLink } from '../../../common/components/links';
 import { NetworkPanelKey } from '../../../flyout/network_details';
 import { FlyoutLink } from '../../../flyout/shared/components/flyout_link';
 import { OpenFlyoutLink } from '../../../flyout_v2/shared/components/open_flyout_link';
-import { Network } from '../../../flyout_v2/network/main';
-import { flyoutProviders } from '../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
 
 const tryStringify = (value: string | object | null | undefined): string => {
@@ -62,12 +57,8 @@ const AddressLinksItemComponent: React.FC<AddressLinksItemProps> = ({
   title,
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
   const enableNewFlyout = useIsNewFlyoutEnabled();
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const { openNetworkFlyout } = useFlyoutApi();
 
   const eventContext = useContext(StatefulEventContext);
 
@@ -82,18 +73,7 @@ const AddressLinksItemComponent: React.FC<AddressLinksItemProps> = ({
         : FlowTargetSourceDest.source;
 
       if (enableNewFlyout) {
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: <Network ip={ip} flowTarget={flowTarget} />,
-          }),
-          {
-            ...defaultDocumentFlyoutProperties,
-            session: 'start',
-          }
-        );
+        openNetworkFlyout({ ip, flowTarget });
       } else if (eventContext) {
         openFlyout({
           right: {
@@ -107,18 +87,7 @@ const AddressLinksItemComponent: React.FC<AddressLinksItemProps> = ({
         });
       }
     },
-    [
-      onClick,
-      eventContext,
-      fieldName,
-      openFlyout,
-      enableNewFlyout,
-      defaultDocumentFlyoutProperties,
-      overlays,
-      services,
-      store,
-      history,
-    ]
+    [onClick, eventContext, fieldName, openFlyout, enableNewFlyout, openNetworkFlyout]
   );
 
   // The below is explicitly defined this way as the onClick takes precedence when it and the href are both defined


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is only focusing on the network flyout. A couple of follow up PRs will take care of the other flyouts.

The PR also introduces single developer-facing APIs to open the new ioc flyout, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:
- `useFlyoutApi()`: that is inernally calling the network flyout specific api:
  - `useIocFlyoutApi()` which returns `openIocFlyout` that opens the network flyout

> [!TIP]
> Developers should use - unless not possible - the `useFlyoutApi()` to open all of their flyouts

Every external entry point that opened one of these legacy flyouts now routes through the matching API when the new flyout is enabled.

> [!WARNING]
> No legacy flyout behavior change introduced! Only toggling between the legacy and new flyout based off the advanced setting.

#### Advanced setting off (default)

https://github.com/user-attachments/assets/2b6ebe6c-b416-47e8-9868-40dd51b23bf7

#### Advanced setting on

https://github.com/user-attachments/assets/b6580320-dbc1-4c72-a4d4-f0d8ca8b33d4

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new flyout/tool opens from each surface.
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->