### PR TITLE
[8.19] [Console] Fix requests with comments failing when body contains triple-quote strings (#277259)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -119,6 +119,57 @@ describe('Editor actions provider', () => {
       const curl = await editorActionsProvider.getCurl('http://localhost');
       expect(curl).toBe('curl -XGET "http://localhost/_search" -H "kbn-xsrf: reporting"');
     });
+
+    it.each(['//', '#'])(
+      'removes %s comments from the request body while preserving triple-quote strings',
+      async (commentMarker) => {
+        // Regression test for https://github.com/elastic/kibana/issues/277160
+        const content = [
+          'POST _watcher/watch/test',
+          '{',
+          `  ${commentMarker} watch metadata`,
+          '  "script": """',
+          '    return 1; // painless comment',
+          '  """',
+          '}',
+        ];
+        const totalLength = content.join('\n').length;
+        editor.getModel.mockReturnValue({
+          getLineContent: (lineNumber: number) => content[lineNumber - 1],
+          getValueInRange: ({
+            startLineNumber,
+            endLineNumber,
+          }: {
+            startLineNumber: number;
+            endLineNumber: number;
+          }) => content.slice(startLineNumber - 1, endLineNumber).join('\n'),
+          getLineMaxColumn: (lineNumber: number) => content[lineNumber - 1].length + 1,
+          getPositionAt: (offset: number) => ({ lineNumber: offset === 0 ? 1 : content.length }),
+          getLineCount: () => content.length,
+        } as unknown as monaco.editor.ITextModel);
+        editor.getSelection.mockReturnValue({
+          startLineNumber: 1,
+          endLineNumber: content.length,
+        } as unknown as monaco.Selection);
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: 0,
+            endOffset: totalLength,
+            method: 'POST',
+            url: '_watcher/watch/test',
+          },
+        ]);
+
+        const curl = await editorActionsProvider.getCurl('http://localhost');
+        expect(curl).not.toContain('watch metadata');
+        expect(curl).toContain('return 1; // painless comment');
+        // The body sent in the curl command is valid JSON
+        const body = curl.split(`-d'\n`)[1].slice(0, -1);
+        expect(JSON.parse(body)).toEqual({
+          script: '\n    return 1; // painless comment\n  ',
+        });
+      }
+    );
   });
 
   describe('getDocumentationLink', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -46,7 +46,7 @@ import type { AdjustedParsedRequest } from './types';
 import { type RequestToRestore, RestoreMethod } from '../../../types';
 import { StorageQuotaError } from '../../components/storage_quota_error';
 import { ContextValue } from '../../contexts';
-import { containsComments, indentData } from './utils/requests_utils';
+import { containsComments, removeCommentsFromData } from './utils/requests_utils';
 
 const AUTO_INDENTATION_ACTION_LABEL = 'Apply indentations';
 const TRIGGER_SUGGESTIONS_ACTION_LABEL = 'Trigger suggestions';
@@ -276,8 +276,10 @@ export class MonacoEditorActionsProvider {
       if (requestTextFromEditor && requestTextFromEditor.data.length > 0) {
         requestTextFromEditor.data = requestTextFromEditor.data.map((dataString) => {
           if (containsComments(dataString)) {
-            // parse and stringify to remove comments
-            dataString = indentData(dataString);
+            // Comments must be removed before the request is sent since the body is
+            // flattened into a single line and a line comment would otherwise
+            // comment out the rest of the body (see https://github.com/elastic/kibana/issues/277160)
+            dataString = removeCommentsFromData(dataString);
           }
           return collapseLiteralStrings(dataString);
         });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts
@@ -17,6 +17,7 @@ import {
   trackSentRequests,
   getRequestFromEditor,
   containsComments,
+  removeCommentsFromData,
   collapseTripleQuoteStrings,
   expandTripleQuoteStrings,
   TRIPLE_QUOTE_STRINGS_MARKER,
@@ -535,7 +536,7 @@ describe('requests_utils', () => {
   });
 
   describe('containsComments', () => {
-    it('should return false for JSON with // and /* inside strings', () => {
+    it('should return false for JSON with comment markers inside strings', () => {
       const requestData = `{
       "docs": [
         {
@@ -552,7 +553,7 @@ describe('requests_utils', () => {
           "_source": {
             "vulnerability": {
               "reference": [
-                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15778"
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15778#details"
               ]
             }
           }
@@ -579,6 +580,14 @@ describe('requests_utils', () => {
       expect(containsComments(requestData)).toBe(true);
     });
 
+    it('should return true for text with actual hash comment', () => {
+      const requestData = `{
+      # This is a comment
+      "query": { "match_all": {} }
+    }`;
+      expect(containsComments(requestData)).toBe(true);
+    });
+
     it('should return false for text without any comments', () => {
       const requestData = `{
       "field": "value"
@@ -588,6 +597,18 @@ describe('requests_utils', () => {
 
     it('should return false for empty string', () => {
       expect(containsComments('')).toBe(false);
+    });
+
+    it('should reset token scanning between calls', () => {
+      const requestDataWithComment = `{
+      // This is a comment
+      "query": { "match_all": {} }
+    }`;
+      const requestDataWithoutComment = '{ "query": { "match_all": {} } }';
+
+      expect(containsComments(requestDataWithComment)).toBe(true);
+      expect(containsComments(requestDataWithoutComment)).toBe(false);
+      expect(containsComments(requestDataWithComment)).toBe(true);
     });
 
     it('should correctly handle escaped quotes within strings', () => {
@@ -602,6 +623,109 @@ describe('requests_utils', () => {
       "field": "value" // comment here
     }`;
       expect(containsComments(requestData)).toBe(true);
+    });
+
+    it('should ignore comment-like sequences inside triple-quote strings', () => {
+      const requestData = `{
+      "script": """def quote = '"'; // painless comment # still script"""
+    }`;
+      expect(containsComments(requestData)).toBe(false);
+    });
+
+    it('should detect comments outside triple-quote strings', () => {
+      const requestData = `{
+      // request comment
+      "script": """def quote = '"'; // painless comment"""
+    }`;
+      expect(containsComments(requestData)).toBe(true);
+    });
+  });
+
+  describe('removeCommentsFromData', () => {
+    it('removes line and block comments from the request data', () => {
+      const requestData = `{
+  // line comment
+  "query": {
+    /* block comment */
+    "match_all": {}
+  } // trailing comment
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(containsComments(result)).toBe(false);
+      expect(JSON.parse(result)).toEqual({ query: { match_all: {} } });
+    });
+
+    it('removes comments when the data also contains multi-line triple-quote strings', () => {
+      // Regression test for https://github.com/elastic/kibana/issues/277160
+      const requestData = `{
+  // watch metadata
+  "script": {
+    "lang": "painless",
+    "source": """
+      def a = 1; // painless comment
+      return a;
+    """
+  } /* end of script */
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// watch metadata');
+      expect(result).not.toContain('/* end of script */');
+      // The triple-quote string is preserved, including the comments inside it
+      expect(result).toContain(`"source": """
+      def a = 1; // painless comment
+      return a;
+    """`);
+    });
+
+    it('preserves comment-like sequences inside strings', () => {
+      const requestData = `{
+  "url": "https://elastic.co", // comment
+  "pattern": "/*"
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// comment');
+      expect(JSON.parse(result)).toEqual({ url: 'https://elastic.co', pattern: '/*' });
+    });
+
+    it('preserves a literal value matching the triple-quote placeholder', () => {
+      const requestData = `{
+  // comment
+  "literal": ${TRIPLE_QUOTE_STRINGS_MARKER},
+  "script": """return 1;"""
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// comment');
+      expect(result).toMatch(/"literal"\s*:\s*"\{tripleQuoteString\}"/);
+      expect(result).toMatch(/"script"\s*:\s*"""return 1;"""/);
+    });
+
+    it('preserves triple-quote values when object keys are reordered during parsing', () => {
+      const requestData = `{
+  // comment
+  "z": """first""",
+  "1": """second"""
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('// comment');
+      expect(result).toMatch(/"z"\s*:\s*"""first"""/);
+      expect(result).toMatch(/"1"\s*:\s*"""second"""/);
+    });
+
+    it('ignores triple-quote delimiters inside comments', () => {
+      const requestData = `{
+  // this comment mentions """
+  /* this block comment also mentions """ */
+  "script": """return 1;"""
+}`;
+      const result = removeCommentsFromData(requestData);
+      expect(result).not.toContain('this comment mentions');
+      expect(result).not.toContain('this block comment');
+      expect(result).toMatch(/"script"\s*:\s*"""return 1;"""/);
+    });
+
+    it('returns invalid data unchanged', () => {
+      const requestData = '{\n  "query": // comment\n    {';
+      expect(removeCommentsFromData(requestData)).toBe(requestData);
     });
   });
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts
@@ -271,26 +271,31 @@ export const getRequestFromEditor = (
   return { method: upperCaseMethod, url, data };
 };
 
+const requestDataTokensRegex = new RegExp(
+  [
+    /"""[\s\S]*?"""/.source, // Triple-quoted strings
+    /"(?:\\.|[^"\\])*"/.source, // JSON strings
+    /\/\/[^\r\n]*/.source, // // comments
+    /#[^\r\n]*/.source, // # comments
+    /\/\*[\s\S]*?\*\//.source, // Block comments
+  ].join('|'),
+  'g'
+);
+
+const isSlashCommentToken = (token: string) => token.startsWith('//') || token.startsWith('/*');
+const isCommentToken = (token: string) => isSlashCommentToken(token) || token.startsWith('#');
+
 export const containsComments = (requestData: string) => {
-  let insideString = false;
-  let prevChar = '';
-  for (let i = 0; i < requestData.length; i++) {
-    const char = requestData[i];
-    const nextChar = requestData[i + 1];
-
-    if (!insideString && char === '"') {
-      insideString = true;
-    } else if (insideString && char === '"' && prevChar !== '\\') {
-      insideString = false;
-    } else if (!insideString) {
-      if (char === '/' && (nextChar === '/' || nextChar === '*')) {
-        return true;
-      }
+  requestDataTokensRegex.lastIndex = 0;
+  let match = requestDataTokensRegex.exec(requestData);
+  while (match) {
+    if (isCommentToken(match[0])) {
+      requestDataTokensRegex.lastIndex = 0;
+      return true;
     }
-
-    prevChar = char;
+    match = requestDataTokensRegex.exec(requestData);
   }
-
+  requestDataTokensRegex.lastIndex = 0;
   return false;
 };
 
@@ -301,6 +306,40 @@ export const indentData = (dataString: string): string => {
     return JSON.stringify(parsedData, null, 2);
   } catch (e) {
     return dataString;
+  }
+};
+
+const removeCommentsFromDataWithTripleQuotes = (dataString: string): string | null => {
+  const dataWithoutComments = dataString.replace(requestDataTokensRegex, (token) =>
+    isCommentToken(token) ? ' ' : token
+  );
+
+  const { collapsedTripleQuotesData } = collapseTripleQuoteStrings(dataWithoutComments);
+  try {
+    parse(collapsedTripleQuotesData);
+    return dataWithoutComments;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * This function removes comments from the request data.
+ *
+ * The comment removal is done by parsing the data with hjson and stringifying the result.
+ * Since hjson can't parse multi-line strings in triple quotes, a token-aware fallback removes
+ * comments outside quoted strings and validates the result after collapsing triple-quote strings.
+ * Comments inside triple-quote strings (e.g. Painless comments) are preserved.
+ * If the data can't be parsed at all, it is returned unchanged.
+ */
+export const removeCommentsFromData = (dataString: string): string => {
+  try {
+    return JSON.stringify(parse(dataString), null, 2);
+  } catch {
+    if (!dataString.includes('"""')) {
+      return dataString;
+    }
+    return removeCommentsFromDataWithTripleQuotes(dataString) ?? dataString;
   }
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix requests with comments failing when body contains triple-quote strings (#277259)](https://github.com/elastic/kibana/pull/277259)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T08:38:20Z","message":"[Console] Fix requests with comments failing when body contains triple-quote strings (#277259)\n\nCloses #277160\n\n## Summary\n\nRequests whose body combines `//` comments with `\"\"\"` triple-quote\nstrings (for example, Watcher definitions with inline Painless scripts)\nfail with `400 x_content_e_o_f_exception \"Unexpected end of file\"` since\n8.16.0. This PR makes Console's client-side comment removal work for\nthose bodies without changing string contents.\n\n## Root Cause\n\nSince #188552 (8.16.0), Console flattens every request body into a\nsingle line before sending it to Elasticsearch. Once flattened, the\nfirst `//` comment consumes everything after it and Elasticsearch\nreaches the end of an incomplete body.\n\nConsole strips comments client-side in `getRequests()`, but the existing\n`hjson` parsing step fails on `\"\"\"` strings and returns the original\nbody unchanged. The comments then survive until the newline-flattening\nstep.\n\n## Fix\n\n`removeCommentsFromData()` still uses `hjson` for ordinary request\nbodies. When triple-quote strings prevent parsing, it now:\n\n- tokenizes JSON strings, triple-quote strings, and `//`, `#`, and `/*\n*/` comments;\n- removes only comments outside quoted strings;\n- validates the resulting XJSON before returning it; and\n- returns invalid bodies unchanged.\n\nThis preserves comments and whitespace inside Painless scripts while\navoiding positional placeholder restoration, which could collide with\nliteral values or associate strings with the wrong keys after\nserialization reordered the object. Comment detection now uses the same\ntriple-quote-aware tokenization, recognizes both documented single-line\ncomment markers, stops after the first comment token, and skips the\nfallback for parse failures without triple-quote strings.\n\n## Before/After Screenshots\n\n### Before\n\n_Same request returns `400 Bad Request` with\n`x_content_e_o_f_exception`:_\n\n<img width=\"1440\" height=\"900\" alt=\"before_fix\"\nsrc=\"https://github.com/user-attachments/assets/93419315-2674-4ebe-b1b8-d0e899b0c215\"\n/>\n\n### After\n\n_Same request returns `200 OK`; the script is stored with the Painless\n`//` comment intact:_\n\n<img width=\"1440\" height=\"900\" alt=\"after_fix\"\nsrc=\"https://github.com/user-attachments/assets/8e86a672-4321-464f-a57e-f457ac0964ce\"\n/>\n\n## Test Plan\n\nRun in Dev Tools Console:\n\n```\nPOST _scripts/comment-repro\n{\n  // count all docs\n  \"script\": {\n    \"lang\": \"painless\",\n    \"source\": \"\"\"\n      return 1; // painless comment\n    \"\"\"\n  }\n}\n```\n\n- Before this fix: the request returns `400` with\n`x_content_e_o_f_exception \"[2:1] Unexpected end of file\"`.\n- After this fix: the request returns `200 OK`, and `GET\n_scripts/comment-repro` shows the Painless comment preserved inside the\nscript source.\n- Verified in a local development instance against a fresh Elasticsearch\nsnapshot, A/B on the same instance by toggling the change.\n- Automated coverage repeats the request with `# count all docs` and\nverifies the generated body is valid JSON with the outer comment\nremoved.\n- `node scripts/jest\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts`\n— 86 tests passed.\n- `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js` — 483 tests\npassed.\n- `node scripts/eslint\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts`\n— passed.\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — passed.\n\n## Release Note\n\nFixed a Console error where requests containing comments together with\ntriple-quote strings (such as Watcher definitions with inline Painless\nscripts) failed with `x_content_e_o_f_exception`.\n\nAssisted with Copilot using GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>","sha":"7c19505050c4a290f281be5f027517e399370e3b","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","regression","release_note:fix","Team:Kibana Management","backport:all-open","v9.5.0","v9.6.0"],"title":"[Console] Fix requests with comments failing when body contains triple-quote strings","number":277259,"url":"https://github.com/elastic/kibana/pull/277259","mergeCommit":{"message":"[Console] Fix requests with comments failing when body contains triple-quote strings (#277259)\n\nCloses #277160\n\n## Summary\n\nRequests whose body combines `//` comments with `\"\"\"` triple-quote\nstrings (for example, Watcher definitions with inline Painless scripts)\nfail with `400 x_content_e_o_f_exception \"Unexpected end of file\"` since\n8.16.0. This PR makes Console's client-side comment removal work for\nthose bodies without changing string contents.\n\n## Root Cause\n\nSince #188552 (8.16.0), Console flattens every request body into a\nsingle line before sending it to Elasticsearch. Once flattened, the\nfirst `//` comment consumes everything after it and Elasticsearch\nreaches the end of an incomplete body.\n\nConsole strips comments client-side in `getRequests()`, but the existing\n`hjson` parsing step fails on `\"\"\"` strings and returns the original\nbody unchanged. The comments then survive until the newline-flattening\nstep.\n\n## Fix\n\n`removeCommentsFromData()` still uses `hjson` for ordinary request\nbodies. When triple-quote strings prevent parsing, it now:\n\n- tokenizes JSON strings, triple-quote strings, and `//`, `#`, and `/*\n*/` comments;\n- removes only comments outside quoted strings;\n- validates the resulting XJSON before returning it; and\n- returns invalid bodies unchanged.\n\nThis preserves comments and whitespace inside Painless scripts while\navoiding positional placeholder restoration, which could collide with\nliteral values or associate strings with the wrong keys after\nserialization reordered the object. Comment detection now uses the same\ntriple-quote-aware tokenization, recognizes both documented single-line\ncomment markers, stops after the first comment token, and skips the\nfallback for parse failures without triple-quote strings.\n\n## Before/After Screenshots\n\n### Before\n\n_Same request returns `400 Bad Request` with\n`x_content_e_o_f_exception`:_\n\n<img width=\"1440\" height=\"900\" alt=\"before_fix\"\nsrc=\"https://github.com/user-attachments/assets/93419315-2674-4ebe-b1b8-d0e899b0c215\"\n/>\n\n### After\n\n_Same request returns `200 OK`; the script is stored with the Painless\n`//` comment intact:_\n\n<img width=\"1440\" height=\"900\" alt=\"after_fix\"\nsrc=\"https://github.com/user-attachments/assets/8e86a672-4321-464f-a57e-f457ac0964ce\"\n/>\n\n## Test Plan\n\nRun in Dev Tools Console:\n\n```\nPOST _scripts/comment-repro\n{\n  // count all docs\n  \"script\": {\n    \"lang\": \"painless\",\n    \"source\": \"\"\"\n      return 1; // painless comment\n    \"\"\"\n  }\n}\n```\n\n- Before this fix: the request returns `400` with\n`x_content_e_o_f_exception \"[2:1] Unexpected end of file\"`.\n- After this fix: the request returns `200 OK`, and `GET\n_scripts/comment-repro` shows the Painless comment preserved inside the\nscript source.\n- Verified in a local development instance against a fresh Elasticsearch\nsnapshot, A/B on the same instance by toggling the change.\n- Automated coverage repeats the request with `# count all docs` and\nverifies the generated body is valid JSON with the outer comment\nremoved.\n- `node scripts/jest\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts`\n— 86 tests passed.\n- `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js` — 483 tests\npassed.\n- `node scripts/eslint\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts`\n— passed.\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — passed.\n\n## Release Note\n\nFixed a Console error where requests containing comments together with\ntriple-quote strings (such as Watcher definitions with inline Painless\nscripts) failed with `x_content_e_o_f_exception`.\n\nAssisted with Copilot using GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>","sha":"7c19505050c4a290f281be5f027517e399370e3b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277665","number":277665,"state":"MERGED","mergeCommit":{"sha":"a79fb017ebfad622304efd2d84a351dc7e216694","message":"[9.5] [Console] Fix requests with comments failing when body contains triple-quote strings (#277259) (#277665)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Console] Fix requests with comments failing when body contains\ntriple-quote strings\n(#277259)](https://github.com/elastic/kibana/pull/277259)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277259","number":277259,"mergeCommit":{"message":"[Console] Fix requests with comments failing when body contains triple-quote strings (#277259)\n\nCloses #277160\n\n## Summary\n\nRequests whose body combines `//` comments with `\"\"\"` triple-quote\nstrings (for example, Watcher definitions with inline Painless scripts)\nfail with `400 x_content_e_o_f_exception \"Unexpected end of file\"` since\n8.16.0. This PR makes Console's client-side comment removal work for\nthose bodies without changing string contents.\n\n## Root Cause\n\nSince #188552 (8.16.0), Console flattens every request body into a\nsingle line before sending it to Elasticsearch. Once flattened, the\nfirst `//` comment consumes everything after it and Elasticsearch\nreaches the end of an incomplete body.\n\nConsole strips comments client-side in `getRequests()`, but the existing\n`hjson` parsing step fails on `\"\"\"` strings and returns the original\nbody unchanged. The comments then survive until the newline-flattening\nstep.\n\n## Fix\n\n`removeCommentsFromData()` still uses `hjson` for ordinary request\nbodies. When triple-quote strings prevent parsing, it now:\n\n- tokenizes JSON strings, triple-quote strings, and `//`, `#`, and `/*\n*/` comments;\n- removes only comments outside quoted strings;\n- validates the resulting XJSON before returning it; and\n- returns invalid bodies unchanged.\n\nThis preserves comments and whitespace inside Painless scripts while\navoiding positional placeholder restoration, which could collide with\nliteral values or associate strings with the wrong keys after\nserialization reordered the object. Comment detection now uses the same\ntriple-quote-aware tokenization, recognizes both documented single-line\ncomment markers, stops after the first comment token, and skips the\nfallback for parse failures without triple-quote strings.\n\n## Before/After Screenshots\n\n### Before\n\n_Same request returns `400 Bad Request` with\n`x_content_e_o_f_exception`:_\n\n<img width=\"1440\" height=\"900\" alt=\"before_fix\"\nsrc=\"https://github.com/user-attachments/assets/93419315-2674-4ebe-b1b8-d0e899b0c215\"\n/>\n\n### After\n\n_Same request returns `200 OK`; the script is stored with the Painless\n`//` comment intact:_\n\n<img width=\"1440\" height=\"900\" alt=\"after_fix\"\nsrc=\"https://github.com/user-attachments/assets/8e86a672-4321-464f-a57e-f457ac0964ce\"\n/>\n\n## Test Plan\n\nRun in Dev Tools Console:\n\n```\nPOST _scripts/comment-repro\n{\n  // count all docs\n  \"script\": {\n    \"lang\": \"painless\",\n    \"source\": \"\"\"\n      return 1; // painless comment\n    \"\"\"\n  }\n}\n```\n\n- Before this fix: the request returns `400` with\n`x_content_e_o_f_exception \"[2:1] Unexpected end of file\"`.\n- After this fix: the request returns `200 OK`, and `GET\n_scripts/comment-repro` shows the Painless comment preserved inside the\nscript source.\n- Verified in a local development instance against a fresh Elasticsearch\nsnapshot, A/B on the same instance by toggling the change.\n- Automated coverage repeats the request with `# count all docs` and\nverifies the generated body is valid JSON with the outer comment\nremoved.\n- `node scripts/jest\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts`\n— 86 tests passed.\n- `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js` — 483 tests\npassed.\n- `node scripts/eslint\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.test.ts`\n— passed.\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json` — passed.\n\n## Release Note\n\nFixed a Console error where requests containing comments together with\ntriple-quote strings (such as Watcher definitions with inline Painless\nscripts) failed with `x_content_e_o_f_exception`.\n\nAssisted with Copilot using GPT-5.6 Sol\n\n---------\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>","sha":"7c19505050c4a290f281be5f027517e399370e3b"}},{"url":"https://github.com/elastic/kibana/pull/277660","number":277660,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/277663","number":277663,"branch":"9.4","state":"MERGED","mergeCommit":{"sha":"e53174acd8d2ea32530e94092d11a8fdbfb2754f","message":"[9.4] [Console] Fix requests with comments failing when body contains triple-quote strings (#277259) (#277663)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Console] Fix requests with comments failing when body contains\ntriple-quote strings\n(#277259)](https://github.com/elastic/kibana/pull/277259)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"}}]}] BACKPORT-->