### PR TITLE
[Security Solution] Removes deprecated prebuilt rules feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -274,12 +274,6 @@ export const allowedExperimentalValues = Object.freeze({
   entityAnalyticsAnomalyDetails: false,
 
   /**
-   * Enables the deprecated prebuilt rules UI
-   * Release: 9.4
-   */
-  prebuiltRulesDeprecationUIEnabled: true,
-
-  /**
    * Enables the Detection Rule Changes History API endpoint
    * (`GET /api/detection_engine/rules/_history`).
    *

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/use_deprecated_rule_details_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/use_deprecated_rule_details_callout.test.tsx
@@ -12,7 +12,6 @@ import { I18nProvider } from '@kbn/i18n-react';
 import type { RuleResponse } from '../../../../../common/api/detection_engine';
 import { BulkActionTypeEnum } from '../../../../../common/api/detection_engine/rule_management';
 import { DuplicateOptions } from '../../../../../common/detection_engine/rule_management/constants';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useExecuteBulkAction } from '../../logic/bulk_actions/use_execute_bulk_action';
 import { usePrebuiltRulesDeprecationReview } from '../../logic/prebuilt_rules/use_prebuilt_rules_deprecation_review';
@@ -22,7 +21,6 @@ import { savedRuleMock } from '../../logic/mock';
 import { useDeprecatedRuleDetailsCallout } from './use_deprecated_rule_details_callout';
 import { createDefaultExternalRuleSource } from '../../../../../server/lib/detection_engine/rule_management/logic/detection_rules_client/mergers/rule_source/create_default_external_rule_source';
 
-jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../common/components/user_privileges');
 jest.mock('../../logic/bulk_actions/use_execute_bulk_action');
 jest.mock('../../logic/prebuilt_rules/use_prebuilt_rules_deprecation_review');
@@ -31,7 +29,6 @@ jest.mock(
 );
 jest.mock('../../../../common/lib/kibana');
 
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
 const mockUseExecuteBulkAction = useExecuteBulkAction as jest.Mock;
 const mockUsePrebuiltRulesDeprecationReview = usePrebuiltRulesDeprecationReview as jest.Mock;
@@ -89,8 +86,6 @@ function TestComponent(
 describe('useDeprecatedRuleDetailsCallout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
 
     mockUseUserPrivileges.mockReturnValue({
       rulesPrivileges: {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/use_deprecated_rule_details_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/use_deprecated_rule_details_callout.tsx
@@ -14,7 +14,6 @@ import { RuleDeprecationEventTypes } from '../../../../common/lib/telemetry/even
 import type { RuleResponse } from '../../../../../common/api/detection_engine';
 import { BulkActionTypeEnum } from '../../../../../common/api/detection_engine/rule_management';
 import { DuplicateOptions } from '../../../../../common/detection_engine/rule_management/constants';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useBulkDuplicateExceptionsConfirmation } from '../../../rule_management_ui/components/rules_table/bulk_actions/use_bulk_duplicate_confirmation';
 import { useExecuteBulkAction } from '../../logic/bulk_actions/use_execute_bulk_action';
 import { usePrebuiltRulesDeprecationReview } from '../../logic/prebuilt_rules/use_prebuilt_rules_deprecation_review';
@@ -49,11 +48,10 @@ export const useDeprecatedRuleDetailsCallout = ({
     rules: { edit: canEditRules },
   } = useUserPrivileges().rulesPrivileges;
 
-  const isFeatureEnabled = useIsExperimentalFeatureEnabled('prebuiltRulesDeprecationUIEnabled');
   const isPrebuiltRule = rule?.rule_source?.type === 'external';
   const { data, isLoading } = usePrebuiltRulesDeprecationReview(
     { ids: rule?.id ? [rule.id] : [] },
-    { enabled: isFeatureEnabled && isPrebuiltRule }
+    { enabled: isPrebuiltRule }
   );
   const { executeBulkAction } = useExecuteBulkAction();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/use_deprecated_rules_table_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_deprecation/use_deprecated_rules_table_callout.tsx
@@ -10,7 +10,6 @@ import { EuiButton, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useBoolState } from '../../../../common/hooks/use_bool_state';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useTimedDismissal } from '../../../../common/hooks/use_timed_dismissal';
 import { useKibana } from '../../../../common/lib/kibana';
 import { RuleDeprecationEventTypes } from '../../../../common/lib/telemetry/events/rule_deprecation/types';
@@ -25,7 +24,6 @@ import * as i18n from './translations';
 export const DISMISSAL_STORAGE_KEY = 'securitySolution.deprecatedRulesCallout.dismissedAt';
 
 export const useDeprecatedRulesTableCallout = () => {
-  const isFeatureEnabled = useIsExperimentalFeatureEnabled('prebuiltRulesDeprecationUIEnabled');
   const [isModalVisible, showModal, hideModal] = useBoolState();
   const [isConfirmVisible, showConfirm, hideConfirm] = useBoolState();
   const [isDismissed, dismiss] = useTimedDismissal(DISMISSAL_STORAGE_KEY);
@@ -38,14 +36,12 @@ export const useDeprecatedRulesTableCallout = () => {
       },
     },
   } = useKibana().services;
-  const { data, isLoading } = usePrebuiltRulesDeprecationReview(null, {
-    enabled: isFeatureEnabled,
-  });
+  const { data, isLoading } = usePrebuiltRulesDeprecationReview(null);
   const { executeBulkAction } = useExecuteBulkAction();
 
   const hasReportedShown = useRef(false);
   const rulesCount = data?.rules.length ?? 0;
-  const isCalloutVisible = isFeatureEnabled && !isDismissed && !isLoading && rulesCount > 0;
+  const isCalloutVisible = !isDismissed && !isLoading && rulesCount > 0;
 
   useEffect(() => {
     if (isCalloutVisible && !hasReportedShown.current) {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/deprecation/deprecated_rule_details_callout.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/deprecation/deprecated_rule_details_callout.cy.ts
@@ -71,15 +71,6 @@ describe(
   'Deprecated rules - Rule Details page callout',
   {
     tags: ['@ess', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'prebuiltRulesDeprecationUIEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     before(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/deprecation/deprecated_rules_management_callout.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/deprecation/deprecated_rules_management_callout.cy.ts
@@ -50,15 +50,6 @@ describe(
   'Deprecated rules - Rule Management page callout',
   {
     tags: ['@ess', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'prebuiltRulesDeprecationUIEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     before(() => {


### PR DESCRIPTION
## Summary

Closes #266612

Removes the `prebuiltRulesDeprecationUIEnabled` experimental feature flag

The prebuilt rule deprecation UI was introduced behind a flag in #259673 and has been enabled by default since 9.4. This PR finalises the rollout by:
- Deleting the flag from `allowedExperimentalValues` in `experimental_features.ts`
- Removing all `useIsExperimentalFeatureEnabled('prebuiltRulesDeprecationUIEnabled')` call sites from the two hooks that gate the deprecation callouts (`useDeprecatedRulesTableCallout` and `useDeprecatedRuleDetailsCallout`)
- Cleaning up the corresponding mock from the unit test for `useDeprecatedRuleDetailsCallout`
- Removing the `kbnServerArgs` that were enabling the flag in the two Cypress E2E tests for the deprecation callouts


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





