### PR TITLE
[ESQL] Enable tech preview for Subqueries

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/operators/handlers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/operators/handlers.ts
@@ -47,7 +47,10 @@ export async function handleListOperator(ctx: ExpressionContext): Promise<ISugge
   // No list yet: suggest opening parenthesis
   if (shouldSuggestRightOperandStart(rightOperand)) {
     if (allowSubqueryOperand) {
-      return [listCompleteItem, ...buildSubqueryCompleteItems()];
+      return [
+        listCompleteItem,
+        ...buildSubqueryCompleteItems({ previewCommands: ['from', 'row', 'ts'] }),
+      ];
     }
 
     return [listCompleteItem];

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/complete_items.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/complete_items.ts
@@ -376,26 +376,37 @@ export interface MapKeySuggestionOptions {
   replacementRangeStrategy?: ISuggestionItem['replacementRangeStrategy'];
 }
 
-function buildSubqueryCompleteItem(sourceCommand: string): ISuggestionItem {
+function buildSubqueryCompleteItem(sourceCommand: string, preview = false): ISuggestionItem {
   const commandName = sourceCommand.toUpperCase();
+  const detailText = i18n.translate('kbn-esql-language.esql.autocomplete.subquerySourceDoc', {
+    defaultMessage: 'Adds a nested ES|QL query to your current query',
+  });
+  const declaration = `(${commandName} ...)`;
+  const documentationDetail = preview ? `**[${techPreviewLabel}]** ${detailText}` : detailText;
 
   return withAutoSuggest({
-    label: `(${commandName} ...)`,
+    label: declaration,
     text: `(${commandName} $0)`,
     asSnippet: true,
     kind: 'Method',
-    detail: i18n.translate('kbn-esql-language.esql.autocomplete.subquerySourceDoc', {
-      defaultMessage: 'Adds a nested ES|QL query to your current query',
-    }),
+    documentation: {
+      value: buildDocumentation(documentationDetail, declaration),
+    },
     category: SuggestionCategory.SUBQUERY,
   });
 }
 
-export function buildSubqueryCompleteItems(): ISuggestionItem[] {
+export function buildSubqueryCompleteItems(options?: {
+  previewCommands?: readonly string[];
+}): ISuggestionItem[] {
+  const previewCommands = options?.previewCommands?.map((command) => command.toLowerCase());
+
   return esqlCommandRegistry
     .getAllCommands()
     .filter(({ metadata }) => metadata.subquerySource === true && metadata.hidden !== true)
-    .map(({ name }) => buildSubqueryCompleteItem(name));
+    .map(({ name }) =>
+      buildSubqueryCompleteItem(name, previewCommands?.includes(name.toLowerCase()) ?? false)
+    );
 }
 
 export const minMaxValueCompleteItem: ISuggestionItem = {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/autocomplete.ts
@@ -77,7 +77,9 @@ async function handleFromAutocomplete(
   // checks need to operate on the current command only, not the entire query
   const commandText = query.substring(command.location.min, cursorPos);
   const subquerySuggestions =
-    commandText.length > command.name.length ? buildSubqueryCompleteItems() : undefined;
+    commandText.length > command.name.length
+      ? buildSubqueryCompleteItems({ previewCommands: ['row', 'ts'] })
+      : undefined;
   const indicesBrowserSuggestion = await getIndicesBrowserSuggestion({
     callbacks,
     context,


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/b9c3b8e5-87ff-4e0c-9efe-28b779ff27cc

This time I'm avoiding metadata flags, since these operations are intended to be removed. I simplify things.

-  All subqueries commands are visible in `GA`
- all subqueries command (in` FROM (...)` and` WHERE IN(...) `are in tech preview now except `FROM(FROM...)`