### PR TITLE
[Data Views] Add data views as-code feature flag

### DIFF
--- a/src/platform/plugins/shared/data_views_as_code/README.md
+++ b/src/platform/plugins/shared/data_views_as_code/README.md
@@ -2,4 +2,11 @@
 
 This plugin contains the defined endpoints for data views as code, following the as code standards.
 
+The public API is in technical preview and disabled by default. To enable it for local development or self-managed testing, add the following override to `kibana.yml`:
+
+```yaml
+feature_flags.overrides:
+  dataViewsAsCode.enabled: true
+```
+
 Why a different plugin from `@kbn/data-views-plugin`? Because the as code utilities, schemas and transforms, rely on `@kbn/data-views-plugin` mainly for typing. This means that we can't reuse this utilities inside `@kbn/data-views-plugin` without causing a circular dependency. That can be fixed by creating a new package that relies on this pieces.

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/constants.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/constants.ts
@@ -9,3 +9,6 @@
 
 export const BASE_PATH = '/api/data_views';
 export const INITIAL_REST_VERSION = '2023-10-31';
+
+export const DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG = 'dataViewsAsCode.enabled';
+export const DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG_DEFAULT = false;

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/delete_data_view.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/delete_data_view.ts
@@ -10,7 +10,7 @@
 import type { IRouter, StartServicesAccessor } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
 
-import { getDataViewsAsCodeService, handleErrors } from './utils';
+import { getDataViewsAsCodeService, handleErrors, withDataViewsAsCodeEnabled } from './utils';
 import { BASE_PATH, INITIAL_REST_VERSION } from './constants';
 import type { DataViewsAsCodeServerPluginStartDependencies } from '../types';
 
@@ -25,6 +25,12 @@ export const registerDeleteDataViewAsCodeRoute = (
       path: DELETE_DATA_VIEW_AS_CODE_PATH,
       access: 'public',
       description: 'Delete a data view by id',
+      options: {
+        availability: {
+          stability: 'tech_preview',
+          since: '9.5.0',
+        },
+      },
       security: {
         authz: {
           requiredPrivileges: ['indexPatterns:manage'],
@@ -56,12 +62,18 @@ export const registerDeleteDataViewAsCodeRoute = (
           },
         },
       },
-      handleErrors(async (ctx, req, res) => {
-        const id = req.params.id;
+      withDataViewsAsCodeEnabled(
+        handleErrors(async (ctx, req, res) => {
+          const id = req.params.id;
 
-        const dataViewsAsCodeService = await getDataViewsAsCodeService(ctx, getStartServices, req);
-        await dataViewsAsCodeService.delete(id);
+          const dataViewsAsCodeService = await getDataViewsAsCodeService(
+            ctx,
+            getStartServices,
+            req
+          );
+          await dataViewsAsCodeService.delete(id);
 
-        return res.ok();
-      })
+          return res.ok();
+        })
+      )
     );

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/get_data_view.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/get_data_view.ts
@@ -10,7 +10,7 @@
 import type { IRouter, StartServicesAccessor } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
 import { asCodeResponseSchema } from './schema';
-import { getDataViewsAsCodeService, handleErrors } from './utils';
+import { getDataViewsAsCodeService, handleErrors, withDataViewsAsCodeEnabled } from './utils';
 import { BASE_PATH, INITIAL_REST_VERSION } from './constants';
 import type { DataViewsAsCodeServerPluginStartDependencies } from '../types';
 
@@ -25,6 +25,12 @@ export const registerGetDataViewAsCodeRoute = (
       path: GET_DATA_VIEW_AS_CODE_PATH,
       access: 'public',
       description: 'Get a data view by id',
+      options: {
+        availability: {
+          stability: 'tech_preview',
+          since: '9.5.0',
+        },
+      },
       security: {
         authz: {
           enabled: false,
@@ -51,15 +57,24 @@ export const registerGetDataViewAsCodeRoute = (
             200: {
               body: () => asCodeResponseSchema,
             },
+            404: {
+              description: 'not found',
+            },
           },
         },
       },
-      handleErrors(async (ctx, req, res) => {
-        const id = req.params.id;
+      withDataViewsAsCodeEnabled(
+        handleErrors(async (ctx, req, res) => {
+          const id = req.params.id;
 
-        const dataViewsAsCodeService = await getDataViewsAsCodeService(ctx, getStartServices, req);
-        const response = await dataViewsAsCodeService.get(id);
+          const dataViewsAsCodeService = await getDataViewsAsCodeService(
+            ctx,
+            getStartServices,
+            req
+          );
+          const response = await dataViewsAsCodeService.get(id);
 
-        return res.ok({ body: response });
-      })
+          return res.ok({ body: response });
+        })
+      )
     );

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/post_data_view.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/post_data_view.ts
@@ -9,7 +9,7 @@
 
 import type { IRouter, StartServicesAccessor } from '@kbn/core/server';
 import { asCodeResponseSchema, savedDataViewSpecSchemaWithoutId } from './schema';
