### PR TITLE
[One workflow] Truncate bloated workflow validation error toast

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.test.ts
@@ -157,6 +157,31 @@ describe('testWorkflowThunk', () => {
     expect(result.payload).toBe(expectedMessage);
   });
 
+  it('should truncate an oversized validation reason to keep the toast readable', async () => {
+    const longReason = `filter must be one of ${'x'.repeat(500)}`;
+    const error = {
+      body: {
+        message: 'Workflow validation failed',
+        attributes: {
+          validationErrors: [longReason],
+        },
+      },
+      message: 'Bad Request',
+    };
+
+    store.dispatch({ type: 'detail/setYamlString', payload: 'name: Test Workflow\nsteps: []' });
+    mockWorkflowApi.testWorkflow.mockRejectedValue(error);
+
+    const result = await store.dispatch(testWorkflowThunk({ inputs: {} }));
+
+    const [[reportedError]] = mockServices.notifications.toasts.addError.mock.calls;
+    expect(reportedError.message).toContain('Workflow validation failed:\n• filter must be one of');
+    expect(reportedError.message.endsWith('…')).toBe(true);
+    // Base message + bullet prefix + capped reason (200) + ellipsis, well under the raw 500+ chars.
+    expect(reportedError.message.length).toBeLessThan(250);
+    expect(result.type).toBe('detail/testWorkflowThunk/rejected');
+  });
+
   it('should fall back to body message when validationErrors is empty', async () => {
     const error = {
       body: { message: 'Workflow validation failed', attributes: { validationErrors: [] } },

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.test.ts
@@ -157,7 +157,7 @@ describe('testWorkflowThunk', () => {
     expect(result.payload).toBe(expectedMessage);
   });
 
-  it('should truncate an oversized validation reason to keep the toast readable', async () => {
+  it('should truncate the displayed reason but keep the full context copyable via stack', async () => {
     const longReason = `filter must be one of ${'x'.repeat(500)}`;
     const error = {
       body: {
@@ -175,11 +175,21 @@ describe('testWorkflowThunk', () => {
     const result = await store.dispatch(testWorkflowThunk({ inputs: {} }));
 
     const [[reportedError]] = mockServices.notifications.toasts.addError.mock.calls;
+
+    // Displayed toast body is trimmed with an ellipsis and stays compact.
     expect(reportedError.message).toContain('Workflow validation failed:\n• filter must be one of');
     expect(reportedError.message.endsWith('…')).toBe(true);
     // Base message + bullet prefix + capped reason (200) + ellipsis, well under the raw 500+ chars.
     expect(reportedError.message.length).toBeLessThan(250);
+
+    // Full, untruncated reason is preserved on `stack` so Kibana's
+    // "See the full error" modal renders it in a copyable code block.
+    expect(reportedError.stack).toBe(`Workflow validation failed:\n• ${longReason}`);
+    expect(reportedError.stack).not.toContain('…');
+
     expect(result.type).toBe('detail/testWorkflowThunk/rejected');
+    // The rejected payload carries the trimmed message (matches the toast body).
+    expect(result.payload).toBe(reportedError.message);
   });
 
   it('should fall back to body message when validationErrors is empty', async () => {

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.ts
@@ -24,11 +24,29 @@ export interface TestWorkflowParams {
 
 // A single validation reason can be huge when it echoes a whole schema
 // (e.g. the Elasticsearch `filter` union lists every query type). Cap each
-// reason so the error toast stays readable instead of dumping the schema.
+// reason for the *displayed* toast body so it stays readable; the untruncated
+// text is kept on the error object (see `buildValidationError`) so Kibana's
+// "See the full error" modal can show and copy the complete reasons.
 const MAX_REASON_LENGTH = 200;
 
 const truncateReason = (reason: string): string =>
   reason.length > MAX_REASON_LENGTH ? `${reason.slice(0, MAX_REASON_LENGTH).trimEnd()}…` : reason;
+
+const formatReasons = (reasons: string[], transform: (reason: string) => string): string =>
+  reasons.map((reason) => `• ${transform(reason)}`).join('\n');
+
+// Build an Error whose `message` is the trimmed, display-friendly text and
+// whose `stack` carries the full untruncated reasons. Kibana's error toast
+// renders `message` in the toast body and exposes `stack` in a copyable code
+// block behind the "See the full error" button, so users get a compact toast
+// but can still read/copy the complete validation output when needed.
+const buildValidationError = (baseMessage: string, reasons: string[]): Error => {
+  const displayMessage = `${baseMessage}:\n${formatReasons(reasons, truncateReason)}`;
+  const fullMessage = `${baseMessage}:\n${formatReasons(reasons, (reason) => reason)}`;
+  const error = new Error(displayMessage);
+  error.stack = fullMessage;
+  return error;
+};
 
 export interface TestWorkflowResponse {
   workflowExecutionId: string;
@@ -98,13 +116,14 @@ export const testWorkflowThunk = createAsyncThunk<
       const baseMessage = error.body?.message || error.message || 'Failed to test workflow';
       const validationErrors: string[] | undefined =
         error.body?.attributes?.validationErrors ?? error.body?.validationErrors;
-      const errorMessage =
+      const errorObj =
         Array.isArray(validationErrors) && validationErrors.length > 0
-          ? `${baseMessage}:\n${validationErrors
-              .map((reason) => `• ${truncateReason(reason)}`)
-              .join('\n')}`
-          : baseMessage;
-      const errorObj = error instanceof Error ? error : new Error(errorMessage);
+          ? buildValidationError(baseMessage, validationErrors)
+          : error instanceof Error
+          ? error
+          : new Error(baseMessage);
+      // Displayed toast body (trimmed for validation errors, plain otherwise).
+      const errorMessage = errorObj.message;
 
       const errorState = getState();
       const workflow = selectWorkflow(errorState);
@@ -124,7 +143,7 @@ export const testWorkflowThunk = createAsyncThunk<
         hasCustomEventTrigger,
       });
 
-      notifications.toasts.addError(new Error(errorMessage), {
+      notifications.toasts.addError(errorObj, {
         title: i18n.translate('workflows.detail.testWorkflow.error', {
           defaultMessage: 'Failed to test workflow',
         }),

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.ts
@@ -22,6 +22,14 @@ export interface TestWorkflowParams {
   triggerTab?: WorkflowTriggerTab;
 }
 
+// A single validation reason can be huge when it echoes a whole schema
+// (e.g. the Elasticsearch `filter` union lists every query type). Cap each
+// reason so the error toast stays readable instead of dumping the schema.
+const MAX_REASON_LENGTH = 200;
+
+const truncateReason = (reason: string): string =>
+  reason.length > MAX_REASON_LENGTH ? `${reason.slice(0, MAX_REASON_LENGTH).trimEnd()}…` : reason;
+
 export interface TestWorkflowResponse {
   workflowExecutionId: string;
 }
@@ -92,7 +100,9 @@ export const testWorkflowThunk = createAsyncThunk<
         error.body?.attributes?.validationErrors ?? error.body?.validationErrors;
       const errorMessage =
         Array.isArray(validationErrors) && validationErrors.length > 0
-          ? `${baseMessage}:\n${validationErrors.map((reason) => `• ${reason}`).join('\n')}`
+          ? `${baseMessage}:\n${validationErrors
+              .map((reason) => `• ${truncateReason(reason)}`)
+              .join('\n')}`
           : baseMessage;
       const errorObj = error instanceof Error ? error : new Error(errorMessage);
 


### PR DESCRIPTION
## Summary
Improve Validation Error
<img width="2360" height="1712" alt="CleanShot 2026-07-09 at 15 32 23@2x" src="https://github.com/user-attachments/assets/84596877-17d7-4353-9bf6-7da3a352b81d" />



- When testing a workflow that fails schema validation on a field backed by a large Zod union (e.g. the Elasticsearch `filter` field, which lists every query type), the "Failed to test workflow" toast could dump the entire schema and overflow the viewport.
- Cap each individual validation reason at 200 chars (with an ellipsis) before assembling the toast message, keeping the actionable prefix while trimming the exhaustive type list.
- Added a unit test asserting an oversized reason is truncated.

## Before / After

Before: the toast rendered the full `filter` union schema, spanning the whole screen.
After: each reason is capped so the toast stays compact and readable.

## References

Closes elastic/security-team#18189

Made with [Cursor](https://cursor.com)