### PR TITLE
[Agent Builder] Implement attachment allowlist

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isAllowedBuiltinAttachment } from './allow_lists';
+
+describe('isAllowedBuiltinAttachment', () => {
+  it('returns true for listed attachment type ids', () => {
+    expect(isAllowedBuiltinAttachment('text')).toBe(true);
+    expect(isAllowedBuiltinAttachment('esql')).toBe(true);
+    expect(isAllowedBuiltinAttachment('platform.dashboard.dashboard_state')).toBe(true);
+    expect(isAllowedBuiltinAttachment('security.alert')).toBe(true);
+    expect(isAllowedBuiltinAttachment('observability.service-map')).toBe(true);
+  });
+
+  it('returns false for unlisted attachment type ids', () => {
+    expect(isAllowedBuiltinAttachment('not-an-attachment')).toBe(false);
+    expect(isAllowedBuiltinAttachment('')).toBe(false);
+    expect(isAllowedBuiltinAttachment('security.unknown')).toBe(false);
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -226,3 +226,76 @@ export type AgentBuilderBuiltinPlugin = (typeof AGENT_BUILDER_BUILTIN_PLUGINS)[n
 export const isAllowedBuiltinPlugin = (pluginId: string) => {
   return (AGENT_BUILDER_BUILTIN_PLUGINS as readonly string[]).includes(pluginId);
 };
+
+/**
+ * This is a manually maintained list of all built-in attachment types registered in Agent Builder.
+ * The intention is to force a code review from the Agent Builder team when any team adds a new attachment type.
+ */
+export const AGENT_BUILDER_BUILTIN_ATTACHMENTS = [
+  // Platform (agent_builder_platform)
+  'text',
+  'screen_context',
+  'esql',
+  'graph',
+  'connector',
+  'connector_setup',
+  'skill',
+
+  // Platform – Visualizations
+  'visualization',
+
+  // Platform – Dashboards
+  'platform.dashboard.dashboard_state',
+
+  // Platform – Streams (significant events)
+  'platform.sig_event',
+
+  // Platform – Discover
+  'esql.query_results',
+
+  // Platform – Workflows
+  'workflow.yaml',
+  'workflow.yaml.diff',
+
+  // Platform – Cases
+  'case',
+  'cases',
+
+  // Platform – Alerting v2
+  'rule',
+  'action_policy',
+
+  // Security Solution
+  'security.alert',
+  'security.alerts',
+  'security.entity',
+  'security.entity_analytics_dashboard',
+  'security.rule',
+  'security.siem_readiness',
+  // gated behind experimentalFeatures.rulePreviewAttachmentEnabled
+  'security.rule.preview',
+
+  // Security Solution – Attack Discovery (discoveries plugin)
+  // gated behind the workflows feature flag
+  'diagnostic_report',
+
+  // Observability
+  'observability.ai_insight',
+  'observability.error',
+  'observability.alert',
+  'observability.log',
+  'observability.service',
+  'observability.slo',
+  'observability.host',
+  'observability.transaction',
+  'observability.synthetics_monitor',
+
+  // Observability – APM
+  'observability.service-map',
+] as const;
+
+export type AgentBuilderBuiltinAttachment = (typeof AGENT_BUILDER_BUILTIN_ATTACHMENTS)[number];
+
+export const isAllowedBuiltinAttachment = (attachmentTypeId: string) => {
+  return (AGENT_BUILDER_BUILTIN_ATTACHMENTS as readonly string[]).includes(attachmentTypeId);
+};

--- a/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
+++ b/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
@@ -348,6 +348,16 @@ const textAttachmentType: AttachmentTypeDefinition = {
 Refer to [`AttachmentTypeDefinition`](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts)
 for the full list of available configuration options.
 
+#### Adding the attachment type to the allow list
+
+Similar to tools and agents, we keep an hardcoded list of registered attachment types to trigger a code review from the team when
+attachment types are added.
+
+To add an attachment type to the allow list, simply add the attachment type's id to the `AGENT_BUILDER_BUILTIN_ATTACHMENTS` array,
+in `x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts`
+
+(Kibana will fail to start otherwise, with an explicit error message explaining what to do)
+
 #### `getAgentDescription` — describing inline rendering to the agent
 
 When your attachment type supports inline rendering, `getAgentDescription` should tell

--- a/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
+++ b/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
@@ -350,7 +350,7 @@ for the full list of available configuration options.
 
 #### Adding the attachment type to the allow list
 
-Similar to tools and agents, we keep an hardcoded list of registered attachment types to trigger a code review from the team when
+Similar to tools and agents, we keep a hardcoded list of registered attachment types to trigger a code review from the team when
 attachment types are added.
 
 To add an attachment type to the allow list, simply add the attachment type's id to the `AGENT_BUILDER_BUILTIN_ATTACHMENTS` array,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isAllowedBuiltinAttachment } from '@kbn/agent-builder-server/allow_lists';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import { createAttachmentService } from './attachment_service';
+
+jest.mock('@kbn/agent-builder-server/allow_lists');
+
+const isAllowedBuiltinAttachmentMock = isAllowedBuiltinAttachment as jest.MockedFunction<
+  typeof isAllowedBuiltinAttachment
+>;
+
+const createMockedAttachmentType = (id = 'test-attachment'): AttachmentTypeDefinition => ({
+  id,
+  validate: () => ({ valid: true, data: { content: 'test' } }),
+  format: () => ({ getRepresentation: () => ({ type: 'text', value: 'test' }) }),
+});
+
+describe('AttachmentService', () => {
+  let service: ReturnType<typeof createAttachmentService>;
+
+  beforeEach(() => {
+    service = createAttachmentService();
+  });
+
+  afterEach(() => {
+    isAllowedBuiltinAttachmentMock.mockReset();
+  });
+
+  describe('#setup', () => {
+    it('allows registering allowed built-in attachment types', () => {
+      isAllowedBuiltinAttachmentMock.mockReturnValue(true);
+
+      const serviceSetup = service.setup();
+
+      expect(() => serviceSetup.registerType(createMockedAttachmentType())).not.toThrow();
+    });
+
+    it('throws an error trying to register non-allowed built-in attachment types', () => {
+      isAllowedBuiltinAttachmentMock.mockReturnValue(false);
+
+      const serviceSetup = service.setup();
+
+      expect(() => serviceSetup.registerType(createMockedAttachmentType()))
+        .toThrowErrorMatchingInlineSnapshot(`
+        "Built-in attachment with id \\"test-attachment\\" is not in the list of allowed built-in attachments.
+                     Please add it to the list of allowed built-in attachments in the \\"@kbn/agent-builder-server/allow_lists.ts\\" file."
+      `);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
@@ -7,6 +7,7 @@
 
 import type { SavedObjectsServiceStart } from '@kbn/core/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import { isAllowedBuiltinAttachment } from '@kbn/agent-builder-server/allow_lists';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import {
   createAttachmentTypeRegistry,
@@ -38,7 +39,15 @@ export class AttachmentServiceImpl implements AttachmentService {
 
   setup(): AttachmentServiceSetup {
     return {
-      registerType: (attachmentType) => this.attachmentTypeRegistry.register(attachmentType),
+      registerType: (attachmentType) => {
+        if (!isAllowedBuiltinAttachment(attachmentType.id)) {
+          throw new Error(
+            `Built-in attachment with id "${attachmentType.id}" is not in the list of allowed built-in attachments.
+             Please add it to the list of allowed built-in attachments in the "@kbn/agent-builder-server/allow_lists.ts" file.`
+          );
+        }
+        return this.attachmentTypeRegistry.register(attachmentType);
+      },
     };
   }
 


### PR DESCRIPTION
## Summary

Adds an attachment allow list to Agent Builder that mirrors the existing tool, agent, and plugin allow lists.

`AttachmentService.setup().registerType` now rejects any attachment whose id is not present in the `AGENT_BUILDER_BUILTIN_ATTACHMENTS` array, so Kibana fails to start with an explicit error:

```
[FATAL][root] Reason: Built-in attachment with id "<attachment-id>" is not in the list of allowed built-in attachments.
             Please add it to the list of allowed built-in attachments in the "@kbn/agent-builder-server/allow_lists.ts" file.
```

This forces a code review from Agent Builder whenever another team registers a new built-in attachment type. The `CONTRIBUTOR_GUIDE.md` has been updated accordingly.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