-import { getDataViewsAsCodeService, handleErrors } from './utils';
+import { getDataViewsAsCodeService, handleErrors, withDataViewsAsCodeEnabled } from './utils';
 import { BASE_PATH, INITIAL_REST_VERSION } from './constants';
 import type { DataViewsAsCodeServerPluginStartDependencies } from '../types';
 
@@ -24,6 +24,12 @@ export const registerPostDataViewAsCodeRoute = (
       path: CREATE_DATA_VIEW_AS_CODE_PATH,
       access: 'public',
       description: 'Create a data view',
+      options: {
+        availability: {
+          stability: 'tech_preview',
+          since: '9.5.0',
+        },
+      },
       security: {
         authz: {
           requiredPrivileges: ['indexPatterns:manage'],
@@ -47,16 +53,25 @@ export const registerPostDataViewAsCodeRoute = (
             403: {
               description: 'forbidden',
             },
+            404: {
+              description: 'not found',
+            },
             409: {
               description: 'conflict',
             },
           },
         },
       },
-      handleErrors(async (ctx, req, res) => {
-        const dataViewsAsCodeService = await getDataViewsAsCodeService(ctx, getStartServices, req);
-        const storedDataView = await dataViewsAsCodeService.create(req.body);
+      withDataViewsAsCodeEnabled(
+        handleErrors(async (ctx, req, res) => {
+          const dataViewsAsCodeService = await getDataViewsAsCodeService(
+            ctx,
+            getStartServices,
+            req
+          );
+          const storedDataView = await dataViewsAsCodeService.create(req.body);
 
-        return res.created({ body: storedDataView });
-      })
+          return res.created({ body: storedDataView });
+        })
+      )
     );

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.test.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RequestHandlerContext } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import {
+  DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG,
+  DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG_DEFAULT,
+} from './constants';
+import { withDataViewsAsCodeEnabled } from './utils';
+
+describe('withDataViewsAsCodeEnabled', () => {
+  const request = httpServerMock.createKibanaRequest();
+
+  it('returns not found without calling the handler when the feature is disabled', async () => {
+    const coreContext = coreMock.createRequestHandlerContext();
+    coreContext.featureFlags.getBooleanValue.mockResolvedValue(false);
+    const context = jest.mocked<RequestHandlerContext>({
+      core: Promise.resolve(coreContext),
+      resolve: jest.fn(),
+    });
+    const response = httpServerMock.createResponseFactory();
+    const handler = jest.fn();
+
+    const result = await withDataViewsAsCodeEnabled(handler)(context, request, response);
+
+    expect(coreContext.featureFlags.getBooleanValue).toHaveBeenCalledWith(
+      DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG,
+      DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG_DEFAULT
+    );
+    expect(response.notFound).toHaveBeenCalledWith();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toBe(response.notFound.mock.results[0].value);
+  });
+
+  it('returns the handler result when the feature is enabled', async () => {
+    const coreContext = coreMock.createRequestHandlerContext();
+    coreContext.featureFlags.getBooleanValue.mockResolvedValue(true);
+    const context = jest.mocked<RequestHandlerContext>({
+      core: Promise.resolve(coreContext),
+      resolve: jest.fn(),
+    });
+    const response = httpServerMock.createResponseFactory();
+    const handlerResult = response.ok();
+    const handler = jest.fn().mockResolvedValue(handlerResult);
+
+    const result = await withDataViewsAsCodeEnabled(handler)(context, request, response);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(context, request, response);
+    expect(response.notFound).not.toHaveBeenCalled();
+    expect(result).toBe(handlerResult);
+  });
+});

--- a/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.ts
+++ b/src/platform/plugins/shared/data_views_as_code/server/rest_routes/utils.ts
@@ -20,6 +20,10 @@ import type { ErrorIndexPatternNotFound } from '@kbn/data-views-plugin/server/er
 import { DuplicateDataViewError } from '@kbn/data-views-plugin/common';
 import type { DataViewsAsCodeServerPluginStartDependencies } from '../types';
 import { DataViewsAsCodeService } from '../services/data_views_as_code_service';
