### PR TITLE
[Agent Builder] Tool steps: show Running/Ran instead of Responded

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/round_events.render.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/round_events.render.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import { createToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
+import { RoundEvents } from './round_events';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const toolStep = (id: string, toolId: string) =>
+  createToolCallStep({ tool_call_id: id, tool_id: toolId, params: {}, results: [] });
+
+describe('RoundEvents — single vs grouped tool calls', () => {
+  it('renders a lone tool call as a plain step, without the group wrapper', () => {
+    renderWithProviders(<RoundEvents steps={[toolStep('tc-1', 'search')]} />);
+    expect(screen.getByTestId('agentBuilderToolCallStep')).toBeInTheDocument();
+    expect(screen.queryByTestId('agentBuilderToolCallGroup')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^1 tool/)).not.toBeInTheDocument();
+  });
+
+  it('renders two consecutive tool calls inside the group wrapper', () => {
+    renderWithProviders(
+      <RoundEvents steps={[toolStep('tc-1', 'search'), toolStep('tc-2', 'read')]} />
+    );
+    expect(screen.getByTestId('agentBuilderToolCallGroup')).toBeInTheDocument();
+    expect(screen.queryByTestId('agentBuilderToolCallStep')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/round_events.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/round_events.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@kbn/agent-builder-common/attachments';
 import { StepItem } from './step_item';
 import { ToolCallGroup } from './steps/tool_call_group';
+import { ToolCallStep } from './steps/tool_call_step';
 import { groupSteps } from './group_steps';
 
 interface RoundEventsProps {
@@ -45,7 +46,11 @@ export const RoundEvents: React.FC<RoundEventsProps> = ({
             if (item.kind === 'group') {
               return (
                 <EuiFlexItem grow={false} key={`group-${item.steps[0].tool_call_id}`}>
-                  <ToolCallGroup steps={item.steps} />
+                  {item.steps.length === 1 ? (
+                    <ToolCallStep step={item.steps[0]} />
+                  ) : (
+                    <ToolCallGroup steps={item.steps} />
+                  )}
                 </EuiFlexItem>
               );
             }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/step_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/step_layout.tsx
@@ -19,6 +19,7 @@ interface StepLayoutProps {
   label: ReactNode;
   onClick?: () => void;
   isExpanded?: boolean;
+  isExpandable?: boolean;
   expansion?: ReactNode;
   ebtAction?: ConversationAction;
 }
@@ -27,6 +28,7 @@ export const StepLayout: React.FC<StepLayoutProps> = ({
   label,
   onClick,
   isExpanded = false,
+  isExpandable = true,
   expansion,
   ebtAction,
 }) => {
@@ -79,11 +81,11 @@ export const StepLayout: React.FC<StepLayoutProps> = ({
           : {})}
       >
         <EuiFlexItem grow={false}>{label}</EuiFlexItem>
-        {isClickable && (
+        {isClickable && isExpandable && (
           <EuiFlexItem grow={false}>
             <EuiIcon
-              type={isExpanded ? 'arrowDown' : 'arrowRight'}
-              color="subdued"
+              type={isExpanded ? 'arrowUp' : 'arrowDown'}
+              color={euiTheme.colors.textDisabled}
               size="s"
               aria-hidden={true}
             />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.tsx
@@ -51,6 +51,7 @@ export const AskUserQuestionStepEvent: React.FC<AskUserQuestionStepEventProps> =
             </EuiFlexItem>
           </EuiFlexGroup>
         }
+        isExpandable={false}
         onClick={openFlyout}
       />
       <AskUserQuestionFlyout

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
+import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolCallGroup } from './tool_call_group';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const otherResult = (id: string): ToolResult => ({
+  tool_result_id: id,
+  type: ToolResultType.other,
+  data: {},
+});
+
+const toolStep = (id: string, toolId: string, results: ToolResult[] = []) =>
+  createToolCallStep({ tool_call_id: id, tool_id: toolId, params: {}, results });
+
+describe('ToolCallGroup', () => {
+  it('shows "N tools ran." once every step in the group has a result', () => {
+    renderWithProviders(
+      <ToolCallGroup
+        steps={[
+          toolStep('c1', 'search', [otherResult('r1')]),
+          toolStep('c2', 'read', [otherResult('r2')]),
+          toolStep('c3', 'write', [otherResult('r3')]),
+        ]}
+      />
+    );
+    expect(screen.getByText('3 tools ran.')).toBeInTheDocument();
+  });
+
+  it('shows "N tools running…" while at least one step is still in progress', () => {
+    renderWithProviders(
+      <ToolCallGroup
+        steps={[toolStep('c1', 'search', [otherResult('r1')]), toolStep('c2', 'read')]}
+      />
+    );
+    expect(screen.getByText('2 tools running…')).toBeInTheDocument();
+  });
+
+  it('expands to show each individual step, which opens its own flyout on click', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ToolCallGroup
+        steps={[
+          toolStep('c1', 'search', [otherResult('r1')]),
+          toolStep('c2', 'read', [otherResult('r2')]),
+        ]}
+      />
+    );
+    await user.click(screen.getByText('2 tools ran.'));
+    const childStatuses = screen
+      .getAllByRole('status')
+      .filter((el) => el.textContent !== '2 tools ran.');
+    expect(childStatuses.map((el) => el.querySelector('.euiBadge')?.textContent)).toEqual([
+      'tool: search',
+      'tool: read',
+    ]);
+    expect(childStatuses.every((el) => el.textContent?.includes('ran.'))).toBe(true);
+
+    await user.click(screen.getAllByRole('button')[1]);
+    expect(screen.getByText('Inspect tool response')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_group.tsx
@@ -24,22 +24,22 @@ export const ToolCallGroup: React.FC<ToolCallGroupProps> = ({ steps }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const onToggle = () => setIsExpanded((v) => !v);
 
-  const allResponded = steps.every((s) => s.results.length > 0);
+  const allRan = steps.every((s) => s.results.length > 0);
   const hasError = steps.some((s) => s.results.some(isErrorResult));
 
   const label = (
     <EuiText size="s" color={hasError ? 'danger' : 'inherit'}>
       <p role="status">
-        {allResponded ? (
+        {allRan ? (
           <FormattedMessage
-            id="xpack.agentBuilder.roundEvents.toolCallGroup.responded"
-            defaultMessage="{count, plural, one {# tool responded} other {# tools responded}}"
+            id="xpack.agentBuilder.roundEvents.toolCallGroup.ran"
+            defaultMessage="{count, plural, one {# tool ran.} other {# tools ran.}}"
             values={{ count: steps.length }}
           />
         ) : (
           <FormattedMessage
-            id="xpack.agentBuilder.roundEvents.toolCallGroup.calling"
-            defaultMessage="{count, plural, one {Calling # tool} other {Calling # tools}}"
+            id="xpack.agentBuilder.roundEvents.toolCallGroup.running"
+            defaultMessage="{count, plural, one {# tool running…} other {# tools running…}}"
             values={{ count: steps.length }}
           />
         )}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { internalTools } from '@kbn/agent-builder-common';
+import { createToolCallStep } from '@kbn/agent-builder-common/chat/conversation';
+import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolCallStep } from './tool_call_step';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const otherResult = (id: string): ToolResult => ({
+  tool_result_id: id,
+  type: ToolResultType.other,
+  data: {},
+});
+
+const errorResult = (id: string): ToolResult => ({
+  tool_result_id: id,
+  type: ToolResultType.error,
+  data: { message: 'boom' },
+});
+
+const makeStep = (results: ToolResult[]) =>
+  createToolCallStep({
+    tool_call_id: 'call-1',
+    tool_id: 'search',
+    params: {},
+    results,
+  });
+
+describe('ToolCallStep', () => {
+  it('shows "tool: search" and "running…" and is not clickable while no results have arrived', () => {
+    renderWithProviders(<ToolCallStep step={makeStep([])} />);
+    const status = screen.getByRole('status');
+    expect(status.querySelector('.euiBadge')).toHaveTextContent('tool: search');
+    expect(status).toHaveTextContent('running…');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows "tool: search" and "ran." and opens the response flyout directly on click', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ToolCallStep step={makeStep([otherResult('r1')])} />);
+    const status = screen.getByRole('status');
+    expect(status.querySelector('.euiBadge')).toHaveTextContent('tool: search');
+    expect(status).toHaveTextContent('ran.');
+    expect(screen.queryByText('Inspect tool response')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('Inspect tool response')).toBeInTheDocument();
+  });
+
+  it('closes the flyout when its close button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ToolCallStep step={makeStep([otherResult('r1')])} />);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('Inspect tool response')).toBeInTheDocument();
+    await user.click(screen.getByTestId('euiFlyoutCloseButton'));
+    expect(screen.queryByText('Inspect tool response')).not.toBeInTheDocument();
+  });
+
+  it('still shows "ran." for an error result, with the danger badge color', () => {
+    renderWithProviders(<ToolCallStep step={makeStep([errorResult('r1')])} />);
+    const badge = screen.getByRole('status').querySelector('.euiBadge');
+    expect(badge).toHaveTextContent('tool: search');
+    expect(badge?.className).toContain('danger');
+  });
+
+  it('is clickable for a running sub-agent call once its execution id is known', () => {
+    const step = createToolCallStep({
+      tool_call_id: 'call-1',
+      tool_id: internalTools.runSubagent,
+      params: {},
+      results: [],
+      progression: [{ message: 'started', metadata: { agent_execution_id: 'exec-1' } }],
+    });
+    renderWithProviders(<ToolCallStep step={step} />);
+    expect(screen.getByRole('status')).toHaveTextContent('running…');
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step.tsx
@@ -5,307 +5,52 @@
  * 2.0.
  */
 
-import React, { Fragment, useCallback, useState } from 'react';
-import {
-  EuiAccordion,
-  EuiBadge,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiLink,
-  EuiSpacer,
-  EuiText,
-  useEuiTheme,
-} from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
+import React, { Fragment } from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { useBoolean } from '@kbn/react-hooks';
 import { internalTools, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
-import {
-  isErrorResult,
-  type ToolResult as ToolResultData,
-} from '@kbn/agent-builder-common/tools/tool_result';
-import { getEbtProps } from '@kbn/ebt-click';
 import { StepLayout } from '../step_layout';
-import { JsonCodeBlock } from '../json_code_block';
-import { ToolResult, isInlineRenderableResult } from '../results/tool_result';
+import { ToolResult } from '../results/tool_result';
 import { ToolResponseFlyout } from '../flyouts/tool_response_flyout';
 import { SubAgentExecutionFlyout } from '../flyouts/sub_agent_execution_flyout';
-
-const labels = {
-  toolCall: i18n.translate('xpack.agentBuilder.roundEvents.steps.toolCall.ariaLabel', {
-    defaultMessage: 'Tool call',
-  }),
-  parameters: i18n.translate('xpack.agentBuilder.roundEvents.steps.toolCall.parametersLabel', {
-    defaultMessage: 'Parameters sent',
-  }),
-  result: i18n.translate('xpack.agentBuilder.roundEvents.steps.toolCall.resultLabel', {
-    defaultMessage: 'Response returned',
-  }),
-  viewJson: i18n.translate('xpack.agentBuilder.roundEvents.steps.toolCall.viewJson', {
-    defaultMessage: 'View JSON',
-  }),
-  viewExecution: i18n.translate('xpack.agentBuilder.roundEvents.steps.toolCall.viewExecution', {
-    defaultMessage: 'View execution',
-  }),
-};
+import { ToolCallStepHeadline } from './tool_call_step_headline';
 
 interface ToolCallStepProps {
   step: ToolCallStepData;
 }
 
 export const ToolCallStep: React.FC<ToolCallStepProps> = ({ step }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const onToggle = () => setIsExpanded((v) => !v);
+  const [isFlyoutOpen, { on: openFlyout, off: closeFlyout }] = useBoolean();
 
   const hasResults = step.results.length > 0;
 
-  return (
-    <StepLayout
-      label={<ToolCallHeadline step={step} hasResults={hasResults} />}
-      onClick={onToggle}
-      isExpanded={isExpanded}
-      expansion={<ToolCallExpansion step={step} />}
-      ebtAction={AGENT_BUILDER_UI_EBT.action.conversation.EXPAND_TOOL_CALL_STEP}
-    />
-  );
-};
-
-const ToolCallHeadline: React.FC<{ step: ToolCallStepData; hasResults: boolean }> = ({
-  step,
-  hasResults,
-}) => {
-  const hasErrorResult = step.results.some(isErrorResult);
-
-  const toolBadge = (
-    <EuiBadge
-      iconType="wrench"
-      color={hasErrorResult ? 'danger' : 'default'}
-      css={css`
-        vertical-align: inherit;
-      `}
-    >
-      {step.tool_id}
-    </EuiBadge>
-  );
-
-  return (
-    <EuiText color={hasErrorResult ? 'danger' : 'inherit'}>
-      <p role="status" aria-label={labels.toolCall}>
-        {hasResults ? (
-          <FormattedMessage
-            id="xpack.agentBuilder.roundEvents.steps.toolCall.responded"
-            defaultMessage="Tool {tool} responded"
-            values={{ tool: toolBadge }}
-          />
-        ) : (
-          <FormattedMessage
-            id="xpack.agentBuilder.roundEvents.steps.toolCall.calling"
-            defaultMessage="Calling tool {tool}"
-            values={{ tool: toolBadge }}
-          />
-        )}
-      </p>
-    </EuiText>
-  );
-};
-
-const ToolCallExpansion: React.FC<{ step: ToolCallStepData }> = ({ step }) => {
-  const { euiTheme } = useEuiTheme();
-
-  // Sub-agent invocations get the rich `SubAgentExecutionFlyout` (nested steps + final response).
   const isSubAgentCall = step.tool_id === internalTools.runSubagent;
   const subAgentExecutionId = isSubAgentCall ? getSubAgentExecutionId(step) : undefined;
-
-  // Three mutually exclusive forms for the response section:
-  //   1. Sub-agent → inline "View execution" link (rich nested-steps flyout)
-  //   2. Any inline-renderable result → accordion with chevron
-  //   3. Only "other" results → inline "View JSON" link (raw JSON flyout)
-  const showSubAgentLink = isSubAgentCall && Boolean(subAgentExecutionId);
-  const showResponseAccordion = !showSubAgentLink && step.results.some(isInlineRenderableResult);
-  const showJsonLink = !showSubAgentLink && !showResponseAccordion && step.results.length > 0;
-
-  const containerStyles = css`
-    padding-left: ${euiTheme.size.s};
-    display: flex;
-    flex-direction: column;
-    gap: ${euiTheme.size.s};
-  `;
-
-  return (
-    <div css={containerStyles}>
-      <ParametersAccordion id={`${step.tool_call_id}-parameters`} params={step.params} />
-
-      {step.progression?.map((p, idx) => (
-        <EuiText key={`progression-${idx}`} size="s" color="subdued">
-          <p>{p.message}</p>
-        </EuiText>
-      ))}
-
-      {showResponseAccordion && (
-        <ResponseAccordion stepId={step.tool_call_id} results={step.results} />
-      )}
-      {(showSubAgentLink || showJsonLink) && (
-        <ResponseLink
-          step={step}
-          isSubAgentCall={isSubAgentCall}
-          subAgentExecutionId={subAgentExecutionId}
-        />
-      )}
-    </div>
-  );
-};
-
-const ParametersAccordion: React.FC<{
-  id: string;
-  params: ToolCallStepData['params'];
-}> = ({ id, params }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <EuiAccordion
-      id={id}
-      forceState={isOpen ? 'open' : 'closed'}
-      onToggle={setIsOpen}
-      arrowDisplay="none"
-      buttonContent={
-        <EuiFlexGroup
-          direction="row"
-          gutterSize="s"
-          alignItems="center"
-          responsive={false}
-          css={css`
-            width: fit-content;
-          `}
-        >
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color="subdued">
-              {labels.parameters}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiIcon
-              type={isOpen ? 'arrowUp' : 'arrowDown'}
-              size="s"
-              color="subdued"
-              aria-hidden={true}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      paddingSize="s"
-    >
-      <JsonCodeBlock data={params} />
-    </EuiAccordion>
-  );
-};
-
-const ResponseAccordion: React.FC<{
-  stepId: string;
-  results: ToolResultData[];
-}> = ({ stepId, results }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <EuiAccordion
-      id={`${stepId}-response`}
-      forceState={isOpen ? 'open' : 'closed'}
-      onToggle={setIsOpen}
-      arrowDisplay="none"
-      buttonContent={
-        <EuiFlexGroup
-          direction="row"
-          gutterSize="s"
-          alignItems="center"
-          responsive={false}
-          css={css`
-            width: fit-content;
-          `}
-        >
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color="subdued">
-              {labels.result}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiIcon
-              type={isOpen ? 'arrowUp' : 'arrowDown'}
-              size="s"
-              color="subdued"
-              aria-hidden={true}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      paddingSize="s"
-    >
-      {results.map((result, idx) => (
-        <Fragment key={`response-result-${idx}`}>
-          <ToolResult result={result} />
-          {idx < results.length - 1 && <EuiSpacer size="s" />}
-        </Fragment>
-      ))}
-    </EuiAccordion>
-  );
-};
-
-const ResponseLink: React.FC<{
-  step: ToolCallStepData;
-  isSubAgentCall: boolean;
-  subAgentExecutionId: string | undefined;
-}> = ({ step, isSubAgentCall, subAgentExecutionId }) => {
-  const { euiTheme } = useEuiTheme();
-
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
-  const openFlyout = useCallback(() => setIsFlyoutOpen(true), []);
-  const closeFlyout = useCallback(() => setIsFlyoutOpen(false), []);
-
   const showSubAgentFlyout = isSubAgentCall && Boolean(subAgentExecutionId);
-  const linkLabel = showSubAgentFlyout ? labels.viewExecution : labels.viewJson;
-  const linkTestSubj = showSubAgentFlyout ? 'toolCallViewExecutionLink' : 'toolCallViewJsonLink';
-  const linkAction = showSubAgentFlyout
-    ? AGENT_BUILDER_UI_EBT.action.conversation.VIEW_SUB_AGENT_EXECUTION
-    : AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE;
+  const canOpenFlyout = showSubAgentFlyout || hasResults;
 
   return (
-    <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
-      <EuiFlexItem grow={false}>
-        <EuiText size="s" color="subdued">
-          {labels.result}
-        </EuiText>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiIcon
-          type="dot"
-          size="s"
-          css={css`
-            color: ${euiTheme.colors.textDisabled};
-          `}
-          aria-hidden={true}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiLink
-          color="text"
-          onClick={openFlyout}
-          data-test-subj={linkTestSubj}
-          {...getEbtProps({
-            element: AGENT_BUILDER_UI_EBT.element.pageContent,
-            action: linkAction,
-            detail: 'conversation',
-          })}
-        >
-          {linkLabel}
-        </EuiLink>
-      </EuiFlexItem>
-      {showSubAgentFlyout && isFlyoutOpen && (
+    <div data-test-subj="agentBuilderToolCallStep">
+      <StepLayout
+        label={<ToolCallStepHeadline step={step} hasResults={hasResults} />}
+        isExpandable={false}
+        onClick={canOpenFlyout ? openFlyout : undefined}
+        ebtAction={
+          showSubAgentFlyout
+            ? AGENT_BUILDER_UI_EBT.action.conversation.VIEW_SUB_AGENT_EXECUTION
+            : AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TOOL_RESPONSE
+        }
+      />
+      {isFlyoutOpen && showSubAgentFlyout && (
         <SubAgentExecutionFlyout
           executionId={subAgentExecutionId!}
           params={step.params}
           onClose={closeFlyout}
         />
       )}
-      {!showSubAgentFlyout && (
-        <ToolResponseFlyout isOpen={isFlyoutOpen} onClose={closeFlyout}>
+      {isFlyoutOpen && !showSubAgentFlyout && (
+        <ToolResponseFlyout isOpen onClose={closeFlyout}>
           {step.results.map((result, idx) => (
             <Fragment key={`flyout-result-${idx}`}>
               <ToolResult result={result} />
@@ -314,7 +59,7 @@ const ResponseLink: React.FC<{
           ))}
         </ToolResponseFlyout>
       )}
-    </EuiFlexGroup>
+    </div>
   );
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step_headline.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/tool_call_step_headline.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  useEuiFontSize,
+  useEuiTheme,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
+import { isErrorResult } from '@kbn/agent-builder-common/tools/tool_result';
+import type { ToolCallStep as ToolCallStepData } from '@kbn/agent-builder-common/chat/conversation';
+
+const toolCallAriaLabel = i18n.translate(
+  'xpack.agentBuilder.roundEvents.steps.toolCall.ariaLabel',
+  {
+    defaultMessage: 'Tool call',
+  }
+);
+
+const toolBadgeToolLabel = i18n.translate(
+  'xpack.agentBuilder.roundEvents.steps.toolCall.toolBadgeToolLabel',
+  { defaultMessage: 'tool' }
+);
+
+interface ToolCallStepHeadlineProps {
+  step: ToolCallStepData;
+  hasResults: boolean;
+}
+
+export const ToolCallStepHeadline: React.FC<ToolCallStepHeadlineProps> = ({ step, hasResults }) => {
+  const { euiTheme } = useEuiTheme();
+  const suffixFontSize = useEuiFontSize('s');
+  const hasErrorResult = step.results.some(isErrorResult);
+
+  const suffixStyles = css`
+    ${suffixFontSize}
+    color: ${hasErrorResult ? euiTheme.colors.textDanger : euiTheme.colors.textDisabled};
+  `;
+
+  const toolBadge = (
+    <EuiBadge color={hasErrorResult ? 'danger' : 'default'}>
+      <strong
+        css={css`
+          font-weight: ${euiTheme.font.weight.bold};
+        `}
+      >
+        {toolBadgeToolLabel}
+      </strong>
+      : {step.tool_id}
+    </EuiBadge>
+  );
+
+  return (
+    <>
+      <EuiFlexGroup
+        responsive={false}
+        gutterSize="xs"
+        alignItems="center"
+        role="status"
+        aria-label={toolCallAriaLabel}
+      >
+        <EuiFlexItem grow={false}>{toolBadge}</EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <span css={suffixStyles}>
+            {hasResults ? (
+              <FormattedMessage
+                id="xpack.agentBuilder.roundEvents.steps.toolCall.ran"
+                defaultMessage="ran."
+              />
+            ) : (
+              <FormattedMessage
+                id="xpack.agentBuilder.roundEvents.steps.toolCall.running"
+                defaultMessage="running…"
+              />
+            )}
+          </span>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {step.progression?.map((p, idx) => (
+        <EuiText key={`progression-${idx}`} size="s">
+          <p>
+            <span
+              css={css`
+                color: ${euiTheme.colors.textDisabled};
+              `}
+            >
+              {p.message}
+            </span>
+          </p>
+        </EuiText>
+      ))}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/conversation_flow.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/conversation_flow.spec.ts
@@ -64,10 +64,9 @@ test.describe(
         ).toContainText(MOCKED_TITLE);
       }).toPass({ timeout: 120_000 });
 
-      await expect(page.testSubj.locator('agentBuilderToolCallGroup')).toContainText(
-        '1 tool responded',
-        { timeout: 60_000 }
-      );
+      const toolCallStep = page.testSubj.locator('agentBuilderToolCallStep');
+      await expect(toolCallStep).toContainText('tool: platform.core.search', { timeout: 60_000 });
+      await expect(toolCallStep).toContainText('ran.');
 
       await pageObjects.agentBuilder.clickNewConversationButton();
       await expect(async () => {


### PR DESCRIPTION
## Summary

Tool call steps now show "Running"/"Ran" instead of "Responded", restyled to match the design mockup — clicking a step opens its response flyout directly (no more accordion), and a lone tool call no longer gets wrapped in a group.

Closes elastic/search-team#15170

## Codereview

| Commit | What it does |
|---|---|
| 1. Implementation | Renames copy to Running/Ran, restyled badge row that opens the flyout on click, single tool calls no longer wrapped in a group, flyout-opening rows show no chevron, expand/collapse rows use ↓/↑ |
| 2. Tests | Unit tests and e2e copy update |

## Before / After

**Single tool call:**

| Before | After |
|---|---|
| ![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260709/tpz98zf5-before_final.png) | ![after](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260709/9v5kfirz-after_final.png) |

**Grouped tool calls (expanded):**

| Before | After |
|---|---|
| ![before](https://pub-fdecc921aab24330aaebc2e446135f0d.r2.dev/artifacts/20260709/oqru4434-before_group_final2.png) | <img width="294" height="91" alt="image" src="https://github.com/user-attachments/assets/b490b18b-e30c-4458-9c60-8f576c8e586e" />


https://github.com/user-attachments/assets/8651f32e-1c40-4b5a-a56b-0e7cf691b8df



## Test plan
- [x] Single tool call: shows "tool: X running…" while in progress, "tool: X ran." once done, no group wrapper
- [x] Grouped tool calls: header shows "N tools running…"/"N tools ran.", stays "running…" until every tool in the group has a result
- [x] Clicking a tool row opens the response flyout directly (no accordion)
- [x] Clicking a sub-agent tool row opens its execution flyout
- [x] Error result still shows in red/danger styling
- [x] Existing conversations with tool calls still render correctly