### PR TITLE
[9.4] [Fleet] Add agent count to reassign modal (#276557)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -105,7 +105,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
       <>
         {isReassignFlyoutOpen && (
           <EuiPortal>
-            <AgentReassignAgentPolicyModal agents={[agent]} onClose={onClose} />
+            <AgentReassignAgentPolicyModal agents={[agent]} agentCount={1} onClose={onClose} />
           </EuiPortal>
         )}
         {isUnenrollModalOpen && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -397,6 +397,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
         <EuiPortal>
           <AgentReassignAgentPolicyModal
             agents={agents}
+            agentCount={agentCount}
             onClose={() => {
               setIsReassignFlyoutOpen(false);
               refreshAgents();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -370,6 +370,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         <EuiPortal>
           <AgentReassignAgentPolicyModal
             agents={[agentToReassign]}
+            agentCount={1}
             onClose={() => {
               setAgentToReassign(undefined);
               refreshAgents();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
@@ -31,11 +31,13 @@ import { SO_SEARCH_LIMIT } from '../../../../constants';
 interface Props {
   onClose: () => void;
   agents: Agent[] | string;
+  agentCount: number;
 }
 
 export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
   onClose,
   agents,
+  agentCount,
 }) => {
   const modalTitleId = useGeneratedHtmlId();
 
@@ -142,9 +144,9 @@ export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
       <p>
         <FormattedMessage
           id="xpack.fleet.agentReassignPolicy.flyoutDescription"
-          defaultMessage="Choose a new agent policy to assign the selected {count, plural, one {agent} other {agents}} to."
+          defaultMessage="Choose a new agent policy to assign the selected {count, plural, one {agent} other {# agents}} to."
           values={{
-            count: isSingleAgent ? 1 : 0,
+            count: agentCount,
           }}
         />
       </p>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Fleet] Add agent count to reassign modal (#276557)](https://github.com/elastic/kibana/pull/276557)

<!--- Backport version: manual -->

### Manual backport notes

The automated backport failed with a modify/delete conflict on `agent_reassign_policy_modal/index.test.tsx`. That file doesn't exist on `9.4` because it was introduced by #273679, which was intentionally labeled `backport:skip` (targeted `v9.5.0` only). The conflict is not a real logic conflict — it's just a missing baseline file on this branch.

Resolution: the actual source change (`agentCount` prop threaded through the modal, used in the title/description) cherry-picks and applies cleanly. The test-file diff was dropped since the file it modifies doesn't exist on `9.4`.