### PR TITLE
[Synthetics] Close agent policy dropdown when keyboard focus leaves

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/policy_hosts.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/policy_hosts.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { EuiSuperSelectOption } from '@elastic/eui';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render } from '../../../utils/testing/rtl_helpers';
+import { SuperSelect } from './policy_hosts';
+
+// All options disabled reproduces the reported bug: focus never enters the listbox,
+// so EuiSuperSelect leaves the dropdown open when the user tabs away.
+const options: Array<EuiSuperSelectOption<string>> = [
+  { value: 'policy-1', inputDisplay: 'Policy 1', dropdownDisplay: 'Policy 1', disabled: true },
+  { value: 'policy-2', inputDisplay: 'Policy 2', dropdownDisplay: 'Policy 2', disabled: true },
+];
+
+describe('<SuperSelect /> (agent policy dropdown)', () => {
+  const renderSuperSelect = () =>
+    render(
+      <>
+        <SuperSelect
+          aria-label="Select agent policy"
+          options={options}
+          valueOfSelected={undefined}
+          onChange={jest.fn()}
+        />
+        <button type="button" data-test-subj="outsideElement">
+          Next element
+        </button>
+      </>
+    );
+
+  it('closes the dropdown when focus leaves the component', async () => {
+    const { getByTestId, queryByRole, getByRole } = renderSuperSelect();
+
+    fireEvent.click(getByTestId('syntheticsAgentPolicySelect'));
+    expect(getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.blur(getByTestId('syntheticsAgentPolicySelect'), {
+      relatedTarget: getByTestId('outsideElement'),
+    });
+
+    await waitFor(() => expect(queryByRole('listbox')).not.toBeInTheDocument());
+  });
+
+  it('keeps the dropdown open when focus stays within the listbox', () => {
+    const { getByTestId, getByRole } = renderSuperSelect();
+
+    fireEvent.click(getByTestId('syntheticsAgentPolicySelect'));
+    const listbox = getByRole('listbox');
+    expect(listbox).toBeInTheDocument();
+
+    fireEvent.blur(getByTestId('syntheticsAgentPolicySelect'), {
+      relatedTarget: listbox,
+    });
+
+    expect(getByRole('listbox')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/policy_hosts.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/policy_hosts.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import type { EuiSuperSelectProps } from '@elastic/eui';
@@ -172,9 +172,38 @@ const POLICY_HOST_LABEL = i18n.translate('xpack.synthetics.monitorManagement.pol
 });
 
 export const SuperSelect = React.forwardRef<HTMLSelectElement, EuiSuperSelectProps<string>>(
-  (props, ref) => (
-    <span ref={ref} tabIndex={-1}>
-      <EuiSuperSelect data-test-subj="syntheticsAgentPolicySelect" {...props} />
-    </span>
-  )
+  ({ popoverProps, ...props }, ref) => {
+    const panelRef = useRef<HTMLElement | null>(null);
+    const setPanelRef = useCallback((node: HTMLElement | null) => {
+      panelRef.current = node;
+    }, []);
+    // Bumping this key remounts EuiSuperSelect, which is how we dismiss a stale dropdown.
+    const [remountKey, setRemountKey] = useState(0);
+
+    // EuiSuperSelect keeps its dropdown open when keyboard focus leaves the collapsed
+    // control (e.g. tabbing away when every option is disabled, so focus never enters
+    // the listbox). Its own closePopover() refocuses the control, which would yank
+    // keyboard focus back, so we dismiss by remounting instead — closing the overlay
+    // without moving focus away from wherever the user tabbed to.
+    const handleBlur = useCallback((event: React.FocusEvent<HTMLSpanElement>) => {
+      const nextFocused = event.relatedTarget as Node | null;
+      const focusStillInside =
+        event.currentTarget.contains(nextFocused) ||
+        (nextFocused != null && (panelRef.current?.contains(nextFocused) ?? false));
+      if (!focusStillInside) {
+        setRemountKey((key) => key + 1);
+      }
+    }, []);
+
+    return (
+      <span ref={ref} tabIndex={-1} onBlur={handleBlur}>
+        <EuiSuperSelect
+          key={remountKey}
+          data-test-subj="syntheticsAgentPolicySelect"
+          {...props}
+          popoverProps={{ ...popoverProps, panelRef: setPanelRef }}
+        />
+      </span>
+    );
+  }
 );


### PR DESCRIPTION
## Summary

The **Agent policy** dropdown (`syntheticsAgentPolicySelect`) on the Synthetics private location form kept its `EuiSuperSelect` dropdown open when keyboard focus moved away from the collapsed control. This is most reproducible when every option is already used (all options disabled): opening via the keyboard never lands focus inside the listbox, so pressing `Tab` moves focus to the next element while the overlay stays behind — a stale overlay for keyboard users (WCAG SC 1.4.13).

This dismisses the dropdown when focus leaves the component. `EuiSuperSelect`'s own `closePopover()` refocuses the control, which would yank keyboard focus back, so the wrapper remounts the select instead — closing the overlay without moving focus away from wherever the user tabbed to. Blur that stays inside the widget (opening the listbox, selecting an item) is ignored via a panel ref check.

Closes #276916

## Test plan

- [ ] Go to Observability → Applications → Monitors → Settings → Private locations → Create location.
- [ ] Keyboard-navigate to the **Agent policy** dropdown, press the down arrow to open it (use a policy set where options are already used/disabled).
- [ ] Press `Tab` and confirm the dropdown closes and focus moves to the next element.
- [ ] Confirm normal mouse/keyboard selection of an enabled policy still works.
- [ ] Added Jest coverage in `policy_hosts.test.tsx`.

Made with [Cursor](https://cursor.com)