### PR TITLE
[Console] Remove invalid key from index_template autocomplete

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/json/overrides/indices.put_index_template.json
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/json/overrides/indices.put_index_template.json
@@ -6,8 +6,7 @@
       "data_stream":  {
         "__template": {
           "allow_custom_routing": false,
-          "hidden": false,
-          "index_mode": ""
+          "hidden": false
         }
       },
       "template": {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/272889

## Summary

`index_mode` isn't a valid field of the `data_stream` object in the index template body, so this removes it from the autocomplete override.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->