### PR TITLE
[Cases] - Rename cases analytics fields to case

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/README.md
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/README.md
@@ -165,7 +165,7 @@ A future Kibana-side provider (built on the `ImplicitPrivilegesProvider` SPI
 tracked in [elastic/elasticsearch#147176](https://github.com/elastic/elasticsearch/pull/147176))
 will scope which case documents a user can read inside `.cases` via DLS on
 the top-level `space_id` + `owner` fields. These are deliberately placed at
-the document root (not under `cases.*`) to match the implicit-privileges DLS
+the document root (not under `case.*`) to match the implicit-privileges DLS
 convention — `space_id` is singular because cases are space-isolated. Until
 that provider lands, role-granted access to `.cases` is unrestricted across
 cases — apply with care.
@@ -212,16 +212,16 @@ DLS convention. Until that lands, role-granted access is unrestricted (see
 "Authorization" above). The per-space data view
 is orthogonal — it scopes the _runtime field set_, not the document set. The
 two compose cleanly: a user in space A sees only space-A runtime fields
-**and** (once DLS is enforced) only space-A cases.
+**and** (once DLS is enforced) only space-A case.
 
 ## Runtime field lift
 
 Each template-declared extended field is stored at
-`cases.extended_fields.<name>_as_<type>` inside a `flattened` mapping, with
-a typed runtime field published at `cases.<name>_as_<type>` — Lens and
+`case.extended_fields.<name>_as_<type>` inside a `flattened` mapping, with
+a typed runtime field published at `case.<name>_as_<type>` — Lens and
 Discover get numeric / date / boolean filter operators instead of
 string-contains. The runtime field reads the value via
-`doc['cases.extended_fields.<name>_as_<type>']` at query time (flattened
+`doc['case.extended_fields.<name>_as_<type>']` at query time (flattened
 sub-keys are doc-values-backed under the parent's value stream).
 
 `flattened` is used (not `dynamic_template`-per-key) so the index mapping
@@ -242,11 +242,11 @@ The `.cases` index mapping mirrors the cases SO mapping at
   strings (`"low"`, `"open"`, etc.) in the doc-builder so Lens shows readable
   labels.
 - **`observables`**: SO stores nested `[{ typeKey, value, description }]`; v2
-  denormalizes to per-type keyword arrays — `cases.observables.url: ["..."]`,
-  `cases.observables.ipv4: [...]`. Type↔value relationship preserved via the
+  denormalizes to per-type keyword arrays — `case.observables.url: ["..."]`,
+  `case.observables.ipv4: [...]`. Type↔value relationship preserved via the
   field path; `description` dropped (free text, not an analytics dimension).
 - **`extended_fields`**: SO uses `flattened`; v2 matches. Runtime fields
-  at `cases.<snake>` parse the raw string from `_source` at query time
+  at `case.<snake>` parse the raw string from `_source` at query time
   (see "Runtime field lift" above for the field-limit rationale).
 - **`time_to_acknowledge` / `time_to_investigate` / `time_to_resolve` /
   `in_progress_at`**: present in the SO's persisted attributes but not the SO
@@ -548,7 +548,7 @@ deliberate differences driven by the user-action shape:
   cascades to its user-action SOs. Reconciliation walks forward in
   time and never sees the gap, so the activity writer exposes a
   `bulkDeleteActionsByCaseIds` path that runs a `delete_by_query` on
-  `cases.id`. `CasesService.deleteCase` and `bulkDeleteCaseEntities`
+  `case.id`. `CasesService.deleteCase` and `bulkDeleteCaseEntities`
   dispatch this immediately after the SO delete succeeds.
 - **Polymorphic payload + curated extracts.** The user-action
   `attributes.payload` shape is union-typed by `attributes.type`. The
@@ -565,7 +565,7 @@ deliberate differences driven by the user-action shape:
   large, opaque strings queried with grep-style predicates.
 - **No `index.mode: lookup`.** `.cases-activity` is the **fact** table
   in the analytics model. ES|QL queries `FROM .cases-activity | LOOKUP
-  JOIN .cases ON cases.id`; the lookup-mode index is on the cases side.
+  JOIN .cases ON case.id`; the lookup-mode index is on the cases side.
 - **Same reconciliation page size as cases (100).** User-action docs are
   smaller than case docs, but the per-page sync CPU is dominated by the
   `JSON.stringify(payload)` for the polymorphic payload field (which can
@@ -577,7 +577,7 @@ The same managed `Case Analytics` data view spans every surface — its
 title is `.cases,.cases-activity,.cases-attachments`, so a single
 Discover / Lens selection covers all three. A `LOOKUP JOIN` from the
 activity or attachments surface to the cases surface is just
-`LOOKUP JOIN .cases ON cases.id` against the joined view.
+`LOOKUP JOIN .cases ON case.id` against the joined view.
 
 The reconciliation task runs all three surfaces sequentially per tick,
 with **independent cursors** (`cases_last_run_at`,
@@ -608,7 +608,7 @@ cases surface, with the following deliberate differences:
   `legacy:<space>` / `unified:<space>`.
 - **Cascade on case delete.** Same shape as the activity cascade —
   `bulkDeleteAttachmentsByCaseIds` runs a `delete_by_query` on
-  `cases.id` from `CasesService.deleteCase` and
+  `case.id` from `CasesService.deleteCase` and
   `bulkDeleteCaseEntities`. Covers both source SO types in one
   query because the analytics index is the unified normalization
   point.
@@ -631,7 +631,7 @@ cases surface, with the following deliberate differences:
   oversized values from the index).
 - **No `index.mode: lookup`.** `.cases-attachments` is the **fact**
   table in the analytics model, joined to `.cases` via ES|QL `LOOKUP
-  JOIN .cases ON cases.id`.
+  JOIN .cases ON case.id`.
 - **`attachment_id` normalized to `string[]`.** Reference subtypes
   carry the referenced entity ids as `string | string[]` on the SO
   shape (single-id alert vs bulk multi-id alert). The doc-builder

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.test.ts
@@ -71,7 +71,7 @@ describe('suffixToRuntimeType', () => {
   it('maps keyword to a keyword runtime field — flattened sub-keys are not discoverable on their own', () => {
     // Under `flattened`, sub-keys are queryable in ES but invisible to
     // Kibana's data-view field list. Without a keyword runtime field at
-    // `cases.<name>_as_keyword`, every `keyword`-typed template field
+    // `case.<name>_as_keyword`, every `keyword`-typed template field
     // would be dropped from Discover / Lens / Stack Management.
     expect(suffixToRuntimeType('keyword')).toBe('keyword');
   });
@@ -102,12 +102,12 @@ describe('suffixToRuntimeType', () => {
 });
 
 describe('buildPainlessSource', () => {
-  it('reads from doc[cases.extended_fields.<snake>] with a defensive guard', () => {
+  it('reads from doc[case.extended_fields.<snake>] with a defensive guard', () => {
     // ES docs prescribe `doc[parent.subkey]` for `flattened` sub-keys
     // (doc-values-backed under the parent). `_source` access silently
     // returns no value on synthetic-source / `index.mode: lookup` indices.
     const src = buildPainlessSource('riskScore_as_long', 'long');
-    expect(src).toContain("doc['cases.extended_fields.riskScore_as_long']");
+    expect(src).toContain("doc['case.extended_fields.riskScore_as_long']");
     expect(src).toContain('vals.empty');
     expect(src).toContain('for (String v : vals)');
     expect(src).not.toContain('params._source');
@@ -139,7 +139,7 @@ describe('buildPainlessSource', () => {
     // them to a discoverable path. No try/catch needed because there is no
     // parse step.
     const src = buildPainlessSource('summary_as_keyword', 'keyword');
-    expect(src).toContain("doc['cases.extended_fields.summary_as_keyword']");
+    expect(src).toContain("doc['case.extended_fields.summary_as_keyword']");
     expect(src).toContain('emit(v)');
     expect(src).not.toContain('parseLong');
     expect(src).not.toContain('parseDouble');
@@ -165,29 +165,29 @@ describe('buildPainlessSource', () => {
 });
 
 describe('buildRuntimeFieldEntry', () => {
-  it('publishes the runtime field at top-level cases.<snake>', () => {
+  it('publishes the runtime field at top-level case.<snake>', () => {
     // The published field name lives one level above the source location
-    // (cases.extended_fields.<snake>) so Lens / Discover surface the typed
+    // (case.extended_fields.<snake>) so Lens / Discover surface the typed
     // runtime field. The painless reads via `doc[...]` because flattened
     // sub-keys are doc-values-backed under the parent's value stream.
     const entry = buildRuntimeFieldEntry('riskScore_as_long');
     expect(entry).not.toBeNull();
-    expect(entry!.fieldName).toBe('cases.riskScore_as_long');
+    expect(entry!.fieldName).toBe('case.riskScore_as_long');
     expect(entry!.spec.type).toBe('long');
     expect(entry!.spec.script?.source).toContain('Long.parseLong');
-    expect(entry!.spec.script?.source).toContain("doc['cases.extended_fields.riskScore_as_long']");
+    expect(entry!.spec.script?.source).toContain("doc['case.extended_fields.riskScore_as_long']");
   });
 
   it('publishes a keyword runtime field for keyword extended fields (flattened sub-keys are not discoverable)', () => {
     // Without this entry, `<name>_as_keyword` template fields are
     // invisible in Discover / Lens / Stack Management — the parent
-    // `cases.extended_fields` is the only thing the data view sees.
+    // `case.extended_fields` is the only thing the data view sees.
     const entry = buildRuntimeFieldEntry('playbook_as_keyword');
     expect(entry).not.toBeNull();
-    expect(entry!.fieldName).toBe('cases.playbook_as_keyword');
+    expect(entry!.fieldName).toBe('case.playbook_as_keyword');
     expect(entry!.spec.type).toBe('keyword');
     expect(entry!.spec.script?.source).toContain(
-      "doc['cases.extended_fields.playbook_as_keyword']"
+      "doc['case.extended_fields.playbook_as_keyword']"
     );
     expect(entry!.spec.script?.source).toMatch(/emit\(v\)/);
   });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.test.ts
@@ -186,9 +186,7 @@ describe('buildRuntimeFieldEntry', () => {
     expect(entry).not.toBeNull();
     expect(entry!.fieldName).toBe('case.playbook_as_keyword');
     expect(entry!.spec.type).toBe('keyword');
-    expect(entry!.spec.script?.source).toContain(
-      "doc['case.extended_fields.playbook_as_keyword']"
-    );
+    expect(entry!.spec.script?.source).toContain("doc['case.extended_fields.playbook_as_keyword']");
     expect(entry!.spec.script?.source).toMatch(/emit\(v\)/);
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.ts
@@ -28,10 +28,10 @@ export const RUNTIME_FIELDS_BUILD_VERSION = 1;
  *
  * `keyword` is included so keyword-typed template fields surface as
  * discoverable fields in Kibana data views. Their indexed values live
- * inside `cases.extended_fields` (mapped as `flattened`, see
+ * inside `case.extended_fields` (mapped as `flattened`, see
  * `mappings/case.ts`), and Kibana data views don't expose `flattened`
  * sub-keys directly — only the parent shows up in Discover / Lens. The
- * runtime field at `cases.<name>_as_keyword` re-publishes each value as
+ * runtime field at `case.<name>_as_keyword` re-publishes each value as
  * a typed leaf.
  *
  * `unsigned_long` collapses to `long`; values past `Long.MAX_VALUE` lose
@@ -101,10 +101,10 @@ export const splitSnakeKey = (snakeKey: string): { name: string; suffix: string 
 };
 
 /**
- * Painless source that reads `cases.extended_fields.<snakeKey>` and emits
+ * Painless source that reads `case.extended_fields.<snakeKey>` and emits
  * a parsed value of the target runtime type.
  *
- * Access pattern is `doc['cases.extended_fields.<snakeKey>']`: ES exposes
+ * Access pattern is `doc['case.extended_fields.<snakeKey>']`: ES exposes
  * `flattened` sub-keys as doc-values-backed paths under the parent
  * (see "Retrieving flattened fields" in the ES docs). Walking
  * `params._source` returns nothing on `index.mode: lookup` indices like
@@ -120,7 +120,7 @@ export const splitSnakeKey = (snakeKey: string): { name: string; suffix: string 
  * safe.
  */
 export const buildPainlessSource = (snakeKey: string, runtimeType: RuntimeType): string => {
-  const fieldPath = `cases.extended_fields.${snakeKey}`;
+  const fieldPath = `case.extended_fields.${snakeKey}`;
   // `doc[path]` returns a `ScriptDocValues` instance. `.empty` short-circuits
   // when no value is present; iteration yields the typed leaf values (Strings
   // for keyword-backed fields, which is how ES indexes flattened sub-keys).
@@ -188,7 +188,7 @@ export const buildPainlessSource = (snakeKey: string, runtimeType: RuntimeType):
 
 /** A runtime field ready to merge into a data view's `runtimeFieldMap`. */
 export interface RuntimeFieldEntry {
-  /** Published name in the data view — a direct child of `cases`, e.g. `cases.score_as_long`. */
+  /** Published name in the data view — a direct child of `case`, e.g. `case.score_as_long`. */
   fieldName: string;
   spec: RuntimeFieldSpec;
 }
@@ -198,19 +198,19 @@ export interface RuntimeFieldEntry {
  * data view's `runtimeFieldMap`, or `null` when the snake-key isn't shaped
  * like `<name>_as_<type>` or its suffix is unknown.
  *
- * Publication path is `cases.<snakeKey>` (e.g. `cases.riskScore_as_long`),
- * sitting alongside `cases.title`, `cases.severity`, etc. The Painless
- * reads the value via `doc['cases.extended_fields.<snakeKey>']` — the
+ * Publication path is `case.<snakeKey>` (e.g. `case.riskScore_as_long`),
+ * sitting alongside `case.title`, `case.severity`, etc. The Painless
+ * reads the value via `doc['case.extended_fields.<snakeKey>']` — the
  * indexed value lives inside a `flattened` field (see `mappings/case.ts`),
  * and ES exposes flattened sub-keys as doc-values-backed paths under the
  * parent's value stream.
  *
- * The publication path is `cases.<snakeKey>` rather than the indexed path
- * `cases.extended_fields.<snakeKey>` because Kibana data views resolve a
+ * The publication path is `case.<snakeKey>` rather than the indexed path
+ * `case.extended_fields.<snakeKey>` because Kibana data views resolve a
  * field name by merging `{ ...runtime, ...mapped }`: mapped fields take
  * precedence, so a runtime field at the indexed path would be shadowed by
  * the keyword mapping and Lens would lose the typed filter operators.
- * `mappings/schema_drift.test.ts` enforces that no direct child of `cases`
+ * `mappings/schema_drift.test.ts` enforces that no direct child of `case`
  * ends in `_as_<type>` for any supported suffix, bounding the collision
  * risk for the publication path.
  */
@@ -222,7 +222,7 @@ export const buildRuntimeFieldEntry = (snakeKey: string): RuntimeFieldEntry | nu
   if (runtimeType === undefined) return null;
 
   return {
-    fieldName: `cases.${snakeKey}`,
+    fieldName: `case.${snakeKey}`,
     spec: {
       type: runtimeType,
       script: { source: buildPainlessSource(snakeKey, runtimeType) },

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
@@ -86,7 +86,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
 
       expect(dvService.createAndSave).toHaveBeenCalledTimes(1);
       const [spec] = dvService.createAndSave.mock.calls[0];
-      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['cases.risk_as_long']);
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.risk_as_long']);
     });
 
     it('creates the data view with the freshly-computed runtime fields when it does not exist', async () => {
@@ -100,7 +100,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
       expect(dvService.createAndSave).toHaveBeenCalledTimes(1);
       const [spec, overwrite, skipFetchFields] = dvService.createAndSave.mock.calls[0];
       expect(spec.id).toBe(dataViewId);
-      expect(spec.runtimeFieldMap).toMatchObject({ 'cases.score_as_double': { type: 'double' } });
+      expect(spec.runtimeFieldMap).toMatchObject({ 'case.score_as_double': { type: 'double' } });
       expect(overwrite).toBe(false);
       expect(skipFetchFields).toBe(true);
       expect(dvService.updateSavedObject).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
       // Fixture: existing data view holds `risk_as_double`; live template
       // declares `risk_as_long`. Diff must detect drift and update.
       const existing = makeDataViewWithRuntime(dataViewId, {
-        'cases.risk_as_double': {
+        'case.risk_as_double': {
           type: 'double',
           script: { source: 'emit(0)' },
         } as unknown as RuntimeFieldSpec,
@@ -124,7 +124,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
 
       expect(existing.replaceAllRuntimeFields).toHaveBeenCalledTimes(1);
       const [newMap] = existing.replaceAllRuntimeFields.mock.calls[0];
-      expect(Object.keys(newMap)).toEqual(['cases.risk_as_long']);
+      expect(Object.keys(newMap)).toEqual(['case.risk_as_long']);
       expect(dvService.updateSavedObject).toHaveBeenCalledWith(existing);
       expect(dvService.createAndSave).not.toHaveBeenCalled();
     });
@@ -360,7 +360,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
       dvService.createAndSave.mockClear();
 
       const existing = makeDataViewWithRuntime(dataViewId, {
-        'cases.risk_as_long': {
+        'case.risk_as_long': {
           type: 'long',
           script: { source: 'emit(0)' },
         } as unknown as RuntimeFieldSpec,
@@ -371,7 +371,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
 
       expect(existing.replaceAllRuntimeFields).toHaveBeenCalledTimes(1);
       const [newMap] = existing.replaceAllRuntimeFields.mock.calls[0];
-      expect(Object.keys(newMap)).toEqual(['cases.priority_as_keyword']);
+      expect(Object.keys(newMap)).toEqual(['case.priority_as_keyword']);
       expect(dvService.updateSavedObject).toHaveBeenCalledWith(existing);
     });
 
@@ -458,7 +458,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
       dvService.createAndSave.mockClear();
 
       const existing = makeDataViewWithRuntime(dataViewId, {
-        'cases.risk_as_long': {
+        'case.risk_as_long': {
           type: 'long',
           script: { source: 'emit(0)' },
         } as unknown as RuntimeFieldSpec,
@@ -470,7 +470,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
       expect(existing.replaceAllRuntimeFields).toHaveBeenCalledTimes(1);
       const [newMap] = existing.replaceAllRuntimeFields.mock.calls[0];
       expect(new Set(Object.keys(newMap))).toEqual(
-        new Set(['cases.risk_as_long', 'cases.priority_as_keyword'])
+        new Set(['case.risk_as_long', 'case.priority_as_keyword'])
       );
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
@@ -141,8 +141,8 @@ interface BootstrapEntry {
  * nothing until usage.
  *
  * Runtime fields rather than mapped fields. Extended-field values land as
- * keywords under `cases.extended_fields.<snake>`; the data view publishes
- * a typed runtime field at `cases.<snake>` that parses at query time. See
+ * keywords under `case.extended_fields.<snake>`; the data view publishes
+ * a typed runtime field at `case.<snake>` that parses at query time. See
  * `runtime_fields.ts` for the snake-key → Painless transform.
  *
  * Template change → data view propagation:

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/activity.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/activity.ts
@@ -26,7 +26,7 @@ import { ACTIVITY_INDEX_MAPPING } from '../mappings/activity';
  *
  * No `index.mode: lookup`: `.cases-activity` is the fact table in the
  * analytics model. ES|QL queries
- * `FROM .cases-activity | LOOKUP JOIN .cases ON cases.id`; the
+ * `FROM .cases-activity | LOOKUP JOIN .cases ON case.id`; the
  * lookup-mode index is on the `.cases` side.
  *
  * Failure policy: throws on unexpected errors so callers can decide how

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/ensure_indices/attachments.ts
@@ -27,7 +27,7 @@ import { ATTACHMENTS_INDEX_MAPPING } from '../mappings/attachments';
  *     creation with `validation_exception` before the feature can start.
  *
  * No `index.mode: lookup`: `.cases-attachments` is a fact table joined
- * to `.cases` via ES|QL `LOOKUP JOIN cases ON cases.id`; the
+ * to `.cases` via ES|QL `LOOKUP JOIN cases ON case.id`; the
  * lookup-mode index is on the `.cases` side.
  *
  * Failure policy: throws on unexpected errors so callers can decide how

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/activity.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/activity.ts
@@ -27,8 +27,8 @@ import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
  *     implicit-privileges DLS, matching the cases surface (see
  *     `mappings/case.ts`). `space_id` is singular — a user action belongs
  *     to exactly one case in one space.
- *   - `cases.id` — denormalized from the SO `references[case]` so
- *     ES|QL `LOOKUP JOIN .cases ON cases.id` works without an
+ *   - `case.id` — denormalized from the SO `references[case]` so
+ *     ES|QL `LOOKUP JOIN .cases ON case.id` works without an
  *     intermediate aggregation.
  *   - `actor.*` — flattened `created_by` so `actor.username` etc. are
  *     first-class analytics dimensions.
@@ -68,7 +68,7 @@ export const ACTIVITY_INDEX_MAPPING: MappingTypeMapping = {
     space_id: { type: 'keyword' },
     owner: { type: 'keyword' },
 
-    cases: {
+    case: {
       properties: {
         // Denormalized from the user-action SO's `references[case]`.
         // Single value per doc — a user action belongs to exactly one

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/attachments.ts
@@ -39,8 +39,8 @@ import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
  *   - `space_id` / `owner` — top-level (document-root) scoping fields for
  *     implicit-privileges DLS, matching the cases + activity surfaces.
  *     `space_id` is singular — an attachment lives in exactly one space.
- *   - `cases.id` — denormalized from the SO `references[case]` so
- *     ES|QL `LOOKUP JOIN .cases ON cases.id` works without an
+ *   - `case.id` — denormalized from the SO `references[case]` so
+ *     ES|QL `LOOKUP JOIN .cases ON case.id` works without an
  *     intermediate aggregation.
  *   - `created_by.* / updated_by.* / pushed_by.*` — flattened user
  *     refs. Match the cases surface's `created_by` shape.
@@ -91,7 +91,7 @@ export const ATTACHMENTS_INDEX_MAPPING: MappingTypeMapping = {
     space_id: { type: 'keyword' },
     owner: { type: 'keyword' },
 
-    cases: {
+    case: {
       properties: {
         // Denormalized from the SO's `references[case]`. Single value
         // per doc — an attachment belongs to exactly one case.

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/attachments_schema_drift.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/attachments_schema_drift.test.ts
@@ -405,14 +405,14 @@ describe('every legacy AttachmentType has at least one fixture', () => {
 
 // ----- Cases.id denormalization sanity -----
 
-describe('cases.id is denormalized from references[case]', () => {
+describe('case.id is denormalized from references[case]', () => {
   it.each(Object.entries(FIXTURES))(
-    'fixture=%s carries cases.id from the SO reference',
+    'fixture=%s carries case.id from the SO reference',
     (_label, so) => {
       const doc = buildAttachmentDoc(
         so as SavedObject<AttachmentPersistedAttributes | UnifiedAttachmentAttributes>
       );
-      expect(doc.cases.id).toBe('case-1');
+      expect(doc.case.id).toBe('case-1');
     }
   );
 });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/case.ts
@@ -23,17 +23,17 @@ import { CASE_DYNAMIC_TEMPLATES } from './dynamic_templates';
  *   - `@timestamp` — required by Discover / Lens; set to the case's
  *     latest activity timestamp at write time.
  *   - `space_id` / `owner` — top-level (document-root) scoping fields,
- *     deliberately NOT under `cases.*`. This mirrors the Kibana
+ *     deliberately NOT under `case.*`. This mirrors the Kibana
  *     implicit-privileges DLS convention (elasticsearch#148331): a future
  *     ES `ImplicitPrivilegesProvider` can DLS-scope `.cases` by top-level
  *     `space_id` (+ `owner` for solution scoping) the same way the alerts
  *     provider scopes `.rule-events` by top-level `space_id`. Cases SOs
  *     are `multiple-isolated`, so a case lives in exactly one space —
  *     `space_id` is therefore singular, not an array. `owner` is also
- *     mirrored at `cases.owner` so analysts see it in the grouped
+ *     mirrored at `case.owner` so analysts see it in the grouped
  *     data-view namespace; the top-level copy is the DLS field.
- *   - `cases.*` — case-specific fields, namespaced so runtime fields at
- *     `cases.<snake>` can lift extended-field keywords without
+ *   - `case.*` — case-specific fields, namespaced so runtime fields at
+ *     `case.<snake>` can lift extended-field keywords without
  *     colliding.
  *
  * Intentional divergences from the SO mapping:
@@ -45,12 +45,12 @@ import { CASE_DYNAMIC_TEMPLATES } from './dynamic_templates';
  *     `index.mapping.total_fields.limit` (default 1000) on tenants with
  *     many templates × spaces; flattened keeps the mapping at one field
  *     regardless of cluster-wide snake-key cardinality. Per-child typed
- *     querying happens via runtime fields at `cases.<snake>` (see
+ *     querying happens via runtime fields at `case.<snake>` (see
  *     `data_view/runtime_fields.ts`), which read the value via
- *     `doc['cases.extended_fields.<snake>']`.
+ *     `doc['case.extended_fields.<snake>']`.
  *   - `observables`: SO uses a nested array of
  *     `{ typeKey, value, description }`; this index denormalizes to one
- *     keyword array per `typeKey` (`cases.observables.url: ["..."]`) so
+ *     keyword array per `typeKey` (`case.observables.url: ["..."]`) so
  *     analysts run simple term queries instead of nested aggregations.
  *     `description` is dropped — free-text per observable, not an
  *     analytics dimension.
@@ -73,15 +73,15 @@ export const CASE_INDEX_MAPPING: MappingTypeMapping = {
     // Top-level scoping fields for implicit-privileges DLS (see the
     // file-level comment). `space_id` is singular — cases are
     // space-isolated. `owner` carries the solution dimension; it is also
-    // mirrored at `cases.owner` below for data-view grouping.
+    // mirrored at `case.owner` below for data-view grouping.
     space_id: { type: 'keyword' },
     owner: { type: 'keyword' },
 
-    cases: {
+    case: {
       properties: {
         id: { type: 'keyword' },
         // Mirror of the top-level `owner` (the DLS field). Kept under
-        // `cases.*` so analysts see it in the grouped data-view namespace
+        // `case.*` so analysts see it in the grouped data-view namespace
         // alongside the other case fields.
         owner: { type: 'keyword' },
         title: {
@@ -230,9 +230,9 @@ export const CASE_INDEX_MAPPING: MappingTypeMapping = {
         // Denormalized from the SO's nested
         // `{ typeKey, value, description }` array into a flat object
         // keyed by observable type
-        // (`cases.observables.<typeKey>: keyword[]`). Lets analysts run
+        // (`case.observables.<typeKey>: keyword[]`). Lets analysts run
         // simple term queries
-        // (`cases.observables.url: "http://..."`) without nested
+        // (`case.observables.url: "http://..."`) without nested
         // aggregation overhead while preserving the type↔value
         // relationship via the field path.
         //
@@ -247,9 +247,9 @@ export const CASE_INDEX_MAPPING: MappingTypeMapping = {
         // `flattened` keeps the mapping at one field regardless of how
         // many distinct `<name>_as_<type>` snake-keys exist across
         // templates cluster-wide. Typed querying happens via runtime
-        // fields at `cases.<snake>` (see `data_view/runtime_fields.ts`),
+        // fields at `case.<snake>` (see `data_view/runtime_fields.ts`),
         // which read the value via
-        // `doc['cases.extended_fields.<snake>']`. Matches the cases SO
+        // `doc['case.extended_fields.<snake>']`. Matches the cases SO
         // mapping.
         extended_fields: { type: 'flattened' },
       },

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/dynamic_templates.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/dynamic_templates.ts
@@ -10,13 +10,13 @@ import type { MappingDynamicTemplate } from '@elastic/elasticsearch/lib/api/type
 /**
  * Dynamic templates applied to the `.cases` analytics index mapping.
  *
- * `cases.observables.*` — denormalized observables, one keyword array per
+ * `case.observables.*` — denormalized observables, one keyword array per
  * `typeKey`. The case SO stores observables as a nested array of
  * `{ typeKey, value, description }` triples; the doc-builder regroups them
  * so each observable type lives at its own path
- * (e.g. `cases.observables.url: ["http://..."]`). This preserves the
+ * (e.g. `case.observables.url: ["http://..."]`). This preserves the
  * type↔value relationship via the field path while enabling simple term
- * queries like `cases.observables.url: "http://..."`.
+ * queries like `case.observables.url: "http://..."`.
  *
  * Children are indexed as keyword with `ignore_above: 32766` — the standard
  * cap. Values above that length stay in `_source` but drop out of the index.
@@ -28,14 +28,14 @@ import type { MappingDynamicTemplate } from '@elastic/elasticsearch/lib/api/type
  * `extended_fields` deliberately does **not** have a dynamic template —
  * it's mapped as `flattened` directly (see `case.ts`), collapsing the
  * mapping cost to a single field regardless of cluster-wide snake-key
- * cardinality. Typed querying via runtime fields at `cases.<snake>`
- * reading `doc['cases.extended_fields.<snake>']`; see
+ * cardinality. Typed querying via runtime fields at `case.<snake>`
+ * reading `doc['case.extended_fields.<snake>']`; see
  * `data_view/runtime_fields.ts`.
  */
 export const CASE_DYNAMIC_TEMPLATES: Array<Record<string, MappingDynamicTemplate>> = [
   {
     observables_keyword: {
-      path_match: 'cases.observables.*',
+      path_match: 'case.observables.*',
       mapping: {
         type: 'keyword',
         ignore_above: 32766,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/schema_drift.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/schema_drift.test.ts
@@ -30,10 +30,10 @@ import { CASE_INDEX_MAPPING } from './case';
  * resolves in `CASE_INDEX_MAPPING`. Catches a field added to the
  * doc-builder without a matching mapping update.
  *
- * Layer 2 (SO mapping ⊆ CASE_INDEX_MAPPING via `cases.<path>`).
+ * Layer 2 (SO mapping ⊆ CASE_INDEX_MAPPING via `case.<path>`).
  * Every field in the cases SO mapping at
  * `server/saved_object_types/cases/cases.ts` has a corresponding
- * entry in `CASE_INDEX_MAPPING` under `cases.<path>` (or is
+ * entry in `CASE_INDEX_MAPPING` under `case.<path>` (or is
  * explicitly allowlisted as an intentional divergence). Catches a
  * field added to the SO mapping without a mirror in v2.
  *
@@ -45,9 +45,9 @@ import { CASE_INDEX_MAPPING } from './case';
  * about what (or whether) `buildCaseDoc` should emit for it.
  *
  * Excluded from Layer 1:
- *   - `cases.extended_fields.*`: lands via the dynamic_template,
+ *   - `case.extended_fields.*`: lands via the dynamic_template,
  *     not static properties.
- *   - `cases.observables.*`: lands via the dynamic_template
+ *   - `case.observables.*`: lands via the dynamic_template
  *     (denormalized per-typeKey keys are dynamic).
  */
 
@@ -193,11 +193,11 @@ describe('case mapping covers every doc-builder field', () => {
   });
 });
 
-// ----- Layer 2: SO mapping ⊆ v2 mapping (via `cases.<path>` prefix rule) -----
+// ----- Layer 2: SO mapping ⊆ v2 mapping (via `case.<path>` prefix rule) -----
 
 /**
  * Fields present in the cases SO mapping that intentionally don't
- * appear at the parallel `cases.<path>` location in v2 *and* aren't
+ * appear at the parallel `case.<path>` location in v2 *and* aren't
  * covered by an `enabled: false` / `dynamic: true` ancestor (which
  * `isCovered` handles via prefix-match).
  *
@@ -206,17 +206,17 @@ describe('case mapping covers every doc-builder field', () => {
  * exactly what this layer exists to prevent.
  */
 const OMITTED_FROM_ANALYTICS_V2_MIRROR: ReadonlyMap<string, string> = new Map([
-  // Empty. (`owner` is mirrored at `cases.owner` in addition to its
+  // Empty. (`owner` is mirrored at `case.owner` in addition to its
   // top-level DLS copy, so it satisfies the Layer 2 mirror directly.)
   // The intentional divergences are all covered by an opaque
   // (`enabled: false`) or `dynamic: true` parent in v2 and caught by
   // the `isCovered` rule:
-  //  - cases.settings.{syncAlerts,extractObservables}
-  //    → v2 cases.settings is `enabled: false` (per-case config,
+  //  - case.settings.{syncAlerts,extractObservables}
+  //    → v2 case.settings is `enabled: false` (per-case config,
   //      not an analytics dimension).
-  //  - cases.observables.{typeKey,value,description}
-  //    → v2 cases.observables is `dynamic: true` (denormalized to
-  //      `cases.observables.<typeKey>` via dynamic_template;
+  //  - case.observables.{typeKey,value,description}
+  //    → v2 case.observables is `dynamic: true` (denormalized to
+  //      `case.observables.<typeKey>` via dynamic_template;
   //      description dropped).
 ]);
 
@@ -229,8 +229,8 @@ describe('cases SO mapping is mirrored in CASE_INDEX_MAPPING', () => {
   const soPaths = collectMappedPaths(soMapping);
   const v2Paths = collectMappedPaths(CASE_INDEX_MAPPING);
 
-  it('every SO mapping field exists at cases.<path> in v2 (or is covered / allowlisted)', () => {
-    // Mechanical rule: SO field `foo.bar` is expected at `cases.foo.bar` in
+  it('every SO mapping field exists at case.<path> in v2 (or is covered / allowlisted)', () => {
+    // Mechanical rule: SO field `foo.bar` is expected at `case.foo.bar` in
     // v2. `isCovered` also accepts a match on any prefix — so SO subfields
     // of an opaque (`enabled: false`) or `dynamic: true` v2 parent are
     // implicitly covered without needing an allowlist entry. Anything that
@@ -238,7 +238,7 @@ describe('cases SO mapping is mirrored in CASE_INDEX_MAPPING', () => {
     // with a documented reason.
     const missing = [...soPaths].filter((soPath) => {
       if (OMITTED_FROM_ANALYTICS_V2_MIRROR.has(soPath)) return false;
-      const expected = `cases.${soPath}`;
+      const expected = `case.${soPath}`;
       return !isCovered(expected, v2Paths);
     });
     expect(missing).toEqual([]);
@@ -248,9 +248,9 @@ describe('cases SO mapping is mirrored in CASE_INDEX_MAPPING', () => {
 // ----- Snake-key collision guard (runtime field naming invariant) -----
 
 /**
- * Typed runtime fields are published at `cases.<snakeKey>` (e.g.
- * `cases.score_as_long`) — direct children of `cases`. The strict
- * collision is at the exact full path `cases.<snake>`. The check
+ * Typed runtime fields are published at `case.<snakeKey>` (e.g.
+ * `case.score_as_long`) — direct children of `case`. The strict
+ * collision is at the exact full path `case.<snake>`. The check
  * scans the leaf segment everywhere as broader defense against
  * naming-confusion foot-guns and future widening of the runtime
  * publication scheme.

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/reconciliation/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/reconciliation/index.ts
@@ -122,7 +122,7 @@ export function registerReconciliationTask({
           const deps = await getRunnerDeps();
 
           // Cases first (the dimension table). A `LOOKUP JOIN .cases
-          // ON cases.id` from any post-fact-table walk consumer then
+          // ON case.id` from any post-fact-table walk consumer then
           // always sees the joined case row at least as up-to-date as
           // the activity / attachment row that referenced it.
           let casesError: unknown;

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity.test.ts
@@ -187,7 +187,7 @@ describe('CasesActivityV2Writer', () => {
   });
 
   describe('bulkDeleteActionsByCaseIds', () => {
-    it('issues a delete_by_query with a terms filter on cases.id', async () => {
+    it('issues a delete_by_query with a terms filter on case.id', async () => {
       const { writer, esClient } = buildWriterUnderTest();
       (esClient.deleteByQuery as unknown as jest.Mock).mockResolvedValue({ deleted: 3 });
 
@@ -199,7 +199,7 @@ describe('CasesActivityV2Writer', () => {
       expect(arg.index).toBe(ACTIVITY_INDEX_NAME);
       expect(arg.refresh).toBe(false);
       expect(arg.conflicts).toBe('proceed');
-      expect(arg.query).toEqual({ terms: { 'cases.id': ['case-1', 'case-2'] } });
+      expect(arg.query).toEqual({ terms: { 'case.id': ['case-1', 'case-2'] } });
     });
 
     it('skips dispatch on empty input', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity.ts
@@ -93,7 +93,7 @@ export class CasesActivityV2Writer implements CasesActivityV2WriterContract {
   }
 
   /**
-   * Cascade-delete every analytics activity doc whose `cases.id` matches
+   * Cascade-delete every analytics activity doc whose `case.id` matches
    * one of the supplied case ids. Called by `CasesService.bulkDelete*`
    * for case-level deletions. Fire-and-forget. The reconciliation
    * filter (`created_at > tracker`) won't re-emit a doc whose source SO
@@ -103,7 +103,7 @@ export class CasesActivityV2Writer implements CasesActivityV2WriterContract {
    * Implemented as `delete_by_query` rather than `_bulk`: the writer
    * doesn't know which user-action ids existed for the deleted cases,
    * and the SO service has already deleted the user-action SOs, so a
-   * `terms` query on `cases.id` is the cheapest correct path.
+   * `terms` query on `case.id` is the cheapest correct path.
    *
    * Known limitation: this is the ONLY path that drops cascade-orphaned
    * activity docs. Reconciliation walks forward on `created_at` and
@@ -215,7 +215,7 @@ export class CasesActivityV2Writer implements CasesActivityV2WriterContract {
         // re-emit anyway because the source SO is gone.
         conflicts: 'proceed',
         query: {
-          terms: { 'cases.id': caseIds },
+          terms: { 'case.id': caseIds },
         },
       });
     } catch (err) {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.test.ts
@@ -50,18 +50,18 @@ describe('buildActivityDoc', () => {
       expect(doc.action.verb).toBe('update');
     });
 
-    it('resolves cases.id from the associated-cases reference', () => {
+    it('resolves case.id from the associated-cases reference', () => {
       const doc = buildActivityDoc(
         makeUserAction('ua-1', {
           references: [{ id: 'case-xyz', type: CASE_SAVED_OBJECT, name: 'associated-cases' }],
         })
       );
-      expect(doc.cases.id).toBe('case-xyz');
+      expect(doc.case.id).toBe('case-xyz');
     });
 
-    it('sets cases.id to the empty string when no case reference is present (malformed SO)', () => {
+    it('sets case.id to the empty string when no case reference is present (malformed SO)', () => {
       const doc = buildActivityDoc(makeUserAction('ua-1', { references: [] }));
-      expect(doc.cases.id).toBe('');
+      expect(doc.case.id).toBe('');
     });
 
     it('projects created_by into actor.*', () => {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
@@ -30,7 +30,7 @@ import type { UserActionPersistedAttributes } from '../../common/types/user_acti
  *   - `attributes.created_by` → `actor.*`. The SO calls every "who did
  *     this" field `created_by`, but for a user action the relevant
  *     person is the actor.
- *   - `references[case]` → `cases.id`, denormalized for ES|QL
+ *   - `references[case]` → `case.id`, denormalized for ES|QL
  *     `LOOKUP JOIN`.
  *   - `attributes.created_at` → `@timestamp` so Discover/Lens time UX
  *     works without an extra transform.
@@ -44,7 +44,7 @@ export interface ActivityAnalyticsDoc {
   // `mappings/activity.ts`.
   space_id: string;
   owner: string;
-  cases: {
+  case: {
     id: string;
   };
   actor: ActivityActorDoc;
@@ -85,7 +85,7 @@ interface ActivityActorDoc {
  * `references[]` with `name === 'associated-cases'` and
  * `type === 'cases'` (see `services/user_actions/transform.ts`).
  * `pickCaseId` reads the `id` off that reference; if it's missing
- * (malformed SO, not expected in practice) `cases.id` is set to the
+ * (malformed SO, not expected in practice) `case.id` is set to the
  * empty string so the strict mapping still accepts the doc and
  * reconciliation can re-emit a corrected version once upstream is fixed.
  */
@@ -108,7 +108,7 @@ export function buildActivityDoc(
     // `space_id` is the singular scalar the DLS convention expects.
     space_id: so.namespaces?.[0] ?? 'default',
     owner: a.owner,
-    cases: {
+    case: {
       id: caseId,
     },
     actor: toActor(a.created_by),

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments.test.ts
@@ -18,10 +18,10 @@ import { CasesAttachmentsV2Writer } from './attachments';
  *   - The cascade-by-case-ids path (`bulkDeleteAttachmentsByCaseIds`)
  *     uses `delete_by_query` rather than `_bulk` because the writer
  *     doesn't know which attachment SO ids existed for the deleted
- *     cases. Same reasoning as the activity writer's cascade path
+ *     case. Same reasoning as the activity writer's cascade path
  *     but with one extra dimension: the cascade must cover BOTH
  *     source SO types (legacy + unified) — handled implicitly by
- *     querying on the denormalized `cases.id` on the analytics index.
+ *     querying on the denormalized `case.id` on the analytics index.
  *   - The per-id delete path (`bulkDeleteAttachments`) which
  *     attachments need but activity doesn't (user-actions are
  *     immutable; attachments are mutable + per-id-deletable).
@@ -151,7 +151,7 @@ describe('CasesAttachmentsV2Writer', () => {
   });
 
   describe('bulkDeleteAttachmentsByCaseIds (cascade path)', () => {
-    it('dispatches a single delete_by_query against `cases.id` for every supplied case id', async () => {
+    it('dispatches a single delete_by_query against `case.id` for every supplied case id', async () => {
       const { writer, esClient } = buildWriterUnderTest();
       (esClient.deleteByQuery as unknown as jest.Mock).mockResolvedValue({ deleted: 0 });
 
@@ -161,11 +161,11 @@ describe('CasesAttachmentsV2Writer', () => {
       expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
       const arg = (esClient.deleteByQuery as unknown as jest.Mock).mock.calls[0][0];
       expect(arg.index).toBe(ATTACHMENTS_INDEX_NAME);
-      // `terms` query on the denormalized cases.id — implicitly
+      // `terms` query on the denormalized case.id — implicitly
       // covers BOTH source SO types (legacy + unified) because the
       // analytics doc shape is unified and keyed only on the source
       // SO id.
-      expect(arg.query).toEqual({ terms: { 'cases.id': ['case-1', 'case-2'] } });
+      expect(arg.query).toEqual({ terms: { 'case.id': ['case-1', 'case-2'] } });
       expect(arg.refresh).toBe(false);
       expect(arg.conflicts).toBe('proceed');
     });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments.ts
@@ -77,7 +77,7 @@ export interface CasesAttachmentsV2WriterContract {
   bulkUpsertAttachments: (sos: AttachmentSource[]) => void;
   bulkDeleteAttachments: (ids: string[]) => void;
   /**
-   * Cascade-delete every analytics doc whose `cases.id` matches one of
+   * Cascade-delete every analytics doc whose `case.id` matches one of
    * the supplied case ids. Called from `CasesService.deleteCase` /
    * `bulkDeleteCaseEntities` so the analytics mirror tracks the
    * SO-layer cascade — see writer §1.14 in the README.
@@ -146,7 +146,7 @@ export class CasesAttachmentsV2Writer implements CasesAttachmentsV2WriterContrac
   }
 
   /**
-   * Cascade-delete every analytics attachment doc whose `cases.id`
+   * Cascade-delete every analytics attachment doc whose `case.id`
    * matches one of the supplied case ids. Called by
    * `CasesService.deleteCase` / `bulkDeleteCaseEntities` for case-level
    * deletions. Fire-and-forget. Implementation mirrors the activity
@@ -302,7 +302,7 @@ export class CasesAttachmentsV2Writer implements CasesAttachmentsV2WriterContrac
         // re-emit anyway because the source SO is gone.
         conflicts: 'proceed',
         query: {
-          terms: { 'cases.id': caseIds },
+          terms: { 'case.id': caseIds },
         },
       });
     } catch (err) {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments_doc_builder.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments_doc_builder.test.ts
@@ -127,16 +127,16 @@ describe('buildAttachmentDoc', () => {
       expect(doc.space_id).toBe('default');
     });
 
-    it('denormalizes cases.id from the case reference', () => {
+    it('denormalizes case.id from the case reference', () => {
       const doc = buildAttachmentDoc(makeSO(CASE_COMMENT_SAVED_OBJECT, fullUserAttrs));
-      expect(doc.cases.id).toBe('case-1');
+      expect(doc.case.id).toBe('case-1');
     });
 
-    it('emits an empty cases.id when the case reference is missing (keeps the strict mapping happy)', () => {
+    it('emits an empty case.id when the case reference is missing (keeps the strict mapping happy)', () => {
       const doc = buildAttachmentDoc(
         makeSO(CASE_COMMENT_SAVED_OBJECT, fullUserAttrs, { references: [] })
       );
-      expect(doc.cases.id).toBe('');
+      expect(doc.case.id).toBe('');
     });
 
     it('projects updated_by / pushed_by when present and nulls them when absent', () => {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/attachments_doc_builder.ts
@@ -35,7 +35,7 @@ export interface AttachmentAnalyticsDoc {
   // and activity surfaces. `space_id` is singular — an attachment lives in
   // exactly one space. See `mappings/attachments.ts`.
   space_id: string;
-  cases: {
+  case: {
     id: string;
   };
   owner: string;
@@ -139,7 +139,7 @@ export function buildAttachmentDoc(
     // Top-level singular scoping field for implicit-privileges DLS. Attachment
     // SOs are space-isolated, so take the first namespace (default `default`).
     space_id: so.namespaces?.[0] ?? 'default',
-    cases: { id: caseId },
+    case: { id: caseId },
     owner: unified.owner,
     created_at: unified.created_at,
     created_by: toUser(unified.created_by),

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.test.ts
@@ -83,47 +83,47 @@ describe('buildCaseDoc', () => {
     expect(doc.space_id).toBe('security-1');
   });
 
-  it('emits owner at the document root (DLS field) and mirrors it under cases.*', () => {
+  it('emits owner at the document root (DLS field) and mirrors it under case.*', () => {
     const doc = buildCaseDoc(fullCaseSO());
     expect(doc.owner).toBe('securitySolution');
-    expect(doc.cases.owner).toBe('securitySolution');
+    expect(doc.case.owner).toBe('securitySolution');
   });
 
   it('converts numeric severity to a human-readable string', () => {
-    expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.LOW })).cases.severity).toBe(
+    expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.LOW })).case.severity).toBe(
       'low'
     );
     expect(
-      buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.MEDIUM })).cases.severity
+      buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.MEDIUM })).case.severity
     ).toBe('medium');
-    expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.HIGH })).cases.severity).toBe(
+    expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.HIGH })).case.severity).toBe(
       'high'
     );
     expect(
-      buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.CRITICAL })).cases.severity
+      buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.CRITICAL })).case.severity
     ).toBe('critical');
   });
 
   it('converts numeric status to a human-readable string', () => {
-    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.OPEN })).cases.status).toBe(
+    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.OPEN })).case.status).toBe(
       'open'
     );
-    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.IN_PROGRESS })).cases.status).toBe(
+    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.IN_PROGRESS })).case.status).toBe(
       'in-progress'
     );
-    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.CLOSED })).cases.status).toBe(
+    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.CLOSED })).case.status).toBe(
       'closed'
     );
   });
 
   it('passes customFields through as-is (matches SO shape)', () => {
     const doc = buildCaseDoc(fullCaseSO());
-    expect(doc.cases.customFields).toEqual([{ key: 'cf', type: 'text', value: 'x' }]);
+    expect(doc.case.customFields).toEqual([{ key: 'cf', type: 'text', value: 'x' }]);
   });
 
   it('denormalizes observables into per-typeKey keyword arrays', () => {
     const doc = buildCaseDoc(fullCaseSO());
-    expect(doc.cases.observables).toEqual({
+    expect(doc.case.observables).toEqual({
       url: ['http://example.com', 'http://other.com'],
       ipv4: ['1.2.3.4'],
     });
@@ -133,13 +133,13 @@ describe('buildCaseDoc', () => {
     const doc = buildCaseDoc(fullCaseSO());
     // No `description` anywhere in the observables tree — they're collapsed
     // into per-type keyword arrays. The full triple is still on the SO.
-    expect(JSON.stringify(doc.cases.observables)).not.toContain('description');
-    expect(JSON.stringify(doc.cases.observables)).not.toContain('site');
+    expect(JSON.stringify(doc.case.observables)).not.toContain('description');
+    expect(JSON.stringify(doc.case.observables)).not.toContain('site');
   });
 
   it('returns undefined observables when the SO has none', () => {
     const doc = buildCaseDoc(fullCaseSO({ observables: [] }));
-    expect(doc.cases.observables).toBeUndefined();
+    expect(doc.case.observables).toBeUndefined();
   });
 
   it('skips observables without typeKey or value', () => {
@@ -152,14 +152,14 @@ describe('buildCaseDoc', () => {
         ] as never,
       })
     );
-    expect(doc.cases.observables).toEqual({ url: ['http://good'] });
+    expect(doc.case.observables).toEqual({ url: ['http://good'] });
   });
 
   it('passes connector and external_service through (fully indexed per mapping)', () => {
     const doc = buildCaseDoc(fullCaseSO());
     // The none connector has no reference entry, so id is absent.
-    expect(doc.cases.connector).toEqual({ name: 'none', type: '.none', fields: null });
-    expect(doc.cases.external_service).toBeNull();
+    expect(doc.case.connector).toEqual({ name: 'none', type: '.none', fields: null });
+    expect(doc.case.external_service).toBeNull();
   });
 
   it('rehydrates connector.id from so.references', () => {
@@ -177,7 +177,7 @@ describe('buildCaseDoc', () => {
       fields: { issueType: '10006', priority: 'High', parent: null },
     };
     const doc = buildCaseDoc(so);
-    expect(doc.cases.connector).toEqual({
+    expect(doc.case.connector).toEqual({
       id: 'connector-1',
       name: 'jira',
       type: '.jira',
@@ -188,22 +188,22 @@ describe('buildCaseDoc', () => {
   it('omits connector.id when no matching reference exists', () => {
     // None connector — id is a sentinel not stored in references.
     const doc = buildCaseDoc(fullCaseSO());
-    expect((doc.cases.connector as Record<string, unknown>)?.id).toBeUndefined();
+    expect((doc.case.connector as Record<string, unknown>)?.id).toBeUndefined();
   });
 
-  it('preserves the case id under cases.id', () => {
+  it('preserves the case id under case.id', () => {
     const doc = buildCaseDoc(fullCaseSO());
-    expect(doc.cases.id).toBe('case-1');
+    expect(doc.case.id).toBe('case-1');
   });
 
   it('passes extended_fields through as a plain object', () => {
     const doc = buildCaseDoc(fullCaseSO());
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    expect(doc.cases.extended_fields).toEqual({ riskScore_as_long: '42' });
+    expect(doc.case.extended_fields).toEqual({ riskScore_as_long: '42' });
   });
 
   it('emits extended_fields as undefined when absent (keeps the doc small)', () => {
     const doc = buildCaseDoc(fullCaseSO({ extended_fields: undefined }));
-    expect(doc.cases.extended_fields).toBeUndefined();
+    expect(doc.case.extended_fields).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.test.ts
@@ -93,9 +93,9 @@ describe('buildCaseDoc', () => {
     expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.LOW })).case.severity).toBe(
       'low'
     );
-    expect(
-      buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.MEDIUM })).case.severity
-    ).toBe('medium');
+    expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.MEDIUM })).case.severity).toBe(
+      'medium'
+    );
     expect(buildCaseDoc(fullCaseSO({ severity: CasePersistedSeverity.HIGH })).case.severity).toBe(
       'high'
     );
@@ -105,9 +105,7 @@ describe('buildCaseDoc', () => {
   });
 
   it('converts numeric status to a human-readable string', () => {
-    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.OPEN })).case.status).toBe(
-      'open'
-    );
+    expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.OPEN })).case.status).toBe('open');
     expect(buildCaseDoc(fullCaseSO({ status: CasePersistedStatus.IN_PROGRESS })).case.status).toBe(
       'in-progress'
     );

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/case_doc_builder.ts
@@ -36,7 +36,7 @@ import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
  *   - `space_id` and `owner` are emitted at the document root to match the
  *     implicit-privileges DLS convention (see `mappings/case.ts`).
  *     `space_id` is singular — cases are space-isolated. `owner` is also
- *     mirrored at `cases.owner` for data-view grouping.
+ *     mirrored at `case.owner` for data-view grouping.
  *
  * Coupling the two via `extends` would force every additive change to
  * the cases SO into the analytics doc surface. The analytics-doc shape
@@ -57,9 +57,9 @@ export interface CaseAnalyticsDoc {
   // dimension. See `mappings/case.ts`.
   space_id: string;
   owner: string;
-  cases: {
+  case: {
     id: string;
-    // Mirror of the top-level `owner` (the DLS field), kept under `cases.*`
+    // Mirror of the top-level `owner` (the DLS field), kept under `case.*`
     // for data-view grouping. See `mappings/case.ts`.
     owner: string;
     title: string;
@@ -163,7 +163,7 @@ export function buildCaseDoc(so: SavedObject<CasePersistedAttributes>): CaseAnal
     // singular scalar the DLS convention expects.
     space_id: so.namespaces?.[0] ?? 'default',
     owner: a.owner,
-    cases: {
+    case: {
       id: so.id,
       // Mirror of the top-level `owner` for data-view grouping.
       owner: a.owner,

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
@@ -208,7 +208,7 @@ export class CasesService {
    * AttachmentService. The cascade applies whether the source SO is
    * the legacy `cases-comments` or the unified `cases-attachments`
    * type; the analytics doc id is the source SO id (unique across both
-   * types) so a single delete-by-`cases.id` query covers both.
+   * types) so a single delete-by-`case.id` query covers both.
    */
   private readonly analyticsV2AttachmentsWriter: CasesAttachmentsV2WriterContract;
 
@@ -653,7 +653,7 @@ export class CasesService {
       this.analyticsV2ActivityWriter.bulkDeleteActionsByCaseIds(idsToDelete);
       // Same rationale for `.cases-attachments` — covers both legacy
       // and unified attachment SO sources via a single
-      // delete-by-`cases.id` on the analytics index. No-op when empty.
+      // delete-by-`case.id` on the analytics index. No-op when empty.
       this.analyticsV2AttachmentsWriter.bulkDeleteAttachmentsByCaseIds(idsToDelete);
     } catch (error) {
       this.log.error(`Error bulk deleting case entities ${JSON.stringify(entities)}: ${error}`);

--- a/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/activity.ts
+++ b/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/activity.ts
@@ -60,7 +60,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const docs = await waitForActivityForCase(es, created.id, 1);
       const createDoc = docs.find((d) => d.action.type === 'create_case');
       expect(createDoc).to.be.an('object');
-      expect(createDoc!.cases.id).to.eql(created.id);
+      expect(createDoc!.case.id).to.eql(created.id);
       expect(createDoc!.action.verb).to.eql('create');
       // `getAuthWithSuperUser()` defaults to `space1` → the case (and its
       // user actions) live in space1, so the real-time activity write

--- a/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/attachments.ts
+++ b/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/attachments.ts
@@ -90,7 +90,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const docs = await waitForAttachmentForCase(es, created.id, 1);
       const userDoc = docs.find((d) => d.attachment.type === UNIFIED_COMMENT_TYPE);
       expect(userDoc).to.be.an('object');
-      expect(userDoc!.cases.id).to.eql(created.id);
+      expect(userDoc!.case.id).to.eql(created.id);
       // The suite creates every case in `space1` (see `getAuthWithSuperUser`),
       // so the analytics doc's `space_id` — derived from the SO namespaces —
       // is `space1`, not the default space.

--- a/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/helpers.ts
+++ b/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/helpers.ts
@@ -241,7 +241,7 @@ export async function runReconcileSoon(
 
 /**
  * Poll `.cases-activity` until the count of docs matching
- * `cases.id = caseId` reaches at least `minCount`. The activity
+ * `case.id = caseId` reaches at least `minCount`. The activity
  * writer is fire-and-forget on a separate code path from the
  * user-actions SO write — `?refresh=true` on the cases API doesn't
  * refresh `.cases-activity`, so tests must poll-with-refresh.
@@ -271,7 +271,7 @@ export async function waitForActivityForCase(
         // caller passing `minCount > 100` loop until timeout.
         size: Math.max(minCount, 100),
         sort: [{ '@timestamp': { order: 'asc' } }],
-        query: { term: { 'cases.id': caseId } },
+        query: { term: { 'case.id': caseId } },
       });
       const hits = search.hits.hits.map((h) => h._source!).filter(Boolean);
       if (hits.length >= minCount) return hits;
@@ -286,7 +286,7 @@ export async function waitForActivityForCase(
 }
 
 /**
- * Poll `.cases-activity` until ZERO docs match `cases.id = caseId`.
+ * Poll `.cases-activity` until ZERO docs match `case.id = caseId`.
  * Used after a cases delete to assert the cascade-delete fired.
  */
 export async function waitForActivityAbsent(
@@ -300,7 +300,7 @@ export async function waitForActivityAbsent(
       await es.indices.refresh({ index: ACTIVITY_INDEX });
       const count = await es.count({
         index: ACTIVITY_INDEX,
-        query: { term: { 'cases.id': caseId } },
+        query: { term: { 'case.id': caseId } },
       });
       if ((count.count ?? 0) === 0) return;
     } catch {
@@ -317,7 +317,7 @@ export async function waitForActivityAbsent(
 
 /**
  * Poll `.cases-attachments` until the count of docs matching
- * `cases.id = caseId` reaches at least `minCount`. Same fire-and-forget
+ * `case.id = caseId` reaches at least `minCount`. Same fire-and-forget
  * caveat as `waitForActivityForCase`: the analytics writer runs on a
  * separate code path from the SO write, so tests must poll-with-refresh.
  */
@@ -339,7 +339,7 @@ export async function waitForAttachmentForCase(
         index: ATTACHMENTS_INDEX,
         size: 100,
         sort: [{ '@timestamp': { order: 'asc' } }],
-        query: { term: { 'cases.id': caseId } },
+        query: { term: { 'case.id': caseId } },
       });
       const hits = search.hits.hits.map((h) => h._source!).filter(Boolean);
       if (hits.length >= minCount) return hits;
@@ -354,7 +354,7 @@ export async function waitForAttachmentForCase(
 }
 
 /**
- * Poll `.cases-attachments` until ZERO docs match `cases.id = caseId`.
+ * Poll `.cases-attachments` until ZERO docs match `case.id = caseId`.
  * Used after a cases delete to assert the cascade-delete fired against
  * BOTH source SO types (legacy + unified).
  */
@@ -369,7 +369,7 @@ export async function waitForAttachmentsAbsent(
       await es.indices.refresh({ index: ATTACHMENTS_INDEX });
       const count = await es.count({
         index: ATTACHMENTS_INDEX,
-        query: { term: { 'cases.id': caseId } },
+        query: { term: { 'case.id': caseId } },
       });
       if ((count.count ?? 0) === 0) return;
     } catch {
@@ -392,7 +392,7 @@ export interface AnalyticsCaseSource {
   // cases are space-isolated). See server `mappings/case.ts`.
   space_id: string;
   owner: string;
-  cases: {
+  case: {
     id: string;
     title: string;
     description?: string;
@@ -483,7 +483,7 @@ export interface ActivityDocSource {
   '@timestamp': string;
   // Top-level singular scoping field, matching the cases surface (DLS).
   space_id: string;
-  cases: { id: string };
+  case: { id: string };
   owner: string;
   actor: {
     username?: string | null;
@@ -514,7 +514,7 @@ export interface AttachmentDocSource {
   '@timestamp': string;
   // Top-level singular scoping field, matching the cases + activity surfaces (DLS).
   space_id: string;
-  cases: { id: string };
+  case: { id: string };
   owner: string;
   created_at: string;
   created_by: {

--- a/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/writer.ts
+++ b/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/analytics_v2/writer.ts
@@ -53,11 +53,11 @@ export default ({ getService }: FtrProviderContext): void => {
       await waitForAnalyticsCase(es, created.id);
       const doc = await getAnalyticsCase(es, created.id);
 
-      expect(doc.cases.id).to.eql(created.id);
-      expect(doc.cases.title).to.eql(created.title);
+      expect(doc.case.id).to.eql(created.id);
+      expect(doc.case.title).to.eql(created.title);
       // Doc-builder converts numeric SO enums to human strings.
-      expect(doc.cases.status).to.eql('open');
-      expect(doc.cases.severity).to.eql('low');
+      expect(doc.case.status).to.eql('open');
+      expect(doc.case.severity).to.eql('low');
       // `getAuthWithSuperUser()` defaults to `space1` → case lives in
       // space1 → analytics doc inherits that namespace (non-default
       // propagation). Top-level singular `space_id` (implicit-privileges
@@ -80,13 +80,13 @@ export default ({ getService }: FtrProviderContext): void => {
       await waitForAnalyticsCaseUpdate(
         es,
         created.id,
-        (source) => source.cases.title === 'updated title'
+        (source) => source.case.title === 'updated title'
       );
 
       // Confirm it's still a single doc, not two — the writer
       // upserts on the same `_id`.
       await es.indices.refresh({ index: '.cases' });
-      const countResult = await es.count({ index: '.cases', q: `cases.id:"${created.id}"` });
+      const countResult = await es.count({ index: '.cases', q: `case.id:"${created.id}"` });
       expect(countResult.count).to.eql(1);
     });
 


### PR DESCRIPTION
## Summary

Renaming `cases` field references to `case`. For example `cases.id` now becomes `case.id`






<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->