### PR TITLE
[9.3] [Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239)

### DIFF
--- a/src/platform/plugins/shared/console/public/lib/autocomplete/engine.js
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/engine.js
@@ -8,6 +8,7 @@
  */
 
 import _ from 'lodash';
+import { ConstantComponent } from './components/constant_component';
 
 export function wrapComponentWithDefaults(component, defaults) {
   const originalGetTerms = component.getTerms;
@@ -46,12 +47,19 @@ function passThroughContext(context, extensionList) {
   return result;
 }
 
-export function WalkingState(parentName, components, contextExtensionList, depth, priority) {
+export function WalkingState(
+  parentName,
+  components,
+  contextExtensionList,
+  { depth = 0, priority, specificity = 0 } = {}
+) {
   this.parentName = parentName;
   this.components = components;
   this.contextExtensionList = contextExtensionList;
-  this.depth = depth || 0;
+  this.depth = depth;
   this.priority = priority;
+  // Number of path segments matched literally (via a ConstantComponent).
+  this.specificity = specificity;
 }
 
 export function walkTokenPath(tokenPath, walkingStates, context, editor) {
@@ -94,8 +102,14 @@ export function walkTokenPath(tokenPath, walkingStates, context, editor) {
           }
         }
 
+        const specificity = ws.specificity + (component instanceof ConstantComponent ? 1 : 0);
+
         nextWalkingStates.push(
-          new WalkingState(component.name, next, extensionList, ws.depth + 1, priority)
+          new WalkingState(component.name, next, extensionList, {
+            depth: ws.depth + 1,
+            priority,
+            specificity,
+          })
         );
       }
     });
@@ -140,12 +154,16 @@ export function populateContext(tokenPath, context, editor, includeAutoComplete,
     context.autoCompleteSet = autoCompleteSet;
   }
 
-  // apply what values were set so far to context, selecting the deepest on which sets the context
+  // Apply accumulated context from the best matching state.
   if (walkStates.length !== 0) {
     let wsToUse;
-    walkStates = _.sortBy(walkStates, function (ws) {
-      return _.isNumber(ws.priority) ? ws.priority : Number.MAX_VALUE;
-    });
+    // Sort by explicit priority first (lower wins), then prefer the most specific
+    // path (more literally-matched segments) so a concrete endpoint is chosen over
+    // a competing parameter pattern regardless of endpoint registration order.
+    walkStates = _.sortBy(walkStates, [
+      (ws) => (_.isNumber(ws.priority) ? ws.priority : Number.MAX_VALUE),
+      (ws) => -ws.specificity,
+    ]);
     wsToUse = _.find(walkStates, function (ws) {
       return _.isEmpty(ws.components);
     });

--- a/src/platform/plugins/shared/console/public/lib/autocomplete/url_autocomplete.test.js
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/url_autocomplete.test.js
@@ -418,4 +418,72 @@ describe('Url autocomplete', () => {
       method: 'PUT',
     });
   })();
