### PR TITLE
[Alerting v2] [Create rule form] Use EUIcode component in read-only query

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
@@ -18,11 +18,6 @@ import type { FormValues, RuleQuery } from '../../../form/types';
 import { AlertConditionStep } from './alert_condition_step';
 import { ComposeDiscoverTimeFieldContextProvider } from '../compose_discover_time_field_context';
 
-jest.mock('@kbn/code-editor', () => ({
-  ...jest.requireActual('@kbn/code-editor'),
-  CodeEditor: ({ value }: { value: string }) => <pre data-test-subj="codeEditorMock">{value}</pre>,
-}));
-
 jest.mock('@kbn/esql-utils', () => ({
   getEsqlColumns: jest.fn(async () => []),
 }));

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.test.tsx
@@ -15,11 +15,6 @@ import {
   type EsqlSummaryState,
 } from './esql_query_summary_section';
 
-jest.mock('@kbn/code-editor', () => ({
-  CodeEditor: () => <div data-test-subj="codeEditorMock" />,
-  ESQL_LANG_ID: 'esql',
-}));
-
 const BASE = 'FROM logs-*';
 const ALERT_SEGMENT = '| WHERE count > 100';
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.tsx
@@ -6,21 +6,11 @@
  */
 
 import React from 'react';
-import {
-  EuiButton,
-  EuiButtonIcon,
-  EuiCallOut,
-  EuiCopy,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-} from '@elastic/eui';
+import { EuiButton, EuiCallOut, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { RuleQuery } from '../../../form/types';
-import { QuerySummary } from '../query_summary';
+import { QueryBlock, QuerySummary } from '../query_summary';
 
 /**
  * Read-only summary of the applied ES|QL query on step 1. The heuristic split
@@ -64,10 +54,6 @@ const NOT_DEFINED = i18n.translate('xpack.alertingV2.composeDiscover.esqlSummary
   defaultMessage: 'Not defined',
 });
 
-const COPY_LABEL = i18n.translate('xpack.alertingV2.composeDiscover.esqlSummary.copyAriaLabel', {
-  defaultMessage: 'Copy query',
-});
-
 const DESCRIPTIONS: Record<EsqlSummaryState, string> = {
   before_apply: i18n.translate(
     'xpack.alertingV2.composeDiscover.esqlSummary.beforeApplyDescription',
@@ -91,48 +77,6 @@ const DESCRIPTIONS: Record<EsqlSummaryState, string> = {
   empty: i18n.translate('xpack.alertingV2.composeDiscover.esqlSummary.emptyDescription', {
     defaultMessage: 'Define an ES|QL query in the editor',
   }),
-};
-
-interface QueryBlockProps {
-  label: React.ReactNode;
-  query: string;
-}
-
-const QueryBlock: React.FC<QueryBlockProps> = ({ label, query }) => {
-  const hasQuery = query.trim().length > 0;
-  return (
-    <>
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
-        alignItems="center"
-        responsive={false}
-        gutterSize="xs"
-      >
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            <strong>{label}</strong>
-          </EuiText>
-        </EuiFlexItem>
-        {hasQuery && (
-          <EuiFlexItem grow={false}>
-            <EuiCopy textToCopy={query}>
-              {(copy) => (
-                <EuiButtonIcon
-                  iconType="copyClipboard"
-                  color="text"
-                  aria-label={COPY_LABEL}
-                  onClick={copy}
-                  data-test-subj="esqlSummaryCopy"
-                />
-              )}
-            </EuiCopy>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
-      <EuiSpacer size="xs" />
-      <QuerySummary query={query} emptyMessage={NOT_DEFINED} />
-    </>
-  );
 };
 
 const EmptyCallout: React.FC = () => (
@@ -261,6 +205,7 @@ export const EsqlQuerySummarySection: React.FC<EsqlQuerySummarySectionProps> = (
               />
             }
             query={baseQuery}
+            emptyMessage={NOT_DEFINED}
           />
           <EuiSpacer size="m" />
           <QueryBlock
@@ -271,14 +216,11 @@ export const EsqlQuerySummarySection: React.FC<EsqlQuerySummarySectionProps> = (
               />
             }
             query={alertBlock}
+            emptyMessage={NOT_DEFINED}
           />
         </>
       ) : (
-        <EuiPanel color="subdued" paddingSize="m">
-          <EuiText size="s" color="subdued">
-            {NOT_DEFINED}
-          </EuiText>
-        </EuiPanel>
+        <QuerySummary query="" emptyMessage={NOT_DEFINED} />
       )}
 
       <EuiSpacer size="s" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_recovery_content.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_recovery_content.tsx
@@ -7,12 +7,22 @@
 
 import React from 'react';
 import { useWatch } from 'react-hook-form';
-import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButton, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { CustomRecoveryRenderProps } from '../types';
 import type { FormValues } from '../../../form/types';
-import { QuerySummary } from '../query_summary';
+import { QueryBlock } from '../query_summary';
+
+const noBaseQueryDefined = i18n.translate(
+  'xpack.alertingV2.composeDiscover.recoveryCondition.noBaseQueryDefined',
+  { defaultMessage: 'No base query defined' }
+);
+
+const noRecoveryConditionDefined = i18n.translate(
+  'xpack.alertingV2.composeDiscover.recoveryCondition.noRecoveryConditionDefined',
+  { defaultMessage: 'No recovery condition defined' }
+);
 
 export const EsqlRecoveryContent: React.FC<CustomRecoveryRenderProps> = ({ state, dispatch }) => {
   const query = useWatch<FormValues, 'query'>({ name: 'query' });
@@ -21,38 +31,26 @@ export const EsqlRecoveryContent: React.FC<CustomRecoveryRenderProps> = ({ state
 
   return (
     <>
-      <EuiText size="xs" color="subdued">
-        <strong>
+      <QueryBlock
+        label={
           <FormattedMessage
             id="xpack.alertingV2.composeDiscover.recoveryCondition.baseQueryLabel"
             defaultMessage="Base query"
           />
-        </strong>
-      </EuiText>
-      <EuiSpacer size="xs" />
-      <QuerySummary
+        }
         query={baseQuery}
-        emptyMessage={i18n.translate(
-          'xpack.alertingV2.composeDiscover.recoveryCondition.noBaseQueryDefined',
-          { defaultMessage: 'No base query defined' }
-        )}
+        emptyMessage={noBaseQueryDefined}
       />
       <EuiSpacer size="m" />
-      <EuiText size="xs" color="subdued">
-        <strong>
+      <QueryBlock
+        label={
           <FormattedMessage
             id="xpack.alertingV2.composeDiscover.recoveryCondition.recoveryConditionLabel"
             defaultMessage="Recovery condition"
           />
-        </strong>
-      </EuiText>
-      <EuiSpacer size="xs" />
-      <QuerySummary
+        }
         query={recoveryBlock}
-        emptyMessage={i18n.translate(
-          'xpack.alertingV2.composeDiscover.recoveryCondition.noRecoveryConditionDefined',
-          { defaultMessage: 'No recovery condition defined' }
-        )}
+        emptyMessage={noRecoveryConditionDefined}
       />
       <EuiSpacer size="s" />
       <EuiButton

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
@@ -18,11 +18,6 @@ import type { FormValues, RuleQuery } from '../../../form/types';
 import { RecoveryConditionStep } from './recovery_condition_step';
 import { EsqlRecoveryContent } from './esql_recovery_content';
 
-jest.mock('@kbn/code-editor', () => ({
-  ...jest.requireActual('@kbn/code-editor'),
-  CodeEditor: ({ value }: { value: string }) => <pre data-test-subj="codeEditorMock">{value}</pre>,
-}));
-
 const BASE_QUERY = 'FROM logs-*\n| STATS count = COUNT(*) BY host.name';
 const ALERT_SEGMENT = 'WHERE count > 100';
 const RECOVERY_SEGMENT = 'WHERE count < 100';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.test.tsx
@@ -8,10 +8,31 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { QueryBlock, QuerySummary } from './query_summary';
+import { QueryBlock, QuerySummary, getQuerySummaryOverflowHeight } from './query_summary';
 
 const renderWithIntl = (ui: React.ReactElement) =>
   render(<IntlProvider locale="en">{ui}</IntlProvider>);
+
+describe('getQuerySummaryOverflowHeight', () => {
+  it('returns undefined for empty queries', () => {
+    expect(getQuerySummaryOverflowHeight('')).toBeUndefined();
+    expect(getQuerySummaryOverflowHeight('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for queries up to MAX_VISIBLE_LINES', () => {
+    const fiveLineQuery = Array.from({ length: 5 }, (_, index) => `line ${index + 1}`).join('\n');
+
+    expect(getQuerySummaryOverflowHeight('FROM logs-*')).toBeUndefined();
+    expect(getQuerySummaryOverflowHeight('FROM logs-*\n| STATS count = COUNT(*)')).toBeUndefined();
+    expect(getQuerySummaryOverflowHeight(fiveLineQuery)).toBeUndefined();
+  });
+
+  it('returns overflow height when query exceeds MAX_VISIBLE_LINES', () => {
+    const sixLineQuery = Array.from({ length: 6 }, (_, index) => `line ${index + 1}`).join('\n');
+
+    expect(getQuerySummaryOverflowHeight(sixLineQuery)).toBe(240);
+  });
+});
 
 describe('QuerySummary', () => {
   it('renders empty state when query is blank', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { QueryBlock, QuerySummary } from './query_summary';
+
+const renderWithIntl = (ui: React.ReactElement) =>
+  render(<IntlProvider locale="en">{ui}</IntlProvider>);
+
+describe('QuerySummary', () => {
+  it('renders empty state when query is blank', () => {
+    renderWithIntl(<QuerySummary query="" emptyMessage="Not defined" />);
+
+    expect(screen.getByText('Not defined')).toBeInTheDocument();
+    expect(screen.queryByTestId('composeDiscoverQuerySummary')).not.toBeInTheDocument();
+  });
+
+  it('renders esql code block when query has content', () => {
+    renderWithIntl(<QuerySummary query="FROM logs-*" />);
+
+    const codeBlock = screen.getByTestId('composeDiscoverQuerySummary');
+    expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock).toHaveAttribute('data-code-language', 'esql');
+    expect(screen.getByText('FROM logs-*')).toBeInTheDocument();
+  });
+});
+
+describe('QueryBlock', () => {
+  it('renders label and query summary', () => {
+    renderWithIntl(<QueryBlock label="Base query" query="FROM logs-*" />);
+
+    expect(screen.getByText('Base query')).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverQuerySummary')).toBeInTheDocument();
+    expect(screen.getByText('FROM logs-*')).toBeInTheDocument();
+  });
+
+  it('renders empty state with custom message', () => {
+    renderWithIntl(<QueryBlock label="Alert condition" query="" emptyMessage="Not defined" />);
+
+    expect(screen.getByText('Alert condition')).toBeInTheDocument();
+    expect(screen.getByText('Not defined')).toBeInTheDocument();
+    expect(screen.queryByTestId('composeDiscoverQuerySummary')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.tsx
@@ -19,6 +19,20 @@ const copyAriaLabel = i18n.translate(
   { defaultMessage: 'Copy query' }
 );
 
+/** Visible line cap before the block scrolls (matches the old CodeEditor summary). */
+const MAX_VISIBLE_LINES = 5;
+
+/** Matches ES|QL code block height in alerting-v2-episodes-ui rule_overview_panel. */
+const QUERY_SUMMARY_OVERFLOW_HEIGHT = 240;
+
+export const getQuerySummaryOverflowHeight = (query: string): number | undefined => {
+  if (!query.trim()) {
+    return undefined;
+  }
+
+  return query.split('\n').length > MAX_VISIBLE_LINES ? QUERY_SUMMARY_OVERFLOW_HEIGHT : undefined;
+};
+
 interface QuerySummaryProps {
   query: string;
   emptyMessage?: string;
@@ -38,6 +52,8 @@ export const QuerySummary: React.FC<QuerySummaryProps> = ({
     );
   }
 
+  const overflowHeight = getQuerySummaryOverflowHeight(query);
+
   return (
     <EuiCodeBlock
       language="esql"
@@ -45,6 +61,7 @@ export const QuerySummary: React.FC<QuerySummaryProps> = ({
       copyAriaLabel={copyAriaLabel}
       paddingSize="s"
       fontSize="s"
+      overflowHeight={overflowHeight}
       data-test-subj="composeDiscoverQuerySummary"
     >
       {query}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.tsx
@@ -6,31 +6,28 @@
  */
 
 import React from 'react';
-import { EuiPanel, EuiText } from '@elastic/eui';
+import { EuiCodeBlock, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { CodeEditor, ESQL_LANG_ID } from '@kbn/code-editor';
 
 const defaultEmptyMessage = i18n.translate(
   'xpack.alertingV2.composeDiscover.querySummary.noQueryDefined',
   { defaultMessage: 'No query defined' }
 );
 
+const copyAriaLabel = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySummary.copyAriaLabel',
+  { defaultMessage: 'Copy query' }
+);
+
 interface QuerySummaryProps {
   query: string;
   emptyMessage?: string;
-  maxLines?: number;
 }
 
 export const QuerySummary: React.FC<QuerySummaryProps> = ({
   query,
   emptyMessage = defaultEmptyMessage,
-  maxLines = 5,
 }) => {
-  const actualLines = query.split('\n').length;
-  const lineCount = Math.max(2, Math.min(actualLines, maxLines));
-  const height = lineCount * 18 + 16;
-  const isScrollable = actualLines > maxLines;
-
   if (!query.trim()) {
     return (
       <EuiPanel color="subdued" paddingSize="s">
@@ -42,23 +39,31 @@ export const QuerySummary: React.FC<QuerySummaryProps> = ({
   }
 
   return (
-    <EuiPanel color="subdued" paddingSize="none" hasBorder>
-      <CodeEditor
-        languageId={ESQL_LANG_ID}
-        value={query}
-        height={height}
-        options={{
-          readOnly: true,
-          minimap: { enabled: false },
-          lineNumbers: 'off',
-          scrollBeyondLastLine: false,
-          folding: false,
-          renderLineHighlight: 'none',
-          overviewRulerLanes: 0,
-          scrollbar: { vertical: isScrollable ? 'auto' : 'hidden', horizontal: 'hidden' },
-          domReadOnly: true,
-        }}
-      />
-    </EuiPanel>
+    <EuiCodeBlock
+      language="esql"
+      isCopyable
+      copyAriaLabel={copyAriaLabel}
+      paddingSize="s"
+      fontSize="s"
+      data-test-subj="composeDiscoverQuerySummary"
+    >
+      {query}
+    </EuiCodeBlock>
   );
 };
+
+interface QueryBlockProps {
+  label: React.ReactNode;
+  query: string;
+  emptyMessage?: string;
+}
+
+export const QueryBlock: React.FC<QueryBlockProps> = ({ label, query, emptyMessage }) => (
+  <>
+    <EuiText size="xs" color="subdued">
+      <strong>{label}</strong>
+    </EuiText>
+    <EuiSpacer size="xs" />
+    <QuerySummary query={query} emptyMessage={emptyMessage} />
+  </>
+);


### PR DESCRIPTION
Closes [elastic/rna-program#541](https://github.com/elastic/rna-program/issues/541)

Replaces read-only ES|QL query summaries in the v2 rule authoring flyout with `EuiCodeBlock` (per M2 design audit), matching the pattern already used in rule details.

- Swap `QuerySummary` from a read-only Monaco `CodeEditor` to `EuiCodeBlock` with ES|QL syntax highlighting and built-in copy.
- Remove the manual copy button from the alert condition summary section (now handled by `EuiCodeBlock`).
- Extract a shared `QueryBlock` component (label + summary) used by alert and recovery steps.
- Unify empty-state rendering via `QuerySummary` across all read-only query blocks.

## Test plan
1. Kibana running with `alertingv2: enabled`
2. Open rule authoring flyout (create) → apply an ES|QL query → verify base query and alert condition render as `EuiCodeBlock` with copy button
3. Edit an existing rule → verify read-only query summaries match design
4. Recovery step (custom recovery) → verify base query and recovery condition use the same component
5. Empty blocks show correct placeholder text ("Not defined", "No base query defined", etc.)
6. Copy button copies the full query text

 Unit tests pass:
```
node scripts/jest \
  x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_summary.test.tsx \
  x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.test.tsx \
  x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx \
  x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
```


<img width="483" height="641" alt="create alert rule" src="https://github.com/user-attachments/assets/18465861-a267-4eda-94e9-1323eb1b3ce1" />
