### PR TITLE
[typed-react-router-config] Make createRouter zod-aware (additive) — enables APM client routing io-ts→zod

### DIFF
--- a/src/platform/packages/shared/kbn-typed-react-router-config/moon.yml
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/moon.yml
@@ -21,6 +21,7 @@ dependsOn:
   - '@kbn/shared-ux-router'
   - '@kbn/core'
   - '@kbn/kibana-react-plugin'
+  - '@kbn/zod'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.test.tsx
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { toNumberRt } from '@kbn/io-ts-utils';
 import { createRouter, MAX_PATH_LENGTH, toReactRouterPath } from './create_router';
 import { InvalidRouteParamsException } from './errors/invalid_route_params_exception';
@@ -664,6 +665,119 @@ describe('createRouter', () => {
         query: { filter: null },
       });
     });
+  });
+});
+
+describe('createRouter with zod params', () => {
+  const zodRoutes = {
+    '/': {
+      element: <></>,
+      params: z.object({
+        query: z.object({
+          rangeFrom: z.string(),
+          rangeTo: z.string(),
+        }),
+      }),
+      defaults: {
+        query: {
+          rangeFrom: 'now-30m',
+        },
+      },
+      children: {
+        '/services': {
+          element: <></>,
+          params: z.object({
+            query: z.object({
+              transactionType: z.string(),
+            }),
+          }),
+        },
+        '/service-map': {
+          element: <></>,
+          params: z.object({
+            query: z.object({
+              maxNumNodes: z.coerce.number(),
+            }),
+          }),
+        },
+      },
+    },
+  };
+
+  let history = createMemoryHistory();
+  const router = createRouter(zodRoutes);
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+  });
+
+  it('returns and coerces params for a matching route', () => {
+    history.push('/service-map?rangeFrom=now-15m&rangeTo=now&maxNumNodes=3');
+
+    expect(router.getParams('/', history.location)).toEqual({
+      path: {},
+      query: { rangeFrom: 'now-15m', rangeTo: 'now' },
+    });
+
+    expect(router.getParams('/service-map', history.location)).toEqual({
+      path: {},
+      query: { rangeFrom: 'now-15m', rangeTo: 'now', maxNumNodes: 3 },
+    });
+  });
+
+  it('applies defaults', () => {
+    history.push('/services?rangeTo=now&transactionType=request');
+
+    expect(router.getParams('/', history.location)).toEqual({
+      path: {},
+      query: { rangeFrom: 'now-30m', rangeTo: 'now' },
+    });
+  });
+
+  it('recovers a null query param that has a default via InvalidRouteParamsException', () => {
+    history.push('/services?rangeFrom&rangeTo=now&transactionType=request');
+
+    expect(() => {
+      router.getParams('/services', history.location);
+    }).toThrow(InvalidRouteParamsException);
+
+    try {
+      router.getParams('/services', history.location);
+    } catch (e) {
+      const error = e as InvalidRouteParamsException;
+      expect(error.patched.query).toEqual(
+        expect.objectContaining({
+          rangeFrom: 'now-30m',
+          rangeTo: 'now',
+          transactionType: 'request',
+        })
+      );
+    }
+  });
+
+  it('throws a plain Error when recovery with defaults also fails', () => {
+    history.push('/services?transactionType=request');
+
+    expect(() => {
+      router.getParams('/services', history.location);
+    }).not.toThrow(InvalidRouteParamsException);
+    expect(() => {
+      router.getParams('/services', history.location);
+    }).toThrow(Error);
+  });
+
+  it('builds and validates links', () => {
+    expect(
+      router.link('/service-map', {
+        query: { maxNumNodes: '3', rangeFrom: 'now-15m', rangeTo: 'now' },
+      } as any)
+    ).toEqual('/service-map?maxNumNodes=3&rangeFrom=now-15m&rangeTo=now');
+
+    expect(() => {
+      router.link('/service-map', {
+        query: { rangeFrom: 'now-15m', rangeTo: 'now' },
+      } as any);
+    }).toThrowError();
   });
 });
 

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.ts
@@ -12,11 +12,20 @@ import { isLeft, isRight } from 'fp-ts/Either';
 import type { Location } from 'history';
 import type { Errors } from 'io-ts';
 import { PathReporter } from 'io-ts/lib/PathReporter';
+import { isZod } from '@kbn/zod/v4';
+import type { z } from '@kbn/zod/v4';
 import { compact, findLastIndex, mapValues, merge, orderBy } from 'lodash';
 import qs from 'query-string';
 import type { MatchedRoute, RouteConfig as ReactRouterConfig } from 'react-router-config';
 import { matchRoutes as matchRoutesConfig } from 'react-router-config';
