### PR TITLE
[flaky-runner] Bump default Cypress agent disk to 110GB

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -60,7 +60,7 @@ function defaultCypressFlakyAgentOptions(pathHint: string): {
   const defendWorkflows = pathHint.includes('defend_workflows');
   return {
     agentQueue: defendWorkflows ? 'n2-4-virt' : 'n2-4-spot',
-    diskSizeGb: defendWorkflows ? 120 : undefined,
+    diskSizeGb: defendWorkflows ? 120 : 110,
   };
 }
 


### PR DESCRIPTION
## Summary

Bumps the default agent boot-disk size for non-`defend_workflows` Cypress (and `command`-type) suites in the flaky test runner from the agent image default of **105 GB** to **110 GB**.

Previously `defaultCypressFlakyAgentOptions` returned `diskSizeGb: undefined` for these suites, so they fell back to `DEFAULT_AGENT_IMAGE_CONFIG.diskSizeGb` (105 GB). This gives Security Solution Cypress suites (e.g. Investigations) more headroom in the flaky runner, matching the 110 GB the PR pipeline already grants Investigations (`.buildkite/pipelines/pull_request/security_solution/investigations.yml`).

## Scope

`defaultCypressFlakyAgentOptions` is shared by both the Cypress `group` case and the `command` case in `.buildkite/pipelines/flaky_tests/pipeline.ts`, so this applies to every non-`defend_workflows` flaky Cypress suite plus any `command` suite that doesn't set its own `diskSizeGb`. `defend_workflows` (120 GB) is unchanged. There is no per-suite disk override for `group` suites, so the shared default is the intended lever.

## Diff

```diff
-    diskSizeGb: defendWorkflows ? 120 : undefined,
+    diskSizeGb: defendWorkflows ? 120 : 110,
```