### PR TITLE
Retry transient GitHub errors in Saved Objects CI serverless SHA lookup

### DIFF
--- a/src/dev/github/get_serverless_release_sha.test.ts
+++ b/src/dev/github/get_serverless_release_sha.test.ts
@@ -74,7 +74,7 @@ describe('fetchServerlessReleaseShaFromGitHub', () => {
   const createOctokit = (request: jest.Mock) =>
     ({
       request,
-    }) as { request: jest.Mock };
+    } as { request: jest.Mock });
 
   it('returns the qa-ds-1 SHA from versions.yaml', async () => {
     const request = jest.fn().mockResolvedValue({

--- a/src/dev/github/get_serverless_release_sha.test.ts
+++ b/src/dev/github/get_serverless_release_sha.test.ts
@@ -11,6 +11,7 @@ jest.mock('@octokit/rest', () => ({
   Octokit: jest.fn(),
 }));
 
+import type { Octokit } from '@octokit/rest';
 import {
   fetchServerlessReleaseShaFromGitHub,
   isTransientHttpError,
@@ -74,7 +75,7 @@ describe('fetchServerlessReleaseShaFromGitHub', () => {
   const createOctokit = (request: jest.Mock) =>
     ({
       request,
-    } as { request: jest.Mock });
+    }) as unknown as Octokit;
 
   it('returns the qa-ds-1 SHA from versions.yaml', async () => {
     const request = jest.fn().mockResolvedValue({

--- a/src/dev/github/get_serverless_release_sha.test.ts
+++ b/src/dev/github/get_serverless_release_sha.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn(),
+}));
+
+import {
+  fetchServerlessReleaseShaFromGitHub,
+  isTransientHttpError,
+  withTransientHttpRetry,
+} from './get_serverless_release_sha';
+
+const createHttpError = (status: number, message = 'request failed') =>
+  Object.assign(new Error(message), { status });
+
+describe('isTransientHttpError', () => {
+  it.each([408, 429, 500, 502, 503, 504])('returns true for HTTP %i', (status) => {
+    expect(isTransientHttpError(createHttpError(status))).toBe(true);
+  });
+
+  it('returns false for non-retryable HTTP errors', () => {
+    expect(isTransientHttpError(createHttpError(404, 'not found'))).toBe(false);
+  });
+
+  it('returns true for transient network errors', () => {
+    const error = new Error('socket hang up') as NodeJS.ErrnoException;
+    error.code = 'ECONNRESET';
+    expect(isTransientHttpError(error)).toBe(true);
+  });
+});
+
+describe('withTransientHttpRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('retries transient HTTP failures before succeeding', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(createHttpError(502, 'bad gateway'))
+      .mockRejectedValueOnce(createHttpError(502, 'bad gateway'))
+      .mockResolvedValueOnce('success');
+
+    const resultPromise = withTransientHttpRetry(fn);
+    await jest.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toBe('success');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-transient HTTP failures', async () => {
+    const fn = jest.fn().mockRejectedValue(createHttpError(404, 'not found'));
+
+    await expect(withTransientHttpRetry(fn)).rejects.toThrow('not found');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('fetchServerlessReleaseShaFromGitHub', () => {
+  const qaSha = 'abc123def456';
+  const versionsYaml = `qa-ds-1: "${qaSha}"`;
+
+  const createOctokit = (request: jest.Mock) =>
+    ({
+      request,
+    }) as { request: jest.Mock };
+
+  it('returns the qa-ds-1 SHA from versions.yaml', async () => {
+    const request = jest.fn().mockResolvedValue({
+      data: {
+        content: Buffer.from(versionsYaml, 'utf8').toString('base64'),
+      },
+    });
+
+    await expect(fetchServerlessReleaseShaFromGitHub(createOctokit(request))).resolves.toBe(qaSha);
+    expect(request).toHaveBeenCalledWith(`GET /repos/{owner}/{repo}/contents/{path}`, {
+      owner: 'elastic',
+      repo: 'serverless-gitops',
+      path: 'services/kibana/versions.yaml',
+    });
+  });
+
+  it('throws when qa-ds-1 is missing from versions.yaml', async () => {
+    const request = jest.fn().mockResolvedValue({
+      data: {
+        content: Buffer.from('other-field: "value"', 'utf8').toString('base64'),
+      },
+    });
+
+    await expect(fetchServerlessReleaseShaFromGitHub(createOctokit(request))).rejects.toThrow(
+      'Cannot find QA field (qa-ds-1) in versions.yaml'
+    );
+  });
+});

--- a/src/dev/github/get_serverless_release_sha.test.ts
+++ b/src/dev/github/get_serverless_release_sha.test.ts
@@ -75,7 +75,7 @@ describe('fetchServerlessReleaseShaFromGitHub', () => {
   const createOctokit = (request: jest.Mock) =>
     ({
       request,
-    }) as unknown as Octokit;
+    } as unknown as Octokit);
 
   it('returns the qa-ds-1 SHA from versions.yaml', async () => {
     const request = jest.fn().mockResolvedValue({

--- a/src/dev/github/get_serverless_release_sha.ts
+++ b/src/dev/github/get_serverless_release_sha.ts
@@ -8,28 +8,82 @@
  */
 import { run } from '@kbn/dev-cli-runner';
 import { Octokit } from '@octokit/rest';
+import pRetry, { type FailedAttemptError } from 'p-retry';
 
-async function getServerlessReleaseSha(): Promise<string> {
-  if (!process.env.GITHUB_TOKEN) {
-    throw new Error('Missing environment variable: GITHUB_TOKEN');
+// Keep in sync with packages/kbn-check-saved-objects-cli/src/snapshots/resolve_snapshot_sha.ts
+export const TRANSIENT_HTTP_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+export const RETRY_DELAY_MS = 3_000;
+export const MAX_RETRIES = 5;
+
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'EPIPE',
+]);
+
+export const isTransientHttpError = (error: unknown): boolean => {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status: unknown }).status;
+    if (typeof status === 'number' && TRANSIENT_HTTP_STATUS_CODES.has(status)) {
+      return true;
+    }
   }
-  const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
-  });
 
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && TRANSIENT_NETWORK_ERROR_CODES.has(code)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export async function fetchServerlessReleaseShaFromGitHub(octokit: Octokit): Promise<string> {
   const releasesFile = await octokit.request(`GET /repos/{owner}/{repo}/contents/{path}`, {
     owner: 'elastic',
     repo: 'serverless-gitops',
     path: 'services/kibana/versions.yaml',
   });
 
-  const fileContent = Buffer.from((releasesFile.data as any).content, 'base64').toString('utf8');
+  const fileContent = Buffer.from(
+    (releasesFile.data as { content: string }).content,
+    'base64'
+  ).toString('utf8');
   const sha = fileContent.match(`qa-ds-1: "([a-z0-9]+)"`)?.[1];
   if (sha) {
     return sha;
-  } else {
-    throw new Error('Cannot find QA field (qa-ds-1) in versions.yaml');
   }
+
+  throw new Error('Cannot find QA field (qa-ds-1) in versions.yaml');
+}
+
+export async function withTransientHttpRetry<T>(fn: () => Promise<T>): Promise<T> {
+  return pRetry(fn, {
+    retries: MAX_RETRIES,
+    minTimeout: RETRY_DELAY_MS,
+    factor: 1,
+    onFailedAttempt: (error: FailedAttemptError) => {
+      if (!isTransientHttpError(error)) {
+        throw error;
+      }
+    },
+  });
+}
+
+export async function getServerlessReleaseSha(): Promise<string> {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error('Missing environment variable: GITHUB_TOKEN');
+  }
+
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+  });
+
+  return withTransientHttpRetry(() => fetchServerlessReleaseShaFromGitHub(octokit));
 }
 
 run(async ({ log }) => log.write(await getServerlessReleaseSha()));


### PR DESCRIPTION
## Summary
- Add retry logic to `get_serverless_release_sha.ts` when fetching the current serverless release SHA from `serverless-gitops/versions.yaml` via the GitHub API
- Treat the same HTTP status codes as transient failures as the Saved Objects snapshot resolver (`408`, `429`, `500`, `502`, `503`, `504`), plus common network socket errors
- Retry up to 6 attempts total with a fixed 3s delay between attempts; non-transient errors (e.g. `404`, missing `qa-ds-1`) fail immediately

This addresses CI failures like `Couldn't determine current serverless release SHA` caused by transient GitHub API `502` responses during the "Check changes in Saved Objects" step.

## Test plan
- [x] `node scripts/jest --config src/dev/jest.config.js src/dev/github/get_serverless_release_sha.test.ts`
- [ ] Verify Saved Objects CI check passes on a PR targeting `main`


Made with [Cursor](https://cursor.com)