### PR TITLE
[Significant Events] Round-robin detection scan batch scheduling

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/scheduled_detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/scheduled_detection.yaml
@@ -26,3 +26,5 @@ steps:
       workflow-id: "system-significant-events-detection"
       inputs:
         lookback: "now-__DETECTION_LOOKBACK_MINUTES__m"
+        # Threaded so the detection workflow can size its round-robin scan batch to the run cadence.
+        detectionIntervalMinutes: __DETECTION_INTERVAL_MINUTES__

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
@@ -28,8 +28,10 @@ triggers:
         description: "Fixed interval for the date_histogram bucketing inside change_point."
       - name: quickRecoveryLookback
         type: string
-        default: "now-11m"
+        default: "now-12m"
         required: false
+        # At 30s buckets with extended_bounds max:now, now-12m yields ~25 buckets (ES found=24),
+        # a safe margin over the 22-bucket minimum.
         description: "Short window for fast-path recovery; must yield ≥22 buckets at bucket_interval."
       - name: cooldown
         type: string
@@ -39,8 +41,11 @@ triggers:
 consts:
   ACTIVITY_HISTORY_LOOKBACK: "now-1h"
   ACTIVITY_WINDOW_INTERVAL: "30m"
-  BOOTSTRAP_MIN_ALERT_COUNT: 20
-  CP_TYPE_INDETERMINABLE: "indeterminable"
+  # Allowlist of change_point types that represent an ACTUAL change.
+  CP_CHANGE_TYPES: ["spike", "dip", "step_change", "trend_change", "distribution_change"]
+  # BOTH mean no change: "stationary" (no change found) and "non_stationary"
+  CP_NO_CHANGE_TYPES: ["stationary", "non_stationary"]
+  # Canonical no-change type written on resolution (quiet) docs.
   CP_TYPE_STATIONARY: "stationary"
   DETECTIONS_INDEX: ".significant_events-detections"
   DETECTION_RETENTION_WINDOW: "now-24h"
@@ -52,15 +57,18 @@ consts:
   STALE_SCAN_SIZE: 100
   RECENT_ACTIVITY_MINUTES: 5
   RESOLUTION_WINDOW_MINUTES: 60
-  RULES_BUCKET_SIZE: 1000
+  # Min historical peak (distinct alerts) for is_quiet_stationary to auto-resolve on silence alone.
+  QUIET_STATIONARY_MIN_PEAK: 30
 steps:
   # Copy workflow.spaceId into variables so ES body Liquid expressions can reference it.
-  - name: set_space_vars
+  - name: set_init_vars
     type: data.set
     with:
       spaceId: "{{ workflow.spaceId }}"
+      floor_seconds: "${{ consts.LOOKBACK_MINUTES_FLOOR | times: 60 }}"
   # -----------------------------------------------------------------------
-  # Pre-pass: Early exit — skip when no alerts and no active detections.
+  # Pre-pass: early exit on idle spaces — two cheap counts skip the expensive scan when there are
+  # no alerts and no active detections (per-space scheduled workflow; many spaces may be idle).
   # -----------------------------------------------------------------------
   - name: count_alerts_in_lookback
     type: kibana.request
@@ -108,11 +116,15 @@ steps:
       reason: "No recent alerts and no active detections — change point scan skipped"
 
   # -----------------------------------------------------------------------
-  # Stale sweep — two-step truth check to avoid redundant quiet writes.
+  # Stale sweep — resolve rules that went silent (no alerts → absent from the scan below, so the
+  # per-rule recovery never sees them). This sweep is their only resolution path.
   # -----------------------------------------------------------------------
   - name: get_stale_candidates
-    # WITH lte — candidates whose latest doc within the window is a detection.
-    # lte excludes rules resolved within LOOKBACK_MINUTES_FLOOR.
+    # Latest non-handled doc per rule (collapse, no lte): a rule resolved by a recent quiet doc
+    # collapses to that quiet and fails the kind==detection check below; staleness (age > floor)
+    # is decided per-item from @timestamp — no second query needed.
+    # must_not:handled is resolution semantics: `quiet` closes a detection, `handled` (discovery's
+    # "consumed" marker) does not. Do NOT add `quiet` here — it would hide the closure signal.
     type: elasticsearch.request
     with:
       method: POST
@@ -129,37 +141,6 @@ steps:
             filter:
               - term:
                   kibana.space_ids: "{{ variables.spaceId }}"
-              - range:
-                  "@timestamp":
-                    gte: '{{ consts.DETECTION_RETENTION_WINDOW }}'
-                    lte: "now-{{ consts.LOOKBACK_MINUTES_FLOOR }}m"
-            must_not:
-              - term:
-                  kind: '{{ consts.KIND_HANDLED }}'
-    on-failure:
-      continue: true
-
-  - name: get_stale_candidate_docs
-    # WITHOUT lte — reveals quiet docs outside the lte window.
-    type: elasticsearch.request
-    if: "${{ steps.get_stale_candidates.error == null and steps.get_stale_candidates.output.hits.total.value > 0 }}"
-    with:
-      method: POST
-      path: '/{{ consts.DETECTIONS_INDEX }}/_search?ignore_unavailable=true'
-      body:
-        size: "${{ consts.STALE_SCAN_SIZE }}"
-        sort:
-          - "@timestamp":
-              order: desc
-        collapse:
-          field: rule_uuid
-        query:
-          bool:
-            filter:
-              - term:
-                  kibana.space_ids: "{{ variables.spaceId }}"
-              - terms:
-                  rule_uuid: "${{ steps.get_stale_candidates.output.hits.hits | where: '_source.kind', 'detection' | map: '_source.rule_uuid' }}"
               - range:
                   "@timestamp":
                     gte: '{{ consts.DETECTION_RETENTION_WINDOW }}'
@@ -171,44 +152,28 @@ steps:
 
   - name: foreach_stale_candidate
     type: foreach
-    if: "${{ steps.get_stale_candidate_docs.error == null and steps.get_stale_candidate_docs.output.hits.total.value > 0 }}"
-    foreach: "${{ steps.get_stale_candidate_docs.output.hits.hits }}"
+    if: "${{ steps.get_stale_candidates.error == null and steps.get_stale_candidates.output.hits.total.value > 0 }}"
+    foreach: "${{ steps.get_stale_candidates.output.hits.hits }}"
     steps:
-      - name: check_doc_is_fresh
-        # get_stale_candidate_docs (no lte) can surface detections written within
-        # LOOKBACK_MINUTES_FLOOR that get_stale_candidates (with lte) never saw.
-        if: "${{ foreach.item._source.kind == consts.KIND_DETECTION }}"
-        type: elasticsearch.request
-        with:
-          method: POST
-          path: '/{{ consts.DETECTIONS_INDEX }}/_count?ignore_unavailable=true'
-          body:
-            query:
-              bool:
-                filter:
-                  - term:
-                      kibana.space_ids: "{{ variables.spaceId }}"
-                  - term:
-                      rule_uuid: "${{ foreach.item._source.rule_uuid }}"
-                  - term:
-                      kind: '{{ consts.KIND_DETECTION }}'
-                  - range:
-                      "@timestamp":
-                        gte: "now-{{ consts.LOOKBACK_MINUTES_FLOOR }}m"
-        on-failure:
-          continue: true
-
-      - name: compute_stale_candidate
+      - name: compute_stale_epochs
+        # Epoch numbers so the age check is a plain compare below (liquid has no date math, and
+        # sibling data.set fields can't reference each other). floor_seconds = LOOKBACK_MINUTES_FLOOR*60.
         type: data.set
         with:
-          is_not_fresh: >-
+          item_epoch: "${{ foreach.item._source['@timestamp'] | date: '%s' | plus: 0 }}"
+          stale_before_epoch: "${{ 'now' | date: '%s' | minus: variables.floor_seconds | plus: 0 }}"
+
+      - name: compute_stale_candidate
+        # Stale = latest non-handled doc is a detection older than the floor. is_stale implies
+        # kind==detection, so downstream steps don't re-check it.
+        type: data.set
+        with:
+          is_stale: >-
             ${{ foreach.item._source.kind == consts.KIND_DETECTION
-            and steps.check_doc_is_fresh.error != null
-            or foreach.item._source.kind == consts.KIND_DETECTION
-            and steps.check_doc_is_fresh.output.count < 1 }}
+            and steps.compute_stale_epochs.output.item_epoch < steps.compute_stale_epochs.output.stale_before_epoch }}
 
       - name: check_recent_alerts_for_stale
-        if: "${{ foreach.item._source.kind == consts.KIND_DETECTION and steps.compute_stale_candidate.output.is_not_fresh }}"
+        if: "${{ steps.compute_stale_candidate.output.is_stale }}"
         type: kibana.request
         with:
           method: POST
