### PR TITLE
[Streams & Index Management] DLM phases design review fixes - Priority 2

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_data_lifecycle_flyout/__stories__/edit_data_lifecycle_flyout.stories.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_data_lifecycle_flyout/__stories__/edit_data_lifecycle_flyout.stories.tsx
@@ -244,12 +244,12 @@ const PlainFlyoutFooter = ({
         `}
       >
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={onCancel} flush="left">
+          <EuiButtonEmpty onClick={onCancel} flush="left" size="s">
             Cancel
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={onApply} disabled={isApplyDisabled}>
+          <EuiButton fill onClick={onApply} disabled={isApplyDisabled} size="s">
             Apply
           </EuiButton>
         </EuiFlexItem>

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_failed_data_lifecycle_flyout/__stories__/edit_failed_data_lifecycle_flyout_body.stories.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_failed_data_lifecycle_flyout/__stories__/edit_failed_data_lifecycle_flyout_body.stories.tsx
@@ -118,12 +118,12 @@ const PlainFlyoutFooter = ({
         `}
       >
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={onCancel} flush="left">
+          <EuiButtonEmpty onClick={onCancel} flush="left" size="s">
             Cancel
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={onApply} disabled={isApplyDisabled}>
+          <EuiButton fill onClick={onApply} disabled={isApplyDisabled} size="s">
             Apply
           </EuiButton>
         </EuiFlexItem>

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_failed_data_lifecycle_flyout/edit_failed_data_lifecycle_flyout_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_failed_data_lifecycle_flyout/edit_failed_data_lifecycle_flyout_body.tsx
@@ -92,8 +92,8 @@ export const EditFailedDataLifecycleFlyoutBody = ({
               />
             </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiText size="s" color="subdued">
+            <EuiFlexItem grow={false} css={styles.failureStoreHelpText}>
+              <EuiText size="xs" color="subdued">
                 {strings.enableFailureStoreHelpText}
               </EuiText>
             </EuiFlexItem>

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_failed_data_lifecycle_flyout/styles.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/edit_failed_data_lifecycle_flyout/styles.ts
@@ -16,4 +16,7 @@ export const getEditFailedDataLifecycleFlyoutBodyStyles = ({
   headerSection: css`
     padding: ${euiTheme.size.l};
   `,
+  failureStoreHelpText: css`
+    margin-inline-start: calc(${euiTheme.size.base} + ${euiTheme.size.s});
+  `,
 });

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/flyout_footer_with_retention_warning/flyout_footer_with_retention_warning.tsx
@@ -113,6 +113,7 @@ export const FlyoutFooterWithRetentionWarning = ({
           <EuiButtonEmpty
             onClick={onCancel}
             flush="left"
+            size="s"
             data-test-subj="dataLifecycleFlyoutCancelButton"
           >
             {cancelLabel}
@@ -122,6 +123,7 @@ export const FlyoutFooterWithRetentionWarning = ({
         <EuiFlexItem grow={false}>
           <EuiButton
             fill
+            size="s"
             onClick={onApply}
             disabled={isApplyDisabled}
             data-test-subj="dataLifecycleFlyoutApplyButton"

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/inspect_ilm_policy_flyout/ilm_policy_json_tab.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/inspect_ilm_policy_flyout/ilm_policy_json_tab.tsx
@@ -47,7 +47,7 @@ export const IlmPolicyJsonTab = ({ policyName, policy }: IlmPolicyJsonTabProps) 
           transparentBackground
           paddingSize="l"
           fontSize="s"
-          whiteSpace="pre"
+          whiteSpace="pre-wrap"
           overflowHeight={containerHeight > 0 ? containerHeight : undefined}
           copyAriaLabel={strings.copyRequestAriaLabel}
           data-test-subj="ilmPolicyJsonTabCodeBlock"

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/inspect_ilm_policy_flyout/ilm_policy_summary_tab.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/inspect_ilm_policy_flyout/ilm_policy_summary_tab.tsx
@@ -74,6 +74,12 @@ export const PhaseAccordion = ({ phase, phases }: PhaseAccordionProps) => {
     padding: 0 ${euiTheme.size.l} ${euiTheme.size.base} ${euiTheme.size.xxxl};
   `;
 
+  const accordionButtonStyles = css`
+    .euiAccordion__buttonContent {
+      inline-size: 100%;
+    }
+  `;
+
   const toggleIconCss = css`
     transform: ${isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
     transition: transform 150ms ease-in-out;
@@ -122,7 +128,7 @@ export const PhaseAccordion = ({ phase, phases }: PhaseAccordionProps) => {
         onToggle={setIsOpen}
         paddingSize="none"
         arrowDisplay="none"
-        buttonProps={{ paddingSize: 'l' }}
+        buttonProps={{ paddingSize: 'l', css: accordionButtonStyles }}
       >
         {content.length > 0 && (
           <EuiFlexGroup

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/inspect_ilm_policy_flyout/inspect_ilm_policy_flyout.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/inspect_ilm_policy_flyout/inspect_ilm_policy_flyout.tsx
@@ -101,6 +101,7 @@ export const InspectIlmPolicyFlyout = ({
                 <EuiButtonEmpty
                   onClick={onBack}
                   flush="left"
+                  size="s"
                   data-test-subj="inspectIlmPolicyFlyoutBackButton"
                 >
                   {strings.backButton}
@@ -112,6 +113,7 @@ export const InspectIlmPolicyFlyout = ({
                   <EuiFlexItem grow={false}>
                     <EuiButtonEmpty
                       onClick={() => onEditPolicy(policyName)}
+                      size="s"
                       data-test-subj="inspectIlmPolicyFlyoutEditPolicyButton"
                     >
                       {strings.editPolicyButton}
@@ -120,6 +122,7 @@ export const InspectIlmPolicyFlyout = ({
                   <EuiFlexItem grow={false}>
                     <EuiButton
                       fill
+                      size="s"
                       onClick={() => primaryAction.onClick(policyName)}
                       data-test-subj={primaryActionTestSubj}
                       disabled={primaryAction.isDisabled}

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.tsx
@@ -117,6 +117,7 @@ export const FrozenPhaseCard = ({
         description={strings.frozenPhaseDescription}
         icon={<EuiIcon type="dot" color={color} size="m" aria-hidden />}
         badges={disabledBadge}
+        preserveBadgeColors={Boolean(disabledBadge)}
         onChange={(checked) => onChange({ ...duration, enabled: checked })}
       >
         {showConfig && (
@@ -145,14 +146,10 @@ export const FrozenPhaseCard = ({
 
             <EuiSpacer size="m" />
 
-            <EuiText size="s" data-test-subj="frozenSearchableSnapshotLabel">
+            <EuiText size="xs" data-test-subj="frozenSearchableSnapshotLabel">
               <strong>
                 {strings.searchableSnapshotLabel}{' '}
-                <EuiIconTip
-                  content={strings.searchableSnapshotTooltip}
-                  type="info"
-                  color="subdued"
-                />
+                <EuiIconTip content={strings.searchableSnapshotTooltip} type="info" />
               </strong>
             </EuiText>
 
@@ -179,7 +176,7 @@ export const FrozenPhaseCard = ({
                 <>
                   <EuiSpacer size="xs" />
 
-                  <EuiText size="s" color="subdued" data-test-subj="frozenSearchableSnapshotInfo">
+                  <EuiText size="xs" data-test-subj="frozenSearchableSnapshotInfo">
                     <SearchableSnapshotRepositoryInfo
                       defaultRepository={defaultSnapshotRepository}
                       manageRepositoriesHref={manageRepositoriesHref}

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/phase_card.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/phase_card.tsx
@@ -19,6 +19,7 @@ export interface PhaseCardProps {
   description: string;
   icon?: React.ReactNode;
   badges?: React.ReactNode;
+  preserveBadgeColors?: boolean;
   children?: React.ReactNode;
   onChange?: (checked: boolean) => void;
   showCheckbox?: boolean;
@@ -34,31 +35,37 @@ export const PhaseCard = ({
   description,
   icon,
   badges,
+  preserveBadgeColors = false,
   children,
   onChange,
   showCheckbox = true,
 }: PhaseCardProps) => {
   const styles = usePhaseCardStyles();
 
-  const titleColor = disabled ? 'subdued' : undefined;
-  const descriptionColor = disabled ? 'subdued' : undefined;
+  const disabledTextStyle = disabled ? styles.disabledText : undefined;
+  const disabledBadgeTextStyle =
+    disabled && !preserveBadgeColors ? styles.disabledBadgeText : undefined;
 
   const headerContent = (
     <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
           {icon && <EuiFlexItem grow={false}>{icon}</EuiFlexItem>}
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color={titleColor} css={styles.titleText}>
+          <EuiFlexItem grow={false} css={styles.titleItem}>
+            <EuiText size="s" css={[styles.titleText, disabledTextStyle]}>
               {title}
             </EuiText>
           </EuiFlexItem>
-          {badges && <EuiFlexItem grow={false}>{badges}</EuiFlexItem>}
+          {badges && (
+            <EuiFlexItem grow={false} css={disabledBadgeTextStyle}>
+              {badges}
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>
-        <EuiText size="s" color={descriptionColor}>
+        <EuiText size="xs" css={disabledTextStyle}>
           {description}
         </EuiText>
       </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/styles.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/styles.ts
@@ -15,6 +15,17 @@ export const usePhaseCardStyles = () => {
     titleText: css`
       font-weight: ${euiTheme.font.weight.bold};
     `,
+    disabledText: css`
+      color: ${euiTheme.colors.disabledText};
+    `,
+    disabledBadgeText: css`
+      .euiBadge__text {
+        color: ${euiTheme.colors.disabledText};
+      }
+    `,
+    titleItem: css`
+      min-width: 0;
+    `,
     fields: css`
       max-width: 100%;
     `,

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/edit_data_lifecycle_flyout/edit_data_lifecycle_flyout.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/edit_data_lifecycle_flyout/edit_data_lifecycle_flyout.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexItem,
   EuiFlyoutFooter,
   EuiSpacer,
-  EuiTitle,
+  EuiText,
   type EuiFlyoutProps,
   useEuiTheme,
   useGeneratedHtmlId,
@@ -241,13 +241,14 @@ export const EditDataLifecycleFlyout = ({
         css={footerStyles}
       >
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={onClose} flush="left">
+          <EuiButtonEmpty onClick={onClose} flush="left" size="s">
             {strings.cancelButton}
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButton
             fill
+            size="s"
             onClick={handleApply}
             disabled={isApplyDisabled}
             data-test-subj="editDataLifecycleFlyoutApplyButton"
@@ -262,10 +263,10 @@ export const EditDataLifecycleFlyout = ({
   const dlmContent =
     successfulData.dlm != null && effectiveMethod === 'dlm' ? (
       <>
-        <EuiTitle size="xxs">
-          <h3>{strings.dataPhasesTitle}</h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
+        <EuiText size="xs">
+          <strong>{strings.dataPhasesTitle}</strong>
+        </EuiText>
+        <EuiSpacer size="xs" />
         <DlmPhasesSelector
           {...successfulData.dlm}
           defaultValue={
@@ -289,10 +290,10 @@ export const EditDataLifecycleFlyout = ({
 
   const failedDeletePhaseContent = (
     <>
-      <EuiTitle size="xxs">
-        <h3>{strings.dataPhasesTitle}</h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
+      <EuiText size="xs">
+        <strong>{strings.dataPhasesTitle}</strong>
+      </EuiText>
+      <EuiSpacer size="xs" />
       <DeletePhaseCard
         id={failedDeletePhaseCardId}
         duration={

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_detail_panel.tsx
@@ -250,106 +250,113 @@ export const DataStreamDetailPanel: React.FunctionComponent<Props> = ({
 
   return (
     <>
-      <EuiFlyout
-        onClose={() => onClose()}
-        data-test-subj="dataStreamDetailPanel"
-        aria-labelledby="dataStreamDetailPanelTitle"
-        size={400}
-      >
-        <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m">
-            <h2 id="dataStreamDetailPanelTitle" data-test-subj="dataStreamDetailPanelTitle">
-              {dataStreamName}
-              {dataStream && <DataStreamsBadges dataStream={dataStream} />}
-            </h2>
-          </EuiTitle>
-        </EuiFlyoutHeader>
-
-        <EuiFlyoutBody
-          data-test-subj="content"
-          banner={
-            dataStream && dataStream.hidden !== true ? (
-              <StreamsPromotion dataStreamName={dataStreamName} />
-            ) : undefined
-          }
+      {!isEditingDataLifecycle && (
+        <EuiFlyout
+          onClose={() => onClose()}
+          data-test-subj="dataStreamDetailPanel"
+          aria-labelledby="dataStreamDetailPanelTitle"
+          size={400}
         >
-          {content}
-        </EuiFlyoutBody>
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="s">
+              <h2 id="dataStreamDetailPanelTitle" data-test-subj="dataStreamDetailPanelTitle">
+                {dataStreamName}
+                {dataStream && <DataStreamsBadges dataStream={dataStream} />}
+              </h2>
+            </EuiTitle>
+          </EuiFlyoutHeader>
 
-        <EuiFlyoutFooter>
-          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                flush="left"
-                onClick={() => onClose()}
-                data-test-subj="closeDetailsButton"
-                aria-label={i18n.translate('xpack.idxMgmt.dataStreamDetailPanel.closeButtonLabel', {
-                  defaultMessage: 'Close',
-                })}
-              >
-                {i18n.translate('xpack.idxMgmt.dataStreamDetailPanel.closeButtonLabel', {
-                  defaultMessage: 'Close',
-                })}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
+          <EuiFlyoutBody
+            data-test-subj="content"
+            banner={
+              dataStream && dataStream.hidden !== true ? (
+                <StreamsPromotion dataStreamName={dataStreamName} />
+              ) : undefined
+            }
+          >
+            {content}
+          </EuiFlyoutBody>
 
-            <EuiFlexItem grow={false}>
-              {hasActions ? (
-                <EuiPopover
+          <EuiFlyoutFooter>
+            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  flush="left"
+                  size="s"
+                  onClick={() => onClose()}
+                  data-test-subj="closeDetailsButton"
                   aria-label={i18n.translate(
-                    'xpack.idxMgmt.dataStreamDetailPanel.actionsMenuAriaLabel',
-                    { defaultMessage: 'Data stream actions menu' }
+                    'xpack.idxMgmt.dataStreamDetailPanel.closeButtonLabel',
+                    {
+                      defaultMessage: 'Close',
+                    }
                   )}
-                  button={
-                    <EuiSplitButton size="m">
-                      <EuiSplitButton.ActionPrimary
-                        iconType="discoverApp"
-                        onClick={viewInDiscover}
-                        isDisabled={!discoverLocator}
-                        data-test-subj="viewInDiscoverButton"
-                      >
-                        {viewInDiscoverLabel}
-                      </EuiSplitButton.ActionPrimary>
+                >
+                  {i18n.translate('xpack.idxMgmt.dataStreamDetailPanel.closeButtonLabel', {
+                    defaultMessage: 'Close',
+                  })}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
 
-                      <EuiSplitButton.ActionSecondary
-                        iconType="gear"
-                        tooltipProps={{
-                          content: i18n.translate(
-                            'xpack.idxMgmt.dataStreamDetailPanel.actionsButtonToolTip',
-                            { defaultMessage: 'Actions' }
-                          ),
-                          disableScreenReaderOutput: true,
-                        }}
-                        aria-label={i18n.translate(
-                          'xpack.idxMgmt.dataStreamDetailPanel.actionsButtonAriaLabel',
-                          { defaultMessage: 'Open data stream actions menu' }
-                        )}
-                        onClick={() => setActionsPopOverOpen((open) => !open)}
-                        data-test-subj="manageDataStreamButton"
-                      />
-                    </EuiSplitButton>
-                  }
-                  isOpen={isActionsPopOverOpen}
-                  closePopover={closePopover}
-                  panelPaddingSize="none"
-                  anchorPosition="upLeft"
-                >
-                  <EuiContextMenu initialPanelId={0} panels={panels} />
-                </EuiPopover>
-              ) : (
-                <EuiButton
-                  iconType="discoverApp"
-                  onClick={viewInDiscover}
-                  isDisabled={!discoverLocator}
-                  data-test-subj="viewInDiscoverButton"
-                >
-                  {viewInDiscoverLabel}
-                </EuiButton>
-              )}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlyoutFooter>
-      </EuiFlyout>
+              <EuiFlexItem grow={false}>
+                {hasActions ? (
+                  <EuiPopover
+                    aria-label={i18n.translate(
+                      'xpack.idxMgmt.dataStreamDetailPanel.actionsMenuAriaLabel',
+                      { defaultMessage: 'Data stream actions menu' }
+                    )}
+                    button={
+                      <EuiSplitButton size="s">
+                        <EuiSplitButton.ActionPrimary
+                          iconType="discoverApp"
+                          onClick={viewInDiscover}
+                          isDisabled={!discoverLocator}
+                          data-test-subj="viewInDiscoverButton"
+                        >
+                          {viewInDiscoverLabel}
+                        </EuiSplitButton.ActionPrimary>
+
+                        <EuiSplitButton.ActionSecondary
+                          iconType="gear"
+                          tooltipProps={{
+                            content: i18n.translate(
+                              'xpack.idxMgmt.dataStreamDetailPanel.actionsButtonToolTip',
+                              { defaultMessage: 'Actions' }
+                            ),
+                            disableScreenReaderOutput: true,
+                          }}
+                          aria-label={i18n.translate(
+                            'xpack.idxMgmt.dataStreamDetailPanel.actionsButtonAriaLabel',
+                            { defaultMessage: 'Open data stream actions menu' }
+                          )}
+                          onClick={() => setActionsPopOverOpen((open) => !open)}
+                          data-test-subj="manageDataStreamButton"
+                        />
+                      </EuiSplitButton>
+                    }
+                    isOpen={isActionsPopOverOpen}
+                    closePopover={closePopover}
+                    panelPaddingSize="none"
+                    anchorPosition="upLeft"
+                  >
+                    <EuiContextMenu initialPanelId={0} panels={panels} />
+                  </EuiPopover>
+                ) : (
+                  <EuiButton
+                    iconType="discoverApp"
+                    size="s"
+                    onClick={viewInDiscover}
+                    isDisabled={!discoverLocator}
+                    data-test-subj="viewInDiscoverButton"
+                  >
+                    {viewInDiscoverLabel}
+                  </EuiButton>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlyoutFooter>
+        </EuiFlyout>
+      )}
 
       {isDeleting && (
         <DeleteDataStreamConfirmationModal

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_detail_summary.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_detail_summary.tsx
@@ -72,7 +72,6 @@ const DetailsList: React.FunctionComponent<DetailsListProps> = ({ details }) => 
     `,
     [euiTheme]
   );
-
   const descriptionListItems = details.map((detail, index) => {
     const { name, toolTip, content, dataTestSubj } = detail;
 
@@ -101,7 +100,11 @@ const DetailsList: React.FunctionComponent<DetailsListProps> = ({ details }) => 
     );
   });
 
-  return <EuiDescriptionList textStyle="reverse">{descriptionListItems}</EuiDescriptionList>;
+  return (
+    <EuiDescriptionList textStyle="reverse" rowGutterSize="m">
+      {descriptionListItems}
+    </EuiDescriptionList>
+  );
 };
 
 interface DataStreamDetailSummaryProps {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/streams_promotion.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/streams_promotion.tsx
@@ -34,7 +34,7 @@ export function StreamsPromotion({ dataStreamName }: { dataStreamName: string })
   return (
     <EuiBanner
       css={css`
-        margin: ${euiTheme.size.l};
+        margin: ${euiTheme.size.l} ${euiTheme.size.l} 0;
       `}
       title={i18n.translate('xpack.idxMgmt.streamsPromotion.title', {
         defaultMessage: 'A new way to manage streams',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_bar.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_bar.tsx
@@ -134,7 +134,6 @@ export const LifecycleBar: React.FC<LifecycleBarProps> = ({
           responsive={false}
           css={{
             gridTemplateColumns,
-            paddingInline: euiTheme.size.xxs,
             boxSizing: 'border-box',
             height: '100%',
           }}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_delete_phase_flyout/edit_delete_phase_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_delete_phase_flyout/edit_delete_phase_flyout.tsx
@@ -234,6 +234,7 @@ export const EditDeletePhaseFlyout = ({
   const applyButton = (
     <EuiButton
       fill
+      size="s"
       type="submit"
       form={formId}
       isLoading={Boolean(isSaving) || isSubmitting}
@@ -247,7 +248,7 @@ export const EditDeletePhaseFlyout = ({
   return (
     <EuiFlyout
       type="push"
-      size="s"
+      size={400}
       paddingSize="none"
       ownFocus={false}
       onClose={onClose}
@@ -330,6 +331,7 @@ export const EditDeletePhaseFlyout = ({
               data-test-subj={`${dataTestSubj}CancelButton`}
               onClick={onClose}
               flush="left"
+              size="s"
             >
               {editDeletePhaseFlyoutI18n.cancelButtonLabel}
             </EuiButtonEmpty>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dsl_steps_flyout/edit_dsl_steps_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dsl_steps_flyout/edit_dsl_steps_flyout.tsx
@@ -241,6 +241,7 @@ export const EditDslStepsFlyout = ({
     const button = (
       <EuiButton
         fill
+        size="s"
         isLoading={Boolean(isSaving) || form.isSubmitting}
         data-test-subj={`${dataTestSubj}SaveButton`}
         onClick={() => form.submit()}
@@ -268,7 +269,7 @@ export const EditDslStepsFlyout = ({
   return (
     <EuiFlyout
       type="push"
-      size="s"
+      size={400}
       paddingSize="none"
       ownFocus={false}
       onClose={onClose}
@@ -317,6 +318,7 @@ export const EditDslStepsFlyout = ({
               data-test-subj={`${dataTestSubj}CancelButton`}
               onClick={onClose}
               flush="left"
+              size="s"
             >
               {i18n.translate('xpack.streams.editDslStepsFlyout.cancel', {
                 defaultMessage: 'Cancel',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
@@ -323,7 +323,7 @@ export const DslStepsFlyoutArrayView = ({
           css={[headerStyles, items.length === 0 && headerNoStepsStyles]}
         >
           <EuiFlexItem grow={false}>
-            <EuiTitle size="m">
+            <EuiTitle size="s">
               <h2 id={flyoutTitleId}>
                 {i18n.translate('xpack.streams.editDslStepsFlyout.title', {
                   defaultMessage: 'Edit downsample steps',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.test.tsx
@@ -90,8 +90,8 @@ describe('EditPolicyModal', () => {
 
       const description = screen.getByTestId('editPolicyModal-description');
       expect(description).toHaveTextContent(policyName);
-      expect(description).toHaveTextContent('is managed by Elastic and currently used in');
-      expect(description).toHaveTextContent('3 streams and 2 indices besides this stream');
+      expect(description).toHaveTextContent('is managed by Elastic and is already being used in');
+      expect(description).toHaveTextContent('3 streams and 2 indices in addition to this stream');
 
       expect(screen.getByTestId('editPolicyModal-affectedResourcesTitle')).toHaveTextContent(
         'Affected data sources'
@@ -121,7 +121,7 @@ describe('EditPolicyModal', () => {
       const description = screen.getByTestId('editPolicyModal-description');
       expect(description).toHaveTextContent(policyName);
       expect(description).toHaveTextContent(
-        'is currently used in 3 streams and 2 indices besides this stream'
+        'is already being used in 3 streams and 2 indices in addition to this stream'
       );
       expect(description).not.toHaveTextContent('is managed by Elastic');
 
@@ -143,7 +143,7 @@ describe('EditPolicyModal', () => {
       );
 
       expect(screen.getByTestId('editPolicyModal-description')).toHaveTextContent(
-        'is currently used in 2 streams besides this stream'
+        'is already being used in 2 streams in addition to this stream'
       );
     });
 
@@ -162,7 +162,7 @@ describe('EditPolicyModal', () => {
       );
 
       expect(screen.getByTestId('editPolicyModal-description')).toHaveTextContent(
-        'is currently used in 2 indices besides this stream'
+        'is already being used in 2 indices in addition to this stream'
       );
     });
 
@@ -181,7 +181,7 @@ describe('EditPolicyModal', () => {
       );
 
       expect(screen.getByTestId('editPolicyModal-description')).toHaveTextContent(
-        'is currently used in 1 stream and 1 index besides this stream'
+        'is already being used in 1 stream and 1 index in addition to this stream'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.test.tsx
@@ -91,7 +91,7 @@ describe('EditPolicyModal', () => {
       const description = screen.getByTestId('editPolicyModal-description');
       expect(description).toHaveTextContent(policyName);
       expect(description).toHaveTextContent('is managed by Elastic and currently used in');
-      expect(description).toHaveTextContent('3 streams and 2 indices');
+      expect(description).toHaveTextContent('3 streams and 2 indices besides this stream');
 
       expect(screen.getByTestId('editPolicyModal-affectedResourcesTitle')).toHaveTextContent(
         'Affected data sources'
@@ -120,7 +120,9 @@ describe('EditPolicyModal', () => {
 
       const description = screen.getByTestId('editPolicyModal-description');
       expect(description).toHaveTextContent(policyName);
-      expect(description).toHaveTextContent('is currently used in 3 streams and 2 indices');
+      expect(description).toHaveTextContent(
+        'is currently used in 3 streams and 2 indices besides this stream'
+      );
       expect(description).not.toHaveTextContent('is managed by Elastic');
 
       expect(screen.getByTestId('editPolicyModal-affectedResourcesList')).toBeInTheDocument();
@@ -141,7 +143,7 @@ describe('EditPolicyModal', () => {
       );
 
       expect(screen.getByTestId('editPolicyModal-description')).toHaveTextContent(
-        'is currently used in 2 streams'
+        'is currently used in 2 streams besides this stream'
       );
     });
 
@@ -160,7 +162,26 @@ describe('EditPolicyModal', () => {
       );
 
       expect(screen.getByTestId('editPolicyModal-description')).toHaveTextContent(
-        'is currently used in 2 indices'
+        'is currently used in 2 indices besides this stream'
+      );
+    });
+
+    it('renders singular usage for one other stream and one other index', () => {
+      renderWithI18n(
+        <EditPolicyModal
+          policyName={policyName}
+          affectedResources={[
+            { name: 'stream-1', type: 'stream' },
+            { name: 'index-1', type: 'index' },
+          ]}
+          onCancel={() => {}}
+          onOverwrite={() => {}}
+          onSaveAsNew={() => {}}
+        />
+      );
+
+      expect(screen.getByTestId('editPolicyModal-description')).toHaveTextContent(
+        'is currently used in 1 stream and 1 index besides this stream'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.tsx
@@ -94,13 +94,13 @@ export function EditPolicyModal({
     isManaged && isInUse ? (
       <FormattedMessage
         id="xpack.streams.editPolicyModal.managedAndInUseDescription"
-        defaultMessage="ILM policy {policyName} is managed by Elastic and currently used in {usageLabel} besides this stream. Consider saving as a new ILM policy to avoid unintended changes."
+        defaultMessage="ILM policy {policyName} is managed by Elastic and is already being used in {usageLabel} in addition to this stream. Consider saving as a new ILM policy to avoid unintended changes."
         values={{ policyName: policyNameNode, usageLabel }}
       />
     ) : isInUse ? (
       <FormattedMessage
         id="xpack.streams.editPolicyModal.inUseDescription"
-        defaultMessage="ILM policy {policyName} is currently used in {usageLabel} besides this stream. Consider saving as a new ILM policy to avoid unintended changes."
+        defaultMessage="ILM policy {policyName} is already being used in {usageLabel} in addition to this stream. Consider saving as a new ILM policy to avoid unintended changes."
         values={{ policyName: policyNameNode, usageLabel }}
       />
     ) : (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_policy_modal/edit_policy_modal.tsx
@@ -94,13 +94,13 @@ export function EditPolicyModal({
     isManaged && isInUse ? (
       <FormattedMessage
         id="xpack.streams.editPolicyModal.managedAndInUseDescription"
-        defaultMessage="ILM policy {policyName} is managed by Elastic and currently used in {usageLabel}. Consider saving as a new ILM policy to avoid unintended changes."
+        defaultMessage="ILM policy {policyName} is managed by Elastic and currently used in {usageLabel} besides this stream. Consider saving as a new ILM policy to avoid unintended changes."
         values={{ policyName: policyNameNode, usageLabel }}
       />
     ) : isInUse ? (
       <FormattedMessage
         id="xpack.streams.editPolicyModal.inUseDescription"
-        defaultMessage="ILM policy {policyName} is currently used in {usageLabel}. Consider saving as a new ILM policy to avoid unintended changes."
+        defaultMessage="ILM policy {policyName} is currently used in {usageLabel} besides this stream. Consider saving as a new ILM policy to avoid unintended changes."
         values={{ policyName: policyNameNode, usageLabel }}
       />
     ) : (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/shared/flyout_shell.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/shared/flyout_shell.tsx
@@ -52,6 +52,7 @@ export const FlyoutShell = ({
   const button = (
     <EuiButton
       fill
+      size="s"
       type="submit"
       form={formId}
       isLoading={Boolean(isSaving) || isSubmitting}
@@ -77,7 +78,7 @@ export const FlyoutShell = ({
   return (
     <EuiFlyout
       type="push"
-      size="s"
+      size={400}
       paddingSize="none"
       ownFocus={false}
       onClose={onClose}
@@ -89,7 +90,7 @@ export const FlyoutShell = ({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
               <EuiFlexItem grow={true}>
-                <EuiTitle size="m">
+                <EuiTitle size="s">
                   <h2 id={flyoutTitleId}>{title}</h2>
                 </EuiTitle>
               </EuiFlexItem>
@@ -115,6 +116,7 @@ export const FlyoutShell = ({
               data-test-subj={`${dataTestSubj}CancelButton`}
               onClick={onClose}
               flush="left"
+              size="s"
             >
               {i18n.translate('xpack.streams.flyoutShell.cancel', {
                 defaultMessage: 'Cancel',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/failure_store/no_failure_store_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/failure_store/no_failure_store_panel.tsx
@@ -29,14 +29,14 @@ export const NoFailureStorePanel = ({
     >
       <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
         <EuiFlexItem>
-          <EuiText>
+          <EuiText size="s">
             <b>
               {i18n.translate('xpack.streams.streamDetailView.failureStoreDisabled.title', {
                 defaultMessage: 'Failure store disabled',
               })}
             </b>
           </EuiText>
-          <EuiText color="subdued">
+          <EuiText size="s" color="subdued">
             {i18n.translate('xpack.streams.streamDetailView.failureStoreDisabled.description', {
               defaultMessage:
                 "Enable the failure store to collect this stream's failed documents for later review.",
@@ -45,18 +45,17 @@ export const NoFailureStorePanel = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           {manageFailureStorePrivilege && (
-            <div>
-              <EuiButton
-                type="button"
-                onClick={onEnableFailureStore}
-                data-test-subj="streamsAppFailureStoreEnableButton"
-                disabled={isExternalFlyoutOpen}
-              >
-                {i18n.translate('xpack.streams.streamDetailView.failureStoreDisabled.button', {
-                  defaultMessage: 'Enable failure store',
-                })}
-              </EuiButton>
-            </div>
+            <EuiButton
+              type="button"
+              size="s"
+              onClick={onEnableFailureStore}
+              data-test-subj="streamsAppFailureStoreEnableButton"
+              disabled={isExternalFlyoutOpen}
+            >
+              {i18n.translate('xpack.streams.streamDetailView.failureStoreDisabled.button', {
+                defaultMessage: 'Enable failure store',
+              })}
+            </EuiButton>
           )}
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/276789

## Summary

This PR addresses the **Priority 2** design-review items from #276789 (the one remaining Priority 2 item, the ILM policy selectable scroll fade, is handled separately in #277642).

General:
- Set all flyout headers to 20px (`EuiTitle size="s"`) and all flyout footer buttons to `size="s"` across the project (including Storybook footers) for consistency.

Streams / Data lifecycle:
- Made the edit data phase and edit data lifecycle flyouts both 400px wide.
- Inspect ILM policy: right-aligned the accordion chevrons and switched the JSON tab to `pre-wrap` so there is no horizontal scrolling.
- Reworded the "save as new policy" confirmation modal so the current (edited) stream is no longer counted in the usage message.
- Reduced the lifecycle segment container horizontal padding to a 4px total, matching the vertical padding.
- Failure store: enable-failure-store subtext is now 12px and aligned under the checkbox label; the disabled panel title/description are 14px and the "Enable failure store" button is `size="s"`.

Index management / Index and component templates:
- Phase card subtext is now 12px; for disabled phases all text uses `euiTheme.colors.disabledText` (including the "Required" badge), while the "Enterprise required" / "Default repository required" badges keep their colors.

Index management / Data streams:
- Inspect flyout spacing: 24px below the announcement banner and 16px between each description list group (via `EuiDescriptionList` `rowGutterSize`).
- Data phases header is now 12px with 4px of space below it.
- Data phase titles and badges can now wrap to a new line.
- The summary flyout now unmounts while the edit flyout is open and remounts when the user clicks Cancel/Back.
- Frozen phase searchable-snapshot text is now 12px and uses the default EUI text and tooltip icon color.

## Issues fixed

Addresses the **Priority 2** items from #276789:

### General

- [x] **Modal header font size** (Priority 2)
  Can we use 20px font size for all flyout headers used in this project for consistency and to better match the designs?
  <img width="420" height="122" alt="Image" src="https://github.com/user-attachments/assets/288fe2c9-7b9d-4496-aa75-04a35c521799" />

- [x] **Modal footer button sizes** (Priority 2)
  Can we make sure that all flyout footers in this project are using the button `size="s"` for consistency?
  <img width="418" height="88" alt="Image" src="https://github.com/user-attachments/assets/59722197-14f6-4d45-ba47-225306ce09e2" />

### Streams / Data lifecycle

- [x] **Edit data phase and data lifecycle flyouts should be the same width** (Priority 2)
  Is it possible to change it so that they are both 400px wide?

- [x] **Inspect ILM policy chevron alignment** (Priority 2)
  Possible to align the ILM policy accordion chevrons to the right to better match the designs?
  <img width="410" height="306" alt="Image" src="https://github.com/user-attachments/assets/410cdd64-61df-40a1-afe1-f62408ba9b2e" />

- [x] **ILM inspect JSON code block scrolling** (Priority 2)
  Can we use the default `pre-wrap` style here so there is no horizontal scrolling? Can we also remove the right margin and adjust the right padding so that the scroll bar is aligned to the right of the copy and full-screen buttons?
  <img width="403" height="570" alt="Image" src="https://github.com/user-attachments/assets/5a31880d-82e1-408d-b479-e52a8582818a" />

- [x] **Change copy for stream in confirmation modal** (Priority 2)
  The current stream is not included in the count and the list so the message and the number displayed is missleading. We must change the copy to "(...) is currently used in other X streams"
  <img width="1440" height="1125" alt="Image" src="https://github.com/user-attachments/assets/32b4b4e6-cb39-4237-9a0e-295e8d677417" />

- [x] **Reduce lifecycle segment container horizontal padding** (Priority 2)
  Currently, the lifecycle segment container has a total of 6px horizontal padding (3 elements with 2px padding). Can we reduce to a total of 4px to be consistent with the vertical padding?
  <img width="981" height="96" alt="Image" src="https://github.com/user-attachments/assets/59546cbc-34cb-4cd8-af6a-1330ad5175a0" />

- [x] **Enable failure store subtext size and alignment** (Priority 2)
  Can we adjust the size of the enable failure store subtext to be 12px and aligned with the text that precedes it?
  <img width="408" height="345" alt="Image" src="https://github.com/user-attachments/assets/f64d6118-615a-4d58-a178-9f0e8686a249" />

- [x] **Failure store disabled panel** (Priority 2)
  Please change the failure store disabled panel title and description to be 14px. Also change the "Enable failure store" button to be `size="s"`. Doing so will better match the designs.
  <img width="1422" height="106" alt="Image" src="https://github.com/user-attachments/assets/a0c076cc-7ece-46b6-99d2-c7a0d00a3990" />

### Index management / Index and component templates

- [x] **Phase subtext font size** (Priority 2)
  Can we change the phase subtext font size to 12px to better match the designs?
  <img width="613" height="284" alt="Image" src="https://github.com/user-attachments/assets/bd7bdbe0-c2c2-4504-9100-3d74f463c145" />

- [x] **Disabled phase text color** (Priority 2)
  For disabled phases, all text within the card should be `euiTheme.colors.disabledText`. This includes the text in the "Required" badge. This does not include the text in the "Enterprise required" or "Default repository required" badges.
  <img width="609" height="195" alt="Image" src="https://github.com/user-attachments/assets/375578d8-991c-4a33-b4d0-eb5ece13ff56" />x

### Index management / Data streams

- [x] **Inspect flyout content spacing** (Priority 2)
  Can we adjust the content spacing for this flyout's content so that there is only 24px of space below the announcement banner and 16px of space between each group in the description list?
  <img width="405" height="430" alt="Image" src="https://github.com/user-attachments/assets/ba919f3e-4999-4276-8662-8aa8b14c2d52" />

- [x] **Data phases header font size and margin** (Priority 2)
  Can we change the data phases header text to 12px and reduce the space under it to 4px?
  <img width="374" height="156" alt="Image" src="https://github.com/user-attachments/assets/0611018f-6608-4a8e-8a4c-35741105cb08" />

- [x] **Allow line breaks for data phase titles and badges** (Priority 2)
  To avoid awkward looking situations like this, can we allow the badge to break a line?
  <img width="365" height="148" alt="Image" src="https://github.com/user-attachments/assets/debec409-5c74-4b33-89d6-e03459d60d53" />

- [x] **Avoid flyout stacking behavior** (Priority 2)
  Rather than stacking the data stream inspect and edit flyouts, can we automatically close the inspect flyout when the edit flyout gets opened? Or do ya'll think it's problematic to not return to the inspect flyout after completing your edits?
  **Agreement** leave at it is but unmount the summary flyout when the edit one is open. Mount it again if the user clicks Cancel/Back.
  <img width="800" height="637" alt="Image" src="https://github.com/user-attachments/assets/462b5580-03b0-4a06-973c-c9027028c35b" />

- [x] **Frozen phase snapshot font size and color** (Priority 2)
  The text under "searchable snapshot" should be 12px. Also, the text color and tooltip icon color should be the default EUI text color.
  <img width="365" height="334" alt="Image" src="https://github.com/user-attachments/assets/19954fc1-62cd-4708-ab0e-f7b426ffdfd7" />


### Test plan

- Automated: updated/ran the affected Jest suites (`kbn-data-lifecycle-phases`, and the `index_management` data stream detail panel / data streams tab suites); all green.
- Manual (Storybook): `yarn storybook data_lifecycle_phases` and `yarn storybook streams_app` — verify flyout headers are 20px, footer buttons are `size="s"`, and the inspect ILM policy chevron alignment + JSON `pre-wrap`.
- Manual (Streams): verify edit data phase and edit data lifecycle flyouts are both 400px; the confirmation modal copy; the lifecycle segment padding; the failure store subtext/disabled panel.
- Manual (Index Management): verify phase card subtext/disabled colors (index & component templates), and the data stream inspect flyout spacing, data phases header, title/badge wrapping, summary-flyout unmount-on-edit, and frozen phase snapshot text.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->