### PR TITLE
[8.19] [BUG][Synthetics] Fix Stats panel not updating on time range change and null values display (#250743)

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
@@ -110,6 +110,7 @@ export function getSyntheticsSingleMetricConfig({ dataView }: ConfigProps): Seri
         format: 'number',
         field: RECORDS_FIELD,
         columnFilter: { language: 'kuery', query: 'summary: *' },
+        emptyAsNull: false,
       },
       {
         id: 'monitor_successful',
@@ -122,6 +123,7 @@ export function getSyntheticsSingleMetricConfig({ dataView }: ConfigProps): Seri
         format: 'number',
         field: RECORDS_FIELD,
         columnFilter: { language: 'kuery', query: 'summary.down: 0' },
+        emptyAsNull: false,
       },
       {
         id: 'monitor_errors',
@@ -151,6 +153,7 @@ export function getSyntheticsSingleMetricConfig({ dataView }: ConfigProps): Seri
           language: 'kuery',
           query: 'summary.status: down',
         },
+        emptyAsNull: false,
       },
     ],
     labels: FieldLabels,

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/index.test.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import { render, mockCore } from '../rtl_helpers';
+import * as useAppDataViewHook from './use_app_data_view';
+import { getExploratoryViewEmbeddable } from '.';
+import type { ExploratoryEmbeddableProps } from './embeddable';
+
+// Capture props passed to Embeddable
+let capturedEmbeddableProps: ExploratoryEmbeddableProps | null = null;
+
+jest.mock('./embeddable', () => ({
+  __esModule: true,
+  default: jest.fn((props) => {
+    capturedEmbeddableProps = props;
+    return <div data-test-subj="mock-embeddable">mockEmbeddable</div>;
+  }),
+}));
+
+jest.mock('@kbn/observability-shared-plugin/public', () => ({
+  useFetcher: jest.fn(() => ({
+    data: { formula: {} },
+    loading: false,
+  })),
+}));
+
+const mockTimeRange1 = {
+  from: '2022-02-15T16:00:00.000Z',
+  to: '2022-02-16T15:59:59.999Z',
+};
+
+const mockTimeRange2 = {
+  from: '2022-02-17T16:00:00.000Z',
+  to: '2022-02-18T15:59:59.999Z',
+};
+
+const mockLens = {
+  EmbeddableComponent: jest.fn(() => <div>mockEmbeddableComponent</div>),
+  SaveModalComponent: jest.fn(() => <div>mockSaveModalComponent</div>),
+  stateHelperApi: jest.fn().mockResolvedValue({ formula: {} }),
+} as unknown as LensPublicStart;
+
+const createMockAttributes = (time: { from: string; to: string }) => [
+  {
+    name: 'test-series',
+    dataType: 'synthetics' as const,
+    time,
+    reportDefinitions: {},
+    selectedMetricField: 'monitor.duration.us',
+  },
+];
+
+describe('getExploratoryViewEmbeddable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedEmbeddableProps = null;
+
+    // Mock useAppDataView to return valid dataViews
+    jest.spyOn(useAppDataViewHook, 'useAppDataView').mockReturnValue({
+      dataViews: { synthetics: {} },
+      loading: false,
+    } as any);
+  });
+
+  it('should NOT use cached time when time range changes', async () => {
+    const core = mockCore();
+    core.lens = mockLens;
+    core.data!.search.session.getSessionId = jest.fn().mockReturnValue('test-session');
+
+    const ExploratoryViewEmbeddable = getExploratoryViewEmbeddable(core as any);
+
+    const initialProps: ExploratoryEmbeddableProps = {
+      id: 'test-embeddable-id',
+      attributes: createMockAttributes(mockTimeRange1),
+      reportType: 'kpi-over-time',
+    };
+
+    // Initial render with first time range
+    const { rerender } = render(<ExploratoryViewEmbeddable {...initialProps} />, { core });
+
+    // Wait for Embeddable to be rendered
+    await waitFor(() => {
+      expect(capturedEmbeddableProps).not.toBeNull();
+    });
+
+    // Verify initial time range is passed to Embeddable
+    expect(capturedEmbeddableProps?.attributes?.[0].time).toEqual(mockTimeRange1);
+
+    // Rerender with different time range
+    const updatedProps: ExploratoryEmbeddableProps = {
+      ...initialProps,
+      attributes: createMockAttributes(mockTimeRange2),
+    };
+
+    rerender(<ExploratoryViewEmbeddable {...updatedProps} />);
+
+    // Wait for re-render to complete
+    await waitFor(() => {
+      expect(capturedEmbeddableProps?.attributes?.[0].time).toEqual(mockTimeRange2);
+    });
+  });
+
+  it('should update cached time when time range changes', async () => {
+    const core = mockCore();
+    core.lens = mockLens;
+    core.data!.search.session.getSessionId = jest.fn().mockReturnValue('test-session');
+
+    const ExploratoryViewEmbeddable = getExploratoryViewEmbeddable(core as any);
+
+    const mockTimeRange3 = {
+      from: '2022-02-19T16:00:00.000Z',
+      to: '2022-02-20T15:59:59.999Z',
+    };
+
+    const baseProps: ExploratoryEmbeddableProps = {
+      id: 'test-cache-update-id',
+      attributes: createMockAttributes(mockTimeRange1),
+      reportType: 'kpi-over-time',
+    };
+
+    const { rerender } = render(<ExploratoryViewEmbeddable {...baseProps} />, { core });
+
+    await waitFor(() => {
+      expect(capturedEmbeddableProps).not.toBeNull();
+    });
+    expect(capturedEmbeddableProps?.attributes?.[0].time).toEqual(mockTimeRange1);
+
+    // Change to mockTimeRange2
+    rerender(
+      <ExploratoryViewEmbeddable {...baseProps} attributes={createMockAttributes(mockTimeRange2)} />
+    );
+    await waitFor(() => {
+      expect(capturedEmbeddableProps?.attributes?.[0].time).toEqual(mockTimeRange2);
+    });
+
+    // Change to mockTimeRange3
+    rerender(
+      <ExploratoryViewEmbeddable {...baseProps} attributes={createMockAttributes(mockTimeRange3)} />
+    );
+    await waitFor(() => {
+      expect(capturedEmbeddableProps?.attributes?.[0].time).toEqual(mockTimeRange3);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/index.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/index.tsx
@@ -107,10 +107,18 @@ export function getExploratoryViewEmbeddable(
         newProps.legendIsVisible = false;
         newProps.hideTicks = true;
       }
-      if (props.id && lastRefreshed[props.id] && loadCount < 2) {
+      const cachedTime = props.id ? lastRefreshed[props.id] : undefined;
+      const timeRangeChanged = cachedTime
+        ? cachedTime.from !== series.time.from || cachedTime.to !== series.time.to
+        : false;
+
+      // Use cached time only during initial load (loadCount < 2) and when time range hasn't changed
+      const shouldUseCachedTime =
+        Boolean(props.id) && Boolean(cachedTime) && loadCount < 2 && !timeRangeChanged;
+      if (shouldUseCachedTime && cachedTime) {
         newProps.attributes = props.attributes?.map((seriesT) => ({
           ...seriesT,
-          time: lastRefreshed[props.id!],
+          time: cachedTime,
         }));
       } else if (props.id) {
         lastRefreshed[props.id] = series.time;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[BUG][Synthetics] Fix Stats panel not updating on time range change and null values display (#250743)](https://github.com/elastic/kibana/pull/250743)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yiannis Nikolopoulos","email":"yiannis.nikolopoulos@elastic.co"},"sourceCommit":{"committedDate":"2026-02-03T09:38:22Z","message":"[BUG][Synthetics] Fix Stats panel not updating on time range change and null values display (#250743)\n\n## Summary\n\nCloses #250595\nCloses #250748\n\nThis PR addresses two issues in the Synthetics Monitor History Stats\npanel:\n\n1. **Stats showing \"(null)\" when no data exists** - Successful and Total\nruns now display `0` instead of `(null)` when there's no data for the\nselected time range\n2. **Stats not updating on time range change** - The Stats panel now\nupdates automatically when the time range is changed, without requiring\na manual page refresh\n\n\n## 🔬 How to test\n\n### Test 1: No-data values (#250595)\n\n1. Create a new monitor\n2. Trigger the initial test run\n3. Go to the monitor history \n4. Select a time-range which has no data\n5. Notice the values of Successful & Total runs under Stats, they\nshouldn't be `null`\n\n### Test 2: Stats update on time range change (#250748)\n\n1. Navigate to **Observability → Synthetics**\n2. Select a monitor and go to the **History** tab\n3. Confirm the default time range (e.g., Last 24 hours)\n4. Note the current values in the **Stats** panel:\n   - Successful\n   - Total runs\n   - Availability\n   - Errors\n   - Median duration\n\n6. **Change the time range** using the date picker (e.g., Last 7 days,\nLast 48 hours, or a custom range)\n\n7. **Verify:** The Stats panel updates automatically to reflect the new\ntime range **without requiring a manual page refresh**\n\n8. Change the time range again to a different period\n\n9. **Verify:** Stats panel updates again without refresh\n\n> [!NOTE]\n> **Availability displays \"(null)\" when there's no data for the selected\ntime range.**\n>\n> This is intentional - unlike other metrics (Total runs, Errors, etc.)\nthat use simple count aggregations with `emptyAsNull: false` to show\n\"0\", Availability requires a formula `(1 - down_count/total_count)`\nwhich results in division by zero when no data exists.\n>\n> We deliberately show \"(null)\" rather than fabricating \"100%\" or \"0%\"\nbecause:\n> - It honestly represents the absence of data vs. assumed perfect or no\navailability\n> - It makes data collection issues immediately visible for debugging\n> - It avoids misleading SLO/SLA reporting with fabricated metrics","sha":"f7b0d31021db6c17aff6467b2f76c12bd27bb9f7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:actionable-obs","v9.4.0","author:actionable-obs","Team:obs-ux-management"],"title":"[BUG][Synthetics] Fix Stats panel not updating on time range change and null values display","number":250743,"url":"https://github.com/elastic/kibana/pull/250743","mergeCommit":{"message":"[BUG][Synthetics] Fix Stats panel not updating on time range change and null values display (#250743)\n\n## Summary\n\nCloses #250595\nCloses #250748\n\nThis PR addresses two issues in the Synthetics Monitor History Stats\npanel:\n\n1. **Stats showing \"(null)\" when no data exists** - Successful and Total\nruns now display `0` instead of `(null)` when there's no data for the\nselected time range\n2. **Stats not updating on time range change** - The Stats panel now\nupdates automatically when the time range is changed, without requiring\na manual page refresh\n\n\n## 🔬 How to test\n\n### Test 1: No-data values (#250595)\n\n1. Create a new monitor\n2. Trigger the initial test run\n3. Go to the monitor history \n4. Select a time-range which has no data\n5. Notice the values of Successful & Total runs under Stats, they\nshouldn't be `null`\n\n### Test 2: Stats update on time range change (#250748)\n\n1. Navigate to **Observability → Synthetics**\n2. Select a monitor and go to the **History** tab\n3. Confirm the default time range (e.g., Last 24 hours)\n4. Note the current values in the **Stats** panel:\n   - Successful\n   - Total runs\n   - Availability\n   - Errors\n   - Median duration\n\n6. **Change the time range** using the date picker (e.g., Last 7 days,\nLast 48 hours, or a custom range)\n\n7. **Verify:** The Stats panel updates automatically to reflect the new\ntime range **without requiring a manual page refresh**\n\n8. Change the time range again to a different period\n\n9. **Verify:** Stats panel updates again without refresh\n\n> [!NOTE]\n> **Availability displays \"(null)\" when there's no data for the selected\ntime range.**\n>\n> This is intentional - unlike other metrics (Total runs, Errors, etc.)\nthat use simple count aggregations with `emptyAsNull: false` to show\n\"0\", Availability requires a formula `(1 - down_count/total_count)`\nwhich results in division by zero when no data exists.\n>\n> We deliberately show \"(null)\" rather than fabricating \"100%\" or \"0%\"\nbecause:\n> - It honestly represents the absence of data vs. assumed perfect or no\navailability\n> - It makes data collection issues immediately visible for debugging\n> - It avoids misleading SLO/SLA reporting with fabricated metrics","sha":"f7b0d31021db6c17aff6467b2f76c12bd27bb9f7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250743","number":250743,"mergeCommit":{"message":"[BUG][Synthetics] Fix Stats panel not updating on time range change and null values display (#250743)\n\n## Summary\n\nCloses #250595\nCloses #250748\n\nThis PR addresses two issues in the Synthetics Monitor History Stats\npanel:\n\n1. **Stats showing \"(null)\" when no data exists** - Successful and Total\nruns now display `0` instead of `(null)` when there's no data for the\nselected time range\n2. **Stats not updating on time range change** - The Stats panel now\nupdates automatically when the time range is changed, without requiring\na manual page refresh\n\n\n## 🔬 How to test\n\n### Test 1: No-data values (#250595)\n\n1. Create a new monitor\n2. Trigger the initial test run\n3. Go to the monitor history \n4. Select a time-range which has no data\n5. Notice the values of Successful & Total runs under Stats, they\nshouldn't be `null`\n\n### Test 2: Stats update on time range change (#250748)\n\n1. Navigate to **Observability → Synthetics**\n2. Select a monitor and go to the **History** tab\n3. Confirm the default time range (e.g., Last 24 hours)\n4. Note the current values in the **Stats** panel:\n   - Successful\n   - Total runs\n   - Availability\n   - Errors\n   - Median duration\n\n6. **Change the time range** using the date picker (e.g., Last 7 days,\nLast 48 hours, or a custom range)\n\n7. **Verify:** The Stats panel updates automatically to reflect the new\ntime range **without requiring a manual page refresh**\n\n8. Change the time range again to a different period\n\n9. **Verify:** Stats panel updates again without refresh\n\n> [!NOTE]\n> **Availability displays \"(null)\" when there's no data for the selected\ntime range.**\n>\n> This is intentional - unlike other metrics (Total runs, Errors, etc.)\nthat use simple count aggregations with `emptyAsNull: false` to show\n\"0\", Availability requires a formula `(1 - down_count/total_count)`\nwhich results in division by zero when no data exists.\n>\n> We deliberately show \"(null)\" rather than fabricating \"100%\" or \"0%\"\nbecause:\n> - It honestly represents the absence of data vs. assumed perfect or no\navailability\n> - It makes data collection issues immediately visible for debugging\n> - It avoids misleading SLO/SLA reporting with fabricated metrics","sha":"f7b0d31021db6c17aff6467b2f76c12bd27bb9f7"}}]}] BACKPORT-->