@@ -224,8 +189,7 @@ steps:
       - name: write_stale_quiet_doc
         type: elasticsearch.request
         if: >-
-          ${{ foreach.item._source.kind == consts.KIND_DETECTION
-          and steps.compute_stale_candidate.output.is_not_fresh
+          ${{ steps.compute_stale_candidate.output.is_stale
           and steps.check_recent_alerts_for_stale.error == null
           and steps.check_recent_alerts_for_stale.output.count < 1 }}
         with:
@@ -380,34 +344,49 @@ steps:
           prior_type: "{% if steps.check_recent_active.output.hits.total.value > 0 and steps.check_recent_active.output.hits.hits[0]._source.kind == consts.KIND_DETECTION %}{{ steps.check_recent_active.output.hits.hits[0]._source.detection_evidence.change_point_type | default: '' }}{% else %}{% endif %}"
 
       - name: compute_event_signals
+        # Both occurrence signals require the state lookups to have succeeded: check_recent_active/
+        # check_recent_clearance run on-failure:continue, so on error their flags read false and
+        # would flip these true → spurious detection. The error==null guards suppress that write.
         type: data.set
         with:
-          has_change_point: >-
-            ${{ steps.compute_rule_context.output.change_point_type != ''
-            and steps.compute_rule_context.output.change_point_type != consts.CP_TYPE_STATIONARY }}
+          has_change_point: "${{ consts.CP_CHANGE_TYPES contains steps.compute_rule_context.output.change_point_type }}"
           is_new_occurrence: >-
-            ${{ not steps.compute_rule_state.output.is_recent_active
+            ${{ steps.check_recent_active.error == null
+            and steps.check_recent_clearance.error == null
+            and not steps.compute_rule_state.output.is_recent_active
             and not steps.compute_rule_state.output.is_recent_clearance
             and foreach.item.last_5m.doc_count > 0 }}
           is_type_changed: >-
-            ${{ steps.compute_rule_context.output.change_point_type != steps.compute_change_point_type.output.prior_type
+            ${{ steps.check_recent_active.error == null
+            and steps.check_recent_clearance.error == null
+            and steps.compute_rule_context.output.change_point_type != steps.compute_change_point_type.output.prior_type
             and not steps.compute_rule_state.output.is_recent_clearance
             and foreach.item.last_5m.doc_count > 0 }}
 
       - name: compute_gates
         type: data.set
         with:
-          is_detectable: >-
-            ${{ steps.compute_event_signals.output.has_change_point
-            or steps.compute_rule_context.output.change_point_type == consts.CP_TYPE_STATIONARY
-            and steps.check_active_result.output.hits.total.value < 1
-            and foreach.item.doc_count >= consts.BOOTSTRAP_MIN_ALERT_COUNT }}
+          # A real change point is the only detectable signal (the old stationary-bootstrap branch
+          # was unreachable under v2's ~1 cardinality doc_count; new rules → is_new_occurrence).
+          is_detectable: "${{ steps.compute_event_signals.output.has_change_point }}"
+          # Genuine state transitions only — a transient lookup error must not force a write.
           needs_new_event: >-
-            ${{ steps.check_recent_active.error != null
-            or steps.check_recent_clearance.error != null
-            or steps.compute_change_point_type.error != null
-            or steps.compute_event_signals.output.is_new_occurrence
+            ${{ steps.compute_event_signals.output.is_new_occurrence
             or steps.compute_event_signals.output.is_type_changed }}
+
+      - name: compute_write_gate
+        # Split into flat booleans because the Liquid engine gives and/or EQUAL precedence: an
+        # inline `A and B and C or A and D` mis-parses and drops the is_new_occurrence path. The
+        # write step ORs these two already-resolved booleans instead.
+        type: data.set
+        with:
+          should_write_change_point: >-
+            ${{ steps.compute_rule_context.output.has_rule_uuid
+            and steps.compute_gates.output.is_detectable
+            and steps.compute_gates.output.needs_new_event }}
+          should_write_new_occurrence: >-
+            ${{ steps.compute_rule_context.output.has_rule_uuid
+            and steps.compute_event_signals.output.is_new_occurrence }}
 
       # Phase 2: Quick recovery
       - name: run_quick_recovery
@@ -431,7 +410,9 @@ steps:
           - name: compute_quick_recovery_type
             type: data.set
             with:
-              quick_recovery_type: "${{ steps.get_quick_recovery_change_point.output.aggregations.change_points.type | entries | map: 'key' | first | default: consts.CP_TYPE_INDETERMINABLE }}"
+              # "" when the agg returned nothing (e.g. failed). Downstream only tests membership in
+              # CP_NO_CHANGE_TYPES, so "" reads as "not recovered" without a bogus type.
+              quick_recovery_type: "${{ steps.get_quick_recovery_change_point.output.aggregations.change_points.type | entries | map: 'key' | first | default: '' }}"
 
           - name: get_quick_recovery_day_over_day
             type: kibana.request
@@ -465,7 +446,7 @@ steps:
                 and steps.compute_quick_recovery_thresholds.output.quick_recovery_current <= steps.compute_quick_recovery_thresholds.output.quick_recovery_spike_threshold }}
               first_run_all_clear: >-
                 ${{ steps.compute_quick_recovery_thresholds.output.quick_recovery_reference < 1
-                and steps.compute_rule_context.output.change_point_type == consts.CP_TYPE_STATIONARY }}
+                and consts.CP_NO_CHANGE_TYPES contains steps.compute_rule_context.output.change_point_type }}
               first_run_rate_dropped: >-
                 ${{ steps.compute_quick_recovery_thresholds.output.quick_recovery_reference < 1
                 and steps.compute_quick_recovery_thresholds.output.current_rate_scaled <= steps.compute_quick_recovery_thresholds.output.detection_rate_scaled }}
@@ -499,46 +480,42 @@ steps:
         with:
           peak_alert_count: "${{ steps.get_rule_activity.output.aggregations.peak.value | default: 0 }}"
           resolution_lookback_minutes: "{% assign parent = steps.check_active_result.output.hits.hits[0]._source.resolution_lookback_minutes | default: 0 | plus: 0 %}{% if parent > 0 %}{{ parent }}{% else %}{%- assign peak = steps.get_rule_activity.output.aggregations.peak.value | default: 0 | at_least: 1 -%}{{ consts.RESOLUTION_WINDOW_MINUTES | divided_by: peak | at_least: consts.LOOKBACK_MINUTES_FLOOR | at_most: consts.LOOKBACK_MINUTES_CEILING }}{% endif %}"
+          # Recovery = an open detection (a real change) has gone quiet and is back to no-change.
+          # is_quick_recovery vs is_stationary_recovery differ only on whether the QUICK re-scan
+          # confirms no-change (mutually exclusive on that).
           is_quick_recovery: >-
             ${{ steps.compute_rule_state.output.latest_is_detection
             and foreach.item.last_5m.doc_count == 0
-            and steps.compute_quick_recovery_type.output.quick_recovery_type == consts.CP_TYPE_STATIONARY
+            and consts.CP_NO_CHANGE_TYPES contains steps.compute_quick_recovery_type.output.quick_recovery_type
             and steps.compute_quick_recovery_gate.output.quick_recovery_rate_is_normal
-            and steps.check_active_result.output.hits.hits[0]._source.detection_evidence.change_point_type != consts.CP_TYPE_STATIONARY }}
+            and consts.CP_CHANGE_TYPES contains steps.check_active_result.output.hits.hits[0]._source.detection_evidence.change_point_type }}
           is_stationary_recovery: >-
             ${{ steps.compute_rule_state.output.latest_is_detection
             and foreach.item.last_5m.doc_count == 0
-            and steps.compute_rule_context.output.change_point_type == consts.CP_TYPE_STATIONARY
-            and steps.check_active_result.output.hits.hits[0]._source.detection_evidence.change_point_type != consts.CP_TYPE_STATIONARY
-            and steps.compute_quick_recovery_type.output.quick_recovery_type != consts.CP_TYPE_STATIONARY }}
+            and consts.CP_NO_CHANGE_TYPES contains steps.compute_rule_context.output.change_point_type
+            and consts.CP_CHANGE_TYPES contains steps.check_active_result.output.hits.hits[0]._source.detection_evidence.change_point_type
+            and not consts.CP_NO_CHANGE_TYPES contains steps.compute_quick_recovery_type.output.quick_recovery_type }}
           is_quiet_stationary: >-
             ${{ steps.compute_rule_state.output.latest_is_detection
             and foreach.item.last_5m.doc_count == 0
             and foreach.item.last_floor_window.doc_count == 0
-            and steps.check_active_result.output.hits.hits[0]._source.peak_alert_count >= 30 }}
+            and steps.check_active_result.output.hits.hits[0]._source.peak_alert_count >= consts.QUIET_STATIONARY_MIN_PEAK }}
 
       - name: compute_write_ids
