### PR TITLE
[Discoveries] Replace `npx playwright` with safer `node scripts/playwright` command in README

### DIFF
--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/README.md
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/README.md
@@ -48,13 +48,13 @@ node scripts/scout.js start-server --location local --arch serverless --domain s
 ### Run the tests
 
 ```sh
-npx playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local
+node scripts/playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local
 ```
 
 To run a single spec:
 
 ```sh
-npx playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local isolation.spec.ts
+node scripts/playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local isolation.spec.ts
 ```
 
 ## Test Structure
@@ -121,7 +121,7 @@ These tests run in Buildkite. The command in CI matches the local invocation:
 
 ```sh
 node scripts/scout.js start-server --location local --arch stateful --domain classic
-npx playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local
+node scripts/playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
This PR replaces the `npx playwright` commands in the Discoveries plugin's Scout API test docs with the safer `node scripts/playwright` option. `npx` isn't safe as it might auto-install software, circumventing dependency version restrictions.
