### PR TITLE
[Rules] Custom Threshold: grouped count<1 + alertOnGroupDisappear never fires when alert_delay.active >= 2 (9.3.x)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
@@ -41,6 +41,7 @@ import {
   ALERT_START,
   ALERT_STATE_NAMESPACE,
   ALERT_STATUS,
+  ALERT_STATUS_DELAYED,
   ALERT_STATUS_UNTRACKED,
   ALERT_TIME_RANGE,
   ALERT_UUID,
@@ -4043,10 +4044,15 @@ describe('Alerts Client', () => {
       });
 
       describe('isTrackedAlert()', () => {
-        test('should return true if alert was active in a previous execution, false otherwise', async () => {
+        test('should return true for active or delayed alerts, false otherwise', async () => {
           const alertsClient = new AlertsClient<{}, {}, {}, 'default', 'recovered'>(
             alertsClientParams
           );
+
+          const delayedAlert = {
+            ...fetchedAlert2,
+            [ALERT_STATUS]: ALERT_STATUS_DELAYED,
+          };
 
           clusterClient.search.mockResolvedValue({
             took: 10,
@@ -4067,7 +4073,7 @@ describe('Alerts Client', () => {
                   _index: '.internal.alerts-test.alerts-default-000002',
                   _seq_no: 42,
                   _primary_term: 666,
-                  _source: fetchedAlert2,
+                  _source: delayedAlert,
                 },
               ],
             },
@@ -4078,8 +4084,8 @@ describe('Alerts Client', () => {
             activeAlertsFromState: { '1': trackedAlert1Raw, '2': trackedAlert2Raw },
           });
 
-          expect(alertsClient.isTrackedAlert('1')).toBe(true);
-          expect(alertsClient.isTrackedAlert('2')).toBe(true);
+          expect(alertsClient.isTrackedAlert('1')).toBe(true); // active
+          expect(alertsClient.isTrackedAlert('2')).toBe(true); // delayed
           expect(alertsClient.isTrackedAlert('3')).toBe(false);
         });
       });

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
@@ -17,6 +17,7 @@ import {
   ALERT_SNOOZED,
   ALERT_STATUS,
   ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_DELAYED,
 } from '@kbn/rule-data-utils';
 import { get, isEmpty } from 'lodash';
 import type {
@@ -275,12 +276,8 @@ export class AlertsClient<
   }
 
   public isTrackedAlert(id: string) {
-    const alert = this.trackedAlerts.getById(id);
-    const uuid = alert?.[ALERT_UUID];
-    if (uuid) {
-      return !!this.trackedAlerts.active[uuid];
-    }
-    return false;
+    const status = get(this.trackedAlerts.getById(id), ALERT_STATUS);
+    return status === ALERT_STATUS_ACTIVE || status === ALERT_STATUS_DELAYED;
   }
 
   public hasReachedAlertLimit(): boolean {


### PR DESCRIPTION
Closes #275018 

Fix isTrackedAlert to treat delayed alerts as tracked.
- Fixes grouped Custom Threshold rules with `alertOnGroupDisappear` + `alert_delay.active >= 2` never fire `custom_threshold.nodata` because `isTrackedAlert()` only checked `active` status.
- While an alert is delayed, Custom/Metric Threshold filter `previousMissingGroups` with `isTrackedAlert`. Delayed alerts returned `false`, so missing-group memory was wiped on the next run and the alert never reached the delay threshold.
- Update `isTrackedAlert()` to return `true` for both `active` and `delayed` alerts (still `false` for recovered/missing/untracked).

## Test plan
- [ ] Unit: `node scripts/jest x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts -t "isTrackedAlert"`
- [ ] Repro from #275018 with `alert_delay.active = 2`: after 2 consecutive missing-group detections, AAD has an **active** `custom_threshold.nodata` alert
- [ ] Same rule with `alert_delay.active = 1`: still fires on first detection (no regression)
- [ ] `alert_delay.active = 3`: activates on the 3rd consecutive detection
- [ ] Untrack a missing-group alert: group is dropped from `missingGroups` and not re-checked
- [ ] Recovery: data for the group returns → alert recovers

<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->