### PR TITLE
[scout] eslint rule to warn applying FF in parallel tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2953,6 +2953,7 @@ module.exports = {
         '@kbn/eslint/scout_test_file_naming': 'error',
         '@kbn/eslint/scout_require_global_setup_hook_in_parallel_tests': 'error',
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
+        '@kbn/eslint/scout_no_core_settings_in_space_test': 'warn',
         '@kbn/eslint/scout_no_cross_boundary_imports': 'error',
         '@kbn/eslint/scout_expect_import': 'error',
         '@kbn/eslint/scout_no_deprecated_tags': 'error',

--- a/docs/extend/testing/feature-flags.md
+++ b/docs/extend/testing/feature-flags.md
@@ -25,6 +25,8 @@ Use `apiServices.core.settings()` to toggle feature flags while the server is ru
 
 ::::::{note}
 Feature flag overrides are **server-wide**: they apply to the entire Kibana instance, not to a single space or worker. In [parallel suites](./parallelism.md) all workers share the same server, so a flag set by one worker is visible to every other worker. For parallel tests, enable flags in the **[global setup hook](./global-setup-hook.md)** so they are set once before any worker starts.
+
+The `@kbn/eslint/scout_no_core_settings_in_space_test` ESLint rule warns when `apiServices.core.settings(...)` is called inside `spaceTest` scope (directly, in `spaceTest.describe`/`beforeAll`/`afterAll`/`step`, etc.), since that scope runs in parallel across spaces sharing the same server.
 ::::::
 
 ### In a global setup hook (recommended for parallel suites) [scout-feature-flags-global-setup]

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -31,6 +31,7 @@ module.exports = {
     scout_require_api_client_in_api_test: require('./rules/scout_require_api_client_in_api_test'),
     scout_require_global_setup_hook_in_parallel_tests: require('./rules/scout_require_global_setup_hook_in_parallel_tests'),
     scout_no_es_archiver_in_parallel_tests: require('./rules/scout_no_es_archiver_in_parallel_tests'),
+    scout_no_core_settings_in_space_test: require('./rules/scout_no_core_settings_in_space_test'),
     scout_expect_import: require('./rules/scout_expect_import'),
     scout_no_deprecated_tags: require('./rules/scout_no_deprecated_tags'),
     scout_no_cross_boundary_imports: require('./rules/scout_no_cross_boundary_imports'),

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_core_settings_in_space_test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_core_settings_in_space_test.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.CallExpression} CallExpression */
+
+const ERROR_MSG =
+  '`apiServices.core.settings(...)` sets dynamic config overrides (e.g. `feature_flags.overrides`) that are server-wide, not scoped to a single space. `spaceTest` runs suites in parallel across spaces sharing the same server, so calling it here can leak into other spaces/workers running concurrently. Use `globalSetupHook`/`globalTeardownHook` in `global.setup.ts`/`global.teardown.ts` instead.';
+
+/**
+ * Checks if a node's callee is `spaceTest` or a member access on it
+ * (e.g. `spaceTest(...)`, `spaceTest.describe(...)`, `spaceTest.beforeAll(...)`, `spaceTest.step(...)`).
+ * @param {CallExpression} node
+ * @returns {boolean}
+ */
+const isSpaceTestCall = (node) => {
+  const { callee } = node;
+
+  if (callee.type === 'Identifier') {
+    return callee.name === 'spaceTest';
+  }
+
+  if (callee.type === 'MemberExpression') {
+    return callee.object.type === 'Identifier' && callee.object.name === 'spaceTest';
+  }
+
+  return false;
+};
+
+/**
+ * Checks if a node represents an `apiServices.core.settings(...)` call.
+ * @param {CallExpression} node
+ * @returns {boolean}
+ */
+const isCoreSettingsCall = (node) => {
+  const { callee } = node;
+
+  if (callee.type !== 'MemberExpression' || callee.property.type !== 'Identifier') {
+    return false;
+  }
+  if (callee.property.name !== 'settings') {
+    return false;
+  }
+
+  const coreObject = callee.object;
+  if (coreObject.type !== 'MemberExpression' || coreObject.property.type !== 'Identifier') {
+    return false;
+  }
+  if (coreObject.property.name !== 'core') {
+    return false;
+  }
+
+  const apiServicesObject = coreObject.object;
+  return apiServicesObject.type === 'Identifier' && apiServicesObject.name === 'apiServices';
+};
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Warn against `apiServices.core.settings(...)` calls inside `spaceTest` scope, since dynamic config overrides are server-wide and leak across parallel spaces/workers.',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noCoreSettingsInSpaceTest: ERROR_MSG,
+    },
+  },
+
+  create(context) {
+    let spaceTestDepth = 0;
+
+    return {
+      CallExpression(node) {
+        if (isSpaceTestCall(node)) {
+          spaceTestDepth++;
+        }
+
+        if (spaceTestDepth > 0 && isCoreSettingsCall(node)) {
+          context.report({ node, messageId: 'noCoreSettingsInSpaceTest' });
+        }
+      },
+      'CallExpression:exit'(node) {
+        if (isSpaceTestCall(node)) {
+          spaceTestDepth--;
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_core_settings_in_space_test.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_core_settings_in_space_test.test.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_core_settings_in_space_test');
+const dedent = require('dedent');
+
+const errors = [{ messageId: 'noCoreSettingsInSpaceTest' }];
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2020,
+  },
+});
+
+ruleTester.run('@kbn/eslint/scout_no_core_settings_in_space_test', rule, {
+  valid: [
+    // apiServices.core.settings in a sequential `test` hook is allowed
+    {
+      code: dedent`
+        test.beforeAll(async ({ apiServices }) => {
+          await apiServices.core.settings({
+            'feature_flags.overrides': { 'my-plugin.my-flag': true },
+          });
+        });
+      `,
+    },
+    // apiServices.core.settings in globalSetupHook is allowed
+    {
+      code: dedent`
+        globalSetupHook('Enable feature flags', async ({ apiServices }) => {
+          await apiServices.core.settings({
+            'feature_flags.overrides': { 'my-plugin.my-flag': true },
+          });
+        });
+      `,
+    },
+    // apiServices.core.settings in globalTeardownHook is allowed
+    {
+      code: dedent`
+        globalTeardownHook('Revert feature flags', async ({ apiServices }) => {
+          await apiServices.core.settings({
+            'feature_flags.overrides': { 'my-plugin.my-flag': false },
+          });
+        });
+      `,
+    },
+    // spaceTest without apiServices.core.settings is allowed
+    {
+      code: dedent`
+        spaceTest.beforeAll(async ({ apiServices, scoutSpace }) => {
+          await apiServices.cases.cleanup.deleteAllCases(scoutSpace.id);
+        });
+      `,
+    },
+    // Other apiServices calls inside spaceTest are allowed
+    {
+      code: dedent`
+        spaceTest('should work', async ({ apiServices }) => {
+          await apiServices.core.someOtherMethod();
+        });
+      `,
+    },
+  ],
+
+  invalid: [
+    // spaceTest.describe > beforeAll
+    {
+      code: dedent`
+        spaceTest.describe('My suite', () => {
+          spaceTest.beforeAll(async ({ apiServices }) => {
+            await apiServices.core.settings({
+              'feature_flags.overrides': { 'my-plugin.my-flag': true },
+            });
+          });
+        });
+      `,
+      errors,
+    },
+    // spaceTest.describe > afterAll
+    {
+      code: dedent`
+        spaceTest.describe('My suite', () => {
+          spaceTest.afterAll(async ({ apiServices }) => {
+            await apiServices.core.settings({
+              'feature_flags.overrides': { 'my-plugin.my-flag': null },
+            });
+          });
+        });
+      `,
+      errors,
+    },
+    // Directly inside a spaceTest(...) test body
+    {
+      code: dedent`
+        spaceTest('should work', async ({ apiServices }) => {
+          await apiServices.core.settings({
+            'feature_flags.overrides': { 'my-plugin.my-flag': true },
+          });
+        });
+      `,
+      errors,
+    },
+    // Nested inside a spaceTest.step
+    {
+      code: dedent`
+        spaceTest('should work', async ({ apiServices }) => {
+          await spaceTest.step('enable flag', async () => {
+            await apiServices.core.settings({
+              'feature_flags.overrides': { 'my-plugin.my-flag': true },
+            });
+          });
+        });
+      `,
+      errors,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

This PR adds ESLint rule to warn about potential test flakiness cause in parallel tests:

 Feature flag is applied across multiple spaces/workers and can affect concurrently running test in the other worker. For now rule is not blocking, we might change it if we see more problematic use cases.

<img width="1329" height="455" alt="Screenshot 2026-07-09 at 10 05 05" src="https://github.com/user-attachments/assets/822c7973-c08d-4149-b704-045c433a1842" />



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->