### PR TITLE
[As Code] As code data view schema should use asCodeIdSchema for alignment

### DIFF
--- a/src/platform/packages/shared/as-code/data-views-schema/moon.yml
+++ b/src/platform/packages/shared/as-code/data-views-schema/moon.yml
@@ -19,6 +19,7 @@ project:
 dependsOn:
   - '@kbn/config-schema'
   - '@kbn/data-views-plugin'
+  - '@kbn/as-code-shared-schemas'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/as-code/data-views-schema/src/data_views/schema_saved_data_view.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/data_views/schema_saved_data_view.ts
@@ -8,6 +8,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { asCodeIdSchema } from '@kbn/as-code-shared-schemas';
 import { fieldSettingsFieldNameSchema, indexPatternSchema, timeFieldSchema } from './common';
 import {
   savedCompositeRuntimeFieldSchema,
@@ -33,17 +34,7 @@ export const savedFieldSettingsSchema = schema.oneOf(
 
 export const savedDataViewSpecSchema = schema.object(
   {
-    id: schema.maybe(
-      schema.string({
-        minLength: 1,
-        maxLength: 256,
-        meta: {
-          title: 'Data view ID',
-          description:
-            'Kibana provides a unique identifier for each data view, or you can create your own.',
-        },
-      })
-    ),
+    id: schema.maybe(asCodeIdSchema),
     name: schema.maybe(
       schema.string({
         minLength: 1,

--- a/src/platform/packages/shared/as-code/data-views-schema/tsconfig.json
+++ b/src/platform/packages/shared/as-code/data-views-schema/tsconfig.json
@@ -8,5 +8,6 @@
   "kbn_references": [
     "@kbn/config-schema",
     "@kbn/data-views-plugin",
+    "@kbn/as-code-shared-schemas",
   ]
 }


### PR DESCRIPTION
## Summary

Changes the as code data view schema to use the common `asCodeIdSchema` for the id. This was a [note in the original PR](https://github.com/elastic/kibana/pull/265484/changes#r3156299849) that appeared to be missed or overwritten. 

There are two notable differences with this change.
- `maxLength` of `id` drops from `256` to `250`
- custom validation function ensures that only certain characters may be used in the `id`.

AFAICT, this schema only supports the as code data view endpoint specification which is not yet publicly available, so I don't think this is a breaking change. 