### PR TITLE
[Cases] Analytics V2: Add attachment_reference_id to .cases-activity

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/activity.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/activity.ts
@@ -127,6 +127,13 @@ export const ACTIVITY_INDEX_MAPPING: MappingTypeMapping = {
         // For `connector` actions: the new connector instance id.
         // High-signal for connector-adoption dashboards.
         connector_id_new: { type: 'keyword' },
+        // For `comment` actions: the id of the attachment *record* the
+        // action targets — the `cases-comments` (legacy) or
+        // `cases-attachments` (unified) SO id, resolved source-agnostically.
+        // Equals `.cases-attachments._id`. Distinct from that surface's
+        // `attachment.attachment_id` (referenced alert/event/external-ref
+        // ids). Unset for non-comment actions.
+        attachment_reference_id: { type: 'keyword' },
       },
     },
   },

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/activity_schema_drift.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/mappings/activity_schema_drift.test.ts
@@ -7,8 +7,12 @@
 
 import type { MappingProperty, MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 import type { SavedObject, SavedObjectReference } from '@kbn/core/server';
-import { CASE_SAVED_OBJECT, CASE_USER_ACTION_SAVED_OBJECT } from '../../../common/constants';
-import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
+import {
+  CASE_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_USER_ACTION_SAVED_OBJECT,
+} from '../../../common/constants';
+import { CONNECTOR_ID_REFERENCE_NAME, COMMENT_REF_NAME } from '../../common/constants';
 import { UserActionTypes } from '../../../common/types/domain';
 import type { UserActionPersistedAttributes } from '../../common/types/user_actions';
 import { createCaseUserActionSavedObjectType } from '../../saved_object_types/user_actions';
@@ -176,7 +180,16 @@ const PER_TYPE_FIXTURES: {
   comment: makeUserActionSO(
     'comment',
     { comment: { type: 'user', comment: 'A comment', owner: 'securitySolution' } },
-    { action: 'create' }
+    {
+      action: 'create',
+      // A comment user action references the created attachment SO in
+      // addition to the case, so the fixture exercises the `comment_id`
+      // extraction path (legacy `cases-comments` source type here).
+      references: [
+        caseRef,
+        { id: 'comment-1', type: CASE_COMMENT_SAVED_OBJECT, name: COMMENT_REF_NAME },
+      ],
+    }
   ),
   // Real persisted shape: `extractConnectorId` strips the id out of
   // `payload.connector` (leaving `{ name, type, fields }`) and stores it in
@@ -280,6 +293,10 @@ describe('per-action-type curated extracts', () => {
     const doc = buildActivityDoc(PER_TYPE_FIXTURES.connector);
     expect(doc.action.connector_id_new).toBe('connector-1');
   });
+  it('comment: populates action.attachment_reference_id from the associated attachment reference', () => {
+    const doc = buildActivityDoc(PER_TYPE_FIXTURES.comment);
+    expect(doc.action.attachment_reference_id).toBe('comment-1');
+  });
   it('non-extract types do not leak any curated extract field', () => {
     // Spot-check — `description` carries no curated extract, so
     // every optional extract field on `action` should be undefined.
@@ -289,6 +306,7 @@ describe('per-action-type curated extracts', () => {
     expect(doc.action.assignees_changed).toBeUndefined();
     expect(doc.action.tags_changed).toBeUndefined();
     expect(doc.action.connector_id_new).toBeUndefined();
+    expect(doc.action.attachment_reference_id).toBeUndefined();
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.test.ts
@@ -5,8 +5,16 @@
  * 2.0.
  */
 
-import { CASE_SAVED_OBJECT } from '../../../common/constants';
-import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
+import {
+  CASE_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_ATTACHMENT_SAVED_OBJECT,
+} from '../../../common/constants';
+import {
+  CONNECTOR_ID_REFERENCE_NAME,
+  COMMENT_REF_NAME,
+  CASE_ATTACHMENT_REF_NAME,
+} from '../../common/constants';
 import { makeUserAction } from '../__test_helpers__';
 import { buildActivityDoc } from './activity_doc_builder';
 
@@ -165,6 +173,51 @@ describe('buildActivityDoc', () => {
       expect(doc.action.assignees_changed).toBeUndefined();
       expect(doc.action.tags_changed).toBeUndefined();
       expect(doc.action.connector_id_new).toBeUndefined();
+    });
+  });
+
+  describe('attachment reference id', () => {
+    it('resolves attachment_reference_id from a legacy cases-comments reference', () => {
+      const doc = buildActivityDoc(
+        makeUserAction('ua-1', {
+          type: 'comment',
+          payload: { comment: { type: 'user', comment: 'hi', owner: 'securitySolution' } },
+          references: [
+            { id: 'case-1', type: CASE_SAVED_OBJECT, name: 'associated-cases' },
+            { id: 'comment-1', type: CASE_COMMENT_SAVED_OBJECT, name: COMMENT_REF_NAME },
+          ],
+        })
+      );
+      expect(doc.action.attachment_reference_id).toBe('comment-1');
+    });
+
+    it('resolves attachment_reference_id from a unified cases-attachments reference', () => {
+      const doc = buildActivityDoc(
+        makeUserAction('ua-1', {
+          type: 'comment',
+          payload: { comment: { type: 'user', comment: 'hi', owner: 'securitySolution' } },
+          references: [
+            { id: 'case-1', type: CASE_SAVED_OBJECT, name: 'associated-cases' },
+            {
+              id: 'attachment-1',
+              type: CASE_ATTACHMENT_SAVED_OBJECT,
+              name: CASE_ATTACHMENT_REF_NAME,
+            },
+          ],
+        })
+      );
+      expect(doc.action.attachment_reference_id).toBe('attachment-1');
+    });
+
+    it('leaves attachment_reference_id unset when no comment/attachment reference is present', () => {
+      const doc = buildActivityDoc(
+        makeUserAction('ua-1', {
+          type: 'status',
+          payload: { status: 'open' },
+          references: [{ id: 'case-1', type: CASE_SAVED_OBJECT, name: 'associated-cases' }],
+        })
+      );
+      expect(doc.action.attachment_reference_id).toBeUndefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
@@ -8,6 +8,7 @@
 import type { SavedObject } from '@kbn/core/server';
 import { CASE_SAVED_OBJECT } from '../../../common/constants';
 import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
+import { findCommentReferenceId } from '../../common/references';
 import type { UserActionPersistedAttributes } from '../../common/types/user_actions';
 
 /**
@@ -61,6 +62,15 @@ export interface ActivityAnalyticsDoc {
     assignees_changed?: string[];
     tags_changed?: string[];
     connector_id_new?: string;
+    // The id of the attachment *record* this action targets — the
+    // `cases-comments` (legacy) or `cases-attachments` (unified) SO id,
+    // resolved source-agnostically. Equals `.cases-attachments._id`, so it
+    // correlates an activity row to the specific attachment it created /
+    // edited. NOTE: this is the attachment record id, NOT the
+    // referenced-entity ids the attachments surface stores under
+    // `attachment.attachment_id` (alert / event / external-reference ids) —
+    // hence the distinct name. Present only on `comment` user actions.
+    attachment_reference_id?: string;
   };
 }
 
@@ -101,6 +111,13 @@ export function buildActivityDoc(
   // cases doc-builder does (`case_doc_builder.ts`).
   const connectorId = so.references?.find((ref) => ref.name === CONNECTOR_ID_REFERENCE_NAME)?.id;
 
+  // The attachment record this action targets. A `comment` user action
+  // references exactly one attachment SO — legacy `cases-comments` or unified
+  // `cases-attachments`; `findCommentReferenceId` resolves either source type
+  // to that SO's id, which equals `.cases-attachments._id`. Absent on
+  // non-comment actions, which carry no such reference.
+  const attachmentReferenceId = findCommentReferenceId(so.references);
+
   return {
     '@timestamp': a.created_at,
     // Top-level scoping fields for implicit-privileges DLS. `namespaces` is a
@@ -117,6 +134,11 @@ export function buildActivityDoc(
       verb: a.action,
       payload_json: stringifyPayload(a.payload),
       ...extractCuratedFields(a.type, a.payload, connectorId),
+      // Omit when absent so the strict mapping stays sparse (a no-op under
+      // `dynamic: 'strict'`), consistent with the curated extracts above.
+      ...(attachmentReferenceId != null
+        ? { attachment_reference_id: attachmentReferenceId }
+        : {}),
     },
   };
 }

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
@@ -133,10 +133,7 @@ export function buildActivityDoc(
       type: a.type,
       verb: a.action,
       payload_json: stringifyPayload(a.payload),
-      ...extractCuratedFields(a.type, a.payload, connectorId),
-      // Omit when absent so the strict mapping stays sparse (a no-op under
-      // `dynamic: 'strict'`), consistent with the curated extracts above.
-      ...(attachmentReferenceId != null ? { attachment_reference_id: attachmentReferenceId } : {}),
+      ...extractCuratedFields(a.type, a.payload, connectorId, attachmentReferenceId),
     },
   };
 }
@@ -189,9 +186,12 @@ function stringifyPayload(payload: Record<string, unknown> | null | undefined): 
 /**
  * Extracts the curated typed sub-fields for the analytics doc,
  * conditional on the action `type`. Most clauses read from `payload`;
- * `connector_id_new` is the exception — its id is stripped from the
- * payload at persist time and lives in `so.references`, so the caller
- * resolves it and passes it in via `connectorId`.
+ * `connector_id_new` and `attachment_reference_id` are the exceptions —
+ * their ids live in `so.references`, not `payload`, so the caller resolves
+ * them and passes them in via `connectorId` / `attachmentReferenceId`. Keeping
+ * every curated extract here (rather than spreading some inline in
+ * `buildActivityDoc`) keeps the extraction — and its per-type gating — in one
+ * place.
  *
  * For each clause:
  *   1. Confirm the relevant value is present (in `payload`, or in
@@ -209,7 +209,8 @@ function stringifyPayload(payload: Record<string, unknown> | null | undefined): 
 function extractCuratedFields(
   type: string,
   payload: Record<string, unknown> | null | undefined,
-  connectorId: string | undefined
+  connectorId: string | undefined,
+  attachmentReferenceId: string | undefined
 ): Partial<ActivityAnalyticsDoc['action']> {
   const out: Partial<ActivityAnalyticsDoc['action']> = {};
 
@@ -219,6 +220,18 @@ function extractCuratedFields(
   // it runs even when `payload` is null.
   if (type === 'connector' && typeof connectorId === 'string' && connectorId.length > 0) {
     out.connector_id_new = connectorId;
+  }
+
+  // `attachment_reference_id` is likewise sourced from `so.references`
+  // (resolved by the caller via `findCommentReferenceId`). Gate on the
+  // `comment` action type so the code matches the "comment actions only"
+  // contract asserted in the interface and mapping. Independent of `payload`.
+  if (
+    type === 'comment' &&
+    typeof attachmentReferenceId === 'string' &&
+    attachmentReferenceId.length > 0
+  ) {
+    out.attachment_reference_id = attachmentReferenceId;
   }
 
   if (payload == null) return out;

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/writer/activity_doc_builder.ts
@@ -136,9 +136,7 @@ export function buildActivityDoc(
       ...extractCuratedFields(a.type, a.payload, connectorId),
       // Omit when absent so the strict mapping stays sparse (a no-op under
       // `dynamic: 'strict'`), consistent with the curated extracts above.
-      ...(attachmentReferenceId != null
-        ? { attachment_reference_id: attachmentReferenceId }
-        : {}),
+      ...(attachmentReferenceId != null ? { attachment_reference_id: attachmentReferenceId } : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds `action.attachment_reference_id` to the `.cases-activity` analytics index so an activity row can be tied back to the specific attachment it created or edited.

It's a single, source-agnostic field. Resolved via `findCommentReferenceId`, it holds the `cases-comments` (legacy) or `cases-attachments` (unified) SO id, which is equal to `.cases-attachments._id`. I kept it distinct from the attachments surface's `attachment.attachment_id` (the referenced alert/event/external-ref ids) and named it to line up with the `cases-attachments` SO model, so anything cross-referencing the two systems doesn't have to translate between them.

Part of the Cases-as-Data work — addresses the "add comment/attachment ids to activity" feedback and sets up the upcoming AI-assistant analytics skill to correlate activity ↔ attachments.

### Notes
- The field is added to the `dynamic: strict` mapping, so existing `.cases-activity` indices need a `POST /internal/cases/_analyticsV2/reset` to pick up the new mapping (fresh deployments get it on bootstrap).
- This is a filter/correlation key for now. A true ES|QL `LOOKUP JOIN` from activity → `.cases-attachments` will need the attachments surface to expose its record id as a `_source` field (today it's only `_id`) — small follow-up.

## Testing
- Unit + schema-drift coverage in `activity_doc_builder.test.ts` and `activity_schema_drift.test.ts` (50 passing).
- Verified locally end-to-end: created a case, added a comment, and confirmed `action.attachment_reference_id` on the `.cases-activity` doc — exercised both the legacy `cases-comments` and unified `cases-attachments` paths by toggling `xpack.cases.attachments.enabled`.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->