### PR TITLE
[9.5] [ES|QL][Vega] Propagates the approximation value from the switch (#276999)

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -288,3 +288,4 @@ export {
 export { apiCanFocusPanel, type CanFocusPanel } from './interfaces/containers/can_focus_panel';
 
 export { apiPublishesESQLQuery, type PublishesESQLQuery } from './interfaces/publishes_esql_query';
+export { apiPublishesEsqlUsage, type PublishesEsqlUsage } from './interfaces/publishes_esql_usage';

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_esql_usage.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_esql_usage.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PublishingSubject } from '../publishing_subject';
+
+/**
+ * For embeddables that can use ES|QL internally without necessarily publishing
+ * an ES|QL `query$` (e.g. a Vega spec with one or more ES|QL data sources).
+ */
+export interface PublishesEsqlUsage {
+  usesEsql$: PublishingSubject<boolean>;
+}
+
+export const apiPublishesEsqlUsage = (unknownApi: unknown): unknownApi is PublishesEsqlUsage =>
+  Boolean(unknownApi && (unknownApi as PublishesEsqlUsage)?.usesEsql$ !== undefined);

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.test.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.test.ts
@@ -196,4 +196,76 @@ describe('SearchAPI', () => {
       });
     });
   });
+
+  describe('searchEsql', () => {
+    const esqlRequest = { query: 'FROM logs-*', name: 'esql-request' };
+
+    test('should call search with the esql_async strategy', (done) => {
+      const searchAPI = new SearchAPI(mockDependencies);
+      searchAPI.searchEsql([esqlRequest]).subscribe(() => {
+        expect(mockSearch).toHaveBeenCalled();
+        const searchOptions = mockSearch.mock.calls[0][1];
+        expect(searchOptions.strategy).toBe('esql_async');
+        done();
+      });
+    });
+
+    test('should include approximation in search options when isApproximate is true', (done) => {
+      const searchAPI = new SearchAPI(
+        mockDependencies,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true
+      );
+      searchAPI.searchEsql([esqlRequest]).subscribe(() => {
+        const searchOptions = mockSearch.mock.calls[0][1];
+        expect(searchOptions.approximation).toBe(true);
+        done();
+      });
+    });
+
+    test('should default approximation to false when isApproximate is not provided', (done) => {
+      const searchAPI = new SearchAPI(mockDependencies);
+      searchAPI.searchEsql([esqlRequest]).subscribe(() => {
+        const searchOptions = mockSearch.mock.calls[0][1];
+        expect(searchOptions.approximation).toBe(false);
+        done();
+      });
+    });
+
+    test('should include projectRouting and approximation in the inspector request json', (done) => {
+      const jsonMock = jest.fn();
+      const inspectorAdapters = {
+        requests: {
+          start: jest.fn().mockReturnValue({
+            json: jsonMock,
+            stats: jest.fn().mockReturnThis(),
+            ok: jest.fn(),
+          }),
+        },
+      };
+      const searchAPI = new SearchAPI(
+        mockDependencies,
+        undefined,
+        inspectorAdapters as any,
+        undefined,
+        undefined,
+        '_alias:_origin',
+        true
+      );
+      searchAPI.searchEsql([esqlRequest]).subscribe(() => {
+        expect(jsonMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: 'FROM logs-*',
+            projectRouting: '_alias:_origin',
+            approximation: true,
+          })
+        );
+        done();
+      });
+    });
+  });
 });

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
@@ -56,7 +56,9 @@ export class SearchAPI {
     public readonly inspectorAdapters?: VegaInspectorAdapters,
     private readonly searchSessionId?: string,
     private readonly executionContext?: KibanaExecutionContext,
-    public readonly projectRouting?: ProjectRouting
+    public readonly projectRouting?: ProjectRouting,
+    /** Only applies to ES|QL requests, see {@link searchEsql} */
+    private readonly isApproximate: boolean = false
   ) {}
 
   search(searchRequests: SearchRequest[]) {
@@ -153,7 +155,11 @@ export class SearchAPI {
                 ...request,
                 searchSessionId: this.searchSessionId,
               });
