### PR TITLE
[Synthetics] Announce success/failure when deleting a private location

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/private_locations/effects.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/private_locations/effects.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deletePrivateLocationEffect } from './effects';
+import { deleteSyntheticsPrivateLocation } from './api';
+import { deletePrivateLocationAction } from './actions';
+import { fetchEffectFactory } from '../utils/fetch_effect';
+
+jest.mock('../utils/fetch_effect', () => ({
+  fetchEffectFactory: jest.fn(() => function* noop() {}),
+}));
+
+describe('deletePrivateLocationEffect', () => {
+  // Regression guard for #276922: a delete must surface a toast so screen
+  // readers announce completion via the toast aria-live region.
+  it('wires success and failure toast messages into the fetch effect', () => {
+    deletePrivateLocationEffect().next();
+
+    expect(fetchEffectFactory).toHaveBeenCalledWith(
+      deleteSyntheticsPrivateLocation,
+      deletePrivateLocationAction.success,
+      deletePrivateLocationAction.fail,
+      'Successfully deleted private location.',
+      'Failed to delete private location.'
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/private_locations/effects.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/private_locations/effects.ts
@@ -72,7 +72,13 @@ export function* deletePrivateLocationEffect() {
     fetchEffectFactory(
       deleteSyntheticsPrivateLocation,
       deletePrivateLocationAction.success,
-      deletePrivateLocationAction.fail
+      deletePrivateLocationAction.fail,
+      i18n.translate('xpack.synthetics.deletePrivateLocationSuccess', {
+        defaultMessage: 'Successfully deleted private location.',
+      }),
+      i18n.translate('xpack.synthetics.deletePrivateLocationFailure', {
+        defaultMessage: 'Failed to delete private location.',
+      })
     )
   );
 }


### PR DESCRIPTION
## Summary

Deleting a private location in **Synthetics → Settings → Private locations** showed no confirmation at all. Screen reader users only heard "Loading Delete location" and were never told whether the action completed (WCAG 4.1.3 Status Messages).

Unlike the create and edit private-location effects, `deletePrivateLocationEffect` was not passing success/failure messages to `fetchEffectFactory`, so no toast was ever shown. This wires those messages in. EUI renders toasts inside an `aria-live="polite"` region, so the outcome is now announced automatically to assistive technology.

Closes #276922

## Test plan

- [ ] Go to Observability → Applications → Monitors → Settings → Private locations.
- [ ] Delete a private location and confirm a "Successfully deleted private location." toast appears.
- [ ] With VoiceOver enabled, confirm the success message is announced automatically after deletion.

Made with [Cursor](https://cursor.com)