### PR TITLE
[Synthetics] Don't log invalid location errors as server errors

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.test.ts
@@ -234,6 +234,46 @@ describe('ProjectMonitorFormatter', () => {
     });
   });
 
+  it('returns invalid location error without logging it as a server error', async () => {
+    logger.error.mockClear();
+
+    const invalidLocationMonitor = {
+      ...testMonitors[0],
+      locations: [],
+      privateLocations: ['does not exist'],
+    };
+    const pushMonitorFormatter = new ProjectMonitorFormatter({
+      projectId: 'test-project',
+      spaceId: 'default',
+      routeContext,
+      monitors: [invalidLocationMonitor],
+    });
+
+    pushMonitorFormatter.getProjectMonitorsForProject = jest.fn().mockResolvedValue([]);
+
+    await pushMonitorFormatter.configureAllProjectMonitors();
+
+    expect({
+      createdMonitors: pushMonitorFormatter.createdMonitors,
+      updatedMonitors: pushMonitorFormatter.updatedMonitors,
+      failedMonitors: pushMonitorFormatter.failedMonitors,
+    }).toStrictEqual({
+      createdMonitors: [],
+      updatedMonitors: [],
+      failedMonitors: [
+        {
+          details:
+            "Invalid locations specified. Private Location(s) 'does not exist' not found. Available private locations are 'Test private location'",
+          id: 'check if title is present 10 0',
+          payload: invalidLocationMonitor,
+          reason: "Couldn't save or update monitor because of an invalid configuration.",
+        },
+      ],
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
   it('catches errors from bulk edit method', async () => {
     soClient.bulkCreate.mockImplementation(async () => {
       return {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.ts
@@ -229,10 +229,15 @@ export class ProjectMonitorFormatter {
 
       return decodedMonitor;
     } catch (e) {
-      this.server.logger.error(e);
+      const isInvalidLocation = e instanceof InvalidLocationError;
 
-      const reason =
-        e instanceof InvalidLocationError ? INVALID_CONFIGURATION_ERROR : FAILED_TO_UPDATE_MONITOR;
+      // Invalid locations are a user input error that we surface in the API response via
+      // `failedMonitors`; don't log them as a server error (see issue #221378).
+      if (!isInvalidLocation) {
+        this.server.logger.error(e);
+      }
+
+      const reason = isInvalidLocation ? INVALID_CONFIGURATION_ERROR : FAILED_TO_UPDATE_MONITOR;
 
       this.failedMonitors.push({
         reason,


### PR DESCRIPTION
## Summary

Invalid locations in a project monitor payload are a **user input error** that is already surfaced in the API response via `failedMonitors`. Previously `ProjectMonitorFormatter.validateProjectMonitor` logged every caught error (including `InvalidLocationError`) via `server.logger.error`, polluting server logs with messages like:

```
Invalid locations specified. Elastic managed Location(s) '...' not found. Available locations are '...'
Invalid locations specified. Private Location(s) '...' not found. Available private locations are '...'
```

This change skips the `logger.error` call for `InvalidLocationError` while still returning the proper API response (the monitor is still added to `failedMonitors` with the `INVALID_CONFIGURATION_ERROR` reason). The single add/edit monitor routes already returned `badRequest` without logging, so no change was needed there.

Closes #221378

## Test plan

- [ ] Added a Jest unit test in `project_monitor_formatter.test.ts` asserting an invalid location is returned in `failedMonitors` and `logger.error` is not called.
- [ ] Verify project monitor push with an invalid location returns a validation error in the API response and produces no `error`-level server log.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->