### PR TITLE
[Streams] Bound content pack import decompression

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/content/archive.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/content/archive.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type AdmZip from 'adm-zip';
+import { DecompressionBudget, assertArchiveWithinLimits } from './archive';
+import { InvalidContentPackError } from './error';
+
+// adm-zip decompression cannot run under Kibana's jsdom jest environment: a Node `Buffer` is not
+// `instanceof Uint8Array` there (jsdom realm mismatch), which makes `new AdmZip(buffer)` misread
+// its input and `entry.getData()` return an empty buffer. The read/inflate paths are therefore
+// exercised in the deployment-agnostic api_integration tests (real Node). Here we unit-test the
+// pure metadata guard, which only reads `entries.length` and `entry.header.size`.
+const entry = (entryName: string, size: number): AdmZip.IZipEntry =>
+  ({ entryName, header: { size } } as unknown as AdmZip.IZipEntry);
+
+const entries = (count: number, size: number): AdmZip.IZipEntry[] =>
+  Array.from({ length: count }, (_, i) => entry(`root/entry-${i}.json`, size));
+
+describe('assertArchiveWithinLimits', () => {
+  it('accepts an archive within both caps', () => {
+    expect(() => assertArchiveWithinLimits(entries(10, 4 * 1024))).not.toThrow();
+  });
+
+  it('accepts an archive at the entry-count boundary (500)', () => {
+    expect(() => assertArchiveWithinLimits(entries(500, 1))).not.toThrow();
+  });
+
+  it('rejects an archive with too many entries', () => {
+    expect(() => assertArchiveWithinLimits(entries(501, 1))).toThrow(InvalidContentPackError);
+    expect(() => assertArchiveWithinLimits(entries(501, 1))).toThrow(
+      'Content pack has too many entries (max 500)'
+    );
+  });
+
+  it('accepts an archive at the total-size boundary (50MB)', () => {
+    // 50 entries * ~1MB = exactly 50MB across 50 entries (within the 500-entry cap).
+    expect(() => assertArchiveWithinLimits(entries(50, 1024 * 1024))).not.toThrow();
+  });
+
+  it('rejects an archive whose aggregate declared size exceeds the total cap', () => {
+    // 51 entries * 1MB = 51MB > 50MB, while staying under the 500-entry cap so the size cap is
+    // the failing check.
+    const bomb = entries(51, 1024 * 1024);
+    expect(() => assertArchiveWithinLimits(bomb)).toThrow(InvalidContentPackError);
+    expect(() => assertArchiveWithinLimits(bomb)).toThrow(
+      'Content pack exceeds the maximum total uncompressed size of 52428800 bytes'
+    );
+  });
+
+  it('checks the entry count before the total size', () => {
+    // Over both caps: 501 entries each 1MB. The count message must win.
+    expect(() => assertArchiveWithinLimits(entries(501, 1024 * 1024))).toThrow(
+      'Content pack has too many entries (max 500)'
+    );
+  });
+});
+
+describe('DecompressionBudget', () => {
+  const MAX = 50 * 1024 * 1024;
+
+  it('allows reads whose running total stays within the budget', () => {
+    const budget = new DecompressionBudget(MAX);
+    expect(() => {
+      for (let i = 0; i < 50; i++) budget.account(1024 * 1024);
+    }).not.toThrow();
+  });
+
+  it('throws when the running total exceeds the budget', () => {
+    const budget = new DecompressionBudget(MAX);
+    for (let i = 0; i < 50; i++) budget.account(1024 * 1024);
+    expect(() => budget.account(1)).toThrow(InvalidContentPackError);
+  });
+
+  it('reports the total uncompressed size message', () => {
+    const budget = new DecompressionBudget(MAX);
+    expect(() => budget.account(MAX + 1)).toThrow(
+      'Content pack exceeds the maximum total uncompressed size of 52428800 bytes'
+    );
+  });
+
+  it('accumulates across many small reads (dashboard reference fan-out)', () => {
+    // Mirrors the fan-out bypass: the same ~1MB reference read 60 times sums past the budget even
+    // though each individual read is well under the per-entry cap.
+    const budget = new DecompressionBudget(MAX);
+    expect(() => {
+      for (let i = 0; i < 60; i++) budget.account(1024 * 1024);
+    }).toThrow('Content pack exceeds the maximum total uncompressed size of 52428800 bytes');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/content/archive.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/content/archive.ts
@@ -32,7 +32,9 @@ import type { Readable } from 'stream';
 import { compact, pick, uniqBy } from 'lodash';
 import { InvalidContentPackError } from './error';
 
-const ARCHIVE_ENTRY_MAX_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
+const ARCHIVE_ENTRY_MAX_SIZE_BYTES = 1 * 1024 * 1024; // 1MB per entry
+const ARCHIVE_MAX_TOTAL_UNCOMPRESSED_BYTES = 50 * 1024 * 1024; // 50MB across all entries
+const ARCHIVE_MAX_ENTRIES = 500;
 
 // Strict wired upsert schema: `DeepStrict` over the wired upsert shape (equivalent to
 // `Streams.WiredStream.UpsertRequest.is`), applied so the parsed request can be `safeParse`d
@@ -68,6 +70,29 @@ export function rejectStreamQueries(
   }
 }
 
+/**
+ * Rejects decompression bombs at the zip metadata stage, before any entry is inflated. Bounds
+ * both the number of entries and the sum of their declared uncompressed sizes. This is a sound
+ * upper bound because `readEntry` decompresses synchronously and enforces the per-entry declared
+ * size (see the note there), so an entry's actual bytes never exceed its declared `header.size`.
+ * The caps apply to every zip entry, not only supported ones, so an archive padded with junk is
+ * rejected too.
+ */
+export function assertArchiveWithinLimits(entries: AdmZip.IZipEntry[]): void {
+  if (entries.length > ARCHIVE_MAX_ENTRIES) {
+    throw new InvalidContentPackError(
+      `Content pack has too many entries (max ${ARCHIVE_MAX_ENTRIES})`
+    );
+  }
+
+  const totalUncompressedSize = entries.reduce((sum, entry) => sum + entry.header.size, 0);
+  if (totalUncompressedSize > ARCHIVE_MAX_TOTAL_UNCOMPRESSED_BYTES) {
+    throw new InvalidContentPackError(
+      `Content pack exceeds the maximum total uncompressed size of ${ARCHIVE_MAX_TOTAL_UNCOMPRESSED_BYTES} bytes`
+    );
+  }
+}
+
 export async function parseArchive(archive: Readable): Promise<ContentPack> {
   const zip: AdmZip = await new Promise((resolve, reject) => {
     const bufs: Buffer[] = [];
@@ -82,13 +107,41 @@ export async function parseArchive(archive: Readable): Promise<ContentPack> {
     archive.on('error', (error) => reject(error));
   });
 
-  const rootDir = getRootDir(zip.getEntries());
+  const zipEntries = zip.getEntries();
+  assertArchiveWithinLimits(zipEntries);
+
+  const budget = new DecompressionBudget(ARCHIVE_MAX_TOTAL_UNCOMPRESSED_BYTES);
+  const rootDir = getRootDir(zipEntries);
   // @ts-expect-error upgrade typescript v5.9.3
-  const manifest = await extractManifest(rootDir, zip);
+  const manifest = extractManifest(rootDir, zip, budget);
   // @ts-expect-error upgrade typescript v5.9.3
-  const entries = await extractEntries(rootDir, zip);
+  const entries = extractEntries(rootDir, zip, budget);
 
   return { ...manifest, entries };
+}
+
+/**
+ * Tracks the running total of actually-decompressed bytes across every `readEntry` call for a single
+ * archive and rejects once it exceeds the cap. `assertArchiveWithinLimits` bounds the sum of the
+ * DISTINCT entry sizes, but a dashboard can reference the same saved object and `resolveDashboard`
+ * materializes referenced entries once per dashboard. A pack with a few large shared references
+ * fanned out across many dashboards stays within the metadata caps yet expands to gigabytes when
+ * materialized. This runtime budget closes that path (and any other repeated-read path) by bounding
+ * the total materialized bytes rather than only the distinct declared bytes.
+ */
+export class DecompressionBudget {
+  private used = 0;
+
+  constructor(private readonly max: number) {}
+
+  account(bytes: number): void {
+    this.used += bytes;
+    if (this.used > this.max) {
+      throw new InvalidContentPackError(
+        `Content pack exceeds the maximum total uncompressed size of ${this.max} bytes`
+      );
+    }
+  }
 }
 
 export async function generateArchive(manifest: ContentPackManifest, objects: ContentPackEntry[]) {
@@ -133,18 +186,39 @@ export async function generateArchive(manifest: ContentPackManifest, objects: Co
   return zip.toBufferPromise();
 }
 
-async function readEntry(entry: AdmZip.IZipEntry): Promise<Buffer> {
-  const buf = await new Promise<Buffer>((resolve, reject) => {
-    entry.getDataAsync((data, err) => {
-      if (err) return reject(new Error(err));
-      resolve(data);
-    });
-  });
+/**
+ * Decompresses a single entry synchronously. The sync path routes through zlib's `inflateRawSync`,
+ * which honors `maxOutputLength = header.size` and throws `ERR_BUFFER_TOO_LARGE` when the deflate
+ * stream inflates past the declared size. The async `getDataAsync` (streaming `createInflateRaw`)
+ * does NOT enforce that cap, so a lying entry (tiny declared size, huge deflate stream) would
+ * inflate without bound. Combined with `assertUncompressedSize` rejecting any entry declaring more
+ * than 1MB, this guarantees actual bytes per entry never exceed 1MB and surfaces a 400 instead of
+ * a raw zlib crash.
+ */
+function readEntry(entry: AdmZip.IZipEntry, budget: DecompressionBudget): Buffer {
+  let data: Buffer;
+  try {
+    data = entry.getData();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ERR_BUFFER_TOO_LARGE') {
+      throw new InvalidContentPackError(
+        `Object [${entry.entryName}] exceeds the limit of ${ARCHIVE_ENTRY_MAX_SIZE_BYTES} bytes`
+      );
+    }
+    throw err;
+  }
 
-  return buf;
+  // Accounts for every read, so repeated reads of the same referenced entry (dashboard fan-out)
+  // count against the budget too.
+  budget.account(data.length);
+  return data;
 }
 
-async function extractManifest(rootDir: string, zip: AdmZip): Promise<ContentPackManifest> {
+function extractManifest(
+  rootDir: string,
+  zip: AdmZip,
+  budget: DecompressionBudget
+): ContentPackManifest {
   const manifestPath = `${rootDir}/manifest.yml`;
   const entry = zip.getEntry(manifestPath);
   if (!entry) {
@@ -154,7 +228,7 @@ async function extractManifest(rootDir: string, zip: AdmZip): Promise<ContentPac
   assertUncompressedSize(entry);
 
   const { data: manifest, success } = contentPackManifestSchema.safeParse(
-    YAML.parse((await readEntry(entry)).toString())
+    YAML.parse(readEntry(entry, budget).toString())
   );
   if (!success) {
     throw new InvalidContentPackError('Invalid content pack manifest format');
@@ -163,71 +237,76 @@ async function extractManifest(rootDir: string, zip: AdmZip): Promise<ContentPac
   return manifest;
 }
 
-async function extractEntries(rootDir: string, zip: AdmZip): Promise<ContentPackEntry[]> {
+function extractEntries(
+  rootDir: string,
+  zip: AdmZip,
+  budget: DecompressionBudget
+): ContentPackEntry[] {
   const supportedEntries = zip
     .getEntries()
     .filter((entry) => isSupportedFile(rootDir, entry.entryName));
 
   supportedEntries.forEach((entry) => assertUncompressedSize(entry));
 
-  const entries = await Promise.all(
-    supportedEntries.map((entry) => {
-      const type = getEntryTypeByFile(rootDir, entry.entryName);
-      switch (type) {
-        case 'lens':
-        case 'index-pattern':
-          // these are handled by their parent dashboard
-          return [];
+  const entries: ContentPackEntry[] = [];
+  for (const entry of supportedEntries) {
+    const type = getEntryTypeByFile(rootDir, entry.entryName);
+    switch (type) {
+      case 'lens':
+      case 'index-pattern':
+        // these are handled by their parent dashboard
+        break;
 
-        case 'dashboard':
-          return resolveDashboard(rootDir, zip, entry);
+      case 'dashboard':
+        entries.push(...resolveDashboard(rootDir, zip, entry, budget));
+        break;
 
-        case 'stream':
-          return readEntry(entry).then((data) => {
-            const parsed = JSON.parse(data.toString()) as {
-              name?: string;
-              request?: Record<string, unknown>;
-            };
-            const requestObject =
-              parsed.request && typeof parsed.request === 'object' && !Array.isArray(parsed.request)
-                ? parsed.request
-                : undefined;
+      case 'stream': {
+        const parsed = JSON.parse(readEntry(entry, budget).toString()) as {
+          name?: string;
+          request?: Record<string, unknown>;
+        };
+        const requestObject =
+          parsed.request && typeof parsed.request === 'object' && !Array.isArray(parsed.request)
+            ? parsed.request
+            : undefined;
 
-            if (requestObject) {
-              rejectStreamQueries(parsed.name, entry.entryName, requestObject);
-            }
+        if (requestObject) {
+          rejectStreamQueries(parsed.name, entry.entryName, requestObject);
+        }
 
-            const request = parsed.request;
-            if (!parsed.name || !isContentPackStreamRequest(request)) {
-              throw new InvalidContentPackError(
-                `Invalid stream definition in entry [${entry.entryName}]`
-              );
-            }
+        const request = parsed.request;
+        if (!parsed.name || !isContentPackStreamRequest(request)) {
+          throw new InvalidContentPackError(
+            `Invalid stream definition in entry [${entry.entryName}]`
+          );
+        }
 
-            const streamEntry: ContentPackStream = {
-              type: 'stream',
-              name: parsed.name,
-              request,
-            };
-            return streamEntry;
-          });
-
-        default:
-          missingEntryTypeImpl(type);
+        const streamEntry: ContentPackStream = {
+          type: 'stream',
+          name: parsed.name,
+          request,
+        };
+        entries.push(streamEntry);
+        break;
       }
-    })
-  );
 
-  return entries.flat();
+      default:
+        missingEntryTypeImpl(type);
+    }
+  }
+
+  return entries;
 }
 
-async function resolveDashboard(
+function resolveDashboard(
   rootDir: string,
   zip: AdmZip,
-  dashboardEntry: AdmZip.IZipEntry
-): Promise<ContentPackSavedObject[]> {
+  dashboardEntry: AdmZip.IZipEntry,
+  budget: DecompressionBudget
+): ContentPackSavedObject[] {
   const dashboard = JSON.parse(
-    (await readEntry(dashboardEntry)).toString()
+    readEntry(dashboardEntry, budget).toString()
   ) as ContentPackDashboard;
 
   const uniqReferences = uniqBy(dashboard.references, (ref) => ref.id);
@@ -249,10 +328,8 @@ async function resolveDashboard(
     )
   );
 
-  const resolvedReferences = await Promise.all(
-    includedReferences.map(
-      async (entry) => JSON.parse((await readEntry(entry)).toString()) as ContentPackSavedObject
-    )
+  const resolvedReferences = includedReferences.map(
+    (entry) => JSON.parse(readEntry(entry, budget).toString()) as ContentPackSavedObject
   );
 
   return [dashboard, ...resolvedReferences];

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/content.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/content.ts
@@ -12,7 +12,8 @@ import {
   parseArchive,
 } from '@kbn/streams-plugin/server/lib/content';
 import { Readable } from 'stream';
-import type { ContentPack, ContentPackStream } from '@kbn/content-packs-schema';
+import { crc32 } from 'zlib';
+import type { ContentPack, ContentPackEntry, ContentPackStream } from '@kbn/content-packs-schema';
 import { ROOT_STREAM_ID } from '@kbn/content-packs-schema';
 import type { FieldDefinition, RoutingDefinition, Streams } from '@kbn/streams-schema';
 import { emptyAssets } from '@kbn/streams-schema';
@@ -55,6 +56,146 @@ const upsertRequest = ({
     },
   },
 });
+
+// Content-pack saved objects are stored as opaque JSON and cast on parse, so these minimal fixtures
+// are enough to exercise the read path. `padding` inflates the lens so a few of them fan out past
+// the total decompression budget.
+const lensEntry = (id: string, padding: number): ContentPackEntry =>
+  ({
+    type: 'lens',
+    id,
+    attributes: { title: id, padding: 'a'.repeat(padding) },
+    references: [],
+  } as unknown as ContentPackEntry);
+
+const dashboardEntry = (id: string, lensIds: string[]): ContentPackEntry =>
+  ({
+    type: 'dashboard',
+    id,
+    attributes: { title: id },
+    references: lensIds.map((lensId, i) => ({ name: `ref_${i}`, type: 'lens', id: lensId })),
+  } as unknown as ContentPackEntry);
+
+const wiredStreamEntry = (name: string, description: string): ContentPackStream => ({
+  type: 'stream',
+  name,
+  request: {
+    stream: {
+      type: 'wired',
+      description,
+      ingest: {
+        processing: { steps: [] },
+        settings: {},
+        wired: { fields: {}, routing: [] },
+        lifecycle: { inherit: {} },
+        failure_store: { inherit: {} },
+      },
+    },
+    ...emptyAssets,
+  },
+});
+
+// zip central-directory + local-header field offsets
+const CENSIG = 0x02014b50;
+const LOCSIG = 0x04034b50;
+const CENLEN = 24; // uncompressed size in central header
+const CENNAM = 28; // file name length
+const CENEXT = 30; // extra field length
+const CENCOM = 32; // comment length
+const CENOFF = 42; // relative offset of local header
+const CENHDR = 46; // central header fixed size
+const LOCLEN = 22; // uncompressed size in local header
+
+// Patches an entry's declared uncompressed size (central + local headers) down to `fakeSize` while
+// leaving the deflate stream intact, simulating a lying entry: the header claims it is tiny but it
+// still inflates large. adm-zip passes the central-header size to zlib as `maxOutputLength`, so the
+// synchronous inflate throws once the real output exceeds the fake size. Returns whether the entry
+// was found and patched.
+const tamperUncompressedSize = (buffer: Buffer, entryName: string, fakeSize: number): boolean => {
+  const nameBuf = Buffer.from(entryName);
+  for (let i = 0; i + CENHDR <= buffer.length; i++) {
+    if (buffer.readUInt32LE(i) !== CENSIG) continue;
+    const nameLen = buffer.readUInt16LE(i + CENNAM);
+    const extraLen = buffer.readUInt16LE(i + CENEXT);
+    const commentLen = buffer.readUInt16LE(i + CENCOM);
+    const name = buffer.subarray(i + CENHDR, i + CENHDR + nameLen);
+    if (name.equals(nameBuf)) {
+      buffer.writeUInt32LE(fakeSize, i + CENLEN);
+      const locOff = buffer.readUInt32LE(i + CENOFF);
+      if (buffer.readUInt32LE(locOff) === LOCSIG) {
+        buffer.writeUInt32LE(fakeSize, locOff + LOCLEN);
+      }
+      return true;
+    }
+    i += CENHDR + nameLen + extraLen + commentLen - 1;
+  }
+  return false;
+};
+
+// Builds an uncompressed (STORED) zip with entries at exact paths. `generateArchive` writes saved
+// objects under `<root>/kibana/<type>/`, but the importer only matches saved objects it extracts
+// directly (streams and flat `<root>/dashboard/` entries). A malicious upload is not built by
+// `generateArchive`, so this hand-rolls the exact bytes: dashboards flat under `<root>/dashboard/`
+// (where the importer picks them up and resolves their references) plus one shared lens under
+// `<root>/kibana/lens/` (where `resolveDashboard` looks references up). That is the reference
+// fan-out shape a single large object referenced by many dashboards.
+const buildStoredArchive = (files: Array<{ path: string; content: Buffer }>): Buffer => {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+  for (const { path: filePath, content } of files) {
+    const name = Buffer.from(filePath);
+    const checksum = crc32(content); // zlib.crc32 returns an unsigned 32-bit integer
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(LOCSIG, 0);
+    localHeader.writeUInt16LE(20, 4); // version needed to extract
+    localHeader.writeUInt16LE(0, 6); // general purpose flags
+    localHeader.writeUInt16LE(0, 8); // compression method: stored
+    localHeader.writeUInt16LE(0, 10); // mod time
+    localHeader.writeUInt16LE(0, 12); // mod date
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(content.length, 18); // compressed size
+    localHeader.writeUInt32LE(content.length, LOCLEN); // uncompressed size
+    localHeader.writeUInt16LE(name.length, 26);
+    localHeader.writeUInt16LE(0, 28); // extra field length
+    localParts.push(localHeader, name, content);
+
+    const centralHeader = Buffer.alloc(CENHDR);
+    centralHeader.writeUInt32LE(CENSIG, 0);
+    centralHeader.writeUInt16LE(20, 4); // version made by
+    centralHeader.writeUInt16LE(20, 6); // version needed to extract
+    centralHeader.writeUInt16LE(0, 8); // general purpose flags
+    centralHeader.writeUInt16LE(0, 10); // compression method: stored
+    centralHeader.writeUInt16LE(0, 12); // mod time
+    centralHeader.writeUInt16LE(0, 14); // mod date
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(content.length, 20); // compressed size
+    centralHeader.writeUInt32LE(content.length, CENLEN); // uncompressed size
+    centralHeader.writeUInt16LE(name.length, CENNAM);
+    centralHeader.writeUInt16LE(0, CENEXT);
+    centralHeader.writeUInt16LE(0, CENCOM);
+    centralHeader.writeUInt16LE(0, 34); // disk number start
+    centralHeader.writeUInt16LE(0, 36); // internal file attributes
+    centralHeader.writeUInt32LE(0, 38); // external file attributes
+    centralHeader.writeUInt32LE(offset, CENOFF);
+    centralParts.push(centralHeader, name);
+
+    offset += localHeader.length + name.length + content.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // central directory disk
+  eocd.writeUInt16LE(files.length, 8);
+  eocd.writeUInt16LE(files.length, 10);
+  eocd.writeUInt32LE(centralDirectory.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  eocd.writeUInt16LE(0, 20); // comment length
+  return Buffer.concat([...localParts, centralDirectory, eocd]);
+};
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
@@ -457,6 +598,106 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
         expect((response as unknown as { message: string }).message).to.match(
           /^Object \[content_pack-1.0.0\/stream\/a.big.stream.json\] exceeds the limit of \d+ bytes/
+        );
+      });
+
+      it('fails if an entry lies about its uncompressed size', async () => {
+        const twoMB = 2 * 1024 * 1024;
+        const archive = await generateArchive(
+          { name: 'content_pack', description: 'with a lying entry', version: '1.0.0' },
+          [wiredStreamEntry('a.big.stream', 'a'.repeat(twoMB))]
+        );
+
+        // Declare the entry as 100 bytes while its deflate stream still inflates to ~2MB. The
+        // synchronous inflate must reject it rather than allocate the full 2MB.
+        const entryName = 'content_pack-1.0.0/stream/a.big.stream.json';
+        expect(tamperUncompressedSize(archive, entryName, 100)).to.eql(true);
+
+        const response = await importContent(
+          apiClient,
+          'logs.otel',
+          {
+            include: { objects: { all: {} } },
+            content: Readable.from(archive),
+            filename: 'content_pack-1.0.0.zip',
+          },
+          400
+        );
+
+        expect((response as unknown as { message: string }).message).to.match(
+          /^Object \[content_pack-1.0.0\/stream\/a.big.stream.json\] exceeds the limit of \d+ bytes/
+        );
+      });
+
+      it('fails if the archive exceeds the total uncompressed size', async () => {
+        // ~0.9MB per stream stays under the 1MB per-entry cap; 60 of them sum to ~54MB, over the
+        // 50MB aggregate cap, while staying well under the 500-entry cap. Rejected at the metadata
+        // stage before anything is inflated.
+        const almostOneMB = 900 * 1024;
+        const streams = Array.from({ length: 60 }, (_, i) =>
+          wiredStreamEntry(`a.stream_${i}`, 'a'.repeat(almostOneMB))
+        );
+        const archive = await generateArchive(
+          { name: 'content_pack', description: 'aggregate bomb', version: '1.0.0' },
+          streams
+        );
+
+        const response = await importContent(
+          apiClient,
+          'logs.otel',
+          {
+            include: { objects: { all: {} } },
+            content: Readable.from(archive),
+            filename: 'content_pack-1.0.0.zip',
+          },
+          400
+        );
+
+        expect((response as unknown as { message: string }).message).to.match(
+          /^Content pack exceeds the maximum total uncompressed size of \d+ bytes/
+        );
+      });
+
+      it('fails if referenced objects fan out beyond the total uncompressed size', async () => {
+        // Reference fan-out bypass: one ~0.9MB lens (under the per-entry cap, counted once by the
+        // metadata guard) referenced by many dashboards. The metadata caps pass (few entries, small
+        // declared total), but materializing the lens once per dashboard blows past the runtime
+        // decompression budget. Hand-rolled rather than built with `generateArchive` so the
+        // dashboards land flat under `<root>/dashboard/`, where the importer extracts them and calls
+        // `resolveDashboard` — the path that re-reads the shared lens once per dashboard.
+        const almostOneMB = 900 * 1024;
+        const rootDir = 'content_pack-1.0.0';
+        const dashboardCount = 80;
+        const archive = buildStoredArchive([
+          {
+            path: `${rootDir}/manifest.yml`,
+            content: Buffer.from(
+              'name: content_pack\ndescription: reference fan-out bomb\nversion: 1.0.0\n'
+            ),
+          },
+          {
+            path: `${rootDir}/kibana/lens/shared_lens.json`,
+            content: Buffer.from(JSON.stringify(lensEntry('shared_lens', almostOneMB))),
+          },
+          ...Array.from({ length: dashboardCount }, (_, i) => ({
+            path: `${rootDir}/dashboard/dash_${i}.json`,
+            content: Buffer.from(JSON.stringify(dashboardEntry(`dash_${i}`, ['shared_lens']))),
+          })),
+        ]);
+
+        const response = await importContent(
+          apiClient,
+          'logs.otel',
+          {
+            include: { objects: { all: {} } },
+            content: Readable.from(archive),
+            filename: 'content_pack-1.0.0.zip',
+          },
+          400
+        );
+
+        expect((response as unknown as { message: string }).message).to.match(
+          /^Content pack exceeds the maximum total uncompressed size of \d+ bytes/
         );
       });
 


### PR DESCRIPTION
adresses: elastic/security#12191

description: https://github.com/elastic/security/issues/12191#issuecomment-4922875032
## Summary

Hardens the Streams content pack import against oversized archives. A content pack is an uploaded zip, and the importer previously enforced only a per-file size limit. This adds limits on the whole pack, before and during decompression, so an archive that would expand to an unreasonable size is rejected with a clear 400 instead of being fully materialized in memory.

Details are tracked in the linked private security issue.

## What changed

- Before decompressing, the import is checked against an entry-count limit and a total-size limit, in addition to the existing per-entry limit.
- Decompression now enforces each entry's declared size and stops once the running total of unpacked bytes exceeds the allowed budget. The budget also counts shared objects that are read once per referencing dashboard.
- Entries are decompressed one at a time rather than all at once.
- Applies to both the import and preview routes, which share the same parser.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->