### PR TITLE
[Security Solution][Endpoint] Increase upload-file timeout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
@@ -245,6 +245,7 @@ export function registerResponseActionRoutes(
       )
     );
 
+  const uploadTimeout = 10 * 60 * 1000; // 10 min
   router.versioned
     .post({
       access: 'public',
@@ -259,6 +260,10 @@ export function registerResponseActionRoutes(
           accepts: ['multipart/form-data'],
           output: 'stream',
           maxBytes: endpointContext.serverConfig.maxUploadResponseActionFileBytes,
+          timeout: {
+            payload: uploadTimeout,
+            idleSocket: uploadTimeout,
+          },
         },
       },
     })


### PR DESCRIPTION
## Summary

Increases timeout for upload file route since file size limitation is now configurable and uncapped since #275850 


