### PR TITLE
[DOCS] Document maxUploadResponseActionFileBytes default and maximum values

### DIFF
--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -54,12 +54,20 @@ groups:
 
       - setting: xpack.securitySolution.maxUploadResponseActionFileBytes
         description: |
-          Allow to configure the max file upload size for use with the Upload File Response action available with the Defend Integration. To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
+          Configure the maximum file size for use with the `upload` response action available with the Elastic Defend integration. To learn more, check [Endpoint response actions](docs-content://solutions/security/endpoint-response-actions.md#_upload).
+
+          The default and maximum values vary by version:
+
+          * {applies_to}`stack: ga 9.5+` {applies_to}`serverless:` **Default**: `524288000` bytes (500 MB). **Maximum**: no limit.
+          * {applies_to}`stack: ga 8.9-9.4` **Default**: `26214400` bytes (25 MB). **Maximum**: `104857600` bytes (100 MB).
         datatype: int
         applies_to:
           stack: ga 8.9
           ech: ga
           self: ga
+        note: |
+          :applies_to: {stack: ga 9.5+, serverless: ga}
+          Setting this value too high may cause timeouts, depending on your cluster's setup and resources.
 
       - setting: xpack.securitySolution.disableEndpointRuleAutoInstall
         description: |

--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -58,7 +58,7 @@ groups:
 
           The default and maximum values vary by version:
 
-          * {applies_to}`stack: ga 9.5+` {applies_to}`serverless:` **Default**: `524288000` bytes (500 MB). **Maximum**: no limit.
+          * {applies_to}`stack: ga 9.5+` {applies_to}`serverless:` **Default**: `500000000` bytes (500 MB). **Maximum**: no limit.
           * {applies_to}`stack: ga 8.9-9.4` **Default**: `26214400` bytes (25 MB). **Maximum**: `104857600` bytes (100 MB).
         datatype: int
         applies_to:


### PR DESCRIPTION
## Summary

Documents the file size default and maximum changes for the `upload` endpoint response action (from [#275850](https://github.com/elastic/kibana/pull/275850)) in the Security Solution settings reference source.

Updates the `xpack.securitySolution.maxUploadResponseActionFileBytes` entry in `docs/reference/configuration-reference/security-solution-settings.yml` to:

- Document the per-version **default** and **maximum** cumulatively:
  - `stack: ga 9.5+` / serverless — default `524288000` bytes (500 MB), no maximum.
  - `stack: ga 8.9-9.4` — default `26214400` bytes (25 MB), maximum `104857600` bytes (100 MB).
- Add a note that setting the value too high may cause timeouts, depending on the cluster's setup and resources.

Preview: https://docs-v3-preview.elastic.dev/elastic/kibana/pull/277170/reference/configuration-reference/security-solution-settings#elastic-defend-settings

Companion docs PR: elastic/docs-content#7306
Related issue: elastic/docs-content#7274

Made with [Cursor](https://cursor.com)