### PR TITLE
[Cases][AttachmentsV2] Deprecate include comments in workflow step 

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/get_case.ts
@@ -14,11 +14,14 @@ import { CasesStepCaseIdSchema, CasesStepSingleCaseOutputSchema } from './shared
 export const GetCaseStepTypeId = 'cases.getCase';
 
 const InputSchema = CasesStepCaseIdSchema.extend({
-  include_comments: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe('Include case comments in the response. Default: false.'),
+  // Deprecated: retained so existing workflows don't fail schema validation, but it no
+  // longer has any effect. Comments are always excluded from the response. Removed in a
+  // future release.
+  include_comments: z.boolean().optional().default(false).meta({
+    deprecated: true,
+    description:
+      'Deprecated and ignored. Case comments are never included in the response, regardless of this value.',
+  }),
 });
 
 const OutputSchema = CasesStepSingleCaseOutputSchema;
@@ -46,14 +49,6 @@ export const getCaseStepCommonDefinition: CommonStepDefinition<
   with:
     case_id: "abc-123-def-456"
 \`\`\``,
-      `## With comments included
-\`\`\`yaml
-- name: get_case_with_comments
-  type: ${GetCaseStepTypeId}
-  with:
-    case_id: "abc-123-def-456"
-    include_comments: true
-\`\`\``,
       `## Using case from previous step
 \`\`\`yaml
 - name: find_cases
@@ -65,7 +60,6 @@ export const getCaseStepCommonDefinition: CommonStepDefinition<
   type: ${GetCaseStepTypeId}
   with:
     case_id: \${{ steps.find_cases.output.cases[0].id }}
-    include_comments: true
 \`\`\``,
     ],
   },

--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/get_case.ts
@@ -14,13 +14,13 @@ import { CasesStepCaseIdSchema, CasesStepSingleCaseOutputSchema } from './shared
 export const GetCaseStepTypeId = 'cases.getCase';
 
 const InputSchema = CasesStepCaseIdSchema.extend({
-  // Deprecated: retained so existing workflows don't fail schema validation, but it no
-  // longer has any effect. Comments are always excluded from the response. Removed in a
-  // future release.
+  // Deprecated. Behavior is unchanged (comments are still returned when true) so existing
+  // workflows keep working; the flag only marks the field deprecated in docs and the editor.
+  // Prefer the `cases.getAllAttachments` step. Hard removal deferred to v10, gated on telemetry.
   include_comments: z.boolean().optional().default(false).meta({
     deprecated: true,
     description:
-      'Deprecated and ignored. Case comments are never included in the response, regardless of this value.',
+      'Deprecated: use the `cases.getAllAttachments` step to retrieve case attachments. Include case comments in the response. Default: false.',
   }),
 });
 