-        # detection_id: carry over only when the episode is still open (most recent doc is kind:detection).
-        #   A kind:quiet or kind:handled doc after the detection means the episode closed; a re-fire
-        #   must start a fresh episode with a new id even if the change-point type differs.
-        # quiet_p_value: source differs by recovery type.
+        # detection_id: carry over only while the episode is still open (latest doc is a detection);
+        # a later quiet/handled means it closed → a re-fire starts a fresh id. quiet_p_value source
+        # differs by recovery type.
         type: data.set
         with:
           detection_id: "{% if steps.compute_event_signals.output.is_type_changed and steps.check_recent_active.output.hits.total.value > 0 and steps.check_recent_clearance.output.hits.hits[0]._source.kind == consts.KIND_DETECTION %}{{ steps.check_recent_active.output.hits.hits[0]._source.detection_id }}{% else %}{{ foreach.item.key }}-{{ execution.id }}{% endif %}"
           quiet_p_value: "{% if steps.compute_write_signals.output.is_quick_recovery %}{{ steps.get_quick_recovery_change_point.output.aggregations.change_points.type.stationary.p_value | default: 0 }}{% elsif steps.compute_write_signals.output.is_stationary_recovery %}{{ foreach.item.change_points.type.stationary.p_value | default: 0 }}{% else %}0{% endif %}"
 
       - name: write_detection_doc
-        # Two paths to a new detection doc:
-        # 1. change_point signal (or stationary bootstrap for brand-new rules) + needs_new_event
-        # 2. is_new_occurrence — quiet→active transition bypasses is_detectable because the
-        #    transition itself is the signal; no change_point edge needed.
-        #    doc_count guard keeps the bootstrap minimum consistent with path 1.
+        # Two write paths (flat booleans from compute_write_gate): a real change_point signal, or
+        # is_new_occurrence — a quiet→active transition, which is itself the signal.
         if: >-
-          ${{ steps.compute_rule_context.output.has_rule_uuid
-          and steps.compute_gates.output.is_detectable
-          and steps.compute_gates.output.needs_new_event
-          or steps.compute_rule_context.output.has_rule_uuid
-          and steps.compute_event_signals.output.is_new_occurrence }}
+          ${{ steps.compute_write_gate.output.should_write_change_point
+          or steps.compute_write_gate.output.should_write_new_occurrence }}
         type: elasticsearch.request
         with:
           method: POST

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
@@ -42,12 +42,12 @@ triggers:
         type: number
         default: 10
         required: false
-        description: "Every active rule must be evaluated within this window; drives the per-run scan batch size."
+        description: "Target window within which every active rule should be evaluated (best-effort under periodic scheduling); drives the per-run scan shard size."
       - name: detectionIntervalMinutes
         type: number
         default: 5
         required: false
-        description: "How often this workflow runs (threaded from the scheduler). coverage cycles = target / interval."
+        description: "Actual run cadence, threaded from the scheduler — MUST match the real schedule or coverage skews. coverage cycles = floor(target / interval)."
 consts:
   ACTIVITY_HISTORY_LOOKBACK: "now-1h"
   ACTIVITY_WINDOW_INTERVAL: "30m"
@@ -145,7 +145,7 @@ steps:
       and not steps.compute_idle_counts.output.stale_query_failed }}
     status: cancelled
     with:
-      reason: "No recent alerts and no active detections — change point scan skipped"
+      reason: "No recent alerts and no open detections — change point scan skipped"
 
   # -----------------------------------------------------------------------
   # Stale sweep — resolve rules that went silent (no alerts → absent from the scan below, so the
@@ -217,21 +217,33 @@ steps:
 
   # -----------------------------------------------------------------------
   # Round-robin scan scheduling (stateless, hash-sharded). Each run processes only a bounded shard of
-  # active rules so per-run work stays flat as the fleet grows, while guaranteeing every active rule
-  # is evaluated within targetCoverageMinutes. Two tiers, both derived WITHOUT any persisted state:
+  # active rules so the per-rule state loop (the N+1 fan-out) stays flat as the fleet grows. NOTE: the
+  # main change_point aggregation below still scans the whole fleet each run — only the foreach's
+  # per-rule work is sharded. Two tiers, both derived WITHOUT any persisted state:
   #   Tier 1 (urgent): any rule whose CURRENT scan shows a real change signal is processed EVERY
   #                    cycle, uncapped — a live signal must never wait for queue fairness.
   #   Tier 2 (fairness): a deterministic time-shard. The scan route hashes each rule id into
-  #                    coverage_cycles partitions (ES terms partitioning, murmur3); this run takes the
-  #                    partition equal to the wall-clock cycle. Over coverage_cycles runs every
-  #                    partition is covered exactly once = full fleet coverage within the target.
+  #                    coverage_cycles partitions (ES terms partitioning, hash-based); this run takes
+  #                    the partition equal to the wall-clock cycle, sweeping partitions 0..N-1 over N
+  #                    runs. Coverage is best-effort within targetCoverageMinutes under periodic
+  #                    execution — a skipped/jittered run defers a partition up to ~2× the target
+  #                    (rules self-heal next sweep); the independent stale sweep backstops silence.
+  #                    Bounded by the by_rule RULES_BUCKET_SIZE (1000) cap the foreach iterates.
   # -----------------------------------------------------------------------
-  - name: compute_scan_cycles
-    # coverage_cycles = runs needed to sweep the fleet once = ceil(target / interval), min 1.
-    # Doubles as num_partitions for the hash shard.
+  - name: compute_scan_config
+    # safe_interval guards the divisions below against a misconfigured detectionIntervalMinutes <= 0
+    # (divide-by-zero → NaN → the scan route's z.number() rejects → the whole run aborts).
     type: data.set
     with:
-      coverage_cycles: "${{ inputs.targetCoverageMinutes | divided_by: inputs.detectionIntervalMinutes | ceil | at_least: 1 }}"
+      safe_interval_minutes: "${{ inputs.detectionIntervalMinutes | at_least: 1 }}"
+
+  - name: compute_scan_cycles
+    # coverage_cycles = partitions to sweep the fleet once = floor(target / interval), min 1. floor (not
+    # ceil) keeps the sweep (coverage_cycles * interval) WITHIN targetCoverageMinutes; ceil would
+    # overshoot (e.g. 10/3 → 4 partitions → 12min > 10). Doubles as num_partitions for the hash shard.
+    type: data.set
+    with:
+      coverage_cycles: "${{ inputs.targetCoverageMinutes | divided_by: steps.compute_scan_config.output.safe_interval_minutes | floor | at_least: 1 }}"
 
   - name: compute_current_cycle
     # cycle = floor(now_seconds / (interval * 60)) mod coverage_cycles — advances by 1 each run on the
@@ -240,7 +252,7 @@ steps:
     type: data.set
     with:
       current_cycle: >-
