### PR TITLE
[8.19] chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27699,9 +27699,9 @@ property-information@^5.0.0, property-information@^5.0.1, property-information@^
     xtend "^4.0.0"
 
 protobufjs@^7.5.3:
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.4.tgz#8bb000300026efd63eb7951d26e5dbb38f5658f2"
-  integrity sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==
+  version "7.6.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
+  integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205)](https://github.com/elastic/kibana/pull/277205)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-09T16:48:03Z","message":"chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205)\n\n## Summary\n\nRelocked `protobufjs` to 7.6.5.\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>","sha":"30a0ab5abad24f7cc13a6e500af39dbcff6f74ee","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0","v9.4.4","v9.6.0"],"title":"chore(deps): relock protobufjs from 7.6.4 to 7.6.5","number":277205,"url":"https://github.com/elastic/kibana/pull/277205","mergeCommit":{"message":"chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205)\n\n## Summary\n\nRelocked `protobufjs` to 7.6.5.\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>","sha":"30a0ab5abad24f7cc13a6e500af39dbcff6f74ee"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277264","number":277264,"state":"MERGED","mergeCommit":{"sha":"89e9d4c2ee96176f5ac7011b6e1f3e596772d1d4","message":"[9.5] chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205) (#277264)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [chore(deps): relock protobufjs from 7.6.4 to 7.6.5\n(#277205)](https://github.com/elastic/kibana/pull/277205)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: Elena Shostak <165678770+elena-shostak@users.noreply.github.com>\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277262","number":277262,"state":"MERGED","mergeCommit":{"sha":"9eb299fe8ed04f9419d5fc59db0cc5160a3f0bb0","message":"[9.4] chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205) (#277262)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [chore(deps): relock protobufjs from 7.6.4 to 7.6.5\n(#277205)](https://github.com/elastic/kibana/pull/277205)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elena Shostak <165678770+elena-shostak@users.noreply.github.com>\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277205","number":277205,"mergeCommit":{"message":"chore(deps): relock protobufjs from 7.6.4 to 7.6.5 (#277205)\n\n## Summary\n\nRelocked `protobufjs` to 7.6.5.\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>","sha":"30a0ab5abad24f7cc13a6e500af39dbcff6f74ee"}}]}] BACKPORT-->