### PR TITLE
[Security Solution] fallback document fetch for restored indices

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { buildFallbackIndexName, useTimelineEventsDetails } from '.';
+import { useKibana } from '../../../common/lib/kibana';
+import { useAppToasts } from '../../../common/hooks/use_app_toasts';
+
+jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/hooks/use_app_toasts');
+
+describe('buildFallbackIndexName', () => {
+  it('inserts a wildcard before a plain index name', () => {
+    expect(buildFallbackIndexName('packetbeat-8.0-2026.01.01')).toEqual(
+      '*packetbeat-8.0-2026.01.01'
+    );
+  });
+
+  it('inserts a wildcard before an index name that starts with a dot', () => {
+    expect(buildFallbackIndexName('.ds-logs-windows.forwarded-default-2026.05.17-012831')).toEqual(
+      '*.ds-logs-windows.forwarded-default-2026.05.17-012831'
+    );
+  });
+
+  it('preserves a cross-cluster alias and inserts the wildcard after it', () => {
+    expect(
+      buildFallbackIndexName('sysapp:.ds-logs-windows.forwarded-default-2026.05.17-012831')
+    ).toEqual('sysapp:*.ds-logs-windows.forwarded-default-2026.05.17-012831');
+  });
+
+  it('broadens each entry of a comma-separated list independently', () => {
+    expect(buildFallbackIndexName('.ds-logs-a,sysapp:.ds-logs-b')).toEqual(
+      '*.ds-logs-a,sysapp:*.ds-logs-b'
+    );
+  });
+});
+
+/**
+ * Regression coverage for SDH https://github.com/elastic/sdh-security-team/issues/1666.
+ *
+ * When a document lookup uses an index name that has gone stale (e.g. the source index was moved to
+ * a searchable-snapshot tier and renamed with a `restored-`/`partial-` prefix), the primary lookup
+ * finds no document. The hook then retries once against a broadened index pattern derived from the
+ * same index name, which matches the prefixed variant.
+ */
+const STALE_INDEX = 'sysapp:.ds-logs-windows.forwarded-default-2026.05.17-012831';
+const BROADENED_INDEX = 'sysapp:*.ds-logs-windows.forwarded-default-2026.05.17-012831';
+const EVENT_ID = 'AZ40wHwLBhzc64FIlyCY';
+
+const foundHit = {
+  _id: EVENT_ID,
+  _index: 'sysapp:restored-.ds-logs-windows.forwarded-default-2026.05.17-012831',
+  fields: { '@timestamp': ['2026-05-17T01:28:31.000Z'] },
+};
+
+const emptyResponse = {
+  isRunning: false,
+  isPartial: false,
+  rawResponse: { hits: { hits: [] } },
+  data: [],
+  ecs: null,
+};
+
+const foundResponse = {
+  isRunning: false,
+  isPartial: false,
+  rawResponse: { hits: { hits: [foundHit] } },
+  data: [{ field: '@timestamp', values: ['2026-05-17T01:28:31.000Z'] }],
+  ecs: { _id: EVENT_ID },
+};
+
+const addError = jest.fn();
+
+// Emits `next`/`error` asynchronously (like the real search service) and returns a Subscription.
+const asyncObservable = (emit: (handlers: { next: Function; error: Function }) => void) => ({
+  subscribe: (handlers: { next: Function; error: Function }) => {
+    const timer = setTimeout(() => emit(handlers), 0);
+    return { unsubscribe: jest.fn(() => clearTimeout(timer)) };
+  },
+});
+
+// Builds a `data.search.search` mock whose outcome is decided per requested index name.
+const mockSearch = (outcomeFor: (indexName: string) => 'found' | 'empty' | 'error') => {
+  const search = jest.fn((request: { indexName: string }) =>
+    asyncObservable(({ next, error }) => {
+      const outcome = outcomeFor(request.indexName);
+      if (outcome === 'found') {
+        next(foundResponse);
+      } else if (outcome === 'error') {
+        error(new Error("Cannot read properties of undefined (reading 'fields')"));
+      } else {
+        next(emptyResponse);
+      }
+    })
+  );
+
+  (useKibana as jest.Mock).mockReturnValue({ services: { data: { search: { search } } } });
+  return search;
+};
+
+const renderDetails = () =>
+  renderHook(() =>
+    useTimelineEventsDetails({
+      indexName: STALE_INDEX,
+      eventId: EVENT_ID,
+      runtimeMappings: {},
+      skip: false,
+    })
+  );
+
+describe('useTimelineEventsDetails - broadened index retry (SDH #1666)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppToasts as jest.Mock).mockReturnValue({ addError });
+  });
+
+  it('retries against the broadened index and resolves the document when the primary index returns no hit', async () => {
+    const search = mockSearch((indexName) => (indexName === BROADENED_INDEX ? 'found' : 'empty'));
+
+    const { result } = renderDetails();
+
+    await waitFor(() => expect(result.current[2]).toEqual(foundHit));
+
+    // Two calls: primary (stale) then the broadened pattern.
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(search.mock.calls[0][0]).toEqual(expect.objectContaining({ indexName: STALE_INDEX }));
+    expect(search.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ indexName: BROADENED_INDEX })
+    );
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('retries against the broadened index when the primary lookup errors', async () => {
+    const search = mockSearch((indexName) => (indexName === BROADENED_INDEX ? 'found' : 'error'));
+
+    const { result } = renderDetails();
+
+    await waitFor(() => expect(result.current[2]).toEqual(foundHit));
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when the primary lookup succeeds', async () => {
+    const search = mockSearch(() => 'found');
+
+    const { result } = renderDetails();
+
+    await waitFor(() => expect(result.current[2]).toEqual(foundHit));
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries at most once and surfaces the error when the broadened index also fails', async () => {
+    const search = mockSearch(() => 'error');
+
+    const { result } = renderDetails();
+
+    await waitFor(() => expect(addError).toHaveBeenCalledTimes(1));
+    // Exactly two calls proves the single-retry guard prevents an infinite loop.
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(result.current[2]).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/details/index.tsx
@@ -24,6 +24,35 @@ import { TimelineEventsQueries } from '../../../../common/search_strategy';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import * as i18n from './translations';
 
+/**
+ * Broadens an index name so a document still resolves after its backing index has been relocated to
+ * a searchable-snapshot tier and renamed with a `restored-` (cold) or `partial-` (frozen) prefix. A
+ * wildcard is inserted immediately before the index name — after the cross-cluster `cluster:` alias
+ * when present, so cross-cluster routing is preserved — which makes the pattern match both the
+ * original and the prefixed variant, e.g. `sysapp:.ds-logs-windows-2026.05.17` ->
+ * `sysapp:*.ds-logs-windows-2026.05.17`, matching `sysapp:restored-.ds-logs-windows-2026.05.17`.
+ * Comma-separated lists are handled per entry.
+ * See SDH https://github.com/elastic/sdh-security-team/issues/1666.
+ */
+export const buildFallbackIndexName = (indexName: string): string =>
+  indexName
+    .split(',')
+    .map((entry) => {
+      const trimmed = entry.trim();
+      if (!trimmed) {
+        return trimmed;
+      }
+      // `cluster:index` is the cross-cluster-search separator; the cluster alias cannot contain `:`.
+      const separatorIndex = trimmed.indexOf(':');
+      if (separatorIndex === -1) {
+        return `*${trimmed}`;
+      }
+      const clusterAlias = trimmed.slice(0, separatorIndex + 1);
+      const index = trimmed.slice(separatorIndex + 1);
+      return `${clusterAlias}*${index}`;
+    })
+    .join(',');
+
 export interface EventsArgs {
   detailsData: TimelineEventsDetailsItem[] | null;
   ecs: Ecs | null;
@@ -55,6 +84,9 @@ export const useTimelineEventsDetails = ({
   const refetch = useRef<() => Promise<void>>(asyncNoop);
   const abortCtrl = useRef(new AbortController());
   const searchSubscription$ = useRef(new Subscription());
+  // Guards the single broadened-index retry so a document that genuinely cannot be found does not
+  // loop between the primary and fallback indices. Reset whenever the lookup inputs change.
+  const attemptedFallbackRef = useRef(false);
 
   // loading = false initial state causes flashes of empty tables
   const [loading, setLoading] = useState(true);
@@ -73,6 +105,24 @@ export const useTimelineEventsDetails = ({
         return;
       }
 
+      // When the primary lookup finds no document, its index name may have gone stale because the
+      // backing index was relocated to a searchable-snapshot tier and renamed with a `restored-`/
+      // `partial-` prefix. Retry once against a broadened index pattern that also matches the
+      // prefixed variant. Such a stale index currently surfaces as a server error rather than an
+      // empty response, so we trigger the retry from both the empty-hit and error paths. See
+      // SDH #1666.
+      const fallbackIndex = request.indexName
+        ? buildFallbackIndexName(request.indexName)
+        : undefined;
+      const canRetryWithFallback =
+        !!fallbackIndex && !attemptedFallbackRef.current && fallbackIndex !== request.indexName;
+
+      const retryWithFallback = () => {
+        attemptedFallbackRef.current = true;
+        searchSubscription$.current.unsubscribe();
+        timelineDetailsSearch({ ...request, indexName: fallbackIndex as string });
+      };
+
       const asyncSearch = async () => {
         abortCtrl.current = new AbortController();
         setLoading(true);
@@ -88,6 +138,10 @@ export const useTimelineEventsDetails = ({
           .subscribe({
             next: (response) => {
               if (!isRunningResponse(response)) {
+                if (!response.rawResponse.hits.hits[0] && canRetryWithFallback) {
+                  retryWithFallback();
+                  return;
+                }
                 Promise.resolve().then(() => {
                   setLoading(false);
                   setTimelineDetailsResponse(response.data || []);
@@ -98,6 +152,10 @@ export const useTimelineEventsDetails = ({
               }
             },
             error: (msg) => {
+              if (canRetryWithFallback) {
+                retryWithFallback();
+                return;
+              }
               setLoading(false);
               addError(msg, { title: i18n.FAIL_TIMELINE_SEARCH_DETAILS });
               searchSubscription$.current.unsubscribe();
@@ -113,6 +171,8 @@ export const useTimelineEventsDetails = ({
   );
 
   useEffect(() => {
+    // A new document (or index) is being requested: allow the fallback retry to run again.
+    attemptedFallbackRef.current = false;
     setTimelineDetailsRequest((prevRequest) => {
       const myRequest = {
         ...(prevRequest ?? {}),


### PR DESCRIPTION
## Summary

This PR introduces a fallback mechanism to fetch documents when their index name may have changed.

### What was happening

We recently had an SDH where the customer was clicking on the `Source event` link within the `Highlighted Fields` section of the alert details flyout, and that link was opening the preview flyout with a big error message.
What was happening is the index that was holding the document had been restored (potentially from being moved to cold/frozen tiers). When that happens, the index is prefixed with a `restored` word. In our case, when opening the source event, we are using the value in the `kibana.alert.ancestors.index` field that we have on the alert document. But that value isn't updated when restoring the source event index, and therefore we are fetching a document id in an index that does not exist anymore.

You can see the issue reproduced locally below

https://github.com/user-attachments/assets/d63176da-2116-44c3-a6dd-b517af4a6429

### Solutions explored

At first we thought about implemented a fallback that - once the first attempt to fetch the document failed - would try to fetch again, but this time using the default data view. But we quickly realized that the restored index might not be in the data view either, which would end up showing the same error message.

It was then decided to have a function that modifies the value of the index and adds a wildcard that will ensure that we fetch the restored index. This only happens in the first fetch fails, which lowers the impact and risk of this change

This is how it will work now:

https://github.com/user-attachments/assets/ecdd0637-418a-4ca5-bfea-f6c839774d17

## How to test

- generate some documents locally (`yarn test:generate`)
- generate some alerts off of those documents (install the `Endpoint Security` rule)

Use Kibana Dev Toolsto make one alert’s source event only available in a restored- index.

Find one alert with ancestor index/id:
GET .alerts-security.alerts-*/_search
{
  "size": 5,
  "_source": [
    "kibana.alert.ancestors",
    "kibana.alert.rule.name",
    "@timestamp"
  ],
  "query": {
    "exists": { "field": "kibana.alert.ancestors.index" }
  },
  "sort": [{ "@timestamp": "desc" }]
}
```

Pick one ancestor event entry and note:
```
OLD_INDEX = kibana.alert.ancestors.index
EVENT_ID = kibana.alert.ancestors.id
```

Create a restored-style index and copy only that event:
```
POST _reindex
{
  "source": {
    "index": "OLD_INDEX",
    "query": {
      "ids": { "values": ["EVENT_ID"] }
    }
  },
  "dest": {
    "index": "restored-OLD_INDEX",
    "op_type": "create"
  }
}
```

Confirm doc exists in restored index:
```
GET restored-OLD_INDEX/_doc/EVENT_ID
```

Remove it from original index so primary lookup fails (this triggers fallback):
```
POST OLD_INDEX/_delete_by_query
{
  "query": {
    "ids": { "values": ["EVENT_ID"] }
  }
}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->