-        ${{ 'now' | date: '%s' | divided_by: inputs.detectionIntervalMinutes | divided_by: 60
+        ${{ 'now' | date: '%s' | divided_by: steps.compute_scan_config.output.safe_interval_minutes | divided_by: 60
         | floor | modulo: steps.compute_scan_cycles.output.coverage_cycles }}
 
   # -----------------------------------------------------------------------
@@ -290,13 +302,14 @@ steps:
       # Phase 1: Read state
       - name: compute_rule_context
         # change_point_type computed once — used as a dynamic key and in multiple conditions.
-        # has_rule_uuid guards writes: by_rule buckets with an empty key produce broken docs.
+        # should_process_rule gates every write/lookup in this iteration. It combines TWO conditions:
+        # (a) a non-empty rule key (empty-key buckets produce broken docs), and (b) this rule is in
+        # this run's scan batch (urgent ∪ shard) — rules outside the shard are skipped entirely (no
+        # work) and picked up a later cycle. Named for the gate it performs, not just the key check.
         type: data.set
         with:
           change_point_type: "${{ foreach.item.change_points.type | entries | map: 'key' | first | default: '' }}"
-          # has_rule_uuid gates every write in this iteration; ANDing the batch membership here means
-          # rules outside this run's shard are skipped entirely (no work) and picked up a later cycle.
-          has_rule_uuid: >-
+          should_process_rule: >-
             ${{ foreach.item.key != null and foreach.item.key != ''
             and steps.compute_scan_batch.output.batch_rule_uuids contains foreach.item.key }}
 
@@ -307,9 +320,9 @@ steps:
         # reproduce the three former result sets exactly:
         #   latest_state    ≡ check_active_result   (latest doc, excl handled)
         #   recent_detection ≡ check_recent_active   (latest kind:detection within cooldown)
-        #   recent_any      ≡ check_recent_clearance (latest doc within 5m)
+        #   recent_any      ≡ check_recent_clearance (latest doc within RECENT_ACTIVITY_MINUTES)
         # size:0 at top level — only the sub-agg top_hits are consumed.
-        if: "${{ steps.compute_rule_context.output.has_rule_uuid }}"
+        if: "${{ steps.compute_rule_context.output.should_process_rule }}"
         type: elasticsearch.request
         with:
           method: POST
@@ -356,7 +369,7 @@ steps:
                         - "@timestamp":
                             order: desc
               recent_any:
-                # Latest doc of any kind within 5m; is_recent_clearance then checks kind == quiet.
+                # Latest doc of any kind within RECENT_ACTIVITY_MINUTES; is_recent_clearance then checks kind == quiet.
                 # Do NOT filter to quiet — handled docs act as timestamp barriers.
                 filter:
                   bool:
@@ -429,11 +442,11 @@ steps:
         type: data.set
         with:
           should_write_change_point: >-
-            ${{ steps.compute_rule_context.output.has_rule_uuid
+            ${{ steps.compute_rule_context.output.should_process_rule
             and steps.compute_gates.output.is_detectable
             and steps.compute_gates.output.needs_new_event }}
           should_write_new_occurrence: >-
-            ${{ steps.compute_rule_context.output.has_rule_uuid
+            ${{ steps.compute_rule_context.output.should_process_rule
             and steps.compute_event_signals.output.is_new_occurrence }}
 
       # Phase 2: Quick recovery

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
@@ -38,6 +38,16 @@ triggers:
         default: "now-30m"
         required: false
         description: "Suppress re-detection for this duration after a rule resolves."
+      - name: targetCoverageMinutes
+        type: number
+        default: 10
+        required: false
+        description: "Every active rule must be evaluated within this window; drives the per-run scan batch size."
+      - name: detectionIntervalMinutes
+        type: number
+        default: 5
+        required: false
+        description: "How often this workflow runs (threaded from the scheduler). coverage cycles = target / interval."
 consts:
   ACTIVITY_HISTORY_LOOKBACK: "now-1h"
   ACTIVITY_WINDOW_INTERVAL: "30m"
@@ -67,8 +77,8 @@ steps:
       spaceId: "{{ workflow.spaceId }}"
       floor_seconds: "${{ consts.LOOKBACK_MINUTES_FLOOR | times: 60 }}"
   # -----------------------------------------------------------------------
-  # Pre-pass: early exit on idle spaces — two cheap counts skip the expensive scan when there are
-  # no alerts and no active detections (per-space scheduled workflow; many spaces may be idle).
+  # Pre-pass: early exit on idle spaces — skip the expensive scan when there are no recent alerts
+  # and no open detections (per-space scheduled workflow; many spaces may be idle).
   # -----------------------------------------------------------------------
   - name: count_alerts_in_lookback
     type: kibana.request
@@ -82,49 +92,14 @@ steps:
     on-failure:
       continue: true
 
-  - name: count_active_detections
-    # Conservative overcount (ignores later quiet docs) — false positives just run change_point.
-    type: elasticsearch.request
-    with:
-      method: POST
-      path: '/{{ consts.DETECTIONS_INDEX }}/_count?ignore_unavailable=true'
-      body:
-        query:
-          bool:
-            filter:
-              - term:
-                  kibana.space_ids: "{{ variables.spaceId }}"
-              - term:
-                  kind: '{{ consts.KIND_DETECTION }}'
-              - range:
-                  "@timestamp":
-                    gte: '{{ consts.DETECTION_RETENTION_WINDOW }}'
-    on-failure:
-      continue: true
-
-  - name: compute_idle_counts
-    type: data.set
-    with:
-      alerts_count: "${{ steps.count_alerts_in_lookback.output.count | default: 1 }}"
-      detections_count: "${{ steps.count_active_detections.output.count | default: 1 }}"
-
-  - name: exit_no_active_alerts
-    type: workflow.output
-    if: "${{ steps.compute_idle_counts.output.alerts_count == 0 and steps.compute_idle_counts.output.detections_count == 0 }}"
-    status: cancelled
-    with:
-      reason: "No recent alerts and no active detections — change point scan skipped"
-
-  # -----------------------------------------------------------------------
-  # Stale sweep — resolve rules that went silent (no alerts → absent from the scan below, so the
-  # per-rule recovery never sees them). This sweep is their only resolution path.
-  # -----------------------------------------------------------------------
+  # get_stale_candidates runs FIRST (before the idle exit) so its result serves double duty:
+  # (a) the accurate open-detection count for the exit decision below, and (b) the input to the
+  # stale-resolution foreach further down. Latest non-handled doc per rule (collapse,
+  # no lte): a rule resolved by a recent quiet doc collapses to that quiet and fails the
+  # kind==detection check; staleness (age > floor) is decided per-item from @timestamp.
+  # must_not:handled is resolution semantics: `quiet` closes a detection, `handled` (discovery's
+  # "consumed" marker) does not. Do NOT add `quiet` here — it would hide the closure signal.
   - name: get_stale_candidates
-    # Latest non-handled doc per rule (collapse, no lte): a rule resolved by a recent quiet doc
-    # collapses to that quiet and fails the kind==detection check below; staleness (age > floor)
-    # is decided per-item from @timestamp — no second query needed.
-    # must_not:handled is resolution semantics: `quiet` closes a detection, `handled` (discovery's
-    # "consumed" marker) does not. Do NOT add `quiet` here — it would hide the closure signal.
     type: elasticsearch.request
     with:
       method: POST
@@ -150,6 +125,32 @@ steps:
     on-failure:
       continue: true
 
+  - name: compute_idle_counts
+    type: data.set
+    with:
+      alerts_count: "${{ steps.count_alerts_in_lookback.output.count | default: 1 }}"
+      # Open detections = collapsed latest-per-rule docs (handled already excluded) whose
+      # latest doc is still a detection. More accurate than a raw kind:detection _count, which also
+      # counts detections already resolved by a later quiet doc.
+      open_detections_count: "${{ steps.get_stale_candidates.output.hits.hits | default: [] | where: '_source.kind', consts.KIND_DETECTION | size }}"
+      # On a get_stale_candidates error the count above collapses to 0; this flag preserves the
+      # error-conservatism (error → run anyway, never silently skip) the old `| default: 1` gave.
+      stale_query_failed: "${{ steps.get_stale_candidates.error != null }}"
+
+  - name: exit_no_active_alerts
+    type: workflow.output
+    if: >-
+      ${{ steps.compute_idle_counts.output.alerts_count == 0
+      and steps.compute_idle_counts.output.open_detections_count == 0
+      and not steps.compute_idle_counts.output.stale_query_failed }}
+    status: cancelled
+    with:
+      reason: "No recent alerts and no active detections — change point scan skipped"
+
+  # -----------------------------------------------------------------------
+  # Stale sweep — resolve rules that went silent (no alerts → absent from the scan below, so the
+  # per-rule recovery never sees them). This sweep is their only resolution path.
+  # -----------------------------------------------------------------------
   - name: foreach_stale_candidate
     type: foreach
     if: "${{ steps.get_stale_candidates.error == null and steps.get_stale_candidates.output.hits.total.value > 0 }}"
@@ -215,7 +216,37 @@ steps:
           continue: true
 
   # -----------------------------------------------------------------------
-  # Step 1: Per-rule change_point over the main lookback.
+  # Round-robin scan scheduling (stateless, hash-sharded). Each run processes only a bounded shard of
+  # active rules so per-run work stays flat as the fleet grows, while guaranteeing every active rule
+  # is evaluated within targetCoverageMinutes. Two tiers, both derived WITHOUT any persisted state:
+  #   Tier 1 (urgent): any rule whose CURRENT scan shows a real change signal is processed EVERY
+  #                    cycle, uncapped — a live signal must never wait for queue fairness.
+  #   Tier 2 (fairness): a deterministic time-shard. The scan route hashes each rule id into
+  #                    coverage_cycles partitions (ES terms partitioning, murmur3); this run takes the
+  #                    partition equal to the wall-clock cycle. Over coverage_cycles runs every
+  #                    partition is covered exactly once = full fleet coverage within the target.
+  # -----------------------------------------------------------------------
+  - name: compute_scan_cycles
+    # coverage_cycles = runs needed to sweep the fleet once = ceil(target / interval), min 1.
+    # Doubles as num_partitions for the hash shard.
+    type: data.set
+    with:
+      coverage_cycles: "${{ inputs.targetCoverageMinutes | divided_by: inputs.detectionIntervalMinutes | ceil | at_least: 1 }}"
+
+  - name: compute_current_cycle
+    # cycle = floor(now_seconds / (interval * 60)) mod coverage_cycles — advances by 1 each run on the
+    # wall clock, so consecutive runs sweep partitions 0..coverage_cycles-1. Stateless: read from the
+    # clock, not a stored cursor. Chained divided_by (÷interval ÷60) = ÷ interval-seconds.
+    type: data.set
+    with:
+      current_cycle: >-
+        ${{ 'now' | date: '%s' | divided_by: inputs.detectionIntervalMinutes | divided_by: 60
+        | floor | modulo: steps.compute_scan_cycles.output.coverage_cycles }}
+
+  # -----------------------------------------------------------------------
+  # Step 1: Per-rule change_point over the main lookback. The route also returns partitionRuleIds —
+  # the rules in this run's hash shard (partition == current_cycle of coverage_cycles) — sharded
+  # server-side via ES terms partitioning, since the workflow can neither hash nor read the alerts index.
   # -----------------------------------------------------------------------
   - name: run_change_point_aggregation
     type: kibana.request
@@ -227,6 +258,26 @@ steps:
       body:
         lookback: '{{ inputs.lookback }}'
         bucketInterval: '{{ inputs.bucketInterval }}'
+        numPartitions: "${{ steps.compute_scan_cycles.output.coverage_cycles }}"
+        partition: "${{ steps.compute_current_cycle.output.current_cycle }}"
+
+  - name: compute_urgent_rules
+    type: data.set
+    with:
+      # Tier 1: buckets whose change_points.type carries any real change-type key (paren-free OR chain
+      # — liquid rejects parenthesized piped sub-expressions; membership-by-presence avoids extracting
+      # the key). Mirrors consts.CP_CHANGE_TYPES; keep the two in sync.
+      urgent_rule_uuids: >-
+        ${{ steps.run_change_point_aggregation.output.aggregations.by_rule.buckets | default: []
+        | where_exp: 'b', 'b.change_points.type.spike or b.change_points.type.dip or b.change_points.type.step_change or b.change_points.type.trend_change or b.change_points.type.distribution_change'
+        | map: 'key' | compact }}
+
+  - name: compute_scan_batch
+    # Final batch = tier-1 urgent (every cycle, uncapped) ∪ tier-2 shard (this cycle's partition, from
+    # the scan route). uniq guards the overlap. No persisted state, no marker writes, no extra query.
+    type: data.set
+    with:
+      batch_rule_uuids: "${{ steps.compute_urgent_rules.output.urgent_rule_uuids | concat: steps.run_change_point_aggregation.output.partitionRuleIds | uniq }}"
 
   # -----------------------------------------------------------------------
   # Step 2: Foreach rule bucket — detect, recover, resolve.
@@ -243,19 +294,28 @@ steps:
         type: data.set
         with:
           change_point_type: "${{ foreach.item.change_points.type | entries | map: 'key' | first | default: '' }}"
-          has_rule_uuid: "${{ foreach.item.key != null and foreach.item.key != '' }}"
+          # has_rule_uuid gates every write in this iteration; ANDing the batch membership here means
+          # rules outside this run's shard are skipped entirely (no work) and picked up a later cycle.
+          has_rule_uuid: >-
+            ${{ foreach.item.key != null and foreach.item.key != ''
+            and steps.compute_scan_batch.output.batch_rule_uuids contains foreach.item.key }}
 
-      - name: check_active_result
+      - name: check_rule_state
+        # Consolidated per-rule state lookup (N+1 fix): one request replaces the former three
+        # (check_active_result + check_recent_active + check_recent_clearance) — 3 round-trips per
+        # rule → 1. Three `filter` sub-aggs, each with a `top_hits` sub-agg preserving `_source`,
+        # reproduce the three former result sets exactly:
+        #   latest_state    ≡ check_active_result   (latest doc, excl handled)
+        #   recent_detection ≡ check_recent_active   (latest kind:detection within cooldown)
+        #   recent_any      ≡ check_recent_clearance (latest doc within 5m)
+        # size:0 at top level — only the sub-agg top_hits are consumed.
         if: "${{ steps.compute_rule_context.output.has_rule_uuid }}"
         type: elasticsearch.request
         with:
           method: POST
           path: '/{{ consts.DETECTIONS_INDEX }}/_search?ignore_unavailable=true'
           body:
-            size: 1
-            sort:
-              - "@timestamp":
-                  order: desc
+            size: 0
             query:
               bool:
                 filter:
@@ -263,64 +323,54 @@ steps:
                       kibana.space_ids: "{{ variables.spaceId }}"
                   - term:
                       rule_uuid: "{{ foreach.item.key }}"
-                must_not:
-                  - term:
-                      kind: '{{ consts.KIND_HANDLED }}'
-        on-failure:
-          continue: true
-
-      - name: check_recent_active
-        # kind:detection filter — a quiet doc written after a detection would otherwise
-        # suppress is_recent_active and allow re-detection after cooldown expires.
-        if: "${{ steps.compute_rule_context.output.has_rule_uuid }}"
-        type: elasticsearch.request
-        with:
-          method: POST
-          path: '/{{ consts.DETECTIONS_INDEX }}/_search?ignore_unavailable=true'
-          body:
-            size: 1
-            sort:
-              - "@timestamp":
-                  order: desc
-            query:
-              bool:
+            aggs:
+              latest_state:
                 filter:
-                  - term:
-                      kibana.space_ids: "{{ variables.spaceId }}"
-                  - term:
-                      rule_uuid: "{{ foreach.item.key }}"
-                  - term:
-                      kind: '{{ consts.KIND_DETECTION }}'
-                  - range:
-                      "@timestamp":
-                        gte: '{{ inputs.cooldown }}'
-        on-failure:
-          continue: true
-
-      - name: check_recent_clearance
-        # No kind filter — returns the most recent doc of any kind; is_recent_clearance
-        # then checks kind == KIND_QUIET. Do NOT add kind:quiet here — it would hide
-        # handled docs that act as timestamp barriers, allowing re-detection during cooldown.
-        if: "${{ steps.compute_rule_context.output.has_rule_uuid }}"
-        type: elasticsearch.request
-        with:
-          method: POST
-          path: '/{{ consts.DETECTIONS_INDEX }}/_search?ignore_unavailable=true'
-          body:
-            size: 1
-            sort:
-              - "@timestamp":
-                  order: desc
-            query:
-              bool:
+                  bool:
+                    must_not:
+                      - term:
+                          kind: '{{ consts.KIND_HANDLED }}'
+                aggs:
+                  doc:
+                    top_hits:
+                      size: 1
+                      sort:
+                        - "@timestamp":
+                            order: desc
+              recent_detection:
+                # kind:detection within cooldown — a quiet doc written after a detection would
+                # otherwise suppress is_recent_active and allow re-detection once cooldown expires.
                 filter:
-                  - term:
-                      kibana.space_ids: "{{ variables.spaceId }}"
-                  - term:
-                      rule_uuid: "{{ foreach.item.key }}"
-                  - range:
-                      "@timestamp":
-                        gte: "now-{{ consts.RECENT_ACTIVITY_MINUTES }}m"
+                  bool:
+                    filter:
+                      - term:
+                          kind: '{{ consts.KIND_DETECTION }}'
+                      - range:
+                          "@timestamp":
+                            gte: '{{ inputs.cooldown }}'
+                aggs:
+                  doc:
+                    top_hits:
+                      size: 1
+                      sort:
+                        - "@timestamp":
+                            order: desc
+              recent_any:
+                # Latest doc of any kind within 5m; is_recent_clearance then checks kind == quiet.
+                # Do NOT filter to quiet — handled docs act as timestamp barriers.
+                filter:
+                  bool:
+                    filter:
+                      - range:
+                          "@timestamp":
+                            gte: "now-{{ consts.RECENT_ACTIVITY_MINUTES }}m"
+                aggs:
+                  doc:
+                    top_hits:
+                      size: 1
+                      sort:
+                        - "@timestamp":
+                            order: desc
         on-failure:
           continue: true
 
@@ -328,37 +378,35 @@ steps:
         type: data.set
         with:
           latest_is_detection: >-
-            ${{ steps.check_active_result.output.hits.total.value > 0
-            and steps.check_active_result.output.hits.hits[0]._source.kind == consts.KIND_DETECTION }}
+            ${{ steps.check_rule_state.output.aggregations.latest_state.doc.hits.total.value > 0
+            and steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.kind == consts.KIND_DETECTION }}
           is_recent_active: >-
-            ${{ steps.check_recent_active.output.hits.total.value > 0
-            and steps.check_recent_active.output.hits.hits[0]._source.kind == consts.KIND_DETECTION }}
+            ${{ steps.check_rule_state.output.aggregations.recent_detection.doc.hits.total.value > 0
+            and steps.check_rule_state.output.aggregations.recent_detection.doc.hits.hits[0]._source.kind == consts.KIND_DETECTION }}
           is_recent_clearance: >-
-            ${{ steps.check_recent_clearance.output.hits.total.value > 0
-            and steps.check_recent_clearance.output.hits.hits[0]._source.kind == consts.KIND_QUIET }}
+            ${{ steps.check_rule_state.output.aggregations.recent_any.doc.hits.total.value > 0
+            and steps.check_rule_state.output.aggregations.recent_any.doc.hits.hits[0]._source.kind == consts.KIND_QUIET }}
 
       - name: compute_change_point_type
         type: data.set
         with:
           detection_p_value: "${{ foreach.item.change_points.type[steps.compute_rule_context.output.change_point_type].p_value | default: 0 }}"
-          prior_type: "{% if steps.check_recent_active.output.hits.total.value > 0 and steps.check_recent_active.output.hits.hits[0]._source.kind == consts.KIND_DETECTION %}{{ steps.check_recent_active.output.hits.hits[0]._source.detection_evidence.change_point_type | default: '' }}{% else %}{% endif %}"
+          prior_type: "{% if steps.check_rule_state.output.aggregations.recent_detection.doc.hits.total.value > 0 and steps.check_rule_state.output.aggregations.recent_detection.doc.hits.hits[0]._source.kind == consts.KIND_DETECTION %}{{ steps.check_rule_state.output.aggregations.recent_detection.doc.hits.hits[0]._source.detection_evidence.change_point_type | default: '' }}{% else %}{% endif %}"
 
       - name: compute_event_signals
-        # Both occurrence signals require the state lookups to have succeeded: check_recent_active/
-        # check_recent_clearance run on-failure:continue, so on error their flags read false and
-        # would flip these true → spurious detection. The error==null guards suppress that write.
+        # Both occurrence signals require the state lookup to have succeeded: check_rule_state runs
+        # on-failure:continue, so on error its flags read false and would flip these true → spurious
+        # detection. The error==null guard suppresses that write.
         type: data.set
         with:
           has_change_point: "${{ consts.CP_CHANGE_TYPES contains steps.compute_rule_context.output.change_point_type }}"
           is_new_occurrence: >-
-            ${{ steps.check_recent_active.error == null
-            and steps.check_recent_clearance.error == null
+            ${{ steps.check_rule_state.error == null
             and not steps.compute_rule_state.output.is_recent_active
             and not steps.compute_rule_state.output.is_recent_clearance
             and foreach.item.last_5m.doc_count > 0 }}
           is_type_changed: >-
-            ${{ steps.check_recent_active.error == null
-            and steps.check_recent_clearance.error == null
+            ${{ steps.check_rule_state.error == null
             and steps.compute_rule_context.output.change_point_type != steps.compute_change_point_type.output.prior_type
             and not steps.compute_rule_state.output.is_recent_clearance
             and foreach.item.last_5m.doc_count > 0 }}
@@ -436,7 +484,7 @@ steps:
               quick_recovery_current: "${{ steps.get_quick_recovery_day_over_day.output.aggregations.current_window.doc_count }}"
               quick_recovery_spike_threshold: "${{ steps.get_quick_recovery_day_over_day.output.aggregations.reference_window.doc_count | times: 2 }}"
               current_rate_scaled: "${{ steps.get_quick_recovery_day_over_day.output.aggregations.current_window.doc_count | times: 60 }}"
-              detection_rate_scaled: "${{ steps.check_active_result.output.hits.hits[0]._source.peak_alert_count | times: 11 }}"
+              detection_rate_scaled: "${{ steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.peak_alert_count | times: 11 }}"
 
           - name: check_quick_recovery_rate
             type: data.set
@@ -479,7 +527,7 @@ steps:
         type: data.set
         with:
           peak_alert_count: "${{ steps.get_rule_activity.output.aggregations.peak.value | default: 0 }}"
-          resolution_lookback_minutes: "{% assign parent = steps.check_active_result.output.hits.hits[0]._source.resolution_lookback_minutes | default: 0 | plus: 0 %}{% if parent > 0 %}{{ parent }}{% else %}{%- assign peak = steps.get_rule_activity.output.aggregations.peak.value | default: 0 | at_least: 1 -%}{{ consts.RESOLUTION_WINDOW_MINUTES | divided_by: peak | at_least: consts.LOOKBACK_MINUTES_FLOOR | at_most: consts.LOOKBACK_MINUTES_CEILING }}{% endif %}"
+          resolution_lookback_minutes: "{% assign parent = steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.resolution_lookback_minutes | default: 0 | plus: 0 %}{% if parent > 0 %}{{ parent }}{% else %}{%- assign peak = steps.get_rule_activity.output.aggregations.peak.value | default: 0 | at_least: 1 -%}{{ consts.RESOLUTION_WINDOW_MINUTES | divided_by: peak | at_least: consts.LOOKBACK_MINUTES_FLOOR | at_most: consts.LOOKBACK_MINUTES_CEILING }}{% endif %}"
           # Recovery = an open detection (a real change) has gone quiet and is back to no-change.
           # is_quick_recovery vs is_stationary_recovery differ only on whether the QUICK re-scan
           # confirms no-change (mutually exclusive on that).
@@ -488,18 +536,18 @@ steps:
             and foreach.item.last_5m.doc_count == 0
             and consts.CP_NO_CHANGE_TYPES contains steps.compute_quick_recovery_type.output.quick_recovery_type
             and steps.compute_quick_recovery_gate.output.quick_recovery_rate_is_normal
-            and consts.CP_CHANGE_TYPES contains steps.check_active_result.output.hits.hits[0]._source.detection_evidence.change_point_type }}
+            and consts.CP_CHANGE_TYPES contains steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.detection_evidence.change_point_type }}
           is_stationary_recovery: >-
             ${{ steps.compute_rule_state.output.latest_is_detection
             and foreach.item.last_5m.doc_count == 0
             and consts.CP_NO_CHANGE_TYPES contains steps.compute_rule_context.output.change_point_type
-            and consts.CP_CHANGE_TYPES contains steps.check_active_result.output.hits.hits[0]._source.detection_evidence.change_point_type
+            and consts.CP_CHANGE_TYPES contains steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.detection_evidence.change_point_type
             and not consts.CP_NO_CHANGE_TYPES contains steps.compute_quick_recovery_type.output.quick_recovery_type }}
           is_quiet_stationary: >-
             ${{ steps.compute_rule_state.output.latest_is_detection
             and foreach.item.last_5m.doc_count == 0
             and foreach.item.last_floor_window.doc_count == 0
-            and steps.check_active_result.output.hits.hits[0]._source.peak_alert_count >= consts.QUIET_STATIONARY_MIN_PEAK }}
+            and steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.peak_alert_count >= consts.QUIET_STATIONARY_MIN_PEAK }}
 
       - name: compute_write_ids
         # detection_id: carry over only while the episode is still open (latest doc is a detection);
@@ -507,7 +555,7 @@ steps:
         # differs by recovery type.
         type: data.set
         with:
-          detection_id: "{% if steps.compute_event_signals.output.is_type_changed and steps.check_recent_active.output.hits.total.value > 0 and steps.check_recent_clearance.output.hits.hits[0]._source.kind == consts.KIND_DETECTION %}{{ steps.check_recent_active.output.hits.hits[0]._source.detection_id }}{% else %}{{ foreach.item.key }}-{{ execution.id }}{% endif %}"
+          detection_id: "{% if steps.compute_event_signals.output.is_type_changed and steps.check_rule_state.output.aggregations.recent_detection.doc.hits.total.value > 0 and steps.check_rule_state.output.aggregations.recent_any.doc.hits.hits[0]._source.kind == consts.KIND_DETECTION %}{{ steps.check_rule_state.output.aggregations.recent_detection.doc.hits.hits[0]._source.detection_id }}{% else %}{{ foreach.item.key }}-{{ execution.id }}{% endif %}"
           quiet_p_value: "{% if steps.compute_write_signals.output.is_quick_recovery %}{{ steps.get_quick_recovery_change_point.output.aggregations.change_points.type.stationary.p_value | default: 0 }}{% elsif steps.compute_write_signals.output.is_stationary_recovery %}{{ foreach.item.change_points.type.stationary.p_value | default: 0 }}{% else %}0{% endif %}"
 
       - name: write_detection_doc
@@ -561,7 +609,7 @@ steps:
             detection_evidence:
               change_point_type: '{{ consts.CP_TYPE_STATIONARY }}'
               p_value: "${{ steps.compute_write_ids.output.quiet_p_value }}"
-            detection_id: "{{ steps.check_active_result.output.hits.hits[0]._source.detection_id }}"
+            detection_id: "{{ steps.check_rule_state.output.aggregations.latest_state.doc.hits.hits[0]._source.detection_id }}"
             resolution_lookback_minutes: "${{ steps.compute_write_signals.output.resolution_lookback_minutes | plus: 0 }}"
             rule_name: "{{ foreach.item.rule_name.top[0].metrics | entries | map: 'value' | first | default: 'unknown' }}"
             rule_uuid: "{{ foreach.item.key }}"

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/alerts_reader.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/alerts_reader.ts
@@ -15,6 +15,8 @@ export interface ChangePointScanParams {
   lookback: string;
   bucketInterval: string;
   spaceId: string;
+  partition?: number;
+  numPartitions?: number;
 }
 
 export interface ChangePointRuleBucket {
@@ -67,7 +69,11 @@ export interface ISignificantEventsAlertsReader {
     esClient: ElasticsearchClient,
     params: ChangePointScanParams,
     queryLinks: QueryLink[]
-  ): Promise<{ took?: number; by_rule: { buckets: ChangePointRuleBucket[] } }>;
+  ): Promise<{
+    took?: number;
+    by_rule: { buckets: ChangePointRuleBucket[] };
+    partition_rule_ids: string[];
+  }>;
 
   runRuleChangePoint(
     esClient: ElasticsearchClient,

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/alerts_readers.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/alerts_readers.test.ts
@@ -144,6 +144,9 @@ describe('SignificantEventsAlertsReaderV1', () => {
               }),
             },
           },
+          by_partition: {
+            terms: { field: 'kibana.alert.rule.uuid', size: RULES_BUCKET_SIZE },
+          },
         },
       })
     );
