### PR TITLE
[Alerting v2] Rename title and description of threshold rule builder

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_flyout.test.tsx
@@ -14,7 +14,7 @@ import { RuleCreateOptionsFlyout } from './rule_create_options_flyout';
 const onClose = jest.fn();
 const onCreateEsqlRule = jest.fn();
 const onCreateWithAgent = jest.fn();
-const onCreateThresholdAlert = jest.fn();
+const onCreateThresholdRule = jest.fn();
 
 const renderFlyout = () =>
   render(
@@ -23,7 +23,7 @@ const renderFlyout = () =>
         onClose={onClose}
         onCreateEsqlRule={onCreateEsqlRule}
         onCreateWithAgent={onCreateWithAgent}
-        onCreateThresholdAlert={onCreateThresholdAlert}
+        onCreateThresholdRule={onCreateThresholdRule}
       />
     </I18nProvider>
   );
@@ -40,7 +40,7 @@ describe('RuleCreateOptionsFlyout', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Create rule' })).toBeInTheDocument();
     expect(screen.getByText('Create ES|QL rule')).toBeInTheDocument();
     expect(screen.getByText('Create with AI Agent')).toBeInTheDocument();
-    expect(screen.getByText('Threshold Alert')).toBeInTheDocument();
+    expect(screen.getByText('Threshold rule')).toBeInTheDocument();
     expect(screen.queryByText(/welcome to the new alerting experience/i)).not.toBeInTheDocument();
   });
 
