### PR TITLE
[8.19] [scout] exclude fixtures updates from test-only mode (#275978)

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/utils.ts
+++ b/.buildkite/pipeline-utils/affected-packages/utils.ts
@@ -42,17 +42,23 @@ export function touchedCriticalFiles(files: string[], criticalFiles: string[]): 
  * Returns true when every file matches a `scope` pattern, treating files
  * that match an `ignore` pattern as irrelevant. Returns false on an empty
  * list or as soon as a file matches neither.
+ *
+ * A file matching an `exclude` pattern forces `false` immediately — it sits
+ * inside the scope but is deliberately treated as out-of-scope (e.g. Scout `fixtures/`).
  */
 export function allChangedFilesInScope(
   files: readonly string[],
   scope: readonly string[],
-  ignore: readonly string[] = []
+  ignore: readonly string[] = [],
+  exclude: readonly string[] = []
 ): boolean {
   const ignoreMatchers = compileMatchers(ignore);
   const scopeMatchers = compileMatchers(scope);
+  const excludeMatchers = compileMatchers(exclude);
   let hasScopedChange = false;
   for (const file of files) {
     if (matchesAny(file, ignoreMatchers)) continue;
+    if (matchesAny(file, excludeMatchers)) return false;
     if (!matchesAny(file, scopeMatchers)) return false;
     hasScopedChange = true;
   }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.test.ts
@@ -30,13 +30,40 @@ describe('isScoutTestsOnlyDiff', () => {
     ).toBe(true);
   });
 
-  it('returns true for shared test code (fixtures, page objects) inside a scope', () => {
+  it('returns true for co-located shared test code (helpers) inside a scope', () => {
     expect(
       isScoutTestsOnlyDiff([
-        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
         'src/platform/plugins/shared/discover/test/scout/ui/helpers/build_query.ts',
       ])
     ).toBe(true);
+  });
+
+  it('returns false for fixtures / page objects (cross-plugin importable surface)', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+      ])
+    ).toBe(false);
+    // namespaced fixtures, both placements
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/apm.ts',
+      ])
+    ).toBe(false);
+    expect(
+      isScoutTestsOnlyDiff([
+        'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/fixtures/data.ts',
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false when a fixtures change is mixed with in-scope specs', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/tests/foo.spec.ts',
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+      ])
+    ).toBe(false);
   });
 
   it('returns true for custom Scout server directories (scout_*)', () => {

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
@@ -13,13 +13,17 @@ import { allChangedFilesInScope } from '../../affected-packages';
  * Scout-tests-only fast path for the Jest/FTR orchestrator.
  *
  * When a PR's diff contains only Scout test files (Playwright configs, specs,
- * page objects, fixtures, generated `.meta` manifests), no Jest unit/integration
- * or FTR config can be affected, so the orchestrator skips emitting them entirely.
- * The Scout pipeline still runs its own selective testing in parallel.
+ * generated `.meta` manifests, co-located helpers/constants), no Jest
+ * unit/integration or FTR config can be affected, so the orchestrator skips
+ * emitting them entirely. The Scout pipeline still runs its own selective
+ * testing in parallel.
  *
- * The two arrays below duplicate constants in `@kbn/scout-info`'s `paths.ts`
+ * Changes under a Scout `fixtures/` directory are excluded: their entry points
+ * can be imported by other plugins, so they're treated as regular changes.
+ *
+ * The three arrays below duplicate constants in `@kbn/scout-info`'s `paths.ts`
  * (the source of truth) — `pipeline-utils/` may not import `@kbn/*`. A unit test