@@ -191,6 +194,43 @@ describe('SignificantEventsAlertsReaderV1', () => {
         last_floor_window: { doc_count: 0 },
       })
     );
+  });
+
+  it('adds a partition-scoped by_partition terms agg and surfaces partition rule ids', async () => {
+    const { client, search } = createEsClient();
+    search.mockResolvedValue({
+      aggregations: {
+        by_rule: { buckets: [] },
+        by_partition: { buckets: [{ key: 'rule-1' }, { key: 'rule-2' }] },
+      },
+    });
+
+    const result = await reader.runChangePointScan(
+      client,
+      {
+        lookback: LOOKBACK,
+        bucketInterval: BUCKET_INTERVAL,
+        spaceId: SPACE_ID,
+        numPartitions: 2,
+        partition: 0,
+      },
+      [makeQueryLink()]
+    );
+
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aggs: expect.objectContaining({
+          by_partition: {
+            terms: {
+              field: 'kibana.alert.rule.uuid',
+              size: RULES_BUCKET_SIZE,
+              include: { partition: 0, num_partitions: 2 },
+            },
+          },
+        }),
+      })
+    );
+    expect(result.partition_rule_ids).toEqual(['rule-1', 'rule-2']);
   });
 
   it('returns rule activity aggregations without normalizing bucket counts', async () => {
@@ -358,6 +398,9 @@ describe('SignificantEventsAlertsReaderV2', () => {
               }),
             },
           },
