### PR TITLE
[Dashboards in Chat] Fall back to the default model when low-effort ES|QL generation fails

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/lens/graph_lens.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/lens/graph_lens.test.ts
@@ -52,9 +52,12 @@ describe('createVisualizationGraph', () => {
   const esClient = { asCurrentUser: {} } as IScopedClusterClient;
 
   // Returns a ModelProvider-shaped mock. `createVisualizationGraph` resolves the default model
-  // via `getDefaultModel()` for the config / time-range nodes.
+  // via `getDefaultModel()` for the config / time-range nodes; the ES|QL node resolves the
+  // low-effort model via `selectModel()`. Both resolve to the same connector so the
+  // default-model fallback in `generateVisualizationEsql` stays out of these tests.
   const createMockModel = (invokeResult: string = '```json\n{"type":"metric"}\n```') => {
     const scopedModel = {
+      connector: { connectorId: 'default-connector' },
       chatModel: {
         // invoke resolves to a message-like object; graph_lens reads `.content` via
         // extractTextFromMessage.
@@ -64,6 +67,7 @@ describe('createVisualizationGraph', () => {
     };
     return {
       getDefaultModel: jest.fn().mockResolvedValue(scopedModel),
+      selectModel: jest.fn().mockResolvedValue(scopedModel),
     } as const;
   };
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { ModelProvider, ToolEventEmitter } from '@kbn/agent-builder-server';
+import { EffortLevels } from '@kbn/agent-builder-common';
+import type { ModelProvider, ScopedModel, ToolEventEmitter } from '@kbn/agent-builder-server';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import { generateEsql } from '@kbn/agent-builder-genai-utils';
@@ -23,9 +24,11 @@ const mockedGenerateEsql = jest.mocked(generateEsql);
 
 const logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as Logger;
 const events = {} as ToolEventEmitter;
-const modelProvider = {
-  getDefaultModel: jest.fn().mockResolvedValue({}),
-} as unknown as ModelProvider;
+const lowEffortModel = { connector: { connectorId: 'fast-connector' } } as ScopedModel;
+const defaultModel = { connector: { connectorId: 'default-connector' } } as ScopedModel;
+const selectModel = jest.fn();
+const getDefaultModel = jest.fn();
+const modelProvider = { selectModel, getDefaultModel } as unknown as ModelProvider;
 const asCurrentUser = { name: 'current-user-client' };
 const esClient = { asCurrentUser } as unknown as IScopedClusterClient;
 
@@ -41,6 +44,8 @@ const params = {
 describe('generateVisualizationEsql', () => {
   beforeEach(() => {
     mockedGenerateEsql.mockReset();
+    selectModel.mockReset().mockResolvedValue(lowEffortModel);
+    getDefaultModel.mockReset().mockResolvedValue(defaultModel);
   });
 
   it('returns the query and result columns when generation succeeds with rows', async () => {
@@ -58,36 +63,12 @@ describe('generateVisualizationEsql', () => {
     });
   });
 
-  it('returns an undefined columns list when the query was not executed with rows', async () => {
-    mockedGenerateEsql.mockResolvedValue({
-      query: 'FROM logs-* | STATS c = COUNT() BY status',
-    } as Awaited<ReturnType<typeof generateEsql>>);
-
-    const result = await generateVisualizationEsql(params);
-
-    expect(result).toEqual({
-      query: 'FROM logs-* | STATS c = COUNT() BY status',
-      columns: undefined,
-    });
-  });
-
   it('returns an error when no query is generated', async () => {
     mockedGenerateEsql.mockResolvedValue({} as Awaited<ReturnType<typeof generateEsql>>);
 
     const result = await generateVisualizationEsql(params);
 
     expect(result).toEqual({ error: 'No queries generated' });
-  });
-
-  it('treats a query flagged with an execution error as a failure', async () => {
-    mockedGenerateEsql.mockResolvedValue({
-      query: 'FROM logs-* | EVAL x = half_ms * 1 millisecond',
-      error: 'verification_exception: type mismatch',
-    } as Awaited<ReturnType<typeof generateEsql>>);
-
-    const result = await generateVisualizationEsql(params);
-
-    expect(result).toEqual({ error: 'verification_exception: type mismatch' });
   });
 
   it('forwards the current-user client, shared instructions, and time range', async () => {
@@ -159,6 +140,83 @@ describe('generateVisualizationEsql', () => {
     const { nlQuery } = mockedGenerateEsql.mock.calls[0][0];
     expect(nlQuery).toContain('Existing esql query to modify: "FROM logs-* | STATS c = COUNT()"');
     expect(nlQuery).toContain('User query: count logs by status');
+  });
+
+  describe('default-model fallback', () => {
+    it('runs on the low-effort model and does not fall back on success', async () => {
+      mockedGenerateEsql.mockResolvedValue({ query: 'FROM logs-*' } as Awaited<
+        ReturnType<typeof generateEsql>
+      >);
+
+      const result = await generateVisualizationEsql(params);
+
+      expect(result).toEqual({ query: 'FROM logs-*', columns: undefined });
+      expect(selectModel).toHaveBeenCalledWith({ effortLevel: EffortLevels.low });
+      expect(mockedGenerateEsql).toHaveBeenCalledTimes(1);
+      expect(mockedGenerateEsql).toHaveBeenCalledWith(
+        expect.objectContaining({ model: lowEffortModel })
+      );
+      expect(getDefaultModel).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default model with the failing attempt as context', async () => {
+      const columns = [{ name: 'status', type: 'keyword' }];
+      mockedGenerateEsql
+        .mockResolvedValueOnce({
+          query: 'FROM logs-* | STATS c = COUNT() BY status.keyword',
+          error: 'Unknown column [status.keyword]',
+        } as Awaited<ReturnType<typeof generateEsql>>)
+        .mockResolvedValueOnce({
+          query: 'FROM logs-* | STATS c = COUNT() BY status',
+          results: { columns },
+        } as Awaited<ReturnType<typeof generateEsql>>);
+
+      const result = await generateVisualizationEsql(params);
+
+      expect(result).toEqual({ query: 'FROM logs-* | STATS c = COUNT() BY status', columns });
+      expect(mockedGenerateEsql).toHaveBeenCalledTimes(2);
+      const fallbackCall = mockedGenerateEsql.mock.calls[1][0];
+      expect(fallbackCall).toEqual(expect.objectContaining({ model: defaultModel }));
+      expect(fallbackCall.additionalContext).toContain(
+        'FROM logs-* | STATS c = COUNT() BY status.keyword'
+      );
+      expect(fallbackCall.additionalContext).toContain('Unknown column [status.keyword]');
+    });
+
+    it('skips the fallback when both models resolve to the same connector', async () => {
+      getDefaultModel.mockResolvedValue({
+        connector: { connectorId: 'fast-connector' },
+      } as ScopedModel);
+      mockedGenerateEsql.mockResolvedValue({
+        error: 'parsing_exception',
+      } as Awaited<ReturnType<typeof generateEsql>>);
+
+      const result = await generateVisualizationEsql(params);
+
+      expect(result).toEqual({ error: 'parsing_exception' });
+      expect(mockedGenerateEsql).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the fallback error when the fallback also fails', async () => {
+      mockedGenerateEsql
+        .mockResolvedValueOnce({ error: 'first error' } as Awaited<ReturnType<typeof generateEsql>>)
+        .mockResolvedValueOnce({ error: 'second error' } as Awaited<
+          ReturnType<typeof generateEsql>
+        >);
+
+      const result = await generateVisualizationEsql(params);
+
+      expect(result).toEqual({ error: 'second error' });
+      expect(mockedGenerateEsql).toHaveBeenCalledTimes(2);
+    });
+
+    it('propagates a thrown error without falling back', async () => {
+      mockedGenerateEsql.mockRejectedValueOnce(new Error('connector unavailable'));
+
+      await expect(generateVisualizationEsql(params)).rejects.toThrow('connector unavailable');
+      expect(mockedGenerateEsql).toHaveBeenCalledTimes(1);
+      expect(getDefaultModel).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { EffortLevels } from '@kbn/agent-builder-common';
 import type { ModelProvider, ScopedModel, ToolEventEmitter } from '@kbn/agent-builder-server';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
@@ -24,11 +23,9 @@ const mockedGenerateEsql = jest.mocked(generateEsql);
 
 const logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as Logger;
 const events = {} as ToolEventEmitter;
-const lowEffortModel = { connector: { connectorId: 'fast-connector' } } as ScopedModel;
 const defaultModel = { connector: { connectorId: 'default-connector' } } as ScopedModel;
-const selectModel = jest.fn();
 const getDefaultModel = jest.fn();
-const modelProvider = { selectModel, getDefaultModel } as unknown as ModelProvider;
+const modelProvider = { getDefaultModel } as unknown as ModelProvider;
 const asCurrentUser = { name: 'current-user-client' };
 const esClient = { asCurrentUser } as unknown as IScopedClusterClient;
 
@@ -44,7 +41,6 @@ const params = {
 describe('generateVisualizationEsql', () => {
   beforeEach(() => {
     mockedGenerateEsql.mockReset();
-    selectModel.mockReset().mockResolvedValue(lowEffortModel);
     getDefaultModel.mockReset().mockResolvedValue(defaultModel);
   });
 
@@ -143,7 +139,7 @@ describe('generateVisualizationEsql', () => {
   });
 
   describe('default-model fallback', () => {
-    it('runs on the low-effort model and does not fall back on success', async () => {
+    it('runs on the low-effort model with two attempts and does not fall back on success', async () => {
       mockedGenerateEsql.mockResolvedValue({ query: 'FROM logs-*' } as Awaited<
         ReturnType<typeof generateEsql>
       >);
@@ -151,10 +147,9 @@ describe('generateVisualizationEsql', () => {
       const result = await generateVisualizationEsql(params);
 
       expect(result).toEqual({ query: 'FROM logs-*', columns: undefined });
-      expect(selectModel).toHaveBeenCalledWith({ effortLevel: EffortLevels.low });
       expect(mockedGenerateEsql).toHaveBeenCalledTimes(1);
       expect(mockedGenerateEsql).toHaveBeenCalledWith(
-        expect.objectContaining({ model: lowEffortModel })
+        expect.objectContaining({ modelProvider, maxRetries: 2 })
       );
       expect(getDefaultModel).not.toHaveBeenCalled();
     });
@@ -176,25 +171,11 @@ describe('generateVisualizationEsql', () => {
       expect(result).toEqual({ query: 'FROM logs-* | STATS c = COUNT() BY status', columns });
       expect(mockedGenerateEsql).toHaveBeenCalledTimes(2);
       const fallbackCall = mockedGenerateEsql.mock.calls[1][0];
-      expect(fallbackCall).toEqual(expect.objectContaining({ model: defaultModel }));
+      expect(fallbackCall).toEqual(expect.objectContaining({ model: defaultModel, maxRetries: 1 }));
       expect(fallbackCall.additionalContext).toContain(
         'FROM logs-* | STATS c = COUNT() BY status.keyword'
       );
       expect(fallbackCall.additionalContext).toContain('Unknown column [status.keyword]');
-    });
-
-    it('skips the fallback when both models resolve to the same connector', async () => {
-      getDefaultModel.mockResolvedValue({
-        connector: { connectorId: 'fast-connector' },
-      } as ScopedModel);
-      mockedGenerateEsql.mockResolvedValue({
-        error: 'parsing_exception',
-      } as Awaited<ReturnType<typeof generateEsql>>);
-
-      const result = await generateVisualizationEsql(params);
-
-      expect(result).toEqual({ error: 'parsing_exception' });
-      expect(mockedGenerateEsql).toHaveBeenCalledTimes(1);
     });
 
     it('returns the fallback error when the fallback also fails', async () => {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.ts
@@ -7,7 +7,6 @@
 
 import type { EsqlEsqlColumnInfo } from '@elastic/elasticsearch/lib/api/types';
 import type { TimeRange } from '@kbn/agent-builder-common';
-import { EffortLevels } from '@kbn/agent-builder-common';
 import type { ModelProvider, ToolEventEmitter } from '@kbn/agent-builder-server';
 import type { Logger } from '@kbn/logging';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
@@ -94,11 +93,10 @@ const buildFallbackContext = (failedQuery: string | undefined, error: string): s
  * ensuring an unrunnable query never reaches config/spec authoring. On edits,
  * `existingQueries` seed the request so a query-changing edit is not blocked.
  *
- * Generation runs on the low-effort model first. When it soft-fails (no usable
- * query after the internal retries), one fallback run uses the default model,
- * seeded with the failing query. Thrown errors (infra) never trigger the
- * fallback, and it is skipped when both models resolve to the same connector
- * (no dedicated fast endpoint configured).
+ * Generation runs on the low-effort model first (two attempts). When it
+ * soft-fails (no usable query), one fallback attempt uses the default model,
+ * seeded with the failing query — three attempts in total. Thrown errors
+ * (infra) never trigger the fallback.
  */
 export const generateVisualizationEsql = async ({
   nlQuery,
@@ -123,8 +121,7 @@ export const generateVisualizationEsql = async ({
     ...(timeRange ? { timeRange } : {}),
   };
 
-  const lowEffortModel = await modelProvider.selectModel({ effortLevel: EffortLevels.low });
-  const response = await generateEsql({ ...requestParams, model: lowEffortModel });
+  const response = await generateEsql({ ...requestParams, modelProvider, maxRetries: 2 });
 
   if (response.query && !response.error) {
     return { query: response.query, columns: response.results?.columns };
@@ -132,18 +129,15 @@ export const generateVisualizationEsql = async ({
 
   const error = response.error ?? 'No queries generated';
 
-  const defaultModel = await modelProvider.getDefaultModel();
-  if (defaultModel.connector.connectorId === lowEffortModel.connector.connectorId) {
-    return { error };
-  }
-
   logger.warn(
     `ES|QL generation with the low-effort model failed (${error}), retrying with the default model`
   );
 
+  const defaultModel = await modelProvider.getDefaultModel();
   const fallbackResponse = await generateEsql({
     ...requestParams,
     model: defaultModel,
+    maxRetries: 1,
     additionalContext: buildFallbackContext(response.query, error),
   });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/shared/generate_visualization_esql.ts
@@ -7,6 +7,7 @@
 
 import type { EsqlEsqlColumnInfo } from '@elastic/elasticsearch/lib/api/types';
 import type { TimeRange } from '@kbn/agent-builder-common';
+import { EffortLevels } from '@kbn/agent-builder-common';
 import type { ModelProvider, ToolEventEmitter } from '@kbn/agent-builder-server';
 import type { Logger } from '@kbn/logging';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
@@ -75,6 +76,15 @@ export const buildEsqlEditContext = (
 };
 
 /**
+ * Context given to the default-model fallback run so it does not repeat the
+ * low-effort model's mistake.
+ */
+const buildFallbackContext = (failedQuery: string | undefined, error: string): string =>
+  failedQuery
+    ? `A previous attempt with a smaller model produced this failing query: "${failedQuery}" (error: ${error}). Avoid repeating this mistake.`
+    : `A previous attempt with a smaller model failed to produce a query (error: ${error}).`;
+
+/**
  * Resolve a visualization-ready ES|QL query, shared by the Lens and Vega
  * engines so both generate queries the same way.
  *
@@ -83,6 +93,12 @@ export const buildEsqlEditContext = (
  * failed when none was produced or the loop still reported an execution error,
  * ensuring an unrunnable query never reaches config/spec authoring. On edits,
  * `existingQueries` seed the request so a query-changing edit is not blocked.
+ *
+ * Generation runs on the low-effort model first. When it soft-fails (no usable
+ * query after the internal retries), one fallback run uses the default model,
+ * seeded with the failing query. Thrown errors (infra) never trigger the
+ * fallback, and it is skipped when both models resolve to the same connector
+ * (no dedicated fast endpoint configured).
  */
 export const generateVisualizationEsql = async ({
   nlQuery,
@@ -95,11 +111,9 @@ export const generateVisualizationEsql = async ({
   timeRange,
   extraInstructions,
 }: GenerateVisualizationEsqlParams): Promise<GeneratedVisualizationEsql> => {
-  const model = await modelProvider.getDefaultModel();
-  const response = await generateEsql({
+  const requestParams = {
     nlQuery: buildEsqlEditContext(nlQuery, existingQueries),
     index,
-    model,
     events,
     logger,
     esClient: esClient.asCurrentUser,
@@ -107,11 +121,35 @@ export const generateVisualizationEsql = async ({
       ? `${esqlAdditionalInstructions}\n${extraInstructions}`
       : esqlAdditionalInstructions,
     ...(timeRange ? { timeRange } : {}),
-  });
+  };
 
-  if (!response.query || response.error) {
-    return { error: response.error ?? 'No queries generated' };
+  const lowEffortModel = await modelProvider.selectModel({ effortLevel: EffortLevels.low });
+  const response = await generateEsql({ ...requestParams, model: lowEffortModel });
+
+  if (response.query && !response.error) {
+    return { query: response.query, columns: response.results?.columns };
   }
 
-  return { query: response.query, columns: response.results?.columns };
+  const error = response.error ?? 'No queries generated';
+
+  const defaultModel = await modelProvider.getDefaultModel();
+  if (defaultModel.connector.connectorId === lowEffortModel.connector.connectorId) {
+    return { error };
+  }
+
+  logger.warn(
+    `ES|QL generation with the low-effort model failed (${error}), retrying with the default model`
+  );
+
+  const fallbackResponse = await generateEsql({
+    ...requestParams,
+    model: defaultModel,
+    additionalContext: buildFallbackContext(response.query, error),
+  });
+
+  if (!fallbackResponse.query || fallbackResponse.error) {
+    return { error: fallbackResponse.error ?? 'No queries generated' };
+  }
+
+  return { query: fallbackResponse.query, columns: fallbackResponse.results?.columns };
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -65,10 +65,15 @@ describe('createVegaGraph', () => {
     // without a REFERENCE EXAMPLES block. Individual tests override this.
     selectInvoke = jest.fn().mockResolvedValue({ exampleIds: [] });
     withStructuredOutput = jest.fn(() => ({ invoke: selectInvoke }));
+    // The default and low-effort models share a connector so the default-model
+    // fallback in `generateVisualizationEsql` stays out of these tests.
+    const scopedModel = {
+      connector: { connectorId: 'default-connector' },
+      chatModel: { invoke, withStructuredOutput },
+    };
     modelProvider = {
-      getDefaultModel: jest.fn().mockResolvedValue({
-        chatModel: { invoke, withStructuredOutput },
-      }),
+      getDefaultModel: jest.fn().mockResolvedValue(scopedModel),
+      selectModel: jest.fn().mockResolvedValue(scopedModel),
     } as unknown as ModelProvider;
     mockedGenerateEsql.mockResolvedValue({ query: GENERATED_ESQL } as Awaited<
       ReturnType<typeof generateEsql>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/recover_esql.integration.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/recover_esql.integration.test.ts
@@ -68,8 +68,15 @@ describe.skip('recover_esql end-to-end (real build_config + real graph)', () => 
         }) +
         '\n```'
     );
+    // The default and low-effort models share a connector so the default-model
+    // fallback in `generateVisualizationEsql` stays out of this test.
+    const scopedModel = {
+      connector: { connectorId: 'default-connector' },
+      chatModel: { invoke },
+    };
     modelProvider = {
-      getDefaultModel: jest.fn().mockResolvedValue({ chatModel: { invoke } }),
+      getDefaultModel: jest.fn().mockResolvedValue(scopedModel),
+      selectModel: jest.fn().mockResolvedValue(scopedModel),
     } as unknown as ModelProvider;
     mockedValidateEsqlQuery.mockResolvedValue(undefined);
     // A visual-only edit: the generator keeps the seeded query unchanged and


### PR DESCRIPTION
## Summary

Since #276893, visualization ES|QL generation always runs on the default model. This PR brings back the cheaper low-effort model for the first attempt and keeps the default model as a fallback: when the low-effort run produces no usable query after its internal retries, we retry once with the default model, seeding it with the failing query and error (usually a small slip like missing backticks) so it doesn't repeat the mistake.

A few guardrails:
- The fallback only triggers on soft failures (no valid query). Thrown errors are infra problems and keep propagating.
- It's skipped when no dedicated fast inference endpoint is configured, since both models would resolve to the same connector anyway.

The change lives entirely in `generateVisualizationEsql`, so Lens and Vega, in both the dashboard and visualization tools, pick it up without any changes of their own.

Example [trace](https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDoxMzEw/spans/b9b88c43121cb845c81b02c79924ba86?selectedSpanNodeId=U3Bhbjo4OTQzNTA%3D) to showcase the fallback feature.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->