### PR TITLE
[Console] Fix requests with comments failing when body contains triple-quote strings

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -129,6 +129,54 @@ describe('Editor actions provider', () => {
       const curl = await editorActionsProvider.getCurl('http://localhost');
       expect(curl).toBe('curl -XGET "http://localhost/_search" -H "kbn-xsrf: reporting"');
     });
+
+    it('removes comments from the request body while preserving triple-quote strings', async () => {
+      // Regression test for https://github.com/elastic/kibana/issues/277160
+      const content = [
+        'POST _watcher/watch/test',
+        '{',
+        '  // watch metadata',
+        '  "script": """',
+        '    return 1; // painless comment',
+        '  """',
+        '}',
+      ];
+      const totalLength = content.join('\n').length;
+      editor.getModel.mockReturnValue({
+        getLineContent: (lineNumber: number) => content[lineNumber - 1],
+        getValueInRange: ({
+          startLineNumber,
+          endLineNumber,
+        }: {
+          startLineNumber: number;
+          endLineNumber: number;
+        }) => content.slice(startLineNumber - 1, endLineNumber).join('\n'),
+        getLineMaxColumn: (lineNumber: number) => content[lineNumber - 1].length + 1,
+        getPositionAt: (offset: number) => ({ lineNumber: offset === 0 ? 1 : content.length }),
+        getLineCount: () => content.length,
+      } as unknown as monaco.editor.ITextModel);
+      editor.getSelection.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: content.length,
+      } as unknown as monaco.Selection);
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: totalLength,
+          method: 'POST',
+          url: '_watcher/watch/test',
+        },
+      ]);
+
+      const curl = await editorActionsProvider.getCurl('http://localhost');
+      expect(curl).not.toContain('// watch metadata');
+      expect(curl).toContain('return 1; // painless comment');
+      // The body sent in the curl command is valid JSON
+      const body = curl.split(`-d'\n`)[1].slice(0, -1);
+      expect(JSON.parse(body)).toEqual({
+        script: '\n    return 1; // painless comment\n  ',
+      });
+    });
   });
 
   describe('getDocumentationLink', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -130,53 +130,56 @@ describe('Editor actions provider', () => {
       expect(curl).toBe('curl -XGET "http://localhost/_search" -H "kbn-xsrf: reporting"');
     });
 
-    it('removes comments from the request body while preserving triple-quote strings', async () => {
-      // Regression test for https://github.com/elastic/kibana/issues/277160
-      const content = [
-        'POST _watcher/watch/test',
-        '{',
-        '  // watch metadata',
-        '  "script": """',
-        '    return 1; // painless comment',
-        '  """',
-        '}',
-      ];
-      const totalLength = content.join('\n').length;
-      editor.getModel.mockReturnValue({
-        getLineContent: (lineNumber: number) => content[lineNumber - 1],
-        getValueInRange: ({
-          startLineNumber,
-          endLineNumber,
-        }: {
-          startLineNumber: number;
-          endLineNumber: number;
-        }) => content.slice(startLineNumber - 1, endLineNumber).join('\n'),
-        getLineMaxColumn: (lineNumber: number) => content[lineNumber - 1].length + 1,
-        getPositionAt: (offset: number) => ({ lineNumber: offset === 0 ? 1 : content.length }),
-        getLineCount: () => content.length,
-      } as unknown as monaco.editor.ITextModel);
-      editor.getSelection.mockReturnValue({
-        startLineNumber: 1,
-        endLineNumber: content.length,
-      } as unknown as monaco.Selection);
-      mockGetParsedRequests.mockResolvedValue([
-        {
-          startOffset: 0,
-          endOffset: totalLength,
-          method: 'POST',
-          url: '_watcher/watch/test',
-        },
-      ]);
+    it.each(['//', '#'])(
+      'removes %s comments from the request body while preserving triple-quote strings',
+      async (commentMarker) => {
+        // Regression test for https://github.com/elastic/kibana/issues/277160
+        const content = [
+          'POST _watcher/watch/test',
+          '{',
+          `  ${commentMarker} watch metadata`,
+          '  "script": """',
+          '    return 1; // painless comment',
+          '  """',
+          '}',
+        ];
+        const totalLength = content.join('\n').length;
+        editor.getModel.mockReturnValue({
+          getLineContent: (lineNumber: number) => content[lineNumber - 1],
+          getValueInRange: ({
+            startLineNumber,
+            endLineNumber,
+          }: {
+            startLineNumber: number;
+            endLineNumber: number;
+          }) => content.slice(startLineNumber - 1, endLineNumber).join('\n'),
+          getLineMaxColumn: (lineNumber: number) => content[lineNumber - 1].length + 1,
+          getPositionAt: (offset: number) => ({ lineNumber: offset === 0 ? 1 : content.length }),
+          getLineCount: () => content.length,
+        } as unknown as monaco.editor.ITextModel);
+        editor.getSelection.mockReturnValue({
+          startLineNumber: 1,
+          endLineNumber: content.length,
+        } as unknown as monaco.Selection);
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: 0,
+            endOffset: totalLength,
+            method: 'POST',
+            url: '_watcher/watch/test',
+          },
+        ]);
 
-      const curl = await editorActionsProvider.getCurl('http://localhost');
-      expect(curl).not.toContain('// watch metadata');
-      expect(curl).toContain('return 1; // painless comment');
-      // The body sent in the curl command is valid JSON
-      const body = curl.split(`-d'\n`)[1].slice(0, -1);
-      expect(JSON.parse(body)).toEqual({
-        script: '\n    return 1; // painless comment\n  ',
-      });
-    });
+        const curl = await editorActionsProvider.getCurl('http://localhost');
+        expect(curl).not.toContain('watch metadata');
+        expect(curl).toContain('return 1; // painless comment');
+        // The body sent in the curl command is valid JSON
+        const body = curl.split(`-d'\n`)[1].slice(0, -1);
+        expect(JSON.parse(body)).toEqual({
+          script: '\n    return 1; // painless comment\n  ',
+        });
+      }
+    );
   });
 
   describe('getDocumentationLink', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -274,7 +274,7 @@ export class MonacoEditorActionsProvider {
         requestTextFromEditor.data = requestTextFromEditor.data.map((dataString) => {
           if (containsComments(dataString)) {
             // Comments must be removed before the request is sent since the body is
-            // flattened into a single line and a `//` comment would otherwise
+            // flattened into a single line and a line comment would otherwise
             // comment out the rest of the body (see https://github.com/elastic/kibana/issues/277160)
             dataString = removeCommentsFromData(dataString);
           }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -45,7 +45,7 @@ import {
 import type { AdjustedParsedRequest } from './types';
 import { type RequestToRestore, RestoreMethod } from '../../../types';
 import type { ContextValue } from '../../contexts';
-import { containsComments, indentData } from './utils/requests_utils';
+import { containsComments, removeCommentsFromData } from './utils/requests_utils';
 
 const AUTO_INDENTATION_ACTION_LABEL = 'Apply indentations';
 const TRIGGER_SUGGESTIONS_ACTION_LABEL = 'Trigger suggestions';
@@ -273,8 +273,10 @@ export class MonacoEditorActionsProvider {
       if (requestTextFromEditor && requestTextFromEditor.data.length > 0) {
         requestTextFromEditor.data = requestTextFromEditor.data.map((dataString) => {
           if (containsComments(dataString)) {
-            // parse and stringify to remove comments
-            dataString = indentData(dataString);
+            // Comments must be removed before the request is sent since the body is
+            // flattened into a single line and a `//` comment would otherwise
+            // comment out the rest of the body (see https://github.com/elastic/kibana/issues/277160)
+            dataString = removeCommentsFromData(dataString);
           }
           return collapseLiteralStrings(dataString);
         });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
@@ -17,6 +17,7 @@ import {
   trackSentRequests,
   getRequestFromEditor,
   containsComments,
+  removeCommentsFromData,
   collapseTripleQuoteStrings,
   expandTripleQuoteStrings,
   TRIPLE_QUOTE_STRINGS_MARKER,
@@ -671,6 +672,58 @@ describe('requests_utils', () => {
       "field": "value" // comment here
     }`;
       expect(containsComments(requestData)).toBe(true);
+    });
+  });
+
+  describe('removeCommentsFromData', () => {
+    it('removes line and block comments from the request data', () => {
+      const requestData = `{
+  // line comment
+  "query": {
+    /* block comment */
+    "match_all": {}
+  } // trailing comment
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(containsComments(result)).toBe(false);
+      expect(JSON.parse(result)).toEqual({ query: { match_all: {} } });
+    });
+
+    it('removes comments when the data also contains multi-line triple-quote strings', () => {
+      // Regression test for https://github.com/elastic/kibana/issues/277160
+      const requestData = `{
+  // watch metadata
+  "script": {
+    "lang": "painless",
+    "source": """
+      def a = 1; // painless comment
+      return a;
+    """
+  } /* end of script */
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// watch metadata');
+      expect(result).not.toContain('/* end of script */');
+      // The triple-quote string is preserved, including the comments inside it
+      expect(result).toContain(`"source": """
+      def a = 1; // painless comment
+      return a;
+    """`);
+    });
+
+    it('preserves comment-like sequences inside strings', () => {
+      const requestData = `{
+  "url": "https://elastic.co", // comment
+  "pattern": "/*"
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// comment');
+      expect(JSON.parse(result)).toEqual({ url: 'https://elastic.co', pattern: '/*' });
+    });
+
+    it('returns invalid data unchanged', () => {
+      const requestData = '{\n  "query": // comment\n    {';
+      expect(removeCommentsFromData(requestData)).toBe(requestData);
     });
   });
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
@@ -605,7 +605,7 @@ describe('requests_utils', () => {
   });
 
   describe('containsComments', () => {
-    it('should return false for JSON with // and /* inside strings', () => {
+    it('should return false for JSON with comment markers inside strings', () => {
       const requestData = `{
       "docs": [
         {
@@ -622,7 +622,7 @@ describe('requests_utils', () => {
           "_source": {
             "vulnerability": {
               "reference": [
-                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15778"
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15778#details"
               ]
             }
           }
@@ -645,6 +645,14 @@ describe('requests_utils', () => {
       /* Bulk insert */
       "index": { "_index": "test" },
       "field1": "value1"
+    }`;
+      expect(containsComments(requestData)).toBe(true);
+    });
+
+    it('should return true for text with actual hash comment', () => {
+      const requestData = `{
+      # This is a comment
+      "query": { "match_all": {} }
     }`;
       expect(containsComments(requestData)).toBe(true);
     });
@@ -676,7 +684,7 @@ describe('requests_utils', () => {
 
     it('should ignore comment-like sequences inside triple-quote strings', () => {
       const requestData = `{
-      "script": """def quote = '"'; // painless comment"""
+      "script": """def quote = '"'; // painless comment # still script"""
     }`;
       expect(containsComments(requestData)).toBe(false);
     });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
@@ -668,6 +668,18 @@ describe('requests_utils', () => {
       expect(containsComments('')).toBe(false);
     });
 
+    it('should reset token scanning between calls', () => {
+      const requestDataWithComment = `{
+      // This is a comment
+      "query": { "match_all": {} }
+    }`;
+      const requestDataWithoutComment = '{ "query": { "match_all": {} } }';
+
+      expect(containsComments(requestDataWithComment)).toBe(true);
+      expect(containsComments(requestDataWithoutComment)).toBe(false);
+      expect(containsComments(requestDataWithComment)).toBe(true);
+    });
+
     it('should correctly handle escaped quotes within strings', () => {
       const requestData = `{
       "field": \"value with \\\"escaped quotes\\\"\"

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
@@ -673,6 +673,21 @@ describe('requests_utils', () => {
     }`;
       expect(containsComments(requestData)).toBe(true);
     });
+
+    it('should ignore comment-like sequences inside triple-quote strings', () => {
+      const requestData = `{
+      "script": """def quote = '"'; // painless comment"""
+    }`;
+      expect(containsComments(requestData)).toBe(false);
+    });
+
+    it('should detect comments outside triple-quote strings', () => {
+      const requestData = `{
+      // request comment
+      "script": """def quote = '"'; // painless comment"""
+    }`;
+      expect(containsComments(requestData)).toBe(true);
+    });
   });
 
   describe('removeCommentsFromData', () => {
@@ -719,6 +734,42 @@ describe('requests_utils', () => {
       const result = removeCommentsFromData(requestData);
       expect(result).not.toContain('// comment');
       expect(JSON.parse(result)).toEqual({ url: 'https://elastic.co', pattern: '/*' });
+    });
+
+    it('preserves a literal value matching the triple-quote placeholder', () => {
+      const requestData = `{
+  // comment
+  "literal": ${TRIPLE_QUOTE_STRINGS_MARKER},
+  "script": """return 1;"""
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// comment');
+      expect(result).toMatch(/"literal"\s*:\s*"\{tripleQuoteString\}"/);
+      expect(result).toMatch(/"script"\s*:\s*"""return 1;"""/);
+    });
+
+    it('preserves triple-quote values when object keys are reordered during parsing', () => {
+      const requestData = `{
+  // comment
+  "z": """first""",
+  "1": """second"""
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// comment');
+      expect(result).toMatch(/"z"\s*:\s*"""first"""/);
+      expect(result).toMatch(/"1"\s*:\s*"""second"""/);
+    });
+
+    it('ignores triple-quote delimiters inside comments', () => {
+      const requestData = `{
+  // this comment mentions """
+  /* this block comment also mentions """ */
+  "script": """return 1;"""
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('this comment mentions');
+      expect(result).not.toContain('this block comment');
+      expect(result).toMatch(/"script"\s*:\s*"""return 1;"""/);
     });
 
     it('returns invalid data unchanged', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
@@ -286,7 +286,7 @@ const isSlashCommentToken = (token: string) => token.startsWith('//') || token.s
 const isCommentToken = (token: string) => isSlashCommentToken(token) || token.startsWith('#');
 
 export const containsComments = (requestData: string) =>
-  requestData.match(requestDataTokensRegex)?.some(isSlashCommentToken) ?? false;
+  requestData.match(requestDataTokensRegex)?.some(isCommentToken) ?? false;
 
 export const indentData = (dataString: string): string => {
   try {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
@@ -285,8 +285,19 @@ const requestDataTokensRegex = new RegExp(
 const isSlashCommentToken = (token: string) => token.startsWith('//') || token.startsWith('/*');
 const isCommentToken = (token: string) => isSlashCommentToken(token) || token.startsWith('#');
 
-export const containsComments = (requestData: string) =>
-  requestData.match(requestDataTokensRegex)?.some(isCommentToken) ?? false;
+export const containsComments = (requestData: string) => {
+  requestDataTokensRegex.lastIndex = 0;
+  let match = requestDataTokensRegex.exec(requestData);
+  while (match) {
+    if (isCommentToken(match[0])) {
+      requestDataTokensRegex.lastIndex = 0;
+      return true;
+    }
+    match = requestDataTokensRegex.exec(requestData);
+  }
+  requestDataTokensRegex.lastIndex = 0;
+  return false;
+};
 
 export const indentData = (dataString: string): string => {
   try {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
@@ -271,28 +271,22 @@ export const getRequestFromEditor = (
   return { method: upperCaseMethod, url, data };
 };
 
-export const containsComments = (requestData: string) => {
-  let insideString = false;
-  let prevChar = '';
-  for (let i = 0; i < requestData.length; i++) {
-    const char = requestData[i];
-    const nextChar = requestData[i + 1];
+const requestDataTokensRegex = new RegExp(
+  [
+    /"""[\s\S]*?"""/.source, // Triple-quoted strings
+    /"(?:\\.|[^"\\])*"/.source, // JSON strings
+    /\/\/[^\r\n]*/.source, // // comments
+    /#[^\r\n]*/.source, // # comments
+    /\/\*[\s\S]*?\*\//.source, // Block comments
+  ].join('|'),
+  'g'
+);
 
-    if (!insideString && char === '"') {
-      insideString = true;
-    } else if (insideString && char === '"' && prevChar !== '\\') {
-      insideString = false;
-    } else if (!insideString) {
-      if (char === '/' && (nextChar === '/' || nextChar === '*')) {
-        return true;
-      }
-    }
+const isSlashCommentToken = (token: string) => token.startsWith('//') || token.startsWith('/*');
+const isCommentToken = (token: string) => isSlashCommentToken(token) || token.startsWith('#');
 
-    prevChar = char;
-  }
-
-  return false;
-};
+export const containsComments = (requestData: string) =>
+  requestData.match(requestDataTokensRegex)?.some(isSlashCommentToken) ?? false;
 
 export const indentData = (dataString: string): string => {
   try {
@@ -304,24 +298,37 @@ export const indentData = (dataString: string): string => {
   }
 };
 
+const removeCommentsFromDataWithTripleQuotes = (dataString: string): string | null => {
+  const dataWithoutComments = dataString.replace(requestDataTokensRegex, (token) =>
+    isCommentToken(token) ? ' ' : token
+  );
+
+  const { collapsedTripleQuotesData } = collapseTripleQuoteStrings(dataWithoutComments);
+  try {
+    parse(collapsedTripleQuotesData);
+    return dataWithoutComments;
+  } catch {
+    return null;
+  }
+};
+
 /**
  * This function removes comments from the request data.
  *
  * The comment removal is done by parsing the data with hjson and stringifying the result.
- * Since hjson can't parse multi-line strings in triple quotes, if the direct parsing fails,
- * the triple-quote strings are temporarily collapsed before parsing and restored afterwards.
- * This way comments are removed even when the data combines them with triple-quote strings,
- * while comments inside triple-quote strings (e.g. Painless comments) are preserved.
+ * Since hjson can't parse multi-line strings in triple quotes, a token-aware fallback removes
+ * comments outside quoted strings and validates the result after collapsing triple-quote strings.
+ * Comments inside triple-quote strings (e.g. Painless comments) are preserved.
  * If the data can't be parsed at all, it is returned unchanged.
  */
 export const removeCommentsFromData = (dataString: string): string => {
   try {
     return JSON.stringify(parse(dataString), null, 2);
-  } catch (e) {
-    const { collapsedTripleQuotesData, tripleQuoteStrings } =
-      collapseTripleQuoteStrings(dataString);
-    const dataWithoutComments = indentData(collapsedTripleQuotesData);
-    return expandTripleQuoteStrings(dataWithoutComments, tripleQuoteStrings);
+  } catch {
+    if (!dataString.includes('"""')) {
+      return dataString;
+    }
+    return removeCommentsFromDataWithTripleQuotes(dataString) ?? dataString;
   }
 };
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
@@ -304,6 +304,27 @@ export const indentData = (dataString: string): string => {
   }
 };
 
+/**
+ * This function removes comments from the request data.
+ *
+ * The comment removal is done by parsing the data with hjson and stringifying the result.
+ * Since hjson can't parse multi-line strings in triple quotes, if the direct parsing fails,
+ * the triple-quote strings are temporarily collapsed before parsing and restored afterwards.
+ * This way comments are removed even when the data combines them with triple-quote strings,
+ * while comments inside triple-quote strings (e.g. Painless comments) are preserved.
+ * If the data can't be parsed at all, it is returned unchanged.
+ */
+export const removeCommentsFromData = (dataString: string): string => {
+  try {
+    return JSON.stringify(parse(dataString), null, 2);
+  } catch (e) {
+    const { collapsedTripleQuotesData, tripleQuoteStrings } =
+      collapseTripleQuoteStrings(dataString);
+    const dataWithoutComments = indentData(collapsedTripleQuotesData);
+    return expandTripleQuoteStrings(dataWithoutComments, tripleQuoteStrings);
+  }
+};
+
 // ---------------------------------- Internal helpers ----------------------------------
 
 const isJsonString = (str: string) => {


### PR DESCRIPTION
Closes #277160

## Summary

Requests whose body combines `//` comments with `"""` triple-quote strings (for example, Watcher definitions with inline Painless scripts) fail with `400 x_content_e_o_f_exception "Unexpected end of file"` since 8.16.0. This PR makes Console's client-side comment removal work for those bodies without changing string contents.

## Root Cause

Since #188552 (8.16.0), Console flattens every request body into a single line before sending it to Elasticsearch. Once flattened, the first `//` comment consumes everything after it and Elasticsearch reaches the end of an incomplete body.

Console strips comments client-side in `getRequests()`, but the existing `hjson` parsing step fails on `"""` strings and returns the original body unchanged. The comments then survive until the newline-flattening step.

## Fix

`removeCommentsFromData()` still uses `hjson` for ordinary request bodies. When triple-quote strings prevent parsing, it now:

- tokenizes JSON strings, triple-quote strings, and `//`, `#`, and `/* */` comments;
- removes only comments outside quoted strings;
- validates the resulting XJSON before returning it; and
- returns invalid bodies unchanged.

This preserves comments and whitespace inside Painless scripts while avoiding positional placeholder restoration, which could collide with literal values or associate strings with the wrong keys after serialization reordered the object. Comment detection now uses the same triple-quote-aware tokenization, recognizes both documented single-line comment markers, stops after the first comment token, and skips the fallback for parse failures without triple-quote strings.

## Before/After Screenshots

### Before

_Same request returns `400 Bad Request` with `x_content_e_o_f_exception`:_

<img width="1440" height="900" alt="before_fix" src="https://github.com/user-attachments/assets/93419315-2674-4ebe-b1b8-d0e899b0c215" />

### After

_Same request returns `200 OK`; the script is stored with the Painless `//` comment intact:_

<img width="1440" height="900" alt="after_fix" src="https://github.com/user-attachments/assets/8e86a672-4321-464f-a57e-f457ac0964ce" />

## Test Plan

Run in Dev Tools Console:

```
POST _scripts/comment-repro
{
  // count all docs
  "script": {
    "lang": "painless",
    "source": """
      return 1; // painless comment
    """
  }
}
```

- Before this fix: the request returns `400` with `x_content_e_o_f_exception "[2:1] Unexpected end of file"`.
- After this fix: the request returns `200 OK`, and `GET _scripts/comment-repro` shows the Painless comment preserved inside the script source.
- Verified in a local development instance against a fresh Elasticsearch snapshot, A/B on the same instance by toggling the change.
- Automated coverage repeats the request with `# count all docs` and verifies the generated body is valid JSON with the outer comment removed.
- `node scripts/jest src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts` — 86 tests passed.
- `node scripts/jest --config=src/platform/plugins/shared/console/jest.config.js` — 483 tests passed.
- `node scripts/eslint src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts` — passed.
- `node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json` — passed.

## Release Note

Fixed a Console error where requests containing comments together with triple-quote strings (such as Watcher definitions with inline Painless scripts) failed with `x_content_e_o_f_exception`.

Assisted with Copilot using GPT-5.6 Sol


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->