### PR TITLE
[9.4] [Dashboard][a11y] Return focus to triggering element when panel config flyout closes (#276475)

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_util/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_util/index.ts
@@ -8,4 +8,5 @@
  */
 
 export { openLazyFlyout } from './src/open_lazy_flyout';
+export { getPanelContextMenuTriggerId } from './src/focus_helpers';
 export { tracksOverlays, type TracksOverlays } from './src/tracks_overlays';

--- a/src/platform/packages/shared/presentation/presentation_util/src/focus_helpers.test.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/focus_helpers.test.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { focusFirstFocusable } from './focus_helpers';
+
+describe('focusFirstFocusable', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('focuses the first focusable descendant of the target', () => {
+    const container = document.createElement('div');
+    const button = document.createElement('button');
+    container.appendChild(button);
+    document.body.appendChild(container);
+
+    focusFirstFocusable(container);
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('focuses the target itself when it is focusable', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    focusFirstFocusable(button);
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('does nothing when the resolved target is null', () => {
+    const previouslyFocused = document.createElement('input');
+    document.body.appendChild(previouslyFocused);
+    previouslyFocused.focus();
+
+    focusFirstFocusable(null);
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(previouslyFocused);
+  });
+
+  it('resolves the target lazily inside the deferred callback', () => {
+    // The element only exists by the time the deferred focus runs, mirroring a
+    // trigger that is re-rendered after focus is requested.
+    focusFirstFocusable(() => document.getElementById('deferred'));
+
+    const button = document.createElement('button');
+    button.id = 'deferred';
+    document.body.appendChild(button);
+
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('does not steal focus when it is already inside the target', () => {
+    const container = document.createElement('div');
+    const outerButton = document.createElement('button');
+    const innerButton = document.createElement('button');
+    container.appendChild(outerButton);
+    container.appendChild(innerButton);
+    document.body.appendChild(container);
+
+    innerButton.focus();
+
+    focusFirstFocusable(container);
+    jest.runAllTimers();
+
+    // focus stays on the already-focused descendant instead of jumping to the first one
+    expect(document.activeElement).toBe(innerButton);
+  });
+
+  describe('when the target is hidden with visibility: hidden', () => {
+    it('temporarily overrides visibility so the focus lands', () => {
+      const hiddenContainer = document.createElement('div');
+      hiddenContainer.style.visibility = 'hidden';
+      const button = document.createElement('button');
+      hiddenContainer.appendChild(button);
+      document.body.appendChild(hiddenContainer);
+
+      focusFirstFocusable(hiddenContainer);
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(button);
+      // the focusable element's own visibility is overridden so it can receive focus,
+      // while the hidden ancestor is left untouched
+      expect(button.style.visibility).toBe('visible');
+      expect(hiddenContainer.style.visibility).toBe('hidden');
+    });
+
+    it('restores the original visibility once focus leaves', () => {
+      const hiddenContainer = document.createElement('div');
+      hiddenContainer.style.visibility = 'hidden';
+      const button = document.createElement('button');
+      hiddenContainer.appendChild(button);
+      document.body.appendChild(hiddenContainer);
+
+      focusFirstFocusable(hiddenContainer);
+      jest.runAllTimers();
+      expect(button.style.visibility).toBe('visible');
+
+      button.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+
+      expect(button.style.visibility).toBe('');
+    });
+
+    it('does not touch visibility when the target is already visible', () => {
+      const container = document.createElement('div');
+      const button = document.createElement('button');
+      container.appendChild(button);
+      document.body.appendChild(container);
+
+      focusFirstFocusable(container);
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(button);
+      expect(container.style.visibility).toBe('');
+    });
+
+    it('restores the overridden visibility immediately when the focus does not land', () => {
+      const hiddenContainer = document.createElement('div');
+      hiddenContainer.style.visibility = 'hidden';
+      const button = document.createElement('button');
+      // A disabled button cannot receive focus, so no `focusout` will ever fire.
+      button.disabled = true;
+      hiddenContainer.appendChild(button);
+      document.body.appendChild(hiddenContainer);
+
+      focusFirstFocusable(hiddenContainer);
+      jest.runAllTimers();
+
+      expect(document.activeElement).not.toBe(button);
+      // the element's overridden visibility is restored right away instead of being
+      // left overridden forever
+      expect(button.style.visibility).toBe('');
+    });
+  });
+});

--- a/src/platform/packages/shared/presentation/presentation_util/src/focus_helpers.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/focus_helpers.tsx
@@ -7,20 +7,50 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-const getFirstFocusable = (el: HTMLElement | null): { focus: () => void } | null => {
-  const selector = 'button, [href], input, select, textarea, [tabindex]';
+// Shared with the embeddable panel hover actions (which render the button) so focus can
+// return to the panel's context menu toggle when a flyout opened from the panel closes.
+export const getPanelContextMenuTriggerId = (panelId: string) =>
+  `presentationPanelContextMenu-${panelId}`;
+
+const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]';
+
+const getFirstFocusable = (el: HTMLElement | null): HTMLElement | null => {
   if (!el) return null;
-  if (el.matches(selector)) return el;
-  return el.querySelector(selector) as HTMLElement | null;
+  if (el.matches(FOCUSABLE_SELECTOR)) return el;
+  return el.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
 };
 
-export const focusFirstFocusable = (elId: Element | null) => {
-  if (!elId) return;
-  const focusable = getFirstFocusable(elId as HTMLElement);
+const focusPreservingVisibility = (el: HTMLElement) => {
+  const previousInlineVisibility = el.style.visibility;
+  // `visibility: visible` on the element overrides an inherited `hidden` (e.g. from the
+  // hover-actions toolbar), so focus can land without revealing the whole toolbar.
+  el.style.visibility = 'visible';
+
+  el.focus();
+
+  const restore = () => {
+    el.removeEventListener('focusout', restore);
+    el.style.visibility = previousInlineVisibility;
+  };
+
+  // No focusout will fire if focus didn't land (e.g. disabled/detached), so restore now.
+  if (document.activeElement !== el) {
+    restore();
+    return;
+  }
+
+  el.addEventListener('focusout', restore);
+};
+
+export const focusFirstFocusable = (target: Element | null | (() => Element | null)) => {
   setTimeout(() => {
-    if (!elId.contains(document.activeElement)) {
-      // only focus on the first element of the flyout if the currently focused element is not a descendant of the flyout (ie. the focus was not set by the content)
-      focusable?.focus();
+    const el = typeof target === 'function' ? target() : target;
+    if (!el) return;
+    if (el.contains(document.activeElement)) {
+      // don't steal focus if it's already inside the target (set by the target's own content)
+      return;
     }
+    const focusable = getFirstFocusable(el as HTMLElement);
+    if (focusable) focusPreservingVisibility(focusable);
   });
 };

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { openLazyFlyout } from './open_lazy_flyout';
+import { getPanelContextMenuTriggerId } from './focus_helpers';
 import type { CoreStart } from '@kbn/core/public';
 import type { OverlayRef } from '@kbn/core-mount-utils-browser';
 
@@ -70,5 +71,128 @@ describe('openLazyFlyout', () => {
     const parentApi = {}; // no openOverlay
     openLazyFlyout({ core, parentApi, loadContent });
     expect(openFlyout).toHaveBeenCalled();
+  });
+
+  describe('focus management', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+      document.body.innerHTML = '';
+    });
+
+    const getOnClose = () =>
+      (openFlyout.mock.calls[0] as unknown as [unknown, { onClose: () => void }])[1].onClose;
+
+    it('returns focus to the element that was focused when the flyout was opened', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      openLazyFlyout({ core, loadContent });
+
+      // Simulate the flyout taking focus away from the trigger.
+      const insideFlyout = document.createElement('input');
+      document.body.appendChild(insideFlyout);
+      insideFlyout.focus();
+
+      getOnClose()();
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('re-queries the trigger by id when the original node was replaced by a re-render', () => {
+      const trigger = document.createElement('button');
+      trigger.id = 'panelActionButton';
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      openLazyFlyout({ core, loadContent });
+
+      getOnClose()();
+
+      // Simulate the triggering panel re-rendering as a result of closing the
+      // flyout (after onClose runs, before the deferred focus fires): the original
+      // node is replaced by a fresh node with the same id.
+      document.body.removeChild(trigger);
+      const refreshed = document.createElement('button');
+      refreshed.id = 'panelActionButton';
+      document.body.appendChild(refreshed);
+
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(refreshed);
+    });
+
+    it('does not throw when the trigger was removed and has no id to re-query', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      openLazyFlyout({ core, loadContent });
+
+      document.body.removeChild(trigger);
+
+      expect(() => {
+        getOnClose()();
+        jest.runAllTimers();
+      }).not.toThrow();
+    });
+
+    it('returns focus to the triggerId element when provided', () => {
+      const trigger = document.createElement('button');
+      trigger.id = 'myTrigger';
+      document.body.appendChild(trigger);
+
+      openLazyFlyout({ core, loadContent, flyoutProps: { triggerId: 'myTrigger' } });
+
+      getOnClose()();
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it("returns focus to the panel's context menu toggle when focus was lost after the menu closed", () => {
+      // Mirrors a flyout opened asynchronously from the panel "..." context menu: by
+      // the time the flyout opens the menu (and the menu item that had focus) is gone
+      // and focus has fallen to <body>. Focus must return to the persistent toggle
+      // identified by focusedPanelId.
+      const panelId = 'panel-1';
+      const toggle = document.createElement('button');
+      toggle.id = getPanelContextMenuTriggerId(panelId);
+      document.body.appendChild(toggle);
+
+      // No element is focused (focus was dropped to <body>).
+      openLazyFlyout({ core, loadContent, flyoutProps: { focusedPanelId: panelId } });
+
+      getOnClose()();
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(toggle);
+    });
+
+    it('prefers the previously focused element over the panel context menu fallback', () => {
+      const panelId = 'panel-1';
+      const toggle = document.createElement('button');
+      toggle.id = getPanelContextMenuTriggerId(panelId);
+      document.body.appendChild(toggle);
+
+      // A quick-action button had focus when the flyout opened.
+      const quickAction = document.createElement('button');
+      quickAction.id = 'quickActionButton';
+      document.body.appendChild(quickAction);
+      quickAction.focus();
+
+      openLazyFlyout({ core, loadContent, flyoutProps: { focusedPanelId: panelId } });
+
+      getOnClose()();
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(quickAction);
+    });
   });
 });

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -12,7 +12,7 @@ import { htmlIdGenerator } from '@elastic/eui';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import useAsync from 'react-use/lib/useAsync';
 import { i18n } from '@kbn/i18n';
-import { focusFirstFocusable } from './focus_helpers';
+import { focusFirstFocusable, getPanelContextMenuTriggerId } from './focus_helpers';
 import { LoadingFlyout } from './loading_flyout';
 import { tracksOverlays } from './tracks_overlays';
 
@@ -29,6 +29,17 @@ interface OpenLazyFlyoutParams {
   loadContent: (args: LoadContentArgs) => Promise<JSX.Element | null | void>;
   flyoutProps?: Partial<OverlayFlyoutOpenOptions> & { triggerId?: string; focusedPanelId?: string };
 }
+
+// Re-query by id so focus survives a re-render that replaced the node; fall back to the
+// node itself while it is still attached.
+const resolveAttachedElement = (el: HTMLElement | null): HTMLElement | null => {
+  if (!el) return null;
+  if (el.id) {
+    const refreshed = document.getElementById(el.id);
+    if (refreshed) return refreshed;
+  }
+  return document.body.contains(el) ? el : null;
+};
 
 /**
  * Opens a flyout panel with lazily loaded content.
@@ -56,12 +67,30 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
   const ariaLabelledBy = flyoutProps?.['aria-labelledby'] ?? htmlId();
   const overlayTracker = tracksOverlays(parentApi) ? parentApi : undefined;
 
+  const previouslyFocusedElement =
+    document.activeElement instanceof HTMLElement && document.activeElement !== document.body
+      ? document.activeElement
+      : null;
+
+  const getTriggerElement = () => {
+    // Priority: explicit triggerId → the element that had focus (re-queried by id to
+    // survive a re-render) → the panel's "..." toggle (for context-menu actions whose
+    // menu item is gone by the time an async flyout opens).
+    const byTriggerId = triggerId ? document.getElementById(triggerId) : null;
+    if (byTriggerId) return byTriggerId;
+    const byFocusedElement = resolveAttachedElement(previouslyFocusedElement);
+    if (byFocusedElement) return byFocusedElement;
+    return focusedPanelId
+      ? document.getElementById(getPanelContextMenuTriggerId(focusedPanelId))
+      : null;
+  };
+
   const onClose = () => {
     overlayTracker?.clearOverlays();
     flyoutRef?.close();
-    if (triggerId) {
-      focusFirstFocusable(document.getElementById(triggerId));
-    }
+    // Resolve lazily: closing can re-render the panel, so the trigger is looked up after
+    // that render (inside focusFirstFocusable's deferred callback).
+    focusFirstFocusable(getTriggerElement);
   };
 
   const flyoutRef = core.overlays.openFlyout(

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.test.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Action, ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import type { EmbeddableApiContext } from '@kbn/presentation-publishing';
+import { createClickHandler } from './presentation_panel_hover_actions';
+
+describe('createClickHandler', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  const buildAction = () => ({ execute: jest.fn() } as unknown as Action<EmbeddableApiContext>);
+  const context = {} as ActionExecutionContext<EmbeddableApiContext>;
+
+  const buildEvent = (currentTarget: HTMLElement) =>
+    ({
+      currentTarget,
+      button: 0,
+      defaultPrevented: false,
+      preventDefault: jest.fn(),
+    } as unknown as React.MouseEvent);
+
+  it('executes the action', () => {
+    const action = buildAction();
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    createClickHandler(action, context)(buildEvent(button));
+
+    expect(action.execute).toHaveBeenCalledWith(context);
+  });
+
+  it('keeps focus on the triggering button so the opened overlay can return focus to it', () => {
+    // Regression guard for WCAG 2.4.3: the handler must not blur the trigger,
+    // otherwise the element focus should be returned to is destroyed before the
+    // action's flyout opens.
+    const action = buildAction();
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    createClickHandler(action, context)(buildEvent(button));
+
+    expect(document.activeElement).toBe(button);
+  });
+});

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx
@@ -32,6 +32,7 @@ import {
   apiCanLockHoverActions,
   useBatchedOptionalPublishingSubjects,
 } from '@kbn/presentation-publishing';
+import { getPanelContextMenuTriggerId } from '@kbn/presentation-util';
 import type { ActionWithContext } from '@kbn/ui-actions-plugin/public/context_menu/build_eui_context_menu_panels';
 import { Subscription, switchMap } from 'rxjs';
 import {
@@ -64,7 +65,10 @@ const getContextMenuAriaLabel = (title?: string, index?: number) => {
 
 const ALLOWED_NOTIFICATIONS = ['ACTION_FILTERS_NOTIFICATION'] as const;
 
-const createClickHandler =
+const getQuickActionElementId = (actionId: string, uuid: string) =>
+  `presentationPanelQuickAction-${actionId}-${uuid}`;
+
+export const createClickHandler =
   (action: AnyApiAction, context: ActionExecutionContext<EmbeddableApiContext>) =>
   (event: React.MouseEvent) => {
     if (event.currentTarget instanceof HTMLAnchorElement) {
@@ -78,7 +82,6 @@ const createClickHandler =
         event.preventDefault();
       }
     }
-    (event.currentTarget as HTMLElement).blur();
     action.execute(context);
   };
 
@@ -380,6 +383,7 @@ export const PresentationPanelHoverActions = ({
 
   const ContextMenuButton = (
     <EuiButtonIcon
+      id={api?.uuid ? getPanelContextMenuTriggerId(api.uuid) : undefined}
       color="text"
       data-test-subj="embeddablePanelToggleMenuIcon"
       aria-label={getContextMenuAriaLabel(title, index)}
@@ -461,13 +465,14 @@ export const PresentationPanelHoverActions = ({
               />
             )}
             {quickActionElements.map(
-              ({ iconType, 'data-test-subj': dataTestSubj, onClick, name }, i) => (
+              ({ iconType, 'data-test-subj': dataTestSubj, onClick, name, id }) => (
                 <EuiToolTip
                   key={`main_action_${dataTestSubj}_${api?.uuid}`}
                   content={name}
                   disableScreenReaderOutput
                 >
                   <EuiButtonIcon
+                    id={api?.uuid ? getQuickActionElementId(id, api.uuid) : undefined}
                     iconType={iconType}
                     color="text"
                     onClick={onClick as MouseEventHandler}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/alert_rule_from_vis_ui_action.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/alert_rule_from_vis_ui_action.tsx
@@ -79,6 +79,7 @@ export class AlertRuleFromVisAction implements Action<Context> {
         css: css({ containerType: 'inline-size' }),
         'data-test-subj': 'lensAlertRule',
         'aria-labelledby': 'flyoutTitle',
+        focusedPanelId: embeddable.uuid,
       },
       loadContent: async ({ closeFlyout }) => {
         const { loadAlertRuleFlyoutContent } = await import('./load_alert_rule_flyout_content');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Dashboard][a11y] Return focus to triggering element when panel config flyout closes (#276475)](https://github.com/elastic/kibana/pull/276475)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"teresaalvarezsoler","email":"99645649+teresaalvarezsoler@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-09T21:58:29Z","message":"[Dashboard][a11y] Return focus to triggering element when panel config flyout closes (#276475)\n\n## Summary\n\nCloses #182764 (customer request #28568, ITZBund).\n\nWhen a panel action flyout (e.g. the panel **Settings** / customize\nflyout) opened from a dashboard panel's hover actions was closed or\nsaved, focus was dropped to the top of the DOM instead of returning to\nthe button that triggered it. This forces keyboard and screen reader\nusers to traverse the DOM back to where they were, violating [WCAG 2.4.3\nFocus Order (Level\nA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).\n\n### Root causes & fixes\n\n1. **`openLazyFlyout` only returned focus when an explicit `triggerId`\nwas passed** — and the panel customize flyout never passed one. It now\ncaptures the element that had focus when the flyout opened and returns\nfocus to it on close (an explicit `triggerId` still takes precedence, so\nexisting callers are unchanged). For actions launched from the panel\ncontext menu (where the menu item that had focus is gone by the time the\nflyout opens), it falls back to the panel's persistent \"…\" toggle.\n\n2. **`createClickHandler` blurred the trigger button before executing\nthe action**, destroying the element focus should return to. The\n`blur()` is removed so focus stays on the triggering button while the\naction runs.\n\n3. **The panel re-renders on some actions (e.g. Lens inline edit),\nreplacing the trigger's DOM node.** Hover-action buttons now have\nstable, uuid-scoped ids, and the focus target is re-queried by id after\nthe re-render so focus lands on the fresh node rather than a detached\none.\n\n4. **`.focus()` on a `visibility: hidden` element is a no-op** — and the\nhover actions are hidden with `visibility: hidden` to keep them out of\nthe tab order. So even after fixes 1–3, restoring focus silently dropped\nit to `<body>`, which is why the earlier work didn't help in practice.\n`focusFirstFocusable` now temporarily overrides **only `visibility`**\n(not `opacity`) on the trigger button itself so the programmatic focus\nlands — a `visibility: visible` set on the element wins over the\n`hidden` it inherits from the hover-actions toolbar, so there's no need\nto touch ancestors — then restores the original value on `focusout` (or\nimmediately if the focus doesn't land). Overriding only `visibility`\nmakes the button focusable without forcing the toolbar into view:\nkeyboard users keep the CSS `:focus-visible` reveal, while mouse\ninteractions don't leave the actions pinned open.\n\nBecause the fix lives in the shared `openLazyFlyout` /\n`focusFirstFocusable` helpers, other flyouts opened through them also\nbenefit from correct focus return.\n\n### How to test\n\n1. Open a dashboard with sample panels and enter **Edit** mode.\n2. Using **only the keyboard**, tab to a panel until its hover actions\nreveal, open the panel **Settings** flyout (and separately, the Lens\n**Edit visualization** inline flyout).\n3. Close or save the flyout.\n4. **Expected:** focus returns to the triggering panel action button\ninstead of jumping to the top of the page — including after the panel\nre-renders (Lens inline edit).\n\n## Release note\n\nDashboard panel action flyouts (such as panel settings) now return\nkeyboard focus to the triggering button when closed, improving keyboard\nand screen reader navigation.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"5005db7e249d25d5e11cc3dc88a52fc12af334a5","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Embedding","release_note:fix","Project:Accessibility","Team:Presentation","WCAG A","Feature:Drilldowns","accessibility: focus","backport:version","v9.4.0","v9.5.0","v9.6.0"],"title":"[Dashboard][a11y] Return focus to triggering element when panel config flyout closes","number":276475,"url":"https://github.com/elastic/kibana/pull/276475","mergeCommit":{"message":"[Dashboard][a11y] Return focus to triggering element when panel config flyout closes (#276475)\n\n## Summary\n\nCloses #182764 (customer request #28568, ITZBund).\n\nWhen a panel action flyout (e.g. the panel **Settings** / customize\nflyout) opened from a dashboard panel's hover actions was closed or\nsaved, focus was dropped to the top of the DOM instead of returning to\nthe button that triggered it. This forces keyboard and screen reader\nusers to traverse the DOM back to where they were, violating [WCAG 2.4.3\nFocus Order (Level\nA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).\n\n### Root causes & fixes\n\n1. **`openLazyFlyout` only returned focus when an explicit `triggerId`\nwas passed** — and the panel customize flyout never passed one. It now\ncaptures the element that had focus when the flyout opened and returns\nfocus to it on close (an explicit `triggerId` still takes precedence, so\nexisting callers are unchanged). For actions launched from the panel\ncontext menu (where the menu item that had focus is gone by the time the\nflyout opens), it falls back to the panel's persistent \"…\" toggle.\n\n2. **`createClickHandler` blurred the trigger button before executing\nthe action**, destroying the element focus should return to. The\n`blur()` is removed so focus stays on the triggering button while the\naction runs.\n\n3. **The panel re-renders on some actions (e.g. Lens inline edit),\nreplacing the trigger's DOM node.** Hover-action buttons now have\nstable, uuid-scoped ids, and the focus target is re-queried by id after\nthe re-render so focus lands on the fresh node rather than a detached\none.\n\n4. **`.focus()` on a `visibility: hidden` element is a no-op** — and the\nhover actions are hidden with `visibility: hidden` to keep them out of\nthe tab order. So even after fixes 1–3, restoring focus silently dropped\nit to `<body>`, which is why the earlier work didn't help in practice.\n`focusFirstFocusable` now temporarily overrides **only `visibility`**\n(not `opacity`) on the trigger button itself so the programmatic focus\nlands — a `visibility: visible` set on the element wins over the\n`hidden` it inherits from the hover-actions toolbar, so there's no need\nto touch ancestors — then restores the original value on `focusout` (or\nimmediately if the focus doesn't land). Overriding only `visibility`\nmakes the button focusable without forcing the toolbar into view:\nkeyboard users keep the CSS `:focus-visible` reveal, while mouse\ninteractions don't leave the actions pinned open.\n\nBecause the fix lives in the shared `openLazyFlyout` /\n`focusFirstFocusable` helpers, other flyouts opened through them also\nbenefit from correct focus return.\n\n### How to test\n\n1. Open a dashboard with sample panels and enter **Edit** mode.\n2. Using **only the keyboard**, tab to a panel until its hover actions\nreveal, open the panel **Settings** flyout (and separately, the Lens\n**Edit visualization** inline flyout).\n3. Close or save the flyout.\n4. **Expected:** focus returns to the triggering panel action button\ninstead of jumping to the top of the page — including after the panel\nre-renders (Lens inline edit).\n\n## Release note\n\nDashboard panel action flyouts (such as panel settings) now return\nkeyboard focus to the triggering button when closed, improving keyboard\nand screen reader navigation.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"5005db7e249d25d5e11cc3dc88a52fc12af334a5"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277340","number":277340,"state":"MERGED","mergeCommit":{"sha":"672ea2410bc9c6873ae264d2719396c3246f96d3","message":"[9.5] [Dashboard][a11y] Return focus to triggering element when panel config flyout closes (#276475) (#277340)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Dashboard][a11y] Return focus to triggering element when panel\nconfig flyout closes\n(#276475)](https://github.com/elastic/kibana/pull/276475)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: teresaalvarezsoler <99645649+teresaalvarezsoler@users.noreply.github.com>\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276475","number":276475,"mergeCommit":{"message":"[Dashboard][a11y] Return focus to triggering element when panel config flyout closes (#276475)\n\n## Summary\n\nCloses #182764 (customer request #28568, ITZBund).\n\nWhen a panel action flyout (e.g. the panel **Settings** / customize\nflyout) opened from a dashboard panel's hover actions was closed or\nsaved, focus was dropped to the top of the DOM instead of returning to\nthe button that triggered it. This forces keyboard and screen reader\nusers to traverse the DOM back to where they were, violating [WCAG 2.4.3\nFocus Order (Level\nA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).\n\n### Root causes & fixes\n\n1. **`openLazyFlyout` only returned focus when an explicit `triggerId`\nwas passed** — and the panel customize flyout never passed one. It now\ncaptures the element that had focus when the flyout opened and returns\nfocus to it on close (an explicit `triggerId` still takes precedence, so\nexisting callers are unchanged). For actions launched from the panel\ncontext menu (where the menu item that had focus is gone by the time the\nflyout opens), it falls back to the panel's persistent \"…\" toggle.\n\n2. **`createClickHandler` blurred the trigger button before executing\nthe action**, destroying the element focus should return to. The\n`blur()` is removed so focus stays on the triggering button while the\naction runs.\n\n3. **The panel re-renders on some actions (e.g. Lens inline edit),\nreplacing the trigger's DOM node.** Hover-action buttons now have\nstable, uuid-scoped ids, and the focus target is re-queried by id after\nthe re-render so focus lands on the fresh node rather than a detached\none.\n\n4. **`.focus()` on a `visibility: hidden` element is a no-op** — and the\nhover actions are hidden with `visibility: hidden` to keep them out of\nthe tab order. So even after fixes 1–3, restoring focus silently dropped\nit to `<body>`, which is why the earlier work didn't help in practice.\n`focusFirstFocusable` now temporarily overrides **only `visibility`**\n(not `opacity`) on the trigger button itself so the programmatic focus\nlands — a `visibility: visible` set on the element wins over the\n`hidden` it inherits from the hover-actions toolbar, so there's no need\nto touch ancestors — then restores the original value on `focusout` (or\nimmediately if the focus doesn't land). Overriding only `visibility`\nmakes the button focusable without forcing the toolbar into view:\nkeyboard users keep the CSS `:focus-visible` reveal, while mouse\ninteractions don't leave the actions pinned open.\n\nBecause the fix lives in the shared `openLazyFlyout` /\n`focusFirstFocusable` helpers, other flyouts opened through them also\nbenefit from correct focus return.\n\n### How to test\n\n1. Open a dashboard with sample panels and enter **Edit** mode.\n2. Using **only the keyboard**, tab to a panel until its hover actions\nreveal, open the panel **Settings** flyout (and separately, the Lens\n**Edit visualization** inline flyout).\n3. Close or save the flyout.\n4. **Expected:** focus returns to the triggering panel action button\ninstead of jumping to the top of the page — including after the panel\nre-renders (Lens inline edit).\n\n## Release note\n\nDashboard panel action flyouts (such as panel settings) now return\nkeyboard focus to the triggering button when closed, improving keyboard\nand screen reader navigation.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"5005db7e249d25d5e11cc3dc88a52fc12af334a5"}}]}] BACKPORT-->