### PR TITLE
[One Workflow] Adopt workflow title for invalid workflow

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/lib/workflow_prepare.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/lib/workflow_prepare.test.ts
@@ -13,8 +13,10 @@ import {
   applyFieldUpdates,
   applyYamlUpdate,
   getTriggerTypesFromDefinition,
+  prepareWorkflowDocumentFromYaml,
   workflowYamlDeclaresTopLevelEnabled,
 } from './workflow_prepare';
+import { getWorkflowZodSchema } from '../../../common/schema';
 import type { WorkflowProperties } from '../../storage/workflow_storage';
 
 describe('getTriggerTypesFromDefinition', () => {
@@ -161,5 +163,117 @@ describe('applyYamlUpdate', () => {
     expect(result.updatedDataPatch.enabled).toBe(false);
     expect(result.updatedDataPatch.valid).toBe(false);
     expect(result.updatedDataPatch.triggerTypes).toEqual([]);
+  });
+
+  it('recovers name/description from YAML that has a valid title but fails schema validation', () => {
+    const zodSchema = getWorkflowZodSchema({});
+    const invalidYamlWithName = [
+      'version: "1"',
+      'name: Multi-Source IOC Enrichment and Tiered Response',
+      'description: Check an IOC against six threat-intel sources in parallel, aggregate the risk, then route to a tiered response.',
+      'triggers:',
+      '  - type: manual',
+      'steps:',
+      '  - name: step1',
+      '    type: nonexistent_connector_type_xyz',
+      '    with:',
+      '      message: hello',
+    ].join('\n');
+
+    const result = applyYamlUpdate({
+      workflowYaml: invalidYamlWithName,
+      zodSchema,
+      triggerDefinitions: [],
+    });
+
+    expect(result.updatedDataPatch.name).toBe('Multi-Source IOC Enrichment and Tiered Response');
+    expect(result.updatedDataPatch.description).toBe(
+      'Check an IOC against six threat-intel sources in parallel, aggregate the risk, then route to a tiered response.'
+    );
+    expect(result.updatedDataPatch.valid).toBe(false);
+    expect(result.updatedDataPatch.definition).toBeNull();
+  });
+
+  it('omits name/description from the patch when invalid YAML has no title, so the stored name is preserved', () => {
+    const zodSchema = getWorkflowZodSchema({});
+    const invalidYamlWithoutName = [
+      'version: "1"',
+      'triggers:',
+      '  - type: manual',
+      'steps:',
+      '  - name: step1',
+      '    type: nonexistent_connector_type_xyz',
+      '    with:',
+      '      message: hello',
+    ].join('\n');
+
+    const result = applyYamlUpdate({
+      workflowYaml: invalidYamlWithoutName,
+      zodSchema,
+      triggerDefinitions: [],
+    });
+
+    expect(result.updatedDataPatch).not.toHaveProperty('name');
+    expect(result.updatedDataPatch).not.toHaveProperty('description');
+  });
+});
+
+describe('prepareWorkflowDocumentFromYaml', () => {
+  const now = new Date('2024-01-01T00:00:00.000Z');
+
+  it('recovers name/description from YAML that has a valid title but fails schema validation', () => {
+    const zodSchema = getWorkflowZodSchema({});
+    const invalidYamlWithName = [
+      'version: "1"',
+      'name: Multi-Source IOC Enrichment and Tiered Response',
+      'description: Check an IOC against six threat-intel sources in parallel, aggregate the risk, then route to a tiered response.',
+      'triggers:',
+      '  - type: manual',
+      'steps:',
+      '  - name: step1',
+      '    type: nonexistent_connector_type_xyz',
+      '    with:',
+      '      message: hello',
+    ].join('\n');
+
+    const result = prepareWorkflowDocumentFromYaml({
+      yaml: invalidYamlWithName,
+      zodSchema,
+      authenticatedUser: 'user1',
+      now,
+      spaceId: 'default',
+    });
+
+    expect(result.workflowData.name).toBe('Multi-Source IOC Enrichment and Tiered Response');
+    expect(result.workflowData.description).toBe(
+      'Check an IOC against six threat-intel sources in parallel, aggregate the risk, then route to a tiered response.'
+    );
+    expect(result.workflowData.valid).toBe(false);
+    expect(result.workflowData.definition).toBeNull();
+  });
+
+  it('falls back to "Untitled workflow" when invalid YAML has no name', () => {
+    const zodSchema = getWorkflowZodSchema({});
+    const invalidYamlWithoutName = [
+      'version: "1"',
+      'triggers:',
+      '  - type: manual',
+      'steps:',
+      '  - name: step1',
+      '    type: nonexistent_connector_type_xyz',
+      '    with:',
+      '      message: hello',
+    ].join('\n');
+
+    const result = prepareWorkflowDocumentFromYaml({
+      yaml: invalidYamlWithoutName,
+      zodSchema,
+      authenticatedUser: 'user1',
+      now,
+      spaceId: 'default',
+    });
+
+    expect(result.workflowData.name).toBe('Untitled workflow');
+    expect(result.workflowData.description).toBeUndefined();
   });
 });