-import type { FlattenRoutesOf, Route, RouteMap, Router, RouteWithPath } from './types';
+import type {
+  FlattenRoutesOf,
+  Route,
+  RouteMap,
+  RouteParamsRT,
+  Router,
+  RouteWithPath,
+} from './types';
 import { encodePath } from './encode_path';
 import { InvalidRouteParamsException } from './errors/invalid_route_params_exception';
 import { NotFoundRouteException } from './errors';
@@ -51,6 +60,67 @@ function extractFailingQueryKeys(errors: Errors): Set<string> {
     }
   }
   return keys;
+}
+
+// zod counterpart of extractFailingQueryKeys: an issue path looks like
+// ['query', <key>, ...], so take the first non-numeric segment after 'query'.
+function extractFailingQueryKeysZod(error: z.ZodError): Set<string> {
+  const keys = new Set<string>();
+  for (const issue of error.issues) {
+    const queryIndex = issue.path.indexOf('query');
+    if (queryIndex === -1) {
+      continue;
+    }
+    for (let i = queryIndex + 1; i < issue.path.length; i++) {
+      const segment = issue.path[i];
+      if (typeof segment === 'string' && !Number.isInteger(Number(segment))) {
+        keys.add(segment);
+        break;
+      }
+    }
+  }
+  return keys;
+}
+
+interface DecodeSuccess {
+  ok: true;
+  value: any;
+}
+interface DecodeFailure {
+  ok: false;
+  failingQueryKeys: Set<string>;
+  report: string;
+}
+type DecodeResult = DecodeSuccess | DecodeFailure;
+
+// Validates {path, query} against a route's params codec, branching on whether
+// it's io-ts (default) or zod (io-ts -> zod migration). io-ts routes keep the
+// exact-decode behavior; zod routes use safeParse. On failure both surface the
+// query keys that failed, so matchRoutes can retry with defaults identically.
+function decodeRouteParams(params: RouteParamsRT, input: unknown): DecodeResult {
+  if (isZod(params)) {
+    const result = params.safeParse(input);
+    if (result.success) {
+      return { ok: true, value: result.data };
+    }
+    return {
+      ok: false,
+      failingQueryKeys: extractFailingQueryKeysZod(result.error),
+      report: result.error.issues
+        .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+        .join('\n'),
+    };
+  }
+
+  const decoded = deepExactRt(params).decode(input);
+  if (isRight(decoded)) {
+    return { ok: true, value: decoded.right };
+  }
+  return {
+    ok: false,
+    failingQueryKeys: extractFailingQueryKeys(decoded.left),
+    report: PathReporter.report(decoded).join('\n'),
+  };
 }
 
 export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<TRoutes> {
@@ -177,22 +247,23 @@ export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<
         return decodeURIComponent(value);
       });
 
-      const decoded = deepExactRt(route.params).decode(
+      const decoded = decodeRouteParams(
+        route.params,
         merge({}, route.defaults ?? {}, {
           path: pathParams,
           query: parsedQuery,
         })
       );
 
-      if (isRight(decoded)) {
+      if (decoded.ok) {
         results.push({
-          match: { ...matchedRoute.match, params: decoded.right },
+          match: { ...matchedRoute.match, params: decoded.value },
           route,
         });
         continue;
       }
 
-      const failingKeys = extractFailingQueryKeys(decoded.left);
+      const failingKeys = decoded.failingQueryKeys;
       const defaultQuery = (route.defaults?.query as Record<string, string>) ?? {};
       const patchedQuery: Record<string, any> = { ...parsedQuery };
 
@@ -204,25 +275,26 @@ export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<
         }
       }
 
