### PR TITLE
[ES|QL] Console highlighting should rely on esqlCommandRegistry for available commands

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts
@@ -44,6 +44,9 @@ const mockConsoleParsedRequestsProvider = jest.fn<
 
 jest.mock('@kbn/esql-language', () => ({
   suggest: (...args: Parameters<typeof mockSuggest>) => mockSuggest(...args),
+  // esql_lexer_rules.ts reads this eagerly at module-load time to build its keyword list, so
+  // it needs a stub here even though this suite doesn't exercise highlighting.
+  esqlCommandRegistry: { getAllCommandNames: () => [] },
 }));
 
 jest.mock('../esql/lib/converters/suggestions', () => ({

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/nested_esql.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/nested_esql.test.ts
@@ -95,5 +95,14 @@ describe('Console nested ES|QL lexer rules', () => {
       expect(esqlLanguageAttributes.keywords).toEqual(keywords);
       expect(esqlLanguageAttributes.builtinFunctions).toEqual(builtinFunctions);
     });
+
+    it('includes source commands and other commands missing from the generated command list', () => {
+      // These are registered in @kbn/esql-language's command registry but are absent from the
+      // auto-generated EsqlCommandNames enum (which is derived from Elasticsearch definitions
+      // and omits source commands). See https://github.com/elastic/kibana/issues/265521.
+      expect(keywords).toEqual(
+        expect.arrayContaining(['from', 'row', 'show', 'ts', 'promql', 'join', 'set', 'fuse'])
+      );
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/esql_lexer_rules.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/esql_lexer_rules.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EsqlCommandNames } from '@kbn/esql-language/src/commands/definitions/generated/commands/commands';
+import { esqlCommandRegistry } from '@kbn/esql-language';
 import { esqlFunctionNames } from '@kbn/esql-language/src/commands/definitions/generated/function_names';
 import type { monaco } from '../../../monaco_imports';
 
@@ -20,7 +20,11 @@ const brackets = [
 // to ensure single-quoted and triple-quoted ES|QL strings in Console share the same highlighting.
 const CLAUSE_KEYWORDS = ['by', 'on', 'with', 'metadata'];
 
-export const keywords = [...Object.values(EsqlCommandNames), ...CLAUSE_KEYWORDS];
+// The command registry is the source of truth for which commands Kibana supports (it's what
+// drives validation and autocomplete), so it's used here too. The generated `EsqlCommandNames`
+// enum is derived from Elasticsearch definitions and omits source commands (e.g. FROM, ROW,
+// SHOW, TS, PROMQL) plus a few others, which used to leave them unhighlighted.
+export const keywords = [...esqlCommandRegistry.getAllCommandNames(), ...CLAUSE_KEYWORDS];
 
 export const builtinFunctions = esqlFunctionNames;
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.test.tsx
@@ -73,6 +73,9 @@ jest.mock('@kbn/esql-language', () => ({
   EsqlQuery: {
     fromSrc: jest.fn().mockReturnValue({}),
   },
+  // @kbn/monaco's Console ES|QL lexer reads this eagerly at module-load time to build its
+  // keyword list, so it needs a stub here even though this suite doesn't exercise highlighting.
+  esqlCommandRegistry: { getAllCommandNames: () => [] },
 }));
 
 const mockGetESQLStatsQueryMeta = jest.requireMock('@kbn/esql-utils').getESQLStatsQueryMeta;

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.perf.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.perf.test.ts
@@ -12,6 +12,9 @@ const mockValidateQuery = jest.fn();
 jest.mock('@kbn/esql-language', () => ({
   __esModule: true,
   validateQuery: (...args: unknown[]) => mockValidateQuery(...args),
+  // @kbn/monaco's Console ES|QL lexer reads this eagerly at module-load time to build its
+  // keyword list, so it needs a stub here even though this suite doesn't exercise highlighting.
+  esqlCommandRegistry: { getAllCommandNames: () => [] },
 }));
 
 // eslint-disable-next-line import/no-nodejs-modules

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/esql_query/get_esql_query_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/esql_query/get_esql_query_suggestions.test.ts
@@ -18,6 +18,9 @@ const mockSuggest = jest.fn();
 jest.mock('@kbn/esql-language', () => ({
   __esModule: true,
   suggest: (...args: unknown[]) => mockSuggest(...args),
+  // @kbn/monaco's Console ES|QL lexer reads this eagerly at module-load time to build its
+  // keyword list, so it needs a stub here even though this suite doesn't exercise highlighting.
+  esqlCommandRegistry: { getAllCommandNames: () => [] },
 }));
 
 const stubCallbacks: ESQLCallbacks = {};


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/273324

## Summary

Console's ES|QL syntax highlighter should source its keyword list from `esqlCommandRegistry` instead of the auto-generated command enum, which was missing several source commands and left them as plain text.

<img width="717" height="293" alt="Screenshot 2026-07-09 at 13 53 28" src="https://github.com/user-attachments/assets/b86e0333-c34c-492d-8d86-9b488251084c" />

