### PR TITLE
[Entity Analytics] Fix Threat hunting leads AI connector

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
@@ -207,11 +207,13 @@ describe('TopThreatHuntingLeads', () => {
     expect(screen.queryByTestId('generateLeadsButton')).not.toBeInTheDocument();
   });
 
-  it('shows disabled "Generate" and Options under Agent experience when no valid connector is selected', () => {
+  it('shows disabled "Generate" and Options under Agent experience when no connector is available', () => {
     render(<TopThreatHuntingLeads {...defaultProps} connectorId="" hasValidConnector={false} />);
 
     expect(
-      screen.getByText('Select a connector from Options to start generating leads')
+      screen.getByText(
+        'No AI connector configured. Add a connector in Options to start generating leads'
+      )
     ).toBeInTheDocument();
     expect(screen.queryByTestId('openGenAiSettingsButton')).not.toBeInTheDocument();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
@@ -207,11 +207,18 @@ describe('TopThreatHuntingLeads', () => {
     expect(screen.queryByTestId('generateLeadsButton')).not.toBeInTheDocument();
   });
 
-  it('shows "Open GenAI Settings" button (not "Generate") under Agent experience when no valid connector is selected', () => {
+  it('shows disabled "Generate" and Options under Agent experience when no valid connector is selected', () => {
     render(<TopThreatHuntingLeads {...defaultProps} connectorId="" hasValidConnector={false} />);
 
-    expect(screen.getByTestId('openGenAiSettingsButton')).toBeInTheDocument();
-    expect(screen.queryByTestId('generateLeadsButton')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Select a connector from Options to start generating leads')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('openGenAiSettingsButton')).not.toBeInTheDocument();
+
+    const generateButton = screen.getByTestId('generateLeadsButton');
+    expect(generateButton).toBeInTheDocument();
+    expect(generateButton).toBeDisabled();
+    expect(screen.getByTestId('leadsOptionsButton')).toBeInTheDocument();
   });
 
   it('shows "Generate" button when no leads exist and calls onGenerate', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
@@ -111,14 +111,16 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
   const { getUrlForApp } = useKibana().services.application;
   const genAiSettingsUrl = getUrlForApp('management', { path: '/ai/genAiSettings' });
 
+  const isAgentChatExperienceDisabled = !isAgentChatExperienceEnabled;
+  const hasNoConnectorSelected = isAgentChatExperienceEnabled && !hasValidConnector;
   const generateTooltipContent = hasWritePermissionError
     ? i18n.GENERATE_DISABLED_NO_WRITE_PERMISSION_TOOLTIP
+    : hasNoConnectorSelected
+    ? i18n.GENERATE_DISABLED_NO_CONNECTOR_TOOLTIP
     : undefined;
-  const isGenerateDisabled = !!hasWritePermissionError;
+  const isGenerateDisabled = !!hasWritePermissionError || hasNoConnectorSelected;
   const renderCount = Math.min(leads.length, visibleCardCount);
   const hasFewLeads = leads.length < visibleCardCount;
-  const noConnector = !isAgentChatExperienceEnabled || !hasValidConnector;
-
   const openGenAiSettingsButton = (
     <EuiButton
       size="s"
@@ -229,11 +231,13 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
       ? i18n.GENERATING_LEADS_DESCRIPTION
       : hasGenerated
       ? i18n.NO_DATA_DESCRIPTION
-      : noConnector
+      : isAgentChatExperienceDisabled
       ? i18n.NO_CONNECTOR_DESCRIPTION
+      : hasNoConnectorSelected
+      ? i18n.NO_CONNECTOR_SELECTED_DESCRIPTION
       : i18n.NO_LEADS_DESCRIPTION;
 
-    const actions = isGenerating ? undefined : noConnector ? (
+    const actions = isGenerating ? undefined : isAgentChatExperienceDisabled ? (
       openGenAiSettingsButton
     ) : (
       <>
@@ -307,17 +311,13 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
             {leads.length > 0 && (
               <EuiFlexItem grow={false}>
                 <EuiToolTip
-                  content={
-                    hasWritePermissionError
-                      ? i18n.GENERATE_DISABLED_NO_WRITE_PERMISSION_TOOLTIP
-                      : undefined
-                  }
+                  content={generateTooltipContent}
                 >
                   <EuiButtonEmpty
                     size="s"
                     iconType="refresh"
                     isLoading={isGenerating}
-                    isDisabled={!!hasWritePermissionError}
+                    isDisabled={isGenerateDisabled}
                     onClick={onGenerate}
                     data-test-subj="refreshLeadsButton"
                   >

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
@@ -310,9 +310,7 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
             )}
             {leads.length > 0 && (
               <EuiFlexItem grow={false}>
-                <EuiToolTip
-                  content={generateTooltipContent}
-                >
+                <EuiToolTip content={generateTooltipContent}>
                   <EuiButtonEmpty
                     size="s"
                     iconType="refresh"

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
@@ -232,7 +232,7 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
       : hasGenerated
       ? i18n.NO_DATA_DESCRIPTION
       : isAgentChatExperienceDisabled
-      ? i18n.NO_CONNECTOR_DESCRIPTION
+      ? i18n.NO_AGENT_CHAT_EXPERIENCE_DESCRIPTION
       : hasNoConnectorSelected
       ? i18n.NO_CONNECTOR_SELECTED_DESCRIPTION
       : i18n.NO_LEADS_DESCRIPTION;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/shared_lead_components.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/shared_lead_components.tsx
@@ -18,7 +18,6 @@ import { getOpenEntityFlyoutLabel, VIEW_ENTITY_DETAILS } from './translations';
 import { getEntityIcon } from './utils';
 
 const ENTITY_BADGE_NAME_CLASS = 'leadEntityBadge__name';
-const ENTITY_BADGE_NAME_MAX_WIDTH = 220;
 
 // Lets the badge shrink below its content width (rather than overflowing the
 // card) when the surrounding card/panel is narrower than the badge's natural
@@ -67,7 +66,7 @@ export const EntityBadge: React.FC<EntityBadgeProps> = ({ entity, scopeId }) => 
           font-weight: ${euiTheme.font.weight.medium};
           display: inline-block;
           min-width: 0;
-          max-width: min(${ENTITY_BADGE_NAME_MAX_WIDTH}px, 100%);
+          max-width: 100%;
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
@@ -124,7 +123,16 @@ export const EntityBadge: React.FC<EntityBadgeProps> = ({ entity, scopeId }) => 
   // sit inside other clickable elements (cards/panels) that are themselves
   // rendered as `<button>`, and nested buttons are invalid HTML.
   return (
-    <EuiToolTip content={VIEW_ENTITY_DETAILS} position="top">
+    <EuiToolTip
+      content={VIEW_ENTITY_DETAILS}
+      position="top"
+      // EuiToolTip's anchor wrapper defaults to `display: inline-block`, which
+      // sizes itself to its own preferred content width rather than
+      // respecting the badge's `max-width: 100%` below it, letting long names
+      // overflow their container. `inline` lets it flow within the
+      // surrounding line box instead, so the max-width constraint applies.
+      anchorProps={{ style: { display: 'inline' } }}
+    >
       <span
         role="button"
         tabIndex={0}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
@@ -218,8 +218,8 @@ export const OPEN_GENAI_SETTINGS = i18n.translate(
   { defaultMessage: 'Open GenAI settings' }
 );
 
-export const NO_CONNECTOR_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.entityAnalytics.threatHunting.noConnectorDescription',
+export const NO_AGENT_CHAT_EXPERIENCE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.threatHunting.noAgentChatExperienceDescription',
   {
     defaultMessage: 'Enable AI Agent as your default chat experience to start generating leads',
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
@@ -228,7 +228,8 @@ export const NO_CONNECTOR_DESCRIPTION = i18n.translate(
 export const NO_CONNECTOR_SELECTED_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.entityAnalytics.threatHunting.noConnectorSelectedDescription',
   {
-    defaultMessage: 'Select a connector from Options to start generating leads',
+    defaultMessage:
+      'No AI connector configured. Add a connector in Options to start generating leads',
   }
 );
 
@@ -247,7 +248,7 @@ export const GENERATE_DISABLED_NO_WRITE_PERMISSION_TOOLTIP = i18n.translate(
 
 export const GENERATE_DISABLED_NO_CONNECTOR_TOOLTIP = i18n.translate(
   'xpack.securitySolution.entityAnalytics.threatHunting.leads.generateDisabledNoConnectorTooltip',
-  { defaultMessage: 'Select a connector from Options to enable lead generation' }
+  { defaultMessage: 'Add a connector in Options to enable lead generation' }
 );
 
 export const getStalenessLabel = (staleness: string): string => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
@@ -225,6 +225,13 @@ export const NO_CONNECTOR_DESCRIPTION = i18n.translate(
   }
 );
 
+export const NO_CONNECTOR_SELECTED_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.threatHunting.noConnectorSelectedDescription',
+  {
+    defaultMessage: 'Select a connector from Options to start generating leads',
+  }
+);
+
 export const SCHEDULE_UPDATE_ERROR = i18n.translate(
   'xpack.securitySolution.entityAnalytics.threatHunting.leads.scheduleUpdateError',
   { defaultMessage: 'Failed to update schedule' }
@@ -236,6 +243,11 @@ export const GENERATE_DISABLED_NO_WRITE_PERMISSION_TOOLTIP = i18n.translate(
     defaultMessage: "You don't have write access to the {index} index",
     values: { index: LEADS_INDEX_PATTERN },
   }
+);
+
+export const GENERATE_DISABLED_NO_CONNECTOR_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.threatHunting.leads.generateDisabledNoConnectorTooltip',
+  { defaultMessage: 'Select a connector from Options to enable lead generation' }
 );
 
 export const getStalenessLabel = (staleness: string): string => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { useLoadConnectors } from '@kbn/inference-connectors';
+import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
 import { EntityAnalyticsHomePage } from './entity_analytics_home_page';
 import { TestProviders, kibanaMock } from '../../common/mock';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
@@ -20,6 +22,7 @@ import { useEntityStoreDataView } from '../components/home/use_entity_store_data
 import { HUNT_WITH_AI_PROMPT } from '../prompts';
 import { EntityEventTypes } from '../../common/lib/telemetry';
 import type { StartServices } from '../../types';
+import { useStoredAssistantConnectorId } from '../../onboarding/components/hooks/use_stored_state';
 
 jest.mock('../../common/components/links/link_props', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -52,6 +55,9 @@ jest.mock('../../common/hooks/use_experimental_features', () => ({
 }));
 
 jest.mock('../../common/hooks/use_license');
+jest.mock('@kbn/inference-connectors', () => ({
+  useLoadConnectors: jest.fn(() => ({ data: [] })),
+}));
 
 jest.mock('../../data_view_manager/hooks/use_data_view', () => ({
   useDataView: jest.fn(() => ({
@@ -182,6 +188,8 @@ const mockUseMissingRiskEnginePrivileges = useMissingRiskEnginePrivileges as jes
 const mockUseEntityEnginePrivileges = useEntityEnginePrivileges as jest.Mock;
 const mockUseLeadGenerationPrivileges = useLeadGenerationPrivileges as jest.Mock;
 const mockUseHuntingLeads = useHuntingLeads as jest.Mock;
+const mockUseLoadConnectors = useLoadConnectors as jest.Mock;
+const mockUseStoredAssistantConnectorId = useStoredAssistantConnectorId as jest.Mock;
 
 describe('EntityAnalyticsHomePage', () => {
   beforeEach(() => {
@@ -229,6 +237,9 @@ describe('EntityAnalyticsHomePage', () => {
       readPermissionError: false,
       writePermissionError: false,
     });
+
+    mockUseLoadConnectors.mockReturnValue({ data: [] });
+    mockUseStoredAssistantConnectorId.mockReturnValue(['', jest.fn()]);
   });
 
   it('renders the page title', () => {
@@ -632,5 +643,107 @@ describe('EntityAnalyticsHomePage', () => {
       autoSendInitialMessage: false,
       sessionTag: 'security',
     });
+  });
+
+  it('prefers the stored connector over global default connector when both are valid', () => {
+    mockUseStoredAssistantConnectorId.mockReturnValue(['stored-connector-id', jest.fn()]);
+    mockUseLoadConnectors.mockReturnValue({
+      data: [{ id: 'stored-connector-id' }, { id: 'global-connector-id' }],
+    });
+
+    const startServices = {
+      ...kibanaMock,
+      settings: {
+        ...kibanaMock.settings,
+        client: {
+          ...kibanaMock.settings.client,
+          get: jest.fn((settingKey: string, defaultValue?: unknown) =>
+            settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR
+              ? 'global-connector-id'
+              : defaultValue
+          ),
+        },
+      },
+    } as unknown as StartServices;
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      {
+        wrapper: ({ children }) => (
+          <TestProviders startServices={startServices}>{children}</TestProviders>
+        ),
+      }
+    );
+
+    const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);
+    expect(latestHookCall?.[0]).toBe('stored-connector-id');
+  });
+
+  it('falls back to global default connector when no stored connector is set', () => {
+    mockUseStoredAssistantConnectorId.mockReturnValue(['', jest.fn()]);
+    mockUseLoadConnectors.mockReturnValue({ data: [{ id: 'global-connector-id' }] });
+
+    const startServices = {
+      ...kibanaMock,
+      settings: {
+        ...kibanaMock.settings,
+        client: {
+          ...kibanaMock.settings.client,
+          get: jest.fn((settingKey: string, defaultValue?: unknown) =>
+            settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR
+              ? 'global-connector-id'
+              : defaultValue
+          ),
+        },
+      },
+    } as unknown as StartServices;
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      {
+        wrapper: ({ children }) => (
+          <TestProviders startServices={startServices}>{children}</TestProviders>
+        ),
+      }
+    );
+
+    const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);
+    expect(latestHookCall?.[0]).toBe('global-connector-id');
+  });
+
+  it('does not fall back to the first available connector when stored and global defaults are unset', () => {
+    mockUseStoredAssistantConnectorId.mockReturnValue(['', jest.fn()]);
+    mockUseLoadConnectors.mockReturnValue({ data: [{ id: 'arbitrary-connector-id' }] });
+
+    const startServices = {
+      ...kibanaMock,
+      settings: {
+        ...kibanaMock.settings,
+        client: {
+          ...kibanaMock.settings.client,
+          get: jest.fn((settingKey: string, defaultValue?: unknown) =>
+            settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR ? undefined : defaultValue
+          ),
+        },
+      },
+    } as unknown as StartServices;
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      {
+        wrapper: ({ children }) => (
+          <TestProviders startServices={startServices}>{children}</TestProviders>
+        ),
+      }
+    );
+
+    const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);
+    expect(latestHookCall?.[0]).toBe('');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { useLoadConnectors } from '@kbn/inference-connectors';
-import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
 import { EntityAnalyticsHomePage } from './entity_analytics_home_page';
 import { TestProviders, kibanaMock } from '../../common/mock';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
@@ -645,102 +644,64 @@ describe('EntityAnalyticsHomePage', () => {
     });
   });
 
-  it('prefers the stored connector over global default connector when both are valid', () => {
+  it('prefers the stored connector when it is still a valid lead_generation connector', () => {
     mockUseStoredAssistantConnectorId.mockReturnValue(['stored-connector-id', jest.fn()]);
     mockUseLoadConnectors.mockReturnValue({
-      data: [{ id: 'stored-connector-id' }, { id: 'global-connector-id' }],
+      data: [{ id: 'first-resolved-id' }, { id: 'stored-connector-id' }],
     });
-
-    const startServices = {
-      ...kibanaMock,
-      settings: {
-        ...kibanaMock.settings,
-        client: {
-          ...kibanaMock.settings.client,
-          get: jest.fn((settingKey: string, defaultValue?: unknown) =>
-            settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR
-              ? 'global-connector-id'
-              : defaultValue
-          ),
-        },
-      },
-    } as unknown as StartServices;
 
     render(
       <MemoryRouter>
         <EntityAnalyticsHomePage />
       </MemoryRouter>,
-      {
-        wrapper: ({ children }) => (
-          <TestProviders startServices={startServices}>{children}</TestProviders>
-        ),
-      }
+      { wrapper: TestProviders }
     );
 
     const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);
     expect(latestHookCall?.[0]).toBe('stored-connector-id');
   });
 
-  it('falls back to global default connector when no stored connector is set', () => {
+  it('falls back to the first resolved connector on first run when nothing is stored', () => {
     mockUseStoredAssistantConnectorId.mockReturnValue(['', jest.fn()]);
-    mockUseLoadConnectors.mockReturnValue({ data: [{ id: 'global-connector-id' }] });
-
-    const startServices = {
-      ...kibanaMock,
-      settings: {
-        ...kibanaMock.settings,
-        client: {
-          ...kibanaMock.settings.client,
-          get: jest.fn((settingKey: string, defaultValue?: unknown) =>
-            settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR
-              ? 'global-connector-id'
-              : defaultValue
-          ),
-        },
-      },
-    } as unknown as StartServices;
+    mockUseLoadConnectors.mockReturnValue({
+      data: [{ id: 'first-resolved-id' }, { id: 'other-id' }],
+    });
 
     render(
       <MemoryRouter>
         <EntityAnalyticsHomePage />
       </MemoryRouter>,
-      {
-        wrapper: ({ children }) => (
-          <TestProviders startServices={startServices}>{children}</TestProviders>
-        ),
-      }
+      { wrapper: TestProviders }
     );
 
     const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);
-    expect(latestHookCall?.[0]).toBe('global-connector-id');
+    expect(latestHookCall?.[0]).toBe('first-resolved-id');
   });
 
-  it('does not fall back to the first available connector when stored and global defaults are unset', () => {
-    mockUseStoredAssistantConnectorId.mockReturnValue(['', jest.fn()]);
-    mockUseLoadConnectors.mockReturnValue({ data: [{ id: 'arbitrary-connector-id' }] });
-
-    const startServices = {
-      ...kibanaMock,
-      settings: {
-        ...kibanaMock.settings,
-        client: {
-          ...kibanaMock.settings.client,
-          get: jest.fn((settingKey: string, defaultValue?: unknown) =>
-            settingKey === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR ? undefined : defaultValue
-          ),
-        },
-      },
-    } as unknown as StartServices;
+  it('falls back to the first resolved connector when the stored connector is no longer available', () => {
+    mockUseStoredAssistantConnectorId.mockReturnValue(['deleted-connector-id', jest.fn()]);
+    mockUseLoadConnectors.mockReturnValue({ data: [{ id: 'first-resolved-id' }] });
 
     render(
       <MemoryRouter>
         <EntityAnalyticsHomePage />
       </MemoryRouter>,
-      {
-        wrapper: ({ children }) => (
-          <TestProviders startServices={startServices}>{children}</TestProviders>
-        ),
-      }
+      { wrapper: TestProviders }
+    );
+
+    const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);
+    expect(latestHookCall?.[0]).toBe('first-resolved-id');
+  });
+
+  it('resolves to an empty connector only when no lead_generation connector exists', () => {
+    mockUseStoredAssistantConnectorId.mockReturnValue(['', jest.fn()]);
+    mockUseLoadConnectors.mockReturnValue({ data: [] });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
     );
 
     const latestHookCall = mockUseHuntingLeads.mock.calls.at(-1);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -20,7 +20,6 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useLoadConnectors } from '@kbn/inference-connectors';
-import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
 import { useQueryClient } from '@kbn/react-query';
 import { useOnAssetCriticalityToolEvent } from '../hooks/use_on_asset_criticality_tool_event';
 import { SecurityPageName } from '../../app/types';
@@ -136,7 +135,7 @@ export const EntityAnalyticsHomePage = () => {
 };
 
 const EntityAnalyticsHomePageContent = () => {
-  const { telemetry, agentBuilder, http, settings } = useKibana().services;
+  const { telemetry, agentBuilder, http } = useKibana().services;
   const { isAgentChatExperienceEnabled } = useAgentBuilderAvailability();
   const queryClient = useQueryClient();
 
@@ -153,19 +152,21 @@ const EntityAnalyticsHomePageContent = () => {
 
   const resolvedSpaceId = spaceId ?? 'default';
   const [storedConnectorId, setStoredConnectorId] = useStoredAssistantConnectorId(resolvedSpaceId);
-  const defaultConnectorId = settings.client.get<string | undefined>(
-    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
-    undefined
-  );
+  // Mirror the entity details flyout "Generate" behavior: prefer the stored
+  // Options selection when it is still valid, otherwise fall back to the first
+  // connector resolved for the lead_generation feature. The server orders that
+  // list by Feature Settings (a feature-specific override, else the Global
+  // model), so the fallback follows those settings rather than an arbitrary
+  // pick. Only when no connector exists at all does this resolve to ''.
   const connectorId = useMemo(() => {
-    const storedConnectorCandidate = spaceId ? storedConnectorId : undefined;
-    const candidates = [storedConnectorCandidate, defaultConnectorId];
-
-    return (
-      candidates.find((id) => id && availableConnectors?.some((connector) => connector.id === id)) ??
-      ''
-    );
-  }, [availableConnectors, defaultConnectorId, spaceId, storedConnectorId]);
+    if (!availableConnectors?.length) {
+      return '';
+    }
+    const storedConnector = spaceId
+      ? availableConnectors.find((connector) => connector.id === storedConnectorId)
+      : undefined;
+    return storedConnector?.id ?? availableConnectors[0]?.id ?? '';
+  }, [availableConnectors, spaceId, storedConnectorId]);
   const hasValidConnector = connectorId !== '';
   const safeSetConnectorId = useCallback(
     (id: string | undefined) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -20,6 +20,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useLoadConnectors } from '@kbn/inference-connectors';
+import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
 import { useQueryClient } from '@kbn/react-query';
 import { useOnAssetCriticalityToolEvent } from '../hooks/use_on_asset_criticality_tool_event';
 import { SecurityPageName } from '../../app/types';
@@ -135,7 +136,7 @@ export const EntityAnalyticsHomePage = () => {
 };
 
 const EntityAnalyticsHomePageContent = () => {
-  const { telemetry, agentBuilder, http } = useKibana().services;
+  const { telemetry, agentBuilder, http, settings } = useKibana().services;
   const { isAgentChatExperienceEnabled } = useAgentBuilderAvailability();
   const queryClient = useQueryClient();
 
@@ -152,8 +153,20 @@ const EntityAnalyticsHomePageContent = () => {
 
   const resolvedSpaceId = spaceId ?? 'default';
   const [storedConnectorId, setStoredConnectorId] = useStoredAssistantConnectorId(resolvedSpaceId);
-  const connectorId = spaceId ? storedConnectorId ?? '' : '';
-  const hasValidConnector = !!availableConnectors?.find((c) => c.id === connectorId);
+  const defaultConnectorId = settings.client.get<string | undefined>(
+    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+    undefined
+  );
+  const connectorId = useMemo(() => {
+    const storedConnectorCandidate = spaceId ? storedConnectorId : undefined;
+    const candidates = [storedConnectorCandidate, defaultConnectorId];
+
+    return (
+      candidates.find((id) => id && availableConnectors?.some((connector) => connector.id === id)) ??
+      ''
+    );
+  }, [availableConnectors, defaultConnectorId, spaceId, storedConnectorId]);
+  const hasValidConnector = connectorId !== '';
   const safeSetConnectorId = useCallback(
     (id: string | undefined) => {
       if (spaceId) {


### PR DESCRIPTION
## Summary

Fixes the UI flow when the AI chat experience is enabled but no connector is selected for generating leads. Instead of showing an "Open GenAI Settings" button on the first run, it shows an enabled "Generate" button, and only when there is no available connector at all is that a disabled "Generate" button is displayed alongside "Options" and a message guiding users to select a connector from the options.

Enhances the logic for determining the active AI connector, prioritizing a space-specific stored connector over the global default connector, mirroring the logic on the Entities Flyout.

## Screenshots

When AI Agent is enabled, but no connectors are configured it shows a disabled generate button with "selected model"

<img width="1512" height="869" alt="image" src="https://github.com/user-attachments/assets/36c9e10c-2320-44c5-9d01-4bbd8afabb75" />

When AI Agent is enabled, and connectors are configured, the Generate button is always enabled, and the connectors options follows the Threat Hunting Lead Generation settings

<img width="1498" height="862" alt="image" src="https://github.com/user-attachments/assets/80be3a44-cb24-4a5d-9e6b-d9acc76d0370" />

<img width="1479" height="719" alt="image" src="https://github.com/user-attachments/assets/55fa8a03-07b3-497d-8ac8-4b50c5810836" />

Only when AI Assistant is enabled, it shows the message to Enable AI Agent

<img width="1496" height="859" alt="image" src="https://github.com/user-attachments/assets/0194580f-c2d1-400f-aece-1feb6a35cd68" />


It also includes a minor styling fix to entity badges to ensure long names truncate correctly within their container and tooltips render appropriately.

<img width="1499" height="862" alt="image" src="https://github.com/user-attachments/assets/15039c22-d4f9-4b43-9526-f25a33484cfb" />



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->