-      const retryDecoded = deepExactRt(route.params).decode(
+      const retryDecoded = decodeRouteParams(
+        route.params,
         merge({}, route.defaults ?? {}, {
           path: pathParams,
           query: patchedQuery,
         })
       );
 
-      if (isRight(retryDecoded)) {
-        errorMessages.push(PathReporter.report(decoded).join('\n'));
+      if (retryDecoded.ok) {
+        errorMessages.push(decoded.report);
         for (const key of failingKeys) {
           allPatchedKeys.set(key, patchedQuery[key]);
         }
         results.push({
-          match: { ...matchedRoute.match, params: retryDecoded.right },
+          match: { ...matchedRoute.match, params: retryDecoded.value },
           route,
         });
       } else {
         hasUnrecoverableError = true;
-        errorMessages.push(PathReporter.report(decoded).join('\n'));
+        errorMessages.push(decoded.report);
       }
     }
 
@@ -257,13 +329,7 @@ export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<
 
     const matchedRoutes = getRoutesToMatch(path);
 
-    const validationType = mergeRt(
-      ...(compact(
-        matchedRoutes.map((match) => {
-          return match.params;
-        })
-      ) as [any, any])
-    );
+    const matchedParams = compact(matchedRoutes.map((route) => route.params));
 
     const paramsWithRouteDefaults = merge(
       {},
@@ -271,10 +337,23 @@ export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<
       paramsWithBuiltInDefaults
     );
 
-    const validation = validationType.decode(paramsWithRouteDefaults);
+    if (matchedParams.some((matchedParam) => isZod(matchedParam))) {
+      // Mixed or all-zod chain: validate each route's params independently
+      // (non-strict, so sibling routes' keys are ignored) instead of merging
+      // io-ts and zod codecs, which cannot be combined.
+      for (const matchedParam of matchedParams) {
+        const decoded = decodeRouteParams(matchedParam, paramsWithRouteDefaults);
+        if (!decoded.ok) {
+          throw new Error(decoded.report);
+        }
+      }
+    } else {
+      const validationType = mergeRt(...(matchedParams as [any, any]));
+      const validation = validationType.decode(paramsWithRouteDefaults);
 
-    if (isLeft(validation)) {
-      throw new Error(PathReporter.report(validation).join('\n'));
+      if (isLeft(validation)) {
+        throw new Error(PathReporter.report(validation).join('\n'));
+      }
     }
 
     return qs.stringifyUrl(

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/types/index.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/types/index.ts
@@ -9,9 +9,31 @@
 
 import type { Location } from 'history';
 import type * as t from 'io-ts';
+import type { z } from '@kbn/zod/v4';
 import type { ReactElement } from 'react';
 import type { RequiredKeys, ValuesType, UnionToIntersection } from 'utility-types';
 import type { NormalizePath } from './utils';
+
+/**
+ * A route's `params` codec. io-ts (`t.Type`) is the original; `z.ZodType` is
+ * additive for the io-ts -> zod migration (elastic/kibana#243355). The helpers
+ * below derive param types from either, so io-ts inference is unchanged.
+ */
+export type RouteParamsRT = t.Type<any> | z.ZodType;
+
+// Decoded (post-parse) type — io-ts `TypeOf` / zod `output`. Used by getParams.
+export type TypeOfRouteParams<T> = T extends t.Type<any>
+  ? t.TypeOf<T>
+  : T extends z.ZodType
+  ? z.output<T>
+  : {};
+
+// Encoded (pre-parse) type — io-ts `OutputOf` / zod `input`. Used by link args.
+export type OutputOfRouteParams<T> = T extends t.Type<any>
+  ? t.OutputOf<T>
+  : T extends z.ZodType
+  ? z.input<T>
+  : {};
 
 export type PathsOf<TRouteMap extends RouteMap> = string &
   ValuesType<{
@@ -27,7 +49,7 @@ export type RouteMap = Record<string, Route>;
 export interface Route {
   element: ReactElement;
   children?: RouteMap;
-  params?: t.Type<any>;
+  params?: RouteParamsRT;
   defaults?: Record<string, Record<string, string>>;
   pre?: ReactElement;
 }
@@ -43,9 +65,9 @@ export interface RouteMatch<TRoute extends Route = Route> {
     path: string;
     url: string;
     params: TRoute extends {
-      params: t.Type<any>;
+      params: RouteParamsRT;
     }
-      ? t.TypeOf<TRoute['params']>
+      ? TypeOfRouteParams<TRoute['params']>
       : {};
   };
 }
@@ -66,9 +88,9 @@ export interface DefaultOutput {
 }
 
 type OutputOfRoute<TRoute extends Route> = TRoute extends {
-  params: t.Type<any>;
+  params: RouteParamsRT;
 }
-  ? t.OutputOf<TRoute['params']>
+  ? OutputOfRouteParams<TRoute['params']>
   : {};
 
 type OutputOfRoutes<TRoutes extends Route[]> = TRoutes extends [Route]
@@ -83,9 +105,9 @@ export type OutputOf<TRoutes extends RouteMap, TPath extends PathsOf<TRoutes>> =
   DefaultOutput;
 
 type TypeOfRoute<TRoute extends Route> = TRoute extends {
-  params: t.Type<any>;
+  params: RouteParamsRT;
 }
-  ? t.TypeOf<TRoute['params']>
+  ? TypeOfRouteParams<TRoute['params']>
   : {};
 
 type TypeOfRoutes<TRoutes extends Route[]> = TRoutes extends [Route]

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/types/utils.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/types/utils.ts
@@ -8,8 +8,13 @@
  */
 
 import type * as t from 'io-ts';
+import type { z } from '@kbn/zod/v4';
 
-export type MaybeOutputOf<T> = T extends t.Type<any> ? [t.OutputOf<T>] : [];
+export type MaybeOutputOf<T> = T extends t.Type<any>
+  ? [t.OutputOf<T>]
+  : T extends z.ZodType
+  ? [z.input<T>]
+  : [];
 export type NormalizePath<T extends string> = T extends `//${infer TRest}`
   ? NormalizePath<`/${TRest}`>
   : T extends '/'
@@ -20,6 +25,8 @@ export type NormalizePath<T extends string> = T extends `//${infer TRest}`
 export type DeeplyMutableRoutes<T> = T extends React.ReactElement
   ? T
   : T extends t.Type<any>
+  ? T
+  : T extends z.ZodType
   ? T
   : T extends readonly [infer U]
   ? [DeeplyMutableRoutes<U>]

--- a/src/platform/packages/shared/kbn-typed-react-router-config/tsconfig.json
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/tsconfig.json
@@ -17,6 +17,7 @@
     "@kbn/shared-ux-router",
     "@kbn/core",
     "@kbn/kibana-react-plugin",
+    "@kbn/zod",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Part of #243355 (migrate APM's `io-ts` validators to `@kbn/zod`).

APM's server route params are now fully on zod. The remaining io-ts lives in **client-side URL routing**, which runs on this shared package — `@kbn/typed-react-router-config`. Its `createRouter` is currently io-ts-only: `Route.params` is typed `t.Type<any>` and decoded via `deepExactRt`/`mergeRt`/`PathReporter`. This PR makes the router accept **zod schemas additively** so APM (and any of the ~7 consumer plugins) can migrate route params to zod incrementally, without breaking the io-ts consumers.

**This PR changes only the router package — no consumer is migrated yet.** All existing io-ts routes keep working exactly as before.

## Changes

- `Route.params` now accepts `t.Type<any> | z.ZodType` (new exported `RouteParamsRT`). The `TypeOf`/`OutputOf` type helpers derive the param type from either codec via a conditional (`T extends t.Type<any> ? t.TypeOf<T> : T extends z.ZodType ? z.output<T> : {}`), so **io-ts inference is byte-identical** and zod routes infer from `z.output`/`z.input`.
- `matchRoutes` decodes each matched route through a new `decodeRouteParams` helper that branches on `isZod`:
  - io-ts → unchanged (`deepExactRt(...).decode`)
  - zod → `safeParse`
  - The retry-with-defaults / failing-query-key recovery (and `InvalidRouteParamsException`) behaves identically for both — zod's failing keys are extracted from `error.issues` paths, mirroring the io-ts `extractFailingQueryKeys`.
- `link` keeps the existing `mergeRt` path for all-io-ts matched chains. When a zod schema is present in the chain it validates each route's params independently (non-strict, so sibling routes' keys are ignored), avoiding the need to merge io-ts and zod codecs — which can't be combined.

### Why additive
io-ts and zod can't be merged in a single codec, and this package has ~7 consumers (APM, profiling, ux, streams_app, both AI-assistant plugins, ...). Making the router dual-mode (branch on `isZod`) mirrors exactly what was done for the APM server-route registrar in the earlier phases, and lets each consumer migrate on its own schedule.

## Test plan

- [x] Full existing `create_router` suite green — io-ts behavior unchanged (30 cases incl. the invalid-query recovery / `InvalidRouteParamsException` paths).
- [x] New zod-path cases (5): decode + coercion (`z.coerce.number`), defaults, `InvalidRouteParamsException` recovery of a null-with-default query param, unrecoverable → plain `Error`, and `link` build/validate.
- [x] Type-check clean via the oblt CLI across the package and its consumers — `apm`, `profiling`, `ux`, `streams_app` (and the full 896-project graph) — confirming the widened `params` type breaks no consumer.
- [x] `node scripts/lint_ts_projects.js` clean (added `@kbn/zod` to `kbn_references`); eslint clean.

## Follow-up

A subsequent PR migrates APM's own client route definitions (`public/components/routing/**`) to zod and rewrites `is_route_with_time_range.ts` to introspect zod schema internals instead of io-ts `_tag`s.