### PR TITLE
[Exploratory View] Fix duplicate "Add to case" action in Lens charts

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.test.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.test.tsx
@@ -173,6 +173,24 @@ describe('Embeddable', () => {
     );
   });
 
+  it('disables the built-in cases action to avoid a duplicate "Add to case" entry', () => {
+    render(
+      <Embeddable
+        caseOwner={mockOwner}
+        customTimeRange={mockTimeRange}
+        dataViewState={mockDataViews}
+        lens={mockLens}
+        reportType={mockReportType}
+        withActions={mockActions}
+        attributes={[]}
+      />
+    );
+
+    expect((mockLens.EmbeddableComponent as jest.Mock).mock.calls[0][0].disabledActions).toEqual([
+      'embeddable_addToExistingCase',
+    ]);
+  });
+
   it('renders AddToCaseAction', () => {
     render(
       <Embeddable

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
@@ -25,6 +25,11 @@ import { useActions } from './use_actions';
 import { AddToCaseAction } from '../header/add_to_case_action';
 import { useEmbeddableAttributes } from './use_embeddable_attributes';
 
+// The cases plugin auto-registers its own "Add to case" action on the Lens panel
+// menu. Exploratory View already provides its own `expViewAddToCase` action, so we
+// disable the built-in one to avoid a duplicate menu entry (see issue #231475).
+const DISABLED_ACTIONS = ['embeddable_addToExistingCase'];
+
 export interface ExploratoryEmbeddableProps {
   id?: string;
   appendTitle?: JSX.Element;
@@ -204,6 +209,7 @@ export default function Embeddable(props: ExploratoryEmbeddableComponentProps) {
         attributes={{ ...attributesJSON, title: '', description: '' }}
         onBrushEnd={onBrushEnd}
         withDefaultActions={Boolean(withActions)}
+        disabledActions={DISABLED_ACTIONS}
         extraActions={actions}
         viewMode={'view'}
         searchSessionId={searchSessionId}


### PR DESCRIPTION
## Summary

In the Synthetics UI (and any Observability view using the shared `ExploratoryViewEmbeddable`), Lens embeddable-based charts showed **"Add to case" twice** in the three-dot action menu — two entries with different icons doing effectively the same thing.

Root cause:
- Exploratory View adds its own custom `expViewAddToCase` action (icon `link`) via `extraActions`.
- The `cases` plugin auto-registers a built-in `embeddable_addToExistingCase` action (icon `casesApp`) on the Lens panel-menu trigger, which is pulled in via `withDefaultActions`.

This fix disables the built-in cases action (`embeddable_addToExistingCase`) in the shared `exploratory_view` embeddable, keeping the existing custom Observability add-to-case flow (which handles the correct case owner/routing). This mirrors the pattern already used by the `infra` plugin's `LensChart`.

Because the fix lives in the shared `ExploratoryViewEmbeddable`, it resolves the duplicate across Synthetics, Uptime, and the Observability overview.

Closes #231475

## Test plan
- [ ] Open a Synthetics monitor detail page (or overview) with Lens-based charts.
- [ ] Open the chart three-dot action menu.
- [ ] Verify only a single "Add to case" entry appears and it works.


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->