### PR TITLE
Add AI.md with guidelines for AI-assisted contributions

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,23 @@
+# Using AI to contribute to Kibana
+
+We're glad you're here. AI tools can make you a faster, more effective contributor, and we welcome pull requests that were built with their help. What follows is how to make those contributions land.
+
+## Talk to us before you build
+
+Open an issue or leave a comment on an existing one to let us know what you're planning. A quick conversation early on helps us point you toward an approach that fits the codebase and is likely to get merged. Surprise PRs with no prior discussion tend to stall, no matter how good the code is.
+
+## Keep the scope tight
+
+The contributions that go smoothest are the ones you can verify from end to end. A focused bug fix, a doc that needed fixing, a missing test, an accessibility improvement. Pick something you can fully wrap your head around and confirm works.
+
+## Own every line
+
+If AI helped you write the code, that's fine, but the diff is still yours. You should be able to walk through it and explain why each part is there. Read it closely, run it, and make sure the tests pass. We close PRs when it's clear the author doesn't understand what the tool produced.
+
+## Write your own words
+
+When you're talking with maintainers, whether in an issue, on a PR, or in Slack, we want to hear from you and not from a model. Dropping generated text into a conversation wastes reviewer time and chips away at trust. Keep it real.
+
+## Let AI amplify what you already know
+
+The strongest AI-assisted work we've seen comes from people using these tools to move quickly on problems they already understand. AI is great for going faster. It won't stand in for knowing the codebase, the problem, or your solution, and that part is still on you.


### PR DESCRIPTION
## Summary

Adds a top-level `AI.md` with guidance for contributors using AI tools to work on Kibana.

We're seeing more AI-assisted PRs, and the ones that land well share a few habits: they start with a conversation, stay tightly scoped, and come from someone who understands every line in the diff. This doc spells that out so contributors know what we expect and reviewers have something to point to.

### What it covers

- Engage with the team before writing code
- Keep changes scoped to something you can verify end to end
- Own your diff, even when AI wrote it
- Keep maintainer conversations genuinely yours
- Use AI to amplify what you already understand, not to replace understanding

The tone is deliberately warm and welcoming. We want these contributions, and the doc is meant to help them succeed rather than gatekeep.