### PR TITLE
[Synthetics] Fix retest_on_failure: false ignored on monitor update

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.test.ts
@@ -9,6 +9,7 @@ import { ScheduleUnit } from '../../../../common/runtime_types';
 import type { NormalizedProjectProps } from './common_fields';
 import {
   flattenAndFormatObject,
+  getMaxAttempts,
   getMonitorSchedule,
   getNormalizeCommonFields,
   getUrlsField,
@@ -45,6 +46,34 @@ describe('getUrlsField', () => {
     expect(getUrlsField(['https://elastic.co?foo=bar,baz'])).toEqual([
       'https://elastic.co?foo=bar,baz',
     ]);
+  });
+});
+
+describe('getMaxAttempts', () => {
+  it('returns the default (2) when nothing is provided', () => {
+    expect(getMaxAttempts()).toBe(2);
+  });
+
+  it('returns the default (2) when retest_on_failure is true', () => {
+    expect(getMaxAttempts(true)).toBe(2);
+  });
+
+  it('returns 1 when retest_on_failure is false', () => {
+    expect(getMaxAttempts(false)).toBe(1);
+  });
+
+  // Regression for #243891: on update the merged payload still carries the
+  // previous max_attempts, which must not override an explicit disable request.
+  it('returns 1 when retest_on_failure is false even if a stale max_attempts is present', () => {
+    expect(getMaxAttempts(false, 2)).toBe(1);
+  });
+
+  it('returns the default (2) when retest_on_failure is true even if max_attempts is present', () => {
+    expect(getMaxAttempts(true, 1)).toBe(2);
+  });
+
+  it('falls back to max_attempts when retest_on_failure is not provided', () => {
+    expect(getMaxAttempts(undefined, 3)).toBe(3);
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
@@ -141,13 +141,17 @@ const ONLY_ONE_ATTEMPT = 1;
 
 export const getMaxAttempts = (retestOnFailure?: boolean, maxAttempts?: number) => {
   const defaultFields = DEFAULT_COMMON_FIELDS;
-  if (!retestOnFailure && maxAttempts) {
-    return maxAttempts;
-  }
-  if (retestOnFailure) {
+  // An explicit `retest_on_failure` always wins. On update the merged payload
+  // still carries the previous `max_attempts`, so checking `maxAttempts` first
+  // would ignore a request that sets `retest_on_failure: false` (see #243891).
+  if (retestOnFailure === true) {
     return defaultFields[ConfigKey.MAX_ATTEMPTS];
-  } else if (retestOnFailure === false) {
+  }
+  if (retestOnFailure === false) {
     return ONLY_ONE_ATTEMPT;
+  }
+  if (maxAttempts) {
+    return maxAttempts;
   }
   return defaultFields[ConfigKey.MAX_ATTEMPTS];
 };


### PR DESCRIPTION
## Summary

Setting `retest_on_failure: false` via the Synthetics update API did not disable retests on an existing monitor (`max_attempts` stayed at `2`). Disabling only worked at create time or via the undocumented `max_attempts: 1`.

On update, the incoming body is merged with the existing monitor (`mergeSourceMonitor`), so the payload always carries the previous `max_attempts`. `getMaxAttempts` checked `max_attempts` **before** the explicit `retest_on_failure` flag (`!retestOnFailure && maxAttempts`), so a request with `retest_on_failure: false` returned the stale `2` and left retests enabled.

This makes an explicit `retest_on_failure` take precedence; `max_attempts` is only the fallback when the flag is omitted. Added regression unit tests for `getMaxAttempts`.

Closes #243891

## Test plan
- [ ] Create a monitor with retests enabled, then `PUT` `retest_on_failure: false` and verify `max_attempts` becomes `1` (retests disabled)
- [ ] Verify `retest_on_failure: true` still enables retests, and standalone `max_attempts` updates are respected when the flag is omitted

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->