### PR TITLE
[Streams] Grant monitor_inference and actions:read to the Relay Agent Builder API key

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
@@ -108,7 +108,8 @@ describe('SlackAppService', () => {
           metadata: expect.objectContaining({ managed: true, managed_by: 'nightshift-relay' }),
           kibana_role_descriptors: {
             nightshift_relay_agent_builder: expect.objectContaining({
-              kibana: [{ spaces: ['*'], feature: { agentBuilder: ['read'] } }],
+              elasticsearch: { cluster: ['monitor_inference'], indices: [], run_as: [] },
+              kibana: [{ spaces: ['*'], feature: { agentBuilder: ['read'], actions: ['read'] } }],
             }),
           },
         })

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
@@ -119,13 +119,15 @@ export class SlackAppService {
     // is granted on behalf of the connecting user but survives their deletion (ES keys
     // outlive their owner). The connecting user must hold `agentBuilder:read`, otherwise
     // the granted key is under-privileged (grant intersects with the owner's privileges).
+    // `monitor_inference` and the `actions` feature are required for converse to list
+    // inference endpoints and stack connectors (see getConnectorList).
     const apiKeyResult = await this.server.security.authc.apiKeys.grantAsInternalUser(request, {
       name: 'nightshift-relay-agent-builder',
       metadata: { managed: true, managed_by: 'nightshift-relay', type: 'agent_builder_converse' },
       kibana_role_descriptors: {
         nightshift_relay_agent_builder: {
-          elasticsearch: { cluster: [], indices: [], run_as: [] },
-          kibana: [{ spaces: ['*'], feature: { agentBuilder: ['read'] } }],
+          elasticsearch: { cluster: ['monitor_inference'], indices: [], run_as: [] },
+          kibana: [{ spaces: ['*'], feature: { agentBuilder: ['read'], actions: ['read'] } }],
         },
       },
     });


### PR DESCRIPTION
## Summary

Fixes an authorization failure in the Nightshift Relay / Slack app converse flow introduced in #276518.

The Agent Builder API key minted for the Relay in `SlackAppService.connect` was scoped to only the `agentBuilder:read` Kibana feature, with `elasticsearch.cluster: []`. Converse resolves the connector/model to use via `getConnectorList`, which needs:
- the `actions:read` Kibana feature, for `actionsClient.getAll()` to list stack connectors
- the ES `monitor_inference` cluster privilege, for `esClient.inference.get()` to list inference endpoints

Without either, both lookups fail and converse errors out:

```
Failed to retrieve connectors and inference endpoints: Error: Unauthorized to get actions, ResponseError: security_exception
    Root causes:
        security_exception: action [cluster:monitor/xpack/inference/get] is unauthorized for API key id [...] of user [...], this action is granted by the cluster privileges [monitor_inference,manage_inference,monitor,manage,all]
```

This adds both to the granted role descriptor, matching the same combination already used by the agentBuilder Scout access-control test fixtures for a working `agentBuilder` role.

## Test plan

- [x] `node scripts/jest x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts` passes
- [x] `node scripts/eslint --fix` clean on the changed files
- [x] Manually verify: connect the Slack app, converse from Slack, confirm connectors/inference endpoints resolve without the security_exception