+          by_partition: {
+            terms: { field: 'rule.id', size: RULES_BUCKET_SIZE },
+          },
         },
       })
     );
@@ -375,6 +418,43 @@ describe('SignificantEventsAlertsReaderV2', () => {
         last_floor_window: { doc_count: 8 },
       },
     ]);
+  });
+
+  it('adds a partition-scoped by_partition terms agg and surfaces partition rule ids', async () => {
+    const { client, search } = createEsClient();
+    search.mockResolvedValue({
+      aggregations: {
+        by_rule: { buckets: [] },
+        by_partition: { buckets: [{ key: 'rule-a' }] },
+      },
+    });
+
+    const result = await reader.runChangePointScan(
+      client,
+      {
+        lookback: LOOKBACK,
+        bucketInterval: BUCKET_INTERVAL,
+        spaceId: SPACE_ID,
+        numPartitions: 2,
+        partition: 0,
+      },
+      [makeQueryLink()]
+    );
+
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aggs: expect.objectContaining({
+          by_partition: {
+            terms: {
+              field: 'rule.id',
+              size: RULES_BUCKET_SIZE,
+              include: { partition: 0, num_partitions: 2 },
+            },
+          },
+        }),
+      })
+    );
+    expect(result.partition_rule_ids).toEqual(['rule-a']);
   });
 
   it('normalizes rule activity windows to doc_count from signal_count', async () => {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/change_point_scan_shared.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/change_point_scan_shared.test.ts
@@ -49,15 +49,32 @@ describe('buildChangePointTimeSeriesAggs', () => {
     });
   });
 