- * in `kbn-scout-info` fails CI if the two copies drift.
+ * in `kbn-scout-info` fails CI if the copies drift.
  */
 
 const SCOUT_TESTS_ONLY_IGNORE_PATTERNS: readonly string[] = [
@@ -35,16 +39,22 @@ const SCOUT_TESTS_ONLY_SCOPE_GLOBS: readonly string[] = [
   '**/test/scout{_*,}/*/.meta/{api,ui}/**',
 ];
 
+const SCOUT_TESTS_ONLY_EXCLUDE_GLOBS: readonly string[] = [
+  '**/test/scout{_*,}/{api,ui}/fixtures/**',
+  '**/test/scout{_*,}/*/{api,ui}/fixtures/**',
+];
+
 /**
  * Returns `true` only when every changed file is either documentation noise
- * (README, *.md, CHANGELOG*) or sits inside a Scout test scope. Falls back
- * to `false` on an empty diff or anything unrecognised, so unrelated changes
- * keep using the default test discovery.
+ * (README, *.md, CHANGELOG*) or sits inside a Scout test scope, excluding
+ * `fixtures/` changes. Falls back to `false` on an empty diff or anything
+ * unrecognised, so unrelated changes keep using the default test discovery.
  */
 export function isScoutTestsOnlyDiff(changedFiles: readonly string[]): boolean {
   return allChangedFilesInScope(
     changedFiles,
     SCOUT_TESTS_ONLY_SCOPE_GLOBS,
-    SCOUT_TESTS_ONLY_IGNORE_PATTERNS
+    SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
+    SCOUT_TESTS_ONLY_EXCLUDE_GLOBS
   );
 }

--- a/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
@@ -21,6 +21,7 @@ import {
   TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX,
   SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
   SCOUT_TESTS_ONLY_SCOPE_GLOBS,
+  SCOUT_TESTS_ONLY_EXCLUDE_GLOBS,
 } from './paths';
 
 describe('Scout path globs', () => {
@@ -117,6 +118,45 @@ describe('Scout path globs', () => {
 
     it.each(shouldNotMatch)('does not match: %s', (testPath) => {
       expect(mm.isMatch(testPath, SCOUT_CONFIG_MANIFEST_PATH_GLOB)).toBe(false);
+    });
+  });
+
+  describe('SCOUT_TESTS_ONLY_EXCLUDE_GLOBS', () => {
+    const shouldMatch = [
+      // fixtures directly under the category
+      'src/platform/plugins/shared/my_plugin/test/scout/ui/fixtures/index.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/api/fixtures/params.ts',
+      // page objects (live under fixtures/)
+      'src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts',
+      // namespace nested under fixtures
+      'src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/apm.ts',
+      // namespace before the category (matches the second glob form)
+      'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/fixtures/data.ts',
+      // custom scout_<server> scope
+      'src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_list_page.ts',
+    ];
+
+    const shouldNotMatch = [
+      // non-fixtures files inside a scope stay on the tests-only fast path
+      'src/platform/plugins/shared/my_plugin/test/scout/ui/tests/a.spec.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/ui/parallel_tests/b.spec.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/ui/helpers/foo.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/ui/playwright.config.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/.meta/ui/standard.json',
+      // fixtures outside any scout scope must not match
+      'src/platform/plugins/shared/my_plugin/public/fixtures/foo.ts',
+    ];
+
+    it.each(shouldMatch)('matches: %s', (testPath) => {
+      expect(picomatch.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
+        true
+      );
+    });
+
+    it.each(shouldNotMatch)('does not match: %s', (testPath) => {
+      expect(picomatch.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
+        false
+      );
     });
   });
 });
@@ -512,6 +552,13 @@ describe('Scout tests-only patterns duplicated in pipeline-utils/selective_scout
 
   it.each(SCOUT_TESTS_ONLY_SCOPE_GLOBS)(
     'selective_scout.ts contains scope glob verbatim: %s',
+    (pattern) => {
+      expect(containsPatternLiteral(duplicateSource, pattern)).toBe(true);
+    }
+  );
+
+  it.each(SCOUT_TESTS_ONLY_EXCLUDE_GLOBS)(
+    'selective_scout.ts contains exclude glob verbatim: %s',
     (pattern) => {
       expect(containsPatternLiteral(duplicateSource, pattern)).toBe(true);
     }

--- a/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
@@ -148,13 +148,13 @@ describe('Scout path globs', () => {
     ];
 
     it.each(shouldMatch)('matches: %s', (testPath) => {
-      expect(picomatch.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
+      expect(mm.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
         true
       );
     });
 
     it.each(shouldNotMatch)('does not match: %s', (testPath) => {
-      expect(picomatch.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
+      expect(mm.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
         false
       );
     });

--- a/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
@@ -148,15 +148,11 @@ describe('Scout path globs', () => {
     ];
 
     it.each(shouldMatch)('matches: %s', (testPath) => {
-      expect(mm.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
-        true
-      );
+      expect(mm.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(true);
     });
 
     it.each(shouldNotMatch)('does not match: %s', (testPath) => {
-      expect(mm.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(
-        false
-      );
+      expect(mm.isMatch(testPath, [...SCOUT_TESTS_ONLY_EXCLUDE_GLOBS], { dot: true })).toBe(false);
     });
   });
 });

--- a/src/platform/packages/private/kbn-scout-info/src/paths.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.ts
@@ -148,6 +148,20 @@ export const SCOUT_TESTS_ONLY_SCOPE_GLOBS: readonly string[] = [
 ];
 
 /**
+ * Scout `fixtures/` directories, excluded from the "tests-only" fast path: their
+ * entry points (e.g. page objects) can be imported by other plugins, so a change
+ * must run downstream configs (dependency-tree mode) rather than tests-only.
+ *
+ * The globstar is kept only at the end; a globstar-before-`fixtures` form is
+ * avoided because minimatch fails to match a single trailing segment when a
+ * leading globstar collapses to zero.
+ */
+export const SCOUT_TESTS_ONLY_EXCLUDE_GLOBS: readonly string[] = [
+  `**/test/scout{_*,}/{${SCOUT_TEST_CATEGORIES.join(',')}}/fixtures/**`,
+  `**/test/scout{_*,}/*/{${SCOUT_TEST_CATEGORIES.join(',')}}/fixtures/**`,
+];
+
+/**
  * Captures `<prefix>/test/scout{_*}[/<namespace>]/(api|ui)/<rest?>` and its `.meta/` variant.
  * A negative lookahead prevents `.meta` from being captured as a namespace; backtracking
  * prevents `api`/`ui` from being captured as a namespace.

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.test.ts
@@ -38,7 +38,7 @@ describe('isScoutTestsOnlyDiff', () => {
   it('returns true when every non-noise file is in a Scout test scope', () => {
     const files = [
       'pkg/test/scout/ui/tests/a.spec.ts',
-      'pkg/test/scout/ui/fixtures/page_objects/foo.ts',
+      'pkg/test/scout/ui/helpers/foo.ts',
       'pkg/README.md', // noise — ignored
     ];
     expect(isScoutTestsOnlyDiff(files)).toBe(true);
@@ -47,6 +47,41 @@ describe('isScoutTestsOnlyDiff', () => {
   it('returns false when at least one non-noise file is outside Scout scope', () => {
     const files = ['pkg/test/scout/ui/tests/a.spec.ts', 'pkg/public/foo.ts'];
     expect(isScoutTestsOnlyDiff(files)).toBe(false);
+  });
+
+  it('returns false for a fixtures-only diff (cross-plugin importable surface)', () => {
+    expect(isScoutTestsOnlyDiff(['pkg/test/scout/ui/fixtures/page_objects/foo.ts'])).toBe(false);
+    expect(isScoutTestsOnlyDiff(['pkg/test/scout/api/fixtures/params.ts'])).toBe(false);
+  });
+
+  it('returns false when a fixtures file is mixed with in-scope test files', () => {
+    const files = [
+      'pkg/test/scout/ui/tests/a.spec.ts',
+      'pkg/test/scout/ui/fixtures/page_objects/foo.ts',
+    ];
+    expect(isScoutTestsOnlyDiff(files)).toBe(false);
+  });
+
+  it('returns false for namespaced fixtures (both namespace placements)', () => {
+    // namespace nested under fixtures/
+    expect(
+      isScoutTestsOnlyDiff(['pkg/test/scout/ui/fixtures/traces_experience/page_objects/apm.ts'])
+    ).toBe(false);
+    // namespace before the category
+    expect(isScoutTestsOnlyDiff(['pkg/test/scout/detection_engine/ui/fixtures/data.ts'])).toBe(
+      false
+    );
+  });
+
+  it('keeps non-fixtures scope files (helpers, configs) on the tests-only fast path', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'pkg/test/scout/ui/helpers/foo.ts',
+        'pkg/test/scout/ui/constants.ts',
+        'pkg/test/scout/ui/playwright.config.ts',
+        'pkg/test/scout/ui/parallel.playwright.config.ts',
+      ])
+    ).toBe(true);
   });
 
   it('matches custom scout_<server> scopes', () => {

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.ts
@@ -15,6 +15,7 @@ import { REPO_ROOT } from '@kbn/repo-info';
 import type { ToolingLog } from '@kbn/tooling-log';
 import {
   CRITICAL_FILES_SCOUT,
+  SCOUT_TESTS_ONLY_EXCLUDE_GLOBS,
   SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
   SCOUT_TESTS_ONLY_SCOPE_GLOBS,
   SCOUT_TEST_SCOPE_PATTERN,
@@ -33,6 +34,7 @@ const compileMatchers = (patterns: readonly string[]): readonly Minimatch[] =>
 const CRITICAL_FILES_MATCHERS = compileMatchers(CRITICAL_FILES_SCOUT);
 const IGNORE_MATCHERS = compileMatchers(SCOUT_TESTS_ONLY_IGNORE_PATTERNS);
 const SCOPE_MATCHERS = compileMatchers(SCOUT_TESTS_ONLY_SCOPE_GLOBS);
+const EXCLUDE_MATCHERS = compileMatchers(SCOUT_TESTS_ONLY_EXCLUDE_GLOBS);
 
 const matchesAny = (file: string, matchers: readonly Minimatch[]): boolean =>
   matchers.some((m) => m.match(file));
@@ -61,12 +63,16 @@ export const criticalScoutFilesTouched = (changedFiles: readonly string[]): bool
  * Returns true when, after dropping noise files (READMEs, markdown, changelogs),
  * every remaining changed file lives inside a Scout test scope. Empty diffs
  * (or noise-only diffs) return false — there is nothing to fast-path.
+ *
+ * Changes under a Scout `fixtures/` directory are excluded: page objects there
+ * can be imported by other plugins, so they fall through to dependency-tree mode.
  */
 export const isScoutTestsOnlyDiff = (changedFiles: readonly string[]): boolean => {
   let sawMeaningful = false;
   for (const file of changedFiles) {
     if (matchesAny(file, IGNORE_MATCHERS)) continue;
     sawMeaningful = true;
+    if (matchesAny(file, EXCLUDE_MATCHERS)) return false;
     if (!matchesAny(file, SCOPE_MATCHERS)) return false;
   }
   return sawMeaningful;
@@ -107,8 +113,8 @@ export const deriveScoutConfigsForFile = (
     return filterExisting([`${scope}/${PARALLEL_PLAYWRIGHT_CONFIG}`], repoRoot, existsCache);
   }
 
-  // Shared scope file (fixtures/, helpers, constants, page_objects/, .meta/, ...)
-  // or the playwright config itself: map to whichever configs exist in the scope.
+  // Shared scope file (helpers, constants, .meta/, ...) or the playwright config
+  // itself: map to whichever configs exist in the scope.
   return filterExisting(
     [`${scope}/${PLAYWRIGHT_CONFIG}`, `${scope}/${PARALLEL_PLAYWRIGHT_CONFIG}`],
     repoRoot,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] exclude fixtures updates from test-only mode (#275978)](https://github.com/elastic/kibana/pull/275978)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-07T14:03:59Z","message":"[scout] exclude fixtures updates from test-only mode (#275978)\n\n## Summary\n\nRelated to https://github.com/elastic/kibana/pull/273466\n\nScout `fixtures/` directories should be excluded from the `tests-only`\nfast path since their entry points (e.g. page objects) can be imported\nby other plugins, so a change must run downstream configs\n(`dependency-tree` mode) rather than `tests-only`. The benefit of\nstoring page objects in plugins and using `dependency-tree` mode should\nbe more effective for selective tests compare to storing all shared page\nobjects in `kbn/scout`:\n\n1) dependencies between plugins are already in place, we are not adding\nextra.\n2) page objects should be designed closely to source code (components)\nfunctionality and stay scoped to it.\n\nThis PR update `isScoutTestsOnlyDiff` so we can exclude paths matching\n`**/test/scout**/**/fixtures/**` from `test-only` category, later we can\nadjust it if more test code is shared/consumed by other plugins.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f2034601627569556bb4eb9eb828d2f53169560","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0","v9.4.4","reviewer:scout","v9.3.8"],"title":"[scout] exclude fixtures updates from test-only mode","number":275978,"url":"https://github.com/elastic/kibana/pull/275978","mergeCommit":{"message":"[scout] exclude fixtures updates from test-only mode (#275978)\n\n## Summary\n\nRelated to https://github.com/elastic/kibana/pull/273466\n\nScout `fixtures/` directories should be excluded from the `tests-only`\nfast path since their entry points (e.g. page objects) can be imported\nby other plugins, so a change must run downstream configs\n(`dependency-tree` mode) rather than `tests-only`. The benefit of\nstoring page objects in plugins and using `dependency-tree` mode should\nbe more effective for selective tests compare to storing all shared page\nobjects in `kbn/scout`:\n\n1) dependencies between plugins are already in place, we are not adding\nextra.\n2) page objects should be designed closely to source code (components)\nfunctionality and stay scoped to it.\n\nThis PR update `isScoutTestsOnlyDiff` so we can exclude paths matching\n`**/test/scout**/**/fixtures/**` from `test-only` category, later we can\nadjust it if more test code is shared/consumed by other plugins.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f2034601627569556bb4eb9eb828d2f53169560"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275978","number":275978,"mergeCommit":{"message":"[scout] exclude fixtures updates from test-only mode (#275978)\n\n## Summary\n\nRelated to https://github.com/elastic/kibana/pull/273466\n\nScout `fixtures/` directories should be excluded from the `tests-only`\nfast path since their entry points (e.g. page objects) can be imported\nby other plugins, so a change must run downstream configs\n(`dependency-tree` mode) rather than `tests-only`. The benefit of\nstoring page objects in plugins and using `dependency-tree` mode should\nbe more effective for selective tests compare to storing all shared page\nobjects in `kbn/scout`:\n\n1) dependencies between plugins are already in place, we are not adding\nextra.\n2) page objects should be designed closely to source code (components)\nfunctionality and stay scoped to it.\n\nThis PR update `isScoutTestsOnlyDiff` so we can exclude paths matching\n`**/test/scout**/**/fixtures/**` from `test-only` category, later we can\nadjust it if more test code is shared/consumed by other plugins.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3f2034601627569556bb4eb9eb828d2f53169560"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276717","number":276717,"state":"MERGED","mergeCommit":{"sha":"e0fbb0a0d29415b4c1b32b7fe29f58866f38de32","message":"[9.4] [scout] exclude fixtures updates from test-only mode (#275978) (#276717)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[scout] exclude fixtures updates from test-only mode\n(#275978)](https://github.com/elastic/kibana/pull/275978)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/276716","number":276716,"state":"MERGED","mergeCommit":{"sha":"e2721e3531eedbd64f24f0f3e78038e943240903","message":"[9.3] [scout] exclude fixtures updates from test-only mode (#275978) (#276716)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[scout] exclude fixtures updates from test-only mode\n(#275978)](https://github.com/elastic/kibana/pull/275978)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->