--- a/src/platform/plugins/shared/workflows_management/server/api/lib/workflow_prepare.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/lib/workflow_prepare.ts
@@ -38,6 +38,23 @@ export const workflowYamlDeclaresTopLevelEnabled = (yamlString: string): boolean
 };
 
 /**
+ * Reads `name`/`description` straight off the YAML without requiring it to pass
+ * schema validation, so a workflow that fails strict validation still keeps its
+ * author-given title instead of collapsing to the "Untitled workflow" fallback.
+ */
+const extractLooseTitleFields = (yamlString: string): { name?: string; description?: string } => {
+  const parsed = parseYamlToJSONWithoutValidation(yamlString);
+  if (!parsed.success || parsed.json == null || typeof parsed.json !== 'object') {
+    return {};
+  }
+  const json = parsed.json as Record<string, unknown>;
+  return {
+    name: typeof json.name === 'string' && json.name.trim() !== '' ? json.name : undefined,
+    description: typeof json.description === 'string' ? json.description : undefined,
+  };
+};
+
+/**
  * Validates YAML and builds a WorkflowProperties document ready for indexing.
  * Shared by user-created and managed workflow creation paths.
  */
@@ -60,9 +77,10 @@ export const prepareWorkflowDocumentFromYaml = (params: {
     triggerDefinitions,
   } = params;
 
+  const looseTitle = extractLooseTitleFields(yaml);
   let workflowToCreate: EsWorkflowCreate = {
-    name: 'Untitled workflow',
-    description: undefined,
+    name: looseTitle.name ?? 'Untitled workflow',
+    description: looseTitle.description,
     enabled: false,
     tags: [],
     definition: undefined,
@@ -123,8 +141,16 @@ export const applyYamlUpdate = (params: {
   const validation = validateWorkflowYaml(workflowYaml, zodSchema, { triggerDefinitions });
 
   if (!validation.valid || !validation.parsedWorkflow) {
+    const looseTitle = extractLooseTitleFields(workflowYaml);
     return {
-      updatedDataPatch: { definition: null, enabled: false, valid: false, triggerTypes: [] },
+      updatedDataPatch: {
+        definition: null,
+        enabled: false,
+        valid: false,
+        triggerTypes: [],
+        ...(looseTitle.name !== undefined ? { name: looseTitle.name } : {}),
+        ...(looseTitle.description !== undefined ? { description: looseTitle.description } : {}),
+      },
       validationErrors: validation.diagnostics
         .filter((d) => d.severity === 'error')
         .map((d) => d.message),


### PR DESCRIPTION
## Summary

This PR make the workflow plugin adopt the yaml name as title also for invalid workflow (for instance workflows that do not pass schema validation).
The previous version fallback to `Untitled Workflow` in this case, which is now adopted only for yaml without `name` property.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->