### PR TITLE
fix(.claude/skills): quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/activate-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/activate-connector/SKILL.md
@@ -2,7 +2,7 @@
 name: activate-connector
 description: Creates a connector instance in a running Kibana. Use when asked to activate, connect, enable, or instantiate a connector in Kibana.
 allowed-tools: Bash, Read, Glob, Grep
-argument-hint: [connector-type]
+argument-hint: "[connector-type]"
 ---
 
 # Activate a Connector in Kibana

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md
@@ -2,7 +2,7 @@
 name: build-connector
 description: End-to-end orchestrator that creates a new connector from scratch, reviews the code, activates it in Kibana, tests it via an Agent Builder agent, iterates until quality is met, and delivers a polished result. Use when asked to build, develop, or implement a complete connector.
 allowed-tools: Bash, Read, Glob, Grep, Write, Edit, Skill
-argument-hint: [3rd-party-service-name]
+argument-hint: "[3rd-party-service-name]"
 ---
 
 # Build a Connector End-to-End

--- a/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md
+++ b/src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md
@@ -3,7 +3,7 @@ name: create-connector
 description: Creates a new connector spec for Kibana. Use when asked to create (or add) a new connector, integration, or data source.
 allowed-tools: WebFetch, WebSearch, Read, Grep, Glob, Write, Edit, Bash, Skill
 context: fork
-argument-hint: [3rd-party-service-name]
+argument-hint: "[3rd-party-service-name]"
 ---
 
 # Create a Connector

--- a/x-pack/platform/plugins/shared/agent_builder/.claude/skills/chat-with-agent/SKILL.md
+++ b/x-pack/platform/plugins/shared/agent_builder/.claude/skills/chat-with-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: chat-with-agent
 description: Sends a message to an Agent Builder agent and displays the response including reasoning and tool calls. Use when asked to chat with, test, or talk to a Kibana agent.
 allowed-tools: Bash, Read, Glob, Grep
-argument-hint: [agent-id-or-name]
+argument-hint: "[agent-id-or-name]"
 ---
 
 # Chat with an Agent Builder Agent

--- a/x-pack/platform/plugins/shared/agent_builder/.claude/skills/create-agent/SKILL.md
+++ b/x-pack/platform/plugins/shared/agent_builder/.claude/skills/create-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: create-agent
 description: Creates an Agent Builder agent in a running Kibana instance, wired to data source tools. Use when asked to create, set up, or configure an AI agent in Kibana.
 allowed-tools: Bash, Read, Glob, Grep
-argument-hint: [agent-name]
+argument-hint: "[agent-name]"
 ---
 
 # Create an Agent Builder Agent in Kibana

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/generate-security-data/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/generate-security-data/SKILL.md
@@ -7,7 +7,7 @@ description: >
   development, testing, and debugging only, not cloud deployments or
   customer-facing demos.
 allowed-tools: Bash
-argument-hint: [quick|attacks|cases|clean|local flags]
+argument-hint: "[quick|attacks|cases|clean|local flags]"
 ---
 
 # Generate Security Data


### PR DESCRIPTION
Closes #277614.

## Summary

Wrap `argument-hint` values in double quotes across the 7 committed `.claude/skills/**/SKILL.md` and `.agents/skills/**/SKILL.md` files. Purely mechanical one-character-per-line YAML fix, no behavior change on Claude Code.

**Root cause.** Every SKILL.md here declared `argument-hint` with bare brackets:

```yaml
---
argument-hint: [agent-name]
---
```

That is a YAML **flow sequence** (an array of strings), not a string. Downstream slash-command loaders that validate `argument-hint` as a string — notably [GitHub Copilot CLI ≥ 1.0.65](https://github.com/github/copilot-cli) — silently reject the SKILL on load, so the command disappears from `copilot skill list`. Claude Code currently renders the accidental array by concatenation, which is why nobody noticed until Copilot CLI tightened the type check.

**Fix.** One-line change per file — wrap the value in double quotes:

```diff
- argument-hint: [agent-name]
+ argument-hint: "[agent-name]"
```

## Files (7)

| File | CODEOWNERS |
|---|---|
| `x-pack/platform/plugins/shared/agent_builder/.claude/skills/create-agent/SKILL.md` | `@elastic/workchat-eng` |
| `x-pack/platform/plugins/shared/agent_builder/.claude/skills/chat-with-agent/SKILL.md` | `@elastic/workchat-eng` |
| `x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md` | `@elastic/workchat-eng` |
| `src/platform/packages/shared/kbn-connector-specs/.claude/skills/create-connector/SKILL.md` | `@elastic/response-ops` |
| `src/platform/packages/shared/kbn-connector-specs/.claude/skills/build-connector/SKILL.md` | `@elastic/response-ops` |
| `src/platform/packages/shared/kbn-connector-specs/.claude/skills/activate-connector/SKILL.md` | `@elastic/response-ops` |
| `x-pack/solutions/security/plugins/security_solution/.agents/skills/generate-security-data/SKILL.md` | `@elastic/security-solution` |

## Verification

- **YAML round-trip**: `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str` (7/7).
- **Regression sweep**: no vulnerable value contained `"` or `\`, so double-quoting is inert; `grep -r '^argument-hint: \[' x-pack/**/.claude/skills src/**/.claude/skills x-pack/**/.agents/skills` returns 0 hits after this branch.
- **Behavior**: Claude Code will render exactly the same argument hint in its UI (string form matches the docs); Copilot CLI 1.0.65+ will now load the skill instead of silently dropping it.

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string, with string-form examples (`[issue-number]`, `[filename] [format]`).
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same.

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing) — **N/A** (no user-facing text changed; only frontmatter YAML type)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) — **N/A** (no feature)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) — **N/A** (no logic changed; verified via YAML round-trip)
- [x] Plugin configuration key allowlisting — **N/A**
- [x] Breaking HTTP API changes — **N/A**
- [x] Flaky Test Runner — **N/A** (no tests touched)
- [x] Release Notes / `release_note:*` label — this is a very small bug fix; suggest `release_note:skip` (the touched files don't ship to end users, they're skills that live in the repo for Kibana developers using Claude Code)
- [x] Backport labels — suggest **none**: the touched `.claude/skills/**` and `.agents/skills/**` files only exist on `main` (added recently), no backport target

### Identify risks

**None.** The change is a single-character wrap of an already-declared value; YAML string parsing is total, and no downstream code in Kibana reads `argument-hint`. The only observable effect is on external skill loaders (Copilot CLI 1.0.65+), which will start loading these skills instead of silently rejecting them.
