### PR TITLE
Align @kbn/discoveries to langchain 1.x to fix cold yarn install

### DIFF
--- a/x-pack/solutions/security/packages/kbn-discoveries/package.json
+++ b/x-pack/solutions/security/packages/kbn-discoveries/package.json
@@ -9,8 +9,8 @@
     "openapi:generate:debug": "node --inspect-brk scripts/openapi/generate"
   },
   "dependencies": {
-    "@langchain/core": "^0.3.26",
-    "@langchain/langgraph": "^0.2.20"
+    "@langchain/core": "^1.1.31",
+    "@langchain/langgraph": "^1.2.0"
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10194,7 +10194,7 @@
   optionalDependencies:
     langsmith ">=0.4.0 <1.0.0"
 
-"@langchain/core@1.1.31", "@langchain/core@^0.3.26":
+"@langchain/core@1.1.31", "@langchain/core@^1.1.31":
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/@langchain/core/-/core-1.1.31.tgz#81882c7be8dfe138015da67b93aa73c6ab0f6962"
   integrity sha512-FxsgIUONjKaRpjx59sISgmb0OMCbAetPGyhzjGa2kX0y1f8LZ5xm9VB2db7W9HYWyLvzRWcMA51Uu4OSTJmtZQ==
@@ -10240,23 +10240,6 @@
   dependencies:
     uuid "^10.0.0"
 
-"@langchain/langgraph-checkpoint@~0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.0.17.tgz#d0a8824eb0769567da54262adebe65db4ee6d58f"
-  integrity sha512-6b3CuVVYx+7x0uWLG+7YXz9j2iBa+tn2AXvkLxzEvaAsLE6Sij++8PPbS2BZzC+S/FPJdWsz6I5bsrqL0BYrCA==
-  dependencies:
-    uuid "^10.0.0"
-
-"@langchain/langgraph-sdk@~0.0.32":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.42.tgz#401363ac74532b14e36ba94e5ebe7fb6ce287fe7"
-  integrity sha512-seOcLN6+MWxCGEVfKY2pFcFpJB56DZq7iXhe5Br/xF7Uxspm1e50Z8f0k21XOJFQyMheR6AZ9zXEBVeX1ZsDMg==
-  dependencies:
-    "@types/json-schema" "^7.0.15"
-    p-queue "^6.6.2"
-    p-retry "4"
-    uuid "^9.0.0"
-
 "@langchain/langgraph-sdk@~1.6.5":
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/@langchain/langgraph-sdk/-/langgraph-sdk-1.6.5.tgz#1a089f7412239ffad1c3b52364ba6af694966424"
@@ -10267,7 +10250,7 @@
     p-retry "^7.1.1"
     uuid "^13.0.0"
 
-"@langchain/langgraph@1.2.0":
+"@langchain/langgraph@1.2.0", "@langchain/langgraph@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-1.2.0.tgz#cb09262719eaefff71b4ab83c593d27a200f73cd"
   integrity sha512-wyqKIzXTAfXX3L1d8R7icM+HmRQBTbuNLWtUlpRJ/JP/ux1ei/sOSt6p8f90ARoOP2iJVlM70wOBYWaGErdBlA==
@@ -10276,16 +10259,6 @@
     "@langchain/langgraph-sdk" "~1.6.5"
     "@standard-schema/spec" "1.1.0"
     uuid "^10.0.0"
-
-"@langchain/langgraph@^0.2.20":
-  version "0.2.74"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-0.2.74.tgz#37367a1e8bafda3548037a91449a69a84f285def"
-  integrity sha512-oHpEi5sTZTPaeZX1UnzfM2OAJ21QGQrwReTV6+QnX7h8nDCBzhtipAw1cK616S+X8zpcVOjgOtJuaJhXa4mN8w==
-  dependencies:
-    "@langchain/langgraph-checkpoint" "~0.0.17"
-    "@langchain/langgraph-sdk" "~0.0.32"
-    uuid "^10.0.0"
-    zod "^3.23.8"
 
 "@langchain/openai@1.2.12":
   version "1.2.12"
@@ -29512,7 +29485,7 @@ p-queue@^9.0.1:
     eventemitter3 "^5.0.1"
     p-timeout "^7.0.0"
 
-p-retry@4, p-retry@4.6.2:
+p-retry@4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
@@ -37232,7 +37205,7 @@ zod-to-json-schema@^3.24.3, zod-to-json-schema@^3.25.1:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
   integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
 
-zod@4.4.3, zod@^3.23.8, zod@^3.24.1, zod@^3.24.2, "zod@^3.25 || ^4.0", "zod@^3.25.76 || ^4", zod@^4.1.11, zod@^4.3.6:
+zod@4.4.3, zod@^3.24.1, zod@^3.24.2, "zod@^3.25 || ^4.0", "zod@^3.25.76 || ^4", zod@^4.1.11, zod@^4.3.6:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

`@kbn/discoveries` asks for an old langchain version that the rest of the repo stopped using months ago. On a clean `yarn install` this leaves the package on a second, broken copy of langchain, and the install fails while linking dependencies. This PR points the package at the same langchain 1.x everything else already uses.

## What was happening

The repo pins the whole langchain stack to 1.x through the root `resolutions` block. `@kbn/discoveries` is the only package that still declares the old versions directly (`@langchain/core@^0.3.26`, `@langchain/langgraph@^0.2.20`). Those numbers are stale, left over from when the code lived in `elastic_assistant`, before the repo moved to langchain 1.x.

Because of a gap in the resolutions (langgraph is pinned only at the top level, not for nested copies), the package ends up with its own private `@langchain/langgraph@0.2.74`. That old langgraph pulls in a `uuid` version that has to be installed nested under the package. On a clean install, yarn v1 fails to place that nested `uuid` and aborts while linking:

```
error Error: ENOENT: no such file or directory, lstat
  '.../x-pack/solutions/security/packages/kbn-discoveries/node_modules/uuid'
```

This happens on the first attempt of every clean install, stateful and serverless alike. It looks flaky rather than constant for two reasons:

- Kibana CI installs from a warm cache and offline mirror, so it never does the full relink and never hits it.
- The Observability onboarding nightly does install from scratch, but it retries a failed step up to three times. The failed first attempt leaves a half-built `node_modules`, so the retry links `uuid` and passes. Jobs where the retry recovers go green, and the ones where it does not stay red. So the nightly shows a handful of red jobs, not a full wipe, even though every job hit the same error first.

The result is a nightly that has been intermittently red since this package landed, plus a wall for anyone bootstrapping Kibana from a fresh checkout.

## The fix

```diff
   "dependencies": {
-    "@langchain/core": "^0.3.26",
-    "@langchain/langgraph": "^0.2.20"
+    "@langchain/core": "^1.1.31",
+    "@langchain/langgraph": "^1.2.0"
   }
```

`@langchain/core` was already forced to 1.1.31 at runtime, so nothing changes there. The real change is langgraph moving from 0.2.74 to the 1.2.0 the rest of the repo runs. `yarn.lock` is regenerated, which drops the duplicate old subtree so there is no second langchain tree and no nested `uuid` to link. The race is removed, not just avoided.

## Why it matters

Clean installs work again on the first try. That stops the onboarding nightly from going red and removes a trap for anyone bootstrapping Kibana from a fresh checkout. It also fixes a latent correctness problem, since the old langgraph was already being paired with an incompatible core version.

## Verification

Clean `yarn install` on `main`:

- Before: fails with the ENOENT above (`yarn` exit 1)
- After: `success Saved lockfile. Done` (`yarn` exit 0), no duplicate langchain tree, no nested `kbn-discoveries/node_modules`

The nightly failure is an install failure, not a test failure. In the red jobs the only error is `YarnInstallError` raised inside the install the playwright step runs first. There are no test assertion or timeout errors, and no spec ever executed.

On safety: `@kbn/discoveries` only uses `Annotation`, `StateGraph`, `START`, and `END` from langgraph. `elastic_assistant`, which this code was extracted from, already runs those same APIs on langgraph 1.2.0 on `main`. CI runs the full type check and tests.
