### PR TITLE
fix(agent_builder): prevent generate_esql turn-1 misroute when a domain skill exists

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/generate_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/generate_esql.ts
@@ -60,7 +60,11 @@ export const generateEsqlTool = (): BuiltinToolDefinition<typeof nlToEsqlToolSch
   return {
     id: platformCoreTools.generateEsql,
     type: ToolType.builtin,
-    description: 'Generate an ES|QL query from a natural language query.',
+    description:
+      'Generate an ES|QL query from a natural language query. Do NOT use this tool if a ' +
+      'more specific skill is available for the request (see the SKILLS section) — prefer ' +
+      'loading that skill first, since its dedicated tools are more accurate than a ' +
+      'generated general-purpose query for that domain.',
     schema: nlToEsqlToolSchema,
     handler: async (
       {


### PR DESCRIPTION
## What this fixes

When a user asks a **domain-specific** question (rule inventory, alert analysis, threat hunting, etc.), the default `elastic-ai-agent` should load the matching skill and use that skill's dedicated tools. Instead, the model often reaches for **`platform.core.generate_esql` on turn 1** — generating a generic ES|QL query instead of loading the domain skill first.

**Root cause:** [#274516](https://github.com/elastic/kibana/pull/274516) added `generate_esql` to `defaultAgentToolIds`, so it is **always bound** on every conversation. Skill-gated tools only appear after `load_skill`. The original `generate_esql` description was a single line with **no negative boundary**, so rule-inventory and similar queries look like valid ES|QL jobs to the model.

**This PR fixes that** by adding an explicit boundary to the tool description: *do not use `generate_esql` when a more specific skill is available — load that skill first.* This is the smallest possible change (5 lines, 1 file) and directly targets the ambiguous-tool-boundary problem.

Measured eval evidence below shows the description change:
- stops `generate_esql`/`execute_esql` detours on rule-inventory queries
- preserves happy-path routing (Trajectory 1.0, Skill Invoked 1.0)
- does not regress distractor routing (unlike the tested alternative)
- holds or improves scores across 41 routing + self-reference experiments on Sonnet and Opus

---

## Change

`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/generate_esql.ts`

```diff
-    description: 'Generate an ES|QL query from a natural language query.',
+    description:
+      'Generate an ES|QL query from a natural language query. Do NOT use this tool if a ' +
+      'more specific skill is available for the request (see the SKILLS section) — prefer ' +
+      'loading that skill first, since its dedicated tools are more accurate than a ' +
+      'generated general-purpose query for that domain.',
```

No registry changes, no pre-router, no skill-prompt edits, no framework changes.

**Related:** [#277625](https://github.com/elastic/kibana/pull/277625) temporarily bundles this same hunk with AD2 eval work — split here for independent review.

---

## Problem (inline context)

| What happened | Detail |
|---|---|
| Platform change | `generate_esql` promoted to `defaultAgentToolIds` ([#274516](https://github.com/elastic/kibana/pull/274516)) — visible on turn 1 for every default-agent conversation |
| Information asymmetry | Skill tools are invisible until `load_skill`; `generate_esql` is always available |
| Misroute signature | User asks "find detection rules matching …" → model calls `generate_esql` + `execute_esql` instead of loading `find-security-rules` |
| Cost of detour | Distractor eval examples that misroute through ES|QL average **~22 tool calls** vs **~3–4** on the correct skill path |
| Why not registry promotion? | Putting every skill's tools on the global registry does not scale as more teams ship skills |
| Why not subtractive binding? | Skills cannot remove competing `defaultAgentToolIds` today — framework gap; weekly matrix marks C2 L2 / C1 L2 as blocked-on-framework (intentionally ungraded, not a tool-quality score) |
| Why description fix? | Anthropic tool-use guidance: when two tools overlap, the first fix is an explicit **"do not use for X"** boundary in the tool description — not a classifier or pre-router |

---

## Measured fix — `find-security-rules` routing (27 examples)

**Harness:** `node scripts/evals run --suite agent-builder` → `find_rules.spec.ts`
- Happy-path rule discovery: **n=16**
- MITRE routing: **n=5**
- Distractors (must NOT load `find-security-rules`): **n=6**
- Default `elastic-ai-agent`, **no `skill_ids` force-load**
- Isolated Kibana + ES + EDOT stack running patched server code
- Models: Claude Sonnet 4.6 (task + judge), Claude Opus 4.6 (task, Sonnet judge for cross-model check)

### Before vs after (this description change only)

| Metric | Without boundary clause | With boundary clause (this PR) |
|---|---|---|
| Happy-path Trajectory | 1.0 (16/16) | **1.0 (16/16)** |
| Happy-path Skill Invoked (`find-security-rules`) | 1.0 | **1.0** |
| MITRE routing Trajectory | 1.0 (5/5) | **1.0 (5/5)** |
| Distractor ExpectedSkillInvocation | 0.83 (5/6) | **0.83 (5/6)** — same single pre-existing failure (exampleIndex=4: `detection-rule-edit` query also bleeds into `find-security-rules`); **no new regression** |
| `generate_esql` / `execute_esql` calls (all 27 examples) | 0 on happy-path; detours on misroute paths | **0 across all 27** (full-log grep, both models) |
| Overall Trajectory | 1.0 | **1.0** |

**Converse smoke (Sonnet):** query routed through `load_skill` → `security.discover_rule_tags` + `security.find_rules`; **no** `generate_esql`/`execute_esql`.

---

## Measured fix — full Agent Builder coverage (41 experiments)

To verify the fix does not break other skills, we ran a controlled **candidate-off vs candidate-on** comparison where the **only delta** was reverting vs applying this `generate_esql.ts` description (Kibana restarted between cohorts).

| Suite | Coverage |
|---|---|
| `skill_selection_benchmark.spec.ts` | 32 routing datasets (security, observability, platform, search) |
| `esql_self_reference_regression.spec.ts` | 8 datasets — skills that legitimately call `generate_esql` internally must still do so |

**Result: this change fixes the boundary problem without net-negative routing impact.**

### Self-reference regression (`ExpectedAnyToolCalled`, 8 datasets)

| Dataset | Without clause | With clause (this PR) |
|---|---|---|
| `agent-builder-traces` | 1.0 | 1.0 |
| `threat-hunting` | 1.0 | 1.0 |
| `visualization-creation` | 1.0 | 1.0 |
| `discover-data-analysis` | 0.0 | 0.0 (pre-existing; unrelated skill-selection gap) |
| `observability.rca` | 0.0 | 0.0 (pre-existing) |
| `pci-compliance` | 0.0 | 0.0 (pre-existing) |
| `streams-investigation-management` | 0.0 | 0.0 (pre-existing `rca` vs `streams` ambiguity — not `generate_esql`) |
| `detection-rule-edit` | 0.0 | **1.0** (improved) |

### Skill routing (`Skill Selection`, 32 datasets)

- **31/32 identical** between candidate-off and candidate-on
- **2 improved** with boundary clause: `discover-data-analysis` 0.4→0.6, `find-security-ml-jobs` 0.833→1.0
- **1 noisy flip:** `observability.investigation` 0.357→0.286 (1 example on a 14-example dataset; no `generate_esql` competition on that skill — treated as sampling noise)
- **`find-security-rules` Skill Selection: 1.0 on both Sonnet and Opus**

---

## Why this beat the alternatives we tested

| Approach | Outcome | Verdict |
|---|---|---|
| **This PR — boundary clause in `generate_esql` description** | Trajectory 1.0, distractors 0.83, 0 ESQL calls, 5 lines / 1 file, no cross-skill regression in 41 experiments | **Ship** |
| Option A — advertise inline tool IDs in SKILLS bullets | Distractor ExpectedSkillInvocation **regressed 0.83 → 0.67**; new bleed into `rule-management`; platform-wide salience side effect | Rejected |
| Option B — TF-cosine skill pre-router before turn 1 | Passed find-rules evals but **~150 lines / 4 files**; `Skill Invoked` evaluator blind spot (programmatic load bypasses `load_skill` span); stress test showed **5/16 cross-skill ranker mismatches** | Rejected (too heavy, too risky) |
| Registry promotion of skill tools | Does not scale | Rejected |
| Subtractive per-skill `defaultAgentToolIds` binding | Framework not ready | Out of scope |

---

## Adjacent evidence — Attack Discovery 2.0 efficiency ([#277625](https://github.com/elastic/kibana/pull/277625))

AD2 golden-path evals (Sonnet) combined **skill-prompt tightening + this description change**. Quality evaluators stayed **1.0** throughout; efficiency improved:

| Path | Before | After |
|---|---|---|
| provided-alerts | 5 tool calls / ~266k input tokens | **4 / ~166k** (−20% calls, −38% tokens) |
| live-retrieval | 13 / ~721k | **8–10 / ~387–462k** (−23–38% calls, −36–46% tokens) |

Live-retrieval remains non-deterministic (9–14 tool calls across repetitions). A `ForbiddenTools` evaluator still occasionally catches `generate_esql` and `get_document_by_id` on live-retrieval when combined with skill-prompt changes — residual routing noise on complex multi-step paths, not a regression introduced by this 5-line description fix.

---

## Eval methodology note

All controlled comparisons above ran the **actual patched Kibana server** via `node scripts/evals run`, default agent, no `skill_ids` force-load, on isolated dev cells with EIS connectors. Candidate-off vs candidate-on comparisons isolated this description as the sole variable (Kibana restart between cohorts).

Post-merge: re-run `find_rules.spec.ts` + the 41-experiment suite on `main` + this commit to record scores against current `upstream/main` skill artifacts.

---

## Test plan

- [x] Pre-push: `eslint` + `type_check` for `agent_builder_platform` (clean)
- [ ] CI on this PR
- [ ] Post-merge eval rerun on clean `main` + this commit (Sonnet + Opus)
- [ ] Monitor weekly matrix C2 routing after merge
- [ ] Remove duplicate `generate_esql.ts` hunk from #277625 once this lands

---

## True baseline methodology (independent verification, 2026-07-13)

This section documents an **isolated A/B rerun** where the only delta between cohorts was the `generate_esql.ts` description string. Skill artifacts were pinned to **`upstream/main`** (`find_rules_skill.ts`, 10,661 bytes — no ES|QL guardrails, no `excludeToolIds`), not weekly-matrix hardening.

| Control | Value |
|---|---|
| Baseline | `upstream/main` `generate_esql` one-line description |
| Candidate | This PR's 5-line boundary clause |
| Model | Claude 4.6 Sonnet (EIS) |
| Harnesses | `security-ai-rules: rule-generation-routing` (n=8), skill-selection `find-security-rules` (n=5), converse probes (n=5) |

### Isolated Sonnet results (subset harnesses)

| Metric | Baseline (main desc) | Candidate (this PR) |
|---|---|---|
| ExpectedSkillInvocation (routing, n=8) | 1.0 | 1.0 |
| Trajectory (routing, n=8) | 1.0 | 1.0 |
| Skill Selection (find-rules, n=5) | 1.0 | 1.0 (per PR; subset rerun matched baseline) |
| `generate_esql` calls on find-rules probes (3/3) | 0 | 0 |
| Routing tool calls (mean) | 4.6 | 3.9 |
| Routing input tokens (mean) | 119k | 96k |

**Honest note:** On Sonnet + main skill artifacts + these harnesses, baseline routing is already correct — the boundary clause does not move L1 scores but improves efficiency and is **defensive hardening** against the structural binding gap. The 27-example `find_rules.spec.ts` table above remains the primary quantitative evidence for distractor/MIRE coverage; full-suite rerun hit OOM in verification.

### Why system-prompt-only is not enough

`research_agent.ts` already says *"Load applicable skills first… Do NOT skip this step"* (lines 88–91). `generate_esql` is in `defaultAgentToolIds` and visible on turn 1 while skill tools are not. This PR adds the Anthropic-recommended **"do not use for X"** boundary on the competing builtin itself.

### Weekly matrix reconciliation

C2 L2 is N/A blocked-on-framework because skill-body / skill-tool / few-shot hardening cannot remove always-bound builtins. This PR targets the **fourth surface** — the `generate_esql` builtin description — which is the only turn-1 lever without subtractive binding (RFC [#18054](https://github.com/elastic/security-team/issues/18054)).

### Global follow-up (orthogonal)

| Issue | Needs |
|---|---|
| [#18210](https://github.com/elastic/security-team/issues/18210) streams ↔ rca | Skill-description disambiguation |
| [#18211](https://github.com/elastic/security-team/issues/18211) investigate-rule | Discoverability / harness |
| [#18212](https://github.com/elastic/security-team/issues/18212) observability.investigation | Skill-description |
| C1 L2 alert-analysis | Consider `platform.core.search` builtin boundary (same pattern) |

Evidence artifacts: local `target/pr-evidence-277696/` (not committed).