### PR TITLE
[Lens] Fix flaky Lens add layer test wait assertion

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/add_layer.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/add_layer.test.tsx
@@ -12,7 +12,6 @@ import type { XYVisualizationState } from './types';
 import { Position } from '@elastic/charts';
 import { LENS_LAYER_TYPES as LayerTypes } from '@kbn/lens-common';
 import { eventAnnotationServiceMock } from '@kbn/event-annotation-plugin/public/mocks';
-import { IconChartBarAnnotations } from '@kbn/chart-icons';
 
 describe('AddLayerButton', () => {
   const addLayer = jest.fn();
@@ -33,20 +32,12 @@ describe('AddLayerButton', () => {
         },
       ],
     };
+    // Just add the layers needed to satisfy the tests here instead
+    // of mocking the entire eventAnnotationService.
     const supportedLayers = [
       {
         type: LayerTypes.DATA,
         label: 'Visualization',
-      },
-      {
-        type: LayerTypes.REFERENCELINE,
-        label: LayerTypes.REFERENCELINE,
-      },
-      {
-        type: LayerTypes.ANNOTATIONS,
-        label: 'Annotations',
-        icon: IconChartBarAnnotations,
-        disabled: true,
       },
     ];
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/add_layer.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/add_layer.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { AddLayerButton } from './add_layer';
 import type { XYVisualizationState } from './types';
 import { Position } from '@elastic/charts';
@@ -71,9 +71,7 @@ describe('AddLayerButton', () => {
         fireEvent.click(lineOption);
       },
       waitForSeriesOptions: async () => {
-        await waitFor(() => {
-          expect(screen.queryByTestId('lnsXY_seriesType-area')).toBeInTheDocument();
-        });
+        await screen.findByTestId('lnsXY_seriesType-area', {}, { timeout: 1000 });
       },
       getSeriesTypeOptions: () => {
         return screen.getAllByTestId('lnsChartSwitch-option-label').map((el) => el.textContent);


### PR DESCRIPTION
## Summary

Closes #255059.

Updates the Lens `AddLayerButton` unit test to wait directly for the expected series type option with a short explicit timeout instead of using a broad `waitFor` around `queryByTestId`. Also tweaks setting up more lean fixtures. This avoids consuming most of Jest's default per-test timeout when the EUI popover/context-menu render path is slow on CI.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.

### Identify risks

Low risk: test-only change. Mitigation: assertion coverage is preserved while narrowing the async wait to the expected UI element.
