### PR TITLE
[9.4] Change team ownership: obs-onboarding-team > streams-ui (#275734)

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml
@@ -9,7 +9,7 @@ metadata:
       title: Pipeline link
 spec:
   type: buildkite-pipeline
-  owner: 'group:obs-onboarding-team'
+  owner: 'group:streams-ui'
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -21,7 +21,7 @@ spec:
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
-        SLACK_NOTIFICATIONS_CHANNEL: '#obs-onboarding'
+        SLACK_NOTIFICATIONS_CHANNEL: '#streams-ui'
       allow_rebuilds: false
       branch_configuration: main
       default_branch: main
@@ -36,7 +36,7 @@ spec:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true
       teams:
-        obs-onboarding-team:
+        streams-ui:
           access_level: MANAGE_BUILD_AND_READ
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ
@@ -55,4 +55,4 @@ spec:
         - kibana
         - observability
         - opentelemetry
-        - obs-onboarding
+        - streams-ui

--- a/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml
@@ -9,7 +9,7 @@ metadata:
       title: Pipeline link
 spec:
   type: buildkite-pipeline
-  owner: 'group:obs-onboarding-team'
+  owner: 'group:streams-ui'
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -34,7 +34,7 @@ spec:
       teams:
         everyone:
           access_level: BUILD_AND_READ
-        obs-onboarding-team:
+        streams-ui:
           access_level: MANAGE_BUILD_AND_READ
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ

--- a/.buildkite/scripts/steps/otel_semconv_sync.sh
+++ b/.buildkite/scripts/steps/otel_semconv_sync.sh
@@ -107,14 +107,14 @@ create_pull_request() {
     echo "Author: $KIBANA_MACHINE_USERNAME"
     echo ""
     echo "=== LABELS ==="
-    echo "- Team:obs-onboarding"
+    echo "- Team:streams-ui"
     echo "- release_note:skip"
     echo "- backport:skip"
     echo "- otel-semantic-conventions"
     echo ""
     echo "=== ASSIGNEES & REVIEWERS ==="
-    echo "Assignee: elastic/obs-onboarding-team"
-    echo "Reviewer: elastic/obs-onboarding-team"
+    echo "Assignee: elastic/streams-ui"
+    echo "Reviewer: elastic/streams-ui"
     echo ""
     echo "=== FILES TO COMMIT ==="
     echo "- $OTEL_PACKAGE_DIR/assets/resolved-semconv.yaml"
@@ -184,7 +184,7 @@ create_pull_request() {
     --body "$PR_BODY" \
     --base main \
     --head "$BRANCH_NAME" \
-    --label 'Team:obs-onboarding' \
+    --label 'Team:streams-ui' \
     --label 'release_note:skip' \
     --label 'backport:skip' \
     --label 'otel-semantic-conventions'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -567,7 +567,7 @@ src/platform/packages/shared/kbn-ftr-benchmarks @elastic/kibana-operations
 src/platform/packages/shared/kbn-ftr-common-functional-services @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-ftr-common-functional-ui-services @elastic/appex-qa
 src/platform/packages/shared/kbn-ftr-llm-proxy @elastic/appex-ai-infra
-src/platform/packages/shared/kbn-grok-ui @elastic/obs-onboarding-team
+src/platform/packages/shared/kbn-grok-ui @elastic/streams-ui
 src/platform/packages/shared/kbn-grouping @elastic/response-ops
 src/platform/packages/shared/kbn-i18n @elastic/kibana-core
 src/platform/packages/shared/kbn-i18n-react @elastic/kibana-core
@@ -608,13 +608,13 @@ src/platform/packages/shared/kbn-openapi-generator @elastic/security-detection-e
 src/platform/packages/shared/kbn-opentelemetry-attributes @elastic/kibana-core
 src/platform/packages/shared/kbn-opentelemetry-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-osquery-io-ts-types @elastic/security-defend-workflows
-src/platform/packages/shared/kbn-otel-demo @elastic/obs-onboarding-team
-src/platform/packages/shared/kbn-otel-semantic-conventions @elastic/obs-onboarding-team
+src/platform/packages/shared/kbn-otel-demo @elastic/streams-ui
+src/platform/packages/shared/kbn-otel-semantic-conventions @elastic/streams-ui
 src/platform/packages/shared/kbn-palettes @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-profiler @elastic/observability-ui
 src/platform/packages/shared/kbn-profiling-utils @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-react-field @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-react-hooks @elastic/obs-onboarding-team
+src/platform/packages/shared/kbn-react-hooks @elastic/streams-ui
 src/platform/packages/shared/kbn-react-query @elastic/appex-sharedux
 src/platform/packages/shared/kbn-recently-accessed @elastic/appex-sharedux
 src/platform/packages/shared/kbn-repo-info @elastic/kibana-operations
@@ -655,8 +655,8 @@ src/platform/packages/shared/kbn-sse-utils-server @elastic/nightshift-context-an
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
-src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team @elastic/nightshift-context-and-research-team
-src/platform/packages/shared/kbn-synthtrace-client @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team @elastic/nightshift-context-and-research-team
+src/platform/packages/shared/kbn-synthtrace-client @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-telemetry-config @elastic/kibana-core
 src/platform/packages/shared/kbn-test @elastic/kibana-operations @elastic/appex-qa
@@ -666,7 +666,7 @@ src/platform/packages/shared/kbn-test-jest-helpers @elastic/kibana-operations @e
 src/platform/packages/shared/kbn-test-kibana-server @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-test-saml-auth @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-test-subj-selector @elastic/kibana-operations @elastic/appex-qa
-src/platform/packages/shared/kbn-timerange @elastic/obs-onboarding-team
+src/platform/packages/shared/kbn-timerange @elastic/streams-ui
 src/platform/packages/shared/kbn-tooling-log @elastic/kibana-operations
 src/platform/packages/shared/kbn-tour-queue @elastic/appex-sharedux
 src/platform/packages/shared/kbn-traced-es-client @elastic/observability-ui
@@ -685,7 +685,7 @@ src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-tabs @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unsaved-changes-prompt @elastic/kibana-management
-src/platform/packages/shared/kbn-use-tracked-promise @elastic/obs-onboarding-team
+src/platform/packages/shared/kbn-use-tracked-promise @elastic/streams-ui
 src/platform/packages/shared/kbn-user-profile-components @elastic/kibana-security
 src/platform/packages/shared/kbn-utility-types @elastic/kibana-core
 src/platform/packages/shared/kbn-utility-types-jest @elastic/kibana-operations
@@ -697,7 +697,7 @@ src/platform/packages/shared/kbn-visualizations-common @elastic/kibana-visualiza
 src/platform/packages/shared/kbn-workflows @elastic/workflows-eng
 src/platform/packages/shared/kbn-workflows-ui @elastic/workflows-eng
 src/platform/packages/shared/kbn-workspaces @elastic/observability-ui
-src/platform/packages/shared/kbn-xstate-utils @elastic/obs-onboarding-team
+src/platform/packages/shared/kbn-xstate-utils @elastic/streams-ui
 src/platform/packages/shared/kbn-yaml-loader @elastic/fleet
 src/platform/packages/shared/kbn-zod @elastic/kibana-core
 src/platform/packages/shared/kbn-zod-helpers @elastic/security-detection-engineering
@@ -997,9 +997,9 @@ x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
 x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-presentation-team
 x-pack/platform/packages/shared/kbn-change-history @elastic/security-detection-engineering
 x-pack/platform/packages/shared/kbn-classic-stream-flyout @elastic/kibana-management
-x-pack/platform/packages/shared/kbn-content-packs-schema @elastic/obs-onboarding-team
+x-pack/platform/packages/shared/kbn-content-packs-schema @elastic/streams-ui
 x-pack/platform/packages/shared/kbn-data-forge @elastic/actionable-obs-team
-x-pack/platform/packages/shared/kbn-dissect-heuristics @elastic/obs-onboarding-team
+x-pack/platform/packages/shared/kbn-dissect-heuristics @elastic/streams-ui
 x-pack/platform/packages/shared/kbn-elastic-assistant @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-elastic-assistant-common @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-elastic-assistant-shared-state @elastic/security-generative-ai
@@ -1010,11 +1010,11 @@ x-pack/platform/packages/shared/kbn-evals-common @elastic/nightshift-context-and
 x-pack/platform/packages/shared/kbn-evals-extensions @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-evals-phoenix-executor @elastic/nightshift-context-and-research-team
 x-pack/platform/packages/shared/kbn-evals-suite-significant-events @elastic/obs-sig-events-team
-x-pack/platform/packages/shared/kbn-evals-suite-streams @elastic/obs-onboarding-team
+x-pack/platform/packages/shared/kbn-evals-suite-streams @elastic/streams-ui
 x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-team @elastic/obs-exploration-team
 x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
-x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/obs-onboarding-team
+x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/streams-ui
 x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/search-inference-team
 x-pack/platform/packages/shared/kbn-inference-connectors @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/search-kibana
@@ -1028,14 +1028,14 @@ x-pack/platform/packages/shared/kbn-langchain @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-mcp-client @elastic/workchat-eng
 x-pack/platform/packages/shared/kbn-profiler-cli @elastic/observability-ui
-x-pack/platform/packages/shared/kbn-sample-parser @elastic/obs-onboarding-team @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-sample-parser @elastic/streams-ui @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-slo-schema @elastic/actionable-obs-team
-x-pack/platform/packages/shared/kbn-streamlang @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-streamlang-tests @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-streamlang-yaml-editor @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-streams-ai @elastic/obs-onboarding-team @elastic/obs-sig-events-team
-x-pack/platform/packages/shared/kbn-streams-schema @elastic/obs-onboarding-team @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-streamlang @elastic/streams-ui
+x-pack/platform/packages/shared/kbn-streamlang-tests @elastic/streams-ui
+x-pack/platform/packages/shared/kbn-streamlang-yaml-editor @elastic/streams-ui
+x-pack/platform/packages/shared/kbn-streams-ai @elastic/streams-ui @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-streams-schema @elastic/streams-ui @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/logs-overview @elastic/obs-exploration-team
 x-pack/platform/packages/shared/ml/aiops_common @elastic/ml-ui
 x-pack/platform/packages/shared/ml/aiops_log_pattern_analysis @elastic/ml-ui
@@ -1139,14 +1139,14 @@ x-pack/platform/plugins/shared/entity_manager @elastic/core-analysis
 x-pack/platform/plugins/shared/evals @elastic/nightshift-context-and-research-team @elastic/security-generative-ai
 x-pack/platform/plugins/shared/event_log @elastic/response-ops
 x-pack/platform/plugins/shared/features @elastic/kibana-core
-x-pack/platform/plugins/shared/fields_metadata @elastic/obs-onboarding-team
+x-pack/platform/plugins/shared/fields_metadata @elastic/streams-ui
 x-pack/platform/plugins/shared/fleet @elastic/fleet
 x-pack/platform/plugins/shared/fleet/cypress @elastic/fleet
 x-pack/platform/plugins/shared/global_search @elastic/appex-sharedux
 x-pack/platform/plugins/shared/index_management @elastic/kibana-management
 x-pack/platform/plugins/shared/inference @elastic/search-kibana
 x-pack/platform/plugins/shared/inference_endpoint @elastic/search-kibana
-x-pack/platform/plugins/shared/ingest_hub @elastic/obs-onboarding-team
+x-pack/platform/plugins/shared/ingest_hub @elastic/streams-ui
 x-pack/platform/plugins/shared/ingest_pipelines @elastic/kibana-management
 x-pack/platform/plugins/shared/lens @elastic/kibana-visualizations
 x-pack/platform/plugins/shared/license_management @elastic/kibana-management
@@ -1173,8 +1173,8 @@ x-pack/platform/plugins/shared/slo_shared @elastic/actionable-obs-team
 x-pack/platform/plugins/shared/spaces @elastic/kibana-security
 x-pack/platform/plugins/shared/stack_alerts @elastic/response-ops
 x-pack/platform/plugins/shared/stack_connectors @elastic/response-ops
-x-pack/platform/plugins/shared/streams @elastic/obs-onboarding-team @elastic/obs-sig-events-team
-x-pack/platform/plugins/shared/streams_app @elastic/obs-onboarding-team @elastic/obs-sig-events-team
+x-pack/platform/plugins/shared/streams @elastic/streams-ui @elastic/obs-sig-events-team
+x-pack/platform/plugins/shared/streams_app @elastic/streams-ui @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/task_manager @elastic/response-ops
 x-pack/platform/plugins/shared/triggers_actions_ui @elastic/response-ops
 x-pack/platform/plugins/shared/usage_api @elastic/kibana-core
@@ -1246,7 +1246,7 @@ x-pack/solutions/observability/plugins/observability @elastic/observability-ui
 x-pack/solutions/observability/plugins/observability_agent_builder @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/plugins/observability_logs_explorer @elastic/obs-exploration-team
-x-pack/solutions/observability/plugins/observability_onboarding @elastic/obs-onboarding-team
+x-pack/solutions/observability/plugins/observability_onboarding @elastic/streams-ui
 x-pack/solutions/observability/plugins/observability_shared @elastic/observability-ui
 x-pack/solutions/observability/plugins/profiling @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/profiling_data_access @elastic/obs-presentation-team
@@ -1724,10 +1724,10 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/server/routes/log_alerts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-presentation-team @elastic/obs-exploration-team
-/x-pack/platform/test/common/utils/server_route_repository @elastic/obs-onboarding-team @elastic/obs-sig-events-team
+/x-pack/platform/test/common/utils/server_route_repository @elastic/streams-ui @elastic/obs-sig-events-team
 
-## Streams parts owned by Logs UX
-/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management @elastic/obs-onboarding-team
+## Streams parts owned by Streams UI
+/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management @elastic/streams-ui
 
 # Streams parts owned by Kibana Management
 x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/downsampling @elastic/kibana-management
@@ -1842,18 +1842,18 @@ x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events @elasti
 /src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/global.setup.ts @elastic/obs-exploration-team
 /x-pack/performance/journeys_e2e/metrics_* @elastic/obs-exploration-team
 /x-pack/performance/utils/metrics_experience_setup.ts @elastic/obs-exploration-team
- # obs-onboarding-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/functional/configs/config.* @elastic/obs-onboarding-team
+ # streams-ui
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality @elastic/streams-ui
+/x-pack/solutions/observability/test/serverless/functional/configs/config.* @elastic/streams-ui
 /x-pack/solutions/observability/test/serverless/functional/test_suites/navigation.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/functional/configs/index* @elastic/obs-onboarding-team
+/x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts @elastic/streams-ui
+/x-pack/solutions/observability/test/serverless/functional/configs/index* @elastic/streams-ui
 /x-pack/solutions/observability/test/functional/services/infra_source_configuration_form.ts @elastic/obs-presentation-team
-/src/platform/test/functional/services/selectable.ts @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/api_integration/configs/index.feature_flags.ts @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/functional/apps/dataset_quality @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality @elastic/obs-onboarding-team
-/x-pack/solutions/observability/plugins/observability/public/pages/landing @elastic/obs-onboarding-team
+/src/platform/test/functional/services/selectable.ts @elastic/streams-ui
+/x-pack/solutions/observability/test/serverless/api_integration/configs/index.feature_flags.ts @elastic/streams-ui
+/x-pack/solutions/observability/test/functional/apps/dataset_quality @elastic/streams-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality @elastic/streams-ui
+/x-pack/solutions/observability/plugins/observability/public/pages/landing @elastic/streams-ui
 
 # Observability-ui
 /x-pack/solutions/observability/test/serverless/api_integration/configs/index.ts @elastic/observability-ui
@@ -1866,17 +1866,16 @@ x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events @elasti
 # Observability settings
 
 # Streams
-/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams @elastic/obs-sig-events-team  @elastic/obs-onboarding-team
-/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.index.ts @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/x-pack/platform/test/api_integration/apis/streams @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/x-pack/platform/test/api_integration/fixtures/kbn_archives/streams @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/x-pack/performance/configs/streams_* @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/x-pack/performance/journeys_e2e/streams_* @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/.buildkite/pipelines/performance/streams_weekly.yml @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-
+/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams @elastic/obs-sig-events-team  @elastic/streams-ui
+/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.index.ts @elastic/obs-sig-events-team @elastic/streams-ui
+/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts @elastic/obs-sig-events-team @elastic/streams-ui
+/x-pack/platform/test/api_integration/apis/streams @elastic/obs-sig-events-team @elastic/streams-ui
+/x-pack/platform/test/api_integration/fixtures/kbn_archives/streams @elastic/obs-sig-events-team @elastic/streams-ui
+/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests @elastic/obs-sig-events-team @elastic/streams-ui
+/x-pack/performance/configs/streams_* @elastic/obs-sig-events-team @elastic/streams-ui
+/x-pack/performance/journeys_e2e/streams_* @elastic/obs-sig-events-team @elastic/streams-ui
+/.buildkite/pipelines/performance/streams_weekly.yml @elastic/obs-sig-events-team @elastic/streams-ui
+/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml @elastic/obs-sig-events-team @elastic/streams-ui
 
 # Alerting alerting_v2
 /x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2 @elastic/rna-project-team
@@ -3269,10 +3268,10 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_param.ts @elastic/actionable-obs-team @elastic/kibana-security
 
 # OpenTelemetry semantic conventions Buildkite pipeline and scripts
-/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml @elastic/obs-onboarding-team
-/.buildkite/pipelines/otel_semconv_sync.yml @elastic/obs-onboarding-team
-/.buildkite/scripts/steps/otel_semconv_sync.sh @elastic/obs-onboarding-team
-/scripts/generate_otel_semconv.js @elastic/obs-onboarding-team
+/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml @elastic/streams-ui
+/.buildkite/pipelines/otel_semconv_sync.yml @elastic/streams-ui
+/.buildkite/scripts/steps/otel_semconv_sync.sh @elastic/streams-ui
+/scripts/generate_otel_semconv.js @elastic/streams-ui
 
 # Specialised GitHub workflows for the Observability robots
 /.github/workflows/deploy-my-kibana.yml   @elastic/observablt-robots @elastic/kibana-operations

--- a/renovate.json
+++ b/renovate.json
@@ -706,9 +706,9 @@
     {
       "groupName": "@elastic/ecs",
       "matchDepNames": ["@elastic/ecs"],
-      "reviewers": ["team:obs-onboarding-team"],
+      "reviewers": ["team:streams-ui"],
       "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "backport:skip", "Team:obs-onboarding"],
+      "labels": ["release_note:skip", "backport:skip", "Team:streams-ui"],
       "enabled": true,
       "minimumReleaseAge": "14 days"
     },
@@ -2379,9 +2379,9 @@
     {
       "groupName": "XState4",
       "matchDepNames": ["xstate", "@xstate/react"],
-      "reviewers": ["team:obs-onboarding-team"],
+      "reviewers": ["team:streams-ui"],
       "matchBaseBranches": ["main"],
-      "labels": ["Team:obs-onboarding", "release_note:skip", "backport:all-open"],
+      "labels": ["Team:streams-ui", "release_note:skip", "backport:all-open"],
       "minimumReleaseAge": "14 days",
       "separateMajorMinor": true,
       "allowedVersions": "<5.0.0",
@@ -2390,18 +2390,18 @@
     {
       "groupName": "constate",
       "matchDepNames": ["constate"],
-      "reviewers": ["team:obs-onboarding-team"],
+      "reviewers": ["team:streams-ui"],
       "matchBaseBranches": ["main"],
-      "labels": ["Team:obs-onboarding", "release_note:skip", "backport:all-open"],
+      "labels": ["Team:streams-ui", "release_note:skip", "backport:all-open"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },
     {
       "groupName": "Oniguruma to es",
       "matchDepNames": ["oniguruma-to-es"],
-      "reviewers": ["team:obs-onboarding-team"],
+      "reviewers": ["team:streams-ui"],
       "matchBaseBranches": ["main"],
-      "labels": ["Team:obs-onboarding", "release_note:skip", "backport:all-open"],
+      "labels": ["Team:streams-ui", "release_note:skip", "backport:all-open"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },
@@ -2411,9 +2411,9 @@
         "@atlaskit/pragmatic-drag-and-drop",
         "@atlaskit/pragmatic-drag-and-drop-hitbox"
       ],
-      "reviewers": ["team:obs-onboarding-team"],
+      "reviewers": ["team:streams-ui"],
       "matchBaseBranches": ["main"],
-      "labels": ["Team:obs-onboarding", "release_note:skip", "backport:all-open"],
+      "labels": ["Team:streams-ui", "release_note:skip", "backport:all-open"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },

--- a/src/dev/precommit_hook/exceptions.json
+++ b/src/dev/precommit_hook/exceptions.json
@@ -346,7 +346,7 @@
   "@elastic/obs-exploration-team": {
     "src/platform/packages/shared/shared-ux/toolbar_selector": "'toolbar_selector' should be kebab-case"
   },
-  "@elastic/obs-onboarding-team": {
+  "@elastic/streams-ui": {
     "src/platform/packages/shared/kbn-otel-semantic-conventions/src/generated/resolved-semconv.ts": "'resolved-semconv.ts' should be snake_case",
     "x-pack/platform/packages/shared/kbn-sample-parser/parsers/Android": "'Android' should be snake_case",
     "x-pack/platform/packages/shared/kbn-sample-parser/parsers/Apache": "'Apache' should be snake_case",

--- a/src/dev/prs/kibana_qa_pr_list.json
+++ b/src/dev/prs/kibana_qa_pr_list.json
@@ -72,7 +72,7 @@
 "Team:obs-ux-management",
 "Team:Cloud Security",
 "Team:Security Generative AI",
-"Team:obs-onboarding",
+"Team:streams-ui",
 "Team:Defend Workflows",
 "Team:Entity Analytics",
 "Team:Obs AI Assistant",

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -60,7 +60,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-docs',
     'elastic/obs-exploration-team',
     'elastic/obs-knowledge-team',
-    'elastic/obs-onboarding-team',
+    'elastic/streams-ui',
     'elastic/obs-presentation-team',
     'elastic/obs-ux-management-team',
     'elastic/observability-design',

--- a/src/platform/packages/shared/kbn-grok-ui/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-grok-ui/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/grok-ui",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-grok-ui/moon.yml
+++ b/src/platform/packages/shared/kbn-grok-ui/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/grok-ui'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/grok-ui'
   description: Moon project for @kbn/grok-ui
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-grok-ui
 dependsOn:
   - '@kbn/monaco'

--- a/src/platform/packages/shared/kbn-otel-demo/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-otel-demo/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/otel-demo",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-otel-demo/moon.yml
+++ b/src/platform/packages/shared/kbn-otel-demo/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/otel-demo'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/otel-demo'
   description: Moon project for @kbn/otel-demo
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-otel-demo
 dependsOn:
   - '@kbn/tooling-log'

--- a/src/platform/packages/shared/kbn-otel-semantic-conventions/README.md
+++ b/src/platform/packages/shared/kbn-otel-semantic-conventions/README.md
@@ -202,7 +202,7 @@ DEBUG=* node scripts/generate_otel_semconv.js
 
 ## Contributing
 
-This package is maintained by the `@elastic/obs-onboarding-team`. When contributing:
+This package is maintained by the `@elastic/streams-ui`. When contributing:
 
 1. Add tests for new functionality
 2. Update type definitions as needed

--- a/src/platform/packages/shared/kbn-otel-semantic-conventions/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-otel-semantic-conventions/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/otel-semantic-conventions",
   "owner": [
-    "@elastic/obs-onboarding-team"
+    "@elastic/streams-ui"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-otel-semantic-conventions/moon.yml
+++ b/src/platform/packages/shared/kbn-otel-semantic-conventions/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/otel-semantic-conventions'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/otel-semantic-conventions'
   description: Moon project for @kbn/otel-semantic-conventions
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-otel-semantic-conventions
 dependsOn: []
 tags:

--- a/src/platform/packages/shared/kbn-react-hooks/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-react-hooks/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/react-hooks",
   "owner": [
-    "@elastic/obs-onboarding-team"
+    "@elastic/streams-ui"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-react-hooks/moon.yml
+++ b/src/platform/packages/shared/kbn-react-hooks/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/react-hooks'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/react-hooks'
   description: Moon project for @kbn/react-hooks
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-react-hooks
 dependsOn:
   - '@kbn/std'

--- a/src/platform/packages/shared/kbn-synthtrace-client/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-synthtrace-client/kibana.jsonc
@@ -3,7 +3,7 @@
   "id": "@kbn/synthtrace-client",
   "owner": [
     "@elastic/obs-presentation-team",
-    "@elastic/obs-onboarding-team",
+    "@elastic/streams-ui",
     "@elastic/obs-exploration-team"
   ],
   "group": "platform",

--- a/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
@@ -3,7 +3,7 @@
   "id": "@kbn/synthtrace",
   "owner": [
     "@elastic/obs-presentation-team",
-    "@elastic/obs-onboarding-team",
+    "@elastic/streams-ui",
     "@elastic/obs-exploration-team",
     "@elastic/nightshift-context-and-research-team"
   ],

--- a/src/platform/packages/shared/kbn-timerange/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-timerange/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/timerange",
-  "owner": ["@elastic/obs-onboarding-team"],
+  "owner": ["@elastic/streams-ui"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-timerange/moon.yml
+++ b/src/platform/packages/shared/kbn-timerange/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/timerange'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/timerange'
   description: Moon project for @kbn/timerange
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-timerange
 dependsOn:
   - '@kbn/datemath'

--- a/src/platform/packages/shared/kbn-use-tracked-promise/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-use-tracked-promise/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/use-tracked-promise",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-use-tracked-promise/moon.yml
+++ b/src/platform/packages/shared/kbn-use-tracked-promise/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/use-tracked-promise'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/use-tracked-promise'
   description: Moon project for @kbn/use-tracked-promise
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-use-tracked-promise
 dependsOn: []
 tags:

--- a/src/platform/packages/shared/kbn-xstate-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-xstate-utils/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/xstate-utils",
   "owner": [
-    "@elastic/obs-onboarding-team"
+    "@elastic/streams-ui"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-xstate-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-xstate-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/xstate-utils'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/xstate-utils'
   description: Moon project for @kbn/xstate-utils
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: src/platform/packages/shared/kbn-xstate-utils
 dependsOn: []
 tags:

--- a/x-pack/platform/packages/shared/kbn-content-packs-schema/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-content-packs-schema/kibana.jsonc
@@ -1,7 +1,7 @@
 {
     "type": "shared-common",
     "id": "@kbn/content-packs-schema",
-    "owner": "@elastic/obs-onboarding-team",
+    "owner": "@elastic/streams-ui",
     "group": "platform",
     "visibility": "shared"
   }

--- a/x-pack/platform/packages/shared/kbn-content-packs-schema/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-content-packs-schema/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/content-packs-schema'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/content-packs-schema'
   description: Moon project for @kbn/content-packs-schema
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-content-packs-schema
 dependsOn:
   - '@kbn/esql-utils'

--- a/x-pack/platform/packages/shared/kbn-dissect-heuristics/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-dissect-heuristics/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/dissect-heuristics",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-dissect-heuristics/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-dissect-heuristics/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/dissect-heuristics'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/dissect-heuristics'
   description: Moon project for @kbn/dissect-heuristics
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-dissect-heuristics
 dependsOn:
   - '@kbn/grok-heuristics'

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "functional-tests",
   "id": "@kbn/evals-suite-streams",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-suite-streams'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-suite-streams'
   description: Moon project for @kbn/evals-suite-streams
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-evals-suite-streams
 dependsOn:
   - '@kbn/evals'

--- a/x-pack/platform/packages/shared/kbn-grok-heuristics/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-grok-heuristics/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/grok-heuristics",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-grok-heuristics/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-grok-heuristics/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/grok-heuristics'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/grok-heuristics'
   description: Moon project for @kbn/grok-heuristics
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-grok-heuristics
 dependsOn:
   - '@kbn/inference-common'

--- a/x-pack/platform/packages/shared/kbn-sample-parser/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-sample-parser/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/sample-log-parser",
-  "owner": "@elastic/obs-onboarding-team @elastic/obs-sig-events-team",
+  "owner": "@elastic/streams-ui @elastic/obs-sig-events-team",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/x-pack/platform/packages/shared/kbn-sample-parser/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-sample-parser/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sample-log-parser'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  defaultOwner: '@elastic/streams-ui @elastic/obs-sig-events-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/sample-log-parser'
   description: Moon project for @kbn/sample-log-parser
   channel: ''
-  owner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  owner: '@elastic/streams-ui @elastic/obs-sig-events-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-sample-parser
 dependsOn:
   - '@kbn/tooling-log'

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/streamlang-tests",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "private"
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streamlang-tests'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streamlang-tests'
   description: Moon project for @kbn/streamlang-tests
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-streamlang-tests
 dependsOn:
   - '@kbn/scout'

--- a/x-pack/platform/packages/shared/kbn-streamlang-yaml-editor/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streamlang-yaml-editor/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/streamlang-yaml-editor",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang-yaml-editor/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-streamlang-yaml-editor/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streamlang-yaml-editor'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streamlang-yaml-editor'
   description: Moon project for @kbn/streamlang-yaml-editor
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-streamlang-yaml-editor
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/platform/packages/shared/kbn-streamlang/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streamlang/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/streamlang",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-streamlang/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streamlang'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streamlang'
   description: Moon project for @kbn/streamlang
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/packages/shared/kbn-streamlang
 dependsOn:
   - '@kbn/zod'

--- a/x-pack/platform/packages/shared/kbn-streams-ai/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/streams-ai",
-  "owner": "@elastic/obs-onboarding-team @elastic/obs-sig-events-team",
+  "owner": "@elastic/streams-ui @elastic/obs-sig-events-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-streams-ai/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streams-ai'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  defaultOwner: '@elastic/streams-ui @elastic/obs-sig-events-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streams-ai'
   description: Moon project for @kbn/streams-ai
   channel: ''
-  owner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  owner: '@elastic/streams-ui @elastic/obs-sig-events-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-streams-ai
 dependsOn:
   - '@kbn/ai-tools'

--- a/x-pack/platform/packages/shared/kbn-streams-schema/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/streams-schema",
-  "owner": "@elastic/obs-onboarding-team @elastic/obs-sig-events-team",
+  "owner": "@elastic/streams-ui @elastic/obs-sig-events-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-streams-schema/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streams-schema'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  defaultOwner: '@elastic/streams-ui @elastic/obs-sig-events-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streams-schema'
   description: Moon project for @kbn/streams-schema
   channel: ''
-  owner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  owner: '@elastic/streams-ui @elastic/obs-sig-events-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-streams-schema
 dependsOn:
   - '@kbn/zod'

--- a/x-pack/platform/plugins/shared/fields_metadata/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/fields_metadata/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/fields-metadata-plugin",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "group": "platform",
   "visibility": "shared",
   "description": "Exposes services for async usage and search of fields metadata.",

--- a/x-pack/platform/plugins/shared/fields_metadata/moon.yml
+++ b/x-pack/platform/plugins/shared/fields_metadata/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/fields-metadata-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/fields-metadata-plugin'
   description: Moon project for @kbn/fields-metadata-plugin
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/plugins/shared/fields_metadata
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/ingest_hub/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/ingest_hub/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/ingest-hub-plugin",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/streams-ui",
   "description": "Cross-solution onboarding page for adding data sources and integrations.",
   "group": "platform",
   "visibility": "shared",

--- a/x-pack/platform/plugins/shared/ingest_hub/moon.yml
+++ b/x-pack/platform/plugins/shared/ingest_hub/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/ingest-hub-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/ingest-hub-plugin'
   description: Moon project for @kbn/ingest-hub-plugin
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/platform/plugins/shared/ingest_hub
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/streams/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/streams-plugin",
-  "owner": "@elastic/obs-onboarding-team @elastic/obs-sig-events-team",
+  "owner": "@elastic/streams-ui @elastic/obs-sig-events-team",
   "description": "A manager for Streams",
   "group": "platform",
   "visibility": "shared",

--- a/x-pack/platform/plugins/shared/streams/moon.yml
+++ b/x-pack/platform/plugins/shared/streams/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streams-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  defaultOwner: '@elastic/streams-ui @elastic/obs-sig-events-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streams-plugin'
   description: Moon project for @kbn/streams-plugin
   channel: ''
-  owner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  owner: '@elastic/streams-ui @elastic/obs-sig-events-team'
   sourceRoot: x-pack/platform/plugins/shared/streams
 dependsOn:
   - '@kbn/config-schema'

--- a/x-pack/platform/plugins/shared/streams_app/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams_app/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/streams-app-plugin",
-  "owner": "@elastic/obs-onboarding-team @elastic/obs-sig-events-team",
+  "owner": "@elastic/streams-ui @elastic/obs-sig-events-team",
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/streams_app/moon.yml
+++ b/x-pack/platform/plugins/shared/streams_app/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/streams-app-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  defaultOwner: '@elastic/streams-ui @elastic/obs-sig-events-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/streams-app-plugin'
   description: Moon project for @kbn/streams-app-plugin
   channel: ''
-  owner: '@elastic/obs-onboarding-team @elastic/obs-sig-events-team'
+  owner: '@elastic/streams-ui @elastic/obs-sig-events-team'
   sourceRoot: x-pack/platform/plugins/shared/streams_app
 dependsOn:
   - '@kbn/core'

--- a/x-pack/solutions/observability/plugins/observability_onboarding/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/observability-onboarding-plugin",
   "owner": [
-    "@elastic/obs-onboarding-team"
+    "@elastic/streams-ui"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/observability_onboarding/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-onboarding-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/streams-ui'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/observability-onboarding-plugin'
   description: Moon project for @kbn/observability-onboarding-plugin
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/streams-ui'
   sourceRoot: x-pack/solutions/observability/plugins/observability_onboarding
 dependsOn:
   - '@kbn/core'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Change team ownership: obs-onboarding-team > streams-ui (#275734)](https://github.com/elastic/kibana/pull/275734)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kerry Gallagher","email":"kerry.gallagher@elastic.co"},"sourceCommit":{"committedDate":"2026-07-06T14:07:14Z","message":"Change team ownership: obs-onboarding-team > streams-ui (#275734)\n\n## Summary\n\nChanges ownership from `obs-onboarding-team` to `streams-ui`","sha":"f9be86de8e804fd2f3d0c38df19690f2c7c10e0e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","Team:obs-presentation","v9.5.0"],"title":"Change team ownership: obs-onboarding-team > streams-ui","number":275734,"url":"https://github.com/elastic/kibana/pull/275734","mergeCommit":{"message":"Change team ownership: obs-onboarding-team > streams-ui (#275734)\n\n## Summary\n\nChanges ownership from `obs-onboarding-team` to `streams-ui`","sha":"f9be86de8e804fd2f3d0c38df19690f2c7c10e0e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275734","number":275734,"mergeCommit":{"message":"Change team ownership: obs-onboarding-team > streams-ui (#275734)\n\n## Summary\n\nChanges ownership from `obs-onboarding-team` to `streams-ui`","sha":"f9be86de8e804fd2f3d0c38df19690f2c7c10e0e"}}]}] BACKPORT-->