+
+  (function () {
+    // https://github.com/elastic/kibana/issues/182360
+    // When a concrete path segment (e.g. `_sync_job`) also matches a sibling
+    // parameter pattern (e.g. `{connector_id}`), the endpoint whose pattern
+    // matches literally must win, regardless of endpoint registration order.
+    const paramFirst = {
+      'connector.get': {
+        patterns: ['_connector/{connector_id}'],
+        methods: ['GET'],
+      },
+      'connector.sync_job_list': {
+        patterns: ['_connector/_sync_job'],
+        methods: ['GET'],
+      },
+    };
+    patternsTest(
+      'Competing endpoints - literal wins over param (param registered first)',
+      paramFirst,
+      '_connector/_sync_job$',
+      { method: 'GET', endpoint: 'connector.sync_job_list' }
+    );
+
+    const literalFirst = {
+      'connector.sync_job_list': {
+        patterns: ['_connector/_sync_job'],
+        methods: ['GET'],
+      },
+      'connector.get': {
+        patterns: ['_connector/{connector_id}'],
+        methods: ['GET'],
+      },
+    };
+    patternsTest(
+      'Competing endpoints - literal wins over param (literal registered first)',
+      literalFirst,
+      '_connector/_sync_job$',
+      { method: 'GET', endpoint: 'connector.sync_job_list' }
+    );
+
+    // A genuine parameter value must still resolve to the param endpoint.
+    patternsTest(
+      'Competing endpoints - param still matches non-literal value',
+      paramFirst,
+      '_connector/some_id$',
+      { method: 'GET', endpoint: 'connector.get', connector_id: 'some_id' }
+    );
+
+    // Explicit priority remains the primary key: it wins even when the
+    // literal-segment specificity would favor the other endpoint.
+    const paramWithPriority = {
+      'connector.get': {
+        patterns: ['_connector/{connector_id}'],
+        methods: ['GET'],
+        priority: 0,
+      },
+      'connector.sync_job_list': {
+        patterns: ['_connector/_sync_job'],
+        methods: ['GET'],
+      },
+    };
+    patternsTest(
+      'Competing endpoints - explicit priority beats specificity',
+      paramWithPriority,
+      '_connector/_sync_job$',
+      { method: 'GET', endpoint: 'connector.get', connector_id: '_sync_job' }
+    );
+  })();
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239)](https://github.com/elastic/kibana/pull/276239)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-07-09T22:48:12Z","message":"[Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239)\n\n## Summary\n\nCloses #182360\n\nIn Dev Tools Console, the autocomplete engine could match the **wrong**\nAPI endpoint when a typed URL matched both a literal endpoint and a\nsibling parameterized one. For example, typing `GET\n_connector/_sync_job` resolved to `connector.get` (pattern\n`_connector/{connector_id}`, treating `_sync_job` as a `{connector_id}`\nvalue) instead of `connector.sync_job_list` (pattern\n`_connector/_sync_job`).\n\n### Reproduction\n\n1. Open Dev Tools Console.\n2. Type `GET _connector/_sync_job?`.\n3. Trigger URL-param autocomplete.\n4. On `main`, Console suggests params from `connector.get`, including\n`include_deleted`, because `_sync_job` is treated as `{connector_id}`.\n5. On this branch, Console suggests params from\n`connector.sync_job_list`, including `status`, `job_type`, `from`,\n`size`, and `connector_id`.\n### Root cause\n\nIn `populateContext`\n(`src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts`),\nwhen several endpoint patterns match the same path, candidates were\nsorted only by explicit endpoint `priority`. With no priorities set, the\nwinner was decided by endpoint **registration order** (endpoints load\nlexicographically, so `connector.get` registers before\n`connector.sync_job_list`), making the parameter pattern win over the\nliteral one.\n\n### Fix\n\nTrack how many path segments each candidate matched **literally** (via\n`ConstantComponent`) as a `specificity` score, and use it as a\ntie-breaker **after** explicit `priority`. A concrete endpoint now wins\nover a competing parameter pattern regardless of registration order.\nExplicit `priority` remains the primary key, so existing priority-based\nbehavior is unchanged.\n\n| Before  | After |\n| ------------- | ------------- |\n| <img width=\"600\" height=\"320\" alt=\"console_base_bug\"\nsrc=\"https://github.com/user-attachments/assets/bf65fac4-2f09-47ef-adb7-d50b66bad02e\"\n/> | <img width=\"600\" height=\"360\" alt=\"console_head_fixed\"\nsrc=\"https://github.com/user-attachments/assets/30edf112-129d-4e6b-a91b-d54c8a29c7e8\"\n/> |\n\n### Testing\n\nAdded regression tests in `url_autocomplete.test.ts` covering both\nregistration orders and confirming a genuine parameter value still\nresolves to the parameter endpoint. `jest`, `eslint`, and `type_check`\n(console project) all pass.\n\n**Live verification** (Dev Tools Console, query-param autocomplete for\n`GET _connector/_sync_job?`), base vs. this branch:\n\n| | Before (base) | After (this PR) |\n|---|---|---|\n| Suggested URL params | `error_trace, filter_path, format, human,\ninclude_deleted, pretty` | `connector_id, error_trace, filter_path,\nformat, from, human, job_type, pretty, size, status` |\n| `include_deleted` (only on `connector.get`) | present ❌ | absent ✅ |\n| `status` / `job_type` / `from` / `size` / `connector_id`\n(`connector.sync_job_list`) | absent ❌ | present ✅ |\n| Matched endpoint | `connector.get` (wrong) | `connector.sync_job_list`\n(correct) |\n\n### Release Notes\n\nFixed a bug in Dev Tools Console where autocomplete could match an\nincorrect API endpoint when a URL matched both a literal endpoint and a\nparameterized one (for example `GET _connector/_sync_job`).\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"65e6a17f877836e01c1f5c6d17ff871de863bf79","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","v9.5.0","v9.4.4","v9.6.0"],"title":"[Console] Fix autocomplete matching incorrect endpoint for competing URL patterns","number":276239,"url":"https://github.com/elastic/kibana/pull/276239","mergeCommit":{"message":"[Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239)\n\n## Summary\n\nCloses #182360\n\nIn Dev Tools Console, the autocomplete engine could match the **wrong**\nAPI endpoint when a typed URL matched both a literal endpoint and a\nsibling parameterized one. For example, typing `GET\n_connector/_sync_job` resolved to `connector.get` (pattern\n`_connector/{connector_id}`, treating `_sync_job` as a `{connector_id}`\nvalue) instead of `connector.sync_job_list` (pattern\n`_connector/_sync_job`).\n\n### Reproduction\n\n1. Open Dev Tools Console.\n2. Type `GET _connector/_sync_job?`.\n3. Trigger URL-param autocomplete.\n4. On `main`, Console suggests params from `connector.get`, including\n`include_deleted`, because `_sync_job` is treated as `{connector_id}`.\n5. On this branch, Console suggests params from\n`connector.sync_job_list`, including `status`, `job_type`, `from`,\n`size`, and `connector_id`.\n### Root cause\n\nIn `populateContext`\n(`src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts`),\nwhen several endpoint patterns match the same path, candidates were\nsorted only by explicit endpoint `priority`. With no priorities set, the\nwinner was decided by endpoint **registration order** (endpoints load\nlexicographically, so `connector.get` registers before\n`connector.sync_job_list`), making the parameter pattern win over the\nliteral one.\n\n### Fix\n\nTrack how many path segments each candidate matched **literally** (via\n`ConstantComponent`) as a `specificity` score, and use it as a\ntie-breaker **after** explicit `priority`. A concrete endpoint now wins\nover a competing parameter pattern regardless of registration order.\nExplicit `priority` remains the primary key, so existing priority-based\nbehavior is unchanged.\n\n| Before  | After |\n| ------------- | ------------- |\n| <img width=\"600\" height=\"320\" alt=\"console_base_bug\"\nsrc=\"https://github.com/user-attachments/assets/bf65fac4-2f09-47ef-adb7-d50b66bad02e\"\n/> | <img width=\"600\" height=\"360\" alt=\"console_head_fixed\"\nsrc=\"https://github.com/user-attachments/assets/30edf112-129d-4e6b-a91b-d54c8a29c7e8\"\n/> |\n\n### Testing\n\nAdded regression tests in `url_autocomplete.test.ts` covering both\nregistration orders and confirming a genuine parameter value still\nresolves to the parameter endpoint. `jest`, `eslint`, and `type_check`\n(console project) all pass.\n\n**Live verification** (Dev Tools Console, query-param autocomplete for\n`GET _connector/_sync_job?`), base vs. this branch:\n\n| | Before (base) | After (this PR) |\n|---|---|---|\n| Suggested URL params | `error_trace, filter_path, format, human,\ninclude_deleted, pretty` | `connector_id, error_trace, filter_path,\nformat, from, human, job_type, pretty, size, status` |\n| `include_deleted` (only on `connector.get`) | present ❌ | absent ✅ |\n| `status` / `job_type` / `from` / `size` / `connector_id`\n(`connector.sync_job_list`) | absent ❌ | present ✅ |\n| Matched endpoint | `connector.get` (wrong) | `connector.sync_job_list`\n(correct) |\n\n### Release Notes\n\nFixed a bug in Dev Tools Console where autocomplete could match an\nincorrect API endpoint when a URL matched both a literal endpoint and a\nparameterized one (for example `GET _connector/_sync_job`).\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"65e6a17f877836e01c1f5c6d17ff871de863bf79"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277351","number":277351,"state":"MERGED","mergeCommit":{"sha":"188affbbcdf034341a98677e2200f35ccb386522","message":"[9.5] [Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239) (#277351)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Console] Fix autocomplete matching incorrect endpoint for competing\nURL patterns (#276239)](https://github.com/elastic/kibana/pull/276239)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277350","number":277350,"state":"MERGED","mergeCommit":{"sha":"85b150380ab6a5e5ba95a76ab2fdf048e4bd0fb4","message":"[9.4] [Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239) (#277350)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Console] Fix autocomplete matching incorrect endpoint for competing\nURL patterns (#276239)](https://github.com/elastic/kibana/pull/276239)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276239","number":276239,"mergeCommit":{"message":"[Console] Fix autocomplete matching incorrect endpoint for competing URL patterns (#276239)\n\n## Summary\n\nCloses #182360\n\nIn Dev Tools Console, the autocomplete engine could match the **wrong**\nAPI endpoint when a typed URL matched both a literal endpoint and a\nsibling parameterized one. For example, typing `GET\n_connector/_sync_job` resolved to `connector.get` (pattern\n`_connector/{connector_id}`, treating `_sync_job` as a `{connector_id}`\nvalue) instead of `connector.sync_job_list` (pattern\n`_connector/_sync_job`).\n\n### Reproduction\n\n1. Open Dev Tools Console.\n2. Type `GET _connector/_sync_job?`.\n3. Trigger URL-param autocomplete.\n4. On `main`, Console suggests params from `connector.get`, including\n`include_deleted`, because `_sync_job` is treated as `{connector_id}`.\n5. On this branch, Console suggests params from\n`connector.sync_job_list`, including `status`, `job_type`, `from`,\n`size`, and `connector_id`.\n### Root cause\n\nIn `populateContext`\n(`src/platform/plugins/shared/console/public/lib/autocomplete/engine.ts`),\nwhen several endpoint patterns match the same path, candidates were\nsorted only by explicit endpoint `priority`. With no priorities set, the\nwinner was decided by endpoint **registration order** (endpoints load\nlexicographically, so `connector.get` registers before\n`connector.sync_job_list`), making the parameter pattern win over the\nliteral one.\n\n### Fix\n\nTrack how many path segments each candidate matched **literally** (via\n`ConstantComponent`) as a `specificity` score, and use it as a\ntie-breaker **after** explicit `priority`. A concrete endpoint now wins\nover a competing parameter pattern regardless of registration order.\nExplicit `priority` remains the primary key, so existing priority-based\nbehavior is unchanged.\n\n| Before  | After |\n| ------------- | ------------- |\n| <img width=\"600\" height=\"320\" alt=\"console_base_bug\"\nsrc=\"https://github.com/user-attachments/assets/bf65fac4-2f09-47ef-adb7-d50b66bad02e\"\n/> | <img width=\"600\" height=\"360\" alt=\"console_head_fixed\"\nsrc=\"https://github.com/user-attachments/assets/30edf112-129d-4e6b-a91b-d54c8a29c7e8\"\n/> |\n\n### Testing\n\nAdded regression tests in `url_autocomplete.test.ts` covering both\nregistration orders and confirming a genuine parameter value still\nresolves to the parameter endpoint. `jest`, `eslint`, and `type_check`\n(console project) all pass.\n\n**Live verification** (Dev Tools Console, query-param autocomplete for\n`GET _connector/_sync_job?`), base vs. this branch:\n\n| | Before (base) | After (this PR) |\n|---|---|---|\n| Suggested URL params | `error_trace, filter_path, format, human,\ninclude_deleted, pretty` | `connector_id, error_trace, filter_path,\nformat, from, human, job_type, pretty, size, status` |\n| `include_deleted` (only on `connector.get`) | present ❌ | absent ✅ |\n| `status` / `job_type` / `from` / `size` / `connector_id`\n(`connector.sync_job_list`) | absent ❌ | present ✅ |\n| Matched endpoint | `connector.get` (wrong) | `connector.sync_job_list`\n(correct) |\n\n### Release Notes\n\nFixed a bug in Dev Tools Console where autocomplete could match an\nincorrect API endpoint when a URL matched both a literal endpoint and a\nparameterized one (for example `GET _connector/_sync_job`).\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"65e6a17f877836e01c1f5c6d17ff871de863bf79"}}]}] BACKPORT-->