### PR TITLE
[Streams] Create Import from other stream Flyout

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/README.md
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/README.md
@@ -74,13 +74,16 @@ import { InspectIlmPolicyFlyout } from '@kbn/data-lifecycle-phases';
   policy={serializedPolicy}
   onBack={() => {}}
   onEditPolicy={(name) => navigateToIlmEditor(name)}
-  onSelectAndApply={(name) => applyPolicy(name)}
+  primaryAction={{
+    label: 'Select policy and apply',
+    onClick: (name) => applyPolicy(name),
+  }}
 />
 ```
 
-### `RetentionSelector`
+### `RetentionSelector` and `RetentionSelectorSearch`
 
-A searchable selector for retention options, with optional inspect affordances (e.g. “Inspect ILM policy”).
+A searchable selector for retention options, with optional inspect affordances (e.g. “Inspect ILM policy”). Use `RetentionSelectorSearch` when the search input needs to be rendered outside the selector body, such as in a flyout header.
 
 ```typescript
 import type { RetentionOption } from '@kbn/data-lifecycle-phases';
@@ -132,7 +135,7 @@ import { EditDataLifecycleFlyoutBody } from '@kbn/data-lifecycle-phases';
 
 ### `FlyoutFooterWithRetentionWarning` and `useRetentionWarning`
 
-A shared flyout footer with **Cancel / Apply** actions and an optional warning callout. The `useRetentionWarning` hook helps determine whether to show the warning based on the selected ILM policy (e.g. when downsampling steps cannot be applied).
+A shared flyout footer with **Cancel / Apply** actions and an optional warning callout. The `useRetentionWarning` hook helps determine whether to show the warning based on the selected ILM policy (e.g. when downsampling steps cannot be applied). Use `warningType="import_stream"` for imported lifecycle sources and `warningType="ilm_policy"` for selected ILM policies.
 
 ```typescript
 import { FlyoutFooterWithRetentionWarning, useRetentionWarning } from '@kbn/data-lifecycle-phases';
@@ -149,8 +152,10 @@ const showWarning = useRetentionWarning({
   onApply={applyChanges}
   isApplyDisabled={!isValid}
   showWarning={showWarning}
+  warningType="ilm_policy"
 />
 ```
+
 ### `EnterpriseGatingModal`
 
 A stateless modal for gating Enterprise-only data lifecycle actions (for example, enabling the frozen data phase). Consumers control visibility via `isOpen` and should hide/unmount the modal when `onCancel` is called.

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.test.tsx
@@ -62,6 +62,35 @@ describe('FlyoutFooterWithRetentionWarning', () => {
     expect(screen.getByTestId('flyoutFooter-downsamplingNotAppliedCallout')).toBeInTheDocument();
   });
 
