### PR TITLE
[Case][AttachmentV2] enable lens in workflow

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.test.tsx
@@ -58,7 +58,7 @@ describe('getVisualizationAttachmentType', () => {
       getAttachmentRemovalObject: expect.any(Function),
       getAttachmentTabViewObject: expect.any(Function),
       schema: expect.any(Object),
-      workflowSchema: false,
+      workflowSchema: expect.any(Object),
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.test.tsx
@@ -62,6 +62,43 @@ describe('getVisualizationAttachmentType', () => {
     });
   });
 
+  describe('workflowSchema', () => {
+    const getWorkflowSchema = () => {
+      const { workflowSchema } = getVisualizationAttachmentType();
+      if (!workflowSchema) {
+        throw new Error('expected lens to expose a workflow schema');
+      }
+      return workflowSchema;
+    };
+
+    const referencePayload = {
+      type: LENS_ATTACHMENT_TYPE,
+      owner: 'securitySolution',
+      attachmentId: 'lens-so-id',
+      metadata: { title: 'My visualization', soType: 'lens' },
+    };
+
+    it('accepts a by-reference payload', () => {
+      expect(getWorkflowSchema().safeParse(referencePayload).success).toBe(true);
+    });
+
+    it('rejects a by-reference payload carrying an inline data snapshot', () => {
+      expect(
+        getWorkflowSchema().safeParse({ ...referencePayload, data: { attributes: {} } }).success
+      ).toBe(false);
+    });
+
+    it('rejects the by-value persistable-state arm', () => {
+      expect(
+        getWorkflowSchema().safeParse({
+          type: LENS_ATTACHMENT_TYPE,
+          owner: 'securitySolution',
+          data: { state: {} },
+        }).success
+      ).toBe(false);
+    });
+  });
+
   describe('getAttachmentViewObject', () => {
     it('renders the event correctly', () => {
       const lensType = getVisualizationAttachmentType();

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.tsx
@@ -12,6 +12,7 @@ import { LENS_ATTACHMENT_TYPE } from '../../../../common/constants';
 import {
   isLensPersistableData,
   LensAttachmentPayloadSchema,
+  LensSavedObjectAttachmentPayloadSchema,
   type LensPersistableAttachmentData,
   type LensSavedObjectAttachmentData,
   type LensSavedObjectAttachmentMetadata,
@@ -125,7 +126,8 @@ export const getVisualizationAttachmentType = () =>
     getAttachmentRemovalObject: () => ({ event: i18n.REMOVED_VISUALIZATION }),
     getAttachmentTabViewObject: () => ({ children: LensAttachmentsTab }),
     schema: LensAttachmentPayloadSchema,
-    // `data.state` is the embeddable input bag, produced by the "Add to case"
-    // flow and not authorable in YAML, so lens is excluded from workflow steps.
-    workflowSchema: false,
+    // Workflow authors reference a lens visualization by SO id; the by-value
+    // `data.state` arm and the optional `data` snapshot are embeddable bags they
+    // can't hand-author, so only expose the by-reference shape.
+    workflowSchema: LensSavedObjectAttachmentPayloadSchema.omit({ data: true }),
   });

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/attachments/lens.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/attachments/lens.ts
@@ -5,14 +5,18 @@
  * 2.0.
  */
 
-import { LensAttachmentPayloadSchema } from '../../../common/types/domain_zod/attachment/lens/v2';
+import {
+  LensAttachmentPayloadSchema,
+  LensSavedObjectAttachmentPayloadSchema,
+} from '../../../common/types/domain_zod/attachment/lens/v2';
 import type { UnifiedAttachmentTypeSetup } from '../types';
 import { LENS_ATTACHMENT_TYPE } from '../../../common/constants/attachments';
 
 export const lensAttachmentType: UnifiedAttachmentTypeSetup = {
   id: LENS_ATTACHMENT_TYPE,
   schema: LensAttachmentPayloadSchema,
-  // `data.state` is the embeddable input bag, produced by the "Add to case"
-  // flow and not authorable in YAML, so lens is excluded from workflow steps.
-  workflowSchema: false,
+  // Workflow authors reference a lens visualization by SO id; the by-value
+  // `data.state` arm and the optional `data` snapshot are embeddable bags they
+  // can't hand-author, so only expose the by-reference shape.
+  workflowSchema: LensSavedObjectAttachmentPayloadSchema.omit({ data: true }),
 };


### PR DESCRIPTION
## Summary

Following up to https://github.com/elastic/kibana/pull/269993 and https://github.com/elastic/kibana/pull/274959, this PR enables lens as an attachment option in the addAttachments step in workflow

<img width="1295" height="590" alt="image" src="https://github.com/user-attachments/assets/28b3d2ac-e9ab-47ac-86ac-0541c7715bec" />


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->