-  it('uses signal_count for v2 change_point bucket paths', () => {
+  it('always runs change_point over raw _count, even when distinct signal counting is enabled', () => {
     const extendedBounds = buildChangePointHistogramBounds('now-30m', '30s');
     const aggs = buildChangePointTimeSeriesAggs('30s', {
       useDistinctSignalCount: true,
       extendedBounds,
     });
 
+    // The pipeline input must be `_count`, not the `signal_count` cardinality: the latter is ~1
+    // per bucket under v2 and starves change_point of variance.
     expect(aggs.change_points).toEqual({
-      change_point: { buckets_path: 'over_time>signal_count' },
+      change_point: { buckets_path: 'over_time>_count' },
+    });
+  });
+
+  it('does not attach a signal_count sub-agg to over_time under v2 (the pipeline reads _count, and the series is dropped from the response)', () => {
+    const extendedBounds = buildChangePointHistogramBounds('now-30m', '30s');
+    const aggs = buildChangePointTimeSeriesAggs('30s', {
+      useDistinctSignalCount: true,
+      extendedBounds,
+    });
+
+    // over_time is a plain histogram — no wasted per-bucket cardinality.
+    expect(aggs.over_time).toEqual(buildDateHistogramAgg('30s', extendedBounds));
+    // last_5m still carries the distinct signal_count under v2, since that value IS consumed.
+    expect((aggs.last_5m as { aggs?: unknown }).aggs).toEqual({
+      signal_count: { cardinality: { field: 'group_hash' } },
     });
   });
 });

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/change_point_scan_shared.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/change_point_scan_shared.ts
@@ -51,15 +51,17 @@ export function buildChangePointTimeSeriesAggs(
     includeFloorWindow = false,
     extendedBounds,
   }: {
+    // Scope note: this toggles the `signal_count` (group_hash cardinality) sub-agg ONLY on the
+    // recency windows (`last_5m`, `last_floor_window`) — it does NOT affect the change_point input.
     useDistinctSignalCount: boolean;
     includeFloorWindow?: boolean;
     extendedBounds: AggregationsExtendedBounds<AggregationsFieldDateMath>;
   }
 ): Record<string, AggregationsAggregationContainer> {
-  const countPath = useDistinctSignalCount ? 'signal_count' : '_count';
-  const overTime: AggregationsAggregationContainer = useDistinctSignalCount
-    ? { ...buildDateHistogramAgg(bucketInterval, extendedBounds), aggs: SIGNAL_COUNT_CARDINALITY }
-    : buildDateHistogramAgg(bucketInterval, extendedBounds);
+  // We must use `_count`, not the `signal_count` cardinality of `group_hash`: under v2 that cardinality is ~1
+  // per bucket for rules without custom alert grouping, producing a near-binary series that starves
+  // change_point of variance.
+  const overTime = buildDateHistogramAgg(bucketInterval, extendedBounds);
   const last5m: AggregationsAggregationContainer = useDistinctSignalCount
     ? { filter: timestampGteFilter(RECENT_ACTIVITY_MINUTES), aggs: SIGNAL_COUNT_CARDINALITY }
     : { filter: timestampGteFilter(RECENT_ACTIVITY_MINUTES) };
@@ -67,7 +69,7 @@ export function buildChangePointTimeSeriesAggs(
   const aggs: Record<string, AggregationsAggregationContainer> = {
     over_time: overTime,
     last_5m: last5m,
-    change_points: { change_point: { buckets_path: `over_time>${countPath}` } },
+    change_points: { change_point: { buckets_path: 'over_time>_count' } },
   };
 
   if (includeFloorWindow) {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v1_alerts_reader.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v1_alerts_reader.ts
@@ -95,11 +95,17 @@ export class SignificantEventsAlertsReaderV1 implements ISignificantEventsAlerts
     const rawBuckets =
       (response.aggregations?.by_rule as { buckets?: RawRuleBucket[] })?.buckets ?? [];
 
+    const partitionRuleIds =
+      (response.aggregations?.by_partition as { buckets?: Array<{ key: string }> })?.buckets?.map(
+        (bucket) => bucket.key
+      ) ?? [];
+
     return {
       took: response.took,
       by_rule: {
         buckets: rawBuckets.map((bucket) => this.enrichChangePointBucket(bucket, ruleMetadata)),
       },
+      partition_rule_ids: partitionRuleIds,
     };
   }
 
@@ -212,7 +218,14 @@ export class SignificantEventsAlertsReaderV1 implements ISignificantEventsAlerts
     return { aggregations: response.aggregations ?? {} };
   }
 
-  private buildChangePointScanBody({ lookback, bucketInterval, spaceId }: ChangePointScanParams) {
+  private buildChangePointScanBody({
+    lookback,
+    bucketInterval,
+    spaceId,
+    partition,
+    numPartitions,
+  }: ChangePointScanParams) {
+    const shouldPartition = numPartitions !== undefined && numPartitions > 1;
     return {
       query: {
         bool: {
@@ -241,6 +254,15 @@ export class SignificantEventsAlertsReaderV1 implements ISignificantEventsAlerts
               includeFloorWindow: true,
               extendedBounds: buildChangePointHistogramBounds(lookback, bucketInterval),
             }),
+          },
+        },
+        by_partition: {
+          terms: {
+            field: 'kibana.alert.rule.uuid',
+            size: RULES_BUCKET_SIZE,
+            ...(shouldPartition
+              ? { include: { partition: partition as number, num_partitions: numPartitions } }
+              : {}),
           },
         },
       },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v1_alerts_reader.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v1_alerts_reader.ts
@@ -225,7 +225,8 @@ export class SignificantEventsAlertsReaderV1 implements ISignificantEventsAlerts
     partition,
     numPartitions,
   }: ChangePointScanParams) {
-    const shouldPartition = numPartitions !== undefined && numPartitions > 1;
+    const shouldPartition =
+      numPartitions !== undefined && numPartitions > 1 && partition !== undefined;
     return {
       query: {
         bool: {
@@ -260,9 +261,7 @@ export class SignificantEventsAlertsReaderV1 implements ISignificantEventsAlerts
           terms: {
             field: 'kibana.alert.rule.uuid',
             size: RULES_BUCKET_SIZE,
-            ...(shouldPartition
-              ? { include: { partition: partition as number, num_partitions: numPartitions } }
-              : {}),
+            ...(shouldPartition ? { include: { partition, num_partitions: numPartitions } } : {}),
           },
         },
       },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v2_alerts_reader.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v2_alerts_reader.ts
@@ -99,11 +99,17 @@ export class SignificantEventsAlertsReaderV2 implements ISignificantEventsAlerts
     const rawBuckets =
       (response.aggregations?.by_rule as { buckets?: RawRuleBucket[] })?.buckets ?? [];
 
+    const partitionRuleIds =
+      (response.aggregations?.by_partition as { buckets?: Array<{ key: string }> })?.buckets?.map(
+        (bucket) => bucket.key
+      ) ?? [];
+
     return {
       took: response.took,
       by_rule: {
         buckets: rawBuckets.map((bucket) => this.enrichChangePointBucket(bucket, ruleMetadata)),
       },
+      partition_rule_ids: partitionRuleIds,
     };
   }
 
@@ -234,7 +240,14 @@ export class SignificantEventsAlertsReaderV2 implements ISignificantEventsAlerts
     return { aggregations: this.normalizeWindowAggregations(response.aggregations ?? {}) };
   }
 
