### PR TITLE
[9.4] [SLO] Enforce space-level authorization on health scan endpoints (#273939)

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/health_scan.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/health_scan.ts
@@ -14,6 +14,7 @@ import {
   type PostHealthScanResponse,
 } from '@kbn/slo-schema';
 import {
+  getAccessibleSpaceIds,
   getHealthScanResults,
   listHealthScans,
   scheduleHealthScan,
@@ -55,10 +56,18 @@ export const listHealthScanRoute = createSloServerRoute({
     logger,
   }): Promise<ListHealthScanResponse> => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient } = await getScopedClients({ request, logger });
+    const { scopedClusterClient, spaceId } = await getScopedClients({ request, logger });
     const taskManager = await plugins.taskManager.start();
+    const spaceIds = await getAccessibleSpaceIds({
+      plugins,
+      request,
+      activeSpaceId: spaceId,
+    });
 
-    return listHealthScans({ size: params?.query?.size }, { scopedClusterClient, taskManager });
+    return listHealthScans(
+      { size: params?.query?.size },
+      { scopedClusterClient, taskManager, spaceIds }
+    );
   },
 });
 
@@ -82,15 +91,18 @@ export const getHealthScanRoute = createSloServerRoute({
     const taskManager = await plugins.taskManager.start();
     const { scopedClusterClient, spaceId } = await getScopedClients({ request, logger });
 
+    const spaceIds = params.query?.allSpaces
+      ? await getAccessibleSpaceIds({ plugins, request, activeSpaceId: spaceId })
+      : [spaceId];
+
     return getHealthScanResults(
       {
         scanId: params.path.scanId,
         size: params.query?.size,
         problematic: params.query?.problematic,
-        allSpaces: params.query?.allSpaces,
         searchAfter: params.query?.searchAfter,
       },
-      { scopedClusterClient, taskManager, spaceId }
+      { scopedClusterClient, taskManager, spaceIds }
     );
   },
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_accessible_space_ids.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_accessible_space_ids.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { getAccessibleSpaceIds } from './get_accessible_space_ids';
+
+describe('getAccessibleSpaceIds', () => {
+  const request = httpServerMock.createKibanaRequest();
+
+  const createMockPlugins = ({
+    spaces,
+    privileges,
+  }: {
+    spaces?: Array<{ id: string }>;
+    privileges?: Array<{ resource: string; authorized: boolean }>;
+  } = {}) => {
+    const sloReadAction = 'api:slo_read';
+
+    const mockPlugins: any = {
+      security: {
+        setup: {
+          authz: {
+            actions: {
+              api: {
+                get: (action: string) => `api:${action}`,
+              },
+            },
+            checkPrivilegesWithRequest: () => ({
+              atSpaces: async () => ({
+                privileges: {
+                  kibana: (privileges ?? []).map((p) => ({
+                    ...p,
+                    privilege: sloReadAction,
+                  })),
+                },
+              }),
+            }),
+          },
+        },
+      },
+    };
+
+    if (spaces !== undefined) {
+      mockPlugins.spaces = {
+        start: async () => ({
+          spacesService: {
+            createSpacesClient: () => ({
+              getAll: async () => spaces,
+            }),
+          },
+        }),
+      };
+    }
+
+    return mockPlugins;
+  };
+
+  it('returns activeSpaceId when spaces plugin is not available', async () => {
+    const plugins = createMockPlugins();
+
+    const result = await getAccessibleSpaceIds({
+      plugins,
+      request,
+      activeSpaceId: 'my-space',
+    });
+
+    expect(result).toEqual(['my-space']);
+  });
+
+  it('returns activeSpaceId when getAll returns empty', async () => {
+    const plugins = createMockPlugins({ spaces: [], privileges: [] });
+
+    const result = await getAccessibleSpaceIds({
+      plugins,
+      request,
+      activeSpaceId: 'fallback',
+    });
+
+    expect(result).toEqual(['fallback']);
+  });
+
+  it('returns only spaces where the user has slo_read privilege', async () => {
+    const plugins = createMockPlugins({
+      spaces: [{ id: 'space-a' }, { id: 'space-b' }, { id: 'space-c' }],
+      privileges: [
+        { resource: 'space-a', authorized: true },
+        { resource: 'space-b', authorized: false },
+        { resource: 'space-c', authorized: true },
+      ],
+    });
+
+    const result = await getAccessibleSpaceIds({
+      plugins,
+      request,
+      activeSpaceId: 'space-a',
+    });
+
+    expect(result).toEqual(['space-a', 'space-c']);
+  });
+
+  it('returns all spaces when user has slo_read in all', async () => {
+    const plugins = createMockPlugins({
+      spaces: [{ id: 'default' }, { id: 'space-b' }],
+      privileges: [
+        { resource: 'default', authorized: true },
+        { resource: 'space-b', authorized: true },
+      ],
+    });
+
+    const result = await getAccessibleSpaceIds({
+      plugins,
+      request,
+      activeSpaceId: 'default',
+    });
+
+    expect(result).toEqual(['default', 'space-b']);
+  });
+
+  it('falls back to activeSpaceId when no spaces are authorized', async () => {
+    const plugins = createMockPlugins({
+      spaces: [{ id: 'space-a' }, { id: 'space-b' }],
+      privileges: [
+        { resource: 'space-a', authorized: false },
+        { resource: 'space-b', authorized: false },
+      ],
+    });
+
+    const result = await getAccessibleSpaceIds({
+      plugins,
+      request,
+      activeSpaceId: 'space-a',
+    });
+
+    expect(result).toEqual(['space-a']);
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_accessible_space_ids.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_accessible_space_ids.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { SLORoutesDependencies } from '../../routes/utils/types';
+
+interface Params {
+  plugins: SLORoutesDependencies['plugins'];
+  request: KibanaRequest;
+  activeSpaceId: string;
+}
+
+export async function getAccessibleSpaceIds({
+  plugins,
+  request,
+  activeSpaceId,
+}: Params): Promise<string[]> {
+  const spacesStart = await plugins.spaces?.start();
+  if (!spacesStart) {
+    return [activeSpaceId];
+  }
+
+  const spacesClient = spacesStart.spacesService.createSpacesClient(request);
+  const allSpaces = await spacesClient.getAll();
+  const spaceIds = allSpaces.map((space) => space.id);
+
+  if (spaceIds.length === 0) {
+    return [activeSpaceId];
+  }
+
+  const { authz } = plugins.security.setup;
+  const { privileges } = await authz.checkPrivilegesWithRequest(request).atSpaces(spaceIds, {
+    kibana: [authz.actions.api.get('slo_read')],
+  });
+
+  const authorizedSpaceIds = spaceIds.filter(
+    (id) => privileges.kibana.find((p) => p.resource === id)?.authorized ?? false
+  );
+
+  return authorizedSpaceIds.length > 0 ? authorizedSpaceIds : [activeSpaceId];
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_accessible_space_ids.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_accessible_space_ids.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import type { SLORoutesDependencies } from '../../routes/utils/types';
+import type { SLORoutesDependencies } from '../../routes/types';
 
 interface Params {
   plugins: SLORoutesDependencies['plugins'];

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_health_scan_results.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_health_scan_results.test.ts
@@ -91,7 +91,7 @@ describe('getHealthScanResults', () => {
   const deps = {
     scopedClusterClient: {} as ScopedClusterClientMock,
     taskManager: {} as ReturnType<typeof taskManagerMock.createStart>,
-    spaceId: 'default',
+    spaceIds: ['default'],
   };
 
   beforeEach(() => {
@@ -121,7 +121,7 @@ describe('getHealthScanResults', () => {
       });
 
       const result = await getHealthScanResults(
-        { scanId: TEST_SCAN_ID, size, problematic: true, allSpaces: true },
+        { scanId: TEST_SCAN_ID, size, problematic: true },
         deps
       );
 
@@ -146,7 +146,7 @@ describe('getHealthScanResults', () => {
       });
 
       const result = await getHealthScanResults(
-        { scanId: TEST_SCAN_ID, size, problematic: true, allSpaces: true },
+        { scanId: TEST_SCAN_ID, size, problematic: true },
         deps
       );
 
@@ -173,7 +173,6 @@ describe('getHealthScanResults', () => {
           scanId: TEST_SCAN_ID,
           size: 25,
           problematic: true,
-          allSpaces: true,
           searchAfter: JSON.stringify(searchAfter),
         },
         deps
@@ -200,7 +199,6 @@ describe('getHealthScanResults', () => {
           scanId: TEST_SCAN_ID,
           size: 25,
           problematic: true,
-          allSpaces: true,
           searchAfter: 'not-valid-json',
         },
         deps
@@ -243,6 +241,58 @@ describe('getHealthScanResults', () => {
     it('accepts size 100', async () => {
       const result = await getHealthScanResults({ scanId: TEST_SCAN_ID, size: 100 }, deps);
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('space filtering', () => {
+    beforeEach(() => {
+      scopedClusterClient.asInternalUser.search.mockImplementation(async (params: any) => {
+        if (params?.size === 0) {
+          return createMockSummaryAggResponse(10, 2) as any;
+        }
+        return createMockSearchHitsResponse([createMockHealthDoc()], 1) as any;
+      });
+    });
+
+    it('always includes a spaceId filter in the scan results query', async () => {
+      await getHealthScanResults({ scanId: TEST_SCAN_ID }, deps);
+
+      const resultsCall = scopedClusterClient.asInternalUser.search.mock.calls.find(
+        (call: any) => call[0]?.size > 0
+      );
+      const filter = resultsCall?.[0]?.query?.bool?.filter;
+      expect(filter).toEqual(expect.arrayContaining([{ terms: { spaceId: ['default'] } }]));
+    });
+
+    it('always includes a spaceId filter in the summary query', async () => {
+      await getHealthScanResults({ scanId: TEST_SCAN_ID }, deps);
+
+      const summaryCall = scopedClusterClient.asInternalUser.search.mock.calls.find(
+        (call: any) => call[0]?.size === 0
+      );
+      const filter = summaryCall?.[0]?.query?.bool?.filter;
+      expect(filter).toEqual(expect.arrayContaining([{ terms: { spaceId: ['default'] } }]));
+    });
+
+    it('filters by multiple space IDs when provided', async () => {
+      const multiSpaceDeps = { ...deps, spaceIds: ['space-a', 'space-b'] };
+      await getHealthScanResults({ scanId: TEST_SCAN_ID }, multiSpaceDeps);
+
+      const resultsCall = scopedClusterClient.asInternalUser.search.mock.calls.find(
+        (call: any) => call[0]?.size > 0
+      );
+      const filter = resultsCall?.[0]?.query?.bool?.filter;
+      expect(filter).toEqual(
+        expect.arrayContaining([{ terms: { spaceId: ['space-a', 'space-b'] } }])
+      );
+
+      const summaryCall = scopedClusterClient.asInternalUser.search.mock.calls.find(
+        (call: any) => call[0]?.size === 0
+      );
+      const summaryFilter = summaryCall?.[0]?.query?.bool?.filter;
+      expect(summaryFilter).toEqual(
+        expect.arrayContaining([{ terms: { spaceId: ['space-a', 'space-b'] } }])
+      );
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_health_scan_results.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/get_health_scan_results.ts
@@ -15,22 +15,21 @@ import type { HealthDocument } from '../tasks/health_scan_task/types';
 interface Dependencies {
   scopedClusterClient: IScopedClusterClient;
   taskManager: TaskManagerStartContract;
-  spaceId: string;
+  spaceIds: string[];
 }
 
 interface Params {
   scanId: string;
   size?: number;
   problematic?: boolean;
-  allSpaces?: boolean;
   searchAfter?: string;
 }
 
 export async function getHealthScanResults(
   params: Params,
-  { scopedClusterClient, taskManager, spaceId }: Dependencies
+  { scopedClusterClient, taskManager, spaceIds }: Dependencies
 ): Promise<GetHealthScanResultsResponse> {
-  const { scanId, size = 100, problematic, allSpaces, searchAfter: searchAfterStr } = params;
+  const { scanId, size = 100, problematic, searchAfter: searchAfterStr } = params;
   const searchAfter = parseSearchAfter(searchAfterStr);
   if (size <= 0 || size > 100) {
     throw new IllegalArgumentError('Size must be between 1 and 100');
@@ -41,12 +40,11 @@ export async function getHealthScanResults(
     getScanResults(scopedClusterClient, {
       size,
       scanId,
-      allSpaces,
-      spaceId,
+      spaceIds,
       problematic,
       searchAfter,
     }),
-    getGlobalScanSummary(scopedClusterClient, scanId),
+    getScanSummary(scopedClusterClient, scanId, spaceIds),
   ]);
 
   const isScanScheduledSoon = !scanTask && total === 0;
@@ -74,15 +72,13 @@ async function getScanResults(
   {
     size,
     scanId,
-    allSpaces,
-    spaceId,
+    spaceIds,
     problematic,
     searchAfter,
   }: {
-    spaceId: string;
+    spaceIds: string[];
     scanId: string;
     size: number;
-    allSpaces?: boolean;
     problematic?: boolean;
     searchAfter?: any[];
   }
@@ -94,7 +90,7 @@ async function getScanResults(
       bool: {
         filter: [
           { term: { scanId } },
-          ...(allSpaces ? [] : [{ term: { spaceId } }]),
+          { terms: { spaceId: spaceIds } },
           ...(problematic ? [{ term: { 'health.isProblematic': problematic } }] : []),
         ],
       },
@@ -125,7 +121,11 @@ async function getScanTask(taskManager: TaskManagerStartContract, scanId: string
   return await taskManager.get(scanId).catch(() => null);
 }
 
-async function getGlobalScanSummary(scopedClusterClient: IScopedClusterClient, scanId: string) {
+async function getScanSummary(
+  scopedClusterClient: IScopedClusterClient,
+  scanId: string,
+  spaceIds: string[]
+) {
   interface SummaryAgg {
     latest_timestamp: { value: number; value_as_string: string };
     processed: { value: number };
@@ -135,7 +135,7 @@ async function getGlobalScanSummary(scopedClusterClient: IScopedClusterClient, s
   const summary = await scopedClusterClient.asInternalUser.search<unknown, SummaryAgg>({
     index: HEALTH_DATA_STREAM_NAME,
     size: 0,
-    query: { bool: { filter: [{ term: { scanId } }] } },
+    query: { bool: { filter: [{ term: { scanId } }, { terms: { spaceId: spaceIds } }] } },
     aggs: {
       latest_timestamp: {
         max: {

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/index.ts
@@ -8,3 +8,4 @@
 export { scheduleHealthScan } from './schedule_health_scan';
 export { listHealthScans } from './list_health_scans';
 export { getHealthScanResults } from './get_health_scan_results';
+export { getAccessibleSpaceIds } from './get_accessible_space_ids';

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/list_health_scans.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/list_health_scans.test.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { listHealthScans } from './list_health_scans';
+import { IllegalArgumentError } from '../../errors';
+
+type ScopedClusterClientMock = ReturnType<
+  typeof elasticsearchServiceMock.createScopedClusterClient
+>;
+
+function createMockScanBucketsResponse(
+  buckets: Array<{
+    scanId: string;
+    docCount: number;
+    problematic: number;
+    latestTimestamp: string;
+  }>
+) {
+  return {
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+    hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
+    aggregations: {
+      scans: {
+        buckets: buckets.map((b) => ({
+          key: { scanId: b.scanId },
+          doc_count: b.docCount,
+          latest_timestamp: {
+            value: new Date(b.latestTimestamp).getTime(),
+            value_as_string: b.latestTimestamp,
+          },
+          problematic: { doc_count: b.problematic },
+        })),
+      },
+    },
+  };
+}
+
+describe('listHealthScans', () => {
+  let scopedClusterClient: ScopedClusterClientMock;
+  let taskManager: ReturnType<typeof taskManagerMock.createStart>;
+
+  const deps = {
+    scopedClusterClient: {} as ScopedClusterClientMock,
+    taskManager: {} as ReturnType<typeof taskManagerMock.createStart>,
+    spaceIds: ['default'],
+  };
+
+  beforeEach(() => {
+    scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+    taskManager = taskManagerMock.createStart();
+    deps.scopedClusterClient = scopedClusterClient;
+    deps.taskManager = taskManager;
+    taskManager.fetch.mockResolvedValue({ docs: [], versionMap: new Map() });
+    jest.clearAllMocks();
+  });
+
+  describe('space filtering', () => {
+    it('includes a spaceId filter in the composite aggregation query for a single space', async () => {
+      scopedClusterClient.asInternalUser.search.mockResolvedValue(
+        createMockScanBucketsResponse([]) as any
+      );
+
+      await listHealthScans({}, deps);
+
+      const searchCall = scopedClusterClient.asInternalUser.search.mock.calls[0];
+      const filter = searchCall?.[0]?.query?.bool?.filter;
+      expect(filter).toEqual([{ terms: { spaceId: ['default'] } }]);
+    });
+
+    it('includes a spaceId filter with multiple space IDs when provided', async () => {
+      scopedClusterClient.asInternalUser.search.mockResolvedValue(
+        createMockScanBucketsResponse([]) as any
+      );
+
+      const multiSpaceDeps = { ...deps, spaceIds: ['space-a', 'space-b', 'space-c'] };
+      await listHealthScans({}, multiSpaceDeps);
+
+      const searchCall = scopedClusterClient.asInternalUser.search.mock.calls[0];
+      const filter = searchCall?.[0]?.query?.bool?.filter;
+      expect(filter).toEqual([{ terms: { spaceId: ['space-a', 'space-b', 'space-c'] } }]);
+    });
+  });
+
+  describe('size validation', () => {
+    beforeEach(() => {
+      scopedClusterClient.asInternalUser.search.mockResolvedValue(
+        createMockScanBucketsResponse([]) as any
+      );
+    });
+
+    it('throws when size is 0', async () => {
+      await expect(listHealthScans({ size: 0 }, deps)).rejects.toThrow(IllegalArgumentError);
+    });
+
+    it('throws when size exceeds 100', async () => {
+      await expect(listHealthScans({ size: 101 }, deps)).rejects.toThrow(IllegalArgumentError);
+    });
+  });
+
+  describe('scan results', () => {
+    it('returns scans from the composite aggregation buckets', async () => {
+      scopedClusterClient.asInternalUser.search.mockResolvedValue(
+        createMockScanBucketsResponse([
+          {
+            scanId: 'scan-1',
+            docCount: 50,
+            problematic: 5,
+            latestTimestamp: '2026-01-15T10:00:00.000Z',
+          },
+          {
+            scanId: 'scan-2',
+            docCount: 30,
+            problematic: 0,
+            latestTimestamp: '2026-01-14T10:00:00.000Z',
+          },
+        ]) as any
+      );
+
+      const result = await listHealthScans({}, deps);
+
+      expect(result.scans).toHaveLength(2);
+      expect(result.scans[0]).toEqual({
+        scanId: 'scan-1',
+        latestTimestamp: '2026-01-15T10:00:00.000Z',
+        total: 50,
+        problematic: 5,
+        status: 'completed',
+      });
+      expect(result.scans[1]).toEqual({
+        scanId: 'scan-2',
+        latestTimestamp: '2026-01-14T10:00:00.000Z',
+        total: 30,
+        problematic: 0,
+        status: 'completed',
+      });
+    });
+
+    it('marks scans as pending when a matching recent task is not done', async () => {
+      scopedClusterClient.asInternalUser.search.mockResolvedValue(
+        createMockScanBucketsResponse([
+          {
+            scanId: 'scan-1',
+            docCount: 10,
+            problematic: 2,
+            latestTimestamp: '2026-01-15T10:00:00.000Z',
+          },
+        ]) as any
+      );
+
+      taskManager.fetch.mockResolvedValue({
+        docs: [
+          {
+            id: 'scan-1',
+            scheduledAt: new Date('2026-01-15T09:55:00.000Z'),
+            state: { isDone: false },
+          },
+        ],
+      } as any);
+
+      const result = await listHealthScans({}, deps);
+
+      expect(result.scans[0].status).toBe('pending');
+    });
+
+    it('includes scheduled tasks that have not produced documents yet', async () => {
+      scopedClusterClient.asInternalUser.search.mockResolvedValue(
+        createMockScanBucketsResponse([]) as any
+      );
+
+      taskManager.fetch.mockResolvedValue({
+        docs: [
+          {
+            id: 'scan-new',
+            scheduledAt: new Date('2026-01-15T10:00:00.000Z'),
+            state: { isDone: false },
+          },
+        ],
+      } as any);
+
+      const result = await listHealthScans({}, deps);
+
+      expect(result.scans).toHaveLength(1);
+      expect(result.scans[0]).toEqual({
+        scanId: 'scan-new',
+        latestTimestamp: '2026-01-15T10:00:00.000Z',
+        total: 0,
+        problematic: 0,
+        status: 'pending',
+      });
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_scan/list_health_scans.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_scan/list_health_scans.ts
@@ -15,6 +15,7 @@ import { HEALTH_SCAN_TASK_TYPE } from '../tasks/health_scan_task/health_scan_tas
 interface Dependencies {
   scopedClusterClient: IScopedClusterClient;
   taskManager: TaskManagerStartContract;
+  spaceIds: string[];
 }
 
 interface Params {
@@ -23,7 +24,7 @@ interface Params {
 
 export async function listHealthScans(
   params: Params,
-  { scopedClusterClient, taskManager }: Dependencies
+  { scopedClusterClient, taskManager, spaceIds }: Dependencies
 ): Promise<ListHealthScanResponse> {
   const { size = 25 } = params;
   if (size <= 0 || size > 100) {
@@ -32,7 +33,7 @@ export async function listHealthScans(
 
   const [recentTasks, buckets] = await Promise.all([
     getRecentTasks(taskManager, size),
-    getScanBuckets(scopedClusterClient, size),
+    getScanBuckets(scopedClusterClient, size, spaceIds),
   ]);
 
   const scanIds = buckets.map((bucket) => bucket.key.scanId);
@@ -85,7 +86,11 @@ async function getRecentTasks(taskManager: TaskManagerStartContract, size: numbe
     .catch(() => ({ docs: [] }));
 }
 
-async function getScanBuckets(scopedClusterClient: IScopedClusterClient, size: number) {
+async function getScanBuckets(
+  scopedClusterClient: IScopedClusterClient,
+  size: number,
+  spaceIds: string[]
+) {
   interface ScanBucket {
     key: { scanId: string };
     doc_count: number;
@@ -99,6 +104,11 @@ async function getScanBuckets(scopedClusterClient: IScopedClusterClient, size: n
   >({
     index: HEALTH_DATA_STREAM_NAME,
     size: 0,
+    query: {
+      bool: {
+        filter: [{ terms: { spaceId: spaceIds } }],
+      },
+    },
     aggs: {
       scans: {
         composite: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[SLO] Enforce space-level authorization on health scan endpoints (#273939)](https://github.com/elastic/kibana/pull/273939)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-09T12:01:10Z","message":"[SLO] Enforce space-level authorization on health scan endpoints (#273939)\n\n## Summary\n\nThe SLO health scan endpoints used `scopedClusterClient.asInternalUser`\nwithout enforcing space-level authorization, allowing a user with\n`slo_read` in one space to see SLO names, IDs, health status, and space\nidentifiers from every space in the deployment.\n\n### Changes\n\n- **New utility `getAccessibleSpaceIds`**: Resolves which spaces the\nuser has `slo_read` access to using the Spaces and Security plugin APIs\n(following the Fleet pattern with\n`checkPrivilegesWithRequest.atSpaces`).\n- **`getHealthScanResults`**: Services now accept `spaceIds: string[]`\ninstead of `spaceId: string` + `allSpaces?: boolean`. Both the scan\nresults query and the summary aggregation always filter by `{ terms: {\nspaceId: spaceIds } }`.\n- **`listHealthScans`**: The `getScanBuckets` composite aggregation now\nincludes a `spaceId` filter, scoped to the user's accessible spaces.\n- **Route handlers**: The list endpoint always resolves accessible\nspaces. The get-results endpoint resolves accessible spaces when\n`allSpaces=true`, otherwise uses the current space.\n\nThe `allSpaces` API parameter is preserved but its semantics change from\n\"bypass space filter entirely\" to \"show results from all spaces I am\nauthorized to see.\" No schema changes are needed.\n\n### What is NOT changed\n\n- The `POST` endpoint (triggering a scan) is unchanged — scans still run\nglobally across all spaces.\n- The background scan task still processes all SLOs via `namespaces:\n['*']`.\n- The UI (`scan_results_panel.tsx`) continues to send `allSpaces: true`\nand works without modification.\n\n## Test plan\n\n- [ ] Verify a user with `slo_read` in Space A only sees Space A's SLO\nhealth data when calling `GET .../_health/scans/{scanId}?allSpaces=true`\n- [ ] Verify a user with `slo_read` in Space A only sees Space A's\naggregate counts from `GET .../_health/scans`\n- [ ] Verify an admin with `slo_read` in all spaces sees results from\nall spaces (same behavior as before)\n- [ ] Verify the health scan flyout UI works correctly for both admin\nand restricted users\n- [ ] Unit tests pass: `node scripts/jest\nx-pack/solutions/observability/plugins/slo/server/services/health_scan/`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Miguel Martín <miguel.martin@elastic.co>","sha":"faf08b4951062f66b20d3ea2886ac23274a87a4e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","author:actionable-obs","v9.5.0"],"title":"[SLO] Enforce space-level authorization on health scan endpoints","number":273939,"url":"https://github.com/elastic/kibana/pull/273939","mergeCommit":{"message":"[SLO] Enforce space-level authorization on health scan endpoints (#273939)\n\n## Summary\n\nThe SLO health scan endpoints used `scopedClusterClient.asInternalUser`\nwithout enforcing space-level authorization, allowing a user with\n`slo_read` in one space to see SLO names, IDs, health status, and space\nidentifiers from every space in the deployment.\n\n### Changes\n\n- **New utility `getAccessibleSpaceIds`**: Resolves which spaces the\nuser has `slo_read` access to using the Spaces and Security plugin APIs\n(following the Fleet pattern with\n`checkPrivilegesWithRequest.atSpaces`).\n- **`getHealthScanResults`**: Services now accept `spaceIds: string[]`\ninstead of `spaceId: string` + `allSpaces?: boolean`. Both the scan\nresults query and the summary aggregation always filter by `{ terms: {\nspaceId: spaceIds } }`.\n- **`listHealthScans`**: The `getScanBuckets` composite aggregation now\nincludes a `spaceId` filter, scoped to the user's accessible spaces.\n- **Route handlers**: The list endpoint always resolves accessible\nspaces. The get-results endpoint resolves accessible spaces when\n`allSpaces=true`, otherwise uses the current space.\n\nThe `allSpaces` API parameter is preserved but its semantics change from\n\"bypass space filter entirely\" to \"show results from all spaces I am\nauthorized to see.\" No schema changes are needed.\n\n### What is NOT changed\n\n- The `POST` endpoint (triggering a scan) is unchanged — scans still run\nglobally across all spaces.\n- The background scan task still processes all SLOs via `namespaces:\n['*']`.\n- The UI (`scan_results_panel.tsx`) continues to send `allSpaces: true`\nand works without modification.\n\n## Test plan\n\n- [ ] Verify a user with `slo_read` in Space A only sees Space A's SLO\nhealth data when calling `GET .../_health/scans/{scanId}?allSpaces=true`\n- [ ] Verify a user with `slo_read` in Space A only sees Space A's\naggregate counts from `GET .../_health/scans`\n- [ ] Verify an admin with `slo_read` in all spaces sees results from\nall spaces (same behavior as before)\n- [ ] Verify the health scan flyout UI works correctly for both admin\nand restricted users\n- [ ] Unit tests pass: `node scripts/jest\nx-pack/solutions/observability/plugins/slo/server/services/health_scan/`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Miguel Martín <miguel.martin@elastic.co>","sha":"faf08b4951062f66b20d3ea2886ac23274a87a4e"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273939","number":273939,"mergeCommit":{"message":"[SLO] Enforce space-level authorization on health scan endpoints (#273939)\n\n## Summary\n\nThe SLO health scan endpoints used `scopedClusterClient.asInternalUser`\nwithout enforcing space-level authorization, allowing a user with\n`slo_read` in one space to see SLO names, IDs, health status, and space\nidentifiers from every space in the deployment.\n\n### Changes\n\n- **New utility `getAccessibleSpaceIds`**: Resolves which spaces the\nuser has `slo_read` access to using the Spaces and Security plugin APIs\n(following the Fleet pattern with\n`checkPrivilegesWithRequest.atSpaces`).\n- **`getHealthScanResults`**: Services now accept `spaceIds: string[]`\ninstead of `spaceId: string` + `allSpaces?: boolean`. Both the scan\nresults query and the summary aggregation always filter by `{ terms: {\nspaceId: spaceIds } }`.\n- **`listHealthScans`**: The `getScanBuckets` composite aggregation now\nincludes a `spaceId` filter, scoped to the user's accessible spaces.\n- **Route handlers**: The list endpoint always resolves accessible\nspaces. The get-results endpoint resolves accessible spaces when\n`allSpaces=true`, otherwise uses the current space.\n\nThe `allSpaces` API parameter is preserved but its semantics change from\n\"bypass space filter entirely\" to \"show results from all spaces I am\nauthorized to see.\" No schema changes are needed.\n\n### What is NOT changed\n\n- The `POST` endpoint (triggering a scan) is unchanged — scans still run\nglobally across all spaces.\n- The background scan task still processes all SLOs via `namespaces:\n['*']`.\n- The UI (`scan_results_panel.tsx`) continues to send `allSpaces: true`\nand works without modification.\n\n## Test plan\n\n- [ ] Verify a user with `slo_read` in Space A only sees Space A's SLO\nhealth data when calling `GET .../_health/scans/{scanId}?allSpaces=true`\n- [ ] Verify a user with `slo_read` in Space A only sees Space A's\naggregate counts from `GET .../_health/scans`\n- [ ] Verify an admin with `slo_read` in all spaces sees results from\nall spaces (same behavior as before)\n- [ ] Verify the health scan flyout UI works correctly for both admin\nand restricted users\n- [ ] Unit tests pass: `node scripts/jest\nx-pack/solutions/observability/plugins/slo/server/services/health_scan/`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Miguel Martín <miguel.martin@elastic.co>","sha":"faf08b4951062f66b20d3ea2886ac23274a87a4e"}}]}] BACKPORT-->