### PR TITLE
Bound synchronous workflow.execute calls in the significant_events pipeline with timeouts

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/timeout_zone_graph.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/timeout_zone_graph.test.ts
@@ -108,6 +108,33 @@ describe('convertToWorkflowGraph', () => {
       );
       expect(executionGraph.node('enterTimeoutZone_run-child-sync')).toBeUndefined();
     });
+
+    it('a workflow.execute step with an explicit timeout gets a wrapping enter-timeout-zone node', () => {
+      const workflowWithTimedSyncExecute = {
+        name: 'Parent with timed workflow.execute',
+        version: '1' as const,
+        enabled: true,
+        triggers: [{ type: 'manual' as const }],
+        steps: [
+          {
+            name: 'run-child-sync',
+            type: 'workflow.execute',
+            timeout: '15m',
+            with: { 'workflow-id': 'child-workflow-id' },
+          } as WorkflowExecuteStep,
+        ],
+      } as WorkflowYaml;
+
+      const executionGraph = convertToWorkflowGraph(workflowWithTimedSyncExecute);
+
+      expect(executionGraph.node('enterTimeoutZone_run-child-sync')).toEqual(
+        expect.objectContaining({
+          type: 'enter-timeout-zone',
+          stepId: 'run-child-sync',
+          timeout: '15m',
+        })
+      );
+    });
   });
 
   describe('workflow-level timeout', () => {

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/knowledge_indicators/onboarding.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/knowledge_indicators/onboarding.yaml
@@ -130,6 +130,10 @@ steps:
     steps:
       - name: identify_features
         type: workflow.execute
+        # Buffer over the child's own settings.timeout (15m). If the child is terminalized by
+        # its own recovery path instead of completing normally, nothing else notifies this
+        # parent — it would otherwise stay waiting_for_child indefinitely.
+        timeout: "17m"
         with:
           workflow-id: "system-streams-ki-features-identification"
           inputs:
@@ -161,6 +165,9 @@ steps:
     steps:
       - name: generate_queries
         type: workflow.execute
+        # Buffer over the child's own settings.timeout (10m) — see the comment on
+        # `identify_features` above.
+        timeout: "12m"
         with:
           workflow-id: "system-streams-ki-queries-generation"
           inputs:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/scheduled_detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/scheduled_detection.yaml
@@ -22,6 +22,10 @@ triggers:
 steps:
   - name: detect
     type: workflow.execute
+    # Matches the child's own settings.timeout (and this workflow's own 10m ceiling above).
+    # If the child is terminalized by its own recovery path instead of completing normally,
+    # nothing else notifies this parent — it would otherwise stay waiting_for_child indefinitely.
+    timeout: "10m"
     with:
       workflow-id: "system-significant-events-detection"
       inputs:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/scheduled_review.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/scheduled_review.yaml
@@ -35,6 +35,12 @@ steps:
     steps:
       - name: discover
         type: workflow.execute
+        # Matches the child's own settings.timeout. If the child is terminalized by its own
+        # recovery path (e.g. after an interrupted run) instead of completing normally, nothing
+        # else notifies this parent — it would otherwise stay waiting_for_child indefinitely.
+        # No extra buffer: the 50m iteration-timeout above is already sized to exactly
+        # discovery (20m) + triage (30m) with no slack.
+        timeout: "20m"
         with:
           workflow-id: "system-significant-events-discovery"
           inputs:
@@ -42,6 +48,8 @@ steps:
 
       - name: triage
         type: workflow.execute
+        # See the comment on the `discover` step above — same reasoning.
+        timeout: "30m"
         with:
           workflow-id: "system-significant-events-triage"
           inputs:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/orchestrator.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/orchestrator.yaml
@@ -28,11 +28,17 @@ triggers:
 steps:
   - name: detect
     type: workflow.execute
+    # Buffer over the child's own settings.timeout (10m). If the child is terminalized by its
+    # own recovery path instead of completing normally, nothing else notifies this parent — it
+    # would otherwise stay waiting_for_child indefinitely.
+    timeout: "12m"
     with:
       workflow-id: "system-significant-events-detection"
 
   - name: discover
     type: workflow.execute
+    # Buffer over the child's own settings.timeout (20m) — see the comment on `detect` above.
+    timeout: "22m"
     with:
       workflow-id: "system-significant-events-discovery"
       inputs:
@@ -40,6 +46,8 @@ steps:
 
   - name: triage
     type: workflow.execute
+    # Buffer over the child's own settings.timeout (30m) — see the comment on `detect` above.
+    timeout: "32m"
     with:
       workflow-id: "system-significant-events-triage"
       inputs:

--- a/src/platform/packages/shared/kbn-workflows/spec/builtin_step_definitions.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/builtin_step_definitions.ts
@@ -269,6 +269,17 @@ export const builtInStepDefinitions: BaseStepDefinition[] = [
     workflow-id: "child_workflow"
     inputs:
       alertId: "{{ workflow.event.id }}"`,
+        `- name: run_child_workflow_with_timeout
+  type: workflow.execute
+  # Bounds the parent's wait on this child. Set this to at least the child's own
+  # timeout: if the child is terminalized by its own recovery path (e.g. after an
+  # interrupted run), the parent is not otherwise notified and would stay
+  # "waiting_for_child" forever without this.
+  timeout: 15m
+  with:
+    workflow-id: "child_workflow"
+    inputs:
+      alertId: "{{ workflow.event.id }}"`,
       ],
     },
   },

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -906,7 +906,7 @@ export const WorkflowExecuteStepInputSchema = z.object({
 
 const WorkflowExecuteBaseSchema = BaseStepSchema.extend({
   with: WorkflowExecuteStepInputSchema,
-});
+}).merge(TimeoutPropSchema);
 
 export const WorkflowExecuteStepSchema = WorkflowExecuteBaseSchema.extend({
   type: z.literal('workflow.execute'),


### PR DESCRIPTION
## Summary

Closes elastic/nightshift-program#595

Short-term mitigation for [elastic/security-team#18193](https://github.com/elastic/security-team/issues/18193) ("[One Workflow][Bug] `workflow.execute` parent remains `waiting_for_child` when child recovery fails").

A `workflow.execute` step puts the parent execution into `waiting_for_child` and relies on the child completion path to resume it. If the child is instead terminalized by its own recovery path (e.g. after an interrupted run), nothing notifies the parent, and it stays `waiting_for_child` indefinitely — permanently holding its own concurrency slot. This was reproduced locally: a `workflow.execute` child was dropped by a concurrency collision, and the parent (`system-significant-events-scheduled-review`) sat in `waiting_for_child` with zero Task Manager tasks left tracking it, blocking all future runs of that workflow.

The real fix (resuming the parent when a child reaches a terminal state via recovery) is tracked in the linked issue. In the meantime, per that issue's suggested mitigation: give each synchronous `workflow.execute` call an explicit `timeout`, so the parent fails fast on its own once the timeout elapses, regardless of the child's state.

## Changes

- **`kbn-workflows` schema**: `workflow.execute` / `workflow.executeAsync` steps didn't accept a `timeout` property — Zod silently stripped it before the graph compiler (which already generically wraps any step with a `timeout` in a timeout zone) ever saw it. Added `TimeoutPropSchema` to `WorkflowExecuteBaseSchema` so the property is retained.
- **Documentation**: added a `workflow.execute` example showing the new `timeout` property in `builtin_step_definitions.ts`.
- **Test**: added a case to `timeout_zone_graph.test.ts` confirming a `workflow.execute` step with an explicit `timeout` gets wrapped in an `enter-timeout-zone` node (mirroring the existing test that confirms it does *not* get wrapped without one).
- **significant_events managed workflows**: added a `timeout` to every synchronous `workflow.execute` call, sized to the target child's own `settings.timeout` (plus a small buffer where the enclosing budget allows it):
  - `scheduled_review.yaml`: `discover` (20m), `triage` (30m) — matches each child exactly, since the enclosing `iteration-timeout: 50m` was already sized to `discovery + triage` with no slack.
  - `scheduled_detection.yaml`: `detect` (10m) — matches the child; the workflow's own 10m ceiling already dominates.
  - `orchestrator.yaml`: `detect` (12m), `discover` (22m), `triage` (32m).
  - `knowledge_indicators/onboarding.yaml`: `identify_features` (17m), `generate_queries` (12m).

  `workflow.executeAsync` call sites (`continuous_onboarding.yaml`, `triage.yaml`'s `trigger_investigation`) are fire-and-forget — the parent never enters `waiting_for_child` for them — so they're not affected by this bug and were left unchanged.

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/kbn-workflows` — 91 suites / 1674 tests pass
- [x] `node scripts/jest src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts` — confirms all modified/templated YAML definitions still parse and validate
- [x] `node scripts/type_check --project src/platform/packages/shared/kbn-workflows/tsconfig.json` — passes
- [x] `node scripts/eslint --fix` on changed TS files — clean
- [ ] Reviewer: confirm the chosen per-step timeout values are reasonable given production traffic/data volumes for each sub-workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
