### PR TITLE
[ES|QL] Replace query based ES|QL panel detection with explicit usesEsql$ for Lens and Discover

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common-2/index.ts
+++ b/src/platform/packages/shared/kbn-lens-common-2/index.ts
@@ -15,6 +15,7 @@ import type {
   PublishesDataLoading,
   PublishesDataViews,
   PublishesDisabledActionIds,
+  PublishesEsqlUsage,
   PublishesProjectRoutingOverrides,
   PublishesRendered,
   PublishesSavedObjectId,
@@ -120,6 +121,7 @@ export type LensApi = Simplify<
     // Let the container know about unsaved changes
     PublishesUnsavedChanges &
     PublishesProjectRoutingOverrides &
+    PublishesEsqlUsage &
     // Lens specific API methods:
     // Let the container know when the data has been loaded/updated
     LensInspectorAdapters &

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -9,7 +9,7 @@
 
 import deepEqual from 'fast-deep-equal';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { combineLatest, distinctUntilChanged, map } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs';
 import UseUnmount from 'react-use/lib/useUnmount';
 
 import type { EuiBreadcrumb, UseEuiTheme } from '@elastic/eui';
@@ -25,18 +25,15 @@ import {
 import { css } from '@emotion/react';
 import type { MountPoint } from '@kbn/core/public';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
-import type { AggregateQuery, Query } from '@kbn/es-query';
-import { isOfAggregateQueryType } from '@kbn/es-query';
+import type { Query } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getManagedContentBadge } from '@kbn/managed-content-badge';
 import type { TopNavMenuBadgeProps, TopNavMenuProps } from '@kbn/navigation-plugin/public';
 import {
   apiPublishesEsqlUsage,
-  apiPublishesUnifiedSearch,
   combineCompatibleChildrenApis,
   type PublishesEsqlUsage,
-  type PublishesUnifiedSearch,
   useBatchedPublishingSubjects,
 } from '@kbn/presentation-publishing';
 import { LazyLabsFlyout, withSuspense } from '@kbn/presentation-util-plugin/public';
@@ -157,25 +154,14 @@ export function InternalDashboardTopNav({
 
   const [hasEsqlPanel, setHasEsqlPanel] = useState(false);
   useEffect(() => {
-    const hasEsqlQuery$ = combineCompatibleChildrenApis<
-      PublishesUnifiedSearch,
-      (Query | AggregateQuery | undefined)[]
-    >(dashboardApi, 'query$', apiPublishesUnifiedSearch, []).pipe(
-      map((queries) => queries.some((q) => isOfAggregateQueryType(q)))
-    );
-
-    // Vega panels can embed ES|QL data sources directly in their spec, without ever
-    // publishing an aggregate query$, so they publish their own usesEsql$ signal instead.
-    const hasEsqlVegaPanel$ = combineCompatibleChildrenApis<PublishesEsqlUsage, boolean[]>(
+    const subscription = combineCompatibleChildrenApis<PublishesEsqlUsage, boolean[]>(
       dashboardApi,
       'usesEsql$',
       apiPublishesEsqlUsage,
       []
-    ).pipe(map((usesEsqlValues) => usesEsqlValues.some(Boolean)));
-
-    const subscription = combineLatest([hasEsqlQuery$, hasEsqlVegaPanel$])
+    )
       .pipe(
-        map(([hasEsqlQuery, hasEsqlVegaPanel]) => hasEsqlQuery || hasEsqlVegaPanel),
+        map((usesEsqlValues) => usesEsqlValues.some(Boolean)),
         distinctUntilChanged()
       )
       .subscribe(setHasEsqlPanel);

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.test.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.test.tsx
@@ -313,6 +313,49 @@ describe('saved search embeddable', () => {
       expect(search).toHaveBeenCalledTimes(1);
     });
 
+    it('should reflect whether the initial query is an ES|QL query via usesEsql$', async () => {
+      const { search } = createSearchFnMock(1);
+      runtimeState = getInitialRuntimeState({ searchMock: search });
+
+      // getInitialRuntimeState() above sets up its own (query-less) searchSource mock;
+      // override it here with one that has an ES|QL query.
+      const esqlSearchSource = createSearchSourceMock(
+        { index: dataViewMock, query: { esql: 'FROM kibana_sample_data_logs | LIMIT 1' } },
+        undefined,
+        search
+      );
+      discoverServiceMock.data.search.searchSource.create = jest
+        .fn()
+        .mockResolvedValueOnce(esqlSearchSource);
+
+      const { api } = await factory.buildEmbeddable({
+        initializeDrilldownsManager: mockInitializeDrilldownsManager,
+        initialState: { ref_id: 'id', overrides: {} },
+        finalizeApi: finalizeApiMock,
+        uuid,
+        parentApi: mockedDashboardApi,
+      });
+      await waitOneTick();
+
+      expect(api.usesEsql$.getValue()).toBe(true);
+    });
+
+    it('should be false for usesEsql$ when the initial query is not an ES|QL query', async () => {
+      const { search } = createSearchFnMock(1);
+      runtimeState = getInitialRuntimeState({ searchMock: search });
+
+      const { api } = await factory.buildEmbeddable({
+        initializeDrilldownsManager: mockInitializeDrilldownsManager,
+        initialState: { ref_id: 'id', overrides: {} },
+        finalizeApi: finalizeApiMock,
+        uuid,
+        parentApi: mockedDashboardApi,
+      });
+      await waitOneTick();
+
+      expect(api.usesEsql$.getValue()).toBe(false);
+    });
+
     it('should not provide inline editing overrides for by-value embeddables', async () => {
       const { search } = createSearchFnMock(1);
       runtimeState = getInitialRuntimeState({

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -19,6 +19,7 @@ import type {
   PublishesWritableUnifiedSearch,
   PublishesWritableDataViews,
   ProjectRoutingOverrides,
+  PublishesEsqlUsage,
   PublishesProjectRoutingOverrides,
 } from '@kbn/presentation-publishing';
 import type { DiscoverGridSettings, SavedSearch } from '@kbn/saved-search-plugin/common';
@@ -113,7 +114,8 @@ export const initializeSearchEmbeddableApi = async ({
   api: PublishesWritableSavedSearch &
     PublishesWritableDataViews &
     Omit<PublishesWritableUnifiedSearch, keyof PublishesWritableTimeRange> &
-    PublishesProjectRoutingOverrides;
+    PublishesProjectRoutingOverrides &
+    PublishesEsqlUsage;
   stateManager: SearchEmbeddableStateManager;
   anyStateChange$: Observable<void>;
   cleanup: () => void;
@@ -154,6 +156,7 @@ export const initializeSearchEmbeddableApi = async ({
   const projectRoutingOverrides$ = new BehaviorSubject<ProjectRoutingOverrides>(
     getProjectRoutingOverrides(initialQuery)
   );
+  const usesEsql$ = new BehaviorSubject<boolean>(isOfAggregateQueryType(initialQuery));
 
   const canEditUnifiedSearch = () => false;
 
@@ -261,13 +264,18 @@ export const initializeSearchEmbeddableApi = async ({
       savedSearch$.next(newSavedSearch);
     });
 
-  /** Keep projectRoutingOverrides$ in sync with query$ changes */
+  /** Keep projectRoutingOverrides$ and usesEsql$ in sync with query$ changes */
   const syncProjectRoutingOverrides = query$.subscribe((query) => {
     const currentOverrides = projectRoutingOverrides$.getValue();
     const nextOverrides = getProjectRoutingOverrides(query);
 
     if (!deepEqual(currentOverrides, nextOverrides)) {
       projectRoutingOverrides$.next(nextOverrides);
+    }
+
+    const nextUsesEsql = isOfAggregateQueryType(query);
+    if (usesEsql$.getValue() !== nextUsesEsql) {
+      usesEsql$.next(nextUsesEsql);
     }
   });
 
@@ -285,6 +293,7 @@ export const initializeSearchEmbeddableApi = async ({
       query$,
       setQuery,
       projectRoutingOverrides$,
+      usesEsql$,
       canEditUnifiedSearch,
       setColumns,
     },

--- a/src/platform/plugins/shared/discover/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/types.ts
@@ -19,6 +19,7 @@ import type {
   PublishesBlockingError,
   PublishesDataLoading,
   PublishesDescription,
+  PublishesEsqlUsage,
   PublishesProjectRoutingOverrides,
   PublishesSavedObjectId,
   PublishesWritableTitle,
@@ -102,6 +103,7 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<SearchEmbeddablePanelApiS
   PublishesWritableDataViews &
   PublishesWritableUnifiedSearch &
   PublishesProjectRoutingOverrides &
+  PublishesEsqlUsage &
   HasLibraryTransforms &
   HasTimeRange &
   HasInspectorAdapters &

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_search_context.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_search_context.test.ts
@@ -111,4 +111,51 @@ describe('Context API', () => {
       cleanupSubs();
     });
   });
+
+  describe('usesEsql$', () => {
+    it('should be false by default for a non-ES|QL query', () => {
+      const { api, cleanup } = setupSearchContextApi();
+      expect(api.usesEsql$.getValue()).toBe(false);
+      cleanup();
+    });
+
+    it('should become true when the query attribute changes to an ES|QL query', () => {
+      const { api, cleanup, internalApi } = setupSearchContextApi();
+
+      internalApi.updateAttributes({
+        ...internalApi.attributes$.getValue(),
+        state: {
+          ...internalApi.attributes$.getValue().state,
+          query: { esql: 'FROM kibana_sample_data_logs | LIMIT 1' },
+        },
+      });
+
+      expect(api.usesEsql$.getValue()).toBe(true);
+      cleanup();
+    });
+
+    it('should become false again when the query attribute changes back to a non-ES|QL query', () => {
+      const { api, cleanup, internalApi } = setupSearchContextApi();
+
+      internalApi.updateAttributes({
+        ...internalApi.attributes$.getValue(),
+        state: {
+          ...internalApi.attributes$.getValue().state,
+          query: { esql: 'FROM kibana_sample_data_logs | LIMIT 1' },
+        },
+      });
+      expect(api.usesEsql$.getValue()).toBe(true);
+
+      internalApi.updateAttributes({
+        ...internalApi.attributes$.getValue(),
+        state: {
+          ...internalApi.attributes$.getValue().state,
+          query: { query: '', language: 'kuery' },
+        },
+      });
+
+      expect(api.usesEsql$.getValue()).toBe(false);
+      cleanup();
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_search_context.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_search_context.ts
@@ -9,6 +9,7 @@ import type { Filter, Query, AggregateQuery } from '@kbn/es-query';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import type {
   ProjectRoutingOverrides,
+  PublishesEsqlUsage,
   PublishesProjectRoutingOverrides,
   PublishesUnifiedSearch,
   StateComparators,
@@ -35,7 +36,10 @@ export const searchContextComparators: StateComparators<LensUnifiedSearchContext
 };
 
 export interface SearchContextConfig {
-  api: PublishesUnifiedSearch & PublishesSearchSession & PublishesProjectRoutingOverrides;
+  api: PublishesUnifiedSearch &
+    PublishesSearchSession &
+    PublishesProjectRoutingOverrides &
+    PublishesEsqlUsage;
   anyStateChange$: Observable<void>;
   cleanup: () => void;
   getLatestState: () => LensUnifiedSearchContext;
@@ -76,6 +80,8 @@ export function initializeSearchContext(
     getProjectRoutingOverrides(attributes.state.query)
   );
 
+  const usesEsql$ = new BehaviorSubject<boolean>(isOfAggregateQueryType(attributes.state.query));
+
   const timeRangeManager = initializeTimeRangeManager(initialState);
 
   const subscriptions = [
@@ -94,6 +100,7 @@ export function initializeSearchContext(
     query$
       .pipe(map(getProjectRoutingOverrides), distinctUntilChanged(isEqual))
       .subscribe(projectRoutingOverrides$),
+    query$.pipe(map(isOfAggregateQueryType), distinctUntilChanged()).subscribe(usesEsql$),
   ];
 
   return {
@@ -103,6 +110,7 @@ export function initializeSearchContext(
       query$,
       timeslice$,
       projectRoutingOverrides$,
+      usesEsql$,
       isCompatibleWithUnifiedSearch: () => true,
       ...timeRangeManager.api,
     },

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/mocks/index.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/mocks/index.tsx
@@ -112,6 +112,7 @@ function getDefaultLensApiMock() {
     hasUnsavedChanges$: new BehaviorSubject<boolean>(false),
     applySerializedState: jest.fn(),
     projectRoutingOverrides$: new BehaviorSubject<ProjectRoutingOverrides | undefined>(undefined),
+    usesEsql$: new BehaviorSubject<boolean>(false),
   };
   return LensApiMock;
 }


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/276999

The dashboard's "does this dashboard have an ES|QL panel" check  currently combines two separate mechanisms:

  1. A generic check: `apiPublishesUnifiedSearch` + `isOfAggregateQueryType(query$)`, which covers Lens and Discover (Saved Search) today.
  2. An explicit `usesEsql$` (`PublishesEsqlUsage`), which Vega implements, because its ES|QL usage is nested inside the vis spec's `data.url` objects and is never reflected  in the panel's own top-level `query$`.

This PR removes the first and align Discover and Lens with the Vega mechanism

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->