-  private buildChangePointScanBody({ lookback, bucketInterval, spaceId }: ChangePointScanParams) {
+  private buildChangePointScanBody({
+    lookback,
+    bucketInterval,
+    spaceId,
+    partition,
+    numPartitions,
+  }: ChangePointScanParams) {
+    const shouldPartition = numPartitions !== undefined && numPartitions > 1;
     return {
       query: {
         bool: {
@@ -257,6 +270,15 @@ export class SignificantEventsAlertsReaderV2 implements ISignificantEventsAlerts
               includeFloorWindow: true,
               extendedBounds: buildChangePointHistogramBounds(lookback, bucketInterval),
             }),
+          },
+        },
+        by_partition: {
+          terms: {
+            field: 'rule.id',
+            size: RULES_BUCKET_SIZE,
+            ...(shouldPartition
+              ? { include: { partition: partition as number, num_partitions: numPartitions } }
+              : {}),
           },
         },
       },

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v2_alerts_reader.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/alerting/v2_alerts_reader.ts
@@ -247,7 +247,8 @@ export class SignificantEventsAlertsReaderV2 implements ISignificantEventsAlerts
     partition,
     numPartitions,
   }: ChangePointScanParams) {
-    const shouldPartition = numPartitions !== undefined && numPartitions > 1;
+    const shouldPartition =
+      numPartitions !== undefined && numPartitions > 1 && partition !== undefined;
     return {
       query: {
         bool: {
@@ -276,9 +277,7 @@ export class SignificantEventsAlertsReaderV2 implements ISignificantEventsAlerts
           terms: {
             field: 'rule.id',
             size: RULES_BUCKET_SIZE,
-            ...(shouldPartition
-              ? { include: { partition: partition as number, num_partitions: numPartitions } }
-              : {}),
+            ...(shouldPartition ? { include: { partition, num_partitions: numPartitions } } : {}),
           },
         },
       },

--- a/x-pack/platform/plugins/shared/significant_events/server/routes/internal/detections/workflow_route.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/routes/internal/detections/workflow_route.ts
@@ -63,6 +63,8 @@ const changePointScanRoute = createServerRoute({
     body: z.object({
       lookback: z.string().max(64),
       bucketInterval: z.string().max(64),
+      numPartitions: z.number().int().min(1).optional(),
+      partition: z.number().int().min(0).optional(),
     }),
   }),
   handler: async ({ params, request, getScopedClients, server, getSpaceId, telemetry }) => {
@@ -79,15 +81,18 @@ const changePointScanRoute = createServerRoute({
     const queryLinks = await kiClient.getRuleBackedQueryLinks();
 
     const startedAt = Date.now();
-    const { took, ...aggregations } = await sigEventsContext.alertsReader.runChangePointScan(
-      scopedClusterClient.asCurrentUser,
-      {
-        lookback: params.body.lookback,
-        bucketInterval: params.body.bucketInterval,
-        spaceId,
-      },
-      queryLinks
-    );
+    const { took, partition_rule_ids, ...aggregations } =
+      await sigEventsContext.alertsReader.runChangePointScan(
+        scopedClusterClient.asCurrentUser,
+        {
+          lookback: params.body.lookback,
+          bucketInterval: params.body.bucketInterval,
+          spaceId,
+          partition: params.body.partition,
+          numPartitions: params.body.numPartitions,
+        },
+        queryLinks
+      );
     const durationMs = Date.now() - startedAt;
 
     telemetry.trackSignificantEventsDetectionScan({
@@ -101,7 +106,11 @@ const changePointScanRoute = createServerRoute({
       space_id: spaceId,
     });
 
-    return { alertIndex: sigEventsContext.alertsReader.index, aggregations };
+    return {
+      alertIndex: sigEventsContext.alertsReader.index,
+      aggregations,
+      partitionRuleIds: partition_rule_ids,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary

Follow-up to elastic/nightshift-program#596. The Significant Events **detection workflow** previously scanned the whole rule queue every scheduled run, so per-rule work grew unbounded as the rule count grew and noisier rules could starve quieter ones. 
This PR makes each run process only a bounded, hash-sharded slice of rules plus any with a live change signal — keeping per-run work flat while still evaluating every active rule within a target window. Stateless: the shard is derived from the clock and the alert population, with no persisted cursor.

>[!WARNING]
> ⚠️ **Stacked on #277122.** Until that merges, the diff here includes its commits — the PR 2
> changes are the two commits on this branch. Rebase onto `main` after #277122 merges.

### How to test
- `yarn jest --config x-pack/platform/plugins/shared/significant_events/jest.config.js alerts_readers`
- `yarn jest --config src/platform/packages/shared/kbn-workflows/jest.config.js managed_workflow_definitions`
- Validated live against a busy cluster (partition stability/coverage; consolidated state query; idle-exit count).

### Checklist

- [x] Unit or functional tests were updated or added to match the most common scenarios