+import {
+  DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG,
+  DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG_DEFAULT,
+} from './constants';
 
 export async function getDataViewsAsCodeService(
   ctx: RequestHandlerContext,
@@ -46,6 +50,24 @@ interface ErrorResponseBody {
 interface ErrorWithData {
   data?: object;
 }
+
+export const withDataViewsAsCodeEnabled =
+  <P, Q, B, Context extends RequestHandlerContext, Method extends RouteMethod>(
+    handler: RequestHandler<P, Q, B, Context, Method>
+  ): RequestHandler<P, Q, B, Context, Method> =>
+  async (context, request, response) => {
+    const { featureFlags } = await context.core;
+    const isEnabled = await featureFlags.getBooleanValue(
+      DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG,
+      DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG_DEFAULT
+    );
+
+    if (!isEnabled) {
+      return response.notFound();
+    }
+
+    return handler(context, request, response);
+  };
 
 /**
  * This higher order request handler makes sure that errors are returned with

--- a/src/platform/plugins/shared/data_views_as_code/test/scout/api/fixtures/constants.ts
+++ b/src/platform/plugins/shared/data_views_as_code/test/scout/api/fixtures/constants.ts
@@ -21,3 +21,5 @@ export const COMMON_HEADERS = {
 export const BASE_PATH = '/api/data_views';
 
 export const ID_OVER_MAX_LENGTH = 'x'.repeat(1759);
+
+export const DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG = 'dataViewsAsCode.enabled';

--- a/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/feature_flag_disabled.spec.ts
+++ b/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/feature_flag_disabled.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { apiTest, tags, type RoleApiCredentials } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import {
+  BASE_PATH,
+  COMMON_HEADERS,
+  DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG,
+} from '../fixtures/constants';
+
+apiTest.describe('data views as code feature flag', { tag: tags.deploymentAgnostic }, () => {
+  let adminApiCredentials: RoleApiCredentials;
+
+  apiTest.beforeAll(async ({ apiServices, requestAuth }) => {
+    adminApiCredentials = await requestAuth.getApiKeyForAdmin();
+    await apiServices.core.settings({
+      'feature_flags.overrides': {
+        [DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG]: false,
+      },
+    });
+  });
+
+  apiTest.afterAll(async ({ apiServices }) => {
+    await apiServices.core.settings({
+      'feature_flags.overrides': {
+        [DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG]: true,
+      },
+    });
+  });
+
+  apiTest('returns 404 from the GET endpoint when disabled', async ({ apiClient }) => {
+    const response = await apiClient.get(`${BASE_PATH}/disabled-feature-test`, {
+      headers: {
+        ...COMMON_HEADERS,
+        ...adminApiCredentials.apiKeyHeader,
+      },
+      responseType: 'json',
+    });
+
+    expect(response).toHaveStatusCode(404);
+  });
+
+  apiTest('returns 404 from the POST endpoint when disabled', async ({ apiClient }) => {
+    const response = await apiClient.post(BASE_PATH, {
+      headers: {
+        ...COMMON_HEADERS,
+        ...adminApiCredentials.apiKeyHeader,
+      },
+      body: {
+        index_pattern: 'disabled-feature-test-*',
+      },
+      responseType: 'json',
+    });
+
+    expect(response).toHaveStatusCode(404);
+  });
+
+  apiTest('returns 404 from the DELETE endpoint when disabled', async ({ apiClient }) => {
+    const response = await apiClient.delete(`${BASE_PATH}/disabled-feature-test`, {
+      headers: {
+        ...COMMON_HEADERS,
+        ...adminApiCredentials.apiKeyHeader,
+      },
+      responseType: 'json',
+    });
+
+    expect(response).toHaveStatusCode(404);
+  });
+});

--- a/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/global.setup.ts
+++ b/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/global.setup.ts
@@ -7,9 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createPlaywrightConfig } from '@kbn/scout';
+import { globalSetupHook } from '@kbn/scout';
+import { DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG } from '../fixtures/constants';
 
-export default createPlaywrightConfig({
-  testDir: './tests',
-  runGlobalSetup: true,
+globalSetupHook('Enable the data views as code API', async ({ apiServices, log }) => {
+  log.debug('[setup] Enabling the data views as code API');
+  await apiServices.core.settings({
+    'feature_flags.overrides': {
+      [DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG]: true,
+    },
+  });
 });

--- a/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/global.teardown.ts
+++ b/src/platform/plugins/shared/data_views_as_code/test/scout/api/tests/global.teardown.ts
@@ -7,9 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createPlaywrightConfig } from '@kbn/scout';
+import { globalTeardownHook } from '@kbn/scout';
+import { DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG } from '../fixtures/constants';
 
-export default createPlaywrightConfig({
-  testDir: './tests',
-  runGlobalSetup: true,
-});
+globalTeardownHook(
+  'Reset the data views as code API feature flag',
+  async ({ apiServices, log }) => {
+    log.debug('[teardown] Resetting the data views as code API feature flag');
+    await apiServices.core.settings({
+      'feature_flags.overrides': {
+        [DATA_VIEWS_AS_CODE_ENABLED_FEATURE_FLAG]: null,
+      },
+    });
+  }
+);


### PR DESCRIPTION
## Summary

This PR gates the data views as-code APIs behind the default-off `dataViewsAsCode.enabled` feature flag until they are ready for general availability.

When disabled, the GET, POST, and DELETE endpoints return `404`. This also marks the routes as technical preview, documents local enablement, and adds unit and Scout API coverage for enabled and disabled behaviour.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->