### PR TITLE
[9.4] [scout] move dashboard test helper to apiServices (#277167)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/constants.ts
+++ b/src/platform/packages/shared/kbn-scout/constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Dashboards API constants, shared by scout API test suites that call `/api/dashboards` directly.
+export {
+  DASHBOARD_API_PATH,
+  DASHBOARD_API_VERSION,
+} from './src/playwright/fixtures/scope/worker/apis/dashboard/constants';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/dashboard/constants.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/dashboard/constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** Base path for the Dashboards API (no leading slash, for use with `apiClient`). */
+export const DASHBOARD_API_PATH = 'api/dashboards';
+
+/** `elastic-api-version` header value for the Dashboards API. */
+export const DASHBOARD_API_VERSION = '2023-10-31';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/dashboard/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/dashboard/index.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KbnClient, ScoutLogger } from '../../../../../../common';
+import { measurePerformanceAsync } from '../../../../../../common';
+import type { CreatedDashboardPanel } from './types';
+import { DASHBOARD_API_PATH, DASHBOARD_API_VERSION } from './constants';
+
+export type { CreatedDashboardPanel } from './types';
+export { DASHBOARD_API_PATH, DASHBOARD_API_VERSION } from './constants';
+
+/**
+ * Dashboards API Service
+ * Provides methods to interact with Kibana's Dashboards API
+ */
+export interface DashboardApiService {
+  /**
+   * Create a dashboard via the API and return its id.
+   * @param body - Dashboard create request body
+   * @param spaceId - Optional space id to create the dashboard in
+   */
+  create: (body: unknown, spaceId?: string) => Promise<string>;
+
+  /**
+   * Create a dashboard and fetch the auto-generated panel id of its first panel.
+   * @param body - Dashboard create request body
+   * @param spaceId - Optional space id to create the dashboard in
+   */
+  createWithPanelId: (body: unknown, spaceId?: string) => Promise<CreatedDashboardPanel>;
+}
+
+/**
+ * Factory function to create a Dashboards API service helper
+ * @param log - Scout logger instance
+ * @param kbnClient - Kibana client for making API requests
+ * @returns DashboardApiService instance
+ */
+export const getDashboardApiHelper = (
+  log: ScoutLogger,
+  kbnClient: KbnClient
+): DashboardApiService => {
+  const withSpace = (path: string, spaceId?: string) =>
+    spaceId ? `/s/${spaceId}/${path}` : `/${path}`;
+
+  const create: DashboardApiService['create'] = async (body, spaceId) => {
+    return await measurePerformanceAsync(log, 'dashboardApi.create', async (): Promise<string> => {
+      const response = await kbnClient.request<unknown>({
+        method: 'POST',
+        path: withSpace(DASHBOARD_API_PATH, spaceId),
+        body,
+        headers: { 'elastic-api-version': DASHBOARD_API_VERSION },
+      });
+
+      if (response.status !== 201) {
+        throw new Error(
+          `Expected dashboard create status 201, got ${response.status}: ${JSON.stringify(
+            response.data
+          )}`
+        );
+      }
+
+      const { id } = response.data as Record<string, unknown>;
+      if (typeof id !== 'string' || id.length === 0) {
+        throw new Error('Dashboard create response: expected a non-empty string id');
+      }
+      return id;
+    });
+  };
+
+  return {
+    create,
+
+    createWithPanelId: async (body, spaceId) => {
+      return await measurePerformanceAsync(
+        log,
+        'dashboardApi.createWithPanelId',
+        async (): Promise<CreatedDashboardPanel> => {
+          const dashboardId = await create(body, spaceId);
+
+          const getResponse = await kbnClient.request<unknown>({
+            method: 'GET',
+            path: withSpace(`${DASHBOARD_API_PATH}/${dashboardId}`, spaceId),
+            headers: { 'elastic-api-version': DASHBOARD_API_VERSION },
+          });
+
+          const data = (getResponse.data as Record<string, unknown>).data as Record<
+            string,
+            unknown
+          >;
+          const panels = data.panels as Array<Record<string, unknown>>;
+          if (!Array.isArray(panels) || panels.length === 0) {
+            throw new Error(
+              `Dashboard get response for '${dashboardId}': expected at least one panel, got ${JSON.stringify(
+                data.panels
+              )}`
+            );
+          }
+
+          const { id: panelId } = panels[0];
+          if (typeof panelId !== 'string' || panelId.length === 0) {
+            throw new Error(
+              `Dashboard get response for '${dashboardId}': expected a non-empty string panel id, got ${JSON.stringify(
+                panels[0].id
+              )}`
+            );
+          }
+
+          return { dashboardId, panelId };
+        }
+      );
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/dashboard/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/dashboard/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Result of creating a dashboard and reading back the auto-generated id of its first panel.
+ */
+export interface CreatedDashboardPanel {
+  dashboardId: string;
+  panelId: string;
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/index.ts
@@ -14,6 +14,8 @@ import type { CasesApiService } from './cases';
 import { getCasesApiHelper } from './cases';
 import type { CoreApiService } from './core';
 import { getCoreApiHelper } from './core';
+import type { DashboardApiService } from './dashboard';
+import { getDashboardApiHelper } from './dashboard';
 import type { DataViewsApiService } from './data_views';
 import { getDataViewsApiHelper } from './data_views';
 import type { FleetApiService } from './fleet';
@@ -30,6 +32,7 @@ import { getMlApiHelper } from './ml';
 export interface ApiServicesFixture {
   alerting: AlertingApiService;
   cases: CasesApiService;
+  dashboard: DashboardApiService;
   dataViews: DataViewsApiService;
   fleet: FleetApiService;
   ml: MlApiService;
@@ -52,6 +55,7 @@ export const apiServicesFixture = coreWorkerFixtures.extend<
       const services = {
         alerting: getAlertingApiHelper(log, kbnClient),
         cases: getCasesApiHelper(log, kbnClient),
+        dashboard: getDashboardApiHelper(log, kbnClient),
         dataViews: getDataViewsApiHelper(log, kbnClient),
         fleet: getFleetApiHelper(log, kbnClient),
         ml: getMlApiHelper(log, kbnClient, esClient),

--- a/src/platform/plugins/shared/content_management/test/scout/api/fixtures/constants.ts
+++ b/src/platform/plugins/shared/content_management/test/scout/api/fixtures/constants.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/** Dashboard API base path (no leading slash — for use with apiClient). */
-export const DASHBOARD_API_PATH = 'api/dashboards';
-export const DASHBOARD_API_VERSION = '2023-10-31';
+import { DASHBOARD_API_VERSION } from '@kbn/scout/constants';
+
+export { DASHBOARD_API_PATH, DASHBOARD_API_VERSION } from '@kbn/scout/constants';
 
 /** Favorites API base path (no leading slash — for use with apiClient). */
 export const FAVORITES_API_PATH = 'internal/content_management/favorites';

--- a/src/platform/plugins/shared/dashboard/test/scout/api/fixtures/constants.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/fixtures/constants.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/** The base API path for dashboard endpoints (no leading slash for apiClient). */
-export const DASHBOARD_API_PATH = 'api/dashboards';
-export const DASHBOARD_API_VERSION = '2023-10-31';
+import { DASHBOARD_API_VERSION } from '@kbn/scout/constants';
+
+export { DASHBOARD_API_PATH, DASHBOARD_API_VERSION } from '@kbn/scout/constants';
 
 /** Common headers for Dashboard API requests (internal API version 1) */
 export const COMMON_HEADERS = {

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/esql_timeseries_dashboard_api.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/esql_timeseries_dashboard_api.spec.ts
@@ -8,15 +8,10 @@
 import type { DebugState } from '@elastic/charts';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
 import { spaceTest } from '@kbn/scout';
+import type { ApiServicesFixture } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 import { testData } from '../fixtures';
-
-const DASHBOARD_API_PATH = 'api/dashboards';
-const DASHBOARD_API_HEADERS = {
-  'Content-Type': 'application/json',
-  'elastic-api-version': '2023-10-31',
-} as const;
 
 const LOGSTASH_ABSOLUTE_RANGE = {
   from: '2015-09-19T06:31:44.000Z',
@@ -76,16 +71,13 @@ function buildLensLineTimeseriesPanel(esql: EsqlTimeseriesCase) {
 }
 
 async function createDashboardWithLensPanel(
-  kbnClient: import('@kbn/scout').KbnClient,
+  apiServices: ApiServicesFixture,
   spaceId: string,
   title: string,
   esql: EsqlTimeseriesCase
 ): Promise<string> {
-  const response = await kbnClient.request<{ id: string }>({
-    method: 'POST',
-    path: `s/${spaceId}/${DASHBOARD_API_PATH}`,
-    headers: DASHBOARD_API_HEADERS,
-    body: {
+  return apiServices.dashboard.create(
+    {
       title,
       time_range: {
         from: LOGSTASH_ABSOLUTE_RANGE.from,
@@ -94,22 +86,19 @@ async function createDashboardWithLensPanel(
       },
       panels: [buildLensLineTimeseriesPanel(esql)],
     },
-  });
-
-  expect([200, 201]).toContain(response.status);
-  expect(response.data.id).toBeTruthy();
-  return response.data.id;
+    spaceId
+  );
 }
 
 async function getChartDebugState(
   esqlCase: EsqlTimeseriesCase,
-  kbnClient: import('@kbn/scout').KbnClient,
+  apiServices: ApiServicesFixture,
   spaceId: string,
   page: import('@kbn/scout').ScoutPage,
   pageObjects: import('@kbn/scout').PageObjects
 ): Promise<DebugState> {
   const title = `Scout ES|QL timeseries API ${esqlCase.description} ${Date.now()}`;
-  const dashboardId = await createDashboardWithLensPanel(kbnClient, spaceId, title, esqlCase);
+  const dashboardId = await createDashboardWithLensPanel(apiServices, spaceId, title, esqlCase);
 
   const { dashboard } = pageObjects;
   await dashboard.openDashboardWithId(dashboardId);
@@ -156,10 +145,10 @@ spaceTest.describe(
 
     spaceTest(
       'renders a time-scaled x-axis for TBUCKET',
-      async ({ kbnClient, scoutSpace, page, pageObjects }) => {
+      async ({ apiServices, scoutSpace, page, pageObjects }) => {
         const debug = await getChartDebugState(
           TIMESERIES_CASES[0],
-          kbnClient,
+          apiServices,
           scoutSpace.id,
           page,
           pageObjects
@@ -177,10 +166,10 @@ spaceTest.describe(
 
     spaceTest(
       'renders a time-scaled x-axis for BUCKET on timestamp',
-      async ({ kbnClient, scoutSpace, page, pageObjects }) => {
+      async ({ apiServices, scoutSpace, page, pageObjects }) => {
         const debug = await getChartDebugState(
           TIMESERIES_CASES[1],
-          kbnClient,
+          apiServices,
           scoutSpace.id,
           page,
           pageObjects
@@ -198,10 +187,10 @@ spaceTest.describe(
 
     spaceTest(
       'renders a time-scaled x-axis for DATE_TRUNC on timestamp',
-      async ({ kbnClient, scoutSpace, page, pageObjects }) => {
+      async ({ apiServices, scoutSpace, page, pageObjects }) => {
         const debug = await getChartDebugState(
           TIMESERIES_CASES[2],
-          kbnClient,
+          apiServices,
           scoutSpace.id,
           page,
           pageObjects

--- a/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline.spec.ts
+++ b/x-pack/platform/plugins/shared/lens/test/scout/ui/parallel_tests/metric_trendline.spec.ts
@@ -7,43 +7,12 @@
 
 import { spaceTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
-import type { KbnClient } from '@kbn/scout';
 import { testData } from '../fixtures';
-
-const DASHBOARD_API_PATH = '/api/dashboards';
-const DASHBOARD_API_VERSION = '2023-10-31';
 
 const LOGSTASH_TIME_RANGE = {
   from: '2015-09-19T06:31:44.000Z',
   to: '2015-09-23T18:31:44.000Z',
 };
-
-function withSpace(path: string, spaceId: string): string {
-  return `/s/${spaceId}${path}`;
-}
-
-async function createDashboard(client: KbnClient, body: unknown, spaceId: string): Promise<string> {
-  const response = await client.request<unknown>({
-    method: 'POST',
-    path: withSpace(DASHBOARD_API_PATH, spaceId),
-    body,
-    headers: { 'elastic-api-version': DASHBOARD_API_VERSION },
-  });
-
-  if (response.status !== 201) {
-    throw new Error(
-      `Expected dashboard create status 201, got ${response.status}: ${JSON.stringify(
-        response.data
-      )}`
-    );
-  }
-
-  const { id } = response.data as Record<string, unknown>;
-  if (typeof id !== 'string' || id.length === 0) {
-    throw new Error('Dashboard create response: expected a non-empty string id');
-  }
-  return id;
-}
 
 spaceTest.describe(
   'Lens metric trendline on dashboard (DSL)',
@@ -80,7 +49,7 @@ spaceTest.describe(
 
     spaceTest(
       'renders trendline when panel uses inline data view spec',
-      async ({ browserAuth, kbnClient, page, pageObjects, scoutSpace }) => {
+      async ({ apiServices, browserAuth, page, pageObjects, scoutSpace }) => {
         const body = {
           title: 'Metric trendline spec',
           time_range: LOGSTASH_TIME_RANGE,
@@ -109,7 +78,7 @@ spaceTest.describe(
           ],
         };
 
-        const dashboardId = await createDashboard(kbnClient, body, scoutSpace.id);
+        const dashboardId = await apiServices.dashboard.create(body, scoutSpace.id);
         await browserAuth.loginAsPrivilegedUser();
         await pageObjects.dashboard.openDashboardWithId(dashboardId);
 
@@ -120,7 +89,7 @@ spaceTest.describe(
 
     spaceTest(
       'renders trendline when panel uses stored data view reference',
-      async ({ browserAuth, kbnClient, page, pageObjects, scoutSpace }) => {
+      async ({ apiServices, browserAuth, page, pageObjects, scoutSpace }) => {
         spaceTest.fail(!storedDataViewId, 'Stored data view was not created in beforeAll');
 
         const body = {
@@ -150,7 +119,7 @@ spaceTest.describe(
           ],
         };
 
-        const dashboardId = await createDashboard(kbnClient, body, scoutSpace.id);
+        const dashboardId = await apiServices.dashboard.create(body, scoutSpace.id);
         await browserAuth.loginAsPrivilegedUser();
         await pageObjects.dashboard.openDashboardWithId(dashboardId);
 

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/constants.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { DASHBOARD_API_PATH, DASHBOARD_API_VERSION } from '@kbn/scout/constants';

--- a/x-pack/solutions/observability/plugins/slo/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/slo/test/scout/api/fixtures/constants.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-/** The base API path for dashboard endpoints (no leading slash for apiClient). */
-export const DASHBOARD_API_PATH = 'api/dashboards';
+import { DASHBOARD_API_VERSION } from '@kbn/scout-oblt/constants';
+
+export { DASHBOARD_API_PATH } from '@kbn/scout-oblt/constants';
 
 /**
  * SLO embeddable type IDs. Must match common/embeddables/{overview,error_budget,burn_rate}/constants.ts.
@@ -21,5 +22,5 @@ export const SLO_ALERTS_EMBEDDABLE_ID = 'slo_alerts';
 export const COMMON_HEADERS = {
   'kbn-xsrf': 'some-xsrf-token',
   'x-elastic-internal-origin': 'kibana',
-  'elastic-api-version': '2023-10-31',
+  'elastic-api-version': DASHBOARD_API_VERSION,
 } as const;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[scout] move dashboard test helper to apiServices (#277167)](https://github.com/elastic/kibana/pull/277167)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-10T16:58:49Z","message":"[scout] move dashboard test helper to apiServices (#277167)\n\n## Summary\n\n- Moving dashboard API helper into `kbn/scout` since it is useful for\nenvironment setup across multiple plugins/packages. Exposed as\nPlaywright fixture, it is easier to discover it in new tests.\n- Moving `DASHBOARD_API_PATH` / `DASHBOARD_API_VERSION` under the same\nservice to avoid duplication in multiple consumers.","sha":"e988b73a7f0d18a4461299ca5313983e08fafc23","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.4","reviewer:scout","v9.6.0"],"title":"[scout] move dashboard test helper to apiServices","number":277167,"url":"https://github.com/elastic/kibana/pull/277167","mergeCommit":{"message":"[scout] move dashboard test helper to apiServices (#277167)\n\n## Summary\n\n- Moving dashboard API helper into `kbn/scout` since it is useful for\nenvironment setup across multiple plugins/packages. Exposed as\nPlaywright fixture, it is easier to discover it in new tests.\n- Moving `DASHBOARD_API_PATH` / `DASHBOARD_API_VERSION` under the same\nservice to avoid duplication in multiple consumers.","sha":"e988b73a7f0d18a4461299ca5313983e08fafc23"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277167","number":277167,"mergeCommit":{"message":"[scout] move dashboard test helper to apiServices (#277167)\n\n## Summary\n\n- Moving dashboard API helper into `kbn/scout` since it is useful for\nenvironment setup across multiple plugins/packages. Exposed as\nPlaywright fixture, it is easier to discover it in new tests.\n- Moving `DASHBOARD_API_PATH` / `DASHBOARD_API_VERSION` under the same\nservice to avoid duplication in multiple consumers.","sha":"e988b73a7f0d18a4461299ca5313983e08fafc23"}}]}] BACKPORT-->