### PR TITLE
[UIAM OAuth] Add technical preview badges

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/mcp_clients.tsx
@@ -9,7 +9,7 @@ import React, { useEffect, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import type { UseEuiTheme } from '@elastic/eui';
-import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
+import { EuiBetaBadge, EuiButton, EuiButtonEmpty, EuiFlexGroup } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { MANAGEMENT_APP_ID } from '@kbn/management-plugin/public';
 import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
@@ -55,7 +55,16 @@ export const AgentBuilderMcpClients = () => {
     <KibanaPageTemplate data-test-subj="agentBuilderMcpClientsListPage">
       <KibanaPageTemplate.Header
         css={headerStyles}
-        pageTitle={labels.tools.mcpClients.title}
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            {labels.tools.mcpClients.title}
+            <EuiBetaBadge
+              label={labels.tools.mcpClients.techPreviewBadgeLabel}
+              tooltipContent={labels.tools.mcpClients.techPreviewBadgeDescription}
+              size="m"
+            />
+          </EuiFlexGroup>
+        }
         description={labels.tools.mcpClients.description}
         rightSideItems={[
           <EuiButton

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -552,6 +552,16 @@ export const labels = {
       breadcrumb: i18n.translate('xpack.agentBuilder.mcpClients.breadcrumb', {
         defaultMessage: 'MCP clients',
       }),
+      techPreviewBadgeLabel: i18n.translate('xpack.agentBuilder.mcpClients.techPreviewBadgeLabel', {
+        defaultMessage: 'Technical preview',
+      }),
+      techPreviewBadgeDescription: i18n.translate(
+        'xpack.agentBuilder.mcpClients.techPreviewBadgeDescription',
+        {
+          defaultMessage:
+            'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
+        }
+      ),
       addMcpClientButtonLabel: i18n.translate(
         'xpack.agentBuilder.mcpClients.addMcpClientButtonLabel',
         {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { UseEuiTheme } from '@elastic/eui';
-import { EuiButton, EuiCallOut } from '@elastic/eui';
+import { EuiBetaBadge, EuiButton, EuiCallOut, EuiFlexGroup } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React from 'react';
 
@@ -31,7 +31,16 @@ export const ApplicationConnections = () => {
     <>
       <KibanaPageTemplate.Header
         css={headerStyles}
-        pageTitle={labels.page.title}
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            {labels.page.title}
+            <EuiBetaBadge
+              label={labels.page.techPreviewBadgeLabel}
+              tooltipContent={labels.page.techPreviewBadgeTooltip}
+              size="m"
+            />
+          </EuiFlexGroup>
+        }
         rightSideItems={[
           <EuiButton
             color="text"

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
@@ -12,6 +12,17 @@ export const labels = {
     title: i18n.translate('xpack.security.management.applicationConnectionsTitle', {
       defaultMessage: 'Application connections',
     }),
+    techPreviewBadgeLabel: i18n.translate(
+      'xpack.security.management.applicationConnections.techPreviewBadgeLabel',
+      { defaultMessage: 'Technical preview' }
+    ),
+    techPreviewBadgeTooltip: i18n.translate(
+      'xpack.security.management.applicationConnections.techPreviewBadgeTooltip',
+      {
+        defaultMessage:
+          'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
+      }
+    ),
     pageCallout: i18n.translate('xpack.security.management.applicationConnectionsPageCallout', {
       defaultMessage:
         'Manage connections for OAuth-based applications. Currently, only MCP clients are supported.',

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -482,7 +482,7 @@ export const createNavigationTree = ({
             breadcrumbStatus: 'hidden',
             children: [
               { link: 'management:api_keys' },
-              { link: 'management:application_connections', badgeType: 'techPreview' },
+              { link: 'management:application_connections' },
               { link: 'management:roles' },
             ],
           },

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -482,7 +482,7 @@ export const createNavigationTree = ({
             breadcrumbStatus: 'hidden',
             children: [
               { link: 'management:api_keys' },
-              { link: 'management:application_connections' },
+              { link: 'management:application_connections', badgeType: 'techPreview' },
               { link: 'management:roles' },
             ],
           },

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -235,7 +235,11 @@ export function createNavigationTree({
             title: ACCESS_TITLE,
             children: [
               { link: 'management:api_keys', breadcrumbStatus: 'hidden' },
-              { link: 'management:application_connections', breadcrumbStatus: 'hidden' },
+              {
+                link: 'management:application_connections',
+                breadcrumbStatus: 'hidden',
+                badgeType: 'techPreview',
+              },
               { link: 'management:roles', breadcrumbStatus: 'hidden' },
             ],
           },

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -235,11 +235,7 @@ export function createNavigationTree({
             title: ACCESS_TITLE,
             children: [
               { link: 'management:api_keys', breadcrumbStatus: 'hidden' },
-              {
-                link: 'management:application_connections',
-                breadcrumbStatus: 'hidden',
-                badgeType: 'techPreview',
-              },
+              { link: 'management:application_connections', breadcrumbStatus: 'hidden' },
               { link: 'management:roles', breadcrumbStatus: 'hidden' },
             ],
           },

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
@@ -168,7 +168,7 @@ export const createAiNavigationTree = (
           title: i18nStrings.stackManagementV2.access.title,
           children: [
             { link: 'management:api_keys' },
-            { link: 'management:application_connections', badgeType: 'techPreview' },
+            { link: 'management:application_connections' },
             { link: 'management:roles' },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
@@ -168,7 +168,7 @@ export const createAiNavigationTree = (
           title: i18nStrings.stackManagementV2.access.title,
           children: [
             { link: 'management:api_keys' },
-            { link: 'management:application_connections' },
+            { link: 'management:application_connections', badgeType: 'techPreview' },
             { link: 'management:roles' },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/management_footer_items.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/management_footer_items.ts
@@ -96,6 +96,7 @@ export const createManagementFooterItemsTree = (
             {
               link: 'management:application_connections',
               breadcrumbStatus: 'hidden',
+              badgeType: 'techPreview',
             },
             {
               link: 'management:roles',

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/management_footer_items.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/management_footer_items.ts
@@ -96,7 +96,6 @@ export const createManagementFooterItemsTree = (
             {
               link: 'management:application_connections',
               breadcrumbStatus: 'hidden',
-              badgeType: 'techPreview',
             },
             {
               link: 'management:roles',


### PR DESCRIPTION
## Summary

Marks the OAuth-based Application connections and Agent Builder MCP clients experiences as technical preview.

### Demo

<img width="1749" height="938" alt="Screenshot 2026-07-10 at 10 57 14" src="https://github.com/user-attachments/assets/081e867a-78c1-417e-b5a1-7b5ead68f685" />
<img width="1560" height="1172" alt="Screenshot 2026-07-10 at 11 21 17" src="https://github.com/user-attachments/assets/d6941c94-6dce-4477-86ef-6b5c0e6ecd39" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
