### PR TITLE
[UX] Only create static data view for users with save access

### DIFF
--- a/x-pack/solutions/observability/plugins/ux/public/application/ux_app.tsx
+++ b/x-pack/solutions/observability/plugins/ux/public/application/ux_app.tsx
@@ -194,11 +194,15 @@ export const renderApp = ({
 
   createCallApmApi(core);
 
-  // Automatically creates static data view and stores as saved object
-  createStaticDataView().catch((e) => {
-    // eslint-disable-next-line no-console
-    console.log('Error creating static data view', e);
-  });
+  // Creating the static data view requires write access to saved objects, so
+  // only attempt it for users who can save. Read-only users (e.g. `viewer`)
+  // fall back to the ad-hoc data view and would otherwise hit a 403 here.
+  if (core.application.capabilities.savedObjectsManagement.edit) {
+    createStaticDataView().catch((e) => {
+      // eslint-disable-next-line no-console
+      console.log('Error creating static data view', e);
+    });
+  }
 
   ReactDOM.render(
     <UXAppRoot


### PR DESCRIPTION
## Summary

The UX (RUM) dashboard unconditionally calls `POST /internal/apm/data_view/static` on mount to create the APM static data view saved object. That write fails with a `403 Unable to create index-pattern` for read-only users (e.g. the `viewer` role), which is what was reported in the issue.

This gates the call on `savedObjectsManagement.edit`, mirroring what the APM app already does in `apm_main_template`. Read-only users already fall back to the ad-hoc (in-memory) data view for the dashboard charts, so nothing else changes for them — they simply no longer trigger the failing request.

Closes #136855

## Test plan

- [ ] Log in as a `viewer` user and open the UX dashboard; confirm charts load and there is no `Unable to create index-pattern` 403 in the server logs / browser console.
- [ ] Log in as an editor/admin and confirm the static data view is still created as before.
- [ ] Existing Scout UI tests (which log in via `loginAsViewer()`) continue to pass.


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->