### PR TITLE
[Streams & Index Management] Migrate RetentionSelector to EUI selector

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_data_lifecycle_flyout/edit_data_lifecycle_flyout_body.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_data_lifecycle_flyout/edit_data_lifecycle_flyout_body.test.tsx
@@ -181,7 +181,7 @@ describe('EditDataLifecycleFlyoutBody', () => {
       />
     );
 
-    const listItems = screen.getAllByRole('listitem');
+    const listItems = screen.getAllByRole('option');
     const listItemText = listItems.map((el) => el.textContent ?? '');
     const policyAIdx = listItemText.findIndex((t) => t.includes('policy-a'));
     const policyBIdx = listItemText.findIndex((t) => t.includes('policy-b'));
@@ -229,7 +229,7 @@ describe('EditDataLifecycleFlyoutBody', () => {
       />
     );
 
-    const listItems = screen.getAllByRole('listitem');
+    const listItems = screen.getAllByRole('option');
     const listItemText = listItems.map((el) => el.textContent ?? '');
     const policyAIdx = listItemText.findIndex((t) => t.includes('policy-a'));
     const policyBIdx = listItemText.findIndex((t) => t.includes('policy-b'));

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selectable_row.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selectable_row.tsx
@@ -8,19 +8,27 @@
 import React from 'react';
 import {
   EuiBadge,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHighlight,
   EuiIcon,
-  EuiListGroupItem,
   EuiText,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
-import type { EuiListGroupItemExtraActionProps } from '@elastic/eui';
 import type { RetentionOption } from './types';
 import { getRetentionSelectableRowStyles } from './styles';
 
 const TEST_SUBJ_SANITIZE_REGEX = /[^a-zA-Z0-9]+/g;
+
+export const getRetentionSelectableRowTestSubjs = (name: string) => {
+  const safeOptionNameForTestSubj = name.replace(TEST_SUBJ_SANITIZE_REGEX, '_');
+  return {
+    rowTestSubj: `retentionSelectableRow-${safeOptionNameForTestSubj}`,
+    inspectTestSubj: `retentionSelectableRowInspect-${safeOptionNameForTestSubj}`,
+  };
+};
 
 const formatDescriptionLine = ({
   descriptionCategory,
@@ -39,12 +47,9 @@ interface RetentionSelectableRowProps {
   option: RetentionOption;
   searchValue: string;
   inspectButtonLabel: string;
-  onSelect: () => void;
+  inspectTestSubj: string;
   onInspect?: () => void;
-  isSelected?: boolean;
   isDisabled?: boolean;
-  showSelectionIcon?: boolean;
-  showInspectAction?: boolean;
   inspectPlacement?: 'rowAction' | 'badge';
 }
 
@@ -52,39 +57,15 @@ export const RetentionSelectableRow = ({
   option,
   searchValue,
   inspectButtonLabel,
-  onSelect,
+  inspectTestSubj,
   onInspect,
-  isSelected = false,
   isDisabled = false,
-  showSelectionIcon = true,
-  showInspectAction = true,
   inspectPlacement = 'rowAction',
 }: RetentionSelectableRowProps) => {
   const { euiTheme } = useEuiTheme();
   const styles = getRetentionSelectableRowStyles({ euiTheme });
-
-  const iconType = showSelectionIcon ? (isSelected ? 'check' : 'empty') : undefined;
-  const safeOptionNameForTestSubj = option.name.replace(TEST_SUBJ_SANITIZE_REGEX, '_');
-  const rowTestSubj = `retentionSelectableRow-${safeOptionNameForTestSubj}`;
-  const inspectTestSubj = `retentionSelectableRowInspect-${safeOptionNameForTestSubj}`;
   const shouldShowInspectInBadge =
     inspectPlacement === 'badge' && option.inspectable && option.badge && onInspect;
-
-  const extraAction: EuiListGroupItemExtraActionProps | undefined =
-    !shouldShowInspectInBadge && option.inspectable && showInspectAction && onInspect
-      ? {
-          alwaysShow: true,
-          'aria-label': inspectButtonLabel,
-          color: 'text',
-          iconType: 'inspect',
-          'data-test-subj': inspectTestSubj,
-          onClick: (e: React.MouseEvent) => {
-            e.stopPropagation();
-            onInspect();
-          },
-          disabled: isDisabled,
-        }
-      : undefined;
 
   const descriptionLine1 = formatDescriptionLine({
     descriptionCategory: option.descriptionCategory,
@@ -112,67 +93,82 @@ export const RetentionSelectableRow = ({
   };
 
   return (
-    <EuiListGroupItem
-      color="text"
-      iconType={iconType}
-      isDisabled={isDisabled}
-      onClick={onSelect}
-      extraAction={extraAction}
-      css={styles.item}
-      data-test-subj={rowTestSubj}
-      label={
-        <>
-          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-            <EuiFlexItem css={styles.nameColumn}>
-              <EuiText size="s">
-                <EuiHighlight search={searchValue} css={styles.nameText}>
-                  {option.name}
-                </EuiHighlight>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-            <EuiFlexItem css={styles.nameColumn}>
-              <EuiText size="xs" color="subdued">
-                {descriptionLine1}
-              </EuiText>
-            </EuiFlexItem>
-            {shouldShowInspectInBadge && (
-              <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow">
-                  <EuiFlexGroup
-                    gutterSize="xs"
-                    alignItems="center"
-                    responsive={false}
-                    role="button"
-                    tabIndex={isDisabled ? -1 : 0}
-                    aria-label={inspectButtonLabel}
-                    aria-disabled={isDisabled}
-                    data-test-subj={inspectTestSubj}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      if (isDisabled) return;
-                      onInspect?.();
-                    }}
-                    onKeyDown={onInspectBadgeKeyDown}
-                  >
-                    <EuiFlexItem grow={false}>{option.badge}</EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type="inspect" aria-hidden={true} />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiBadge>
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-          {descriptionLine2 && (
-            <EuiText size="xs" color="subdued">
-              {descriptionLine2}
-            </EuiText>
-          )}
-        </>
-      }
-    />
+    <>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem css={styles.nameColumn}>
+          <EuiText size="s">
+            <EuiHighlight search={searchValue} css={styles.nameText}>
+              {option.name}
+            </EuiHighlight>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem css={styles.nameColumn}>
+          <EuiText size="xs" color="subdued">
+            {descriptionLine1}
+          </EuiText>
+        </EuiFlexItem>
+        {shouldShowInspectInBadge && (
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="hollow">
+              <EuiFlexGroup
+                gutterSize="xs"
+                alignItems="center"
+                responsive={false}
+                role="button"
+                tabIndex={isDisabled ? -1 : 0}
+                aria-label={inspectButtonLabel}
+                aria-disabled={isDisabled}
+                data-test-subj={inspectTestSubj}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (isDisabled) return;
+                  onInspect?.();
+                }}
+                onKeyDown={onInspectBadgeKeyDown}
+              >
+                <EuiFlexItem grow={false}>{option.badge}</EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon type="inspect" aria-hidden={true} />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiBadge>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+      {descriptionLine2 && (
+        <EuiText size="xs" color="subdued">
+          {descriptionLine2}
+        </EuiText>
+      )}
+    </>
   );
 };
+
+export const RetentionSelectableInspectButton = ({
+  inspectButtonLabel,
+  inspectTestSubj,
+  onInspect,
+  isDisabled,
+}: {
+  inspectButtonLabel: string;
+  inspectTestSubj: string;
+  onInspect: () => void;
+  isDisabled?: boolean;
+}) => (
+  <EuiToolTip content={inspectButtonLabel} disableScreenReaderOutput>
+    <EuiButtonIcon
+      aria-label={inspectButtonLabel}
+      color="text"
+      iconType="inspect"
+      data-test-subj={inspectTestSubj}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        onInspect();
+      }}
+      disabled={isDisabled}
+    />
+  </EuiToolTip>
+);

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
@@ -223,7 +223,12 @@ export const RetentionSelector = ({
           </EuiPanel>
         </EuiFlexItem>
       ) : (
-        <EuiFlexItem grow={false} ref={listScrollRef} data-test-subj="retentionSelectorListScroll">
+        <EuiFlexItem
+          grow={false}
+          ref={listScrollRef}
+          data-test-subj="retentionSelectorListScroll"
+          css={styles.paddedSection}
+        >
           {list}
         </EuiFlexItem>
       )}

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
@@ -110,11 +110,7 @@ export const RetentionSelector = ({
     flyoutScrollContainerRef ?? NO_FLYOUT_SCROLL_CONTAINER_REF,
     listScrollRef
   );
-  const styles = getRetentionSelectorStyles({
-    euiTheme,
-    height,
-    nestedScrollHeight: height === 'full' ? nestedScrollHeight : undefined,
-  });
+  const styles = getRetentionSelectorStyles({ euiTheme });
 
   const visibleOptions = useMemo(() => {
     const isSearchActive = showSearch || controlledSearchValue !== undefined;
@@ -170,7 +166,7 @@ export const RetentionSelector = ({
   const list =
     visibleOptions.length > 0 ? (
       <EuiSelectable
-        aria-label={searchPlaceholder}
+        aria-label={strings.listAriaLabel}
         options={selectableOptions}
         isPreFiltered
         height={selectableHeight}

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/retention_selector.tsx
@@ -10,13 +10,19 @@ import {
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiListGroup,
+  EuiIcon,
   EuiPanel,
+  EuiSelectable,
   EuiText,
   useEuiTheme,
 } from '@elastic/eui';
+import type { EuiSelectableOption } from '@elastic/eui';
 import type { RetentionOption } from './types';
-import { RetentionSelectableRow } from './retention_selectable_row';
+import {
+  getRetentionSelectableRowTestSubjs,
+  RetentionSelectableInspectButton,
+  RetentionSelectableRow,
+} from './retention_selectable_row';
 import { getRetentionSelectorStyles } from './styles';
 import { retentionSelectorStrings as strings } from './strings';
 import { useFlyoutNestedScrollHeight } from '../hooks/use_flyout_nested_scroll_height';
@@ -54,6 +60,11 @@ export const RetentionSelectorSearch = ({
     />
   );
 };
+
+interface RetentionSelectableOptionData {
+  retentionOption: RetentionOption;
+  inspectTestSubj: string;
+}
 
 export interface RetentionSelectorProps {
   options: RetentionOption[];
@@ -113,27 +124,80 @@ export const RetentionSelector = ({
     return options.filter((option) => option.name.toLowerCase().includes(normalizedSearchValue));
   }, [controlledSearchValue, options, searchValue, showSearch]);
 
+  const selectableOptions = useMemo<
+    Array<EuiSelectableOption<RetentionSelectableOptionData>>
+  >(() => {
+    return visibleOptions.map((option) => {
+      const { rowTestSubj, inspectTestSubj } = getRetentionSelectableRowTestSubjs(option.name);
+      return {
+        key: option.name,
+        label: option.name,
+        checked: option.name === selectedOptionName ? 'on' : undefined,
+        disabled: isDisabled,
+        'data-test-subj': rowTestSubj,
+        retentionOption: option,
+        inspectTestSubj,
+        prepend: showRowActions ? (
+          <EuiIcon
+            type={option.name === selectedOptionName ? 'check' : 'empty'}
+            size="m"
+            aria-hidden
+          />
+        ) : undefined,
+        append:
+          option.inspectable && showRowActions && onInspect && inspectPlacement === 'rowAction' ? (
+            <RetentionSelectableInspectButton
+              inspectButtonLabel={inspectButtonLabel(option.name)}
+              inspectTestSubj={inspectTestSubj}
+              onInspect={() => onInspect(option.name)}
+              isDisabled={isDisabled}
+            />
+          ) : undefined,
+      };
+    });
+  }, [
+    inspectButtonLabel,
+    inspectPlacement,
+    isDisabled,
+    onInspect,
+    selectedOptionName,
+    showRowActions,
+    visibleOptions,
+  ]);
+
+  const selectableHeight = height === 'full' ? nestedScrollHeight : height;
+
   const list =
     visibleOptions.length > 0 ? (
-      <EuiListGroup maxWidth={false} wrapText css={styles.list}>
-        {visibleOptions.map((option) => (
+      <EuiSelectable
+        aria-label={searchPlaceholder}
+        options={selectableOptions}
+        isPreFiltered
+        height={selectableHeight}
+        css={styles.selectable}
+        listProps={{
+          isVirtualized: false,
+          showIcons: false,
+          textWrap: 'wrap',
+          bordered: false,
+        }}
+        onChange={(_newOptions, _event, changedOption) => {
+          if (!isDisabled) onSelectOption(changedOption.label);
+        }}
+        renderOption={(option, optionSearchValue) => (
           <RetentionSelectableRow
-            key={option.name}
-            option={option}
-            searchValue={searchValue}
-            inspectButtonLabel={inspectButtonLabel(option.name)}
-            onSelect={() => {
-              if (!isDisabled) onSelectOption(option.name);
-            }}
-            onInspect={onInspect ? () => onInspect(option.name) : undefined}
-            isSelected={option.name === selectedOptionName}
+            option={option.retentionOption}
+            searchValue={optionSearchValue || searchValue}
+            inspectButtonLabel={inspectButtonLabel(option.label)}
+            inspectTestSubj={option.inspectTestSubj}
+            onInspect={onInspect ? () => onInspect(option.label) : undefined}
             isDisabled={isDisabled}
-            showSelectionIcon={showRowActions}
-            showInspectAction={showRowActions && onInspect !== undefined}
             inspectPlacement={inspectPlacement}
           />
-        ))}
-      </EuiListGroup>
+        )}
+      >
+        {(selectableList) => <>{selectableList}</>}
+      </EuiSelectable>
     ) : (
       <EuiText color="subdued" size="s" css={styles.noOptionsText}>
         {strings.noOptionsFoundDescription}
@@ -159,12 +223,7 @@ export const RetentionSelector = ({
           </EuiPanel>
         </EuiFlexItem>
       ) : (
-        <EuiFlexItem
-          grow={false}
-          ref={listScrollRef}
-          css={styles.scrollContainer}
-          data-test-subj="retentionSelectorListScroll"
-        >
+        <EuiFlexItem grow={false} ref={listScrollRef} data-test-subj="retentionSelectorListScroll">
           {list}
         </EuiFlexItem>
       )}

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/strings.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/strings.ts
@@ -13,4 +13,7 @@ export const retentionSelectorStrings = {
   noOptionsFoundDescription: i18n.translate(`${PREFIX}.noOptionsFoundDescription`, {
     defaultMessage: 'No options found',
   }),
+  listAriaLabel: i18n.translate(`${PREFIX}.listAriaLabel`, {
+    defaultMessage: 'Options list',
+  }),
 };

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/styles.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/styles.ts
@@ -22,15 +22,7 @@ export const getRetentionSelectableRowStyles = ({ euiTheme }: { euiTheme: EuiThe
   `,
 });
 
-export const getRetentionSelectorStyles = ({
-  euiTheme,
-  height,
-  nestedScrollHeight,
-}: {
-  euiTheme: EuiTheme;
-  height?: number | 'full';
-  nestedScrollHeight?: number;
-}) => ({
+export const getRetentionSelectorStyles = ({ euiTheme }: { euiTheme: EuiTheme }) => ({
   paddedSection: css`
     padding: 0 ${euiTheme.size.l};
   `,
@@ -52,26 +44,6 @@ export const getRetentionSelectorStyles = ({
       min-width: 0;
     }
   `,
-  scrollContainer:
-    typeof height === 'number'
-      ? css`
-          max-height: ${height}px;
-          overflow-y: auto;
-          min-height: 0;
-        `
-      : height === 'full'
-      ? css`
-          overflow-y: auto;
-          min-height: 0;
-          /*
-             * The measured height caps the list so it fills the space down to the
-             * bottom of the flyout body (which keeps its own scroll). Until the
-             * measurement is available we fall back to a viewport-relative cap so
-             * the list still gets its own scroll.
-             */
-          max-height: ${nestedScrollHeight !== undefined ? `${nestedScrollHeight}px` : '50vh'};
-        `
-      : undefined,
   panelListPanel: css`
     overflow: hidden;
     background-color: ${euiTheme.colors.backgroundBaseSubdued};

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/styles.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/styles.ts
@@ -11,14 +11,6 @@ import type { EuiThemeComputed } from '@elastic/eui';
 export type EuiTheme = EuiThemeComputed;
 
 export const getRetentionSelectableRowStyles = ({ euiTheme }: { euiTheme: EuiTheme }) => ({
-  item: css`
-    /*
-     * Keep row-level styling minimal; list-level styling handles dividers so the
-     * separator spans both the main button and the optional extra action.
-     */
-    width: 100%;
-    padding: ${euiTheme.size.s} ${euiTheme.size.l};
-  `,
   nameColumn: css`
     min-width: 0;
   `,
@@ -39,22 +31,17 @@ export const getRetentionSelectorStyles = ({
   height?: number | 'full';
   nestedScrollHeight?: number;
 }) => ({
-  list: css`
-    /*
-     * Dividers + gutters live at the list level so the separator spans both the
-     * main button and the optional extra action button.
-     */
-    // Needed so the line doesn't get cut off
-    .euiListItemLayout__wrapper {
-      border-bottom: ${euiTheme.border.thin};
-      padding-right: ${euiTheme.size.l};
-    }
-    .euiListItemLayout__wrapper:last-child {
-      border-bottom: none;
-    }
-  `,
   paddedSection: css`
     padding: 0 ${euiTheme.size.l};
+  `,
+  selectable: css`
+    .euiSelectableListItem {
+      padding: ${euiTheme.size.s} ${euiTheme.size.l};
+    }
+
+    .euiSelectableListItem__text {
+      padding-block: 0;
+    }
   `,
   scrollContainer:
     typeof height === 'number'

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/styles.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/retention_selector/styles.ts
@@ -36,11 +36,20 @@ export const getRetentionSelectorStyles = ({
   `,
   selectable: css`
     .euiSelectableListItem {
-      padding: ${euiTheme.size.s} ${euiTheme.size.l};
+      padding-block: ${euiTheme.size.s};
     }
 
+    /*
+     * EUI's text column is flex-grow:1 but has no min-width, so a long,
+     * unbroken option name keeps its intrinsic width and pushes the append
+     * action (e.g. the inspect button) out of the row. Allowing it to shrink
+     * lets the row's own ellipsis styles truncate the name. We can't use
+     * listProps.textWrap="truncate" here because that collapses the whole
+     * multi-line row (name + description) onto a single truncated line.
+     */
     .euiSelectableListItem__text {
       padding-block: 0;
+      min-width: 0;
     }
   `,
   scrollContainer:


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/276789

## Summary
The ILM policy selector in the edit data lifecycle flyout was missing the gradient fade effect that should appear when scrolling the list of policies. The root cause was that the selector was not built on top of `EuiSelectable` — it used a custom `EuiListGroup`-based list, so it never got the scroll fade that `EuiSelectable` provides out of the box.

This PR migrates the retention selector to `EuiSelectable` and relies on the component's built-in styles (including the animated overflow shadow / fade), instead of re-implementing list behavior by hand.

High-level changes:
- The `plain` and `panel` list variants now render through a single `EuiSelectable`, removing the parallel `EuiListGroup` implementation.
- The scroll fade is provided natively by `EuiSelectable` (`euiYScrollWithShadows`), so no custom fade CSS is needed.
- Removed the now-unused old `RetentionSelectableRow` component and its styles; the row content and inspect action (`RetentionSelectableInspectButton`) are reused by the unified list.
- Rows are now rendered with the semantic `role="option"` provided by `EuiSelectable` (previously `role="listitem"` from `EuiListGroup`).

### Test plan
- Automated: full `kbn-data-lifecycle-phases` suite green (136 tests); dependent `index_management` suites green (`edit_data_lifecycle_flyout.test.tsx`, `data_stream_detail_panel.test.tsx`, and `data_streams_tab.test.ts`, 52 + 52). Two ordering tests in `edit_data_lifecycle_flyout_body.test.tsx` were updated from `getAllByRole('listitem')` to `getAllByRole('option')` to match the new role.
- Manual (Storybook):
  - `yarn storybook data_lifecycle_phases` → "Edit successful data lifecycle": select an ILM policy and scroll the list; the gradient fade should be visible at the top/bottom while scrolling.
  - `yarn storybook streams_app` → "Import from another stream": verify the selector renders and behaves as before, including the inspect badge placement.
- Integration regression check (no behavior change expected): verify "Edit successful data lifecycle" still works the same when embedded in Streams and in Index Management (selection, inspect action, read-only `panel` variant, search).

### Evidence 
<img width="402" height="699" alt="Screenshot 2026-07-13 at 09 20 36" src="https://github.com/user-attachments/assets/09880d65-d518-4d18-aad6-2e1340c189e6" />

<img width="409" height="537" alt="Screenshot 2026-07-13 at 09 20 05" src="https://github.com/user-attachments/assets/35d76837-7f71-4971-87d8-b16a39501240" />


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->