-              requestResponders[requestId].json(restRequest);
+              requestResponders[requestId].json({
+                ...restRequest,
+                projectRouting: this.projectRouting,
+                approximation: this.isApproximate,
+              });
             }
           }),
           switchMap(() => {
@@ -166,6 +172,7 @@ export class SearchAPI {
                   sessionId: this.searchSessionId,
                   executionContext: this.executionContext,
                   projectRouting: this.projectRouting,
+                  approximation: this.isApproximate,
                 }
               )
               .pipe(

--- a/src/platform/plugins/private/vis_types/vega/public/lib/spec_uses_esql.test.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/lib/spec_uses_esql.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { specUsesEsql } from './spec_uses_esql';
+
+describe('specUsesEsql', () => {
+  it('should return true when data is a single ES|QL data object', () => {
+    const spec = {
+      data: {
+        name: 'metric',
+        url: {
+          '%type%': 'esql',
+          query: 'FROM logs-* | STATS count=COUNT()',
+        },
+      },
+    };
+
+    expect(specUsesEsql(spec)).toBe(true);
+  });
+
+  it('should return true when at least one data object in an array is ES|QL', () => {
+    const spec = {
+      data: [
+        {
+          name: 'regular',
+          url: {
+            '%type%': 'elasticsearch',
+            index: 'logs-*',
+          },
+        },
+        {
+          name: 'metric',
+          url: {
+            '%type%': 'esql',
+            query: 'FROM logs-* | STATS count=COUNT()',
+          },
+        },
+      ],
+    };
+
+    expect(specUsesEsql(spec)).toBe(true);
+  });
+
+  it('should return false when no data object uses ES|QL', () => {
+    const spec = {
+      data: [
+        {
+          name: 'regular',
+          url: {
+            '%type%': 'elasticsearch',
+            index: 'logs-*',
+          },
+        },
+      ],
+    };
+
+    expect(specUsesEsql(spec)).toBe(false);
+  });
+
+  it('should return false when the spec has no data', () => {
+    expect(specUsesEsql({})).toBe(false);
+  });
+
+  it('should return false when data.url is a string, not an ES|QL object', () => {
+    const spec = {
+      data: {
+        url: 'https://example.com/data.json',
+      },
+    };
+
+    expect(specUsesEsql(spec)).toBe(false);
+  });
+});

--- a/src/platform/plugins/private/vis_types/vega/public/lib/spec_uses_esql.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/lib/spec_uses_esql.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { CONSTANTS } from '../data_model/types';
+import type { Data, VegaSpec } from '../data_model/types';
+
+/**
+ * Whether a Vega specification contains at least one ES|QL data source.
+ */
+export function specUsesEsql(spec: VegaSpec): boolean {
+  const isEsqlDataObject = (dataObj: Data) =>
+    Boolean(dataObj.url && dataObj.url[CONSTANTS.TYPE] === 'esql');
+
+  if (!spec.data) return false;
+
+  return Array.isArray(spec.data) ? spec.data.some(isEsqlDataObject) : isEsqlDataObject(spec.data);
+}

--- a/src/platform/plugins/private/vis_types/vega/public/vega_fn.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_fn.ts
@@ -71,6 +71,7 @@ export const createVegaFn = (
       searchSessionId: context.getSearchSessionId(),
       executionContext: context.getExecutionContext(),
       projectRouting: context.getSearchContext().projectRouting,
+      isApproximate: context.getSearchContext().isApproximate ?? false,
     });
 
     return {

--- a/src/platform/plugins/private/vis_types/vega/public/vega_request_handler.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_request_handler.ts
@@ -29,6 +29,8 @@ interface VegaRequestHandlerParams {
   searchSessionId?: string;
   executionContext?: KibanaExecutionContext;
   projectRouting?: ProjectRouting;
+  /** Only applies to ES|QL-backed vega data sources */
+  isApproximate: boolean;
 }
 
 interface VegaRequestHandlerContext {
@@ -56,6 +58,7 @@ export function createVegaRequestHandler(
     searchSessionId,
     executionContext,
     projectRouting,
+    isApproximate,
   }: VegaRequestHandlerParams) {
     const { search } = getData();
     const dataViews = getDataViews();
@@ -71,7 +74,8 @@ export function createVegaRequestHandler(
         context.inspectorAdapters,
         searchSessionId,
         executionContext,
-        projectRouting
+        projectRouting,
+        isApproximate
       );
     }
 

--- a/src/platform/plugins/private/vis_types/vega/public/vega_type.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_type.ts
@@ -17,6 +17,7 @@ import { VIS_EVENT_TO_TRIGGER, VisGroups } from '@kbn/visualizations-plugin/publ
 import { getDefaultSpec } from './default_spec';
 import { extractIndexPatternsFromSpec } from './lib/extract_index_pattern';
 import { extractProjectRoutingOverrides } from './lib/extract_project_routing_overrides';
+import { specUsesEsql } from './lib/spec_uses_esql';
 import { createInspectorAdapters } from './vega_inspector';
 import { toExpressionAst } from './to_ast';
 import { getInfoMessage } from './components/vega_info_message';
@@ -72,6 +73,16 @@ export const vegaVisType: VisTypeDefinition<VisParams> = {
       // spec is invalid
     }
     return undefined;
+  },
+  usesEsql: (visParams) => {
+    try {
+      const spec = parse(visParams.spec, { legacyRoot: false, keepWsc: true });
+
+      return specUsesEsql(spec);
+    } catch (e) {
+      // spec is invalid
+    }
+    return false;
   },
   inspectorAdapters: createInspectorAdapters,
   /**

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { BehaviorSubject } from 'rxjs';
+import { waitFor } from '@testing-library/react';
 
 import type { ViewMode } from '@kbn/presentation-publishing';
 import { setMockedPresentationUtilServices } from '@kbn/presentation-util-plugin/public/mocks';
@@ -239,5 +240,53 @@ describe('Internal dashboard top nav', () => {
       }),
       {}
     );
+  });
+
+  describe('esqlApproximation toggle', () => {
+    it('should be disabled when there is no ES|QL panel', async () => {
+      const { api, internalApi } = buildMockDashboardApi();
+
+      renderWithChrome(
+        <DashboardContext.Provider value={api}>
+          <DashboardInternalContext.Provider value={internalApi}>
+            <InternalDashboardTopNav redirectTo={jest.fn()} />
+          </DashboardInternalContext.Provider>
+        </DashboardContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(unifiedSearchService.ui.SearchBar).toHaveBeenCalledWith(
+          expect.objectContaining({
+            esqlApproximation: expect.objectContaining({ disabled: true }),
+          }),
+          {}
+        );
+      });
+    });
+
+    it('should be enabled when a panel publishes usesEsql$ as true (e.g. a Vega panel using ES|QL)', async () => {
+      const { api, internalApi } = buildMockDashboardApi();
+      api.registerChildApi({
+        uuid: 'vega-panel',
+        usesEsql$: new BehaviorSubject(true),
+      } as unknown as Parameters<typeof api.registerChildApi>[0]);
+
+      renderWithChrome(
+        <DashboardContext.Provider value={api}>
+          <DashboardInternalContext.Provider value={internalApi}>
+            <InternalDashboardTopNav redirectTo={jest.fn()} />
+          </DashboardInternalContext.Provider>
+        </DashboardContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(unifiedSearchService.ui.SearchBar).toHaveBeenCalledWith(
+          expect.objectContaining({
+            esqlApproximation: expect.objectContaining({ disabled: false }),
+          }),
+          {}
+        );
+      });
+    });
   });
 });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.test.tsx
@@ -246,7 +246,7 @@ describe('Internal dashboard top nav', () => {
     it('should be disabled when there is no ES|QL panel', async () => {
       const { api, internalApi } = buildMockDashboardApi();
 
-      renderWithChrome(
+      renderWithI18n(
         <DashboardContext.Provider value={api}>
           <DashboardInternalContext.Provider value={internalApi}>
             <InternalDashboardTopNav redirectTo={jest.fn()} />
@@ -271,7 +271,7 @@ describe('Internal dashboard top nav', () => {
         usesEsql$: new BehaviorSubject(true),
       } as unknown as Parameters<typeof api.registerChildApi>[0]);
 
-      renderWithChrome(
+      renderWithI18n(
         <DashboardContext.Provider value={api}>
           <DashboardInternalContext.Provider value={internalApi}>
             <InternalDashboardTopNav redirectTo={jest.fn()} />

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -9,7 +9,7 @@
 
 import deepEqual from 'fast-deep-equal';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { distinctUntilChanged, map } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map } from 'rxjs';
 import UseUnmount from 'react-use/lib/useUnmount';
 
 import type { EuiBreadcrumb, UseEuiTheme } from '@elastic/eui';
@@ -32,8 +32,10 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { getManagedContentBadge } from '@kbn/managed-content-badge';
 import type { TopNavMenuBadgeProps, TopNavMenuProps } from '@kbn/navigation-plugin/public';
 import {
+  apiPublishesEsqlUsage,
   apiPublishesUnifiedSearch,
   combineCompatibleChildrenApis,
+  type PublishesEsqlUsage,
   type PublishesUnifiedSearch,
   useBatchedPublishingSubjects,
 } from '@kbn/presentation-publishing';
@@ -141,12 +143,25 @@ export function InternalDashboardTopNav({
 
   const [hasEsqlPanel, setHasEsqlPanel] = useState(false);
   useEffect(() => {
-    const subscription = combineCompatibleChildrenApis<
+    const hasEsqlQuery$ = combineCompatibleChildrenApis<
       PublishesUnifiedSearch,
       (Query | AggregateQuery | undefined)[]
-    >(dashboardApi, 'query$', apiPublishesUnifiedSearch, [])
+    >(dashboardApi, 'query$', apiPublishesUnifiedSearch, []).pipe(
+      map((queries) => queries.some((q) => isOfAggregateQueryType(q)))
+    );
+
+    // Vega panels can embed ES|QL data sources directly in their spec, without ever
+    // publishing an aggregate query$, so they publish their own usesEsql$ signal instead.
+    const hasEsqlVegaPanel$ = combineCompatibleChildrenApis<PublishesEsqlUsage, boolean[]>(
+      dashboardApi,
+      'usesEsql$',
+      apiPublishesEsqlUsage,
+      []
+    ).pipe(map((usesEsqlValues) => usesEsqlValues.some(Boolean)));
+
+    const subscription = combineLatest([hasEsqlQuery$, hasEsqlVegaPanel$])
       .pipe(
-        map((queries) => queries.some((q) => isOfAggregateQueryType(q))),
+        map(([hasEsqlQuery, hasEsqlVegaPanel]) => hasEsqlQuery || hasEsqlVegaPanel),
         distinctUntilChanged()
       )
       .subscribe(setHasEsqlPanel);

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -1685,6 +1685,22 @@ describe('SearchInterceptor', () => {
         expect(mockCoreSetup.http.post).toBeCalledTimes(1);
       });
 
+      test('should not return from cache when only approximation differs', async () => {
+        mockCoreSetup.http.post.mockImplementation(getHttpMock(basicCompleteResponse));
+
+        searchInterceptor
+          .search(basicReq, { sessionId, approximation: false })
+          .subscribe({ next, error, complete });
+        await timeTravel(10);
+        expect(mockCoreSetup.http.post).toBeCalledTimes(1);
+
+        searchInterceptor
+          .search(basicReq, { sessionId, approximation: true })
+          .subscribe({ next, error, complete });
+        await timeTravel(10);
+        expect(mockCoreSetup.http.post).toBeCalledTimes(2);
+      });
+
       test('aborting a search that didnt get any response should retrigger search', async () => {
         mockCoreSetup.http.post.mockImplementation(getHttpMock(basicCompleteResponse));
 

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -208,11 +208,12 @@ export class SearchInterceptor {
     request: IKibanaSearchRequest,
     options: IAsyncSearchOptions
   ): Observable<string | undefined> {
-    const { sessionId, projectRouting } = options;
+    const { sessionId, projectRouting, approximation } = options;
     const hashOptions = {
       ...request.params,
       sessionId,
       projectRouting,
+      approximation,
     };
 
     if (!sessionId) return of(undefined); // don't use cache if doesn't belong to a session

--- a/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.test.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.test.ts
@@ -52,6 +52,7 @@ describe('getExpressionRendererProps', () => {
           filters: [],
         },
         projectRouting: '_alias:_origin',
+        isApproximate: false,
         timeRange: { from: 'now-15m', to: 'now' },
         disableTriggers: false,
         settings: {
@@ -81,6 +82,7 @@ describe('getExpressionRendererProps', () => {
           filters: [],
         },
         projectRouting: undefined,
+        isApproximate: false,
         timeRange: { from: 'now-15m', to: 'now' },
         disableTriggers: false,
         settings: {
@@ -110,6 +112,7 @@ describe('getExpressionRendererProps', () => {
           filters: [],
         },
         projectRouting: '_alias:*',
+        isApproximate: false,
         timeRange: { from: 'now-15m', to: 'now' },
         disableTriggers: false,
         settings: {
@@ -127,6 +130,66 @@ describe('getExpressionRendererProps', () => {
       expect(result.params?.searchContext).toEqual(
         expect.objectContaining({
           projectRouting: '_alias:*',
+        })
+      );
+    });
+  });
+
+  describe('isApproximate handling', () => {
+    it('should include isApproximate in search context when provided', async () => {
+      const vis = createMockVis();
+      const result = await getExpressionRendererProps({
+        unifiedSearch: {
+          query: { query: '', language: 'kuery' },
+          filters: [],
+        },
+        isApproximate: true,
+        timeRange: { from: 'now-15m', to: 'now' },
+        disableTriggers: false,
+        settings: {
+          syncColors: true,
+          syncCursor: true,
+          syncTooltips: false,
+        },
+        vis,
+        onRender: jest.fn(),
+        onEvent: jest.fn(),
+        onData: jest.fn(),
+      });
+
+      expect(result.params).toBeDefined();
+      expect(result.params?.searchContext).toEqual(
+        expect.objectContaining({
+          isApproximate: true,
+        })
+      );
+    });
+
+    it('should include isApproximate in search context when false', async () => {
+      const vis = createMockVis();
+      const result = await getExpressionRendererProps({
+        unifiedSearch: {
+          query: { query: '', language: 'kuery' },
+          filters: [],
+        },
+        isApproximate: false,
+        timeRange: { from: 'now-15m', to: 'now' },
+        disableTriggers: false,
+        settings: {
+          syncColors: true,
+          syncCursor: true,
+          syncTooltips: false,
+        },
+        vis,
+        onRender: jest.fn(),
+        onEvent: jest.fn(),
+        onData: jest.fn(),
+      });
+
+      expect(result.params).toBeDefined();
+      expect(result.params?.searchContext).toEqual(
+        expect.objectContaining({
+          isApproximate: false,
         })
       );
     });

--- a/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.ts
@@ -24,6 +24,7 @@ interface GetExpressionRendererPropsParams {
     query?: Query | AggregateQuery;
   };
   projectRouting?: ProjectRouting;
+  isApproximate: boolean;
   timeRange?: TimeRange;
   disableTriggers?: boolean;
   settings: {
@@ -47,6 +48,7 @@ export const getExpressionRendererProps: (params: GetExpressionRendererPropsPara
 }> = async ({
   unifiedSearch: { query, filters },
   projectRouting,
+  isApproximate,
   settings: { syncColors = true, syncCursor = true, syncTooltips = false },
   disableTriggers = false,
   parentExecutionContext,
@@ -85,6 +87,7 @@ export const getExpressionRendererProps: (params: GetExpressionRendererPropsPara
       filters,
       disableWarningToasts: true,
       projectRouting,
+      isApproximate,
     },
     variables: {
       embeddableTitle: vis.title,

--- a/src/platform/plugins/shared/visualizations/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/types.ts
@@ -17,6 +17,7 @@ import type {
   HasSupportedTriggers,
   PublishesDataLoading,
   PublishesDataViews,
+  PublishesEsqlUsage,
   PublishesProjectRoutingOverrides,
   PublishesRendered,
   PublishesTimeRange,
@@ -63,6 +64,7 @@ export type VisualizeApi = Partial<HasEditCapabilities> &
   PublishesDataLoading &
   PublishesRendered &
   PublishesProjectRoutingOverrides &
+  PublishesEsqlUsage &
   Required<PublishesTitle> &
   HasVisualizeConfig &
   HasInspectorAdapters &

--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.test.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.test.tsx
@@ -14,10 +14,19 @@ import { BehaviorSubject } from 'rxjs';
 import { initializeDrilldownsManager } from '@kbn/embeddable-plugin/public/drilldowns/drilldowns_manager';
 import type { SerializedVis } from '../vis';
 
+const mockVisTypeRegistry: Record<string, { name: string; usesEsql?: () => boolean }> = {
+  metric: { name: 'metric' },
+  'vega-esql': { name: 'vega', usesEsql: () => true },
+  'vega-no-esql': { name: 'vega', usesEsql: () => false },
+};
+
 jest.mock('./create_vis_instance', () => {
   return {
     createVisInstance: async (serializedVis: SerializedVis) => ({
       ...serializedVis,
+      type: mockVisTypeRegistry[serializedVis.type as unknown as string] ?? {
+        name: serializedVis.type,
+      },
       serialize: () => serializedVis,
     }),
   };
@@ -95,6 +104,52 @@ describe('visualizeEmbeddable', () => {
         done();
       });
       embeddableApi.setTitle('cute puppies');
+    });
+  });
+
+  describe('usesEsql$', () => {
+    test('should be false by default when the vis type does not provide usesEsql', () => {
+      expect(embeddableApi.usesEsql$.getValue()).toBe(false);
+    });
+
+    const buildEmbeddableWithVisType = async (type: string) => {
+      const parent = {};
+      const uuid = '1';
+      const finalizeApi = (api: any) => ({
+        ...api,
+        uuid,
+        parent,
+        type: VISUALIZE_EMBEDDABLE_TYPE,
+        phase$: new BehaviorSubject(undefined),
+      });
+      const { api } = await visualizeEmbeddableFactory.buildEmbeddable({
+        initializeDrilldownsManager,
+        initialState: {
+          savedVis: {
+            title: 'esql test',
+            type,
+            data: {
+              aggs: [],
+              searchSource: {},
+            },
+            params: {},
+          },
+        },
+        finalizeApi,
+        uuid: '1',
+        parentApi: {},
+      });
+      return api;
+    };
+
+    test('should reflect true when the vis type reports it uses ES|QL', async () => {
+      const api = await buildEmbeddableWithVisType('vega-esql');
+      expect(api.usesEsql$.getValue()).toBe(true);
+    });
+
+    test('should reflect false when the vis type reports it does not use ES|QL', async () => {
+      const api = await buildEmbeddableWithVisType('vega-no-esql');
+      expect(api.usesEsql$.getValue()).toBe(false);
     });
   });
 });

--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -98,6 +98,10 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
       initialProjectRoutingOverrides
     );
 
+    const usesEsql$ = new BehaviorSubject<boolean>(
+      initialVisInstance.type.usesEsql?.(initialVisInstance.params) ?? false
+    );
+
     // Track UI state
     const onUiStateChange = () => serializedVis$.next(vis$.getValue().serialize());
 
@@ -117,6 +121,11 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
             if (!isEqual(projectRoutingOverrides$.getValue(), newOverrides)) {
               projectRoutingOverrides$.next(newOverrides);
             }
+          }
+
+          const usesEsql = vis.type.usesEsql?.(vis.params) ?? false;
+          if (usesEsql$.getValue() !== usesEsql) {
+            usesEsql$.next(usesEsql);
           }
 
           const { params, abortController } = await getExpressionParams();
@@ -256,6 +265,7 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
       dataLoading$,
       dataViews$: new BehaviorSubject<DataView[] | undefined>(initialDataViews),
       projectRoutingOverrides$,
+      usesEsql$,
       rendered$: hasRendered$,
       supportedTriggers: () => [
         ON_OPEN_PANEL_MENU,
@@ -344,6 +354,7 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
           const projectRouting = apiPublishesProjectRouting(parentApi)
             ? data.projectRouting
             : undefined;
+          const isApproximate = data.isApproximate;
           const searchSessionId = apiPublishesSearchSession(parentApi) ? data.searchSessionId : '';
           searchSessionId$.next(searchSessionId);
           const settings = apiPublishesSettings(parentApi)
@@ -380,6 +391,7 @@ export const visualizeEmbeddableFactory: EmbeddablePublicDefinition<
             return await getExpressionRendererProps({
               unifiedSearch,
               projectRouting,
+              isApproximate,
               vis: vis$.getValue(),
               settings,
               disableTriggers,

--- a/src/platform/plugins/shared/visualizations/public/vis_types/base_vis_type.ts
+++ b/src/platform/plugins/shared/visualizations/public/vis_types/base_vis_type.ts
@@ -48,6 +48,7 @@ export class BaseVisType<TVisParams extends VisParams = VisParams> {
   public readonly setup;
   public readonly getUsedIndexPattern;
   public readonly getProjectRoutingOverrides;
+  public readonly usesEsql;
   public readonly inspectorAdapters;
   public readonly fetchDatatable: boolean;
   public readonly toExpressionAst;
@@ -85,6 +86,7 @@ export class BaseVisType<TVisParams extends VisParams = VisParams> {
     this.hierarchicalData = opts.hierarchicalData ?? false;
     this.getUsedIndexPattern = opts.getUsedIndexPattern;
     this.getProjectRoutingOverrides = opts.getProjectRoutingOverrides;
+    this.usesEsql = opts.usesEsql;
     this.inspectorAdapters = opts.inspectorAdapters;
     this.fetchDatatable = opts.fetchDatatable ?? false;
     this.toExpressionAst = opts.toExpressionAst;

--- a/src/platform/plugins/shared/visualizations/public/vis_types/types.ts
+++ b/src/platform/plugins/shared/visualizations/public/vis_types/types.ts
@@ -135,6 +135,13 @@ export interface VisTypeDefinition<TVisParams extends VisParams> {
     visParams: VisParams
   ) => Promise<Array<{ name?: string; value: string }> | undefined>;
 
+  /**
+   * Some visualizations (e.g. Vega) can use ES|QL internally without exposing it as
+   * their top-level query. This method should report whether the current vis params
+   * make use of ES|QL, so dashboards can react to it (e.g. enabling ES|QL-only controls).
+   */
+  readonly usesEsql?: (visParams: VisParams) => boolean;
+
   readonly isAccessible?: boolean;
   /**
    * It is the visualization icon, displayed on the wizard.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ES|QL][Vega] Propagates the approximation value from the switch (#276999)](https://github.com/elastic/kibana/pull/276999)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratou","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T07:21:18Z","message":"[ES|QL][Vega] Propagates the approximation value from the switch (#276999)\n\n## Summary\n\nPropagate the approximate value to the vega ES|QL charts.\n\n<img width=\"2502\" height=\"814\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5dcc2ddd-5a60-4801-9c6c-a5440508055b\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"6d88cf48c50f370cce6ea96d4dc7013afd1e2353","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Feature:Vega","Team:Visualizations","Feature:ES|QL","backport:version","v9.5.0","v9.6.0"],"title":"[ES|QL][Vega] Propagates the approximation value from the switch","number":276999,"url":"https://github.com/elastic/kibana/pull/276999","mergeCommit":{"message":"[ES|QL][Vega] Propagates the approximation value from the switch (#276999)\n\n## Summary\n\nPropagate the approximate value to the vega ES|QL charts.\n\n<img width=\"2502\" height=\"814\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5dcc2ddd-5a60-4801-9c6c-a5440508055b\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"6d88cf48c50f370cce6ea96d4dc7013afd1e2353"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276999","number":276999,"mergeCommit":{"message":"[ES|QL][Vega] Propagates the approximation value from the switch (#276999)\n\n## Summary\n\nPropagate the approximate value to the vega ES|QL charts.\n\n<img width=\"2502\" height=\"814\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5dcc2ddd-5a60-4801-9c6c-a5440508055b\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"6d88cf48c50f370cce6ea96d4dc7013afd1e2353"}}]}] BACKPORT-->