### PR TITLE
[One workflow] Show workflow document version in execution Overview

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -1163,6 +1163,10 @@ export const WorkflowDataContextSchema = z.object({
   name: z.string(),
   enabled: z.boolean(),
   spaceId: z.string(),
+  version: z
+    .number()
+    .optional()
+    .describe('Workflow document version captured when the execution was created.'),
 });
 export type WorkflowDataContext = z.infer<typeof WorkflowDataContextSchema>;
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/build_workflow_context.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/build_workflow_context.ts
@@ -9,6 +9,7 @@
 
 import type { CoreStart } from '@kbn/core/server';
 import type { EsWorkflowExecution, WorkflowContext } from '@kbn/workflows';
+import { pickWorkflowDocumentVersion } from '@kbn/workflows';
 import {
   applyInputDefaults,
   getInputsFromDefinition,
@@ -57,6 +58,7 @@ export function buildInputDefaultRenderContext(
       name: workflowExecution.workflowDefinition?.name ?? '',
       enabled: workflowExecution.workflowDefinition?.enabled ?? false,
       spaceId: workflowExecution.spaceId,
+      ...pickWorkflowDocumentVersion(workflowExecution),
     },
     kibanaUrl,
     consts: workflowExecution.workflowDefinition?.consts ?? {},

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/build_workflow_context.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/build_workflow_context.test.ts
@@ -158,6 +158,23 @@ describe('buildWorkflowContext', () => {
       expect(context.execution.usage).toBeUndefined();
     });
 
+    it('should include workflow document version in workflow context when present on execution', () => {
+      const execution: EsWorkflowExecution = {
+        ...baseExecution,
+        version: 7,
+      };
+
+      const context = buildWorkflowContext(execution, undefined, dependencies);
+
+      expect(context.workflow.version).toBe(7);
+    });
+
+    it('should omit workflow document version from workflow context when absent on execution', () => {
+      const context = buildWorkflowContext(baseExecution, undefined, dependencies);
+
+      expect(context.workflow).not.toHaveProperty('version');
+    });
+
     it('should not expose context.hitl links from persisted execution context', () => {
       const execution: EsWorkflowExecution = {
         ...baseExecution,

--- a/src/platform/plugins/shared/workflows_management/public/features/change_history/get_workflow_change_history_row_display.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/change_history/get_workflow_change_history_row_display.test.ts
@@ -25,7 +25,7 @@ describe('getWorkflowChangeHistoryRowDisplay', () => {
     });
   });
 
-  it('maps current committed rows to version numbers', () => {
+  it('maps current committed rows to the current badge and version number', () => {
     expect(
       getWorkflowChangeHistoryRowDisplay({
         id: 'evt-current',
@@ -35,6 +35,8 @@ describe('getWorkflowChangeHistoryRowDisplay', () => {
     ).toEqual({
       kind: 'current',
       version: 3,
+      badgeLabel: CURRENT_VERSION_ONLY_BADGE,
+      badgeColor: 'hollow',
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/change_history/get_workflow_change_history_row_display.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/change_history/get_workflow_change_history_row_display.ts
@@ -53,9 +53,8 @@ export const getWorkflowChangeHistoryRowDisplay = (
     return {
       kind: 'current',
       version,
-      ...(version == null
-        ? { badgeLabel: CURRENT_VERSION_ONLY_BADGE, badgeColor: 'hollow' as const }
-        : {}),
+      badgeLabel: CURRENT_VERSION_ONLY_BADGE,
+      badgeColor: 'hollow',
     };
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/change_history/workflow_change_history.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/change_history/workflow_change_history.test.tsx
@@ -52,6 +52,7 @@ const restorableWorkflow: WorkflowDetailDto = {
 const createStoreWithWorkflow = (workflow: WorkflowDetailDto = restorableWorkflow) => {
   const store = createMockStore();
   store.dispatch(setWorkflow(workflow));
+  store.dispatch(setYamlString(workflow.yaml));
   return store;
 };
 
@@ -382,6 +383,33 @@ describe('WorkflowChangeHistoryListItem', () => {
     });
 
     expect(jest.mocked(services.http.get).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows the current version badge on the first history item when there are no unsaved edits', async () => {
+    mockWorkflowChangeHistoryKibanaServices({
+      configureHttp: (http) => {
+        jest.mocked(http.get).mockResolvedValue(sampleWorkflowHistoryResponse);
+      },
+    });
+
+    render(
+      <TestWrapper store={createStoreWithWorkflow()}>
+        <WorkflowChangeHistoryProvider workflowId="workflow-1" workflowName="My workflow">
+          <WorkflowChangeHistoryListItem />
+        </WorkflowChangeHistoryProvider>
+      </TestWrapper>
+    );
+
+    await openHistoryModal();
+
+    const currentItem = await screen.findByTestId('changeHistoryItem-evt-current');
+
+    expect(
+      within(currentItem).getByTestId('workflowChangeHistoryCurrentVersionBadge')
+    ).toHaveTextContent('Current version');
+    expect(within(currentItem).getByTestId('workflowChangeHistoryVersionBadge')).toHaveTextContent(
+      'v3'
+    );
   });
 
   it('shows unsaved edits as the current version without a sequence', async () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_pseudo_step_context.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_pseudo_step_context.test.ts
@@ -221,4 +221,66 @@ describe('buildOverviewStepExecutionFromContext', () => {
     const input = overview.input as Record<string, unknown>;
     expect(input.skipReason).toBeUndefined();
   });
+
+  it('includes workflow.version in overview input when present on the execution', () => {
+    const overview = buildOverviewStepExecutionFromContext({
+      ...baseOverviewExecution,
+      version: 4,
+      context: {
+        workflow: {
+          id: 'wf-1',
+          name: 'Test',
+          enabled: false,
+          spaceId: 'default',
+        },
+      },
+    });
+    const input = overview.input as Record<string, unknown>;
+    expect(input.workflow).toEqual({
+      id: 'wf-1',
+      name: 'Test',
+      enabled: false,
+      spaceId: 'default',
+      version: 4,
+    });
+  });
+
+  it('omits workflow.version from overview input when absent on the execution', () => {
+    const overview = buildOverviewStepExecutionFromContext({
+      ...baseOverviewExecution,
+      context: {
+        workflow: {
+          id: 'wf-1',
+          name: 'Test',
+          enabled: false,
+          spaceId: 'default',
+        },
+      },
+    });
+    const input = overview.input as Record<string, unknown>;
+    expect(input.workflow).toEqual({
+      id: 'wf-1',
+      name: 'Test',
+      enabled: false,
+      spaceId: 'default',
+    });
+  });
+
+  it('preserves workflow.version already stored in execution context', () => {
+    const overview = buildOverviewStepExecutionFromContext({
+      ...baseOverviewExecution,
+      version: 9,
+      context: {
+        workflow: {
+          id: 'wf-1',
+          name: 'Test',
+          enabled: false,
+          spaceId: 'default',
+          version: 2,
+        },
+      },
+    });
+    const input = overview.input as Record<string, unknown>;
+    expect((input.workflow as Record<string, unknown>).version).toBe(2);
+  });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_pseudo_step_context.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_pseudo_step_context.ts
@@ -13,6 +13,7 @@ import {
   ExecutionStatus,
   isEventDrivenWorkflowTriggerSource,
   isFailedBeforeSteps,
+  isValidWorkflowDocumentVersion,
 } from '@kbn/workflows';
 
 export type TriggerType = 'alert' | 'scheduled' | 'manual' | 'document' | 'event';
@@ -114,6 +115,23 @@ export function buildOverviewStepExecutionFromContext(
   if (workflowExecution.context) {
     const { inputs, event, ...context } = workflowExecution.context;
     contextData = context as Record<string, unknown>;
+  }
+
+  if (isValidWorkflowDocumentVersion(workflowExecution.version)) {
+    const workflowContext =
+      contextData.workflow != null && typeof contextData.workflow === 'object'
+        ? (contextData.workflow as Record<string, unknown>)
+        : {};
+
+    if (!isValidWorkflowDocumentVersion(workflowContext.version)) {
+      contextData = {
+        ...contextData,
+        workflow: {
+          ...workflowContext,
+          version: workflowExecution.version,
+        },
+      };
+    }
   }
 
   // Add trace information to the context data for display in the Overview table


### PR DESCRIPTION
## Description

Display the workflow document version (`workflow.version`) in the execution detail **Overview** field/value table when it is available on the execution.

The version is the monotonic workflow document counter (`_source.version`) captured when the execution starts. It is stored on the execution record and exposed in templates as `{{ workflow.version }}`.

### Problem

The Overview table renders data from the persisted execution context (`workflow.*`, `execution.*`, etc.). The execution record already stored a document version, but `workflow.version` was not included in that context, so the Overview table never showed it.

### Verification

- Run a workflow that has a document version and open execution detail → Overview.
- Confirm `workflow.version` appears in the field/value table.
- Re-open an older execution that has `version` on the execution API response but not in stored context; it should still appear in Overview after refresh.

## 📸  Screenshot

<img width="1723" height="875" alt="Screenshot 2026-07-10 at 12 45 27" src="https://github.com/user-attachments/assets/d53d365e-316e-4a8f-acf0-46655f00ee2c" />


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->