### PR TITLE
[Agent Builder] Exclude bedrock-claude-sonnet-4-5 from preconfigured list during smoke tests

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder_smoke/api/tests/smoke_llm_converse.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder_smoke/api/tests/smoke_llm_converse.spec.ts
@@ -24,7 +24,11 @@ const EIS_CCM_API_KEY_ENV = 'KIBANA_EIS_CCM_API_KEY';
 
 const eisCcmKeyMissingReason = `${EIS_CCM_API_KEY_ENV} not set. For local dev: export ${EIS_CCM_API_KEY_ENV}="$(vault read -field key secret/kibana-issues/dev/inference/kibana-eis-ccm)"`;
 
-const EXCLUDED_STATIC_CONNECTOR_IDS = new Set<string>(['bedrock-claude-sonnet-3-7']);
+const EXCLUDED_STATIC_CONNECTOR_IDS = new Set<string>([
+  'bedrock-claude-sonnet-3-7',
+  // TODO: re-enable once the AWS accessKey in the ai-infra-ci-connectors vault entry is rotated. Currently returns 403
+  'bedrock-claude-sonnet-4-5',
+]);
 
 const safeGetAvailableConnectors = (): AvailableConnectorWithId[] => {
   try {


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/15286

**Description:**

The `bedrock-claude-sonnet-4-5` static connector in the Agent Builder Scout smoke tests has failed 100% of the time since ~July 7/8. The failure only surfaces intermittently on dashboards because the suite samples 1 connector from N per run (`takeRandomLlmSample`).

**Root cause:** The AWS accessKey stored in vault is no longer valid on the AWS side. Reproduced locally by loading the preconfigured connector config and hitting the connector directly:

```
Status code: 403. Message: API Error: Forbidden - The security token included in the request is invalid.
```

**Action needed:** Rotate the AWS credentials for the `bedrock-claude-sonnet-4-5` entry in the vault secret.

**Workaround until we find an owner to update the key:** Connector added to `EXCLUDED_STATIC_CONNECTOR_IDS` in `smoke_llm_converse.spec.ts` — remove once credentials are rotated.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->