### PR TITLE
[9.3] [Console] Fix output copy button clicks being silently swallowed and harden clipboard fallback (#276365)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/components/console_menu.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/console_menu.tsx
@@ -15,6 +15,7 @@ import { EuiContextMenuPanel, EuiContextMenuItem, EuiPopover, EuiButtonIcon } fr
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { copyTextToClipboard } from '../lib/copy_text_to_clipboard';
 
 interface Props {
   getCurl: () => Promise<string>;
@@ -74,11 +75,9 @@ export class ConsoleMenu extends Component<Props, State> {
     if (this.state.curlError) {
       throw this.state.curlError;
     }
-    if (window.navigator?.clipboard) {
-      await window.navigator.clipboard.writeText(text);
-      return;
+    if (!(await copyTextToClipboard(text))) {
+      throw new Error('Could not copy to clipboard!');
     }
-    throw new Error('Could not copy to clipboard!');
   }
 
   onButtonClick = () => {
@@ -125,7 +124,6 @@ export class ConsoleMenu extends Component<Props, State> {
         key="Copy as cURL"
         data-test-subj="consoleMenuCopyAsCurl"
         id="ConCopyAsCurl"
-        disabled={!window.navigator?.clipboard}
         onClick={() => {
           this.closePopover();
           this.copyAsCurl();

--- a/src/platform/plugins/shared/console/public/application/components/variables/variables_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/variables/variables_editor.tsx
@@ -29,6 +29,7 @@ import { css } from '@emotion/react';
 
 import type { NotificationsStart } from '@kbn/core/public';
 import { useServicesContext } from '../../contexts';
+import { copyTextToClipboard } from '../../lib/copy_text_to_clipboard';
 import { VariableEditorForm } from './variables_editor_form';
 import * as utils from './utils';
 import { type DevToolsVariable } from './types';
@@ -38,17 +39,11 @@ export interface Props {
   variables: [];
 }
 
-const sendToBrowserClipboard = async (text: string) => {
-  if (window.navigator?.clipboard) {
-    await window.navigator.clipboard.writeText(text);
-    return;
-  }
-  throw new Error('Could not copy to clipboard!');
-};
-
 const copyToClipboard = async (text: string, notifications: Pick<NotificationsStart, 'toasts'>) => {
   try {
-    await sendToBrowserClipboard(text);
+    if (!(await copyTextToClipboard(text))) {
+      throw new Error('Could not copy to clipboard!');
+    }
 
     notifications.toasts.addSuccess({
       title: i18n.translate('console.variabllesPage.copyToClipboardSuccess', {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.test.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.test.tsx
@@ -15,6 +15,7 @@ import type { NotificationsStart } from '@kbn/core/public';
 import { ContextMenu } from './context_menu';
 import { ServicesContextProvider } from '../../../../contexts';
 import type { ContextValue } from '../../../../contexts/services_context';
+import { copyTextToClipboard } from '../../../../lib/copy_text_to_clipboard';
 
 jest.mock('./language_selector_modal', () => ({
   LanguageSelectorModal: () => <div>Language Selector Modal</div>,
@@ -28,6 +29,14 @@ jest.mock('../../../../../services', () => ({
     DEFAULT_LANGUAGE: 'default_language',
   },
 }));
+
+jest.mock('../../../../lib/copy_text_to_clipboard', () => ({
+  copyTextToClipboard: jest.fn(),
+}));
+
+const mockCopyTextToClipboard = copyTextToClipboard as jest.MockedFunction<
+  typeof copyTextToClipboard
+>;
 
 const mockNotifications: Pick<NotificationsStart, 'toasts'> = {
   toasts: {
@@ -88,6 +97,47 @@ const defaultProps = {
 describe('ContextMenu', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCopyTextToClipboard.mockResolvedValue(true);
+  });
+
+  describe('Copy to language', () => {
+    it('shows a success toast after copying the converted request', async () => {
+      const contextValue = createMockContextValue();
+
+      render(
+        <I18nProvider>
+          <ServicesContextProvider value={contextValue}>
+            <ContextMenu {...defaultProps} />
+          </ServicesContextProvider>
+        </I18nProvider>
+      );
+
+      await userEvent.click(screen.getByTestId('toggleConsoleMenu'));
+      await userEvent.click(await screen.findByTestId('consoleMenuCopyAsButton'));
+
+      await waitFor(() => expect(mockNotifications.toasts.addSuccess).toHaveBeenCalled());
+      expect(mockCopyTextToClipboard).toHaveBeenCalledWith('mocked request code');
+      expect(mockNotifications.toasts.addDanger).not.toHaveBeenCalled();
+    });
+
+    it('shows an error toast when copying the converted request fails', async () => {
+      mockCopyTextToClipboard.mockResolvedValue(false);
+      const contextValue = createMockContextValue();
+
+      render(
+        <I18nProvider>
+          <ServicesContextProvider value={contextValue}>
+            <ContextMenu {...defaultProps} />
+          </ServicesContextProvider>
+        </I18nProvider>
+      );
+
+      await userEvent.click(screen.getByTestId('toggleConsoleMenu'));
+      await userEvent.click(await screen.findByTestId('consoleMenuCopyAsButton'));
+
+      await waitFor(() => expect(mockNotifications.toasts.addDanger).toHaveBeenCalled());
+      expect(mockNotifications.toasts.addSuccess).not.toHaveBeenCalled();
+    });
   });
 
   describe('Copy to language menu item visibility', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.tsx
@@ -28,6 +28,7 @@ import { convertRequestToLanguage } from '../../../../../services';
 import type { EditorRequest } from '../../types';
 
 import { useServicesContext } from '../../../../contexts';
+import { copyTextToClipboard } from '../../../../lib/copy_text_to_clipboard';
 import { StorageKeys } from '../../../../../services';
 import {
   DEFAULT_LANGUAGE,
@@ -99,14 +100,6 @@ export const ContextMenu = ({
     }
   }, [defaultLanguage, isKbnRequestSelected]);
 
-  const copyText = async (text: string) => {
-    if (window.navigator?.clipboard) {
-      await window.navigator.clipboard.writeText(text);
-      return;
-    }
-    throw new Error('Could not copy to clipboard!');
-  };
-
   // This function will convert all the selected requests to the language by
   // calling convertRequestToLanguage and then copy the data to clipboard.
   const copyAs = async (language?: string) => {
@@ -136,7 +129,7 @@ export const ContextMenu = ({
       requests,
     });
 
-    if (requestError) {
+    if (requestError || !(await copyTextToClipboard(requestsAsCode))) {
       notifications.toasts.addDanger({
         title: i18n.translate('console.consoleMenu.copyAsFailedMessage', {
           defaultMessage:
@@ -155,8 +148,6 @@ export const ContextMenu = ({
         values: { language: getLanguageLabelByValue(withLanguage), requestsCount: requests.length },
       }),
     });
-
-    await copyText(requestsAsCode);
   };
 
   const checkIsKbnRequestSelected = async () => {
@@ -241,7 +232,6 @@ export const ContextMenu = ({
             key="Copy to"
             data-test-subj="consoleMenuCopyAsButton"
             id="copyAs"
-            disabled={!window.navigator?.clipboard}
             onClick={() => onCopyAsSubmit()}
             icon="copyClipboard"
             css={styles.button}

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.test.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.test.tsx
@@ -1,0 +1,338 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { monaco } from '@kbn/monaco';
+import { MonacoEditorOutput } from './monaco_editor_output';
+import {
+  useEditorReadContext,
+  useOutputFilterReadContext,
+  useRequestReadContext,
+  useServicesContext,
+} from '../../contexts';
+import { copyTextToClipboard } from '../../lib/copy_text_to_clipboard';
+import { useResizeCheckerUtils } from './hooks';
+
+let mockEditorValue = '';
+let mockSelectionStartLineNumber = 1;
+let mockSelectionEndLineNumber = 1;
+
+const getMockLines = () => mockEditorValue.split('\n');
+
+const getMockPositionAt = (offset: number) => {
+  const lines = getMockLines();
+  let remainingOffset = offset;
+
+  for (let index = 0; index < lines.length; index++) {
+    const lineLengthWithNewLine = lines[index].length + 1;
+    if (remainingOffset < lineLengthWithNewLine || index === lines.length - 1) {
+      return { lineNumber: index + 1, column: remainingOffset + 1 };
+    }
+    remainingOffset -= lineLengthWithNewLine;
+  }
+
+  return { lineNumber: 1, column: 1 };
+};
+
+const createMockModel = (): monaco.editor.ITextModel =>
+  ({
+    getLineContent: (lineNumber: number) => getMockLines()[lineNumber - 1] ?? '',
+    getLineCount: () => getMockLines().length,
+    getLineMaxColumn: (lineNumber: number) => (getMockLines()[lineNumber - 1] ?? '').length + 1,
+    getPositionAt: getMockPositionAt,
+    getValue: () => mockEditorValue,
+    getValueInRange: ({ startLineNumber, endLineNumber }: monaco.IRange) =>
+      getMockLines()
+        .slice(startLineNumber - 1, endLineNumber)
+        .join('\n'),
+  } as unknown as monaco.editor.ITextModel);
+
+const mockEditor = {
+  createDecorationsCollection: jest.fn(() => ({
+    clear: jest.fn(),
+    set: jest.fn(),
+  })),
+  getModel: jest.fn(createMockModel),
+  getScrollTop: jest.fn(() => 0),
+  getSelection: jest.fn(() => ({
+    startLineNumber: mockSelectionStartLineNumber,
+    endLineNumber: mockSelectionEndLineNumber,
+  })),
+  getTopForLineNumber: jest.fn(() => 0),
+  hasTextFocus: jest.fn(() => true),
+  onDidBlurEditorText: jest.fn(),
+  onDidChangeCursorPosition: jest.fn(),
+  onDidChangeCursorSelection: jest.fn(),
+  onDidContentSizeChange: jest.fn(),
+  onDidScrollChange: jest.fn(),
+  setSelection: jest.fn(),
+} as unknown as jest.Mocked<monaco.editor.IStandaloneCodeEditor>;
+
+jest.mock('@kbn/code-editor', () => {
+  const ReactActual = jest.requireActual('react');
+
+  return {
+    CodeEditor: (props: {
+      dataTestSubj: string;
+      editorDidMount: (editor: monaco.editor.IStandaloneCodeEditor) => void;
+      value: string;
+    }) => {
+      mockEditorValue = props.value;
+      ReactActual.useEffect(() => {
+        props.editorDidMount(mockEditor);
+      }, [props]);
+
+      return <div data-test-subj={props.dataTestSubj}>{props.value}</div>;
+    },
+  };
+});
+
+jest.mock('../../contexts', () => ({
+  useEditorReadContext: jest.fn(),
+  useOutputFilterReadContext: jest.fn(),
+  useRequestReadContext: jest.fn(),
+  useServicesContext: jest.fn(),
+}));
+
+jest.mock('./hooks', () => ({
+  useResizeCheckerUtils: jest.fn(),
+}));
+
+jest.mock('../../lib/copy_text_to_clipboard', () => ({
+  copyTextToClipboard: jest.fn(),
+}));
+
+const mockUseEditorReadContext = useEditorReadContext as jest.MockedFunction<
+  typeof useEditorReadContext
+>;
+const mockUseOutputFilterReadContext = useOutputFilterReadContext as jest.MockedFunction<
+  typeof useOutputFilterReadContext
+>;
+const mockUseRequestReadContext = useRequestReadContext as jest.MockedFunction<
+  typeof useRequestReadContext
+>;
+const mockUseServicesContext = useServicesContext as jest.MockedFunction<typeof useServicesContext>;
+const mockUseResizeCheckerUtils = useResizeCheckerUtils as jest.MockedFunction<
+  typeof useResizeCheckerUtils
+>;
+const mockCopyTextToClipboard = copyTextToClipboard as jest.MockedFunction<
+  typeof copyTextToClipboard
+>;
+
+describe('WHEN rendering Console output', () => {
+  const addSuccess = jest.fn();
+  const addDanger = jest.fn();
+  const responseValue = '{\n  "acknowledged": true\n}';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEditorValue = '';
+    mockSelectionStartLineNumber = 1;
+    mockSelectionEndLineNumber = 1;
+    mockEditor.getModel.mockImplementation(createMockModel);
+    mockCopyTextToClipboard.mockResolvedValue(true);
+    mockUseEditorReadContext.mockReturnValue({
+      settings: {
+        fontSize: 14,
+        tripleQuotes: false,
+        wrapMode: false,
+      },
+    } as any);
+    mockUseOutputFilterReadContext.mockReturnValue({
+      expression: '',
+      invertMatch: false,
+      isExpanded: false,
+      mode: 'jq',
+    });
+    mockUseRequestReadContext.mockReturnValue({
+      lastResult: {
+        data: [
+          {
+            request: { data: '', method: 'GET', path: '/' },
+            response: {
+              contentType: 'application/json',
+              statusCode: 200,
+              statusText: 'OK',
+              timeMs: 1,
+              value: responseValue,
+            },
+          },
+        ],
+      },
+    } as any);
+    mockUseServicesContext.mockReturnValue({
+      services: {
+        notifications: {
+          toasts: {
+            addDanger,
+            addSuccess,
+          },
+        },
+      },
+    } as any);
+    mockUseResizeCheckerUtils.mockReturnValue({
+      destroyResizeChecker: jest.fn(),
+      setupResizeChecker: jest.fn(),
+    });
+  });
+
+  it('SHOULD copy the selected output text to the clipboard', async () => {
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    await userEvent.click(screen.getByTestId('copyOutputButton'));
+
+    await waitFor(() => expect(mockCopyTextToClipboard).toHaveBeenCalledWith(`${responseValue}\n`));
+    expect(addSuccess).toHaveBeenCalled();
+    expect(addDanger).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD show an error when copying the selected output text fails', async () => {
+    mockCopyTextToClipboard.mockResolvedValue(false);
+
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    await userEvent.click(screen.getByTestId('copyOutputButton'));
+
+    await waitFor(() => expect(mockCopyTextToClipboard).toHaveBeenCalledWith(`${responseValue}\n`));
+    expect(addSuccess).not.toHaveBeenCalled();
+    expect(addDanger).toHaveBeenCalled();
+  });
+
+  it('SHOULD show an error when reading the selected output fails', async () => {
+    mockEditor.getModel.mockReturnValue({
+      getValue: () => {
+        throw new Error('Output parsing failed');
+      },
+    } as unknown as monaco.editor.ITextModel);
+
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    await userEvent.click(screen.getByTestId('copyOutputButton'));
+
+    await waitFor(() => expect(addDanger).toHaveBeenCalled());
+    expect(mockCopyTextToClipboard).not.toHaveBeenCalled();
+    expect(addSuccess).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD show an error when the selected output is empty', async () => {
+    mockCopyTextToClipboard.mockResolvedValue(false);
+    mockEditor.getModel.mockReturnValue({
+      getLineContent: () => '',
+      getLineCount: () => 1,
+      getLineMaxColumn: () => 1,
+      getPositionAt: getMockPositionAt,
+      getValue: () => '',
+      getValueInRange: () => '',
+    } as unknown as monaco.editor.ITextModel);
+
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    await userEvent.click(screen.getByTestId('copyOutputButton'));
+
+    await waitFor(() => expect(addDanger).toHaveBeenCalled());
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('');
+    expect(addSuccess).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD keep the editor focused when the copy button is pressed', async () => {
+    // Pressing the copy button must not blur the output editor: the editor's blur
+    // handler hides the actions after 100ms, which is faster than a typical human
+    // click is released, so the click would land on a hidden element and never fire.
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    screen.getByTestId('copyOutputButton').dispatchEvent(mouseDownEvent);
+
+    expect(mouseDownEvent.defaultPrevented).toBe(true);
+  });
+
+  it('SHOULD hide the actions and highlight after the copy completes', async () => {
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    const button = screen.getByTestId('copyOutputButton');
+    await userEvent.click(button);
+
+    await waitFor(() => expect(addSuccess).toHaveBeenCalled());
+    // The floating actions container is hidden again as the completion feedback.
+    const actionsContainer = button.closest('[style]') as HTMLElement;
+    await waitFor(() => expect(actionsContainer.style.visibility).toBe('hidden'));
+  });
+
+  it('SHOULD hide the actions and highlight after the copy fails', async () => {
+    mockCopyTextToClipboard.mockResolvedValue(false);
+
+    render(
+      <I18nProvider>
+        <MonacoEditorOutput />
+      </I18nProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('consoleMonacoOutput')).toHaveTextContent('"acknowledged": true')
+    );
+
+    const button = screen.getByTestId('copyOutputButton');
+    await userEvent.click(button);
+
+    await waitFor(() => expect(addDanger).toHaveBeenCalled());
+    const actionsContainer = button.closest('[style]') as HTMLElement;
+    await waitFor(() => expect(actionsContainer.style.visibility).toBe('hidden'));
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.test.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.test.tsx
@@ -13,12 +13,7 @@ import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '@kbn/i18n-react';
 import type { monaco } from '@kbn/monaco';
 import { MonacoEditorOutput } from './monaco_editor_output';
-import {
-  useEditorReadContext,
-  useOutputFilterReadContext,
-  useRequestReadContext,
-  useServicesContext,
-} from '../../contexts';
+import { useEditorReadContext, useRequestReadContext, useServicesContext } from '../../contexts';
 import { copyTextToClipboard } from '../../lib/copy_text_to_clipboard';
 import { useResizeCheckerUtils } from './hooks';
 
@@ -98,7 +93,6 @@ jest.mock('@kbn/code-editor', () => {
 
 jest.mock('../../contexts', () => ({
   useEditorReadContext: jest.fn(),
-  useOutputFilterReadContext: jest.fn(),
   useRequestReadContext: jest.fn(),
   useServicesContext: jest.fn(),
 }));
@@ -113,9 +107,6 @@ jest.mock('../../lib/copy_text_to_clipboard', () => ({
 
 const mockUseEditorReadContext = useEditorReadContext as jest.MockedFunction<
   typeof useEditorReadContext
->;
-const mockUseOutputFilterReadContext = useOutputFilterReadContext as jest.MockedFunction<
-  typeof useOutputFilterReadContext
 >;
 const mockUseRequestReadContext = useRequestReadContext as jest.MockedFunction<
   typeof useRequestReadContext
@@ -147,12 +138,6 @@ describe('WHEN rendering Console output', () => {
         wrapMode: false,
       },
     } as any);
-    mockUseOutputFilterReadContext.mockReturnValue({
-      expression: '',
-      invertMatch: false,
-      isExpanded: false,
-      mode: 'jq',
-    });
     mockUseRequestReadContext.mockReturnValue({
       lastResult: {
         data: [

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output.tsx
@@ -35,6 +35,7 @@ import {
   convertMapboxVectorTileToJson,
 } from './utils';
 import { useEditorReadContext, useRequestReadContext, useServicesContext } from '../../contexts';
+import { copyTextToClipboard } from '../../lib/copy_text_to_clipboard';
 import { MonacoEditorOutputActionsProvider } from './monaco_editor_output_actions_provider';
 import { useResizeCheckerUtils } from './hooks';
 import { useActionStyles, useHighlightedLinesClassName } from './styles';
@@ -183,14 +184,12 @@ export const MonacoEditorOutput: FunctionComponent = () => {
   }, [readOnlySettings, data, value, statusCodeClassNames]);
 
   const copyOutputCallback = useCallback(async () => {
-    const selectedText = (await actionsProvider.current?.getParsedOutput()) as string;
-
     try {
-      if (!window.navigator?.clipboard) {
+      const selectedText = await actionsProvider.current?.getParsedOutput();
+
+      if (selectedText === undefined || !(await copyTextToClipboard(selectedText))) {
         throw new Error('Could not copy to clipboard!');
       }
-
-      await window.navigator.clipboard.writeText(selectedText);
 
       notifications.toasts.addSuccess({
         title: i18n.translate('console.outputPanel.copyOutputToast', {
@@ -203,6 +202,11 @@ export const MonacoEditorOutput: FunctionComponent = () => {
           defaultMessage: 'Could not copy selected output to clipboard',
         }),
       });
+    } finally {
+      // Clear the highlight and hide the actions once the copy attempt completes,
+      // mirroring the pre-existing visual feedback (the selection used to disappear
+      // via the editor blur that the mousedown handler above now prevents).
+      actionsProvider.current?.resetOutputActions();
     }
   }, [notifications.toasts]);
 
@@ -220,6 +224,12 @@ export const MonacoEditorOutput: FunctionComponent = () => {
         style={editorActionsCss}
         justifyContent="center"
         alignItems="center"
+        // Keep the output editor focused while the actions are clicked. Without this,
+        // pressing the copy button blurs the editor, whose blur handler hides the
+        // actions 100ms later -- faster than a typical human click is released -- so
+        // the mouseup lands on a hidden element and the click never fires.
+        // See https://github.com/elastic/kibana/issues/266698.
+        onMouseDown={(e) => e.preventDefault()}
       >
         <EuiFlexItem grow={false}>
           <EuiToolTip

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output_actions_provider.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CSSProperties } from 'react';
+import type { monaco } from '@kbn/monaco';
+import { MonacoEditorOutputActionsProvider } from './monaco_editor_output_actions_provider';
+
+const RESPONSE_VALUE = '{\n  "acknowledged": true\n}';
+
+const createMockModel = (value: string): monaco.editor.ITextModel => {
+  const lines = value.split('\n');
+  return {
+    getValue: () => value,
+    getLineCount: () => lines.length,
+    getLineContent: (lineNumber: number) => lines[lineNumber - 1] ?? '',
+    getLineMaxColumn: (lineNumber: number) => (lines[lineNumber - 1] ?? '').length + 1,
+    getPositionAt: (offset: number) => {
+      let remaining = offset;
+      for (let index = 0; index < lines.length; index++) {
+        const lineLengthWithNewLine = lines[index].length + 1;
+        if (remaining < lineLengthWithNewLine || index === lines.length - 1) {
+          return { lineNumber: index + 1, column: remaining + 1 };
+        }
+        remaining -= lineLengthWithNewLine;
+      }
+      return { lineNumber: 1, column: 1 };
+    },
+    getValueInRange: ({ startLineNumber, endLineNumber }: monaco.IRange) =>
+      lines.slice(startLineNumber - 1, endLineNumber).join('\n'),
+  } as unknown as monaco.editor.ITextModel;
+};
+
+describe('MonacoEditorOutputActionsProvider', () => {
+  let editor: jest.Mocked<monaco.editor.IStandaloneCodeEditor>;
+  let setEditorActionsCss: jest.Mock<void, [CSSProperties]>;
+  let triggerCursorPositionChange: () => Promise<void>;
+  let triggerCursorSelectionChange: () => Promise<void>;
+  let provider: MonacoEditorOutputActionsProvider;
+
+  beforeEach(() => {
+    setEditorActionsCss = jest.fn();
+
+    editor = {
+      createDecorationsCollection: jest.fn(() => ({
+        clear: jest.fn(),
+        set: jest.fn(),
+      })),
+      getModel: jest.fn(() => createMockModel(RESPONSE_VALUE)),
+      getSelection: jest.fn(() => ({ startLineNumber: 1, endLineNumber: 1 })),
+      getTopForLineNumber: jest.fn(() => 0),
+      getScrollTop: jest.fn(() => 0),
+      hasTextFocus: jest.fn(() => true),
+      onDidBlurEditorText: jest.fn(),
+      onDidChangeCursorPosition: jest.fn((callback: () => Promise<void>) => {
+        triggerCursorPositionChange = callback;
+      }),
+      onDidChangeCursorSelection: jest.fn((callback: () => Promise<void>) => {
+        triggerCursorSelectionChange = callback;
+      }),
+      onDidContentSizeChange: jest.fn(),
+      onDidScrollChange: jest.fn(),
+      setSelection: jest.fn(),
+    } as unknown as jest.Mocked<monaco.editor.IStandaloneCodeEditor>;
+
+    provider = new MonacoEditorOutputActionsProvider(
+      editor,
+      setEditorActionsCss,
+      'highlighted-line'
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const getLastActionsCss = (): CSSProperties =>
+    setEditorActionsCss.mock.calls[setEditorActionsCss.mock.calls.length - 1][0];
+
+  it('clamps the actions buttons offset to the editor top when the selected line has scrolled above the viewport', async () => {
+    // getTopForLineNumber() returning less than getScrollTop() means the selected
+    // request's start line has scrolled above the current viewport, which would
+    // otherwise produce a negative `top` offset (see https://github.com/elastic/kibana/issues/266698).
+    editor.getTopForLineNumber.mockReturnValue(50);
+    editor.getScrollTop.mockReturnValue(150);
+
+    await triggerCursorPositionChange();
+
+    const { top, visibility } = getLastActionsCss();
+    expect(visibility).toBe('visible');
+    expect(top).toBe(1);
+  });
+
+  it('positions the actions buttons using the raw offset when it is already non-negative', async () => {
+    editor.getTopForLineNumber.mockReturnValue(200);
+    editor.getScrollTop.mockReturnValue(50);
+
+    await triggerCursorPositionChange();
+
+    const { top, visibility } = getLastActionsCss();
+    expect(visibility).toBe('visible');
+    // offset (200 - 50) + OFFSET_EDITOR_ACTIONS (1)
+    expect(top).toBe(151);
+  });
+
+  it('keeps the actions hidden when a queued highlight follows copy completion', async () => {
+    jest.useFakeTimers();
+
+    await triggerCursorSelectionChange();
+    await triggerCursorSelectionChange();
+    provider.resetOutputActions();
+
+    await jest.advanceTimersByTimeAsync(200);
+
+    expect(getLastActionsCss()).toEqual({ visibility: 'hidden' });
+
+    await triggerCursorSelectionChange();
+
+    expect(getLastActionsCss()).toEqual({ visibility: 'visible', top: 1 });
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_output_actions_provider.ts
@@ -9,6 +9,7 @@
 
 import type { CSSProperties } from 'react';
 import { debounce } from 'lodash';
+import type { DebouncedFunc } from 'lodash';
 import { monaco } from '@kbn/monaco';
 import { createOutputParser } from '@kbn/monaco/src/languages/console/output_parser';
 
@@ -21,6 +22,8 @@ const OFFSET_EDITOR_ACTIONS = 1;
 
 export class MonacoEditorOutputActionsProvider {
   private highlightedLines: monaco.editor.IEditorDecorationsCollection;
+  private readonly debouncedHighlightRequests: DebouncedFunc<() => Promise<void>>;
+
   constructor(
     private editor: monaco.editor.IStandaloneCodeEditor,
     private setEditorActionsCss: (css: CSSProperties) => void,
@@ -28,12 +31,12 @@ export class MonacoEditorOutputActionsProvider {
   ) {
     this.highlightedLines = this.editor.createDecorationsCollection();
 
-    const debouncedHighlightRequests = debounce(
+    this.debouncedHighlightRequests = debounce(
       async () => {
         if (editor.hasTextFocus()) {
           await this.highlightRequests(this.highlightedLinesClassName);
         } else {
-          this.clearEditorDecorations();
+          this.resetOutputActions();
         }
       },
       DEBOUNCE_HIGHLIGHT_WAIT_MS,
@@ -44,16 +47,16 @@ export class MonacoEditorOutputActionsProvider {
 
     // init all listeners
     editor.onDidChangeCursorPosition(async () => {
-      await debouncedHighlightRequests();
+      await this.debouncedHighlightRequests();
     });
     editor.onDidScrollChange(async () => {
-      await debouncedHighlightRequests();
+      await this.debouncedHighlightRequests();
     });
     editor.onDidChangeCursorSelection(async () => {
-      await debouncedHighlightRequests();
+      await this.debouncedHighlightRequests();
     });
     editor.onDidContentSizeChange(async () => {
-      await debouncedHighlightRequests();
+      await this.debouncedHighlightRequests();
     });
 
     editor.onDidBlurEditorText(() => {
@@ -61,12 +64,13 @@ export class MonacoEditorOutputActionsProvider {
       // the clearing of the editor decorations to ensure that the actions buttons
       // are not hidden.
       setTimeout(() => {
-        this.clearEditorDecorations();
+        this.resetOutputActions();
       }, 100);
     });
   }
 
-  private clearEditorDecorations() {
+  public resetOutputActions() {
+    this.debouncedHighlightRequests.cancel();
     // remove the highlighted lines
     this.highlightedLines.clear();
     // hide action buttons
@@ -84,11 +88,19 @@ export class MonacoEditorOutputActionsProvider {
     } else {
       // if a request is selected, the actions buttons are placed at lineNumberOffset - scrollOffset
       const offset = this.editor.getTopForLineNumber(lineNumber) - this.editor.getScrollTop();
+      // The offset can be negative when the selected request's start line has scrolled
+      // above the current viewport (e.g. due to the debounced recalculation lagging behind
+      // a scroll or selection change). A negative offset renders the actions buttons above
+      // the editor's own visible area, where they can end up hidden behind, or overlapping
+      // the click target of, unrelated page chrome (e.g. the Console tab bars) -- silently
+      // swallowing clicks intended for the buttons. Clamp to the editor's own top edge so the
+      // buttons never escape its visible bounds. See https://github.com/elastic/kibana/issues/266698.
+      const clampedOffset = Math.max(offset, 0);
       this.setEditorActionsCss({
         visibility: 'visible',
         // Add a little bit of padding to the top of the actions buttons so that
         // it doesnt overlap with the selected request delimiter
-        top: offset + OFFSET_EDITOR_ACTIONS,
+        top: clampedOffset + OFFSET_EDITOR_ACTIONS,
       });
     }
   }

--- a/src/platform/plugins/shared/console/public/application/lib/copy_text_to_clipboard.test.ts
+++ b/src/platform/plugins/shared/console/public/application/lib/copy_text_to_clipboard.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { copyToClipboard } from '@elastic/eui';
+import { copyTextToClipboard } from './copy_text_to_clipboard';
+
+jest.mock('@elastic/eui', () => ({
+  copyToClipboard: jest.fn(),
+}));
+
+const mockCopyToClipboard = copyToClipboard as jest.MockedFunction<typeof copyToClipboard>;
+
+describe('WHEN copying text to the clipboard', () => {
+  const originalClipboard = window.navigator.clipboard;
+  const writeText = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    mockCopyToClipboard.mockReturnValue(true);
+    writeText.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+
+  it('SHOULD copy with the async Clipboard API first', async () => {
+    await expect(copyTextToClipboard('response')).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith('response');
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD fall back to the document copy helper when the Clipboard API write rejects', async () => {
+    writeText.mockRejectedValue(new Error('Clipboard write failed'));
+
+    await expect(copyTextToClipboard('response')).resolves.toBe(true);
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('response');
+  });
+
+  it('SHOULD fall back to the document copy helper when the Clipboard API is unavailable', async () => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+
+    await expect(copyTextToClipboard('response')).resolves.toBe(true);
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('response');
+  });
+
+  it('SHOULD fall back to the document copy helper when Clipboard API writeText is unavailable', async () => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {},
+    });
+
+    await expect(copyTextToClipboard('response')).resolves.toBe(true);
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('response');
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD return false when both copy methods fail', async () => {
+    writeText.mockRejectedValue(new Error('Clipboard write failed'));
+    mockCopyToClipboard.mockReturnValue(false);
+
+    await expect(copyTextToClipboard('response')).resolves.toBe(false);
+  });
+
+  it('SHOULD return false when the Clipboard API rejects and document copy throws', async () => {
+    writeText.mockRejectedValue(new Error('Clipboard write failed'));
+    mockCopyToClipboard.mockImplementation(() => {
+      throw new Error('Document copy failed');
+    });
+
+    await expect(copyTextToClipboard('response')).resolves.toBe(false);
+  });
+
+  it('SHOULD return false when there is no text to copy', async () => {
+    await expect(copyTextToClipboard('')).resolves.toBe(false);
+
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/lib/copy_text_to_clipboard.ts
+++ b/src/platform/plugins/shared/console/public/application/lib/copy_text_to_clipboard.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { copyToClipboard } from '@elastic/eui';
+
+export const copyTextToClipboard = async (text: string): Promise<boolean> => {
+  if (!text) {
+    return false;
+  }
+
+  // TS types declare `navigator.clipboard` as always present, but the spec marks it
+  // [SecureContext]: it is absent on insecure (plain-HTTP) origins, which self-hosted
+  // Kibana commonly runs on, and can be missing/partial in test environments.
+  // https://w3c.github.io/clipboard-apis/#navigator-interface
+  // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard
+  if (typeof window.navigator.clipboard?.writeText === 'function') {
+    try {
+      await window.navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back to the document-copy helper below.
+    }
+  }
+
+  try {
+    if (copyToClipboard(text)) {
+      return true;
+    }
+  } catch {
+    // Ignore and fall through to return false.
+  }
+
+  return false;
+};

--- a/src/platform/plugins/shared/console/test/scout/ui/fixtures/index.ts
+++ b/src/platform/plugins/shared/console/test/scout/ui/fixtures/index.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PageObjects, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import { test as baseTest, createLazyPageObject } from '@kbn/scout';
+import { ConsolePage } from './page_objects';
+
+export interface ExtScoutTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    console: ConsolePage;
+  };
+}
+
+export const test = baseTest.extend<ExtScoutTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ExtScoutTestFixtures['pageObjects'];
+      page: ExtScoutTestFixtures['page'];
+    },
+    use: (pageObjects: ExtScoutTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = {
+      ...pageObjects,
+      console: createLazyPageObject(ConsolePage, page),
+    };
+
+    await use(extendedPageObjects);
+  },
+});

--- a/src/platform/plugins/shared/console/test/scout/ui/fixtures/page_objects/console_page.ts
+++ b/src/platform/plugins/shared/console/test/scout/ui/fixtures/page_objects/console_page.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { compressToEncodedURIComponent } from 'lz-string';
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+export class ConsolePage {
+  public readonly inputEditor: Locator;
+  public readonly outputEditor: Locator;
+  public readonly sendRequestButton: Locator;
+  public readonly copyOutputButton: Locator;
+  public readonly responseStatusBadge: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.inputEditor = this.page.testSubj.locator('consoleMonacoEditor');
+    this.outputEditor = this.page.testSubj.locator('consoleMonacoOutput');
+    this.sendRequestButton = this.page.testSubj.locator('sendRequestButton');
+    this.copyOutputButton = this.page.testSubj.locator('copyOutputButton');
+    this.responseStatusBadge = this.page.testSubj.locator('consoleResponseStatusBadge');
+  }
+
+  /**
+   * Opens Console with the given request preloaded through the `load_from`
+   * data-URI parameter (the "Open in Console" deep-link mechanism). This avoids
+   * typing into Monaco, which is flaky under autocomplete. The appended request
+   * receives the cursor, so the send button becomes available.
+   */
+  async gotoWithRequestLoaded(request: string) {
+    const encoded = compressToEncodedURIComponent(request);
+    await this.page.gotoApp('dev_tools', {
+      hash: `console?load_from=data:text/plain,${encoded}`,
+    });
+    await this.inputEditor.waitFor({ state: 'visible' });
+    await this.sendRequestButton.waitFor({ state: 'visible' });
+  }
+
+  async sendRequest() {
+    await this.sendRequestButton.click();
+    await this.responseStatusBadge.waitFor({ state: 'visible' });
+  }
+
+  async selectOutput() {
+    await this.focusEditor(this.outputEditor);
+    await this.copyOutputButton.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Presses the copy-output button with a human-speed click: mouse down, hold,
+   * then release. Regression guard for the blur-hide race where the editor blur
+   * (triggered by the button's mousedown) hid the button 100ms later, so clicks
+   * held longer than ~100ms released over a hidden element and never fired.
+   * Fast synthetic clicks win that race and cannot detect the bug.
+   * See https://github.com/elastic/kibana/issues/266698.
+   */
+  async slowClickCopyOutput(holdMs: number) {
+    await this.copyOutputButton.click({ delay: holdMs });
+  }
+
+  /**
+   * Focuses a Monaco editor by clicking its line-number margin. Clicking the
+   * editor container itself does not reliably focus Monaco (its overlay layers
+   * intercept pointer events), so this mirrors the FTR Console page object.
+   */
+  private async focusEditor(editor: Locator) {
+    await editor.locator('.margin-view-overlays').click();
+  }
+}

--- a/src/platform/plugins/shared/console/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/console/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { ConsolePage } from './console_page';

--- a/src/platform/plugins/shared/console/test/scout/ui/playwright.config.ts
+++ b/src/platform/plugins/shared/console/test/scout/ui/playwright.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/src/platform/plugins/shared/console/test/scout/ui/tests/copy_output.spec.ts
+++ b/src/platform/plugins/shared/console/test/scout/ui/tests/copy_output.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+
+// Longer than the 100ms blur-hide delay in the output actions provider, so the
+// release happens after the point where the pre-fix code hid the button mid-click.
+const HUMAN_CLICK_HOLD_MS = 250;
+
+test.describe('Console output copy to clipboard', { tag: tags.deploymentAgnostic }, () => {
+  test.beforeEach(async ({ browserAuth, page, pageObjects }) => {
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await browserAuth.loginAsAdmin();
+    await pageObjects.console.gotoWithRequestLoaded('GET /');
+  });
+
+  test('copies the selected output on a human-speed (held) click', async ({
+    page,
+    pageObjects,
+  }) => {
+    await test.step('run a request and select its output', async () => {
+      await pageObjects.console.sendRequest();
+      await pageObjects.console.selectOutput();
+    });
+
+    await test.step('press the copy button, holding it longer than the blur-hide delay', async () => {
+      await pageObjects.console.slowClickCopyOutput(HUMAN_CLICK_HOLD_MS);
+    });
+
+    await test.step('the copy completes with a success toast', async () => {
+      await pageObjects.toasts.waitFor();
+      expect(await pageObjects.toasts.getHeaderText()).toContain(
+        'Selected output copied to clipboard'
+      );
+      const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+      expect(clipboardText).toContain('"cluster_name"');
+      await expect(pageObjects.console.copyOutputButton).toBeHidden();
+    });
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Console] Fix output copy button clicks being silently swallowed and harden clipboard fallback (#276365)](https://github.com/elastic/kibana/pull/276365)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-07-10T10:50:24Z","message":"[Console] Fix output copy button clicks being silently swallowed and harden clipboard fallback (#276365)\n\nCloses #266698\n\n## Summary\n\nFixes Console output-copy clicks that could be silently swallowed and\nmakes clipboard failures report the correct result across Console copy\nactions.\n\n## Root Cause\n\n- Monaco could hide the floating action between `mousedown` and\n`mouseup`.\n- Scrolling could position the action above the editor, where Console\ntabs intercepted the click.\n- Copy failures and queued highlight work could produce incorrect\nfeedback after the click.\n\n## Fix\n\n- Keep the editor focused during the click, clamp the action position,\nand cancel queued highlights when clearing the action.\n- Use a shared Clipboard API-first helper with an EUI document-copy\nfallback.\n- Show success only after a confirmed clipboard write.\n- Cover the real 250 ms click, clipboard contents, and completion state\nin Jest and Scout.\n\n## Before/After Screenshots (or Video)\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/1ba06878-7964-49ac-bd6d-1067a1ad3dd5\n\n### After\n\n\nhttps://github.com/user-attachments/assets/ec302843-70e5-4d38-8209-13108d605bda\n\n## Test Plan\n\n1. Run a request in Console, select the output, and hold the copy button\nfor about 250 ms.\n2. Confirm the response is on the clipboard, the success toast appears,\nand the copy action hides.\n\n- `node scripts/jest` for four focused Console suites — 21 tests passed.\n- `node scripts/eslint` for the changed Console files — passed.\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — passed.\n- Local browser verification confirmed the 250 ms click copied the\nresponse, showed the success toast, and hid the action.\n\n## Release Note\n\nFixed the Dev Tools Console copy button silently failing to copy\nresponse output.\n\nAssisted with Cursor using GPT-5.5 and Copilot using GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2b3bcbe891b0c8909cf8c07a3bfdae28fba381c5","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","ci:cloud-deploy","reviewer:scout","v9.6.0"],"title":"[Console] Fix output copy button clicks being silently swallowed and harden clipboard fallback","number":276365,"url":"https://github.com/elastic/kibana/pull/276365","mergeCommit":{"message":"[Console] Fix output copy button clicks being silently swallowed and harden clipboard fallback (#276365)\n\nCloses #266698\n\n## Summary\n\nFixes Console output-copy clicks that could be silently swallowed and\nmakes clipboard failures report the correct result across Console copy\nactions.\n\n## Root Cause\n\n- Monaco could hide the floating action between `mousedown` and\n`mouseup`.\n- Scrolling could position the action above the editor, where Console\ntabs intercepted the click.\n- Copy failures and queued highlight work could produce incorrect\nfeedback after the click.\n\n## Fix\n\n- Keep the editor focused during the click, clamp the action position,\nand cancel queued highlights when clearing the action.\n- Use a shared Clipboard API-first helper with an EUI document-copy\nfallback.\n- Show success only after a confirmed clipboard write.\n- Cover the real 250 ms click, clipboard contents, and completion state\nin Jest and Scout.\n\n## Before/After Screenshots (or Video)\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/1ba06878-7964-49ac-bd6d-1067a1ad3dd5\n\n### After\n\n\nhttps://github.com/user-attachments/assets/ec302843-70e5-4d38-8209-13108d605bda\n\n## Test Plan\n\n1. Run a request in Console, select the output, and hold the copy button\nfor about 250 ms.\n2. Confirm the response is on the clipboard, the success toast appears,\nand the copy action hides.\n\n- `node scripts/jest` for four focused Console suites — 21 tests passed.\n- `node scripts/eslint` for the changed Console files — passed.\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — passed.\n- Local browser verification confirmed the 250 ms click copied the\nresponse, showed the success toast, and hid the action.\n\n## Release Note\n\nFixed the Dev Tools Console copy button silently failing to copy\nresponse output.\n\nAssisted with Cursor using GPT-5.5 and Copilot using GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2b3bcbe891b0c8909cf8c07a3bfdae28fba381c5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276365","number":276365,"mergeCommit":{"message":"[Console] Fix output copy button clicks being silently swallowed and harden clipboard fallback (#276365)\n\nCloses #266698\n\n## Summary\n\nFixes Console output-copy clicks that could be silently swallowed and\nmakes clipboard failures report the correct result across Console copy\nactions.\n\n## Root Cause\n\n- Monaco could hide the floating action between `mousedown` and\n`mouseup`.\n- Scrolling could position the action above the editor, where Console\ntabs intercepted the click.\n- Copy failures and queued highlight work could produce incorrect\nfeedback after the click.\n\n## Fix\n\n- Keep the editor focused during the click, clamp the action position,\nand cancel queued highlights when clearing the action.\n- Use a shared Clipboard API-first helper with an EUI document-copy\nfallback.\n- Show success only after a confirmed clipboard write.\n- Cover the real 250 ms click, clipboard contents, and completion state\nin Jest and Scout.\n\n## Before/After Screenshots (or Video)\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/1ba06878-7964-49ac-bd6d-1067a1ad3dd5\n\n### After\n\n\nhttps://github.com/user-attachments/assets/ec302843-70e5-4d38-8209-13108d605bda\n\n## Test Plan\n\n1. Run a request in Console, select the output, and hold the copy button\nfor about 250 ms.\n2. Confirm the response is on the clipboard, the success toast appears,\nand the copy action hides.\n\n- `node scripts/jest` for four focused Console suites — 21 tests passed.\n- `node scripts/eslint` for the changed Console files — passed.\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — passed.\n- Local browser verification confirmed the 250 ms click copied the\nresponse, showed the success toast, and hid the action.\n\n## Release Note\n\nFixed the Dev Tools Console copy button silently failing to copy\nresponse output.\n\nAssisted with Cursor using GPT-5.5 and Copilot using GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <noreply@github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2b3bcbe891b0c8909cf8c07a3bfdae28fba381c5"}},{"url":"https://github.com/elastic/kibana/pull/277433","number":277433,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->