### PR TITLE
[Security Solution] Alert analysis workflow bug fixes (re-land)

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.test.ts
@@ -70,13 +70,13 @@ describe('SECURITY_ALERT_ANALYSIS_WORKFLOW yaml', () => {
     expect(setTagsStep).toBeDefined();
     // The short tag names: `.classification.` and `.confidence.`, not the old longer
     // `.output.classification.` / `.output.confidence_score.` segments. (The trailing
-    // `steps.onechat_runAgent_step.output.structured_output.*` is the agent step's output value that
+    // `steps.runAgent_step.output.structured_output.*` is the agent step's output value that
     // fills the tag, not part of the tag name.)
     expect(setTagsStep.with.tags_to_add).toEqual([
       '{{ variables.tag_prefix }}',
       '{{ variables.tag_prefix }}.version.{{ variables.normalized_version }}',
-      '{{ variables.tag_prefix }}.classification.{{ steps.onechat_runAgent_step.output.structured_output.classification | downcase }}',
-      '{{ variables.tag_prefix }}.confidence.{{ steps.onechat_runAgent_step.output.structured_output.confidence_score }}',
+      '{{ variables.tag_prefix }}.classification.{{ steps.runAgent_step.output.structured_output.classification | downcase }}',
+      '{{ variables.tag_prefix }}.confidence.{{ steps.runAgent_step.output.structured_output.confidence_score }}',
     ]);
     // The auto-close suffix is short too.
     expect(workflow.consts.closed_tag_suffix).toBe('closed');
@@ -103,7 +103,7 @@ describe('SECURITY_ALERT_ANALYSIS_WORKFLOW yaml', () => {
   });
 
   it('passes the runtime connector id and create-conversation flag to the AI agent step', () => {
-    const agentStep = findStepByName(workflow.steps, 'onechat_runAgent_step') as {
+    const agentStep = findStepByName(workflow.steps, 'runAgent_step') as {
       'connector-id': string;
       'create-conversation': string;
     };
@@ -112,6 +112,27 @@ describe('SECURITY_ALERT_ANALYSIS_WORKFLOW yaml', () => {
     expect(agentStep['connector-id']).toBe('{{ variables.connector_id }}');
     // `${{ }}` preserves the boolean; a plain `{{ }}` would render the string "false" (truthy).
     expect(agentStep['create-conversation']).toBe('${{ variables.create_conversation }}');
+  });
+
+  it('adds token usage metadata to the verdict note', () => {
+    const verdictNoteStep = findStepByName(workflow.steps, 'add_verdict_note_to_alert') as {
+      with: { body: { note: { note: string } } };
+    };
+    const note = verdictNoteStep.with.body.note.note;
+
+    expect(note).toContain('steps.runAgent_step.output.metadata.usage.inputTokens');
+    expect(note).toContain('steps.runAgent_step.output.metadata.usage.outputTokens');
+    expect(note).toContain('steps.runAgent_step.output.metadata.usage.totalTokens');
+  });
+
+  it('formats the verdict note timestamp with a human-readable date filter', () => {
+    const verdictNoteStep = findStepByName(workflow.steps, 'add_verdict_note_to_alert') as {
+      with: { body: { note: { note: string } } };
+    };
+
+    expect(verdictNoteStep.with.body.note.note).toContain(
+      "{{ execution.startedAt | date: '%B %d, %Y at %H:%M:%S UTC' }}"
+    );
   });
 
   it('gates auto-close on the runtime thresholds using a 0-1 confidence scale', () => {
@@ -129,7 +150,7 @@ describe('SECURITY_ALERT_ANALYSIS_WORKFLOW yaml', () => {
       'variables.auto_close_confidence_score_max_threshold'
     );
 
-    const agentStep = findStepByName(workflow.steps, 'onechat_runAgent_step') as {
+    const agentStep = findStepByName(workflow.steps, 'runAgent_step') as {
       with: { schema: { properties: { confidence_score: { minimum: number; maximum: number } } } };
     };
     // The LLM schema maximum must stay on the same 0-1 scale as the thresholds, or `score <= 1.0`

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/alert_analysis_workflow.yaml
@@ -940,7 +940,7 @@ steps:
                 {%- endif %}
                 {%- endif %}
 
-          - name: onechat_runAgent_step
+          - name: runAgent_step
             type: ai.agent
             agent-id: "{{ variables.agent_id }}"
             connector-id: "{{ variables.connector_id }}"
@@ -994,7 +994,7 @@ steps:
           # and abort processing for this alert.
           - name: check_if_output_exists
             type: if
-            condition: "not steps.onechat_runAgent_step.output.structured_output.classification:*"
+            condition: "not steps.runAgent_step.output.structured_output.classification:*"
             steps:
               - name: add_no_data_note_to_alert
                 type: kibana.request
@@ -1039,24 +1039,38 @@ steps:
                         ---
                         ## Automated Alert Analysis
                         ### Classification
-                        **{{ steps.onechat_runAgent_step.output.structured_output.classification }}**
+                        **{{ steps.runAgent_step.output.structured_output.classification }}**
 
                         ### Confidence Score
-                        {{ steps.onechat_runAgent_step.output.structured_output.confidence_score }}
+                        {{ steps.runAgent_step.output.structured_output.confidence_score }}
 
                         ### Rationale
-                        {{ steps.onechat_runAgent_step.output.structured_output.rationale }}
+                        {{ steps.runAgent_step.output.structured_output.rationale }}
 
                         ### Contributing Factors
-                        {% for factor in steps.onechat_runAgent_step.output.structured_output.contributing_factors %}
+                        {% for factor in steps.runAgent_step.output.structured_output.contributing_factors %}
                         - {{ factor }}
                         {%- endfor %}
 
-                        ### Timestamp
-                        {{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S' }}
+                        ### Analysis Details
+                        - Workflow version: {{ variables.normalized_version }}
+                        - Tag prefix: {{ variables.tag_prefix }}
+                        - Connector: {{ steps.runAgent_step.output.metadata.usage.connectorId | default: variables.connector_id }}
+                        {% if variables.auto_close_enabled -%}
+                        - Auto-close confidence range: {{ variables.auto_close_confidence_score_min_threshold }} to {{ variables.auto_close_confidence_score_max_threshold }}
+                        {%- endif %}
 
-                        {% if steps.onechat_runAgent_step.output.conversation_id -%}
-                        [Continue conversation](/app/agent_builder/conversations/{{ steps.onechat_runAgent_step.output.conversation_id }})
+                        ### Token Usage
+                        - Input tokens: {{ steps.runAgent_step.output.metadata.usage.inputTokens | default: 0 }}
+                        - Output tokens: {{ steps.runAgent_step.output.metadata.usage.outputTokens | default: 0 }}
+                        - Cached tokens: {{ steps.runAgent_step.output.metadata.usage.cachedTokens | default: 0 }}
+                        - Total tokens: {{ steps.runAgent_step.output.metadata.usage.totalTokens | default: 0 }}
+
+                        ### Timestamp
+                        {{ execution.startedAt | date: '%B %d, %Y at %H:%M:%S UTC' }}
+
+                        {% if steps.runAgent_step.output.conversation_id -%}
+                        [Continue conversation](/app/agent_builder/conversations/{{ steps.runAgent_step.output.conversation_id }})
                         {%- endif %}
 
                       timelineId: ''
@@ -1086,8 +1100,8 @@ steps:
                   tags_to_add:
                     - "{{ variables.tag_prefix }}"
                     - "{{ variables.tag_prefix }}.version.{{ variables.normalized_version }}"
-                    - "{{ variables.tag_prefix }}.classification.{{ steps.onechat_runAgent_step.output.structured_output.classification | downcase }}"
-                    - "{{ variables.tag_prefix }}.confidence.{{ steps.onechat_runAgent_step.output.structured_output.confidence_score }}"
+                    - "{{ variables.tag_prefix }}.classification.{{ steps.runAgent_step.output.structured_output.classification | downcase }}"
+                    - "{{ variables.tag_prefix }}.confidence.{{ steps.runAgent_step.output.structured_output.confidence_score }}"
                   tags_to_remove: "${{ foreach.item.kibana.alert.workflow_tags | where_exp: 'tag', variables.tags_filter_expr }}"
 
               # Remove stale tags first (if any) to avoid conflicts with the add.
@@ -1128,9 +1142,9 @@ steps:
                 type: if
                 condition: >-
                   variables.auto_close_enabled: true
-                  and steps.onechat_runAgent_step.output.structured_output.classification: "false_positive"
-                  and steps.onechat_runAgent_step.output.structured_output.confidence_score >= {{ variables.auto_close_confidence_score_min_threshold }}
-                  and steps.onechat_runAgent_step.output.structured_output.confidence_score <= {{ variables.auto_close_confidence_score_max_threshold }}
+                  and steps.runAgent_step.output.structured_output.classification: "false_positive"
+                  and steps.runAgent_step.output.structured_output.confidence_score >= {{ variables.auto_close_confidence_score_min_threshold }}
+                  and steps.runAgent_step.output.structured_output.confidence_score <= {{ variables.auto_close_confidence_score_max_threshold }}
                 steps:
                   # Tag the alert so it can be identified as auto-closed.
                   - name: set_close_tags

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/index.ts
@@ -19,7 +19,7 @@ export const SECURITY_ALERT_ANALYSIS_WORKFLOW_ID = 'system-security-alert-analys
 export const SECURITY_ALERT_ANALYSIS_WORKFLOW = {
   id: SECURITY_ALERT_ANALYSIS_WORKFLOW_ID,
   pluginId: 'securitySolution',
-  version: 3,
+  version: 2,
   billable: false,
   visibility: {
     selectors: ['rule_action'],

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/alert_analysis/index.ts
@@ -19,7 +19,7 @@ export const SECURITY_ALERT_ANALYSIS_WORKFLOW_ID = 'system-security-alert-analys
 export const SECURITY_ALERT_ANALYSIS_WORKFLOW = {
   id: SECURITY_ALERT_ANALYSIS_WORKFLOW_ID,
   pluginId: 'securitySolution',
-  version: 2,
+  version: 3,
   billable: false,
   visibility: {
     selectors: ['rule_action'],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/markdown_link.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/markdown_link.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderWithI18n as render } from '@kbn/test-jest-helpers';
+import { MarkdownLink } from './markdown_link';
+
+const mockPrepend = jest.fn((path: string) => `/kbn${path}`);
+const mockGet = jest.fn(() => '/kbn');
+
+jest.mock('../../lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      http: {
+        basePath: {
+          prepend: (path: string) => mockPrepend(path),
+          get: () => mockGet(),
+        },
+      },
+    },
+  }),
+}));
+
+describe('MarkdownLink', () => {
+  const defaultProps = { children: 'link text' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prepends the base path to app-internal links', () => {
+    const { getByTestId } = render(<MarkdownLink {...defaultProps} href="/app/security/alerts" />);
+    expect(getByTestId('markdown-link')).toHaveAttribute('href', '/kbn/app/security/alerts');
+  });
+
+  it('leaves absolute external links untouched', () => {
+    const { getByTestId } = render(<MarkdownLink {...defaultProps} href="https://elastic.co" />);
+    expect(getByTestId('markdown-link')).toHaveAttribute('href', 'https://elastic.co');
+  });
+
+  it('leaves protocol-relative links untouched', () => {
+    const { getByTestId } = render(<MarkdownLink {...defaultProps} href="//elastic.co/path" />);
+    expect(getByTestId('markdown-link')).toHaveAttribute('href', '//elastic.co/path');
+  });
+
+  it('does not double-prepend when the base path is already present', () => {
+    const { getByTestId } = render(<MarkdownLink {...defaultProps} href="/kbn/app/security" />);
+    expect(getByTestId('markdown-link')).toHaveAttribute('href', '/kbn/app/security');
+  });
+
+  it('omits the href when links are disabled', () => {
+    const { getByTestId } = render(
+      <MarkdownLink {...defaultProps} disableLinks href="/app/security/alerts" />
+    );
+    expect(getByTestId('markdown-link')).not.toHaveAttribute('href');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/markdown_link.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/markdown_link.tsx
@@ -5,14 +5,21 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import type { EuiLinkAnchorProps } from '@elastic/eui';
 import { EuiLink, EuiToolTip } from '@elastic/eui';
+import { useKibana } from '../../lib/kibana';
 
 type MarkdownLinkProps = { disableLinks?: boolean } & EuiLinkAnchorProps;
 
 /** prevents search engine manipulation by noting the linked document is not trusted or endorsed by us */
 const REL_NOFOLLOW = 'nofollow';
+
+// App-internal links are authored without Kibana's server base path (e.g. `/app/security/...`).
+// Protocol-relative (`//host`) and absolute (`https://`, `mailto:`) URLs are external and must be
+// left untouched.
+const isAppInternalHref = (href?: string): href is string =>
+  typeof href === 'string' && href.startsWith('/') && !href.startsWith('//');
 
 const MarkdownLinkComponent: React.FC<MarkdownLinkProps> = ({
   disableLinks,
@@ -20,17 +27,38 @@ const MarkdownLinkComponent: React.FC<MarkdownLinkProps> = ({
   target,
   children,
   ...props
-}) => (
-  <EuiToolTip content={href}>
-    <EuiLink
-      href={disableLinks ? undefined : href}
-      data-test-subj="markdown-link"
-      rel={`${REL_NOFOLLOW}`}
-      target="_blank"
-    >
-      {children}
-    </EuiLink>
-  </EuiToolTip>
-);
+}) => {
+  const {
+    services: { http },
+  } = useKibana();
+  const basePath = http?.basePath;
+
+  const resolvedHref = useMemo(() => {
+    if (!isAppInternalHref(href) || !basePath) {
+      return href;
+    }
+
+    // Guard against double-prepending when the href already carries the base path.
+    const serverBasePath = basePath.get();
+    if (serverBasePath && href.startsWith(`${serverBasePath}/`)) {
+      return href;
+    }
+
+    return basePath.prepend(href);
+  }, [href, basePath]);
+
+  return (
+    <EuiToolTip content={resolvedHref}>
+      <EuiLink
+        href={disableLinks ? undefined : resolvedHref}
+        data-test-subj="markdown-link"
+        rel={`${REL_NOFOLLOW}`}
+        target="_blank"
+      >
+        {children}
+      </EuiLink>
+    </EuiToolTip>
+  );
+};
 
 export const MarkdownLink = memo(MarkdownLinkComponent);

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachment_routes.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachment_routes.test.ts
@@ -55,12 +55,52 @@ describe('registerAlertAnalysisWorkflowRuleAttachmentRoutes', () => {
   let hasAtLeast: jest.Mock;
   let context: SecuritySolutionRequestHandlerContext;
 
+  // Mirrors the parts of rulesClient.find the service relies on: name search, the "has the workflow
+  // action" KQL filter (detected by the actionRef clause), name sorting, count-only requests
+  // (perPage 0), and page slicing.
   const mockFindRules = (rules: RuleAlertType[]) => {
-    rulesClient.find.mockResolvedValue({
-      data: rules,
-      total: rules.length,
-      page: 1,
-      perPage: 2000,
+    rulesClient.find.mockImplementation(async ({ options } = {}) => {
+      const {
+        filter,
+        search,
+        page = 1,
+        perPage = 0,
+        sortField,
+        sortOrder,
+      } = (options ?? {}) as {
+        filter?: string;
+        search?: string;
+        page?: number;
+        perPage?: number;
+        sortField?: string;
+        sortOrder?: string;
+      };
+
+      let matched = rules;
+      if (typeof search === 'string' && search.length > 0) {
+        const lowerSearch = search.toLowerCase();
+        matched = matched.filter((rule) => rule.name.toLowerCase().includes(lowerSearch));
+      }
+      if (typeof filter === 'string' && filter.includes('actionRef')) {
+        matched = matched.filter((rule) =>
+          [...rule.actions, ...(rule.systemActions ?? [])].some(
+            (action) =>
+              action.id === ALERT_ANALYSIS_WORKFLOW_SYSTEM_CONNECTOR_ID &&
+              (action.params as { subActionParams?: { workflowId?: string } }).subActionParams
+                ?.workflowId === WORKFLOW_ID
+          )
+        );
+      }
+      if (sortField === 'name') {
+        const direction = sortOrder === 'desc' ? -1 : 1;
+        matched = [...matched].sort((a, b) => a.name.localeCompare(b.name) * direction);
+      }
+
+      const total = matched.length;
+      const start = (page - 1) * perPage;
+      const data = perPage === 0 ? [] : matched.slice(start, start + perPage);
+
+      return { data, total, page, perPage };
     });
   };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachments.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachments.test.ts
@@ -36,13 +36,45 @@ const createWorkflowAction = (workflowId = WORKFLOW_ID) => createWorkflowActionF
 const createWorkflowSystemAction = (workflowId = WORKFLOW_ID) =>
   createWorkflowSystemActionFixture(workflowId);
 
+// Emulates the parts of rulesClient.find the service relies on: server-side name sorting,
+// count-only requests (perPage 0), page slicing, and the attachment-filter KQL the service pushes
+// into `filter`. Attachment narrowing is derived from that filter rather than done in memory: each
+// `actionRef` group is a "has the workflow action" requirement, negated when wrapped in `not (...)`.
+// A filter that requires both (e.g. the attached count under the `not_attached` filter) matches
+// nothing, mirroring the contradictory KQL. The id-based path (getRulesByIds) passes an enriched id
+// filter with no `actionRef`, so it falls through to the full set like the real client does.
 const createRulesClient = (rules: RuleAlertType[]): jest.Mocked<RulesClient> =>
   ({
-    find: jest.fn().mockResolvedValue({
-      data: rules,
-      total: rules.length,
-      page: 1,
-      perPage: 2000,
+    find: jest.fn().mockImplementation(async ({ options } = {}) => {
+      const { filter = '', page = 1, perPage = 0, sortField, sortOrder } = options ?? {};
+
+      let matched = rules;
+      if (typeof filter === 'string' && filter.includes('actionRef')) {
+        const negatedGroups = (filter.match(/not \(/g) ?? []).length;
+        const totalGroups = (filter.match(/actionRef/g) ?? []).length;
+        const requireAttached = totalGroups - negatedGroups > 0;
+        const requireNotAttached = negatedGroups > 0;
+        matched = matched.filter((rule) => {
+          const attached = hasAlertAnalysisWorkflowAction(rule, WORKFLOW_ID);
+          if (requireAttached && !attached) {
+            return false;
+          }
+          if (requireNotAttached && attached) {
+            return false;
+          }
+          return true;
+        });
+      }
+      if (sortField === 'name') {
+        const direction = sortOrder === 'desc' ? -1 : 1;
+        matched = [...matched].sort((a, b) => a.name.localeCompare(b.name) * direction);
+      }
+
+      const total = matched.length;
+      const start = (page - 1) * perPage;
+      const data = perPage === 0 ? [] : matched.slice(start, start + perPage);
+
+      return { data, total, page, perPage };
     }),
   } as Partial<jest.Mocked<RulesClient>> as jest.Mocked<RulesClient>);
 
@@ -104,7 +136,7 @@ describe('alert analysis workflow rule attachments', () => {
     );
   });
 
-  it('returns paginated rule attachment summaries', async () => {
+  it('returns a server-paginated page of rule attachment summaries', async () => {
     const rulesClient = createRulesClient([
       createRule({ id: 'rule-3' }),
       createRule({ id: 'rule-2', enabled: false }),
@@ -124,16 +156,16 @@ describe('alert analysis workflow rule attachments', () => {
       perPage: 1,
       rules: [
         {
-          id: 'rule-3',
-          name: 'Rule rule-3',
-          enabled: true,
+          id: 'rule-2',
+          name: 'Rule rule-2',
+          enabled: false,
           attached: false,
         },
       ],
     });
   });
 
-  it('sorts rules deterministically by enabled state, name, and id before paginating', async () => {
+  it('delegates sorting and pagination to the rules client (by name, ascending)', async () => {
     const rulesClient = createRulesClient([
       createRule({ id: 'rule-3', enabled: false }),
       createRule({ id: 'rule-2' }),
@@ -144,17 +176,55 @@ describe('alert analysis workflow rule attachments', () => {
       workflowId: WORKFLOW_ID,
     });
 
-    await expect(
-      service.getRuleAttachments({ search: '', attachmentFilter: 'all', page: 1, perPage: 3 })
-    ).resolves.toEqual(
+    await service.getRuleAttachments({ search: '', attachmentFilter: 'all', page: 1, perPage: 3 });
+
+    expect(rulesClient.find).toHaveBeenCalledWith(
       expect.objectContaining({
-        rules: [
-          expect.objectContaining({ id: 'rule-1' }),
-          expect.objectContaining({ id: 'rule-2' }),
-          expect.objectContaining({ id: 'rule-3' }),
-        ],
+        options: expect.objectContaining({
+          page: 1,
+          perPage: 3,
+          sortField: 'name',
+          sortOrder: 'asc',
+        }),
       })
     );
+  });
+
+  it('returns the true total without throwing when more than the attach cap match', async () => {
+    const rules = Array.from({ length: 2500 }, (_, index) => createRule({ id: `rule-${index}` }));
+    const service = createAlertAnalysisWorkflowRuleAttachmentService({
+      rulesClient: createRulesClient(rules),
+      workflowId: WORKFLOW_ID,
+    });
+
+    await expect(
+      service.getRuleAttachmentStats({ search: '', attachmentFilter: 'all' })
+    ).resolves.toEqual({
+      total: 2500,
+      attached: 0,
+    });
+  });
+
+  it('paginates past the attach cap without throwing', async () => {
+    const rules = Array.from({ length: 2500 }, (_, index) =>
+      // zero-pad so name sort order is deterministic for the assertion below
+      createRule({ id: `rule-${String(index).padStart(4, '0')}` })
+    );
+    const service = createAlertAnalysisWorkflowRuleAttachmentService({
+      rulesClient: createRulesClient(rules),
+      workflowId: WORKFLOW_ID,
+    });
+
+    const result = await service.getRuleAttachments({
+      search: '',
+      attachmentFilter: 'all',
+      page: 3,
+      perPage: 20,
+    });
+
+    expect(result.total).toBe(2500);
+    expect(result.rules).toHaveLength(20);
+    expect(result.rules[0].id).toBe('rule-0040');
   });
 
   it('returns selectable rule ids for all matching rules missing the workflow action', async () => {
@@ -550,20 +620,6 @@ describe('alert analysis workflow rule attachments', () => {
     // empty. What matters is that a blank search adds no `name` condition.
     const { options } = rulesClient.find.mock.calls[0][0] as { options: { filter?: string } };
     expect(options.filter ?? '').not.toContain('alert.attributes.name');
-  });
-
-  it('throws when more than the max number of rules match the search', async () => {
-    const rulesClient = {
-      find: jest.fn().mockResolvedValue({ data: [], total: 2001, page: 1, perPage: 2000 }),
-    } as Partial<jest.Mocked<RulesClient>> as jest.Mocked<RulesClient>;
-    const service = createAlertAnalysisWorkflowRuleAttachmentService({
-      rulesClient,
-      workflowId: WORKFLOW_ID,
-    });
-
-    await expect(
-      service.getRuleAttachmentStats({ search: '', attachmentFilter: 'all' })
-    ).rejects.toThrow('More than 2000 rules matched the filter query');
   });
 
   it('throws when more than the max number of rules are selected for update', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachments.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/alert_analysis_workflow/rule_attachments.ts
@@ -8,6 +8,7 @@
 import pMap from 'p-map';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { RulesClient } from '@kbn/alerting-plugin/server';
+import { systemConnectorActionRefPrefix } from '@kbn/alerting-plugin/common';
 import { BadRequestError } from '@kbn/securitysolution-es-utils';
 import type {
   AlertAnalysisWorkflowRuleAttachmentService,
@@ -76,17 +77,50 @@ const normalizeSearch = (search: string): string | undefined => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
-const compareRulesByStableDefaultSort = (ruleA: RuleAlertType, ruleB: RuleAlertType): number => {
-  if (ruleA.enabled !== ruleB.enabled) {
-    return ruleA.enabled ? -1 : 1;
+// KQL matching rules that have this workflow's system action attached. Mirrors how the connector
+// rules list finds rules using a system connector (see triggers_actions_ui connector_rules_list),
+// but also pins the flattened `workflowId` so a rule attached to a *different* workflow via the same
+// shared `.workflows` system connector is not counted as attached to this one.
+const buildAttachedRulesFilter = (workflowId: string): string =>
+  `alert.attributes.actions:{ actionRef: "${systemConnectorActionRefPrefix}${ALERT_ANALYSIS_WORKFLOW_SYSTEM_CONNECTOR_ID}" and params.subActionParams.workflowId: "${workflowId}" }`;
+
+// Match the Rules page: a single search term becomes a `name.keyword: *term*` substring filter
+// (plus the MITRE/index attributes), so `Endpoin`/`Sec`/`Def` match like they do there. The plain
+// `search`/`searchFields` used before only matched whole words/prefixes.
+const buildSearchClause = (search: string): string | undefined => {
+  const normalizedSearch = normalizeSearch(search);
+  return normalizedSearch ? convertRuleSearchTermToKQL(normalizedSearch) : undefined;
+};
+
+// Translates the attachment filter into a KQL clause so the narrowing happens server-side (via the
+// count-only + paginated read paths) instead of pulling every matching rule into memory to filter.
+const buildAttachmentFilterClause = (
+  workflowId: string,
+  attachmentFilter: RuleAttachmentFilter
+): string | undefined => {
+  const attachedFilter = buildAttachedRulesFilter(workflowId);
+
+  if (attachmentFilter === 'attached') {
+    return attachedFilter;
   }
 
-  const nameComparison = ruleA.name.localeCompare(ruleB.name);
-  if (nameComparison !== 0) {
-    return nameComparison;
+  if (attachmentFilter === 'not_attached') {
+    return `not (${attachedFilter})`;
   }
 
-  return ruleA.id.localeCompare(ruleB.id);
+  return undefined;
+};
+
+// ANDs the provided KQL clauses (dropping empty ones), parenthesizing each so their internal `and`/
+// `or`/`not` operators don't bleed across clause boundaries.
+const combineFilters = (clauses: Array<string | undefined>): string | undefined => {
+  const presentClauses = clauses.filter((clause): clause is string => Boolean(clause));
+
+  if (presentClauses.length === 0) {
+    return undefined;
+  }
+
+  return presentClauses.map((clause) => `(${clause})`).join(' and ');
 };
 
 const getRuleActions = (
@@ -162,43 +196,59 @@ const toRuleAttachmentSummary = (
   attached: hasAlertAnalysisWorkflowAction(rule, workflowId),
 });
 
-const getMatchingRules = async ({
+// Count-only find (no hits fetched) so the preview scales far past the old MAX_RULES_TO_ATTACH cap
+// (which threw once more than 2000 matched) instead of erroring. The alerting rules client does not
+// set `track_total_hits`, so `total` is exact up to Elasticsearch's default 10,000 ceiling and
+// saturates at 10,000 beyond that. The `filter` narrows the count, e.g. to rules matching the search
+// term, the attachment filter, or that already have the workflow attached.
+const countMatchingRules = async ({
   rulesClient,
-  search,
+  filter,
 }: {
   rulesClient: RulesClient;
-  search: string;
-}): Promise<MatchingRulesResult> => {
-  const normalizedSearch = normalizeSearch(search);
-  const result = await findRules({
+  filter?: string;
+}): Promise<number> => {
+  const { total } = await findRules({
     rulesClient,
-    // Match the Rules page: a single search term becomes a `name.keyword: *term*` substring
-    // filter (plus the MITRE/index attributes), so `Endpoin`/`Sec`/`Def` match like they do
-    // there. The plain `search`/`searchFields` used before only matched whole words/prefixes.
-    filter: normalizedSearch ? convertRuleSearchTermToKQL(normalizedSearch) : undefined,
+    filter,
     fields: undefined,
     page: 1,
-    perPage: MAX_RULES_TO_ATTACH,
+    perPage: 0,
     sortField: undefined,
     sortOrder: undefined,
     search: undefined,
     searchFields: undefined,
   });
 
-  if (result.total > MAX_RULES_TO_ATTACH) {
-    throw new BadRequestError(
-      `More than ${MAX_RULES_TO_ATTACH} rules matched the filter query. Try to narrow it down.`
-    );
-  }
-
-  return {
-    total: result.total,
-    rules: result.data.sort(compareRulesByStableDefaultSort),
-  };
+  return total;
 };
 
-const countAttachedRules = (rules: RuleAlertType[], workflowId: string): number => {
-  return rules.filter((rule) => hasAlertAnalysisWorkflowAction(rule, workflowId)).length;
+// Server-side sorted + paginated fetch. Sorting is delegated to the rules client (by name) so the
+// order is stable across pages without pulling every matching rule into memory.
+const fetchMatchingRules = async ({
+  rulesClient,
+  filter,
+  page,
+  perPage,
+}: {
+  rulesClient: RulesClient;
+  filter?: string;
+  page: number;
+  perPage: number;
+}): Promise<MatchingRulesResult> => {
+  const { data, total } = await findRules({
+    rulesClient,
+    filter,
+    fields: undefined,
+    page,
+    perPage,
+    sortField: 'name',
+    sortOrder: 'asc',
+    search: undefined,
+    searchFields: undefined,
+  });
+
+  return { total, rules: data };
 };
 
 const getRulesMissingWorkflowAction = (
@@ -213,22 +263,6 @@ const getRulesWithWorkflowAction = (
   workflowId: string
 ): RuleAlertType[] => {
   return rules.filter((rule) => hasAlertAnalysisWorkflowAction(rule, workflowId));
-};
-
-const filterRulesByAttachment = (
-  rules: RuleAlertType[],
-  workflowId: string,
-  attachmentFilter: RuleAttachmentFilter
-): RuleAlertType[] => {
-  if (attachmentFilter === 'attached') {
-    return getRulesWithWorkflowAction(rules, workflowId);
-  }
-
-  if (attachmentFilter === 'not_attached') {
-    return getRulesMissingWorkflowAction(rules, workflowId);
-  }
-
-  return rules;
 };
 
 const getRulesByIds = async ({
@@ -279,27 +313,48 @@ export const createAlertAnalysisWorkflowRuleAttachmentService = (
 
   return {
     async getRuleAttachmentStats({ search, attachmentFilter }) {
-      const { rules } = await getMatchingRules({ rulesClient, search });
-      const filteredRules = filterRulesByAttachment(rules, workflowId, attachmentFilter);
+      const searchClause = buildSearchClause(search);
+      const attachmentClause = buildAttachmentFilterClause(workflowId, attachmentFilter);
+      const attachedClause = buildAttachedRulesFilter(workflowId);
 
-      return {
-        total: filteredRules.length,
-        attached: countAttachedRules(filteredRules, workflowId),
-      };
+      const [total, attached] = await Promise.all([
+        countMatchingRules({
+          rulesClient,
+          filter: combineFilters([searchClause, attachmentClause]),
+        }),
+        countMatchingRules({
+          rulesClient,
+          filter: combineFilters([searchClause, attachmentClause, attachedClause]),
+        }),
+      ]);
+
+      return { total, attached };
     },
 
     async getRuleAttachments({ search, attachmentFilter, page, perPage }) {
-      const { rules } = await getMatchingRules({ rulesClient, search });
-      const filteredRules = filterRulesByAttachment(rules, workflowId, attachmentFilter);
-      const startIndex = (page - 1) * perPage;
-      const pageRules = filteredRules.slice(startIndex, startIndex + perPage);
+      const searchClause = buildSearchClause(search);
+      const attachmentClause = buildAttachmentFilterClause(workflowId, attachmentFilter);
+      const attachedClause = buildAttachedRulesFilter(workflowId);
+
+      const [{ total, rules }, attached] = await Promise.all([
+        fetchMatchingRules({
+          rulesClient,
+          filter: combineFilters([searchClause, attachmentClause]),
+          page,
+          perPage,
+        }),
+        countMatchingRules({
+          rulesClient,
+          filter: combineFilters([searchClause, attachmentClause, attachedClause]),
+        }),
+      ]);
 
       return {
-        total: filteredRules.length,
-        attached: countAttachedRules(filteredRules, workflowId),
+        total,
+        attached,
         page,
         perPage,
-        rules: pageRules.map((rule) => toRuleAttachmentSummary(rule, workflowId)),
+        rules: rules.map((rule) => toRuleAttachmentSummary(rule, workflowId)),
       };
     },
 
@@ -307,13 +362,24 @@ export const createAlertAnalysisWorkflowRuleAttachmentService = (
       search,
       attachmentFilter,
     }): Promise<RuleAttachmentSelection> {
-      const { rules } = await getMatchingRules({ rulesClient, search });
-      const filteredRules = filterRulesByAttachment(rules, workflowId, attachmentFilter);
-      const rulesMissingWorkflowAction = getRulesMissingWorkflowAction(filteredRules, workflowId);
-      const rulesWithWorkflowAction = getRulesWithWorkflowAction(filteredRules, workflowId);
+      // Bulk attach/detach is bounded platform-wide (the rules client turns ids into KQL OR clauses,
+      // capped by ES maxClauseCount), so selection enumerates at most MAX_RULES_TO_ATTACH matching
+      // rules by name order rather than every match. Browsing/preview stays uncapped via the
+      // count-only + paginated read paths above.
+      const searchClause = buildSearchClause(search);
+      const attachmentClause = buildAttachmentFilterClause(workflowId, attachmentFilter);
+
+      const { total, rules } = await fetchMatchingRules({
+        rulesClient,
+        filter: combineFilters([searchClause, attachmentClause]),
+        page: 1,
+        perPage: MAX_RULES_TO_ATTACH,
+      });
+      const rulesMissingWorkflowAction = getRulesMissingWorkflowAction(rules, workflowId);
+      const rulesWithWorkflowAction = getRulesWithWorkflowAction(rules, workflowId);
 
       return {
-        total: filteredRules.length,
+        total,
         attached: rulesWithWorkflowAction.length,
         selectable: rulesMissingWorkflowAction.length,
         attachedRuleIds: rulesWithWorkflowAction.map(({ id }) => id),


### PR DESCRIPTION
## Summary

Re-lands #276854, which was reverted in #277287. The only difference from the original is that the managed workflow `version` stays at `2` instead of being bumped to `3`. This is a YAML-only change to the managed definition, so per the [managed workflows doc](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/workflows_extensions/dev_docs/MANAGED_WORKFLOWS.md#version--definition-versioning) the YAML content hash drives reconciliation and no version bump is needed.

Fixes several alert analysis workflow bugs and folds in recent product feedback.

- Rule attachment panel now scales past 2000 rules. With thousands of matching rules the preview broke (`0-0 of 0` plus an error toast) because every read path fetched up to 2000 rules and threw beyond that. Stats are now count-only and uncapped, the list paginates server-side, and the selection path no longer hard-throws. 
    <img width="1884" height="844" alt="Screenshot 2026-07-08 at 11 09 59 AM" src="https://github.com/user-attachments/assets/1686592a-3b18-4889-aa3f-b88d99572d7e" />
- The verdict note now includes token usage from the `ai.agent` step (`metadata.usage.*`), a human-readable timestamp, and workflow context (version, tag prefix, connector, auto-close range).
    <img width="1073" height="691" alt="Screenshot 2026-07-08 at 11 18 38 AM" src="https://github.com/user-attachments/assets/090f2c1c-abd7-4f1d-8eb6-22f0aedddc21" />
- `MarkdownLink` prepends `http.basePath` for app-internal links, so the note's "Continue conversation" link (and every other internal note link) resolves correctly when Kibana runs under a base path.
- Renames `onechat_runAgent_step` to `runAgent_step`.

## To test

1. Run Kibana and ES locally with the alert analysis workflow experimental settings enabled (base path `/kbn`).
2. Rule panel: on a stack with 2000+ detection rules, open the alert analysis workflow settings and view the Detection rules section.
   - Seed 2000+ rules fast with the import API (2,500 disabled synthetic query rules in one request):
     ```bash
     # generate the rules file
     awk 'BEGIN{for(i=1;i<=2500;i++) printf "{\"rule_id\":\"perf-rule-%04d\",\"name\":\"Perf Rule %04d\",\"description\":\"perf load rule\",\"risk_score\":21,\"severity\":\"low\",\"type\":\"query\",\"language\":\"kuery\",\"query\":\"*\",\"index\":[\"logs-*\"],\"enabled\":false,\"interval\":\"5m\",\"from\":\"now-6m\",\"to\":\"now\"}\n", i, i}' > /tmp/perf_rules.ndjson

     # import them (dev creds elastic:changeme)
     curl -sk -u elastic:changeme -H "kbn-xsrf: true" \
       -F "file=@/tmp/perf_rules.ndjson;type=application/ndjson" \
       "http://localhost:5601/kbn/api/detection_engine/rules/_import?overwrite=true"
     ```
   - Before: the panel shows `0-0 of 0` with a "Failed to preview matching detection rules" toast.
   - After: it shows the real total (e.g. `2,519 rules`), paginates through every page, and search still works.
3. Note: attach the workflow to a rule, let it run on an alert, and open the alert's note.
   - Before: no token usage and an ISO timestamp.
   - After: the note shows token usage and a human-readable timestamp.
4. Base path link: from that note under `/kbn`, click "Continue conversation".
   - Before: the link drops the base path and 404s.
   - After: it opens the conversation under `/kbn`.

_PR developed with Cursor + Claude Opus 4.8_

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->