### PR TITLE
[Agent Builder] Conversation input message queue

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_ui_ebt.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_ui_ebt.ts
@@ -191,6 +191,7 @@ const ebtAction = {
     VIEW_TOOL_RESPONSE: 'view_tool_response',
     VIEW_SUB_AGENT_EXECUTION: 'view_sub_agent_execution',
     OPEN_ESQL_IN_DISCOVER: 'open_esql_in_discover',
+    MESSAGE_QUEUE_REMOVE: 'message_queue_remove',
   },
   libraryPanel: {
     MANAGE_ALL: 'manage_all',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.test.tsx
@@ -140,6 +140,7 @@ describe('ConversationInput', () => {
       queues: new Map(),
       enqueue: jest.fn(),
       remove: jest.fn(),
+      clear: jest.fn(),
       isMessageQueueFull: jest.fn().mockReturnValue(false),
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.test.tsx
@@ -22,6 +22,8 @@ import { useConversationContext } from '../../../context/conversation/conversati
 import { useSubmitMessage } from '../../../hooks/use_submit_message';
 import { useToasts } from '../../../hooks/use_toasts';
 import { useMessageEditor } from './message_editor';
+import { useExperimentalFeatures } from '../../../hooks/use_experimental_features';
+import { useConversationMessageQueue } from '../../../context/conversation_message_queue/conversation_message_queue_context';
 
 jest.mock('../../../hooks/use_conversation_stream', () => ({
   useConversationStream: jest.fn(),
@@ -59,6 +61,12 @@ jest.mock('./message_editor', () => ({
   ),
   CommandBadgeSerializationError: class extends Error {},
 }));
+jest.mock('../../../hooks/use_experimental_features', () => ({
+  useExperimentalFeatures: jest.fn(),
+}));
+jest.mock('../../../context/conversation_message_queue/conversation_message_queue_context', () => ({
+  useConversationMessageQueue: jest.fn(),
+}));
 jest.mock('./input_actions', () => ({
   InputActions: () => null,
 }));
@@ -81,6 +89,8 @@ const mockedUseConversationContext = jest.mocked(useConversationContext);
 const mockedUseSubmitMessage = jest.mocked(useSubmitMessage);
 const mockedUseToasts = jest.mocked(useToasts);
 const mockedUseMessageEditor = jest.mocked(useMessageEditor);
+const mockedUseExperimentalFeatures = jest.mocked(useExperimentalFeatures);
+const mockedUseConversationMessageQueue = jest.mocked(useConversationMessageQueue);
 
 const submitMessage = jest.fn();
 const editorController = {
@@ -125,6 +135,13 @@ describe('ConversationInput', () => {
       messageEditor: {} as never,
       controller: editorController,
     } as never);
+    mockedUseExperimentalFeatures.mockReturnValue(false);
+    mockedUseConversationMessageQueue.mockReturnValue({
+      queues: new Map(),
+      enqueue: jest.fn(),
+      remove: jest.fn(),
+      isMessageQueueFull: jest.fn().mockReturnValue(false),
+    });
   });
 
   it('calls onSubmitOverride with editor content and skips submitMessage when override is provided', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -22,15 +22,29 @@ import {
   useHasActiveConversation,
   useIsAwaitingPrompt,
 } from '../../../hooks/use_conversation';
+import { useExperimentalFeatures } from '../../../hooks/use_experimental_features';
+import { useConversationMessageQueue } from '../../../context/conversation_message_queue/conversation_message_queue_context';
 import { MessageEditor, useMessageEditor, CommandBadgeSerializationError } from './message_editor';
+import { MessageQueue } from './message_queue';
 import { useToasts } from '../../../hooks/use_toasts';
 import { InputActions } from './input_actions';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
 import { AttachmentPillsRow } from './attachment_pills_row';
 
+const EMPTY_QUEUE: readonly string[] = [];
+
 const containerAriaLabel = i18n.translate('xpack.agentBuilder.conversationInput.container.label', {
   defaultMessage: 'Message input form',
 });
+
+const messages = {
+  invalidCommandBadge: i18n.translate('xpack.agentBuilder.conversationInput.invalidCommandBadge', {
+    defaultMessage: 'Your message contains an invalid command. Remove the command and try again.',
+  }),
+  messageQueueFull: i18n.translate('xpack.agentBuilder.conversationInput.messageQueue.full', {
+    defaultMessage: 'Message queue is full. Wait for the agent to finish before queuing more.',
+  }),
+};
 
 const flexGrowZeroStyles = css`
   flex-grow: 0;
@@ -109,13 +123,29 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
     useConversationContext();
   const submitMessage = useSubmitMessage();
 
+  const isExperimentalFeaturesEnabled = useExperimentalFeatures();
+  const { queues, enqueue, remove, isMessageQueueFull } = useConversationMessageQueue();
+
+  const messageQueue: readonly string[] = conversationId
+    ? queues.get(conversationId) ?? EMPTY_QUEUE
+    : EMPTY_QUEUE;
+  const isQueueFull = Boolean(conversationId) && isMessageQueueFull(conversationId!);
+  const canQueueMessage = isExperimentalFeaturesEnabled && Boolean(conversationId);
+
+  const canDrainQueue =
+    canQueueMessage && !isResponseLoading && !isAwaitingPrompt && messageQueue.length > 0;
+
   const validateAgentId = useValidateAgentId();
   const isAgentIdValid = validateAgentId(agentId);
 
   const isAgentDeleted = !isAgentIdValid && isFetched && Boolean(agentId);
   const isInputDisabled = isAgentDeleted || isAwaitingPrompt || isResuming;
+
   const isSubmitDisabled =
-    messageEditorController.isEmpty || isResponseLoading || !isAgentIdValid || isAwaitingPrompt;
+    messageEditorController.isEmpty ||
+    !isAgentIdValid ||
+    isAwaitingPrompt ||
+    (isExperimentalFeaturesEnabled ? isQueueFull : isResponseLoading);
 
   const placeholder = isAgentDeleted ? disabledPlaceholder(agentId) : enabledPlaceholder;
 
@@ -173,6 +203,22 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
     };
   }, [conversationId, messageEditorController, isAwaitingPrompt]);
 
+  useEffect(() => {
+    if (!canDrainQueue) return;
+    const next = messageQueue[0];
+    if (next === undefined) return;
+
+    // Delay sending the message by 1 second so the user always sees the queue in the UI before sending the message
+    const timeoutId = setTimeout(() => {
+      remove(conversationId!, 0);
+      submitMessage(next);
+    }, 1000);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [canDrainQueue, conversationId, remove, submitMessage, messageQueue]);
+
   const handleSubmit = () => {
     if (isSubmitDisabled) {
       return;
@@ -182,17 +228,18 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
       content = messageEditorController.getContent();
     } catch (contentError) {
       if (contentError instanceof CommandBadgeSerializationError) {
-        addErrorToast(
-          i18n.translate('xpack.agentBuilder.conversationInput.invalidCommandBadge', {
-            defaultMessage:
-              'Your message contains an invalid command. Remove the command and try again.',
-          })
-        );
+        addErrorToast(messages.invalidCommandBadge);
       }
+      return;
+    }
+    if (canQueueMessage && isQueueFull) {
+      addErrorToast(messages.messageQueueFull);
       return;
     }
     if (onSubmitOverride) {
       onSubmitOverride(content);
+    } else if (canQueueMessage && isResponseLoading) {
+      enqueue(conversationId!, content);
     } else {
       submitMessage(content);
     }
@@ -201,34 +248,39 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
   };
 
   return (
-    <InputContainer isDisabled={isInputDisabled} isCollapsed={shouldCollapseInput}>
-      {visibleAttachments.length > 0 && (
-        <EuiFlexItem grow={false}>
-          <AttachmentPillsRow attachments={visibleAttachments} removable />
+    <>
+      {canQueueMessage && (
+        <MessageQueue queue={messageQueue} onRemove={(i) => remove(conversationId!, i)} />
+      )}
+      <InputContainer isDisabled={isInputDisabled} isCollapsed={shouldCollapseInput}>
+        {visibleAttachments.length > 0 && (
+          <EuiFlexItem grow={false}>
+            <AttachmentPillsRow attachments={visibleAttachments} removable />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem css={editorContainerStyles}>
+          <MessageEditor
+            messageEditor={messageEditor}
+            onSubmit={handleSubmit}
+            disabled={isInputDisabled}
+            placeholder={placeholder}
+            ariaLabel={messageEditorAriaLabel}
+            data-test-subj="agentBuilderConversationInputEditor"
+          />
         </EuiFlexItem>
-      )}
-      <EuiFlexItem css={editorContainerStyles}>
-        <MessageEditor
-          messageEditor={messageEditor}
-          onSubmit={handleSubmit}
-          disabled={isInputDisabled}
-          placeholder={placeholder}
-          ariaLabel={messageEditorAriaLabel}
-          data-test-subj="agentBuilderConversationInputEditor"
-        />
-      </EuiFlexItem>
-      {!isAgentDeleted && (
-        <InputActions
-          onSubmit={handleSubmit}
-          isSubmitDisabled={isSubmitDisabled}
-          resetToPendingMessage={() => {
-            if (pendingMessage) {
-              messageEditorController.setContent(pendingMessage);
-            }
-          }}
-          agentId={agentId}
-        />
-      )}
-    </InputContainer>
+        {!isAgentDeleted && (
+          <InputActions
+            onSubmit={handleSubmit}
+            isSubmitDisabled={isSubmitDisabled}
+            resetToPendingMessage={() => {
+              if (pendingMessage) {
+                messageEditorController.setContent(pendingMessage);
+              }
+            }}
+            agentId={agentId}
+          />
+        )}
+      </InputContainer>
+    </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -212,12 +212,13 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
     const timeoutId = setTimeout(() => {
       remove(conversationId!, 0);
       submitMessage(next);
+      onSubmit?.();
     }, 1000);
 
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [canDrainQueue, conversationId, remove, submitMessage, messageQueue]);
+  }, [canDrainQueue, conversationId, remove, submitMessage, onSubmit, messageQueue]);
 
   const handleSubmit = () => {
     if (isSubmitDisabled) {
@@ -240,6 +241,8 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
       onSubmitOverride(content);
     } else if (canQueueMessage && isResponseLoading) {
       enqueue(conversationId!, content);
+      messageEditorController.clear();
+      return;
     } else {
       submitMessage(content);
     }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -247,8 +247,15 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
     onSubmit?.();
   };
 
+  // Positioning ancestor for <MessageQueue> — the queue floats above the input rather than
+  // sitting in the layout flow, so growing the queue never reshapes the conversation
+  // scroll area above it.
+  const inputWithQueueStyles = css`
+    position: relative;
+  `;
+
   return (
-    <>
+    <div css={inputWithQueueStyles}>
       {canQueueMessage && (
         <MessageQueue queue={messageQueue} onRemove={(i) => remove(conversationId!, i)} />
       )}
@@ -281,6 +288,6 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
           />
         )}
       </InputContainer>
-    </>
+    </div>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -124,7 +124,7 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
   const submitMessage = useSubmitMessage();
 
   const isExperimentalFeaturesEnabled = useExperimentalFeatures();
-  const { queues, enqueue, remove, isMessageQueueFull } = useConversationMessageQueue();
+  const { queues, enqueue, remove, clear, isMessageQueueFull } = useConversationMessageQueue();
 
   const messageQueue: readonly string[] = conversationId
     ? queues.get(conversationId) ?? EMPTY_QUEUE
@@ -205,20 +205,20 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
 
   useEffect(() => {
     if (!canDrainQueue) return;
-    const next = messageQueue[0];
-    if (next === undefined) return;
 
-    // Delay sending the message by 1 second so the user always sees the queue in the UI before sending the message
+    // Delay flushing the queue by 1 second so the user always sees the pending bubbles before they merge into a single outgoing message
     const timeoutId = setTimeout(() => {
-      remove(conversationId!, 0);
-      submitMessage(next);
+      // Flush every queued message as one send, separated by a blank line
+      const flushed = messageQueue.join('\n\n');
+      clear(conversationId!);
+      submitMessage(flushed);
       onSubmit?.();
     }, 1000);
 
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [canDrainQueue, conversationId, remove, submitMessage, onSubmit, messageQueue]);
+  }, [canDrainQueue, conversationId, clear, submitMessage, onSubmit, messageQueue]);
 
   const handleSubmit = () => {
     if (isSubmitDisabled) {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_queue.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_queue.tsx
@@ -20,7 +20,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { AGENT_BUILDER_EVENT_TYPES, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { useKibana } from '../../../hooks/use_kibana';
-import { ROUNDED_BORDER_RADIUS_LARGE } from '../../../../common.styles';
+import { ROUNDED_BORDER_RADIUS_LARGE, lineClampStyles } from '../../../../common.styles';
 
 interface MessageQueueProps {
   queue: readonly string[];
@@ -60,26 +60,20 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({ queue, onRemove }) =
     pointer-events: none;
   `;
 
-  // Matches the RoundInput user-bubble shape (padding, radius, max-inline-size, wrap).
-  // Uses a subdued neutral background so the bubble sits visually distinct from a sentuser message
+  // Matches the RoundInput user-bubble shape
   const bubbleStyles = css`
     align-self: flex-end;
+    inline-size: fit-content;
     max-inline-size: 90%;
     background: ${euiTheme.colors.backgroundBaseSubdued};
     ${euiTextBreakWord()}
     white-space: pre-wrap;
     border-radius: ${`${ROUNDED_BORDER_RADIUS_LARGE} ${ROUNDED_BORDER_RADIUS_LARGE} 0 ${ROUNDED_BORDER_RADIUS_LARGE}`};
     pointer-events: auto;
+  `;
 
-    .agentBuilderMessageQueueRemove {
-      opacity: 0;
-      transition: opacity 150ms ease;
-    }
-
-    &:hover .agentBuilderMessageQueueRemove,
-    &:focus-within .agentBuilderMessageQueueRemove {
-      opacity: 1;
-    }
+  const messageTextStyles = css`
+    ${lineClampStyles(2)}
   `;
 
   return (
@@ -96,12 +90,13 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({ queue, onRemove }) =
         >
           <EuiFlexGroup gutterSize="s" alignItems="center" wrap={false} responsive={false}>
             <EuiFlexItem>
-              <EuiText size="m">{message}</EuiText>
+              <EuiText size="m" css={messageTextStyles}>
+                {message}
+              </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={removeLabel} disableScreenReaderOutput>
+              <EuiToolTip content={removeLabel} position="right" disableScreenReaderOutput>
                 <EuiButtonIcon
-                  className="agentBuilderMessageQueueRemove"
                   iconType="cross"
                   size="xs"
                   color="text"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_queue.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_queue.tsx
@@ -14,11 +14,13 @@ import {
   EuiPanel,
   EuiText,
   EuiToolTip,
+  euiTextBreakWord,
   useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { AGENT_BUILDER_EVENT_TYPES, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { useKibana } from '../../../hooks/use_kibana';
+import { ROUNDED_BORDER_RADIUS_LARGE } from '../../../../common.styles';
 
 interface MessageQueueProps {
   queue: readonly string[];
@@ -29,12 +31,6 @@ const removeLabel = i18n.translate('xpack.agentBuilder.conversationInput.message
   defaultMessage: 'Remove queued message',
 });
 
-const moreLabel = (count: number) =>
-  i18n.translate('xpack.agentBuilder.conversationInput.messageQueue.more', {
-    defaultMessage: '+{count} more queued',
-    values: { count },
-  });
-
 export const MessageQueue: React.FC<MessageQueueProps> = ({ queue, onRemove }) => {
   const { euiTheme } = useEuiTheme();
   const {
@@ -42,8 +38,6 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({ queue, onRemove }) =
   } = useKibana();
 
   if (queue.length === 0) return null;
-
-  const [head, ...rest] = queue;
 
   const handleRemoveClick = (index: number) => {
     analytics.reportEvent(AGENT_BUILDER_EVENT_TYPES.UiClick, {
@@ -55,66 +49,71 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({ queue, onRemove }) =
   };
 
   const containerStyles = css`
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(100% + ${euiTheme.size.base});
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     gap: ${euiTheme.size.xs};
-    margin-bottom: ${euiTheme.size.l};
+    pointer-events: none;
   `;
 
+  // Matches the RoundInput user-bubble shape (padding, radius, max-inline-size, wrap).
+  // Uses a subdued neutral background so the bubble sits visually distinct from a sentuser message
   const bubbleStyles = css`
+    align-self: flex-end;
     max-inline-size: 90%;
-    background: ${euiTheme.colors.backgroundBasePlain};
-    border: ${euiTheme.border.thin};
-    border-radius: ${euiTheme.border.radius.medium};
-    padding: ${euiTheme.size.m} ${euiTheme.size.m} ${euiTheme.size.m} ${euiTheme.size.l};
-  `;
+    background: ${euiTheme.colors.backgroundBaseSubdued};
+    ${euiTextBreakWord()}
+    white-space: pre-wrap;
+    border-radius: ${`${ROUNDED_BORDER_RADIUS_LARGE} ${ROUNDED_BORDER_RADIUS_LARGE} 0 ${ROUNDED_BORDER_RADIUS_LARGE}`};
+    pointer-events: auto;
 
-  const messageTextStyles = css`
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    color: ${euiTheme.colors.textParagraph};
-  `;
+    .agentBuilderMessageQueueRemove {
+      opacity: 0;
+      transition: opacity 150ms ease;
+    }
 
-  const moreTextStyles = css`
-    color: ${euiTheme.colors.textSubdued};
+    &:hover .agentBuilderMessageQueueRemove,
+    &:focus-within .agentBuilderMessageQueueRemove {
+      opacity: 1;
+    }
   `;
 
   return (
     <div css={containerStyles} data-test-subj="agentBuilderMessageQueue">
-      <EuiPanel
-        hasShadow={false}
-        hasBorder={false}
-        paddingSize="none"
-        css={bubbleStyles}
-        data-test-subj="agentBuilderMessageQueueItem"
-      >
-        <EuiFlexGroup gutterSize="s" alignItems="center" wrap={false} responsive={false}>
-          <EuiFlexItem>
-            <EuiText size="s" css={messageTextStyles}>
-              {head}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiToolTip content={removeLabel} disableScreenReaderOutput>
-              <EuiButtonIcon
-                iconType="cross"
-                size="s"
-                color="text"
-                aria-label={removeLabel}
-                onClick={() => handleRemoveClick(0)}
-                data-test-subj="agentBuilderMessageQueueRemove"
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
-      {rest.length > 0 && (
-        <EuiText size="xs" css={moreTextStyles} data-test-subj="agentBuilderMessageQueueMore">
-          {moreLabel(rest.length)}
-        </EuiText>
-      )}
+      {queue.map((message, index) => (
+        <EuiPanel
+          key={index}
+          css={bubbleStyles}
+          paddingSize="m"
+          hasShadow={false}
+          hasBorder={false}
+          aria-label={message}
+          data-test-subj="agentBuilderMessageQueueItem"
+        >
+          <EuiFlexGroup gutterSize="s" alignItems="center" wrap={false} responsive={false}>
+            <EuiFlexItem>
+              <EuiText size="m">{message}</EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content={removeLabel} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  className="agentBuilderMessageQueueRemove"
+                  iconType="cross"
+                  size="xs"
+                  color="text"
+                  aria-label={removeLabel}
+                  onClick={() => handleRemoveClick(index)}
+                  data-test-subj="agentBuilderMessageQueueRemove"
+                />
+              </EuiToolTip>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
+      ))}
     </div>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_queue.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_queue.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiText,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { AGENT_BUILDER_EVENT_TYPES, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
+import { useKibana } from '../../../hooks/use_kibana';
+
+interface MessageQueueProps {
+  queue: readonly string[];
+  onRemove: (index: number) => void;
+}
+
+const removeLabel = i18n.translate('xpack.agentBuilder.conversationInput.messageQueue.remove', {
+  defaultMessage: 'Remove queued message',
+});
+
+const moreLabel = (count: number) =>
+  i18n.translate('xpack.agentBuilder.conversationInput.messageQueue.more', {
+    defaultMessage: '+{count} more queued',
+    values: { count },
+  });
+
+export const MessageQueue: React.FC<MessageQueueProps> = ({ queue, onRemove }) => {
+  const { euiTheme } = useEuiTheme();
+  const {
+    services: { analytics },
+  } = useKibana();
+
+  if (queue.length === 0) return null;
+
+  const [head, ...rest] = queue;
+
+  const handleRemoveClick = (index: number) => {
+    analytics.reportEvent(AGENT_BUILDER_EVENT_TYPES.UiClick, {
+      ebt_element: AGENT_BUILDER_UI_EBT.element.pageContent,
+      ebt_action: AGENT_BUILDER_UI_EBT.action.conversation.MESSAGE_QUEUE_REMOVE,
+      element_kind: 'button',
+    });
+    onRemove(index);
+  };
+
+  const containerStyles = css`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: ${euiTheme.size.xs};
+    margin-bottom: ${euiTheme.size.l};
+  `;
+
+  const bubbleStyles = css`
+    max-inline-size: 90%;
+    background: ${euiTheme.colors.backgroundBasePlain};
+    border: ${euiTheme.border.thin};
+    border-radius: ${euiTheme.border.radius.medium};
+    padding: ${euiTheme.size.m} ${euiTheme.size.m} ${euiTheme.size.m} ${euiTheme.size.l};
+  `;
+
+  const messageTextStyles = css`
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: ${euiTheme.colors.textParagraph};
+  `;
+
+  const moreTextStyles = css`
+    color: ${euiTheme.colors.textSubdued};
+  `;
+
+  return (
+    <div css={containerStyles} data-test-subj="agentBuilderMessageQueue">
+      <EuiPanel
+        hasShadow={false}
+        hasBorder={false}
+        paddingSize="none"
+        css={bubbleStyles}
+        data-test-subj="agentBuilderMessageQueueItem"
+      >
+        <EuiFlexGroup gutterSize="s" alignItems="center" wrap={false} responsive={false}>
+          <EuiFlexItem>
+            <EuiText size="s" css={messageTextStyles}>
+              {head}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content={removeLabel} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                size="s"
+                color="text"
+                aria-label={removeLabel}
+                onClick={() => handleRemoveClick(0)}
+                data-test-subj="agentBuilderMessageQueueRemove"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+      {rest.length > 0 && (
+        <EuiText size="xs" css={moreTextStyles} data-test-subj="agentBuilderMessageQueueMore">
+          {moreLabel(rest.length)}
+        </EuiText>
+      )}
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -24,6 +24,7 @@ import { useConversationActions } from './use_conversation_actions';
 import { ConversationChangeNotifier } from './conversation_change_notifier';
 import { usePersistedConversationId } from '../../hooks/use_persisted_conversation_id';
 import { AppLeaveContext } from '../app_leave_context';
+import { ConversationMessageQueueProvider } from '../conversation_message_queue/conversation_message_queue_context';
 
 const noopOnAppLeave = () => {};
 interface EmbeddableConversationsProviderProps extends EmbeddableConversationInternalProps {
@@ -266,7 +267,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
               <StreamingProvider>
                 <ConversationContext.Provider value={conversationContextValue}>
                   <ConversationChangeNotifier />
-                  {children}
+                  <ConversationMessageQueueProvider>{children}</ConversationMessageQueueProvider>
                 </ConversationContext.Provider>
               </StreamingProvider>
             </AppLeaveContext.Provider>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.tsx
@@ -20,6 +20,7 @@ import { useConversationActions } from './use_conversation_actions';
 import { upsertAttachmentsIntoList } from './upsert_attachments_into_list';
 import { removeAttachmentFromList } from './remove_attachment_from_list';
 import { ConversationChangeNotifier } from './conversation_change_notifier';
+import { ConversationMessageQueueProvider } from '../conversation_message_queue/conversation_message_queue_context';
 
 interface RoutedConversationsProviderProps {
   children: React.ReactNode;
@@ -148,7 +149,7 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
   return (
     <ConversationContext.Provider value={contextValue}>
       <ConversationChangeNotifier />
-      {children}
+      <ConversationMessageQueueProvider>{children}</ConversationMessageQueueProvider>
     </ConversationContext.Provider>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.test.tsx
@@ -175,4 +175,49 @@ describe('ConversationMessageQueueContext', () => {
       expect(result.current.queues.has(CONVO_A)).toBe(false);
     });
   });
+
+  describe('clear', () => {
+    it('removes every message for the given conversation', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'a');
+        result.current.enqueue(CONVO_A, 'b');
+        result.current.enqueue(CONVO_A, 'c');
+      });
+
+      act(() => {
+        result.current.clear(CONVO_A);
+      });
+
+      expect(result.current.queues.has(CONVO_A)).toBe(false);
+    });
+
+    it('does not affect other conversations', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'a1');
+        result.current.enqueue(CONVO_B, 'b1');
+      });
+
+      act(() => {
+        result.current.clear(CONVO_A);
+      });
+
+      expect(result.current.queues.has(CONVO_A)).toBe(false);
+      expect(result.current.queues.get(CONVO_B)).toEqual(['b1']);
+    });
+
+    it('is a no-op when the conversation has no queue', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+      const before = result.current.queues;
+
+      act(() => {
+        result.current.clear(CONVO_A);
+      });
+
+      expect(result.current.queues).toBe(before);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import {
+  ConversationMessageQueueProvider,
+  MAX_MESSAGE_QUEUE_SIZE,
+  useConversationMessageQueue,
+} from './conversation_message_queue_context';
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ConversationMessageQueueProvider>{children}</ConversationMessageQueueProvider>
+);
+
+const CONVO_A = 'conv-a';
+const CONVO_B = 'conv-b';
+
+describe('ConversationMessageQueueContext', () => {
+  it('enqueues messages in FIFO order for a conversation', () => {
+    const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+    act(() => {
+      result.current.enqueue(CONVO_A, 'first');
+      result.current.enqueue(CONVO_A, 'second');
+    });
+
+    expect(result.current.queues.get(CONVO_A)).toEqual(['first', 'second']);
+  });
+
+  it('caps the queue at MAX_MESSAGE_QUEUE_SIZE and drops further enqueues silently', () => {
+    const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+    act(() => {
+      for (let i = 1; i <= MAX_MESSAGE_QUEUE_SIZE + 2; i++) {
+        result.current.enqueue(CONVO_A, `msg-${i}`);
+      }
+    });
+
+    expect(result.current.queues.get(CONVO_A)).toEqual(['msg-1', 'msg-2', 'msg-3']);
+    expect(result.current.queues.get(CONVO_A)).toHaveLength(MAX_MESSAGE_QUEUE_SIZE);
+  });
+
+  it('isolates queues across conversation ids', () => {
+    const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+    act(() => {
+      result.current.enqueue(CONVO_A, 'a1');
+      result.current.enqueue(CONVO_B, 'b1');
+      result.current.enqueue(CONVO_A, 'a2');
+    });
+
+    expect(result.current.queues.get(CONVO_A)).toEqual(['a1', 'a2']);
+    expect(result.current.queues.get(CONVO_B)).toEqual(['b1']);
+
+    act(() => {
+      result.current.remove(CONVO_A, 0);
+    });
+
+    expect(result.current.queues.get(CONVO_A)).toEqual(['a2']);
+    expect(result.current.queues.get(CONVO_B)).toEqual(['b1']);
+  });
+
+  it('throws when useConversationMessageQueue is used outside the provider', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => renderHook(() => useConversationMessageQueue())).toThrow(
+        /must be used within a ConversationMessageQueueProvider/
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  describe('isMessageQueueFull', () => {
+    it('returns false while the queue is under capacity', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      expect(result.current.isMessageQueueFull(CONVO_A)).toBe(false);
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'one');
+        result.current.enqueue(CONVO_A, 'two');
+      });
+
+      expect(result.current.isMessageQueueFull(CONVO_A)).toBe(false);
+    });
+
+    it('returns true once the queue has three messages', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'one');
+        result.current.enqueue(CONVO_A, 'two');
+        result.current.enqueue(CONVO_A, 'three');
+      });
+
+      expect(result.current.isMessageQueueFull(CONVO_A)).toBe(true);
+    });
+
+    it('stays true after a rejected enqueue attempt', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'one');
+        result.current.enqueue(CONVO_A, 'two');
+        result.current.enqueue(CONVO_A, 'three');
+        result.current.enqueue(CONVO_A, 'four');
+      });
+
+      expect(result.current.isMessageQueueFull(CONVO_A)).toBe(true);
+      expect(result.current.queues.get(CONVO_A)).toEqual(['one', 'two', 'three']);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes the message at the given index', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'a');
+        result.current.enqueue(CONVO_A, 'b');
+        result.current.enqueue(CONVO_A, 'c');
+      });
+
+      act(() => {
+        result.current.remove(CONVO_A, 1);
+      });
+
+      expect(result.current.queues.get(CONVO_A)).toEqual(['a', 'c']);
+    });
+
+    it('deletes the map entry when the last remaining message is removed', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'only');
+      });
+
+      act(() => {
+        result.current.remove(CONVO_A, 0);
+      });
+
+      expect(result.current.queues.has(CONVO_A)).toBe(false);
+    });
+
+    it('is a no-op for an out-of-range index', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.enqueue(CONVO_A, 'a');
+      });
+
+      const before = result.current.queues.get(CONVO_A);
+
+      act(() => {
+        result.current.remove(CONVO_A, 5);
+        result.current.remove(CONVO_A, -1);
+      });
+
+      expect(result.current.queues.get(CONVO_A)).toEqual(before);
+    });
+
+    it('is a no-op when the conversation has no queue', () => {
+      const { result } = renderHook(() => useConversationMessageQueue(), { wrapper });
+
+      act(() => {
+        result.current.remove(CONVO_A, 0);
+      });
+
+      expect(result.current.queues.has(CONVO_A)).toBe(false);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+export const MAX_MESSAGE_QUEUE_SIZE = 3;
+
+export interface ConversationMessageQueueContextValue {
+  queues: ReadonlyMap<string, readonly string[]>;
+  enqueue: (conversationId: string, message: string) => void;
+  remove: (conversationId: string, index: number) => void;
+  isMessageQueueFull: (conversationId: string) => boolean;
+}
+
+const ConversationMessageQueueContext = createContext<ConversationMessageQueueContextValue | null>(
+  null
+);
+
+export const ConversationMessageQueueProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [queues, setQueues] = useState<Map<string, string[]>>(() => new Map());
+
+  const enqueue = useCallback((conversationId: string, message: string) => {
+    setQueues((prev) => {
+      const current = prev.get(conversationId) ?? [];
+      if (current.length >= MAX_MESSAGE_QUEUE_SIZE) return prev;
+      const next = new Map(prev);
+      next.set(conversationId, [...current, message]);
+      return next;
+    });
+  }, []);
+
+  const remove = useCallback((conversationId: string, index: number) => {
+    setQueues((prev) => {
+      const current = prev.get(conversationId);
+      if (!current || index < 0 || index >= current.length) return prev;
+      const filtered = current.filter((_, i) => i !== index);
+      const next = new Map(prev);
+      if (filtered.length === 0) {
+        next.delete(conversationId);
+      } else {
+        next.set(conversationId, filtered);
+      }
+      return next;
+    });
+  }, []);
+
+  const isMessageQueueFull = useCallback(
+    (conversationId: string): boolean => {
+      const current = queues.get(conversationId);
+      return (current?.length ?? 0) >= MAX_MESSAGE_QUEUE_SIZE;
+    },
+    [queues]
+  );
+
+  const value = useMemo<ConversationMessageQueueContextValue>(
+    () => ({ queues, enqueue, remove, isMessageQueueFull }),
+    [queues, enqueue, remove, isMessageQueueFull]
+  );
+
+  return (
+    <ConversationMessageQueueContext.Provider value={value}>
+      {children}
+    </ConversationMessageQueueContext.Provider>
+  );
+};
+
+export const useConversationMessageQueue = (): ConversationMessageQueueContextValue => {
+  const ctx = useContext(ConversationMessageQueueContext);
+  if (!ctx) {
+    throw new Error(
+      'useConversationMessageQueue must be used within a ConversationMessageQueueProvider'
+    );
+  }
+  return ctx;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation_message_queue/conversation_message_queue_context.tsx
@@ -13,6 +13,7 @@ export interface ConversationMessageQueueContextValue {
   queues: ReadonlyMap<string, readonly string[]>;
   enqueue: (conversationId: string, message: string) => void;
   remove: (conversationId: string, index: number) => void;
+  clear: (conversationId: string) => void;
   isMessageQueueFull: (conversationId: string) => boolean;
 }
 
@@ -50,6 +51,15 @@ export const ConversationMessageQueueProvider: React.FC<{ children: React.ReactN
     });
   }, []);
 
