### PR TITLE
[Search] Notification center userStorage keys

### DIFF
--- a/x-pack/platform/plugins/shared/notification_center/moon.yml
+++ b/x-pack/platform/plugins/shared/notification_center/moon.yml
@@ -23,6 +23,8 @@ dependsOn:
   - '@kbn/std'
   - '@kbn/core-data-streams-server'
   - '@kbn/core-data-streams-server-mocks'
+  - '@kbn/core-user-storage-server'
+  - '@kbn/core-user-storage-server-mocks'
   - '@kbn/es-mappings'
 tags:
   - plugin

--- a/x-pack/platform/plugins/shared/notification_center/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/plugin.ts
@@ -14,6 +14,7 @@ import type {
 } from '@kbn/core/server';
 import type { NotificationCenterConfig } from './config';
 import { registerNotificationDataStream } from './data_stream/notification_data_stream';
+import { registerNotificationUserStorage } from './user_storage';
 import type {
   NotificationCenterPluginSetup,
   NotificationCenterPluginStart,
@@ -39,10 +40,11 @@ export class NotificationCenterPlugin
   public setup(
     core: CoreSetup<NotificationCenterStartDependencies, NotificationCenterPluginStart>
   ): NotificationCenterPluginSetup {
-    // core gates the plugin on xpack.notificationCenter.enabled; setup runs only when enabled
+    // core gates the plugin on xpack.notificationCenter.enabled;
     this.logger.debug('Setting up Notification Center plugin');
 
     registerNotificationDataStream(core.dataStreams);
+    registerNotificationUserStorage(core.userStorage);
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/notification_center/server/user_storage.test.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/user_storage.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { userStorageServiceMock } from '@kbn/core-user-storage-server-mocks';
+import {
+  registerNotificationUserStorage,
+  readAllBeforeSchema,
+  readSchema,
+  READ_ALL_BEFORE_KEY,
+  READ_KEY,
+  READ_ALL_BEFORE_DEFAULT,
+} from './user_storage';
+
+const collectRegistrations = () => {
+  const userStorage = userStorageServiceMock.createSetupContract();
+  registerNotificationUserStorage(userStorage);
+  expect(userStorage.register).toHaveBeenCalledTimes(1);
+  return userStorage.register.mock.calls[0][0];
+};
+
+describe('notification center user storage', () => {
+  describe('registerNotificationUserStorage', () => {
+    it('registers the read-state keys in a single call', () => {
+      expect(Object.keys(collectRegistrations())).toEqual([READ_ALL_BEFORE_KEY, READ_KEY]);
+    });
+
+    it('registers every key as global with no preload', () => {
+      for (const definition of Object.values(collectRegistrations())) {
+        expect(definition.scope).toBe('global');
+        expect(definition.preload).toBeUndefined();
+      }
+    });
+
+    it('defaults the marker to the epoch sentinel and the delta list to empty', () => {
+      const registrations = collectRegistrations();
+      expect(registrations[READ_ALL_BEFORE_KEY].defaultValue).toBe(READ_ALL_BEFORE_DEFAULT);
+      expect(registrations[READ_KEY].defaultValue).toEqual([]);
+    });
+  });
+
+  // The mock stubs register(), so assert core's invariants here: defaultValue must
+  // parse, and schemas must reject `undefined` (absent-cache) and `null` (tombstone).
+  describe('registration invariants enforced by core', () => {
+    const registrations = Object.entries(collectRegistrations());
+
+    it.each(registrations)('key [%s] has a schema-valid defaultValue', (_key, definition) => {
+      expect(definition.schema.safeParse(definition.defaultValue).success).toBe(true);
+    });
+
+    it.each(registrations)('key [%s] schema rejects undefined', (_key, definition) => {
+      expect(definition.schema.safeParse(undefined).success).toBe(false);
+    });
+
+    it.each(registrations)('key [%s] schema rejects null', (_key, definition) => {
+      expect(definition.schema.safeParse(null).success).toBe(false);
+    });
+  });
+
+  describe('readAllBefore schema', () => {
+    it('accepts an ISO-8601 datetime', () => {
+      expect(readAllBeforeSchema.safeParse('2026-07-09T12:00:00.000Z').success).toBe(true);
+    });
+
+    it('accepts the epoch sentinel', () => {
+      expect(readAllBeforeSchema.safeParse(READ_ALL_BEFORE_DEFAULT).success).toBe(true);
+    });
+
+    it('rejects non-ISO strings', () => {
+      expect(readAllBeforeSchema.safeParse('yesterday').success).toBe(false);
+      expect(readAllBeforeSchema.safeParse('2026-07-09').success).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(readAllBeforeSchema.safeParse(1752060000000).success).toBe(false);
+    });
+  });
+
+  describe('read delta-list schema', () => {
+    it('accepts an array of notification ids', () => {
+      expect(readSchema.safeParse([]).success).toBe(true);
+      expect(readSchema.safeParse(['inference:model-a:eol']).success).toBe(true);
+    });
+
+    it('rejects a non-array', () => {
+      expect(readSchema.safeParse('inference:model-a:eol').success).toBe(false);
+    });
+
+    it('rejects an array holding non-string entries', () => {
+      expect(readSchema.safeParse([1, 2, 3]).success).toBe(false);
+    });
+
+    it('rejects a list past the safety ceiling', () => {
+      const overCeiling = Array.from({ length: 501 }, (_, i) => `id-${i}`);
+      expect(readSchema.safeParse(overCeiling).success).toBe(false);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/notification_center/server/user_storage.test.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/user_storage.test.ts
@@ -35,7 +35,7 @@ describe('notification center user storage', () => {
       }
     });
 
-    it('defaults the marker to the epoch sentinel and the delta list to empty', () => {
+    it('defaults the marker to the epoch default and the read list to empty', () => {
       const registrations = collectRegistrations();
       expect(registrations[READ_ALL_BEFORE_KEY].defaultValue).toBe(READ_ALL_BEFORE_DEFAULT);
       expect(registrations[READ_KEY].defaultValue).toEqual([]);
@@ -65,7 +65,7 @@ describe('notification center user storage', () => {
       expect(readAllBeforeSchema.safeParse('2026-07-09T12:00:00.000Z').success).toBe(true);
     });
 
-    it('accepts the epoch sentinel', () => {
+    it('accepts the epoch default', () => {
       expect(readAllBeforeSchema.safeParse(READ_ALL_BEFORE_DEFAULT).success).toBe(true);
     });
 
@@ -79,7 +79,7 @@ describe('notification center user storage', () => {
     });
   });
 
-  describe('read delta-list schema', () => {
+  describe('read notification ids schema', () => {
     it('accepts an array of notification ids', () => {
       expect(readSchema.safeParse([]).success).toBe(true);
       expect(readSchema.safeParse(['inference:model-a:eol']).success).toBe(true);

--- a/x-pack/platform/plugins/shared/notification_center/server/user_storage.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/user_storage.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { UserStorageServiceSetup } from '@kbn/core-user-storage-server';
+
+/**
+ * Register the user storage keys needed for Notification Center.
+ * This is used to track whether users have marked notifications as read.
+ */
+
+/** Timestamp marker: notifications at or before it are read; also used to ensure
+ * new users are not flooded with notifications.
+ */
+export const READ_ALL_BEFORE_KEY = 'notificationCenter:readAllBefore';
+
+/** Individually-read ids newer than `readAllBefore`;
+ * advancing the readAllBefore marker keeps this within a reasonable size.
+ */
+export const READ_KEY = 'notificationCenter:read';
+
+/** userStorage doesn't allow null defaults for key values, so we use this default to represent an unset state. */
+export const READ_ALL_BEFORE_DEFAULT = '1970-01-01T00:00:00.000Z';
+
+/** Celing for the array of read ids */
+const MAX_READ_IDS = 500;
+
+export const readAllBeforeSchema = z.iso.datetime();
+export const readSchema = z.array(z.string()).max(MAX_READ_IDS);
+
+/** Registers the read-state keys; core throws on a duplicate key, so call once. */
+export const registerNotificationUserStorage = (userStorage: UserStorageServiceSetup) => {
+  userStorage.register({
+    [READ_ALL_BEFORE_KEY]: {
+      schema: readAllBeforeSchema,
+      defaultValue: READ_ALL_BEFORE_DEFAULT,
+      scope: 'global',
+    },
+    [READ_KEY]: {
+      schema: readSchema,
+      defaultValue: [],
+      scope: 'global',
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/notification_center/server/user_storage.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/user_storage.ts
@@ -26,7 +26,7 @@ export const READ_KEY = 'notificationCenter:read';
 /** userStorage doesn't allow null defaults for key values, so we use this default to represent an unset state. */
 export const READ_ALL_BEFORE_DEFAULT = '1970-01-01T00:00:00.000Z';
 
-/** Celing for the array of read ids */
+/** Ceiling for the array of read ids */
 const MAX_READ_IDS = 500;
 
 export const readAllBeforeSchema = z.iso.datetime();

--- a/x-pack/platform/plugins/shared/notification_center/tsconfig.json
+++ b/x-pack/platform/plugins/shared/notification_center/tsconfig.json
@@ -12,6 +12,8 @@
     "@kbn/std",
     "@kbn/core-data-streams-server",
     "@kbn/core-data-streams-server-mocks",
+    "@kbn/core-user-storage-server",
+    "@kbn/core-user-storage-server-mocks",
     "@kbn/es-mappings",
   ]
 }


### PR DESCRIPTION
## Summary

Notification Center plugin must keep track of which notifications a user has read.

This is accomplished via new keys set on the `'@kbn/core-user-storage-server'` 

- `read` tracks individual notification IDs
- `readAllBefore` is a timestamp that will ensure the NC plugin properly filters and displays notifications that are new after this timestamp

If we need more complex logic for read/open state, we can update or add more keys to `userStorage` later.

Added tests that validate the new keys.