### PR TITLE
[9.4] Introduces size limit (1024) on the description field of the Logstash pipeline creation UI/API. (#270780)

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -46429,6 +46429,7 @@ paths:
               properties:
                 description:
                   description: A description of the pipeline.
+                  maxLength: 1024
                   type: string
                 pipeline:
                   description: A definition for the pipeline.

--- a/x-pack/platform/plugins/private/logstash/common/constants/index.ts
+++ b/x-pack/platform/plugins/private/logstash/common/constants/index.ts
@@ -11,5 +11,5 @@ export { PAGINATION } from './pagination';
 export { PLUGIN } from './plugin';
 export { ES_SCROLL_SETTINGS } from './es_scroll_settings';
 export { TOOLTIPS } from './tooltips';
-export { PIPELINE } from './pipeline';
+export { PIPELINE, MAX_PIPELINE_DESCRIPTION_LENGTH } from './pipeline';
 export { MONITORING } from './monitoring';

--- a/x-pack/platform/plugins/private/logstash/common/constants/pipeline.ts
+++ b/x-pack/platform/plugins/private/logstash/common/constants/pipeline.ts
@@ -11,3 +11,8 @@ export const PIPELINE = {
     OTHER: 'file_or_command_line_interface_or_pipelines_yml',
   },
 };
+
+/**
+ * Maximum allowed length for the pipeline description field.
+ */
+export const MAX_PIPELINE_DESCRIPTION_LENGTH = 1024;

--- a/x-pack/platform/plugins/private/logstash/docs/openapi/logstash_apis.yaml
+++ b/x-pack/platform/plugins/private/logstash/docs/openapi/logstash_apis.yaml
@@ -114,6 +114,7 @@ paths:
               properties:
                 description:
                   type: string
+                  maxLength: 1024
                   description: A description of the pipeline.
                 pipeline:
                   type: string

--- a/x-pack/platform/plugins/private/logstash/public/application/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
+++ b/x-pack/platform/plugins/private/logstash/public/application/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
@@ -57,6 +57,7 @@ exports[`PipelineEditor component includes required error message for falsy pipe
       <EuiFieldText
         data-test-subj="inputDescription"
         fullWidth={true}
+        maxLength={1024}
         name="pipelineDescription"
         onChange={[Function]}
         value="pipeline description"
@@ -320,6 +321,7 @@ exports[`PipelineEditor component invalidates form for invalid pipeline id input
       <EuiFieldText
         data-test-subj="inputDescription"
         fullWidth={true}
+        maxLength={1024}
         name="pipelineDescription"
         onChange={[Function]}
         value="pipeline description"
@@ -583,6 +585,7 @@ exports[`PipelineEditor component invalidates form for pipeline id with spaces 1
       <EuiFieldText
         data-test-subj="inputDescription"
         fullWidth={true}
+        maxLength={1024}
         name="pipelineDescription"
         onChange={[Function]}
         value="pipeline description"
@@ -823,6 +826,7 @@ exports[`PipelineEditor component matches snapshot for clone pipeline 1`] = `
       <EuiFieldText
         data-test-subj="inputDescription"
         fullWidth={true}
+        maxLength={1024}
         name="pipelineDescription"
         onChange={[Function]}
         value="pipeline description"
@@ -1096,6 +1100,7 @@ exports[`PipelineEditor component matches snapshot for create pipeline 1`] = `
       <EuiFieldText
         data-test-subj="inputDescription"
         fullWidth={true}
+        maxLength={1024}
         name="pipelineDescription"
         onChange={[Function]}
         value="pipeline description"
@@ -1336,6 +1341,7 @@ exports[`PipelineEditor component matches snapshot for edit pipeline 1`] = `
       <EuiFieldText
         data-test-subj="inputDescription"
         fullWidth={true}
+        maxLength={1024}
         name="pipelineDescription"
         onChange={[Function]}
         value="pipeline description"

--- a/x-pack/platform/plugins/private/logstash/public/application/components/pipeline_editor/pipeline_editor.js
+++ b/x-pack/platform/plugins/private/logstash/public/application/components/pipeline_editor/pipeline_editor.js
@@ -12,6 +12,7 @@ import { i18n } from '@kbn/i18n';
 
 import { isEmpty } from 'lodash';
 import { TOOLTIPS } from '../../../../common/constants/tooltips';
+import { MAX_PIPELINE_DESCRIPTION_LENGTH } from '../../../../common/constants/pipeline';
 import { CodeEditor } from '@kbn/code-editor';
 import {
   EuiButton,
@@ -307,6 +308,7 @@ class PipelineEditorUi extends React.Component {
             <EuiFieldText
               data-test-subj="inputDescription"
               fullWidth
+              maxLength={MAX_PIPELINE_DESCRIPTION_LENGTH}
               name="pipelineDescription"
               onChange={this.onPipelineDescriptionChange}
               value={this.state.pipeline.description || ''}

--- a/x-pack/platform/plugins/private/logstash/server/routes/pipeline/save.ts
+++ b/x-pack/platform/plugins/private/logstash/server/routes/pipeline/save.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 
 import { wrapRouteWithLicenseCheck } from '@kbn/licensing-plugin/server';
+import { MAX_PIPELINE_DESCRIPTION_LENGTH } from '../../../common/constants';
 import { Pipeline } from '../../models/pipeline';
 import { checkLicense } from '../../lib/check_license';
 import { validatePipelineId } from '../../lib/validate_pipeline_id';
@@ -35,7 +36,7 @@ export function registerPipelineSaveRoute(router: LogstashPluginRouter) {
           }),
         }),
         body: schema.object({
-          description: schema.maybe(schema.string()),
+          description: schema.maybe(schema.string({ maxLength: MAX_PIPELINE_DESCRIPTION_LENGTH })),
           pipeline: schema.string(),
           settings: schema.maybe(schema.object({}, { unknowns: 'allow' })),
         }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Introduces size limit (1024) on the description field of the Logstash pipeline creation UI/API. (#270780)](https://github.com/elastic/kibana/pull/270780)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mashhur","email":"99575341+mashhurs@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-08T21:52:24Z","message":"Introduces size limit (1024) on the description field of the Logstash pipeline creation UI/API. (#270780)\n\n## Summary\n\nIntroduces size limit (1024) on the description field of the Logstash pipeline creation UI/API\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ca6a922b5b390a8b404df6900c639aac2ed64c5d","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","backport:prev-minor","v9.5.0"],"title":"Introduces size limit (1024) on the description field of the Logstash pipeline creation UI/API.","number":270780,"url":"https://github.com/elastic/kibana/pull/270780","mergeCommit":{"message":"Introduces size limit (1024) on the description field of the Logstash pipeline creation UI/API. (#270780)\n\n## Summary\n\nIntroduces size limit (1024) on the description field of the Logstash pipeline creation UI/API\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ca6a922b5b390a8b404df6900c639aac2ed64c5d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270780","number":270780,"mergeCommit":{"message":"Introduces size limit (1024) on the description field of the Logstash pipeline creation UI/API. (#270780)\n\n## Summary\n\nIntroduces size limit (1024) on the description field of the Logstash pipeline creation UI/API\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ca6a922b5b390a8b404df6900c639aac2ed64c5d"}}]}] BACKPORT-->