### PR TITLE
[Synthetics] Fix cross-space private location deletion check

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/delete_private_location.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/delete_private_location.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { deletePrivateLocationRoute } from './delete_private_location';
+import { MonitorConfigRepository } from '../../../services/monitor_config_repository';
+import { privateLocationSavedObjectName } from '../../../../common/saved_objects/private_locations';
+import { getPrivateLocationsAndAgentPolicies } from './get_private_locations';
+import { migrateLegacyPrivateLocations } from './migrate_legacy_private_locations';
+
+jest.mock('./get_private_locations');
+jest.mock('./migrate_legacy_private_locations');
+
+const locationId = 'test-location-id';
+
+const emptyFindResponse = { total: 0, saved_objects: [], page: 1, per_page: 0 };
+
+const setup = ({ crossSpaceMonitorTotal }: { crossSpaceMonitorTotal: number }) => {
+  (migrateLegacyPrivateLocations as jest.Mock).mockResolvedValue(undefined);
+  (getPrivateLocationsAndAgentPolicies as jest.Mock).mockResolvedValue({
+    locations: [{ id: locationId }],
+  });
+
+  // Internal (unscoped) repository sees monitors in every space.
+  const internalSOClient = {
+    find: jest.fn().mockResolvedValue({ ...emptyFindResponse, total: crossSpaceMonitorTotal }),
+  };
+  // Request-scoped client is bound to the caller's space; it must NOT be used for the count.
+  const savedObjectsClient = {
+    find: jest.fn().mockResolvedValue(emptyFindResponse),
+    delete: jest.fn().mockResolvedValue({}),
+  } as unknown as SavedObjectsClientContract;
+
+  const monitorConfigRepository = new MonitorConfigRepository(savedObjectsClient, {} as never);
+
+  const response = {
+    badRequest: jest.fn((arg) => ({ status: 400, ...arg })),
+  };
+
+  const routeContext = {
+    savedObjectsClient,
+    syntheticsMonitorClient: {},
+    request: { params: { locationId } },
+    response,
+    monitorConfigRepository,
+    server: {
+      logger: { debug: jest.fn(), error: jest.fn() },
+      coreStart: {
+        savedObjects: { createInternalRepository: jest.fn().mockReturnValue(internalSOClient) },
+      },
+    },
+  } as any;
+
+  return { routeContext, internalSOClient, savedObjectsClient, response };
+};
+
+describe('deletePrivateLocationRoute', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('counts monitors across all spaces via the internal repository', async () => {
+    const { routeContext, internalSOClient, savedObjectsClient } = setup({
+      crossSpaceMonitorTotal: 0,
+    });
+
+    await deletePrivateLocationRoute().handler(routeContext);
+
+    expect(internalSOClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ namespaces: [ALL_SPACES_ID] })
+    );
+    // The space-scoped client must not be used to decide whether the location is in use.
+    expect(savedObjectsClient.find).not.toHaveBeenCalled();
+    expect(savedObjectsClient.delete).toHaveBeenCalledWith(
+      privateLocationSavedObjectName,
+      locationId,
+      { force: true }
+    );
+  });
+
+  it('blocks deletion when a monitor in a non-accessible space still uses the location', async () => {
+    const { routeContext, savedObjectsClient, response } = setup({ crossSpaceMonitorTotal: 1 });
+
+    await deletePrivateLocationRoute().handler(routeContext);
+
+    expect(savedObjectsClient.delete).not.toHaveBeenCalled();
+    expect(response.badRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          message: expect.stringContaining('cannot be deleted because it is used'),
+        }),
+      })
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/delete_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/delete_private_location.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 import { getSavedObjectKqlFilter } from '../../common';
 import { PRIVATE_LOCATION_WRITE_API } from '../../../feature';
 import { migrateLegacyPrivateLocations } from './migrate_legacy_private_locations';
@@ -57,10 +58,19 @@ export const deletePrivateLocationRoute: SyntheticsRestApiRouteFactory<undefined
 
     const locationFilter = getSavedObjectKqlFilter({ field: 'locations.id', values: locationId });
 
-    const data = await monitorConfigRepository.find({
-      perPage: 0,
-      filter: locationFilter,
-    });
+    // Private locations are shared across spaces and deleted globally (force: true below),
+    // so the "in use" check must count monitors in every space — not just the caller's.
+    // The request-scoped client only sees the current space, so use the internal repository
+    // scoped to all spaces to avoid deleting a location still used by monitors elsewhere.
+    const data = await monitorConfigRepository.find(
+      {
+        perPage: 0,
+        filter: locationFilter,
+        namespaces: [ALL_SPACES_ID],
+      },
+      undefined,
+      internalSOClient
+    );
 
     if (data.total > 0) {
       return response.badRequest({

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
@@ -339,7 +339,7 @@ export class MonitorConfigRepository {
   async find<T>(
     options: Omit<SavedObjectsFindOptions, 'type'>,
     types: string[] = syntheticsMonitorSOTypes,
-    soClient: SavedObjectsClientContract = this.soClient
+    soClient: SavedObjectsClientContract | ISavedObjectsRepository = this.soClient
   ): Promise<SavedObjectsFindResponse<T>> {
     const perPage = options.perPage ?? 5000;
     const page = options.page ?? 1;


### PR DESCRIPTION
## Summary

`DELETE /api/synthetics/private_locations/{locationId}` guards against deleting a private location that is still in use, but it counted the associated monitors through the **request-scoped (space-scoped)** saved objects client. Private locations are shared across spaces and deleted globally (`force: true`), so a user with write access in only one space could delete a location still used by monitors in other, non-accessible spaces — the guard only ever saw monitors in the caller's current space.

This aligns the check with the location's actual scope: it now counts monitors across **all spaces** via the internal repository (`namespaces: ['*']`), matching the pattern already used by `get_location_monitors`.

## Changes

- `delete_private_location.ts`: count in-use monitors across all spaces using the internal repository instead of the space-scoped client.
- `monitor_config_repository.ts`: widen `find`'s optional client parameter to also accept an internal repository.
- Add `delete_private_location.test.ts` covering the cross-space count and the "blocked when used by a monitor in a non-accessible space" case.

## Test plan

- [ ] Create a private location shared between two spaces (A and B).
- [ ] Add a monitor using it in space B only.
- [ ] As a user with access to space A only, `DELETE` the private location → expect `400` (blocked).
- [ ] Remove the monitor, retry → expect success.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->