### PR TITLE
[APM] Migrate remaining inline io-ts route params + locator to zod (Phase 5 prep)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/index.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/index.ts
@@ -57,4 +57,11 @@ export {
   serviceTransactionDataSourceRt,
   transactionDataSourceRt,
   filtersRt,
+  rangeSchema,
+  kuerySchema,
+  probabilitySchema,
+  offsetSchema,
+  serviceTransactionDataSourceSchema,
+  transactionDataSourceSchema,
+  filtersSchema,
 } from './src/default_api_types';

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/default_api_types.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/default_api_types.ts
@@ -12,6 +12,13 @@ import { isoToEpoch } from '@kbn/zod-helpers/v4';
 import type { BoolQuery } from '@kbn/es-query';
 import { ApmDocumentType, RollupInterval } from '@kbn/apm-types';
 
+// Upper bounds for unbounded query-string inputs, to satisfy the CodeQL
+// "unbounded string in route validation" rule (DoS hardening). Values are
+// generous so they never reject legitimate input.
+const MAX_KUERY_LENGTH = 10_000; // KQL expressions can be long
+const MAX_FILTERS_LENGTH = 100_000; // serialized ES bool query (JSON string)
+const MAX_QUERY_PARAM_LENGTH = 1_024; // short params: ISO/datemath dates, offsets
+
 export const rangeRt = t.type({
   start: isoToEpochRt,
   end: isoToEpochRt,
@@ -94,18 +101,18 @@ export const filtersRt = new t.Type<BoolQuery, string, unknown>(
  */
 
 export const rangeSchema = z.object({
-  start: z.string().transform(isoToEpoch),
-  end: z.string().transform(isoToEpoch),
+  start: z.string().max(MAX_QUERY_PARAM_LENGTH).transform(isoToEpoch),
+  end: z.string().max(MAX_QUERY_PARAM_LENGTH).transform(isoToEpoch),
 });
 
-export const kuerySchema = z.object({ kuery: z.string() });
+export const kuerySchema = z.object({ kuery: z.string().max(MAX_KUERY_LENGTH) });
 
 export const probabilitySchema = z.object({
   probability: z.coerce.number(),
 });
 
 export const offsetSchema = z.object({
-  offset: z.string().optional(),
+  offset: z.string().max(MAX_QUERY_PARAM_LENGTH).optional(),
 });
 
 export const serviceTransactionDataSourceSchema = z.object({
@@ -136,17 +143,20 @@ export const transactionDataSourceSchema = z.object({
 });
 
 // No reverse (BoolQuery -> string) direction, unlike filtersRt.encode() - zod transforms are one-way.
-export const filtersSchema = z.string().transform((value, ctx): BoolQuery => {
-  try {
-    const filters = JSON.parse(value);
-    return {
-      should: [],
-      must: [],
-      must_not: filters.must_not ? [...filters.must_not] : [],
-      filter: filters.filter ? [...filters.filter] : [],
-    };
-  } catch (err) {
-    ctx.addIssue({ code: 'custom', message: err.message });
-    return z.NEVER;
-  }
-});
+export const filtersSchema = z
+  .string()
+  .max(MAX_FILTERS_LENGTH)
+  .transform((value, ctx): BoolQuery => {
+    try {
+      const filters = JSON.parse(value);
+      return {
+        should: [],
+        must: [],
+        must_not: filters.must_not ? [...filters.must_not] : [],
+        filter: filters.filter ? [...filters.filter] : [],
+      };
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  });

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/environment_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/environment_rt.ts
@@ -29,11 +29,16 @@ export type Environment = t.TypeOf<typeof environmentRt>['environment'];
  * migrated (elastic/kibana#243355).
  */
 
+// Bounds the free-form branch to satisfy the CodeQL "unbounded string in route
+// validation" rule (DoS hardening); generous enough not to reject real
+// environment names.
+const MAX_ENVIRONMENT_LENGTH = 1_024;
+
 // nonEmptyStringRt omitted: unreachable in the io-ts union too (t.string matches first).
 export const environmentStringSchema = z.union([
   z.literal(ENVIRONMENT_NOT_DEFINED.value),
   z.literal(ENVIRONMENT_ALL.value),
-  z.string(),
+  z.string().max(MAX_ENVIRONMENT_LENGTH),
 ]);
 
 export const environmentSchema = z.object({

--- a/x-pack/solutions/observability/plugins/apm/public/locator/helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/locator/helpers.ts
@@ -4,11 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { isRight } from 'fp-ts/Either';
-import { PathReporter } from 'io-ts/lib/PathReporter';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import type { Environment } from '../../common/environment_rt';
-import { environmentRt } from '../../common/environment_rt';
 import { apmRouter } from '../components/routing/apm_route_config';
 import type { TimePickerTimeDefaults } from '../components/shared/date_picker/typings';
 
@@ -21,38 +19,39 @@ const SERVICE_OVERVIEW_TAB_PATHS = {
   default: '/services/{serviceName}/overview',
 } as const;
 
-export const APMLocatorPayloadValidator = t.union([
-  t.type({ serviceName: t.undefined }),
-  t.intersection([
-    t.type({ serviceName: t.string }),
-    t.type({ dashboardId: t.string }),
-    t.type({ query: environmentRt }),
-  ]),
-  t.intersection([
-    t.type({
-      serviceName: t.string,
-    }),
-    t.partial({ dashboardId: t.undefined }),
-    t.partial({
-      serviceOverviewTab: t.keyof({
-        traces: null,
-        metrics: null,
-        logs: null,
-        errors: null,
-        transactions: null,
-      }),
-      errorGroupId: t.string,
-    }),
-    t.type({
-      query: t.intersection([
-        environmentRt,
-        t.partial({ kuery: t.string, rangeFrom: t.string, rangeTo: t.string }),
-      ]),
-    }),
-  ]),
+export const APMLocatorPayloadValidator = z.union([
+  z.object({ serviceName: z.undefined() }),
+  z
+    .object({ serviceName: z.string() })
+    .merge(z.object({ dashboardId: z.string() }))
+    .merge(z.object({ query: environmentSchema })),
+  z
+    .object({
+      serviceName: z.string(),
+    })
+    .merge(z.object({ dashboardId: z.undefined().optional() }))
+    .merge(
+      z.object({
+        serviceOverviewTab: z
+          .enum(['traces', 'metrics', 'logs', 'errors', 'transactions'])
+          .optional(),
+        errorGroupId: z.string().optional(),
+      })
+    )
+    .merge(
+      z.object({
+        query: environmentSchema.merge(
+          z.object({
+            kuery: z.string().optional(),
+            rangeFrom: z.string().optional(),
+            rangeTo: z.string().optional(),
+          })
+        ),
+      })
+    ),
 ]);
 
-export type APMLocatorPayload = t.TypeOf<typeof APMLocatorPayloadValidator>;
+export type APMLocatorPayload = z.infer<typeof APMLocatorPayloadValidator>;
 
 export function getPathForServiceDetail(
   payload: APMLocatorPayload,
@@ -66,10 +65,14 @@ export function getPathForServiceDetail(
     defaultEnvironment: string;
   }
 ) {
-  const decodedPayload = APMLocatorPayloadValidator.decode(payload);
+  const decodedPayload = APMLocatorPayloadValidator.safeParse(payload);
 
-  if (!isRight(decodedPayload)) {
-    throw new Error(PathReporter.report(decodedPayload).join('\n'));
+  if (!decodedPayload.success) {
+    throw new Error(
+      decodedPayload.error.issues
+        .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+        .join('\n')
+    );
   }
 
   const defaultQueryParams = {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/diagnostics/route.ts
@@ -15,14 +15,14 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 
 import type { APMIndices } from '@kbn/apm-sources-access-plugin/server';
-import { isoToEpochRt } from '@kbn/io-ts-utils';
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
+import { isoToEpoch } from '@kbn/zod-helpers/v4';
 import type { ApmEvent } from '@kbn/apm-types';
+import { rangeSchema } from '@kbn/apm-api-shared';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 import type { ServiceMapDiagnosticResponse } from '../../../common/service_map_diagnostic_types';
 import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
-import { rangeRt } from '../default_api_types';
 import { getTraceSampleIds } from '../service_map/get_trace_sample_ids';
 import { getDiagnosticsBundle } from './get_diagnostics_bundle';
 import { getFleetPackageInfo } from './get_fleet_package_info';
@@ -92,17 +92,19 @@ export type DiagnosticsBundle = Promise<{
 const getServiceMapDiagnosticsRoute = createApmServerRoute({
   security: { authz: { requiredPrivileges: ['apm'] } },
   endpoint: 'POST /internal/apm/diagnostics/service-map',
-  params: t.type({
-    body: t.intersection([
-      rangeRt,
-      t.type({
-        sourceNode: t.string,
-        destinationNode: t.string,
-      }),
-      t.partial({
-        traceId: t.string,
-      }),
-    ]),
+  params: z.object({
+    body: rangeSchema
+      .merge(
+        z.object({
+          sourceNode: z.string().max(1024),
+          destinationNode: z.string().max(1024),
+        })
+      )
+      .merge(
+        z.object({
+          traceId: z.string().max(1024).optional(),
+        })
+      ),
   }),
   handler: async (resources): Promise<ServiceMapDiagnosticResponse> => {
     const { start, end, destinationNode, traceId, sourceNode } = resources.params.body;
@@ -192,12 +194,14 @@ const getServiceMapDiagnosticsRoute = createApmServerRoute({
 const getDiagnosticsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/diagnostics',
   security: { authz: { requiredPrivileges: ['apm'] } },
-  params: t.partial({
-    query: t.partial({
-      kuery: t.string,
-      start: isoToEpochRt,
-      end: isoToEpochRt,
-    }),
+  params: z.object({
+    query: z
+      .object({
+        kuery: z.string().max(10_000).optional(),
+        start: z.string().max(1024).transform(isoToEpoch).optional(),
+        end: z.string().max(1024).transform(isoToEpoch).optional(),
+      })
+      .optional(),
   }),
   handler: async (
     resources

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/route.ts
@@ -7,7 +7,7 @@
 
 import Boom from '@hapi/boom';
 import {
-  rangeRt,
+  rangeSchema,
   routeDefinitions,
   type ServiceAgentResponse,
   type ServiceAlertsCountRouteResponse,
@@ -29,7 +29,7 @@ import {
   type ServiceTransactionTypesResponse,
   type ServiceAnomalyScoreResponse,
 } from '@kbn/apm-api-shared';
-import { isoToEpochRt } from '@kbn/io-ts-utils';
+import { isoToEpoch } from '@kbn/zod-helpers/v4';
 import {
   InsufficientMLCapabilities,
   MLPrivilegesUninitialized,
@@ -37,8 +37,9 @@ import {
 } from '@kbn/ml-plugin/server';
 import type { Annotation } from '@kbn/observability-plugin/common/annotations';
 import type { ScopedAnnotationsClient } from '@kbn/observability-plugin/server';
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { mergeWith, uniq } from 'lodash';
+import { environmentSchema } from '@kbn/apm-types';
 import { ML_ERRORS } from '../../../common/anomaly_detection';
 import { offsetPreviousPeriodCoordinates } from '../../../common/utils/offset_previous_period_coordinate';
 import { getAnomalyTimeseries } from '../../lib/anomaly_detection/get_anomaly_timeseries';
@@ -52,7 +53,6 @@ import { getSloAlertsClient } from '../../lib/helpers/get_slo_alerts_client';
 import { getSearchTransactionsEvents } from '../../lib/helpers/transactions';
 import { withApmSpan } from '../../utils/with_apm_span';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
-import { environmentRt } from '../default_api_types';
 import { getServiceGroup } from '../service_groups/get_service_group';
 import { getServiceAnnotations } from './annotations';
 import { getServiceAgent } from './get_service_agent';
@@ -386,27 +386,29 @@ const serviceAnnotationsCreateRoute = createApmServerRoute({
       requiredPrivileges: ['apm', 'apm_write'],
     },
   },
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    body: t.intersection([
-      t.type({
-        '@timestamp': isoToEpochRt,
-        service: t.intersection([
-          t.type({
-            version: t.string,
-          }),
-          t.partial({
-            environment: t.string,
-          }),
-        ]),
-      }),
-      t.partial({
-        message: t.string,
-        tags: t.array(t.string),
-      }),
-    ]),
+    body: z
+      .object({
+        '@timestamp': z.string().max(1024).transform(isoToEpoch),
+        service: z
+          .object({
+            version: z.string().max(1024),
+          })
+          .merge(
+            z.object({
+              environment: z.string().max(1024).optional(),
+            })
+          ),
+      })
+      .merge(
+        z.object({
+          message: z.string().max(10_000).optional(),
+          tags: z.array(z.string().max(1024)).optional(),
+        })
+      ),
   }),
   handler: async (
     resources
@@ -842,9 +844,9 @@ const serviceSlosRoute = createApmServerRoute({
 
 const serviceHasSystemMetricsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/services/{serviceName}/has_system_metrics',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([environmentRt, rangeRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema.merge(rangeSchema),
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },
   handler: async (resources): Promise<{ hasSystemMetrics: boolean }> => {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/route.ts
@@ -76,6 +76,10 @@ import { getServicesItems } from './get_services/get_services_items';
 import { getServiceTransactionDetailedStatsPeriods } from './get_services_detailed_statistics/get_service_transaction_detailed_statistics';
 import { getThroughput } from './get_throughput';
 
+// Bounds the serviceName path param to satisfy the CodeQL "unbounded string in
+// route validation" rule; 1024 matches the ES keyword default `ignore_above`.
+const MAX_SERVICE_NAME_LENGTH = 1024;
+
 const servicesRoute = createApmServerRoute({
   endpoint: routeDefinitions.services.servicesList.endpoint,
   params: routeDefinitions.services.servicesList.params,
@@ -388,7 +392,7 @@ const serviceAnnotationsCreateRoute = createApmServerRoute({
   },
   params: z.object({
     path: z.object({
-      serviceName: z.string(),
+      serviceName: z.string().max(MAX_SERVICE_NAME_LENGTH),
     }),
     body: z
       .object({
@@ -845,7 +849,7 @@ const serviceSlosRoute = createApmServerRoute({
 const serviceHasSystemMetricsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/services/{serviceName}/has_system_metrics',
   params: z.object({
-    path: z.object({ serviceName: z.string() }),
+    path: z.object({ serviceName: z.string().max(MAX_SERVICE_NAME_LENGTH) }),
     query: environmentSchema.merge(rangeSchema),
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },


### PR DESCRIPTION
## Summary

Part of #243355 (migrate APM's `io-ts` validators to `@kbn/zod`).

Prep for the Phase 5 cleanup. The earlier phases migrated the route definitions in `@kbn/apm-api-shared/src/routes/**` and the client URL routing, but a few **inline** io-ts route params (defined directly in the plugin) and the client locator still consumed the shared io-ts codecs (`rangeRt`/`environmentRt`). This converts those last consumers so the shared codecs can be deleted once everything lands.

Independent of #277439 (different files); based on `main`.

## Changes

- **`server/routes/diagnostics/route.ts`** — two inline params (service-map body, `GET /internal/apm/diagnostics` query) → zod, using `rangeSchema` + `isoToEpoch`.
- **`server/routes/services/route.ts`** — the service-annotation create body and the `has_system_metrics` query → zod (`environmentSchema` + `rangeSchema` + `isoToEpoch`); removes io-ts from this file entirely.
- **`public/locator/helpers.ts`** — `APMLocatorPayloadValidator` (an io-ts `t.union`) → `z.union`, and `decode()`/`isRight`/`PathReporter` → `safeParse()`. Drops the `io-ts`/`fp-ts`/`PathReporter` imports from the locator.
- Exports the additive zod schemas (`rangeSchema`/`kuerySchema`/`offsetSchema`/etc.) from `@kbn/apm-api-shared`'s index so the plugin can import them; `environmentSchema` comes from `@kbn/apm-types`.
- Free-form strings get `.max()` bounds to satisfy the CodeQL "unbounded string in route request validation" rule.

## What's still io-ts after this (deliberately out of scope)

- The Phase 0 dual-mode registrar (`register_apm_server_routes.ts`) keeps its io-ts branch until every route is zod.
- The Fleet policy form (`apm_policy_form/**`) — io-ts + fp-ts; a separate subsystem.
- Type-only usages of other codecs (`filterOptionsRt`, the external `alertDetailsContextRt`).

These are the remaining blockers before the shared io-ts codecs and the `io-ts`/`fp-ts` package deps can be removed.

## Test plan

- [x] Locator suite (`public/locator`): 2 suites, 21 tests — green (the `getPathForServiceDetail` decode→safeParse behavior is exercised there).
- [x] Type-check clean via the oblt CLI for `@kbn/apm-api-shared` and the `apm` plugin (0 errors) — confirms the handlers still type-check against the zod-inferred params.
- [x] `node scripts/lint_ts_projects.js` clean; eslint clean.
- [x] No colocated route tests exist for the two server routes; relying on the type-check + manual verification.
- [x] Manual checks: 
  1. GET /internal/apm/diagnostics (query all optional — kuery, start, end)
  GET kbn:/internal/apm/diagnostics?start=2026-07-13T00:00:00.000Z&end=2026-07-13T01:00:00.000Z&kuery=

  2. POST /internal/apm/diagnostics/service-map (body: start/end ISO, sourceNode, destinationNode, optional traceId)
  POST kbn:/internal/apm/diagnostics/service-map
  {
    "start": "2026-07-13T00:00:00.000Z",
    "end": "2026-07-13T01:00:00.000Z",
    "sourceNode": "opbeans-java",
    "destinationNode": "postgresql"
  }

  3. GET /internal/apm/services/{serviceName}/has_system_metrics (query: environment, start, end — all required)
  GET kbn:/internal/apm/services/opbeans-java/has_system_metrics?environment=ENVIRONMENT_ALL&start=2026-07-13T00:00:00.000Z&end=2026-07-13T01:00:00.000Z

  4. POST /api/apm/services/{serviceName}/annotation — versioned public API, and it creates an annotation (needs apm_write). Note the version header:
  POST kbn:/api/apm/services/opbeans-java/annotation
  elastic-api-version: 2023-10-31
  {
    "@timestamp": "2026-07-13T00:30:00.000Z",
    "service": { "version": "1.0.0", "environment": "production" },
    "message": "test annotation"
  }


Note: the index export block overlaps with #277439 (both surface the additive zod schemas) — trivial resolve whichever merges second.