### PR TITLE
[8.19][SLO] Preserve selected SLOs when editing alerts embeddable

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALL_VALUE, SLOWithSummaryResponse } from '@kbn/slo-schema';
+import { buildSlo } from '../../../data/slo/slo';
+import { rememberSlos, resolveSelectedSlos, toSloOptionValue } from './slo_selector';
+
+describe('resolveSelectedSlos', () => {
+  const sloA = buildSlo({ id: 'slo-a', name: 'Alpha SLO', instanceId: ALL_VALUE });
+  const sloB = buildSlo({ id: 'slo-b', name: 'Beta SLO', instanceId: ALL_VALUE });
+  const sloC = buildSlo({ id: 'slo-c', name: 'Gamma SLO', instanceId: ALL_VALUE });
+
+  it('keeps previously selected SLOs that are missing from the current search results', () => {
+    const knownSlos = new Map<string, SLOWithSummaryResponse>();
+    // First search page: A and B
+    rememberSlos(knownSlos, [sloA, sloB]);
+    // User selects A and B
+    let selected = resolveSelectedSlos(
+      [
+        { label: sloA.name, value: toSloOptionValue(sloA.id, sloA.instanceId) },
+        { label: sloB.name, value: toSloOptionValue(sloB.id, sloB.instanceId) },
+      ],
+      knownSlos
+    );
+    expect(selected.map((s) => s.id)).toEqual(['slo-a', 'slo-b']);
+
+    // Later search page only returns C — A/B are gone from results but still selected in the UI
+    rememberSlos(knownSlos, [sloC]);
+    selected = resolveSelectedSlos(
+      [
+        { label: sloA.name, value: toSloOptionValue(sloA.id, sloA.instanceId) },
+        { label: sloB.name, value: toSloOptionValue(sloB.id, sloB.instanceId) },
+        { label: sloC.name, value: toSloOptionValue(sloC.id, sloC.instanceId) },
+      ],
+      knownSlos
+    );
+
+    expect(selected.map((s) => s.id)).toEqual(['slo-a', 'slo-b', 'slo-c']);
+  });
+
+  it('preserves initial selections seeded into the known-SLOs cache', () => {
+    const knownSlos = new Map<string, SLOWithSummaryResponse>();
+    rememberSlos(knownSlos, [sloA, sloB]);
+    rememberSlos(knownSlos, [sloC]);
+
+    const selected = resolveSelectedSlos(
+      [
+        { label: sloA.name, value: toSloOptionValue(sloA.id, sloA.instanceId) },
+        { label: sloB.name, value: toSloOptionValue(sloB.id, sloB.instanceId) },
+        { label: sloC.name, value: toSloOptionValue(sloC.id, sloC.instanceId) },
+      ],
+      knownSlos
+    );
+
+    expect(selected.map((s) => s.id)).toEqual(['slo-a', 'slo-b', 'slo-c']);
+  });
+
+  it('returns an empty list when nothing is selected', () => {
+    const knownSlos = new Map<string, SLOWithSummaryResponse>([
+      [toSloOptionValue(sloA.id, sloA.instanceId), sloA],
+    ]);
+    expect(resolveSelectedSlos([], knownSlos)).toEqual([]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.test.tsx
@@ -7,7 +7,13 @@
 
 import { ALL_VALUE, SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { buildSlo } from '../../../data/slo/slo';
-import { rememberSlos, resolveSelectedSlos, toSloOptionValue } from './slo_selector';
+import {
+  buildNameLookup,
+  mapSlosToOptions,
+  rememberSlos,
+  resolveSelectedSlos,
+  toSloOptionValue,
+} from './slo_selector';
 
 describe('resolveSelectedSlos', () => {
   const sloA = buildSlo({ id: 'slo-a', name: 'Alpha SLO', instanceId: ALL_VALUE });
@@ -64,5 +70,57 @@ describe('resolveSelectedSlos', () => {
       [toSloOptionValue(sloA.id, sloA.instanceId), sloA],
     ]);
     expect(resolveSelectedSlos([], knownSlos)).toEqual([]);
+  });
+});
+
+describe('buildNameLookup / mapSlosToOptions', () => {
+  it('refreshes selected option labels from live API names', () => {
+    const stored = {
+      id: 'slo-a',
+      instanceId: ALL_VALUE,
+      name: 'Old name',
+      groupBy: ALL_VALUE,
+    };
+    const live = buildSlo({ id: 'slo-a', name: 'Renamed SLO', instanceId: ALL_VALUE });
+
+    const staleOptions = mapSlosToOptions([stored]);
+    expect(staleOptions[0].label).toBe('Old name');
+
+    const nameLookup = buildNameLookup([live]);
+    const refreshedOptions = mapSlosToOptions([stored], nameLookup);
+    expect(refreshedOptions[0]).toEqual({
+      label: 'Renamed SLO',
+      value: toSloOptionValue('slo-a', ALL_VALUE),
+    });
+  });
+
+  it('applies the live name to a specific instance selection', () => {
+    const stored = {
+      id: 'slo-a',
+      instanceId: 'host-1',
+      name: 'Old name',
+      groupBy: 'host.name',
+    };
+    const live = buildSlo({ id: 'slo-a', name: 'Renamed SLO', instanceId: 'host-1' });
+
+    const nameLookup = buildNameLookup([live]);
+    const options = mapSlosToOptions([stored], nameLookup);
+
+    expect(options[0].label).toBe('Renamed SLO (host-1)');
+  });
+
+  it('uses the definition name for an all-instances selection when only a child instance is returned', () => {
+    const stored = {
+      id: 'slo-a',
+      instanceId: ALL_VALUE,
+      name: 'Old name',
+      groupBy: 'host.name',
+    };
+    const liveInstance = buildSlo({ id: 'slo-a', name: 'Renamed SLO', instanceId: 'host-1' });
+
+    const nameLookup = buildNameLookup([liveInstance]);
+    const options = mapSlosToOptions([stored], nameLookup);
+
+    expect(options[0].label).toBe('Renamed SLO');
   });
 });

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.tsx
@@ -26,6 +26,8 @@ const SLO_REQUIRED = i18n.translate('xpack.slo.sloEmbeddable.config.errors.sloRe
 
 export const toSloOptionValue = (sloId: string, instanceId: string) => `${sloId}-${instanceId}`;
 
+export type SloNameLookup = Map<string, { name: string }>;
+
 /**
  * Resolves combo-box selections against a cache of known SLOs.
  * Avoids filtering against the current async search page, which drops prior
@@ -52,19 +54,63 @@ export function rememberSlos(
   });
 }
 
-export function SloSelector({ initialSlos, onSelected, hasError, singleSelection }: Props) {
-  const mapSlosToOptions = (slos: SloItem[] | SLOWithSummaryResponse[] | undefined) =>
-    slos?.map((slo) => ({
-      label: slo.instanceId !== ALL_VALUE ? `${slo.name} (${slo.instanceId})` : slo.name,
-      value: toSloOptionValue(slo.id, slo.instanceId),
-    })) ?? [];
+/** Build option labels from stored SLO items, optionally overriding names from a live lookup. */
+export function mapSlosToOptions(
+  slos: SloItem[] | SLOWithSummaryResponse[] | undefined,
+  nameLookup?: SloNameLookup
+): Array<EuiComboBoxOptionOption<string>> {
+  return (
+    slos?.map((slo) => {
+      const value = toSloOptionValue(slo.id, slo.instanceId);
+      const name = nameLookup?.get(value)?.name ?? slo.name;
+      return {
+        label: slo.instanceId !== ALL_VALUE ? `${name} (${slo.instanceId})` : name,
+        value,
+      };
+    }) ?? []
+  );
+}
 
+/** Map API results to option-value -> current name for selected SLOs (including `*` instances). */
+export function buildNameLookup(results: SLOWithSummaryResponse[]): SloNameLookup {
+  const map: SloNameLookup = new Map();
+  for (const slo of results) {
+    const key = toSloOptionValue(slo.id, slo.instanceId);
+    if (!map.has(key)) {
+      map.set(key, { name: slo.name });
+    }
+    const starKey = toSloOptionValue(slo.id, ALL_VALUE);
+    if (!map.has(starKey)) {
+      map.set(starKey, { name: slo.name });
+    }
+  }
+  return map;
+}
+
+export function SloSelector({ initialSlos, onSelected, hasError, singleSelection }: Props) {
   const [options, setOptions] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const [selectedOptions, setSelectedOptions] = useState<Array<EuiComboBoxOptionOption<string>>>(
-    mapSlosToOptions(initialSlos)
+    () => mapSlosToOptions(initialSlos)
   );
   const [searchValue, setSearchValue] = useState<string>('');
   const query = `${searchValue}*`;
+
+  const initialSloIds = useMemo(
+    () => (initialSlos?.length ? [...new Set(initialSlos.map((slo) => slo.id))] : []),
+    [initialSlos]
+  );
+  const initialKql = useMemo(
+    () => initialSloIds.map((id) => `slo.id:"${id}"`).join(' or '),
+    [initialSloIds]
+  );
+
+  // Fetch current names for already-selected SLOs so renames show up when reopening config.
+  const { data: initialSlosData } = useFetchSloList({
+    kqlQuery: initialKql,
+    perPage: Math.max(100, initialSloIds.length * 2),
+    disabled: initialSloIds.length === 0,
+  });
+
   const { isLoading, data: sloList } = useFetchSloList({
     kqlQuery: `slo.name: (${query}) or slo.instanceId.text: (${query})`,
     perPage: 100,
@@ -72,9 +118,24 @@ export function SloSelector({ initialSlos, onSelected, hasError, singleSelection
 
   const knownSlosRef = useRef<Map<string, SLOWithSummaryResponse>>(new Map());
 
+  const nameLookup = useMemo(() => {
+    if (!initialSlosData?.results?.length) {
+      return null;
+    }
+    return buildNameLookup(initialSlosData.results);
+  }, [initialSlosData]);
+
   useEffect(() => {
     rememberSlos(knownSlosRef.current, initialSlos);
   }, [initialSlos]);
+
+  useEffect(() => {
+    if (!initialSlos?.length || !nameLookup) {
+      return;
+    }
+    rememberSlos(knownSlosRef.current, initialSlosData?.results);
+    setSelectedOptions(mapSlosToOptions(initialSlos, nameLookup));
+  }, [initialSlos, initialSlosData?.results, nameLookup]);
 
   useEffect(() => {
     const isLoadedWithData = !isLoading && sloList?.results !== undefined;

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { debounce } from 'lodash';
@@ -23,11 +23,40 @@ interface Props {
 const SLO_REQUIRED = i18n.translate('xpack.slo.sloEmbeddable.config.errors.sloRequired', {
   defaultMessage: 'SLO is required.',
 });
+
+export const toSloOptionValue = (sloId: string, instanceId: string) => `${sloId}-${instanceId}`;
+
+/**
+ * Resolves combo-box selections against a cache of known SLOs.
+ * Avoids filtering against the current async search page, which drops prior
+ * selections that are no longer in `sloList.results` (see #222637).
+ */
+export function resolveSelectedSlos(
+  opts: Array<EuiComboBoxOptionOption<string>>,
+  knownSlos: Map<string, SLOWithSummaryResponse>
+): SLOWithSummaryResponse[] {
+  return opts
+    .map((opt) => knownSlos.get(opt.value ?? ''))
+    .filter((slo): slo is SLOWithSummaryResponse => slo !== undefined);
+}
+
+export function rememberSlos(
+  knownSlos: Map<string, SLOWithSummaryResponse>,
+  slos: Array<SloItem | SLOWithSummaryResponse> | undefined
+): void {
+  slos?.forEach((slo) => {
+    knownSlos.set(
+      toSloOptionValue(slo.id, slo.instanceId),
+      slo as unknown as SLOWithSummaryResponse
+    );
+  });
+}
+
 export function SloSelector({ initialSlos, onSelected, hasError, singleSelection }: Props) {
   const mapSlosToOptions = (slos: SloItem[] | SLOWithSummaryResponse[] | undefined) =>
     slos?.map((slo) => ({
       label: slo.instanceId !== ALL_VALUE ? `${slo.name} (${slo.instanceId})` : slo.name,
-      value: `${slo.id}-${slo.instanceId}`,
+      value: toSloOptionValue(slo.id, slo.instanceId),
     })) ?? [];
 
   const [options, setOptions] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
@@ -41,23 +70,32 @@ export function SloSelector({ initialSlos, onSelected, hasError, singleSelection
     perPage: 100,
   });
 
+  const knownSlosRef = useRef<Map<string, SLOWithSummaryResponse>>(new Map());
+
+  useEffect(() => {
+    rememberSlos(knownSlosRef.current, initialSlos);
+  }, [initialSlos]);
+
   useEffect(() => {
     const isLoadedWithData = !isLoading && sloList?.results !== undefined;
     const opts: Array<EuiComboBoxOptionOption<string>> = isLoadedWithData
       ? mapSlosToOptions(sloList?.results)
       : [];
     setOptions(opts);
+    rememberSlos(knownSlosRef.current, sloList?.results);
   }, [isLoading, sloList]);
 
   const onChange = (opts: Array<EuiComboBoxOptionOption<string>>) => {
     setSelectedOptions(opts);
-    const selectedSlos =
-      opts.length >= 1
-        ? sloList!.results?.filter((slo) =>
-            opts.find((opt) => opt.value === `${slo.id}-${slo.instanceId}`)
-          )
-        : undefined;
-    onSelected(singleSelection ? selectedSlos?.[0] : selectedSlos);
+    rememberSlos(knownSlosRef.current, sloList?.results);
+
+    if (opts.length < 1) {
+      onSelected(undefined);
+      return;
+    }
+
+    const selectedSlos = resolveSelectedSlos(opts, knownSlosRef.current);
+    onSelected(singleSelection ? selectedSlos[0] : selectedSlos);
   };
 
   const onSearchChange = useMemo(


### PR DESCRIPTION
## Summary


- Fixes [#222637](https://github.com/elastic/kibana/issues/222637) on 8.19: editing Included SLOs in the dashboard SLO Alerts panel no longer drops previously selected SLOs when confirming/saving.
- Root cause: `SloSelector` resolved the combo-box selection by filtering against the current async search results, so prior picks missing from that page were discarded.
- Targeted 8.19 backport of the selection-preservation behavior from [#256570](https://github.com/elastic/kibana/pull/256570) (main/9.4 schema rewrite). Does **not** bring the dashboards-as-code schema change; keeps the existing `id`/`instanceId`/`name`/`groupBy` saved state.

Before
https://github.com/user-attachments/assets/81ce522b-fd57-4f1e-82c1-8379d18ef38a

After
https://github.com/user-attachments/assets/41ae1f57-4075-42d9-a79b-1b07cbb7d025


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

## Test plan
- [ ] Create a dashboard, add **SLO Alerts** panel, select several SLOs, confirm
- [ ] Re-open Included SLOs, search for a different SLO, add it, confirm — previous selections remain
- [ ] Repeat edit/confirm a few times; all selected SLOs stay in the panel after dashboard save
- [ ] Unit: `node scripts/jest x-pack/solutions/observability/plugins/slo/public/embeddable/slo/alerts/slo_selector.test.tsx`


Made with [Cursor](https://cursor.com)