### PR TITLE
[SharedUX][DateRangePicker] Anchor relative start/end bounds to the same "now"

### DIFF
--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import dateMath from '@elastic/datemath';
 import { textToTimeRange, matchPreset, getNamedRangeAlias } from './parse_text';
 import { DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW, DATE_TYPE_RELATIVE } from '../constants';
 import { getOptionInputText, toLocalPreciseString } from '../utils';
@@ -689,6 +690,38 @@ describe('textToTimeRange', () => {
         expect(range.end).toBe(bounds.end);
       }
     });
+  });
+});
+
+describe('"now" anchoring', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Regression test for https://github.com/elastic/kibana/issues/276537:
+  // "-15m to now" resolves the start and end bounds via two separate
+  // dateMath.parse calls, each defaulting "now" to the real clock. On a
+  // loaded CI runner enough wall-clock time can elapse between those two
+  // calls to skew the window away from a clean 15 minutes. This reproduces
+  // that skew deterministically by advancing the faked clock between the
+  // first ("now-15m") and second ("now") dateMath.parse call.
+  it('resolves relative start/end bounds against the same instant, even if the real clock advances in between', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-07-15T12:00:00.000Z'));
+
+    let callCount = 0;
+    const realParse = dateMath.parse.bind(dateMath);
+    jest.spyOn(dateMath, 'parse').mockImplementation((text, options) => {
+      callCount += 1;
+      if (callCount === 2) {
+        jest.setSystemTime(new Date('2025-07-15T12:00:01.500Z'));
+      }
+      return realParse(text, options);
+    });
+
+    const range = textToTimeRange('-15m to now', { roundRelativeTime: false });
+
+    expect(range.endDate!.getTime() - range.startDate!.getTime()).toBe(15 * 60 * 1000);
   });
 });
 

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
@@ -339,7 +339,7 @@ function containsGrammarVocabulary(text: string, compiled: CompiledGrammar): boo
 function dateStringToDate(
   dateString: DateString,
   formats: string[],
-  options?: { roundUp?: boolean }
+  options?: { roundUp?: boolean; forceNow?: Date }
 ): Date | null {
   const strict = moment(dateString, formats, true);
   if (strict.isValid()) return strict.toDate();
@@ -374,12 +374,14 @@ function buildRange(
 ): TimeRange {
   const startType = dateStringToType(start);
   const endType = dateStringToType(end);
+  // Anchor both bounds to the same instant
+  const forceNow = new Date();
   const range: TimeRange = {
     value: text,
     start,
     end,
-    startDate: dateStringToDate(start, formats),
-    endDate: dateStringToDate(end, formats, { roundUp: true }),
+    startDate: dateStringToDate(start, formats, { forceNow }),
+    endDate: dateStringToDate(end, formats, { roundUp: true, forceNow }),
     type: [startType, endType],
     isNaturalLanguage,
     startOffset: startType === DATE_TYPE_RELATIVE ? dateStringToOffset(start) : null,


### PR DESCRIPTION
## Summary

Fixes #276537

This PR fixes a flaky test. A `Next 15 minutes` string is expected (as the content of a tooltip), but `Next ~15 minutes` could be rendered instead. The tilde represents a time range that is not exact. And it would appear incorrectly for an "exact" 15 minutes range.

Apart from the flakiness issue, this ensures correctness in the UI. It has nothing to do with the output ranges consumers of the component deal with in the end.

### Fix

The same "now" date object is being used as a reference when computing both ends of the range. Via the `forceNow` option in `dateMath.parse` from the `@elastic/datemath` package used in the component.

## Test plan (🤖 LLM-generated)

- [x] Added a regression test (`"now" anchoring"` in `parse_text.test.ts`) that uses fake timers and a `dateMath.parse` spy to deterministically advance the clock by 1.5s between resolving the start and end bounds — reproducing the CI race locally instead of relying on flaky timing.
  - Verified this test fails against the pre-fix code (`901500` vs expected `900000`) and passes with the fix.
- [x] Full package test suite passes: `node scripts/jest --config src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/jest.config.js` (21 suites, 626 tests).
- [x] `node scripts/type_check --project src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/tsconfig.json`
- [x] `node scripts/eslint --fix` on changed files

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->