### PR TITLE
[9.3] [Fleet] Fix unquoted KQL in `findPackagePoliciesUsingSecrets` (#276550)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.test.ts
@@ -6,10 +6,12 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { fromKueryExpression } from '@kbn/es-query';
 
 import { appContextService } from '../app_context';
 import { createAppContextStartContractMock } from '../../mocks';
+import { packagePolicyService } from '../package_policy';
 import type {
   NewPackagePolicy,
   PackageInfo,
@@ -22,7 +24,12 @@ import {
   diffSecretPaths,
   extractAndWriteSecrets,
   extractAndUpdateSecrets,
+  findPackagePoliciesUsingSecrets,
 } from './package_policies';
+
+jest.mock('../package_policy');
+
+const mockedPackagePolicyService = packagePolicyService as jest.Mocked<typeof packagePolicyService>;
 
 describe('Package policy secrets', () => {
   let mockContract: ReturnType<typeof createAppContextStartContractMock>;
@@ -1757,6 +1764,89 @@ describe('Package policy secrets', () => {
 
         expect(result.secretsToDelete).toHaveLength(6);
       });
+    });
+
+    describe('when a secret var is removed entirely from a newer package version', () => {
+      // Mirrors the `secrets` test fixture package used by the policy_secrets FTR suite:
+      // `package_var_multi_secret` exists in 1.0.0 but is dropped from 1.1.0's manifest.
+      const newPackageInfoWithoutMultiSecret = {
+        name: 'mock-package',
+        title: 'Mock package',
+        version: '1.1.0',
+        description: 'description',
+        type: 'integration',
+        status: 'not_installed',
+        vars: [{ name: 'pkg-secret-1', type: 'text', secret: true, required: true }],
+        data_streams: [],
+        policy_templates: [],
+      } as unknown as PackageInfo;
+
+      it('still marks the orphaned secret for deletion even though the new package no longer declares it', async () => {
+        const oldPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: { id: 'pkg-secret-1-id', isSecretRef: true },
+            },
+            'pkg-multi-secret': {
+              value: { ids: ['orphan-id-1', 'orphan-id-2'], isSecretRef: true },
+            },
+          },
+          inputs: [],
+        } as unknown as PackagePolicy;
+
+        const packagePolicyUpdate = {
+          vars: {
+            'pkg-secret-1': {
+              value: { id: 'pkg-secret-1-id', isSecretRef: true },
+            },
+          },
+          inputs: [],
+        } as unknown as UpdatePackagePolicy;
+
+        const result = await extractAndUpdateSecrets({
+          oldPackagePolicy,
+          packagePolicyUpdate,
+          packageInfo: newPackageInfoWithoutMultiSecret,
+          esClient: esClientMock,
+        });
+
+        expect(result.secretsToDelete).toEqual([{ id: 'orphan-id-1' }, { id: 'orphan-id-2' }]);
+      });
+    });
+  });
+
+  describe('findPackagePoliciesUsingSecrets', () => {
+    const soClient = savedObjectsClientMock.create();
+
+    beforeEach(() => {
+      mockedPackagePolicyService.list.mockReset();
+      mockedPackagePolicyService.list.mockResolvedValue({ total: 0, items: [] } as any);
+    });
+
+    it('quotes each id so the generated kuery is valid even when an id contains a KQL keyword', async () => {
+      // Real-world ids from https://github.com/elastic/kibana/issues/273040 that end in "Not",
+      // which an unquoted kuery would parse as the NOT operator.
+      const ids = ['_3bpqZ4BbB0ae8-cYNot', '_nbpqZ4BbB0ae8-cYNot'];
+
+      await findPackagePoliciesUsingSecrets({ soClient, ids });
+
+      const { kuery } = mockedPackagePolicyService.list.mock.calls[0][1];
+
+      expect(kuery).toBe(
+        'ingest-package-policies.secret_references.id: ("_3bpqZ4BbB0ae8-cYNot" or "_nbpqZ4BbB0ae8-cYNot")'
+      );
+      // This is the actual bug: before quoting, this expression throws KQLSyntaxError.
+      expect(() => fromKueryExpression(kuery as string)).not.toThrow();
+    });
+
+    it('produces a parseable kuery for ids containing other KQL keywords and quote characters', async () => {
+      const ids = ['idAndSuffix', 'idOrSuffix', 'id"with"quotes'];
+
+      await findPackagePoliciesUsingSecrets({ soClient, ids });
+
+      const { kuery } = mockedPackagePolicyService.list.mock.calls[0][1];
+
+      expect(() => fromKueryExpression(kuery as string)).not.toThrow();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.ts
@@ -394,8 +394,7 @@ function _getInputSecretPaths(
     if (input.streams.length) {
       input.streams.forEach((stream, streamIndex) => {
         const streamVarDefs =
-          streamSecretVarDefsByDatasetAndInput[`${stream.data_stream.dataset}-${input.type}`] ||
-          {};
+          streamSecretVarDefsByDatasetAndInput[`${stream.data_stream.dataset}-${input.type}`] || {};
         Object.entries(stream.vars || {}).forEach(([name, configEntry]) => {
           if (streamVarDefs[name] || isSecretRefValue(configEntry)) {
             currentInputVarPaths.push({

--- a/x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.ts
@@ -6,10 +6,16 @@
  */
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import { escapeQuotes } from '@kbn/es-query';
 import { keyBy } from 'lodash';
 
 import { packageHasNoPolicyTemplates } from '../../../common/services/policy_template';
-import type { NewPackagePolicy, RegistryStream, UpdatePackagePolicy } from '../../../common';
+import type {
+  NewPackagePolicy,
+  PackagePolicyConfigRecordEntry,
+  RegistryStream,
+  UpdatePackagePolicy,
+} from '../../../common';
 import { SO_SEARCH_LIMIT } from '../../../common';
 import {
   doesPackageHaveIntegrations,
@@ -218,7 +224,9 @@ export async function findPackagePoliciesUsingSecrets(opts: {
 }): Promise<Array<{ id: string; policyIds: string[] }>> {
   const { soClient, ids } = opts;
   const packagePolicies = await packagePolicyService.list(soClient, {
-    kuery: `ingest-package-policies.secret_references.id: (${ids.join(' or ')})`,
+    kuery: `ingest-package-policies.secret_references.id: (${ids
+      .map((id) => `"${escapeQuotes(id)}"`)
+      .join(' or ')})`,
     perPage: SO_SEARCH_LIMIT,
     page: 1,
   });
@@ -318,6 +326,13 @@ function isSecretVar(varDef: RegistryVarsEntry) {
   return varDef.secret === true;
 }
 
+// A var's value can already be a secret reference even if the current package spec
+// no longer marks it `secret: true` (e.g. the var was dropped from a newer package version).
+// Such values must still be treated as secret paths so their underlying secrets get cleaned up.
+function isSecretRefValue(configEntry: PackagePolicyConfigRecordEntry) {
+  return !!configEntry?.value?.isSecretRef;
+}
+
 function containsSecretVar(vars?: RegistryVarsEntry[]) {
   return vars?.some(isSecretVar);
 }
@@ -330,8 +345,8 @@ function _getPackageLevelSecretPaths(
   const packageSecretVarsByName = keyBy(packageSecretVars, 'name');
   const packageVars = Object.entries(packagePolicy.vars || {});
 
-  return packageVars.reduce((vars, [name, configEntry], i) => {
-    if (packageSecretVarsByName[name]) {
+  return packageVars.reduce((vars, [name, configEntry]) => {
+    if (packageSecretVarsByName[name] || isSecretRefValue(configEntry)) {
       vars.push({
         value: configEntry,
         path: ['vars', name],
@@ -364,7 +379,10 @@ function _getInputSecretPaths(
     const inputVars = Object.entries(input.vars || {});
     if (inputVars.length) {
       inputVars.forEach(([name, configEntry]) => {
-        if (inputSecretVarDefsByPolicyTemplateAndType[inputKey]?.[name]) {
+        if (
+          inputSecretVarDefsByPolicyTemplateAndType[inputKey]?.[name] ||
+          isSecretRefValue(configEntry)
+        ) {
           currentInputVarPaths.push({
             path: ['inputs', inputIndex.toString(), 'vars', name],
             value: configEntry,
@@ -376,24 +394,23 @@ function _getInputSecretPaths(
     if (input.streams.length) {
       input.streams.forEach((stream, streamIndex) => {
         const streamVarDefs =
-          streamSecretVarDefsByDatasetAndInput[`${stream.data_stream.dataset}-${input.type}`];
-        if (streamVarDefs && Object.keys(streamVarDefs).length) {
-          Object.entries(stream.vars || {}).forEach(([name, configEntry]) => {
-            if (streamVarDefs[name]) {
-              currentInputVarPaths.push({
-                path: [
-                  'inputs',
-                  inputIndex.toString(),
-                  'streams',
-                  streamIndex.toString(),
-                  'vars',
-                  name,
-                ],
-                value: configEntry,
-              });
-            }
-          });
-        }
+          streamSecretVarDefsByDatasetAndInput[`${stream.data_stream.dataset}-${input.type}`] ||
+          {};
+        Object.entries(stream.vars || {}).forEach(([name, configEntry]) => {
+          if (streamVarDefs[name] || isSecretRefValue(configEntry)) {
+            currentInputVarPaths.push({
+              path: [
+                'inputs',
+                inputIndex.toString(),
+                'streams',
+                streamIndex.toString(),
+                'vars',
+                name,
+              ],
+              value: configEntry,
+            });
+          }
+        });
       });
     }
 

--- a/x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts
@@ -1159,6 +1159,46 @@ export default function (providerContext: FtrProviderContext) {
         ).to.eql(true);
       });
 
+      it('should clean up secrets no longer referenced after package upgrade removes a var', async () => {
+        // `package_var_multi_secret` only exists in package version 1.0.0. Upgrading to 1.1.0
+        // drops it from the package spec, so the package policy update triggered by the upgrade
+        // goes through packagePolicyService.bulkUpdate -> deleteSecretsIfNotReferenced ->
+        // findPackagePoliciesUsingSecrets, which queries by the two now-orphaned secret ids.
+        const agentPolicy = await createAgentPolicy();
+
+        const { fleetServerAgentPolicy } = await createFleetServerAgentPolicy();
+        await createFleetServerAgent(fleetServerAgentPolicy.id, 'server_4', '8.12.0');
+        await callFleetSetup();
+
+        const packagePolicyWithSecrets = await createPackagePolicyWithSecrets(agentPolicy.id);
+        const oldPackageVarMultiIds = packagePolicyWithSecrets.vars.package_var_multi_secret.value
+          .ids as string[];
+
+        await supertest
+          .post('/api/fleet/epm/packages/secrets/1.1.0')
+          .set('kbn-xsrf', 'xxxx')
+          .send({ force: true })
+          .expect(200);
+
+        await supertest
+          .post(`/api/fleet/package_policies/upgrade`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            packagePolicyIds: [packagePolicyWithSecrets.id],
+          })
+          .expect(200);
+
+        // Secret deletion is async — retry until the orphaned secrets are gone.
+        let searchRes: Awaited<ReturnType<typeof getSecrets>> | undefined;
+        for (let i = 0; i < 5; i++) {
+          searchRes = await getSecrets(oldPackageVarMultiIds);
+          if (searchRes.hits.hits.length === 0) break;
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+
+        expect(searchRes!.hits.hits.length).to.eql(0);
+      });
+
       it('should store secrets if additional fleet server does not meet minimum version, but is unenrolled', async () => {
         const { fleetServerAgentPolicy } = await createFleetServerAgentPolicy();
         await createFleetServerAgent(fleetServerAgentPolicy.id, 'server_1', '8.12.0');


### PR DESCRIPTION
# Backport

This is a manual backport of #276550 to `9.3`. The automated backport bot failed due to merge conflicts.

## Conflict and resolution

Two files conflicted during cherry-pick of e5467294007b1079077a590139bed3e3d6beec5e:

- `x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.ts`: the stream-vars branch of `_getInputSecretPaths` conflicted because `main` (as of the PR's parent commit, unrelated to this PR) already keys `streamSecretVarDefsByDatasetAndInput` by `getInputEffectiveName(input)`, a helper introduced by a separate, later main-only refactor (input naming/otel support) that hasn't been backported to `9.3`. `9.3` still keys that map by `input.type`. I preserved `9.3`'s existing `input.type` key and applied only this PR's actual logic change on top: replaced the early-exit `if (streamVarDefs && Object.keys(streamVarDefs).length)` gate with a `|| {}` fallback, and added the `isSecretRefValue(configEntry)` OR-fallback so orphaned secret-ref values are still recognized as secret paths even when the current package spec no longer marks the var `secret: true`. This mirrors the same fallback already applied (conflict-free) at the package-level and input-level var checks in the same file.
- `x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.test.ts`: conflicted because `main`'s test file (again, pre-existing on `main` before this PR, unrelated to it) already contains a `when secret vars are migrated from an input type with migrate_from to another` describe block for a `migrate_from` feature that hasn't been backported to `9.3`. I excluded that unrelated block from this backport and kept only the test additions that are actually part of #276550: the `when a secret var is removed entirely from a newer package version` describe block and the new `findPackagePoliciesUsingSecrets` describe block (KQL-quoting regression tests), plus the associated top-of-file import/mock additions.

`x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts` auto-merged without conflicts.

Verified `node scripts/jest x-pack/platform/plugins/shared/fleet/server/services/secrets/package_policies.test.ts` passes (30/30) on `9.3` after resolution, including the new orphaned-secret and KQL-quoting tests.

<!--BACKPORT [{"sourcePullRequest":{"number":276550,"url":"https://github.com/elastic/kibana/pull/276550","title":"[Fleet] Fix unquoted KQL in `findPackagePoliciesUsingSecrets`"},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"sourceCommit":{"sha":"e5467294007b1079077a590139bed3e3d6beec5e"}}] BACKPORT-->