### PR TITLE
[8.19] [Console] Fix Windows CRLF editor corruption (#277007)

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { monaco } from '@kbn/monaco';
+import { render, waitFor } from '@testing-library/react';
+import { MonacoEditor } from './editor';
+
+const createEvent = (
+  changes: monaco.editor.IModelContentChange[],
+  eol = '\n'
+): monaco.editor.IModelContentChangedEvent => ({
+  changes,
+  eol,
+  versionId: 1,
+  isUndoing: false,
+  isRedoing: false,
+  isFlush: false,
+  isEolChange: false,
+});
+
+const createRange = (): monaco.IRange => ({
+  startLineNumber: 1,
+  startColumn: 1,
+  endLineNumber: 1,
+  endColumn: 1,
+});
+
+const createDisposable = (): monaco.IDisposable => ({ dispose: jest.fn() });
+
+const setupMonacoEditorHarness = (params: {
+  onDidChangeModelContent?: (cb: (e: monaco.editor.IModelContentChangedEvent) => void) => void;
+  onPushUndoStop: jest.Mock;
+  onCreateModel?: (model: monaco.editor.ITextModel) => void;
+}) => {
+  const disposable = createDisposable();
+
+  const createSpy = jest.spyOn(monaco.editor, 'create').mockImplementation((container, options) => {
+    if (!options?.model) {
+      throw new Error('expected create() to be called with a model');
+    }
+
+    const model = options.model;
+    params.onCreateModel?.(model);
+
+    const editor = {
+      onDidChangeModelContent: (cb: (e: monaco.editor.IModelContentChangedEvent) => void) => {
+        params.onDidChangeModelContent?.(cb);
+        return disposable;
+      },
+      getModel: () => model,
+      pushUndoStop: params.onPushUndoStop,
+      updateOptions: jest.fn(),
+      layout: jest.fn(),
+      dispose: jest.fn(),
+      getDomNode: () => null,
+    } as unknown as monaco.editor.IStandaloneCodeEditor;
+
+    return editor;
+  });
+
+  const markersSpy = jest
+    .spyOn(monaco.editor, 'onDidChangeMarkers')
+    .mockImplementation(() => disposable);
+  const getModelMarkersSpy = jest.spyOn(monaco.editor, 'getModelMarkers').mockReturnValue([]);
+
+  const cleanup = () => {
+    createSpy.mockRestore();
+    markersSpy.mockRestore();
+    getModelMarkersSpy.mockRestore();
+  };
+
+  return { cleanup };
+};
+
+describe('react monaco editor onChange performance', () => {
+  let lastOnDidChangeModelContentCb:
+    | ((e: monaco.editor.IModelContentChangedEvent) => void)
+    | undefined;
+
+  beforeEach(() => {
+    lastOnDidChangeModelContentCb = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('does not normalize or push edits when a controlled rerender matches the shadow value', async () => {
+    const originalCreateModel = monaco.editor.createModel.bind(monaco.editor);
+    let pushEditOperationsSpy: jest.SpyInstance | undefined;
+    const createModelSpy = jest
+      .spyOn(monaco.editor, 'createModel')
+      .mockImplementation((...args) => {
+        const model = originalCreateModel(...args);
+        pushEditOperationsSpy = jest.spyOn(model, 'pushEditOperations');
+        return model;
+      });
+
+    const editorPushUndoStop = jest.fn();
+    const { cleanup } = setupMonacoEditorHarness({
+      onDidChangeModelContent: (cb) => {
+        lastOnDidChangeModelContentCb = cb;
+      },
+      onPushUndoStop: editorPushUndoStop,
+    });
+
+    const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+    const { rerender } = render(
+      <MonacoEditor value="abcdefghij" onChange={onChange} options={{}} />
+    );
+
+    await waitFor(() => expect(typeof lastOnDidChangeModelContentCb).toBe('function'));
+
+    const range = createRange();
+    const event = createEvent([{ range, rangeOffset: 2, rangeLength: 2, text: 'XXXX' }]);
+    lastOnDidChangeModelContentCb!(event);
+
+    expect(onChange).toHaveBeenCalledWith('abXXXXefghij', event);
+
+    const stringIncludesSpy = jest.spyOn(String.prototype, 'includes');
+    try {
+      rerender(<MonacoEditor value="abXXXXefghij" onChange={onChange} options={{}} />);
+
+      expect(stringIncludesSpy).not.toHaveBeenCalledWith('\r');
+      expect(pushEditOperationsSpy).toBeDefined();
+      expect(pushEditOperationsSpy!).not.toHaveBeenCalled();
+      expect(editorPushUndoStop).not.toHaveBeenCalled();
+    } finally {
+      stringIncludesSpy.mockRestore();
+      createModelSpy.mockRestore();
+      cleanup();
+    }
+  });
+
+  describe('WHEN the Monaco model uses CRLF and the controlled value uses LF', () => {
+    it('SHOULD apply Monaco change offsets to a CRLF-normalized shadow value', async () => {
+      let createdModel: monaco.editor.ITextModel | undefined;
+
+      const editorPushUndoStop = jest.fn();
+      const { cleanup } = setupMonacoEditorHarness({
+        onDidChangeModelContent: (cb) => {
+          lastOnDidChangeModelContentCb = cb;
+        },
+        onPushUndoStop: editorPushUndoStop,
+        onCreateModel: (model) => {
+          createdModel = model;
+        },
+      });
+
+      const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+      const { rerender } = render(<MonacoEditor value="" onChange={onChange} options={{}} />);
+
+      await waitFor(() => {
+        expect(createdModel).toBeDefined();
+        expect(typeof lastOnDidChangeModelContentCb).toBe('function');
+      });
+
+      createdModel!.setEOL(monaco.editor.EndOfLineSequence.CRLF);
+      rerender(<MonacoEditor value={'A\nB'} onChange={onChange} options={{}} />);
+      onChange.mockClear();
+
+      const range = createRange();
+      const event = createEvent(
+        [{ range, rangeOffset: 3, rangeLength: 1, text: 'X' }],
+        createdModel!.getEOL()
+      );
+      lastOnDidChangeModelContentCb!(event);
+
+      expect(onChange).toHaveBeenCalledWith('A\r\nX', event);
+
+      cleanup();
+    });
+  });
+
+  describe('WHEN the Monaco model uses LF and the controlled value uses CRLF', () => {
+    it('SHOULD apply Monaco change offsets to an LF-normalized shadow value', async () => {
+      let createdModel: monaco.editor.ITextModel | undefined;
+
+      const editorPushUndoStop = jest.fn();
+      const { cleanup } = setupMonacoEditorHarness({
+        onDidChangeModelContent: (cb) => {
+          lastOnDidChangeModelContentCb = cb;
+        },
+        onPushUndoStop: editorPushUndoStop,
+        onCreateModel: (model) => {
+          createdModel = model;
+        },
+      });
+
+      const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+      const { rerender } = render(<MonacoEditor value="" onChange={onChange} options={{}} />);
+
+      await waitFor(() => {
+        expect(createdModel).toBeDefined();
+        expect(typeof lastOnDidChangeModelContentCb).toBe('function');
+      });
+
+      createdModel!.setEOL(monaco.editor.EndOfLineSequence.LF);
+      rerender(<MonacoEditor value={'A\r\nB'} onChange={onChange} options={{}} />);
+      onChange.mockClear();
+
+      const range = createRange();
+      const event = createEvent(
+        [{ range, rangeOffset: 2, rangeLength: 1, text: 'X' }],
+        createdModel!.getEOL()
+      );
+      lastOnDidChangeModelContentCb!(event);
+
+      expect(onChange).toHaveBeenCalledWith('A\nX', event);
+
+      cleanup();
+    });
+  });
+});

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -133,6 +133,36 @@ const applyModelContentChanges = (
     return acc.slice(0, start) + change.text + acc.slice(end);
   }, prevValue);
 };
+
+const ALL_LINE_ENDINGS = /\r\n|\r|\n/g;
+// For CRLF models, this separates values that are already safe to leave untouched
+// (`foo\r\nbar`) from values whose offsets would not line up with Monaco's CRLF model
+// text (`foo\nbar`, `foo\rbar`).
+const HAS_NON_CRLF_LINE_ENDING = /(^|[^\r])\n|\r(?!\n)/;
+
+/**
+ * Keep the shadow value's line endings aligned with Monaco before applying
+ * `IModelContentChangedEvent.changes`.
+ *
+ * Monaco applies edits against its text buffer: it normalizes edit text to the buffer
+ * EOL, then records `rangeOffset` / `rangeLength` from that same buffer:
+ * https://github.com/microsoft/vscode/blob/e7e037083ff4455cf320e344325dacb480062c3c/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts#L276-L290
+ *
+ * Without this, an LF shadow is one `\r` shorter per preceding line break than a CRLF
+ * Monaco model, so model offsets replace the wrong character.
+ */
+const normalizeEndOfLine = (value: string, eol: string): string => {
+  if (eol === '\n' && !value.includes('\r')) {
+    return value;
+  }
+
+  if (eol === '\r\n' && !HAS_NON_CRLF_LINE_ENDING.test(value)) {
+    return value;
+  }
+
+  return value.replace(ALL_LINE_ENDINGS, eol);
+};
+
 export function MonacoEditor({
   width = '100%',
   height = '100%',
@@ -170,8 +200,9 @@ export function MonacoEditor({
    */
   const lastKnownValueRef = useRef<string>(value ?? defaultValue);
   useEffect(() => {
-    if (typeof value === 'string') {
-      lastKnownValueRef.current = value;
+    if (typeof value === 'string' && value !== lastKnownValueRef.current) {
+      const modelEol = editor.current?.getModel()?.getEOL();
+      lastKnownValueRef.current = modelEol ? normalizeEndOfLine(value, modelEol) : value;
     }
   }, [value]);
 
@@ -234,6 +265,7 @@ export function MonacoEditor({
       const finalOptions = { ...options, ...handleEditorWillMount() };
 
       const model = monaco.editor.createModel(finalValue!, language);
+      lastKnownValueRef.current = normalizeEndOfLine(finalValue!, model.getEOL());
 
       editor.current = monaco.editor.create(containerElement.current, {
         model,
@@ -259,15 +291,24 @@ export function MonacoEditor({
       }
 
       const model = editor.current.getModel();
+      if (!model) {
+        return;
+      }
+
+      const valueInModelEol = normalizeEndOfLine(value, model.getEOL());
+      if (valueInModelEol === lastKnownValueRef.current) {
+        return;
+      }
+
       __preventTriggerChangeEvent.current = true;
       editor.current.pushUndoStop();
       // pushEditOperations says it expects a cursorComputer, but doesn't seem to need one.
-      model!.pushEditOperations(
+      model.pushEditOperations(
         [],
         [
           {
-            range: model!.getFullModelRange(),
-            text: value!,
+            range: model.getFullModelRange(),
+            text: valueInModelEol,
           },
         ],
         // @ts-expect-error
@@ -277,7 +318,7 @@ export function MonacoEditor({
       __preventTriggerChangeEvent.current = false;
 
       // Keep shadow state in sync for programmatic updates where we suppress onDidChangeModelContent.
-      lastKnownValueRef.current = value;
+      lastKnownValueRef.current = valueInModelEol;
     }
   }, [value]);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix Windows CRLF editor corruption (#277007)](https://github.com/elastic/kibana/pull/277007)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T09:29:14Z","message":"[Console] Fix Windows CRLF editor corruption (#277007)\n\nCloses #276552\n\n## Summary\n\n- Keeps the React-side CodeEditor shadow value in the same end-of-line\nrepresentation as the Monaco model.\n- Prevents Monaco change offsets from being applied to the wrong string\ncoordinate space when the model uses CRLF and the controlled value uses\nLF.\n- Skips EOL normalization and edit operations when a controlled rerender\nalready matches the shadow value, preserving the large-buffer hot path.\n- Adds regression coverage for both LF/CRLF mismatch directions, with\ntest events using the model EOL.\n\n## Root Cause\n\nThe CodeEditor performance optimization in #251173 avoided per-keystroke\n`editor.getValue()` calls by applying Monaco `event.changes` to a\nReact-side shadow string.\n\nOn Windows, Monaco can use CRLF model coordinates while the controlled\nReact value uses LF. Monaco reports `rangeOffset` and `rangeLength` in\nthe model's string coordinate space, so applying those offsets to an LF\nshadow shifts edits after preceding newlines and can corrupt persisted\neditor content.\n\n## Fix\n\n- Normalize controlled values to the current Monaco model EOL before\nstoring or comparing the shadow value.\n- Return the original string when normalization is not needed, including\nthe CRLF case where every line break is already a CRLF pair.\n- Check the controlled value against the shadow before inspecting line\nendings, avoiding repeated full-buffer scans on matching controlled\nrerenders.\n- Keep the existing incremental change path so the performance\noptimization remains in place.\n- Make the EOL-mismatch tests construct change events with the Monaco\nmodel's current EOL.\n\n## Before/After Screenshots (or Video)\n\nNot included. The regression affects persisted editor text after refresh\nrather than a distinct visual presentation.\n\n## Test Plan\n\nManual reproduction/verification:\n\n1. Use a Windows browser, or simulate a Windows user agent before Monaco\nloads.\n2. Open Dev Tools Console with the default multi-line sample text.\n3. Edit a request after several preceding newlines, for example change\n`GET /my-index/_search?q=\"rocky mountain\"` to `GET\n/my-index-2/_search?q=\"rocky mountain\"`.\n4. Wait for Console autosave, then refresh the page.\n5. Before this fix, the restored buffer can contain duplicated/truncated\ntext around the edited range. After this fix, the edited request is\npreserved exactly.\n\nAutomated checks:\n\n- `node scripts/eslint\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx`\npassed.\n- `node scripts/jest\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx`\npassed with 9 tests.\n- `node scripts/type_check --project\nsrc/platform/packages/shared/shared-ux/code_editor/impl/tsconfig.type_check.json`\npassed.\n\n## Release Note\n\nFixed a Windows-specific code editor issue that could corrupt multi-line\nedited text after refresh.\n\nAssisted with Copilot using GPT-5.5 and GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>","sha":"4a2ab7e5edb5e192eb4fb03148a068fe433c51d8","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","regression","release_note:fix","Team:Kibana Management","Platform:Windows","Team:SharedUX","backport:all-open","ci:cloud-redeploy","v9.6.0"],"title":"[Console] Fix Windows CRLF editor corruption","number":277007,"url":"https://github.com/elastic/kibana/pull/277007","mergeCommit":{"message":"[Console] Fix Windows CRLF editor corruption (#277007)\n\nCloses #276552\n\n## Summary\n\n- Keeps the React-side CodeEditor shadow value in the same end-of-line\nrepresentation as the Monaco model.\n- Prevents Monaco change offsets from being applied to the wrong string\ncoordinate space when the model uses CRLF and the controlled value uses\nLF.\n- Skips EOL normalization and edit operations when a controlled rerender\nalready matches the shadow value, preserving the large-buffer hot path.\n- Adds regression coverage for both LF/CRLF mismatch directions, with\ntest events using the model EOL.\n\n## Root Cause\n\nThe CodeEditor performance optimization in #251173 avoided per-keystroke\n`editor.getValue()` calls by applying Monaco `event.changes` to a\nReact-side shadow string.\n\nOn Windows, Monaco can use CRLF model coordinates while the controlled\nReact value uses LF. Monaco reports `rangeOffset` and `rangeLength` in\nthe model's string coordinate space, so applying those offsets to an LF\nshadow shifts edits after preceding newlines and can corrupt persisted\neditor content.\n\n## Fix\n\n- Normalize controlled values to the current Monaco model EOL before\nstoring or comparing the shadow value.\n- Return the original string when normalization is not needed, including\nthe CRLF case where every line break is already a CRLF pair.\n- Check the controlled value against the shadow before inspecting line\nendings, avoiding repeated full-buffer scans on matching controlled\nrerenders.\n- Keep the existing incremental change path so the performance\noptimization remains in place.\n- Make the EOL-mismatch tests construct change events with the Monaco\nmodel's current EOL.\n\n## Before/After Screenshots (or Video)\n\nNot included. The regression affects persisted editor text after refresh\nrather than a distinct visual presentation.\n\n## Test Plan\n\nManual reproduction/verification:\n\n1. Use a Windows browser, or simulate a Windows user agent before Monaco\nloads.\n2. Open Dev Tools Console with the default multi-line sample text.\n3. Edit a request after several preceding newlines, for example change\n`GET /my-index/_search?q=\"rocky mountain\"` to `GET\n/my-index-2/_search?q=\"rocky mountain\"`.\n4. Wait for Console autosave, then refresh the page.\n5. Before this fix, the restored buffer can contain duplicated/truncated\ntext around the edited range. After this fix, the edited request is\npreserved exactly.\n\nAutomated checks:\n\n- `node scripts/eslint\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx`\npassed.\n- `node scripts/jest\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx`\npassed with 9 tests.\n- `node scripts/type_check --project\nsrc/platform/packages/shared/shared-ux/code_editor/impl/tsconfig.type_check.json`\npassed.\n\n## Release Note\n\nFixed a Windows-specific code editor issue that could corrupt multi-line\nedited text after refresh.\n\nAssisted with Copilot using GPT-5.5 and GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>","sha":"4a2ab7e5edb5e192eb4fb03148a068fe433c51d8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277007","number":277007,"mergeCommit":{"message":"[Console] Fix Windows CRLF editor corruption (#277007)\n\nCloses #276552\n\n## Summary\n\n- Keeps the React-side CodeEditor shadow value in the same end-of-line\nrepresentation as the Monaco model.\n- Prevents Monaco change offsets from being applied to the wrong string\ncoordinate space when the model uses CRLF and the controlled value uses\nLF.\n- Skips EOL normalization and edit operations when a controlled rerender\nalready matches the shadow value, preserving the large-buffer hot path.\n- Adds regression coverage for both LF/CRLF mismatch directions, with\ntest events using the model EOL.\n\n## Root Cause\n\nThe CodeEditor performance optimization in #251173 avoided per-keystroke\n`editor.getValue()` calls by applying Monaco `event.changes` to a\nReact-side shadow string.\n\nOn Windows, Monaco can use CRLF model coordinates while the controlled\nReact value uses LF. Monaco reports `rangeOffset` and `rangeLength` in\nthe model's string coordinate space, so applying those offsets to an LF\nshadow shifts edits after preceding newlines and can corrupt persisted\neditor content.\n\n## Fix\n\n- Normalize controlled values to the current Monaco model EOL before\nstoring or comparing the shadow value.\n- Return the original string when normalization is not needed, including\nthe CRLF case where every line break is already a CRLF pair.\n- Check the controlled value against the shadow before inspecting line\nendings, avoiding repeated full-buffer scans on matching controlled\nrerenders.\n- Keep the existing incremental change path so the performance\noptimization remains in place.\n- Make the EOL-mismatch tests construct change events with the Monaco\nmodel's current EOL.\n\n## Before/After Screenshots (or Video)\n\nNot included. The regression affects persisted editor text after refresh\nrather than a distinct visual presentation.\n\n## Test Plan\n\nManual reproduction/verification:\n\n1. Use a Windows browser, or simulate a Windows user agent before Monaco\nloads.\n2. Open Dev Tools Console with the default multi-line sample text.\n3. Edit a request after several preceding newlines, for example change\n`GET /my-index/_search?q=\"rocky mountain\"` to `GET\n/my-index-2/_search?q=\"rocky mountain\"`.\n4. Wait for Console autosave, then refresh the page.\n5. Before this fix, the restored buffer can contain duplicated/truncated\ntext around the edited range. After this fix, the edited request is\npreserved exactly.\n\nAutomated checks:\n\n- `node scripts/eslint\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx`\npassed.\n- `node scripts/jest\nsrc/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx`\npassed with 9 tests.\n- `node scripts/type_check --project\nsrc/platform/packages/shared/shared-ux/code_editor/impl/tsconfig.type_check.json`\npassed.\n\n## Release Note\n\nFixed a Windows-specific code editor issue that could corrupt multi-line\nedited text after refresh.\n\nAssisted with Copilot using GPT-5.5 and GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>","sha":"4a2ab7e5edb5e192eb4fb03148a068fe433c51d8"}},{"url":"https://github.com/elastic/kibana/pull/277686","number":277686,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/277687","number":277687,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/277688","number":277688,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->