### PR TITLE
[Synthetics] Fix data retention index size showing 0 bytes on serverless

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/hooks/use_get_data_stream_statuses.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/hooks/use_get_data_stream_statuses.test.ts
@@ -53,6 +53,32 @@ describe('useGetDataStreamStatuses', () => {
     expect(dataStreamSummary?.lifecycle?.data_retention).toEqual('--');
   });
 
+  it('falls back to metering storage size when data stream stats are disabled (serverless)', () => {
+    (useFetcher as jest.Mock).mockImplementation((callback) => {
+      callback();
+      return {
+        error: undefined,
+        loading: false,
+        status: FETCH_STATUS.SUCCESS,
+        refetch: () => {},
+        fetch: jest.fn(),
+        data: serverlessExampleData,
+      };
+    });
+
+    const {
+      result: {
+        current: { dataStreamStatuses },
+      },
+    } = renderHook(() => useGetDataStreamStatuses());
+
+    const browserChecks = dataStreamStatuses?.find((d) => d.name === 'Browser Checks');
+    expect(browserChecks?.storageSize).toEqual('18 MB');
+
+    const dataStreamSummary = dataStreamStatuses?.find((d) => d.name === 'All Checks');
+    expect(dataStreamSummary?.storageSize).toEqual('18 MB');
+  });
+
   it('returns a undefined set for no data', () => {
     (useFetcher as jest.Mock).mockImplementation((callback) => {
       callback();
@@ -195,5 +221,18 @@ const exampleData = [
   testData({
     name: 'synthetics-http-default',
     indexTemplateName: 'synthetics-http',
+  }),
+];
+
+// On serverless, data stream stats are disabled so `storageSizeBytes` is absent and
+// size is only available via the metering API (`meteringStorageSizeBytes`).
+const serverlessExampleData = [
+  testData({
+    name: 'synthetics-browser-default',
+    indexTemplateName: 'synthetics-browser',
+    storageSize: undefined,
+    storageSizeBytes: undefined,
+    meteringStorageSize: '18.3mb',
+    meteringStorageSizeBytes: 19265414,
   }),
 ];

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/hooks/use_get_data_stream_statuses.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/hooks/use_get_data_stream_statuses.ts
@@ -46,7 +46,7 @@ export function useGetDataStreamStatuses(): DataStreamStatusResponse {
     const dataStream = dataStreamMap[indexTemplate];
     if (dataStream) {
       dataStreamStatuses.push(formatDataStreamInfo(dataStream));
-      totalBytes += dataStream.storageSizeBytes ?? 0;
+      totalBytes += getStorageSizeBytes(dataStream) ?? 0;
     } else {
       const missingStream = toMissingDataStream({ indexTemplate, label });
       dataStreamStatuses.push(missingStream);
@@ -104,16 +104,20 @@ function toMissingDataStream({
 }
 
 /**
+ * On serverless, data stream stats are disabled and size is reported via the metering API,
+ * so `storageSizeBytes` is undefined and we must fall back to `meteringStorageSizeBytes`.
+ */
+function getStorageSizeBytes({ storageSizeBytes, meteringStorageSizeBytes }: DataStream) {
+  return storageSizeBytes ?? meteringStorageSizeBytes;
+}
+
+/**
  * Overlay inferred fields to match the table's expectations.
  */
-function formatDataStreamInfo({
-  name,
-  lifecycle,
-  indexTemplateName,
-  storageSizeBytes,
-  ...rest
-}: DataStream): DataStreamStatus {
+function formatDataStreamInfo(dataStream: DataStream): DataStreamStatus {
+  const { name, lifecycle, indexTemplateName, ...rest } = dataStream;
   const policyLabel = policyLabels.find(({ indexTemplate }) => indexTemplate === indexTemplateName);
+  const storageSizeBytes = getStorageSizeBytes(dataStream);
   return {
     ...rest,
     name: policyLabel?.label ?? name,


### PR DESCRIPTION
## Summary

The data retention settings page (`app/synthetics/settings/data-retention`) showed index size as **0 bytes** on serverless.

On serverless, Index Management disables data stream stats (`xpack.index_management.enableDataStreamStats: false`) and instead reports size via the metering API (`xpack.index_management.enableSizeAndDocCount: true`). This means `storageSizeBytes` is `undefined` and size is only available on `meteringStorageSizeBytes`.

`useGetDataStreamStatuses` only read `storageSizeBytes`, so it always fell back to `0`. This change falls back to `meteringStorageSizeBytes` when data stream stats are unavailable, mirroring what the Index Management data streams table already does.

Closes #188144

## What changed

- `use_get_data_stream_statuses.ts`: prefer `storageSizeBytes`, fall back to `meteringStorageSizeBytes` (serverless).
- Added a Jest unit test covering the serverless metering-only case.
- Added a serverless Scout UI test (`data_retention_index_size.spec.ts`) that asserts the data retention table renders the metering-reported size instead of `0 Bytes`. The Index Management data streams API is mocked with the serverless (metering-only) response shape, since metering size is not computed in the ephemeral serverless test cluster.
- `global.setup.ts`: skip the stateful ILM esArchiver ingestion on serverless (Playwright always runs the setup dependency project regardless of the `--grep` tag, and the archives use `index.lifecycle.rollover_alias`, which serverless rejects).

## Test plan

- [x] Jest: `use_get_data_stream_statuses.test.ts` passes (incl. serverless metering-only case).
- [x] Scout serverless UI: `node scripts/scout run-tests --arch serverless --domain observability_complete --config x-pack/solutions/observability/plugins/synthetics/test/scout/ui/playwright.config.ts` — passes locally.
- [ ] On a serverless Observability project, create a Synthetics monitor, wait for data, then open `app/synthetics/settings/data-retention` and verify the "Current size" column shows the real index size instead of 0 bytes.
