### PR TITLE
Update default redirect URLs for local agents

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/create/sections/redirect_uri_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/create/sections/redirect_uri_section.tsx
@@ -58,7 +58,7 @@ const REDIRECT_TYPE_CONFIG: Record<
     urlsLabel: labels.tools.mcpClients.form.localUrlsLabel,
     helpText: labels.tools.mcpClients.form.localUrlsHelpText,
     addButtonLabel: labels.tools.mcpClients.form.addLocalUrl,
-    placeholder: 'http://localhost:3000/callback',
+    placeholder: 'http://localhost/callback',
     testSubjPrefix: 'mcpClientLocalUri',
   },
   [RedirectUriType.REMOTE]: {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/create/use_mcp_client_form.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/create/use_mcp_client_form.ts
@@ -115,7 +115,7 @@ export const DEFAULT_MCP_CLIENT_FORM_VALUES: McpClientFormData = {
   clientLogo: NO_CLIENT_LOGO,
   redirect: {
     type: RedirectUriType.LOCAL,
-    uris: [{ value: 'http://localhost:3000/callback' }],
+    uris: [{ value: 'http://localhost/callback' }, { value: 'http://localhost/oauth/callback' }],
   },
   isConfidential: false,
 };


### PR DESCRIPTION
## Summary

This PR updates the default redirect URLs for localhost 

* From  `http://localhost:3000/callback`

<img width="558" height="136" alt="image" src="https://github.com/user-attachments/assets/849afb4a-4996-4611-a78d-61703350af84" />

* To `http://localhost/callback` and `http://localhost/oauth/callback`

<img width="560" height="187" alt="image" src="https://github.com/user-attachments/assets/ac23dc2e-32f2-4c35-b820-da34945eabcf" />


The port has been removed since it is ignored and the value can cause confusion since the actual port in use is a random port number. 
`http://localhost/oauth/callback` is added to match Claude desktop configuration. (`http://localhost/callback` matches Claude Code CLI)



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks.