+  it('uses the import-stream warning copy by default', () => {
+    renderWithTheme(
+      <FlyoutFooterWithRetentionWarning onCancel={() => {}} onApply={() => {}} showWarning />
+    );
+
+    const callout = screen.getByTestId('flyoutFooter-downsamplingNotAppliedCallout');
+    expect(callout).toHaveTextContent('Downsampling requires a time series stream');
+    expect(callout).toHaveTextContent(
+      'downsampling steps from the imported lifecycles will be excluded'
+    );
+  });
+
+  it('uses the selected-ILM-policy warning copy when warningType is "ilm_policy"', () => {
+    renderWithTheme(
+      <FlyoutFooterWithRetentionWarning
+        onCancel={() => {}}
+        onApply={() => {}}
+        showWarning
+        warningType="ilm_policy"
+      />
+    );
+
+    const callout = screen.getByTestId('flyoutFooter-downsamplingNotAppliedCallout');
+    expect(callout).toHaveTextContent('Downsampling requires a time series stream');
+    expect(callout).toHaveTextContent(
+      'downsampling steps from the selected ILM policy will be excluded'
+    );
+  });
+
   it('does not show the warning when inheriting lifecycle', () => {
     renderWithTheme(
       <WarningFooter

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.tsx
@@ -47,6 +47,8 @@ export const useRetentionWarning = ({
   }, [ilmPolicies, selectedIlmPolicyName, canUseDownsampling, inheritLifecycle]);
 };
 
+export type DownsamplingWarningType = 'import_stream' | 'ilm_policy';
+
 export interface FlyoutFooterWithRetentionWarningProps {
   /** Label for the cancel button. Defaults to "Cancel". */
   cancelLabel?: string;
@@ -57,6 +59,8 @@ export interface FlyoutFooterWithRetentionWarningProps {
   isApplyDisabled?: boolean;
   /** When true, renders the downsampling warning callout above the action buttons. */
   showWarning?: boolean;
+  /** Controls the downsampling warning callout body copy. Defaults to `import_stream`. */
+  warningType?: DownsamplingWarningType;
 }
 
 /**
@@ -70,9 +74,14 @@ export const FlyoutFooterWithRetentionWarning = ({
   onApply,
   isApplyDisabled = false,
   showWarning = false,
+  warningType = 'import_stream',
 }: FlyoutFooterWithRetentionWarningProps) => {
   const { euiTheme } = useEuiTheme();
   const styles = getFlyoutFooterWithRetentionWarningStyles({ euiTheme });
+  const warningBody =
+    warningType === 'ilm_policy'
+      ? footerStrings.downsamplingNotAppliedBodyIlmPolicy
+      : footerStrings.downsamplingNotAppliedBody;
 
   return (
     <EuiFlyoutFooter>
@@ -85,7 +94,7 @@ export const FlyoutFooterWithRetentionWarning = ({
           css={styles.callout}
           data-test-subj="flyoutFooter-downsamplingNotAppliedCallout"
         >
-          <EuiText size="s">{footerStrings.downsamplingNotAppliedBody}</EuiText>
+          <EuiText size="s">{warningBody}</EuiText>
         </EuiCallOut>
       )}
 

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/strings.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/strings.ts
@@ -20,4 +20,11 @@ export const flyoutFooterWithRetentionWarningStrings = {
     defaultMessage:
       'As this stream is not a time series, downsampling steps from the imported lifecycles will be excluded.',
   }),
+  downsamplingNotAppliedBodyIlmPolicy: i18n.translate(
+    `${EDIT_FLYOUT_PREFIX}.downsamplingNotAppliedBodyIlmPolicy`,
+    {
+      defaultMessage:
+        'As this stream is not a time series, downsampling steps from the selected ILM policy will be excluded.',
+    }
+  ),
 };

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/__stories__/retention_selector.stories.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/__stories__/retention_selector.stories.tsx
@@ -52,7 +52,6 @@ const ILM_OPTIONS: RetentionOption[] = [
 const STREAM_OPTIONS: RetentionOption[] = [
   {
     name: 'logs-elastic_agent-default',
-    method: 'ilm',
     descriptionCategory: 'Success',
     descriptionParts: ['60d', '3 phases', '2 downsamples'],
     descriptionCategorySecondLine: 'Fail',
@@ -60,41 +59,37 @@ const STREAM_OPTIONS: RetentionOption[] = [
     badge: 'ILM',
     inspectable: true,
   },
-  { name: 'logs-synth-default', method: 'dlm', descriptionParts: ['60d'] },
-  { name: 'logs.ecs', method: 'dlm', descriptionParts: ['∞', '1 downsample step'] },
+  { name: 'logs-synth-default', descriptionParts: ['60d'] },
+  { name: 'logs.ecs', descriptionParts: ['∞', '1 downsample step'] },
   {
     name: 'metrics-hostmetrics-default',
-    method: 'ilm',
     descriptionParts: ['.alerts-ilm-policy'],
     badge: 'ILM',
     inspectable: true,
   },
   {
     name: 'profiling-events-5pow01',
-    method: 'ilm',
     descriptionParts: ['.amet-illium-dolor'],
     badge: 'ILM',
     inspectable: true,
   },
   {
     name: 'profiling-events-5pow02',
-    method: 'ilm',
     descriptionParts: ['.amet-ipsum-dolor'],
     badge: 'ILM',
     inspectable: true,
   },
   {
     name: 'logs.ecs.android',
-    method: 'dlm',
     descriptionParts: ['60d'],
     descriptionPartsSecondLine: ['3 data phases', '2 downsample steps'],
   },
-  { name: 'logs.ecs.linux', method: 'dlm', descriptionParts: ['60d'] },
-  { name: 'logs.ecs.windows', method: 'dlm', descriptionParts: ['365d'] },
-  { name: 'logs.otel', method: 'dlm', descriptionParts: ['60d'] },
-  { name: 'logs.otel.android', method: 'dlm', descriptionParts: ['∞'] },
-  { name: 'logs.otel.linux', method: 'dlm', descriptionParts: ['60d'] },
-  { name: 'logs.otel.windows', method: 'dlm', descriptionParts: ['90d'] },
+  { name: 'logs.ecs.linux', descriptionParts: ['60d'] },
+  { name: 'logs.ecs.windows', descriptionParts: ['365d'] },
+  { name: 'logs.otel', descriptionParts: ['60d'] },
+  { name: 'logs.otel.android', descriptionParts: ['∞'] },
+  { name: 'logs.otel.linux', descriptionParts: ['60d'] },
+  { name: 'logs.otel.windows', descriptionParts: ['90d'] },
 ];
 
 const Panel = ({ title, children }: { title: string; children: React.ReactNode }) => (
@@ -182,7 +177,6 @@ export const IlmPoliciesInheritedReadOnly: Story = {
 
 const StreamsExample = () => {
   const [selected, setSelected] = useState('logs.otel');
-  const [selectedMethods, setSelectedMethods] = useState<string[]>([]);
 
   return (
     <>
@@ -195,14 +189,6 @@ const StreamsExample = () => {
           searchPlaceholder="Search by stream name"
           inspectButtonLabel={(name) => `Inspect ILM policy for '${name}'`}
           inspectPlacement="badge"
-          methodFilter={{
-            selectedMethods,
-            onChangeSelectedMethods: setSelectedMethods,
-            methodOptions: [
-              { key: 'dlm', label: 'Data stream lifecycle' },
-              { key: 'ilm', label: 'ILM policy' },
-            ],
-          }}
         />
       </Panel>
 
@@ -218,14 +204,6 @@ const StreamsExample = () => {
           searchPlaceholder="Search by stream name"
           inspectButtonLabel={(name) => `Inspect ILM policy for '${name}'`}
           inspectPlacement="badge"
-          methodFilter={{
-            selectedMethods,
-            onChangeSelectedMethods: setSelectedMethods,
-            methodOptions: [
-              { key: 'dlm', label: 'Data stream lifecycle' },
-              { key: 'ilm', label: 'ILM policy' },
-            ],
-          }}
         />
       </Panel>
     </>

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.test.tsx
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import '@testing-library/jest-dom';
 import { EuiThemeProvider } from '@elastic/eui';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { RetentionOption } from './types';
-import { RetentionSelector } from './retention_selector';
+import { RetentionSelector, RetentionSelectorSearch } from './retention_selector';
 
 describe('RetentionSelector', () => {
   const rowTestSubj = (name: string) =>
@@ -183,37 +183,44 @@ describe('RetentionSelector', () => {
     expect(screen.getByText('Success: 90d · 2 phases')).toBeInTheDocument();
   });
 
-  it('can filter streams options by method', () => {
-    renderWithTheme(
-      <RetentionSelector
-        options={[
-          { name: 'Stream A', descriptionParts: ['60d'], method: 'a' },
-          {
-            name: 'Stream B',
-            descriptionParts: ['policy-a'],
-            badge: 'ILM',
-            inspectable: true,
-            method: 'b',
-          },
-        ]}
-        onSelectOption={() => {}}
-        onInspect={() => {}}
-        searchPlaceholder="Search streams"
-        inspectButtonLabel={(name) => `Inspect ${name}`}
-        inspectPlacement="badge"
-        methodFilter={{
-          selectedMethods: ['b'],
-          onChangeSelectedMethods: () => {},
-          methodOptions: [
-            { key: 'a', label: 'Method A' },
-            { key: 'b', label: 'Method B' },
-          ],
-        }}
-      />
-    );
+  describe('split search (RetentionSelectorSearch + showSearch={false})', () => {
+    const SplitExample = () => {
+      const [searchValue, setSearchValue] = useState('');
+      return (
+        <>
+          <RetentionSelectorSearch
+            searchValue={searchValue}
+            onSearchValueChange={setSearchValue}
+            searchPlaceholder="Search policies"
+          />
+          <RetentionSelector
+            options={options}
+            onSelectOption={() => {}}
+            showSearch={false}
+            searchValue={searchValue}
+            searchPlaceholder="Search policies"
+            inspectButtonLabel={(name) => `Inspect ${name}`}
+          />
+        </>
+      );
+    };
 
-    expect(screen.queryByText('Stream A')).not.toBeInTheDocument();
-    expect(screen.getByText('Stream B')).toBeInTheDocument();
-    expect(screen.getByTestId('retentionSelectorMethodFilterButton')).toBeInTheDocument();
+    it('renders only one search input, in the split-out component', () => {
+      renderWithTheme(<SplitExample />);
+      expect(screen.getAllByTestId('retentionSelectorSearchInput')).toHaveLength(1);
+    });
+
+    it('filters the externally-rendered list by the header search value', async () => {
+      const user = userEvent.setup();
+      renderWithTheme(<SplitExample />);
+
+      expect(screen.getByTestId(rowTestSubj('Policy A'))).toBeInTheDocument();
+      expect(screen.getByTestId(rowTestSubj('Policy B'))).toBeInTheDocument();
+
+      await user.type(screen.getByTestId('retentionSelectorSearchInput'), 'b');
+
+      expect(screen.queryByTestId(rowTestSubj('Policy A'))).not.toBeInTheDocument();
+      expect(screen.getByTestId(rowTestSubj('Policy B'))).toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.test.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 import '@testing-library/jest-dom';
-import { EuiThemeProvider } from '@elastic/eui';
+import { EuiButton, EuiThemeProvider } from '@elastic/eui';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { RetentionOption } from './types';
@@ -181,6 +181,41 @@ describe('RetentionSelector', () => {
     );
 
     expect(screen.getByText('Success: 90d · 2 phases')).toBeInTheDocument();
+  });
+
+  it('ignores internal search value when search is hidden', async () => {
+    const user = userEvent.setup();
+
+    const ToggleSearchExample = () => {
+      const [showSearch, setShowSearch] = useState(true);
+
+      return (
+        <>
+          <EuiButton onClick={() => setShowSearch(false)}>Hide search</EuiButton>
+          <RetentionSelector
+            options={options}
+            onSelectOption={() => {}}
+            showSearch={showSearch}
+            listStyle={showSearch ? 'plain' : 'panel'}
+            showRowActions={showSearch}
+            searchPlaceholder="Search policies"
+            inspectButtonLabel={(name) => `Inspect ${name}`}
+          />
+        </>
+      );
+    };
+
+    renderWithTheme(<ToggleSearchExample />);
+
+    await user.type(screen.getByTestId('retentionSelectorSearchInput'), 'b');
+    expect(screen.queryByTestId(rowTestSubj('Policy A'))).not.toBeInTheDocument();
+    expect(screen.getByTestId(rowTestSubj('Policy B'))).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Hide search' }));
+
+    expect(screen.getByTestId(rowTestSubj('Policy A'))).toBeInTheDocument();
+    expect(screen.getByTestId(rowTestSubj('Policy B'))).toBeInTheDocument();
+    expect(screen.queryByTestId('retentionSelectorSearchInput')).not.toBeInTheDocument();
   });
 
   describe('split search (RetentionSelectorSearch + showSearch={false})', () => {

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
@@ -5,17 +5,13 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useRef, useState, type RefObject } from 'react';
+import React, { useMemo, useRef, useState, type RefObject } from 'react';
 import {
-  EuiFilterButton,
-  EuiFilterGroup,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiListGroup,
   EuiPanel,
-  EuiPopover,
-  EuiSelectable,
   EuiText,
   useEuiTheme,
 } from '@elastic/eui';
@@ -27,36 +23,37 @@ import { useFlyoutNestedScrollHeight } from '../hooks/use_flyout_nested_scroll_h
 
 const NO_FLYOUT_SCROLL_CONTAINER_REF: RefObject<HTMLElement | null> = { current: null };
 
-export type RetentionSelectorMethod = string;
-
-export interface RetentionSelectorMethodOption {
-  key: RetentionSelectorMethod;
-  label: string;
+export interface RetentionSelectorSearchProps {
+  searchValue: string;
+  onSearchValueChange: (value: string) => void;
+  searchPlaceholder: string;
+  isDisabled?: boolean;
 }
 
-export interface RetentionSelectorMethodFilterConfig {
-  /**
-   * Selected methods. Empty means "all methods".
-   */
-  selectedMethods: RetentionSelectorMethod[];
-  onChangeSelectedMethods: (nextSelectedMethods: RetentionSelectorMethod[]) => void;
-  /**
-   * Optional custom method derivation. Defaults to `option.method`.
-   *
-   * Note: pass a stable function reference (e.g. `useCallback`) to avoid
-   * unnecessary recomputation when the parent re-renders.
-   */
-  getMethodForOption?: (option: RetentionOption) => RetentionSelectorMethod | undefined;
-  /**
-   * Optional list of selectable methods.
-   *
-   * When omitted, options will be derived from the provided `options` list
-   * using `getMethodForOption` (or `option.method` by default).
-   */
-  methodOptions?: RetentionSelectorMethodOption[];
-  /** Optional label override for the filter button. */
-  buttonLabel?: string;
-}
+/**
+ * The search input row, extracted so it can be rendered in a
+ * flyout header. Pair with a `showSearch={false}` `RetentionSelector` sharing
+ * the same `searchValue`/`onSearchValueChange` to keep the list in sync.
+ */
+export const RetentionSelectorSearch = ({
+  searchValue,
+  onSearchValueChange,
+  searchPlaceholder,
+  isDisabled = false,
+}: RetentionSelectorSearchProps) => {
+  return (
+    <EuiFieldSearch
+      placeholder={searchPlaceholder}
+      compressed
+      fullWidth
+      disabled={isDisabled}
+      value={searchValue}
+      onChange={(event) => onSearchValueChange(event.target.value)}
+      data-test-subj="retentionSelectorSearchInput"
+      aria-label={searchPlaceholder}
+    />
+  );
+};
 
 export interface RetentionSelectorProps {
   options: RetentionOption[];
@@ -65,29 +62,15 @@ export interface RetentionSelectorProps {
   onInspect?: (name: string) => void;
   isDisabled?: boolean;
   height?: number | 'full';
-  /** Hide the search input (useful when the list is read-only / single item). */
   showSearch?: boolean;
-  /** Render the list inside a panel (used for read-only single-row display). */
   listStyle?: 'plain' | 'panel';
-  /** Hide selection + inspect affordances (used for read-only single-row display). */
   showRowActions?: boolean;
   searchPlaceholder: string;
   inspectButtonLabel: (name: string) => string;
-  /**
-   * Optional method/category filter rendered next to the search input.
-   */
-  methodFilter?: RetentionSelectorMethodFilterConfig;
-  /**
-   * Where the inspect affordance is rendered.
-   * - `rowAction`: right-side action icon (default)
-   * - `badge`: inside the row badge (Streams import flyout)
-   */
   inspectPlacement?: 'rowAction' | 'badge';
-  /**
-   * When provided with `height="full"`, the list gets a fixed nested scroll
-   * height while the surrounding `EuiFlyoutBody` keeps its own scroll.
-   */
   flyoutScrollContainerRef?: RefObject<HTMLElement | null>;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
 }
 
 export const RetentionSelector = ({
@@ -102,13 +85,15 @@ export const RetentionSelector = ({
   showRowActions = true,
   searchPlaceholder,
   inspectButtonLabel,
-  methodFilter,
   inspectPlacement = 'rowAction',
   flyoutScrollContainerRef,
+  searchValue: controlledSearchValue,
+  onSearchValueChange,
 }: RetentionSelectorProps) => {
   const { euiTheme } = useEuiTheme();
-  const [searchValue, setSearchValue] = useState('');
-  const [isMethodFilterPopoverOpen, setIsMethodFilterPopoverOpen] = useState(false);
+  const [internalSearchValue, setInternalSearchValue] = useState('');
+  const searchValue = controlledSearchValue ?? internalSearchValue;
+  const setSearchValue = onSearchValueChange ?? setInternalSearchValue;
   const listScrollRef = useRef<HTMLDivElement>(null);
   const nestedScrollHeight = useFlyoutNestedScrollHeight(
     flyoutScrollContainerRef ?? NO_FLYOUT_SCROLL_CONTAINER_REF,
@@ -120,90 +105,12 @@ export const RetentionSelector = ({
     nestedScrollHeight: height === 'full' ? nestedScrollHeight : undefined,
   });
 
-  const defaultGetMethodForOption = useCallback(
-    (option: RetentionOption): RetentionSelectorMethod | undefined => option.method,
-    []
-  );
-
-  const getMethodForOption = methodFilter?.getMethodForOption ?? defaultGetMethodForOption;
-
-  const selectableMethodOptions = useMemo<RetentionSelectorMethodOption[]>(() => {
-    if (!methodFilter) return [];
-    if (methodFilter.methodOptions) return methodFilter.methodOptions;
-
-    const uniqueKeys = Array.from(
-      new Set(
-        options
-          .map((option) => getMethodForOption(option))
-          .filter((k): k is RetentionSelectorMethod => Boolean(k && k.trim()))
-      )
-    );
-
-    return uniqueKeys.map((key) => ({ key, label: key }));
-  }, [getMethodForOption, methodFilter, options]);
-
-  const methodFilteredOptions = useMemo(() => {
-    const selectedMethods = methodFilter?.selectedMethods ?? [];
-    if (selectedMethods.length === 0) return options;
-    return options.filter((option) => {
-      const method = getMethodForOption(option);
-      return method ? selectedMethods.includes(method) : false;
-    });
-  }, [getMethodForOption, methodFilter?.selectedMethods, options]);
-
   const visibleOptions = useMemo(() => {
-    const normalizedSearchValue = showSearch ? searchValue.trim().toLowerCase() : '';
-    if (!normalizedSearchValue) return methodFilteredOptions;
+    const normalizedSearchValue = searchValue.trim().toLowerCase();
+    if (!normalizedSearchValue) return options;
 
-    return methodFilteredOptions.filter((option) =>
-      option.name.toLowerCase().includes(normalizedSearchValue)
-    );
-  }, [methodFilteredOptions, searchValue, showSearch]);
-
-  const selectedMethodCount = methodFilter?.selectedMethods.length ?? 0;
-
-  const methodFilterControl =
-    methodFilter && selectableMethodOptions.length > 0 ? (
-      <EuiFilterGroup compressed>
-        <EuiPopover
-          aria-label={strings.methodFilterPopoverAriaLabel}
-          isOpen={isDisabled ? false : isMethodFilterPopoverOpen}
-          closePopover={() => setIsMethodFilterPopoverOpen(false)}
-          panelPaddingSize="s"
-          button={
-            <EuiFilterButton
-              iconType="chevronSingleDown"
-              isSelected={isMethodFilterPopoverOpen}
-              onClick={() => setIsMethodFilterPopoverOpen((open) => !open)}
-              isDisabled={isDisabled}
-              hasActiveFilters={selectedMethodCount > 0}
-              numActiveFilters={selectedMethodCount > 0 ? selectedMethodCount : undefined}
-              data-test-subj="retentionSelectorMethodFilterButton"
-            >
-              {methodFilter.buttonLabel ?? strings.methodFilterButtonLabel}
-            </EuiFilterButton>
-          }
-        >
-          <EuiSelectable
-            aria-label={strings.methodFilterSelectableAriaLabel}
-            options={selectableMethodOptions.map(({ key, label }) => ({
-              key,
-              label,
-              checked: methodFilter.selectedMethods.includes(key) ? ('on' as const) : undefined,
-            }))}
-            listProps={{ isVirtualized: false, textWrap: 'wrap' }}
-            onChange={(newOptions) => {
-              const nextSelected = newOptions
-                .filter((o) => o.checked === 'on')
-                .map((o) => o.key as RetentionSelectorMethod);
-              methodFilter.onChangeSelectedMethods(nextSelected);
-            }}
-          >
-            {(list) => <>{list}</>}
-          </EuiSelectable>
-        </EuiPopover>
-      </EuiFilterGroup>
-    ) : null;
+    return options.filter((option) => option.name.toLowerCase().includes(normalizedSearchValue));
+  }, [options, searchValue]);
 
   const list =
     visibleOptions.length > 0 ? (
@@ -236,23 +143,12 @@ export const RetentionSelector = ({
     <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
       {showSearch && (
         <EuiFlexItem grow={false} css={styles.paddedSection}>
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem>
-              <EuiFieldSearch
-                placeholder={searchPlaceholder}
-                compressed
-                fullWidth
-                disabled={isDisabled}
-                value={searchValue}
-                onChange={(event) => setSearchValue(event.target.value)}
-                data-test-subj="retentionSelectorSearchInput"
-                aria-label={searchPlaceholder}
-              />
-            </EuiFlexItem>
-            {methodFilterControl ? (
-              <EuiFlexItem grow={false}>{methodFilterControl}</EuiFlexItem>
-            ) : null}
-          </EuiFlexGroup>
+          <RetentionSelectorSearch
+            searchValue={searchValue}
+            onSearchValueChange={setSearchValue}
+            searchPlaceholder={searchPlaceholder}
+            isDisabled={isDisabled}
+          />
         </EuiFlexItem>
       )}
       {listStyle === 'panel' ? (

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
@@ -106,11 +106,12 @@ export const RetentionSelector = ({
   });
 
   const visibleOptions = useMemo(() => {
-    const normalizedSearchValue = searchValue.trim().toLowerCase();
+    const isSearchActive = showSearch || controlledSearchValue !== undefined;
+    const normalizedSearchValue = isSearchActive ? searchValue.trim().toLowerCase() : '';
     if (!normalizedSearchValue) return options;
 
     return options.filter((option) => option.name.toLowerCase().includes(normalizedSearchValue));
-  }, [options, searchValue]);
+  }, [controlledSearchValue, options, searchValue, showSearch]);
 
   const list =
     visibleOptions.length > 0 ? (

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/strings.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/strings.ts
@@ -13,13 +13,4 @@ export const retentionSelectorStrings = {
   noOptionsFoundDescription: i18n.translate(`${PREFIX}.noOptionsFoundDescription`, {
     defaultMessage: 'No options found',
   }),
-  methodFilterButtonLabel: i18n.translate(`${PREFIX}.methodFilterButtonLabel`, {
-    defaultMessage: 'Method',
-  }),
-  methodFilterPopoverAriaLabel: i18n.translate(`${PREFIX}.methodFilterPopoverAriaLabel`, {
-    defaultMessage: 'Method filter',
-  }),
-  methodFilterSelectableAriaLabel: i18n.translate(`${PREFIX}.methodFilterSelectableAriaLabel`, {
-    defaultMessage: 'Filter by method',
-  }),
 };

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/types.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/types.ts
@@ -9,13 +9,6 @@ export interface RetentionOption {
   /** Unique identifier and display title for the row. */
   name: string;
   /**
-   * Optional method/category key used by `RetentionSelector`'s `methodFilter`.
-   *
-   * The selector itself is agnostic to what the key means (e.g. "ilm", "dlm",
-   * "hot", "warm", etc.) — callers define the semantics.
-   */
-  method?: string;
-  /**
    * Optional category prefix, rendered as:
    * `${descriptionCategory}: ${descriptionParts.join(' · ')}`
    */

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/lifecycle_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/lifecycle_flyout.tsx
@@ -24,6 +24,7 @@ export interface LifecycleFlyoutProps
   > {
   titleId: string;
   title: string;
+  headerContent?: React.ReactNode;
   children: React.ReactNode;
   'data-test-subj'?: string;
 }
@@ -31,6 +32,7 @@ export interface LifecycleFlyoutProps
 export const LifecycleFlyout = ({
   titleId,
   title,
+  headerContent,
   children,
   ownFocus,
   paddingSize,
@@ -38,7 +40,7 @@ export const LifecycleFlyout = ({
 }: LifecycleFlyoutProps) => {
   const { euiTheme } = useEuiTheme();
   const headerStyles = css`
-    padding: ${euiTheme.size.xl};
+    padding: ${euiTheme.size.l};
   `;
 
   return (
@@ -52,12 +54,13 @@ export const LifecycleFlyout = ({
       {...flyoutProps}
     >
       <EuiFlyoutHeader hasBorder>
-        <EuiFlexGroup direction="column" gutterSize="s" responsive={false} css={headerStyles}>
+        <EuiFlexGroup direction="column" gutterSize="l" responsive={false} css={headerStyles}>
           <EuiFlexItem grow={false}>
             <EuiTitle size="s">
               <h2 id={titleId}>{title}</h2>
             </EuiTitle>
           </EuiFlexItem>
+          {headerContent && <EuiFlexItem grow={false}>{headerContent}</EuiFlexItem>}
         </EuiFlexGroup>
       </EuiFlyoutHeader>
       {children}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/lifecycle_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/lifecycle_flyout.tsx
@@ -39,8 +39,9 @@ export const LifecycleFlyout = ({
   ...flyoutProps
 }: LifecycleFlyoutProps) => {
   const { euiTheme } = useEuiTheme();
+  const headerPadding = headerContent ? euiTheme.size.l : euiTheme.size.xl;
   const headerStyles = css`
-    padding: ${euiTheme.size.l};
+    padding: ${headerPadding};
   `;
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/README.md
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/README.md
@@ -11,3 +11,9 @@ Run `yarn storybook streams_app` from the Kibana root to preview these component
 Use `onChange` for debounced draft updates while the user edits the form, such as previewing the resulting lifecycle configuration before it is saved. Use the committed action callback for the footer action that persists the current value. This mirrors the ILM phases flyout pattern, where `onChange` drives preview state and `onSave` commits the final configuration.
 
 When `maximumRetentionPeriod` is provided, the flyout hides the remove action and validates that the delete phase happens before that maximum. When the delete phase is removed, the flyout calls `onSave({ deletePhaseEnabled: false })` and relies on the parent save handler to persist the change and close the flyout.
+
+## `ImportLifecycleFlyout`
+
+`import_lifecycle_flyout/import_lifecycle_flyout.tsx` renders the import picker used to copy lifecycle settings from another stream. It lists DLM and ILM streams through `RetentionSelector`, keeps search and method filtering in the flyout header, and exposes row selection, ILM policy inspection, cancel, and apply callbacks to the parent integration.
+
+Use `import_lifecycle_flyout/import_lifecycle_flyout.stories.tsx` to preview the default mixed DLM/ILM list and the apply warning shown when the selected source includes downsampling configuration and the target stream cannot apply it.

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/constants.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
-export { RetentionSelector, RetentionSelectorSearch } from './retention_selector';
-export type { RetentionSelectorProps, RetentionSelectorSearchProps } from './retention_selector';
-export type { RetentionOption } from './types';
+export const IMPORT_METHOD_DLM = 'dlm';
+export const IMPORT_METHOD_ILM = 'ilm';
+
+export type ImportLifecycleMethod = typeof IMPORT_METHOD_DLM | typeof IMPORT_METHOD_ILM;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/i18n.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/i18n.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const importLifecycleFlyoutI18n = {
+  title: i18n.translate('xpack.streams.importLifecycle.title', {
+    defaultMessage: 'Import from another stream',
+  }),
+  searchPlaceholder: i18n.translate('xpack.streams.importLifecycle.searchPlaceholder', {
+    defaultMessage: 'Search by stream name',
+  }),
+  inspectButtonLabel: (name: string) =>
+    i18n.translate('xpack.streams.importLifecycle.inspectButtonLabel', {
+      defaultMessage: 'Inspect ILM policy for {name}',
+      values: { name },
+    }),
+  methodFilterDlm: i18n.translate('xpack.streams.importLifecycle.methodFilter.dlm', {
+    defaultMessage: 'Data stream lifecycle',
+  }),
+  methodFilterIlm: i18n.translate('xpack.streams.importLifecycle.methodFilter.ilm', {
+    defaultMessage: 'ILM policy',
+  }),
+  methodFilterButtonLabel: i18n.translate(
+    'xpack.streams.importLifecycle.methodFilter.buttonLabel',
+    {
+      defaultMessage: 'Method',
+    }
+  ),
+  methodFilterPopoverAriaLabel: i18n.translate(
+    'xpack.streams.importLifecycle.methodFilter.popoverAriaLabel',
+    {
+      defaultMessage: 'Method filter',
+    }
+  ),
+  methodFilterSelectableAriaLabel: i18n.translate(
+    'xpack.streams.importLifecycle.methodFilter.selectableAriaLabel',
+    {
+      defaultMessage: 'Filter by method',
+    }
+  ),
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.stories.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.stories.tsx
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import React, { useState } from 'react';
+import type { SerializedPolicy } from '@kbn/index-lifecycle-management-common-shared';
+import { InspectIlmPolicyFlyout } from '@kbn/data-lifecycle-phases';
+import { IMPORT_METHOD_DLM, IMPORT_METHOD_ILM } from './constants';
+import type { ImportLifecycleMethod } from './constants';
+import { ImportLifecycleFlyout } from './import_lifecycle_flyout';
+import type { ImportLifecycleOption } from './types';
+
+interface ImportLifecycleStoryOption extends ImportLifecycleOption {
+  ilmPolicyName?: string;
+}
+
+const buildIlmPolicy = ({
+  name,
+  warmMinAge,
+  deleteMinAge,
+  downsampleInterval,
+}: {
+  name: string;
+  warmMinAge: string;
+  deleteMinAge: string;
+  downsampleInterval?: string;
+}): SerializedPolicy => ({
+  name,
+  phases: {
+    hot: {
+      min_age: '0ms',
+      actions: {
+        rollover: { max_primary_shard_size: '50gb', max_age: '30d' },
+        set_priority: { priority: 100 },
+      },
+    },
+    warm: {
+      min_age: warmMinAge,
+      actions: {
+        readonly: {},
+        ...(downsampleInterval ? { downsample: { fixed_interval: downsampleInterval } } : {}),
+        set_priority: { priority: 50 },
+      },
+    },
+    delete: {
+      min_age: deleteMinAge,
+      actions: {
+        delete: {},
+      },
+    },
+  },
+});
+
+const ILM_POLICIES: Record<string, SerializedPolicy> = {
+  'logs-elastic-agent-policy': buildIlmPolicy({
+    name: 'logs-elastic-agent-policy',
+    warmMinAge: '30d',
+    deleteMinAge: '60d',
+    downsampleInterval: '1d',
+  }),
+  'metrics-hostmetrics-policy': buildIlmPolicy({
+    name: 'metrics-hostmetrics-policy',
+    warmMinAge: '90d',
+    deleteMinAge: '365d',
+  }),
+  '.profiling-ilm-policy': buildIlmPolicy({
+    name: '.profiling-ilm-policy',
+    warmMinAge: '30d',
+    deleteMinAge: '180d',
+  }),
+};
+
+const STREAM_OPTIONS: ImportLifecycleStoryOption[] = [
+  {
+    name: 'logs-elastic_agent-default',
+    method: IMPORT_METHOD_ILM,
+    ilmPolicyName: 'logs-elastic-agent-policy',
+    hasDownsampling: true,
+    descriptionCategory: 'Success',
+    descriptionParts: ['60d', '3 phases', '2 downsamples'],
+    descriptionCategorySecondLine: 'Fail',
+    descriptionPartsSecondLine: ['60d', '2 phases'],
+    badge: 'ILM',
+    inspectable: true,
+  },
+  {
+    name: 'logs-synth-default',
+    method: IMPORT_METHOD_DLM,
+    descriptionCategory: 'Success',
+    descriptionParts: ['60d', '2 phases'],
+  },
+  {
+    name: 'logs.ecs',
+    method: IMPORT_METHOD_DLM,
+    hasDownsampling: true,
+    descriptionCategory: 'Success',
+    descriptionParts: ['∞', '1 phase', '1 downsample'],
+  },
+  {
+    name: 'metrics-hostmetrics-default',
+    method: IMPORT_METHOD_ILM,
+    ilmPolicyName: 'metrics-hostmetrics-policy',
+    descriptionCategory: 'Success',
+    descriptionParts: ['365d', '4 phases'],
+    badge: 'ILM',
+    inspectable: true,
+  },
+  {
+    name: 'profiling-events-5pow01',
+    method: IMPORT_METHOD_ILM,
+    ilmPolicyName: '.profiling-ilm-policy',
+    descriptionCategory: 'Success',
+    descriptionParts: ['.profiling-ilm-policy'],
+    badge: 'ILM',
+    inspectable: true,
+  },
+  {
+    name: 'logs.otel',
+    method: IMPORT_METHOD_DLM,
+    descriptionCategory: 'Success',
+    descriptionParts: ['90d', '2 phases'],
+    descriptionCategorySecondLine: 'Fail',
+    descriptionPartsSecondLine: ['∞', '1 phase'],
+  },
+];
+
+const meta: Meta<typeof ImportLifecycleFlyout> = {
+  component: ImportLifecycleFlyout,
+  title: 'streams/ImportLifecycleFlyout',
+  argTypes: {
+    titleId: { control: false },
+    options: { control: false },
+    selectedOptionName: { control: false },
+    onSelectOption: { control: false },
+    onInspect: { control: false },
+    selectedMethods: { control: false },
+    onChangeSelectedMethods: { control: false },
+    onApply: { control: false },
+    onClose: { control: false },
+    'data-test-subj': { control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ImportLifecycleFlyout>;
+
+const StatefulStory = ({
+  isLoadingStreams = false,
+  isApplyDisabled = false,
+  canUseDownsampling = true,
+}: {
+  isLoadingStreams?: boolean;
+  isApplyDisabled?: boolean;
+  canUseDownsampling?: boolean;
+}) => {
+  const [selectedOptionName, setSelectedOptionName] = useState(STREAM_OPTIONS[0].name);
+  const [selectedMethods, setSelectedMethods] = useState<ImportLifecycleMethod[]>([]);
+  const [inspectedStreamName, setInspectedStreamName] = useState<string | null>(null);
+
+  const inspectedOption = inspectedStreamName
+    ? STREAM_OPTIONS.find(({ name }) => name === inspectedStreamName)
+    : undefined;
+  const inspectedPolicyName = inspectedOption?.ilmPolicyName;
+  const inspectedPolicy = inspectedPolicyName ? ILM_POLICIES[inspectedPolicyName] : undefined;
+
+  return (
+    <>
+      <ImportLifecycleFlyout
+        titleId="streamsImportLifecycleFlyoutStoryTitle"
+        options={STREAM_OPTIONS}
+        selectedOptionName={selectedOptionName}
+        onSelectOption={(name) => {
+          action('onSelectOption')(name);
+          setSelectedOptionName(name);
+        }}
+        onInspect={(name) => {
+          action('onInspect')(name);
+          setInspectedStreamName(name);
+        }}
+        isLoadingStreams={isLoadingStreams}
+        selectedMethods={selectedMethods}
+        onChangeSelectedMethods={(methods) => {
+          action('onChangeSelectedMethods')(methods);
+          setSelectedMethods(methods);
+        }}
+        onApply={action('onApply')}
+        onClose={action('onClose')}
+        isApplyDisabled={isApplyDisabled}
+        canUseDownsampling={canUseDownsampling}
+      />
+
+      {inspectedPolicyName && inspectedPolicy ? (
+        <InspectIlmPolicyFlyout
+          policyName={inspectedPolicyName}
+          policy={inspectedPolicy}
+          onBack={() => setInspectedStreamName(null)}
+          onEditPolicy={action('onEditIlmPolicy')}
+          primaryAction={{
+            label: 'Select policy and apply',
+            onClick: (policyName) => action('onSelectAndApply')({ policyName }),
+            'data-test-subj': 'inspectIlmPolicyFlyoutSelectAndApplyButton',
+          }}
+          type="push"
+        />
+      ) : null}
+    </>
+  );
+};
+
+export const TimeSeriesStream: Story = {
+  name: 'Time-series stream',
+  render: () => <StatefulStory />,
+};
+
+export const NonTimeSeriesStream: Story = {
+  name: 'Non-time-series stream',
+  render: () => <StatefulStory canUseDownsampling={false} />,
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { EuiThemeProvider } from '@elastic/eui';
+import { render, screen } from '@testing-library/react';
+import { IMPORT_METHOD_DLM, IMPORT_METHOD_ILM } from './constants';
+import { ImportLifecycleFlyout } from './import_lifecycle_flyout';
+import type { ImportLifecycleOption } from './types';
+
+const options: ImportLifecycleOption[] = [
+  {
+    name: 'ilm-with-downsampling',
+    method: IMPORT_METHOD_ILM,
+    descriptionParts: ['60d', '1 downsample'],
+    hasDownsampling: true,
+  },
+  {
+    name: 'dlm-with-downsampling',
+    method: IMPORT_METHOD_DLM,
+    descriptionParts: ['60d', '1 downsample'],
+    hasDownsampling: true,
+  },
+  {
+    name: 'logs-without-downsampling',
+    method: IMPORT_METHOD_DLM,
+    descriptionParts: ['60d'],
+  },
+];
+
+const renderFlyout = ({
+  selectedOptionName,
+  canUseDownsampling,
+}: {
+  selectedOptionName: string;
+  canUseDownsampling: boolean;
+}) =>
+  render(
+    <ImportLifecycleFlyout
+      titleId="streamsImportLifecycleFlyoutTestTitle"
+      options={options}
+      selectedOptionName={selectedOptionName}
+      onSelectOption={() => {}}
+      onInspect={() => {}}
+      isLoadingStreams={false}
+      selectedMethods={[]}
+      onChangeSelectedMethods={() => {}}
+      onApply={() => {}}
+      onClose={() => {}}
+      isApplyDisabled={false}
+      canUseDownsampling={canUseDownsampling}
+    />,
+    { wrapper: EuiThemeProvider }
+  );
+
+describe('ImportLifecycleFlyout', () => {
+  it('uses the ILM policy warning copy when importing from an ILM source with downsampling', () => {
+    renderFlyout({
+      selectedOptionName: 'ilm-with-downsampling',
+      canUseDownsampling: false,
+    });
+
+    expect(screen.getByTestId('flyoutFooter-downsamplingNotAppliedCallout')).toHaveTextContent(
+      'downsampling steps from the selected ILM policy will be excluded'
+    );
+  });
+
+  it('uses the import-stream warning copy when importing from a DLM source with downsampling', () => {
+    renderFlyout({
+      selectedOptionName: 'dlm-with-downsampling',
+      canUseDownsampling: false,
+    });
+
+    expect(screen.getByTestId('flyoutFooter-downsamplingNotAppliedCallout')).toHaveTextContent(
+      'downsampling steps from the imported lifecycles will be excluded'
+    );
+  });
+
+  it('does not show the warning when selected source has no downsampling', () => {
+    renderFlyout({
+      selectedOptionName: 'logs-without-downsampling',
+      canUseDownsampling: false,
+    });
+
+    expect(
+      screen.queryByTestId('flyoutFooter-downsamplingNotAppliedCallout')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show the warning when the target can use downsampling', () => {
+    renderFlyout({
+      selectedOptionName: 'ilm-with-downsampling',
+      canUseDownsampling: true,
+    });
+
+    expect(
+      screen.queryByTestId('flyoutFooter-downsamplingNotAppliedCallout')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useRef, useState } from 'react';
+import {
+  EuiFilterButton,
+  EuiFilterGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiPopover,
+  EuiSelectable,
+} from '@elastic/eui';
+import {
+  FlyoutFooterWithRetentionWarning,
+  RetentionSelector,
+  RetentionSelectorSearch,
+} from '@kbn/data-lifecycle-phases';
+import { LifecycleFlyout } from '../../common/lifecycle_flyout';
+import { IMPORT_METHOD_DLM, IMPORT_METHOD_ILM } from './constants';
+import { importLifecycleFlyoutI18n } from './i18n';
+import type { ImportLifecycleFlyoutProps } from './types';
+import type { ImportLifecycleMethod } from './constants';
+
+const importMethodFilterOptions: Array<{ key: ImportLifecycleMethod; label: string }> = [
+  { key: IMPORT_METHOD_DLM, label: importLifecycleFlyoutI18n.methodFilterDlm },
+  { key: IMPORT_METHOD_ILM, label: importLifecycleFlyoutI18n.methodFilterIlm },
+];
+
+interface ImportLifecycleMethodFilterProps {
+  selectedMethods: ImportLifecycleMethod[];
+  onChangeSelectedMethods: (methods: ImportLifecycleMethod[]) => void;
+  isDisabled: boolean;
+}
+
+const ImportLifecycleMethodFilter = ({
+  selectedMethods,
+  onChangeSelectedMethods,
+  isDisabled,
+}: ImportLifecycleMethodFilterProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const selectedMethodCount = selectedMethods.length;
+
+  return (
+    <EuiFilterGroup compressed>
+      <EuiPopover
+        aria-label={importLifecycleFlyoutI18n.methodFilterPopoverAriaLabel}
+        isOpen={isDisabled ? false : isPopoverOpen}
+        closePopover={() => setIsPopoverOpen(false)}
+        panelPaddingSize="s"
+        button={
+          <EuiFilterButton
+            iconType="chevronSingleDown"
+            isSelected={isPopoverOpen}
+            onClick={() => setIsPopoverOpen((open) => !open)}
+            isDisabled={isDisabled}
+            hasActiveFilters={selectedMethodCount > 0}
+            numActiveFilters={selectedMethodCount > 0 ? selectedMethodCount : undefined}
+            data-test-subj="streamsImportLifecycleMethodFilterButton"
+          >
+            {importLifecycleFlyoutI18n.methodFilterButtonLabel}
+          </EuiFilterButton>
+        }
+      >
+        <EuiSelectable
+          aria-label={importLifecycleFlyoutI18n.methodFilterSelectableAriaLabel}
+          options={importMethodFilterOptions.map(({ key, label }) => ({
+            key,
+            label,
+            checked: selectedMethods.includes(key) ? 'on' : undefined,
+          }))}
+          listProps={{ isVirtualized: false, textWrap: 'wrap' }}
+          onChange={(newOptions) => {
+            const nextSelectedMethods = importMethodFilterOptions.reduce<ImportLifecycleMethod[]>(
+              (methods, methodOption) => {
+                const option = newOptions.find(({ key }) => key === methodOption.key);
+                return option?.checked === 'on' ? [...methods, methodOption.key] : methods;
+              },
+              []
+            );
+
+            onChangeSelectedMethods(nextSelectedMethods);
+          }}
+        >
+          {(list) => <>{list}</>}
+        </EuiSelectable>
+      </EuiPopover>
+    </EuiFilterGroup>
+  );
+};
+
+export const ImportLifecycleFlyout = ({
+  titleId,
+  options,
+  selectedOptionName,
+  onSelectOption,
+  onInspect,
+  isLoadingStreams,
+  selectedMethods,
+  onChangeSelectedMethods,
+  onApply,
+  onClose,
+  isApplyDisabled,
+  canUseDownsampling = true,
+  'data-test-subj': dataTestSubj = 'streamsImportLifecycleFlyout',
+}: ImportLifecycleFlyoutProps) => {
+  const [searchValue, setSearchValue] = useState('');
+  // Gives the option list a precise scroll height down to the flyout bottom.
+  const flyoutScrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const filteredOptions = useMemo(() => {
+    if (selectedMethods.length === 0) return options;
+    return options.filter(({ method }) => selectedMethods.includes(method));
+  }, [options, selectedMethods]);
+  const selectedOption = options.find(({ name }) => name === selectedOptionName);
+  const showDownsamplingWarning = !canUseDownsampling && Boolean(selectedOption?.hasDownsampling);
+  const downsamplingWarningType =
+    selectedOption?.method === IMPORT_METHOD_ILM ? 'ilm_policy' : 'import_stream';
+
+  return (
+    <LifecycleFlyout
+      onClose={onClose}
+      ownFocus={false}
+      paddingSize="none"
+      data-test-subj={dataTestSubj}
+      titleId={titleId}
+      title={importLifecycleFlyoutI18n.title}
+      headerContent={
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          <EuiFlexItem>
+            <RetentionSelectorSearch
+              searchValue={searchValue}
+              onSearchValueChange={setSearchValue}
+              isDisabled={isLoadingStreams}
+              searchPlaceholder={importLifecycleFlyoutI18n.searchPlaceholder}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <ImportLifecycleMethodFilter
+              selectedMethods={selectedMethods}
+              onChangeSelectedMethods={onChangeSelectedMethods}
+              isDisabled={isLoadingStreams}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+    >
+      <EuiFlyoutBody scrollContainerRef={flyoutScrollContainerRef}>
+        <RetentionSelector
+          options={filteredOptions}
+          selectedOptionName={selectedOptionName}
+          onSelectOption={onSelectOption}
+          onInspect={onInspect}
+          isDisabled={isLoadingStreams}
+          height="full"
+          inspectPlacement="badge"
+          showSearch={false}
+          searchValue={searchValue}
+          flyoutScrollContainerRef={flyoutScrollContainerRef}
+          searchPlaceholder={importLifecycleFlyoutI18n.searchPlaceholder}
+          inspectButtonLabel={importLifecycleFlyoutI18n.inspectButtonLabel}
+        />
+      </EuiFlyoutBody>
+
+      <FlyoutFooterWithRetentionWarning
+        onCancel={onClose}
+        onApply={onApply}
+        isApplyDisabled={isApplyDisabled}
+        showWarning={showDownsamplingWarning}
+        warningType={downsamplingWarningType}
+      />
+    </LifecycleFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/index.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/index.ts
@@ -5,6 +5,5 @@
  * 2.0.
  */
 
-export { RetentionSelector, RetentionSelectorSearch } from './retention_selector';
-export type { RetentionSelectorProps, RetentionSelectorSearchProps } from './retention_selector';
-export type { RetentionOption } from './types';
+export { ImportLifecycleFlyout } from './import_lifecycle_flyout';
+export type { ImportLifecycleFlyoutProps } from './types';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RetentionOption } from '@kbn/data-lifecycle-phases';
+import type { ImportLifecycleMethod } from './constants';
+
+export interface ImportLifecycleOption extends RetentionOption {
+  method: ImportLifecycleMethod;
+  hasDownsampling?: boolean;
+}
+
+export interface ImportLifecycleFlyoutProps {
+  titleId: string;
+  options: ImportLifecycleOption[];
+  selectedOptionName?: string;
+  onSelectOption: (name: string) => void;
+  onInspect: (name: string) => void;
+  isLoadingStreams: boolean;
+  selectedMethods: ImportLifecycleMethod[];
+  onChangeSelectedMethods: (methods: ImportLifecycleMethod[]) => void;
+  onApply: () => void;
+  onClose: () => void;
+  isApplyDisabled: boolean;
+  canUseDownsampling?: boolean;
+  'data-test-subj'?: string;
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/general_data/hooks/use_edit_successful_lifecycle_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/general_data/hooks/use_edit_successful_lifecycle_flyout.tsx
@@ -545,6 +545,7 @@ export const useEditSuccessfulLifecycleFlyout = ({
           }}
           isApplyDisabled={isApplyDisabled}
           showWarning={retentionWarning}
+          warningType="ilm_policy"
         />
       </LifecycleFlyout>
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/266044

## Summary
- Adds the Import from another stream flyout for Streams data lifecycle, including searchable stream selection, DLM/ILM filtering, lifecycle summaries, and ILM policy inspection.
- Updates the shared retention selection components so the search input can be rendered in a flyout header while the option list stays in the flyout body.
- Shows the downsampling exclusion warning only when the selected source lifecycle includes downsampling and the target stream cannot apply it.
- Uses source-specific warning copy: importing from DLM references imported lifecycles, while importing from ILM references the selected ILM policy.

### Test plan
- Manual: run `yarn storybook streams_app` and open `streams/ImportLifecycleFlyout`.
- Manual: verify the default story shows mixed DLM and ILM stream options, search filters by stream name, and the Method filter toggles DLM/ILM sources.
- Manual: select an ILM source and click Inspect ILM policy. Expected: the Inspect ILM policy flyout opens for that policy.
- Manual: open the non-time-series stream warning story and select a DLM source with downsampling. Expected: the warning says downsampling steps from imported lifecycles will be excluded.
- Manual: in the same warning story, select an ILM source with downsampling. Expected: the warning says downsampling steps from the selected ILM policy will be excluded.
- Manual: run `yarn storybook data_lifecycle_phases` and verify the shared retention selector and warning footer stories still render.
- Automated: added/updated Jest coverage for `ImportLifecycleFlyout`, `RetentionSelector`, and `FlyoutFooterWithRetentionWarning`.
- Automated run:
  - `node scripts/jest x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/import_lifecycle_flyout/import_lifecycle_flyout.test.tsx`
  - `node scripts/jest x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.test.tsx`
  - `node scripts/jest x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.test.tsx`
  - `node scripts/type_check --project x-pack/platform/packages/shared/kbn-data-lifecycle-phases/tsconfig.json`
  - `node scripts/type_check --project x-pack/platform/plugins/shared/streams_app/tsconfig.json`
  - ESLint was run on the touched lifecycle/import flyout files.

### Evidence
<img width="423" height="792" alt="Screenshot 2026-07-09 at 10 13 59" src="https://github.com/user-attachments/assets/97bd9ac1-ed35-4be4-9d39-48b5aa51b1ed" />
<img width="451" height="788" alt="Screenshot 2026-07-09 at 10 14 05" src="https://github.com/user-attachments/assets/8a347cb7-62df-4a45-a6c0-2ad87dd407f5" />


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->