--- a/x-pack/platform/plugins/shared/cases/common/workflows/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/translations.ts
@@ -145,7 +145,7 @@ export const GET_CASE_STEP_DOCUMENTATION_DETAILS = i18n.translate(
   'xpack.cases.workflowSteps.getCase.documentation.details',
   {
     defaultMessage:
-      'This step retrieves a complete case object from the cases system using its ID. You can optionally include comments and attachments in the response.',
+      'This step retrieves a complete case object from the cases system using its ID. Comments and attachments are not included in the response.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/cases/common/workflows/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/translations.ts
@@ -145,7 +145,7 @@ export const GET_CASE_STEP_DOCUMENTATION_DETAILS = i18n.translate(
   'xpack.cases.workflowSteps.getCase.documentation.details',
   {
     defaultMessage:
-      'This step retrieves a complete case object from the cases system using its ID. Comments and attachments are not included in the response.',
+      'This step retrieves a complete case object from the cases system using its ID. The `include_comments` parameter is deprecated; use the `cases.getAllAttachments` step to retrieve case attachments.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.test.ts
@@ -28,7 +28,7 @@ describe('getCaseStepDefinition', () => {
     ).toBe(true);
   });
 
-  it('fetches case with includeComments=true when include_comments is true', async () => {
+  it('ignores deprecated include_comments=true and always fetches with includeComments=false', async () => {
     const get = jest.fn().mockResolvedValue(createCaseResponseFixture);
     const getCasesClient = jest.fn().mockResolvedValue({
       cases: { get },
@@ -42,7 +42,7 @@ describe('getCaseStepDefinition', () => {
       })
     );
 
-    expect(get).toHaveBeenCalledWith({ id: 'case-1', includeComments: true });
+    expect(get).toHaveBeenCalledWith({ id: 'case-1', includeComments: false });
     expect(result).toEqual({
       output: {
         case: createCaseResponseFixture,
@@ -65,6 +65,18 @@ describe('getCaseStepDefinition', () => {
     );
 
     expect(get).toHaveBeenCalledWith({ id: 'case-1', includeComments: false });
+  });
+
+  it('still accepts include_comments in the input schema (no validation error)', () => {
+    const getCasesClient = jest.fn();
+    const definition = getCaseStepDefinition(getCasesClient);
+
+    expect(
+      definition.inputSchema.safeParse({
+        case_id: 'case-1',
+        include_comments: true,
+      }).success
+    ).toBe(true);
   });
 
   it('returns error when client.cases.get throws', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.test.ts
@@ -28,7 +28,7 @@ describe('getCaseStepDefinition', () => {
     ).toBe(true);
   });
 
-  it('ignores deprecated include_comments=true and always fetches with includeComments=false', async () => {
+  it('preserves behavior: fetches with includeComments=true when include_comments is true (deprecated but not ignored)', async () => {
     const get = jest.fn().mockResolvedValue(createCaseResponseFixture);
     const getCasesClient = jest.fn().mockResolvedValue({
       cases: { get },
@@ -42,7 +42,7 @@ describe('getCaseStepDefinition', () => {
       })
     );
 
-    expect(get).toHaveBeenCalledWith({ id: 'case-1', includeComments: false });
+    expect(get).toHaveBeenCalledWith({ id: 'case-1', includeComments: true });
     expect(result).toEqual({
       output: {
         case: createCaseResponseFixture,

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.ts
@@ -20,12 +20,12 @@ export const getCaseStepDefinition = (
   createServerStepDefinition({
     ...getCaseStepCommonDefinition,
     handler: createCasesStepHandler(getCasesClient, async (client, input: GetCaseStepInput) => {
-      // `include_comments` is deprecated and intentionally ignored: comments are always
-      // excluded to avoid leaking a silently-mixed legacy/unified `comments[]` array when
-      // the unified-attachment feature flag is on.
+      // `include_comments` is deprecated (see common definition) but behavior is preserved
+      // to avoid breaking existing workflows. Prefer the `cases.getAllAttachments` step.
+      // Hard removal is deferred to v10, gated on usage telemetry.
       const theCase = await client.cases.get({
         id: input.case_id,
-        includeComments: false,
+        includeComments: input.include_comments,
       });
 
       return safeParseCaseForWorkflowOutput(

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_case.ts
@@ -20,9 +20,12 @@ export const getCaseStepDefinition = (
   createServerStepDefinition({
     ...getCaseStepCommonDefinition,
     handler: createCasesStepHandler(getCasesClient, async (client, input: GetCaseStepInput) => {
+      // `include_comments` is deprecated and intentionally ignored: comments are always
+      // excluded to avoid leaking a silently-mixed legacy/unified `comments[]` array when
+      // the unified-attachment feature flag is on.
       const theCase = await client.cases.get({
         id: input.case_id,
-        includeComments: input.include_comments,
+        includeComments: false,
       });
 
       return safeParseCaseForWorkflowOutput(


### PR DESCRIPTION
## Summary

Related: https://github.com/elastic/kibana/issues/207797

The `cases.getCase` workflow step accepted a user-supplied `include_comments: boolean` and passed it into `casesClient.cases.get({ includeComments })`. The problem is that this step's output contract pins `comments[]` to the legacy shape — there's no slot for unified attachment types. 

With the attachment V2 flag on, reads span both saved-object types, so a unified-only attachment comes back in a shape the schema can't represent, yielding a silently-mixed array where YAML expressions reading legacy fields return undefined. Rather than plumb through a mixed or mode-switched shape here, we're steering consumers toward the new unified attachment shape and its dedicated API — so exposing comments from a case fetch no longer makes sense, and the field is being deprecated.

This PR adds `deprecated` label to the field and does not alter existing behavior. We will monitor the usage in telemetry and follow deprecation process. 


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->