### PR TITLE
[Discover][Flyout] fix issue with geoLocation fields in alert overview tab

### DIFF
--- a/x-pack/solutions/security/plugins/timelines/common/utils/field_formatters.test.ts
+++ b/x-pack/solutions/security/plugins/timelines/common/utils/field_formatters.test.ts
@@ -17,6 +17,21 @@ describe('Events Details Helpers', () => {
       const result = getDataFromFieldsHits(fields);
       expect(result).toEqual(resultFields);
     });
+    it('handles geo fields with undefined values', () => {
+      const result = getDataFromFieldsHits({
+        'source.geo.location': undefined,
+      } as unknown as EventHit['fields']);
+
+      expect(result).toEqual([
+        {
+          category: 'source',
+          field: 'source.geo.location',
+          values: [],
+          originalValue: [],
+          isObjectArray: true,
+        },
+      ]);
+    });
     it('lets get weird', () => {
       const whackFields = {
         'crazy.pants': [

--- a/x-pack/solutions/security/plugins/timelines/common/utils/field_formatters.ts
+++ b/x-pack/solutions/security/plugins/timelines/common/utils/field_formatters.ts
@@ -30,7 +30,8 @@ export const getFieldCategory = (field: string): string => {
 };
 
 export const formatGeoLocation = (item: unknown[] | null | undefined) => {
-  const itemGeo = Array.isArray(item) && item.length > 0 ? (item[0] as { coordinates: number[] }) : null;
+  const itemGeo =
+    Array.isArray(item) && item.length > 0 ? (item[0] as { coordinates: number[] }) : null;
   if (itemGeo != null && !isEmpty(itemGeo.coordinates)) {
     try {
       return toStringArray({

--- a/x-pack/solutions/security/plugins/timelines/common/utils/field_formatters.ts
+++ b/x-pack/solutions/security/plugins/timelines/common/utils/field_formatters.ts
@@ -29,8 +29,8 @@ export const getFieldCategory = (field: string): string => {
   return fieldCategory;
 };
 
-export const formatGeoLocation = (item: unknown[]) => {
-  const itemGeo = item.length > 0 ? (item[0] as { coordinates: number[] }) : null;
+export const formatGeoLocation = (item: unknown[] | null | undefined) => {
+  const itemGeo = Array.isArray(item) && item.length > 0 ? (item[0] as { coordinates: number[] }) : null;
   if (itemGeo != null && !isEmpty(itemGeo.coordinates)) {
     try {
       return toStringArray({


### PR DESCRIPTION
## Summary

This PR fixes a small issue with the Highlighted Fields section, specifically related to geo fields.

When opened in Discover, the whole flyout was throwing an error
<img width="1257" height="962" alt="Screenshot 2026-07-10 at 12 50 00 PM" src="https://github.com/user-attachments/assets/dd8eac6e-23bd-4adc-aca0-447adb0ee890" />

The PR fixes that
<img width="1253" height="847" alt="Screenshot 2026-07-10 at 12 48 56 PM" src="https://github.com/user-attachments/assets/347d9621-84f9-40a5-963d-9f723f891e0e" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->