### PR TITLE
[Cases] Fix YAML parser divergence in v2 template connector

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.test.ts
@@ -67,6 +67,25 @@ describe('parseTemplateDefinition', () => {
     const result = parseTemplateDefinition('description: "no name"\nfields: []');
     expect(result).toBeNull();
   });
+
+  it('parses a YAML 1.1 legacy boolean-like scalar as a plain string, matching the UI parser', () => {
+    // js-yaml (YAML 1.1) resolves `no` as a boolean; the `yaml` package (YAML 1.2, used by
+    // the UI/routes) resolves it as the string "no". Both parsers must agree here, otherwise
+    // the connector's `extended_fields` diverge from what the template form pre-fills.
+    const yamlWithLegacyScalarDefault = `
+name: "Legacy scalar"
+fields:
+  - name: field_a
+    type: keyword
+    control: INPUT_TEXT
+    label: Field A
+    metadata:
+      default: no
+`;
+    const result = parseTemplateDefinition(yamlWithLegacyScalarDefault);
+    expect(result).not.toBeNull();
+    expect(result?.fields[0]).toMatchObject({ metadata: { default: 'no' } });
+  });
 });
 
 describe('resolveV2Template', () => {

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.ts
@@ -21,12 +21,6 @@ export type ParsedTemplateDefinition = z.infer<typeof ParsedTemplateDefinitionSc
 /**
  * Parse a raw YAML definition string into a validated ParsedTemplateDefinition.
  * Returns null if the YAML is invalid or fails schema validation.
- *
- * Uses the `yaml` package (not `js-yaml`) to match the parser used everywhere else
- * templates are read (routes, `resolveTemplateFields`, the UI form sync). `js-yaml`
- * defaults to YAML 1.1 scalar resolution (e.g. `no`/`yes`/`off`/`on`/octals parse as
- * booleans or numbers rather than strings), which would silently diverge from the
- * `extended_fields` the UI pre-fills for the same stored definition.
  */
 export const parseTemplateDefinition = (
   definitionYaml: string

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import yaml from 'js-yaml';
+import { parse as parseYaml } from 'yaml';
 import type { Logger } from '@kbn/core/server';
 import type { z } from '@kbn/zod/v4';
 import { ParsedTemplateDefinitionSchema } from '../../../common/types/domain/template/v1';
@@ -21,12 +21,18 @@ export type ParsedTemplateDefinition = z.infer<typeof ParsedTemplateDefinitionSc
 /**
  * Parse a raw YAML definition string into a validated ParsedTemplateDefinition.
  * Returns null if the YAML is invalid or fails schema validation.
+ *
+ * Uses the `yaml` package (not `js-yaml`) to match the parser used everywhere else
+ * templates are read (routes, `resolveTemplateFields`, the UI form sync). `js-yaml`
+ * defaults to YAML 1.1 scalar resolution (e.g. `no`/`yes`/`off`/`on`/octals parse as
+ * booleans or numbers rather than strings), which would silently diverge from the
+ * `extended_fields` the UI pre-fills for the same stored definition.
  */
 export const parseTemplateDefinition = (
   definitionYaml: string
 ): ParsedTemplateDefinition | null => {
   try {
-    const raw = yaml.load(definitionYaml);
+    const raw = parseYaml(definitionYaml);
     const result = ParsedTemplateDefinitionSchema.safeParse(raw);
     return result.success ? result.data : null;
   } catch {


### PR DESCRIPTION
## What & Why
The v2 template connector (`v2_template_utils.ts`) parsed stored YAML definitions with `js-yaml` (YAML 1.1), while every other consumer of the same definitions — the create/patch routes, the shared `resolveTemplateFields`, and the UI form sync — uses the `yaml` package (YAML 1.2). Legacy scalars like `no`/`yes`/`off`/`on` resolve as booleans under YAML 1.1 but as plain strings under 1.2, so a field default of `no` silently became `''` in the connector's `extended_fields` while the UI pre-filled it as `"no"`. Switched the connector to use `yaml`'s `parse` for parity.

## How to Test
1. Create a v2 template with a field `metadata.default: no` (or `yes`/`off`/`on`).
2. Trigger a rule using this template via the Cases connector and inspect the created case's custom field value.
3. Open the same template in the template editor form and confirm the pre-filled default matches what the connector applied.
4. Run `node scripts/jest x-pack/platform/plugins/shared/cases/server/connectors/cases/v2_template_utils.test.ts` — includes a new regression test for the legacy-scalar case.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->