### PR TITLE
[Synthetics] Honor explicit namespace on monitor create

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts
@@ -272,6 +272,62 @@ describe('AddNewMonitorsPublicAPI', () => {
     });
   });
 
+  describe('getMonitorNamespace', () => {
+    const buildApi = (spaceId: string) =>
+      new AddEditMonitorAPI({
+        routeContext: { spaceId },
+        spaceId,
+      } as any);
+
+    it('falls back to the Kibana space namespace when namespace is not explicitly provided', () => {
+      const api = buildApi('test-space');
+      expect(api.getMonitorNamespace('default', false)).toBe('test_space');
+    });
+
+    it('honors an explicitly provided "default" namespace', () => {
+      const api = buildApi('test-space');
+      expect(api.getMonitorNamespace('default', true)).toBe('default');
+    });
+
+    it('honors a custom namespace regardless of whether it was explicitly provided', () => {
+      const api = buildApi('test-space');
+      expect(api.getMonitorNamespace('custom', false)).toBe('custom');
+      expect(api.getMonitorNamespace('custom', true)).toBe('custom');
+    });
+
+    it('throws when the resolved namespace is invalid', () => {
+      const api = buildApi('test-space');
+      expect(() => api.getMonitorNamespace('UPPER_CASE', true)).toThrow(/namespace is invalid/);
+    });
+  });
+
+  describe('hydrateMonitorFields namespace resolution', () => {
+    const buildApi = (spaceId: string, body: Record<string, unknown>) =>
+      new AddEditMonitorAPI({
+        routeContext: { spaceId, request: { query: {}, body } },
+        spaceId,
+        request: { query: {}, body },
+      } as any);
+
+    it('resolves omitted namespace to the Kibana space namespace', () => {
+      const api = buildApi('test-space', { type: 'http' });
+      const result = api.hydrateMonitorFields({
+        newMonitorId: 'id-1',
+        normalizedMonitor: { namespace: 'default' } as any,
+      });
+      expect(result.namespace).toBe('test_space');
+    });
+
+    it('preserves an explicitly provided "default" namespace', () => {
+      const api = buildApi('test-space', { type: 'http', namespace: 'default' });
+      const result = api.hydrateMonitorFields({
+        newMonitorId: 'id-1',
+        normalizedMonitor: { namespace: 'default' } as any,
+      });
+      expect(result.namespace).toBe('default');
+    });
+  });
+
   describe('validateUniqueMonitorName', () => {
     it('should return an error message if the monitor name already exists', async () => {
       const api = new AddEditMonitorAPI({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts
@@ -323,6 +323,10 @@ export class AddEditMonitorAPI {
       string,
       { preserve_namespace?: boolean }
     >;
+    // When the caller explicitly provides a namespace we honor it verbatim (even `default`).
+    // Only when it is omitted do we fall back to the Kibana space namespace. See issue #221335.
+    const isNamespaceProvided =
+      (request.body as CreateMonitorPayLoad | undefined)?.[ConfigKey.NAMESPACE] !== undefined;
     return {
       ...normalizedMonitor,
       [ConfigKey.MONITOR_QUERY_ID]:
@@ -330,15 +334,17 @@ export class AddEditMonitorAPI {
       [ConfigKey.CONFIG_ID]: newMonitorId,
       [ConfigKey.NAMESPACE]: preserveNamespace
         ? normalizedMonitor[ConfigKey.NAMESPACE]
-        : this.getMonitorNamespace(normalizedMonitor[ConfigKey.NAMESPACE]),
+        : this.getMonitorNamespace(normalizedMonitor[ConfigKey.NAMESPACE], isNamespaceProvided),
     };
   }
 
-  getMonitorNamespace(configuredNamespace: string) {
+  getMonitorNamespace(configuredNamespace: string, isNamespaceProvided = false) {
     const { spaceId } = this.routeContext;
     const kibanaNamespace = formatKibanaNamespace(spaceId);
     const namespace =
-      configuredNamespace === DEFAULT_NAMESPACE_STRING ? kibanaNamespace : configuredNamespace;
+      !isNamespaceProvided && configuredNamespace === DEFAULT_NAMESPACE_STRING
+        ? kibanaNamespace
+        : configuredNamespace;
     const { error } = isValidNamespace(namespace);
     if (error) {
       throw new Error(`Cannot save monitor. Monitor namespace is invalid: ${error}`);

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -129,6 +129,22 @@ export const editSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => (
         previousMonitor.attributes.locations
       );
 
+      // When the caller explicitly provides a namespace we honor it verbatim (even `default`),
+      // but still validate it. Omitting it keeps the previous monitor's namespace. See issue #221335.
+      const isNamespaceProvided =
+        (monitor as CreateMonitorPayLoad)[ConfigKey.NAMESPACE] !== undefined;
+      if (isNamespaceProvided) {
+        try {
+          (editedMonitor as MonitorFields)[ConfigKey.NAMESPACE] =
+            editMonitorAPI.getMonitorNamespace(
+              (editedMonitor as MonitorFields)[ConfigKey.NAMESPACE],
+              true
+            );
+        } catch (namespaceError) {
+          return response.badRequest({ body: { message: namespaceError.message } });
+        }
+      }
+
       const validationResult = validateMonitor(editedMonitor as MonitorFields, spaceId);
 
       if (!validationResult.valid || !validationResult.decodedMonitor) {

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor.spec.ts
@@ -58,11 +58,42 @@ apiTest.describe(
     });
 
     apiTest(
-      'sets namespace to Kibana space when not set to a custom namespace',
+      'falls back to the Kibana space namespace when namespace is omitted',
       async ({ apiClient, apiServices, kbnClient }) => {
         const SPACE_ID = `test-space-${uuidv4()}`;
         const SPACE_NAME = `test-space-name ${uuidv4()}`;
         const EXPECTED_NAMESPACE = formatKibanaNamespace(SPACE_ID);
+
+        await kbnClient.spaces.create({ id: SPACE_ID, name: SPACE_NAME });
+        try {
+          const spacePrivateLocation =
+            await apiServices.syntheticsPrivateLocations.addTestPrivateLocation(SPACE_ID);
+
+          const { namespace, ...monitorWithoutNamespace } = httpMonitorFixture;
+          const monitor = {
+            ...monitorWithoutNamespace,
+            locations: [spacePrivateLocation],
+            spaces: [],
+          };
+
+          const res = await apiClient.post(`s/${SPACE_ID}/api/synthetics/monitors`, {
+            headers: { ...editorHeaders, 'elastic-api-version': PUBLIC_API_VERSION },
+            body: monitor,
+            responseType: 'json',
+          });
+          expect(res).toHaveStatusCode(200);
+          expect((res.body as Record<string, unknown>).namespace).toStrictEqual(EXPECTED_NAMESPACE);
+        } finally {
+          await kbnClient.spaces.delete(SPACE_ID);
+        }
+      }
+    );
+
+    apiTest(
+      'honors an explicitly provided namespace, even "default"',
+      async ({ apiClient, apiServices, kbnClient }) => {
+        const SPACE_ID = `test-space-${uuidv4()}`;
+        const SPACE_NAME = `test-space-name ${uuidv4()}`;
 
         await kbnClient.spaces.create({ id: SPACE_ID, name: SPACE_NAME });
         try {
@@ -82,7 +113,7 @@ apiTest.describe(
             responseType: 'json',
           });
           expect(res).toHaveStatusCode(200);
-          expect((res.body as Record<string, unknown>).namespace).toStrictEqual(EXPECTED_NAMESPACE);
+          expect((res.body as Record<string, unknown>).namespace).toBe('default');
         } finally {
           await kbnClient.spaces.delete(SPACE_ID);
         }

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/edit_monitor_private_location.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/edit_monitor_private_location.spec.ts
@@ -10,6 +10,7 @@ import { omit } from 'lodash';
 import { expect } from '@kbn/scout-oblt/api';
 import type { ApiClientFixture } from '@kbn/scout-oblt';
 import { ConfigKey } from '../../../../common/runtime_types';
+import { formatKibanaNamespace } from '../../../../common/formatters';
 import { apiTest, mergeSyntheticsApiHeaders, SYNTHETICS_MONITOR_SO_TYPES } from '../fixtures';
 import type { ScoutPrivateLocation } from '../services/synthetics_private_location_api_service';
 import {
@@ -315,5 +316,54 @@ apiTest.describe(
       });
       expect((updatedResponse2.body as { urls: string }).urls).toBe(toUpdate2.urls);
     });
+
+    apiTest(
+      'honors an explicitly provided namespace on edit and rejects invalid ones',
+      async ({ apiClient, apiServices, kbnClient }) => {
+        const SPACE_ID = `test-space-${uuidv4()}`;
+        const SPACE_NAME = `test-space-name ${uuidv4()}`;
+        await kbnClient.spaces.create({ id: SPACE_ID, name: SPACE_NAME });
+        spacesToCleanUp.push(SPACE_ID);
+
+        const spaceScopedPrivateLocation =
+          await apiServices.syntheticsPrivateLocations.addTestPrivateLocation(SPACE_ID);
+
+        // Omit namespace so create falls back to the Kibana space namespace.
+        const { namespace: _omitNamespace, ...fixtureWithoutNamespace } = httpMonitorFixture;
+        const newMonitor = {
+          ...fixtureWithoutNamespace,
+          name: `namespace-edit ${uuidv4()}`,
+          locations: [spaceScopedPrivateLocation],
+          spaces: [],
+        };
+
+        const savedMonitor = await saveMonitor(apiClient, newMonitor, SPACE_ID);
+        const monitorId = savedMonitor[ConfigKey.CONFIG_ID] as string;
+        expect(savedMonitor[ConfigKey.NAMESPACE]).toBe(formatKibanaNamespace(SPACE_ID));
+
+        // An explicitly provided namespace (even "default") is honored on edit.
+        await editMonitorInternal(
+          apiClient,
+          editorHeaders,
+          monitorId,
+          { ...savedMonitor, [ConfigKey.NAMESPACE]: 'default' },
+          { spaceId: SPACE_ID }
+        );
+        const updated = await getMonitor(apiClient, editorHeaders, monitorId, {
+          space: SPACE_ID,
+          internal: true,
+        });
+        expect((updated.body as Record<string, unknown>)[ConfigKey.NAMESPACE]).toBe('default');
+
+        // An explicitly provided invalid namespace is rejected.
+        await editMonitorInternal(
+          apiClient,
+          editorHeaders,
+          monitorId,
+          { ...savedMonitor, [ConfigKey.NAMESPACE]: 'Invalid Namespace' },
+          { spaceId: SPACE_ID, statusCode: 400 }
+        );
+      }
+    );
   }
 );


### PR DESCRIPTION
## Summary

The Monitors API documents `namespace` with a default of `default`, but the value was not honored consistently across create and update.

**Create (`POST`)** always ran the value through `getMonitorNamespace`, which converted `default` into the Kibana space namespace, so an explicitly provided `namespace` (including `default`) was silently ignored.

**Update (`PUT`)** already honored an explicitly provided namespace verbatim, but never validated it.

This PR makes both routes behave consistently:

- If the request payload includes `namespace` (even `"default"`), it is honored verbatim and validated.
- If `namespace` is omitted:
  - `POST` falls back to the Kibana space namespace (unchanged).
  - `PUT` keeps the previous monitor's namespace (unchanged).

The UI is unaffected because it always sends the resolved space namespace explicitly.

Closes #221335

## Test plan

- [ ] Unit tests in `add_monitor_api.test.ts` cover `getMonitorNamespace` and `hydrateMonitorFields` namespace resolution.
- [ ] Scout API tests (`create_monitor.spec.ts`): omitted namespace → space namespace; explicit `default` → `default`.
- [ ] Scout API test (`edit_monitor_private_location.spec.ts`): explicit `default` honored on edit; invalid namespace → 400.
- [ ] Manual: in a non-default space, `POST`/`PUT /api/synthetics/monitors` with `"namespace": "default"` writes to `synthetics-*-default`; omitting `namespace` on create writes to `synthetics-*-<space>`.