+  const clear = useCallback((conversationId: string) => {
+    setQueues((prev) => {
+      if (!prev.has(conversationId)) return prev;
+      const next = new Map(prev);
+      next.delete(conversationId);
+      return next;
+    });
+  }, []);
+
   const isMessageQueueFull = useCallback(
     (conversationId: string): boolean => {
       const current = queues.get(conversationId);
@@ -59,8 +69,8 @@ export const ConversationMessageQueueProvider: React.FC<{ children: React.ReactN
   );
 
   const value = useMemo<ConversationMessageQueueContextValue>(
-    () => ({ queues, enqueue, remove, isMessageQueueFull }),
-    [queues, enqueue, remove, isMessageQueueFull]
+    () => ({ queues, enqueue, remove, clear, isMessageQueueFull }),
+    [queues, enqueue, remove, clear, isMessageQueueFull]
   );
 
   return (


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/15271

### Description 

Add a message queue to the Agent Builder chat input that lets users type follow-up messages while the agent is still responding. Queued messages are flushed together as a single send when the agent is ready to receive input, so users don't have to wait to capture their next thought.

## Current Scope

- Initially guarded behind the experimental feature flag; behaviour is unchanged when the flag is off.
- Users can queue up to 3 messages per conversation while the agent is responding.
- When the agent finishes, the queue is flushed as one message with the queued messages joined together.
- Nothing sends while the agent is paused on a human-in-the-loop prompt.
- Queue is per-conversation and survives navigating between conversations within a session.
- Tracking events fire when a user queues or removes a message.

### Acceptance criteria
- [ ] Feature is guarded behind the experimental feature flag
- [ ] Users can queue follow-up messages while the agent is responding, up to a per-conversation cap
- [ ] When the agent finishes, queued messages are flushed as a single send
- [ ] Queue is per-conversation and survives navigating between conversations
- [ ] Nothing sends while the agent is paused on a human-in-the-loop prompt
- [ ] Tracking events fire when a user queues or removes a message


https://github.com/user-attachments/assets/5153b800-a53f-4f31-8c0d-7e045a2999fa