@@ -68,19 +68,19 @@ describe('RuleCreateOptionsFlyout', () => {
     expect(onCreateWithAgent).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the builder divider before the Threshold Alert option', () => {
+  it('renders the builder divider before the Threshold rule option', () => {
     renderFlyout();
 
     expect(screen.getByText('or start from a builder')).toBeInTheDocument();
     expect(screen.queryByText('Start from a rule builder')).not.toBeInTheDocument();
   });
 
-  it('calls onCreateThresholdAlert when the Threshold Alert option is selected', () => {
+  it('calls onCreateThresholdRule when the Threshold rule option is selected', () => {
     renderFlyout();
 
-    fireEvent.click(screen.getByRole('button', { name: /threshold alert/i }));
+    fireEvent.click(screen.getByRole('button', { name: /threshold rule/i }));
 
-    expect(onCreateThresholdAlert).toHaveBeenCalledTimes(1);
+    expect(onCreateThresholdRule).toHaveBeenCalledTimes(1);
   });
 
   it('renders the AI Agent option disabled and does not fire onCreateWithAgent when createWithAgentDisabled is set', () => {
@@ -92,7 +92,7 @@ describe('RuleCreateOptionsFlyout', () => {
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentDisabled
           createWithAgentTooltipText="Missing privileges"
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
         />
       </I18nProvider>
     );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_flyout.tsx
@@ -36,7 +36,7 @@ export interface RuleCreateOptionsFlyoutProps {
    * prerequisite). Shown on hover/focus regardless of whether the option is disabled.
    */
   createWithAgentTooltipText?: string;
-  onCreateThresholdAlert?: () => void;
+  onCreateThresholdRule?: () => void;
   legacyRuleTypes?: LegacyRuleTypeItem[];
 }
 
@@ -46,7 +46,7 @@ export const RuleCreateOptionsFlyout = ({
   onCreateWithAgent,
   createWithAgentDisabled,
   createWithAgentTooltipText,
-  onCreateThresholdAlert,
+  onCreateThresholdRule,
   legacyRuleTypes,
 }: RuleCreateOptionsFlyoutProps) => {
   return (
@@ -98,7 +98,7 @@ export const RuleCreateOptionsFlyout = ({
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentDisabled={createWithAgentDisabled}
           createWithAgentTooltipText={createWithAgentTooltipText}
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
           legacyRuleTypes={legacyRuleTypes}
         />
       </EuiFlyoutBody>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.test.tsx
@@ -12,7 +12,7 @@ import { RuleCreateOptionsPanel, getCreateWithAgentTooltipText } from './rule_cr
 
 const onCreateEsqlRule = jest.fn();
 const onCreateWithAgent = jest.fn();
-const onCreateThresholdAlert = jest.fn();
+const onCreateThresholdRule = jest.fn();
 
 const renderPanel = () =>
   render(
@@ -20,7 +20,7 @@ const renderPanel = () =>
       <RuleCreateOptionsPanel
         onCreateEsqlRule={onCreateEsqlRule}
         onCreateWithAgent={onCreateWithAgent}
-        onCreateThresholdAlert={onCreateThresholdAlert}
+        onCreateThresholdRule={onCreateThresholdRule}
       />
     </I18nProvider>
   );
@@ -61,18 +61,18 @@ describe('RuleCreateOptionsPanel', () => {
     expect(screen.queryByText('Start from a rule builder')).not.toBeInTheDocument();
   });
 
-  it('renders the "Threshold Alert" card', () => {
+  it('renders the "Threshold rule" card', () => {
     renderPanel();
 
-    expect(screen.getByText('Threshold Alert')).toBeInTheDocument();
+    expect(screen.getByText('Threshold rule')).toBeInTheDocument();
   });
 
-  it('calls onCreateThresholdAlert when the "Threshold Alert" card is clicked', () => {
+  it('calls onCreateThresholdRule when the "Threshold rule" card is clicked', () => {
     renderPanel();
 
-    fireEvent.click(screen.getByTestId('createThresholdAlertCard'));
+    fireEvent.click(screen.getByTestId('createThresholdRuleCard'));
 
-    expect(onCreateThresholdAlert).toHaveBeenCalledTimes(1);
+    expect(onCreateThresholdRule).toHaveBeenCalledTimes(1);
   });
 
   it('renders the agent card disabled and does not fire onCreateWithAgent when createWithAgentDisabled is set', () => {
@@ -83,7 +83,7 @@ describe('RuleCreateOptionsPanel', () => {
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentDisabled
           createWithAgentTooltipText="Missing privileges"
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
         />
       </I18nProvider>
     );
@@ -104,7 +104,7 @@ describe('RuleCreateOptionsPanel', () => {
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentDisabled
           createWithAgentTooltipText="Missing privileges"
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
         />
       </I18nProvider>
     );
@@ -123,7 +123,7 @@ describe('RuleCreateOptionsPanel', () => {
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentDisabled
           createWithAgentTooltipText="Missing privileges"
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
         />
       </I18nProvider>
     );
@@ -145,7 +145,7 @@ describe('RuleCreateOptionsPanel', () => {
           onCreateEsqlRule={onCreateEsqlRule}
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentDisabled
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
         />
       </I18nProvider>
     );
@@ -164,7 +164,7 @@ describe('RuleCreateOptionsPanel', () => {
           onCreateEsqlRule={onCreateEsqlRule}
           onCreateWithAgent={onCreateWithAgent}
           createWithAgentTooltipText="Extra context"
-          onCreateThresholdAlert={onCreateThresholdAlert}
+          onCreateThresholdRule={onCreateThresholdRule}
         />
       </I18nProvider>
     );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
@@ -181,7 +181,7 @@ const THRESHOLD_ALERT_DESCRIPTION = i18n.translate(
   'xpack.alertingV2.ruleCreateOptionsPanel.thresholdRuleDescription',
   {
     defaultMessage:
-      'Monitor one or more metrics against a threshold. Multi-condition support with custom aggregations.',
+      'Monitor metrics against one or more threshold conditions.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
@@ -180,8 +180,7 @@ const THRESHOLD_RULE_TITLE = i18n.translate(
 const THRESHOLD_RULE_DESCRIPTION = i18n.translate(
   'xpack.alertingV2.ruleCreateOptionsPanel.thresholdRuleDescription',
   {
-    defaultMessage:
-      'Monitor metrics against one or more threshold conditions.',
+    defaultMessage: 'Monitor metrics against one or more threshold conditions.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
@@ -174,14 +174,14 @@ export const getCreateWithAgentTooltipText = ({
   return CREATE_WITH_AGENT_MISSING_SETTING_TOOLTIP;
 };
 const THRESHOLD_ALERT_TITLE = i18n.translate(
-  'xpack.alertingV2.ruleCreateOptionsPanel.thresholdAlertTitle',
-  { defaultMessage: 'Threshold Alert' }
+  'xpack.alertingV2.ruleCreateOptionsPanel.thresholdRuleTitle',
+  { defaultMessage: 'Threshold rule' }
 );
 const THRESHOLD_ALERT_DESCRIPTION = i18n.translate(
-  'xpack.alertingV2.ruleCreateOptionsPanel.thresholdAlertDescription',
+  'xpack.alertingV2.ruleCreateOptionsPanel.thresholdRuleDescription',
   {
     defaultMessage:
-      'Monitor one or more metrics and alert when they cross a threshold. Multi-condition support with custom aggregations.',
+      'Monitor one or more metrics against a threshold. Multi-condition support with custom aggregations.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_create_options/rule_create_options_panel.tsx
@@ -50,7 +50,7 @@ interface RuleCreateOptionsPanelProps {
    * prerequisite). Shown on hover/focus regardless of whether the option is disabled.
    */
   createWithAgentTooltipText?: string;
-  onCreateThresholdAlert?: () => void;
+  onCreateThresholdRule?: () => void;
   legacyRuleTypes?: LegacyRuleTypeItem[];
 }
 
@@ -173,11 +173,11 @@ export const getCreateWithAgentTooltipText = ({
   }
   return CREATE_WITH_AGENT_MISSING_SETTING_TOOLTIP;
 };
-const THRESHOLD_ALERT_TITLE = i18n.translate(
+const THRESHOLD_RULE_TITLE = i18n.translate(
   'xpack.alertingV2.ruleCreateOptionsPanel.thresholdRuleTitle',
   { defaultMessage: 'Threshold rule' }
 );
-const THRESHOLD_ALERT_DESCRIPTION = i18n.translate(
+const THRESHOLD_RULE_DESCRIPTION = i18n.translate(
   'xpack.alertingV2.ruleCreateOptionsPanel.thresholdRuleDescription',
   {
     defaultMessage:
@@ -262,7 +262,7 @@ const RuleCreateOptionsListEmptyState: React.FC<RuleCreateOptionsPanelProps> = (
   onCreateWithAgent,
   createWithAgentDisabled,
   createWithAgentTooltipText,
-  onCreateThresholdAlert,
+  onCreateThresholdRule,
 }) => {
   const styles = useMemoCss(listEmptyStateStyles);
 
@@ -292,14 +292,14 @@ const RuleCreateOptionsListEmptyState: React.FC<RuleCreateOptionsPanelProps> = (
 
   const thresholdCreateOption = useMemo<RuleCreateOptionItem>(
     () => ({
-      id: 'create-threshold-alert',
+      id: 'create-threshold-rule',
       iconType: 'chartThreshold',
-      title: THRESHOLD_ALERT_TITLE,
-      description: THRESHOLD_ALERT_DESCRIPTION,
-      onClick: onCreateThresholdAlert ?? noop,
-      'data-test-subj': 'createThresholdAlertCard',
+      title: THRESHOLD_RULE_TITLE,
+      description: THRESHOLD_RULE_DESCRIPTION,
+      onClick: onCreateThresholdRule ?? noop,
+      'data-test-subj': 'createThresholdRuleCard',
     }),
-    [onCreateThresholdAlert]
+    [onCreateThresholdRule]
   );
 
   return (
@@ -397,7 +397,7 @@ const RuleCreateOptionsFlyoutPanel: React.FC<RuleCreateOptionsPanelProps> = ({
   onCreateWithAgent,
   createWithAgentDisabled,
   createWithAgentTooltipText,
-  onCreateThresholdAlert,
+  onCreateThresholdRule,
   legacyRuleTypes,
 }) => {
   const isAgentDisabled = createWithAgentDisabled === true;
@@ -458,9 +458,9 @@ const RuleCreateOptionsFlyoutPanel: React.FC<RuleCreateOptionsPanelProps> = ({
         titleElement="h3"
         titleSize="xs"
         hasBorder={true}
-        title={THRESHOLD_ALERT_TITLE}
-        description={THRESHOLD_ALERT_DESCRIPTION}
-        onClick={onCreateThresholdAlert ?? noop}
+        title={THRESHOLD_RULE_TITLE}
+        description={THRESHOLD_RULE_DESCRIPTION}
+        onClick={onCreateThresholdRule ?? noop}
         icon={<EuiIcon type="chartThreshold" color="text" size="l" aria-hidden={true} />}
       />
       {legacyRuleTypes && <LegacyRuleTypesSection items={legacyRuleTypes} />}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
@@ -60,10 +60,7 @@ jest.mock('./components/rule_create_options/rule_create_options_flyout', () => (
       <div data-test-subj="mockRuleCreateOptionsFlyout">
         <button data-test-subj="esqlBtn" onClick={props.onCreateEsqlRule as () => void} />
         <button data-test-subj="agentBtn" onClick={props.onCreateWithAgent as () => void} />
-        <button
-          data-test-subj="thresholdBtn"
-          onClick={props.onCreateThresholdAlert as () => void}
-        />
+        <button data-test-subj="thresholdBtn" onClick={props.onCreateThresholdRule as () => void} />
       </div>
     );
   },

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
@@ -303,7 +303,7 @@ const CreateRuleOptionsFlyoutInner = ({
       onCreateWithAgent={navigateToAgentBuilder}
       createWithAgentDisabled={createWithAgentDisabled}
       createWithAgentTooltipText={createWithAgentTooltipText}
-      onCreateThresholdAlert={() => setStep({ type: 'threshold' })}
+      onCreateThresholdRule={() => setStep({ type: 'threshold' })}
       legacyRuleTypes={legacyPanelItems}
     />
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -206,7 +206,7 @@ export const RulesListPage = () => {
     closeCreateOptionsFlyout();
     navigateToAgentBuilder();
   };
-  const onCreateThresholdAlertFromOptionsFlyout = () => {
+  const onCreateThresholdRuleFromOptionsFlyout = () => {
     closeCreateOptionsFlyout();
     openCreateBuilderFlyout('threshold');
   };
@@ -274,7 +274,7 @@ export const RulesListPage = () => {
           onCreateWithAgent={navigateToAgentBuilder}
           createWithAgentDisabled={!isRuleManagementABSkillAvailable}
           createWithAgentTooltipText={createWithAgentTooltipText}
-          onCreateThresholdAlert={onCreateThresholdAlertFromOptionsFlyout}
+          onCreateThresholdRule={onCreateThresholdRuleFromOptionsFlyout}
         />
       ) : null}
       {hasRules || hasActiveFilters ? (
@@ -329,7 +329,7 @@ export const RulesListPage = () => {
           onCreateWithAgent={onCreateWithAgentFromOptionsFlyout}
           createWithAgentDisabled={!isRuleManagementABSkillAvailable}
           createWithAgentTooltipText={createWithAgentTooltipText}
-          onCreateThresholdAlert={onCreateThresholdAlertFromOptionsFlyout}
+          onCreateThresholdRule={onCreateThresholdRuleFromOptionsFlyout}
         />
       ) : null}
       {flyout}

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_builder_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_builder_page.ts
@@ -9,8 +9,8 @@ import type { Locator, ScoutPage } from '@kbn/scout';
 
 const BUILDER_CARDS: Record<string, { testSubj: string; buttonName: RegExp }> = {
   threshold: {
-    testSubj: 'createThresholdAlertCard',
-    buttonName: /threshold alert/i,
+    testSubj: 'createThresholdRuleCard',
+    buttonName: /threshold rule/i,
   },
 };
 


### PR DESCRIPTION
- Renames title and description of threshold rule builder in create menu

<img width="357" height="497" alt="Screenshot 2026-07-09 at 7 00 11 PM" src="https://github.com/user-attachments/assets/645ba5e6-dfbc-41d1-8ba3-afa7cd3cb2ee" />


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->