### PR TITLE
[kbn-scout] Support saved-objects data-only archives and system indices access

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/common/services/__fixtures__/archive_with_index_definition/mappings.json
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/__fixtures__/archive_with_index_definition/mappings.json
@@ -1,0 +1,13 @@
+{
+  "type": "index",
+  "value": {
+    "index": "my-data-index",
+    "mappings": {
+      "properties": {
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/common/services/__fixtures__/plain_data_archive/data.json
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/__fixtures__/plain_data_archive/data.json
@@ -1,0 +1,10 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "1",
+    "index": "my-data-index",
+    "source": {
+      "message": "not a saved object"
+    }
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/common/services/__fixtures__/saved_objects_archive/data.json
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/__fixtures__/saved_objects_archive/data.json
@@ -1,0 +1,53 @@
+{
+  "type": "_doc",
+  "value": {
+    "id": "space:space_1",
+    "index": ".kibana",
+    "source": {
+      "space": {
+        "description": "Test space",
+        "disabledFeatures": [],
+        "name": "Space 1"
+      },
+      "type": "space",
+      "updated_at": "2017-09-21T18:49:16.270Z",
+      "references": []
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "space_1:index-pattern:pattern_1",
+    "index": ".kibana",
+    "source": {
+      "index-pattern": {
+        "title": "logstash-*"
+      },
+      "namespace": "space_1",
+      "type": "index-pattern",
+      "updated_at": "2017-09-21T18:49:16.270Z",
+      "references": []
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "legacy-url-alias:space_1:index-pattern:pattern_1",
+    "index": ".kibana",
+    "source": {
+      "legacy-url-alias": {
+        "sourceId": "pattern_1",
+        "targetId": "pattern_1_new",
+        "targetNamespace": "space_1",
+        "targetType": "index-pattern"
+      },
+      "type": "legacy-url-alias",
+      "updated_at": "2017-09-21T18:49:16.270Z",
+      "references": []
+    }
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/common/services/clients.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/clients.ts
@@ -9,6 +9,7 @@
 
 import { readFileSync } from 'fs';
 import { CA_CERT_PATH } from '@kbn/dev-utils';
+import { SYSTEM_INDICES_SUPERUSER } from '@kbn/es';
 import { KbnClient } from '@kbn/kbn-client';
 import { createEsClientForTesting } from '@kbn/test-es-server';
 import type { ScoutLogger } from './logger';
@@ -54,6 +55,44 @@ export function getEsClient(config: ScoutTestConfig, log: ScoutLogger) {
   }
 
   return esClientInstance;
+}
+
+let systemIndicesEsClientInstance: EsClient | null = null;
+
+/**
+ * Returns an Elasticsearch client that is allowed to read/write the restricted system
+ * indices (e.g. the `.kibana*` saved object indices), which reject writes from the
+ * regular `elastic` superuser.
+ *
+ * On stateful deployments this authenticates as `system_indices_superuser`, a user that
+ * `@kbn/es` provisions at cluster startup (with the same password as `elastic`) and whose
+ * role carries `allow_restricted_indices: true` — the same override FTR's `es` service
+ * applies. Serverless has no such user, so the default client is returned instead,
+ * mirroring FTR.
+ */
+export function getEsClientForSystemIndices(config: ScoutTestConfig, log: ScoutLogger) {
+  if (config.serverless) {
+    return getEsClient(config, log);
+  }
+
+  if (!systemIndicesEsClientInstance) {
+    const password = config.auth.password;
+    const elasticsearchUrl = createClientUrlWithAuth({
+      serviceName: 'systemIndicesEs',
+      url: config.hosts.elasticsearch,
+      username: SYSTEM_INDICES_SUPERUSER,
+      password,
+      log,
+    });
+
+    systemIndicesEsClientInstance = createEsClientForTesting({
+      esUrl: elasticsearchUrl,
+      isCloud: config.isCloud,
+      authOverride: { username: SYSTEM_INDICES_SUPERUSER, password },
+    });
+  }
+
+  return systemIndicesEsClientInstance;
 }
 
 let linkedEsClientInstance: EsClient | null = null;

--- a/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
@@ -7,9 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { getEsClient, getLinkedEsClient, getKbnClient } from './clients';
+export {
+  getEsClient,
+  getEsClientForSystemIndices,
+  getLinkedEsClient,
+  getKbnClient,
+} from './clients';
 export { createScoutConfig } from './config';
 export { getEsArchiver, getLinkedEsArchiver } from './es_archiver';
+export { loadSavedObjectsArchive, unloadSavedObjectsArchive } from './saved_objects_archiver';
+export type { LoadSavedObjectsOptions } from './saved_objects_archiver';
 export { createKbnUrl } from './kibana_url';
 export { createSamlSessionManager } from './saml_auth';
 

--- a/src/platform/packages/shared/kbn-scout/src/common/services/saved_objects_archiver.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/saved_objects_archiver.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Path from 'path';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+import { ToolingLog } from '@kbn/tooling-log';
+import type { EsClient } from '../../types';
+import { loadSavedObjectsArchive, unloadSavedObjectsArchive } from './saved_objects_archiver';
+
+const toRepoRelative = (fixture: string) =>
+  Path.relative(REPO_ROOT, Path.resolve(__dirname, '__fixtures__', fixture));
+
+const SAVED_OBJECTS_ARCHIVE = toRepoRelative('saved_objects_archive');
+const PLAIN_DATA_ARCHIVE = toRepoRelative('plain_data_archive');
+const ARCHIVE_WITH_INDEX_DEFINITION = toRepoRelative('archive_with_index_definition');
+
+const log = new ToolingLog();
+
+const createEsClientMock = () => {
+  const bulk = jest.fn().mockResolvedValue({ errors: false, items: [] });
+  const deleteByQuery = jest.fn().mockResolvedValue({ deleted: 0, total: 0 });
+  return { client: { bulk, deleteByQuery } as unknown as EsClient, bulk, deleteByQuery };
+};
+
+describe('loadSavedObjectsArchive', () => {
+  it('purges the archive types (preserving `space` by default) and bulk-indexes the docs', async () => {
+    const { client, bulk, deleteByQuery } = createEsClientMock();
+
+    await loadSavedObjectsArchive(client, log, SAVED_OBJECTS_ARCHIVE);
+
+    expect(deleteByQuery).toHaveBeenCalledTimes(1);
+    const deleteRequest = deleteByQuery.mock.calls[0][0];
+    expect(deleteRequest.query.terms.type.sort()).toEqual(['index-pattern', 'legacy-url-alias']);
+    expect(deleteRequest.index).toEqual(expect.arrayContaining(['.kibana']));
+
+    expect(bulk).toHaveBeenCalledTimes(1);
+    const { operations, refresh } = bulk.mock.calls[0][0];
+    expect(refresh).toBe(true);
+    // one action + one source entry per archive doc, in archive order
+    expect(operations).toHaveLength(6);
+    expect(operations[0]).toEqual({ index: { _index: '.kibana', _id: 'space:space_1' } });
+    expect(operations[1].type).toBe('space');
+    expect(operations[2]).toEqual({
+      index: { _index: '.kibana', _id: 'space_1:index-pattern:pattern_1' },
+    });
+    expect(operations[4]).toEqual({
+      index: { _index: '.kibana', _id: 'legacy-url-alias:space_1:index-pattern:pattern_1' },
+    });
+  });
+
+  it('honors a custom preservedTypes list', async () => {
+    const { client, deleteByQuery } = createEsClientMock();
+
+    await loadSavedObjectsArchive(client, log, SAVED_OBJECTS_ARCHIVE, { preservedTypes: [] });
+
+    const deleteRequest = deleteByQuery.mock.calls[0][0];
+    expect(deleteRequest.query.terms.type.sort()).toEqual([
+      'index-pattern',
+      'legacy-url-alias',
+      'space',
+    ]);
+  });
+
+  it('throws when the bulk request reports per-document failures', async () => {
+    const { client, bulk } = createEsClientMock();
+    bulk.mockResolvedValue({
+      errors: true,
+      items: [
+        {
+          index: {
+            _index: '.kibana',
+            _id: 'space:space_1',
+            status: 400,
+            error: { type: 'mapper_parsing_exception' },
+          },
+        },
+      ],
+    });
+
+    await expect(loadSavedObjectsArchive(client, log, SAVED_OBJECTS_ARCHIVE)).rejects.toThrow(
+      /Failed to load saved objects archive .*mapper_parsing_exception/s
+    );
+  });
+
+  it('rejects archives with documents outside the saved object indices', async () => {
+    const { client, bulk, deleteByQuery } = createEsClientMock();
+
+    await expect(loadSavedObjectsArchive(client, log, PLAIN_DATA_ARCHIVE)).rejects.toThrow(
+      /\[my-data-index\], which is not a Kibana saved object index/
+    );
+    expect(deleteByQuery).not.toHaveBeenCalled();
+    expect(bulk).not.toHaveBeenCalled();
+  });
+
+  it('rejects archives containing index definitions', async () => {
+    const { client } = createEsClientMock();
+
+    await expect(
+      loadSavedObjectsArchive(client, log, ARCHIVE_WITH_INDEX_DEFINITION)
+    ).rejects.toThrow(/contains a \[index\] record/);
+  });
+
+  it('rejects archives that cannot be resolved', async () => {
+    const { client } = createEsClientMock();
+
+    await expect(loadSavedObjectsArchive(client, log, 'not/a/real/archive')).rejects.toThrow(
+      /could not be resolved/
+    );
+  });
+});
+
+describe('unloadSavedObjectsArchive', () => {
+  it('bulk-deletes every archive doc', async () => {
+    const { client, bulk, deleteByQuery } = createEsClientMock();
+
+    await unloadSavedObjectsArchive(client, log, SAVED_OBJECTS_ARCHIVE);
+
+    expect(deleteByQuery).not.toHaveBeenCalled();
+    expect(bulk).toHaveBeenCalledTimes(1);
+    const { operations } = bulk.mock.calls[0][0];
+    expect(operations).toEqual([
+      { delete: { _index: '.kibana', _id: 'space:space_1' } },
+      { delete: { _index: '.kibana', _id: 'space_1:index-pattern:pattern_1' } },
+      { delete: { _index: '.kibana', _id: 'legacy-url-alias:space_1:index-pattern:pattern_1' } },
+    ]);
+  });
+
+  it('ignores missing documents but throws on other failures', async () => {
+    const { client, bulk } = createEsClientMock();
+    bulk.mockResolvedValue({
+      errors: true,
+      items: [
+        {
+          delete: {
+            _index: '.kibana',
+            _id: 'space:space_1',
+            status: 404,
+            error: { type: 'not_found' },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      unloadSavedObjectsArchive(client, log, SAVED_OBJECTS_ARCHIVE)
+    ).resolves.toBeUndefined();
+
+    bulk.mockResolvedValue({
+      errors: true,
+      items: [
+        {
+          delete: {
+            _index: '.kibana',
+            _id: 'space:space_1',
+            status: 403,
+            error: { type: 'security_exception' },
+          },
+        },
+      ],
+    });
+
+    await expect(unloadSavedObjectsArchive(client, log, SAVED_OBJECTS_ARCHIVE)).rejects.toThrow(
+      /Failed to unload saved objects archive .*security_exception/s
+    );
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/common/services/saved_objects_archiver.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/saved_objects_archiver.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Fs from 'fs';
+import Path from 'path';
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import { REPO_ROOT } from '@kbn/repo-info';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import { createPromiseFromStreams, createConcatStream } from '@kbn/utils';
+import { isGzip, createParseArchiveStreams, isSavedObjectIndex } from '@kbn/es-archiver/src/lib';
+import type { EsClient } from '../../types';
+
+/**
+ * Sent with every request that touches the restricted `.kibana*` indices so
+ * Elasticsearch treats the access as first-party (mirrors `@kbn/es-archiver`).
+ */
+const ES_CLIENT_HEADERS = { 'x-elastic-product-origin': 'kibana' } as const;
+
+const BULK_CHUNK_SIZE = 1000;
+
+interface ArchiveDocRecord {
+  type: string;
+  value: {
+    index?: string;
+    id?: string;
+    source?: Record<string, unknown>;
+  };
+}
+
+interface SavedObjectDoc {
+  index: string;
+  id: string;
+  source: Record<string, unknown>;
+}
+
+export interface LoadSavedObjectsOptions {
+  /**
+   * Saved object types that are never purged before indexing the archive documents.
+   * Defaults to `['space']`: spaces are typically provisioned/torn down by the tests
+   * themselves (or belong to other suites sharing the cluster), so deleting unrelated
+   * `space` documents would break them. Pass your own list to widen or narrow the
+   * exemption.
+   */
+  preservedTypes?: readonly string[];
+}
+
+const resolveArchiveDir = (archivePath: string): string => {
+  const dir = Path.resolve(REPO_ROOT, archivePath);
+  let stats: Fs.Stats;
+  try {
+    stats = Fs.statSync(dir);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error(
+        `Saved objects archive [${archivePath}] could not be resolved (relative to [${REPO_ROOT}])`
+      );
+    }
+    throw error;
+  }
+
+  if (!stats.isDirectory()) {
+    throw new Error(
+      `Saved objects archive [${archivePath}] must be a directory containing a 'data.json' or 'data.json.gz' file`
+    );
+  }
+
+  return dir;
+};
+
+/**
+ * Reads an `@kbn/es-archiver` archive and returns its document records, verifying that
+ * the archive is "saved objects data-only": every record must be a `doc` targeting one
+ * of the Kibana saved object indices. Index definitions (`mappings.json`) and documents
+ * for regular data indices are rejected — use `esArchiver.loadIfNeeded` for those.
+ */
+const readArchiveDocs = async (archivePath: string): Promise<SavedObjectDoc[]> => {
+  const dir = resolveArchiveDir(archivePath);
+  const files = Fs.readdirSync(dir).filter((name) => !name.startsWith('.'));
+
+  const docs: SavedObjectDoc[] = [];
+  for (const filename of files) {
+    const records = await createPromiseFromStreams<ArchiveDocRecord[]>([
+      Fs.createReadStream(Path.resolve(dir, filename)),
+      ...createParseArchiveStreams({ gzip: isGzip(filename) }),
+      createConcatStream([]),
+    ]);
+
+    for (const record of records) {
+      // doc records use type 'doc' ('_doc' in older archives); anything else is an
+      // index/data-stream definition, which a data-only saved objects archive must not have
+      if (record.type === 'index' || record.type === 'data_stream') {
+        throw new Error(
+          `Saved objects archive [${archivePath}] contains a [${record.type}] record (in [${filename}]). ` +
+            `Only data-only archives targeting the existing saved object indices are supported: remove index ` +
+            `definitions (usually by deleting 'mappings.json') or load the archive with 'esArchiver.loadIfNeeded'.`
+        );
+      }
+
+      const { index, id, source } = record.value;
+      if (!index || !id || !source) {
+        throw new Error(
+          `Saved objects archive [${archivePath}] contains a malformed doc record (in [${filename}]): ${JSON.stringify(
+            record.value
+          ).slice(0, 200)}`
+        );
+      }
+
+      if (!isSavedObjectIndex(index)) {
+        throw new Error(
+          `Saved objects archive [${archivePath}] contains a document for [${index}], which is not a ` +
+            `Kibana saved object index. Load regular data indices with 'esArchiver.loadIfNeeded' instead.`
+        );
+      }
+
+      docs.push({ index, id, source });
+    }
+  }
+
+  return docs;
+};
+
+const chunk = <T>(items: readonly T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+};
+
+const runBulk = async (
+  esClient: EsClient,
+  operations: object[],
+  onError: (failures: string[]) => Error,
+  extractOp: (item: Record<string, any>) => Record<string, any> | undefined,
+  ignoredStatuses: readonly number[] = []
+) => {
+  for (const operationsChunk of chunk(operations, BULK_CHUNK_SIZE * 2)) {
+    const response = await esClient.bulk(
+      { operations: operationsChunk, refresh: true },
+      { headers: ES_CLIENT_HEADERS }
+    );
+    if (response.errors) {
+      const failures = response.items
+        .map(extractOp)
+        .filter((op) => op?.error && !ignoredStatuses.includes(op.status))
+        .map((op) => `${op?._index}/${op?._id}: ${JSON.stringify(op?.error)}`);
+      if (failures.length > 0) {
+        throw onError(failures);
+      }
+    }
+  }
+};
+
+/**
+ * Purges every document of the given saved object types across the saved object indices.
+ * This reproduces the pristine state FTR suites get from `esArchiver.load` (which cleans
+ * the saved object indices before indexing) while staying scoped to the archive's own
+ * types, so unrelated fixtures loaded by other suites sharing the cluster survive.
+ */
+const purgeArchiveTypes = async (
+  esClient: EsClient,
+  docs: SavedObjectDoc[],
+  preservedTypes: readonly string[]
+) => {
+  const preserved = new Set(preservedTypes);
+  const types = Array.from(
+    new Set(
+      docs
+        .map((doc) => doc.source.type)
+        .filter((type): type is string => typeof type === 'string' && !preserved.has(type))
+    )
+  );
+  if (types.length === 0) {
+    return;
+  }
+
+  await esClient.deleteByQuery(
+    {
+      index: [...ALL_SAVED_OBJECT_INDICES],
+      conflicts: 'proceed',
+      refresh: true,
+      ignore_unavailable: true,
+      query: { terms: { type: types } },
+    },
+    { headers: ES_CLIENT_HEADERS }
+  );
+};
+
+/**
+ * Loads a "saved objects data-only" es-archiver archive into the existing `.kibana*`
+ * indices: purges any documents of the archive's own saved object types (see
+ * {@link LoadSavedObjectsOptions.preservedTypes}), then bulk-indexes every archive
+ * document. The target indices are never deleted or recreated, and no other saved
+ * objects are touched, which keeps this safe on clusters shared with other suites.
+ *
+ * Requires a client that may write to the restricted saved object indices (see
+ * `getEsClientForSystemIndices`).
+ */
+export const loadSavedObjectsArchive = async (
+  esClient: EsClient,
+  log: ToolingLog,
+  archivePath: string,
+  options?: LoadSavedObjectsOptions
+): Promise<void> => {
+  const docs = await readArchiveDocs(archivePath);
+  if (docs.length === 0) {
+    log.warning(`[${archivePath}] archive has no documents to load`);
+    return;
+  }
+
+  await purgeArchiveTypes(esClient, docs, options?.preservedTypes ?? ['space']);
+
+  const operations = docs.flatMap((doc) => [
+    { index: { _index: doc.index, _id: doc.id } },
+    doc.source,
+  ]);
+
+  await runBulk(
+    esClient,
+    operations,
+    (failures) =>
+      new Error(`Failed to load saved objects archive [${archivePath}]:\n${failures.join('\n')}`),
+    (item) => item.index
+  );
+
+  log.debug(`[${archivePath}] loaded ${docs.length} saved object docs`);
+};
+
+/**
+ * Deletes every document contained in a "saved objects data-only" archive from the
+ * `.kibana*` indices. Documents that are already gone are ignored, but any other
+ * per-document failure throws: a silently partial unload would leak archive fixtures
+ * into later suites.
+ */
+export const unloadSavedObjectsArchive = async (
+  esClient: EsClient,
+  log: ToolingLog,
+  archivePath: string
+): Promise<void> => {
+  const docs = await readArchiveDocs(archivePath);
+  if (docs.length === 0) {
+    return;
+  }
+
+  const operations = docs.map((doc) => ({ delete: { _index: doc.index, _id: doc.id } }));
+
+  await runBulk(
+    esClient,
+    operations,
+    (failures) =>
+      new Error(`Failed to unload saved objects archive [${archivePath}]:\n${failures.join('\n')}`),
+    (item) => item.delete,
+    [404]
+  );
+
+  log.debug(`[${archivePath}] unloaded ${docs.length} saved object docs`);
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/es_archiver.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/es_archiver.ts
@@ -10,7 +10,13 @@
 import type { LoadActionPerfOptions } from '@kbn/es-archiver';
 import type { IndexStats } from '@kbn/es-archiver/src/lib/stats';
 import { coreWorkerFixtures } from './core_fixtures';
-import { getEsArchiver } from '../../../../common/services';
+import type { LoadSavedObjectsOptions } from '../../../../common/services';
+import {
+  getEsArchiver,
+  getEsClientForSystemIndices,
+  loadSavedObjectsArchive,
+  unloadSavedObjectsArchive,
+} from '../../../../common/services';
 
 export interface EsArchiverFixture {
   /**
@@ -24,6 +30,37 @@ export interface EsArchiverFixture {
     name: string,
     performance?: LoadActionPerfOptions | undefined
   ) => Promise<Record<string, IndexStats>>;
+
+  /**
+   * Loads a "saved objects data-only" es-archiver archive (a `data.json[.gz]` whose
+   * documents all target the `.kibana*` saved object indices) into the *existing*
+   * saved object indices.
+   *
+   * Unlike `loadIfNeeded`, which no-ops when the target index already exists (always
+   * true for `.kibana*`), this purges any documents of the archive's own saved object
+   * types and then indexes the archive documents, restoring the pristine fixture state
+   * without deleting or recreating the indices. Writes are performed with a
+   * system-indices-capable client, since the regular `elastic` superuser cannot write
+   * to the restricted saved object indices.
+   *
+   * Prefer `kbnClient.importExport` when your fixtures can be expressed as importable
+   * saved objects; use this only for raw documents the saved objects HTTP APIs cannot
+   * produce (e.g. `legacy-url-alias` docs, objects with `originId`, or pre-seeded
+   * multi-namespace shares).
+   *
+   * @param name Repo-relative path to the archive directory.
+   * @param options See {@link LoadSavedObjectsOptions}.
+   */
+  loadSavedObjects: (name: string, options?: LoadSavedObjectsOptions) => Promise<void>;
+
+  /**
+   * Deletes every document contained in a "saved objects data-only" archive from the
+   * saved object indices. Missing documents are ignored. Counterpart to
+   * `loadSavedObjects` for suite-level cleanup.
+   *
+   * @param name Repo-relative path to the archive directory.
+   */
+  unloadSavedObjects: (name: string) => Promise<void>;
 }
 
 export const esArchiverFixture = coreWorkerFixtures.extend<{}, { esArchiver: EsArchiverFixture }>({
@@ -33,15 +70,24 @@ export const esArchiverFixture = coreWorkerFixtures.extend<{}, { esArchiver: EsA
    * data ingestion.
    *
    * Note: In order to speedup test execution and avoid the overhead of deleting the data
-   * we only expose capability to ingest the data indexes.
+   * we only expose capability to ingest the data indexes. The "loadSavedObjects" /
+   * "unloadSavedObjects" methods are the exception: they reseed saved-objects data-only
+   * archives into the existing `.kibana*` indices, scoped to the archive's own documents.
    */
   esArchiver: [
-    ({ log, esClient }, use) => {
+    ({ log, esClient, config }, use) => {
       const esArchiverInstance = getEsArchiver(esClient, log);
       const loadIfNeeded = async (name: string, performance?: LoadActionPerfOptions | undefined) =>
         esArchiverInstance!.loadIfNeeded(name, performance);
 
-      use({ loadIfNeeded });
+      // resolved lazily so workers that never touch saved objects archives
+      // do not create the privileged client
+      const loadSavedObjects = async (name: string, options?: LoadSavedObjectsOptions) =>
+        loadSavedObjectsArchive(getEsClientForSystemIndices(config, log), log, name, options);
+      const unloadSavedObjects = async (name: string) =>
+        unloadSavedObjectsArchive(getEsClientForSystemIndices(config, log), log, name);
+
+      use({ loadIfNeeded, loadSavedObjects, unloadSavedObjects });
     },
     { scope: 'worker' },
   ],

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/index.ts
@@ -17,6 +17,8 @@ export type { SamlAuth, CoreWorkerFixtures } from './saml_auth';
 export { esArchiverFixture } from './es_archiver';
 export type { EsArchiverFixture } from './es_archiver';
 
+export { systemIndicesEsClientFixture } from './system_indices_es_client';
+
 export { linkedEsFixtures } from './linked_es_archiver';
 export type { LinkedProjectFixture } from './linked_es_archiver';
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/linked_es_archiver.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/linked_es_archiver.ts
@@ -15,7 +15,9 @@ import type { EsArchiverFixture } from './es_archiver';
 
 export interface LinkedProjectFixture {
   esClient: Client;
-  esArchiver: EsArchiverFixture;
+  // saved-objects archive helpers are not exposed for the linked cluster: it is a
+  // serverless-only concept and Kibana saved objects live in the main project
+  esArchiver: Pick<EsArchiverFixture, 'loadIfNeeded'>;
 }
 
 export const linkedEsFixtures = coreWorkerFixtures.extend<

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/system_indices_es_client.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/system_indices_es_client.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import { coreWorkerFixtures } from './core_fixtures';
+import { getEsClientForSystemIndices } from '../../../../common/services';
+
+export const systemIndicesEsClientFixture = coreWorkerFixtures.extend<
+  {},
+  { systemIndicesEsClient: Client }
+>({
+  /**
+   * Elasticsearch client that is allowed to read/write the restricted system indices
+   * (e.g. the `.kibana*` saved object indices), which reject direct access from the
+   * regular `elastic` superuser. On stateful deployments it authenticates as the
+   * `system_indices_superuser` user provisioned by `@kbn/es` at cluster startup — the
+   * same override FTR's `es` service applies; on serverless it is the default client.
+   *
+   * Use it to assert on raw saved object documents (e.g. `legacy-url-alias` docs or
+   * `namespaces` fields) that Kibana's HTTP APIs do not expose. Prefer `esClient` for
+   * everything else.
+   */
+  systemIndicesEsClient: [
+    ({ config, log }, use) => {
+      use(getEsClientForSystemIndices(config, log));
+    },
+    { scope: 'worker' },
+  ],
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/api/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/api/index.ts
@@ -17,10 +17,12 @@ import {
   apiServicesFixture,
   defaultRolesFixture,
   requestAuthFixture,
+  systemIndicesEsClientFixture,
 } from '../../fixtures/scope/worker';
 import type {
   CoreWorkerFixtures,
   EsArchiverFixture,
+  EsClient,
   LinkedProjectFixture,
   RequestAuthFixture,
   ApiClientFixture,
@@ -38,6 +40,7 @@ export interface ApiWorkerFixtures extends CoreWorkerFixtures {
   requestAuth: RequestAuthFixture;
   esArchiver: EsArchiverFixture;
   linkedProject: LinkedProjectFixture;
+  systemIndicesEsClient: EsClient;
 }
 
 // This disables browser-related fixtures by overriding them with undefined
@@ -80,5 +83,6 @@ export const apiTest = mergeTests(
   defaultRolesFixture,
   requestAuthFixture,
   esArchiverFixture,
+  systemIndicesEsClientFixture,
   linkedEsFixtures
 ) as unknown as TestType<{}, ApiWorkerFixtures>;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/single_thread_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/single_thread_fixtures.ts
@@ -13,6 +13,7 @@ import {
   coreWorkerFixtures,
   esArchiverFixture,
   linkedEsFixtures,
+  systemIndicesEsClientFixture,
   uiSettingsFixture,
   lighthouseFixture,
 } from '../../fixtures/scope/worker';
@@ -49,6 +50,7 @@ export const scoutFixtures = mergeTests(
   // worker scope fixtures
   coreWorkerFixtures,
   esArchiverFixture,
+  systemIndicesEsClientFixture,
   linkedEsFixtures,
   uiSettingsFixture,
   // api fixtures
@@ -77,6 +79,7 @@ export interface ScoutWorkerFixtures extends ApiServicesFixture {
   kbnClient: KbnClient;
   esClient: EsClient;
   esArchiver: EsArchiverFixture;
+  systemIndicesEsClient: EsClient;
   linkedProject: LinkedProjectFixture;
   uiSettings: UiSettingsFixture;
   apiServices: ApiServicesFixture;

--- a/src/platform/packages/shared/kbn-scout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-scout/tsconfig.json
@@ -27,6 +27,8 @@
     "@kbn/scout-reporting",
     "@kbn/zod",
     "@kbn/core-http-common",
+    "@kbn/core-saved-objects-server",
+    "@kbn/utils",
     "@kbn/axe-config",
     "@kbn/peggy",
     "@kbn/test-docker-servers",


### PR DESCRIPTION
## Summary

Closes #277592

Scout's `esArchiver` fixture only exposed `loadIfNeeded`, driven by the default `elastic`-authenticated client. That combination cannot (re)seed saved-objects data-only es-archiver archives into the existing `.kibana*` system indices: `loadIfNeeded` no-ops when the target index exists (always true for `.kibana*`), the fixture's `EsArchiver` runs in `dataOnly` mode which rejects SO indices, and the `elastic` superuser cannot access restricted system indices. FTR solves this with an `es` service that authenticates as `system_indices_superuser`; plugins migrating such FTR suites to Scout currently have to hand-roll a privileged client and archive loader (the spaces API migration did exactly that with a ~160-line local helper).

This PR adds the capability to kbn-scout:

- **`getEsClientForSystemIndices`**: lazily-created client authenticated as `system_indices_superuser` (provisioned by `@kbn/es` at cluster startup with the same password as `elastic`) on stateful, falling back to the default client on serverless — mirroring FTR's `es` service.
- **`esArchiver.loadSavedObjects` / `esArchiver.unloadSavedObjects`**: load/unload a saved-objects data-only archive against the *existing* saved object indices. Load purges only the archive's own SO types (preserving `space` by default, overridable) before bulk indexing, so suites sharing the cluster keep their fixtures; unload deletes exactly the archive's documents (missing docs ignored). Archives containing index definitions or non-SO documents are rejected with pointers to `loadIfNeeded` / `kbnClient.importExport`.
- **`systemIndicesEsClient` worker fixture** (`apiTest` and single-thread UI tests): raw client access for asserting on saved object documents that Kibana HTTP APIs do not expose (e.g. `legacy-url-alias` docs, `namespaces` fields). Not added to parallel-run fixtures, consistent with `esArchiver`'s positioning there.

See #277592 for the full design discussion and open questions.

## Testing

- New unit tests for the archive loader (`saved_objects_archiver.test.ts`): purge/bulk semantics, `preservedTypes`, malformed/non-SO/index-definition rejection, partial-failure error surfacing, 404-tolerant unload.
- Validated end-to-end by migrating the spaces Scout API suites (`_get_shareable_references`, `_update_objects_spaces`, `_disable_legacy_url_aliases`) off their local helper onto these primitives: 213 tests pass against a local stateful cluster. That migration will land with the spaces API test migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
