### PR TITLE
[Search Profiler] Fix false "no indices" when remote cluster check fails 

### DIFF
--- a/x-pack/platform/plugins/shared/searchprofiler/server/lib/has_indices.test.ts
+++ b/x-pack/platform/plugins/shared/searchprofiler/server/lib/has_indices.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { hasIndices } from './has_indices';
+
+describe('hasIndices', () => {
+  const log = loggingSystemMock.create().get();
+  let client: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  beforeEach(() => {
+    client = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  it('returns true when local indices exist, without checking remote indices', async () => {
+    client.indices.exists.mockResolvedValueOnce(true);
+
+    await expect(hasIndices(client, log)).resolves.toBe(true);
+
+    expect(client.indices.exists).toHaveBeenCalledTimes(1);
+    expect(client.indices.exists).toHaveBeenCalledWith({ index: '*' });
+  });
+
+  it('falls back to remote indices when there are no local indices', async () => {
+    client.indices.exists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await expect(hasIndices(client, log)).resolves.toBe(true);
+
+    expect(client.indices.exists).toHaveBeenCalledTimes(2);
+    expect(client.indices.exists).toHaveBeenNthCalledWith(1, { index: '*' });
+    expect(client.indices.exists).toHaveBeenNthCalledWith(2, { index: '*:*' });
+  });
+
+  it('returns false when neither local nor remote indices exist', async () => {
+    client.indices.exists.mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+
+    await expect(hasIndices(client, log)).resolves.toBe(false);
+  });
+
+  it('returns false and does not throw when the remote-cluster check errors', async () => {
+    client.indices.exists
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error('failed to resolve *:*'));
+
+    await expect(hasIndices(client, log)).resolves.toBe(false);
+
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Search Profiler remote index check failed')
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/searchprofiler/server/lib/has_indices.ts
+++ b/x-pack/platform/plugins/shared/searchprofiler/server/lib/has_indices.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+
+/**
+ * Checks whether there's at least one index the current user can search, so the Search
+ * Profiler UI knows whether to allow a profiled search.
+ *
+ * Local indices are checked first, since that's the common case and doesn't depend on
+ * cross-cluster search being configured. Remote indices are only checked as a fallback,
+ * and a failure there (e.g. an unreachable or misconfigured remote cluster returning an
+ * error for a `*:*` pattern) is swallowed rather than surfaced, so a broken remote cluster
+ * doesn't disable the profiler for local indices.
+ */
+export async function hasIndices(client: ElasticsearchClient, log: Logger): Promise<boolean> {
+  const hasLocalIndices = await client.indices.exists({ index: '*' });
+  if (hasLocalIndices) {
+    return true;
+  }
+
+  try {
+    return await client.indices.exists({ index: '*:*' });
+  } catch (e) {
+    log.debug(`Search Profiler remote index check failed, ignoring: ${e.message}`);
+    return false;
+  }
+}

--- a/x-pack/platform/plugins/shared/searchprofiler/server/routes/profile.ts
+++ b/x-pack/platform/plugins/shared/searchprofiler/server/routes/profile.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { API_BASE_PATH } from '../../common/constants';
+import { hasIndices } from '../lib/has_indices';
 import type { RouteDependencies } from '../types';
 
 export const register = ({ router, getLicenseStatus, log }: RouteDependencies) => {
@@ -96,11 +97,11 @@ export const register = ({ router, getLicenseStatus, log }: RouteDependencies) =
 
       try {
         const client = (await ctx.core).elasticsearch.client.asCurrentUser;
-        const hasIndices = await client.indices.exists({ index: '*,*:*' });
+        const indicesExist = await hasIndices(client, log);
 
         return response.ok({
           body: {
-            hasIndices,
+            hasIndices: indicesExist,
           },
         });
       } catch (err) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/252994

## Summary

This seems to be a regression introduced by https://github.com/elastic/kibana/pull/208825. Search Profiler was disabled whenever the combined local+remote index-existence check (*,*:*) failed on the remote segment; this splits the check so local indices are verified first and a broken/unreachable remote cluster no longer disables the profiler. 

Test instructions:
- Start ES and kibana locally
- Add sample data from kibana
-  Configure a broken remote cluster with `skip_unavailable: false`
- Go to DevTools -> Search Profiler.
- Confirm the Profile button is enabled and running a query returns profiled results


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->