### PR TITLE
[Entity Analytics][Entity Store] Fix related.user resolution source index

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/left.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/left.ts
@@ -10,10 +10,12 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import { getEuidFromObject } from '../../../../../../common/domain/euid';
 import { SEED_IDENTITY_PREFILTER_FIELDS, type RelatedUserBundle, type SeedEntity } from './types';
 
+// User identities — and the `related.user` alias list this rule reads — live in
+// the per-IDP `.user-*` data streams (IDP integrations reroute user docs there).
 const SOURCE_INDEX_BY_NAMESPACE: Record<string, string> = {
-  active_directory: 'logs-entityanalytics_ad.entity-*',
-  entra_id: 'logs-entityanalytics_entra_id.entity-*',
-  okta: 'logs-entityanalytics_okta.entity-*',
+  active_directory: 'logs-entityanalytics_ad.user-*',
+  entra_id: 'logs-entityanalytics_entra_id.user-*',
+  okta: 'logs-entityanalytics_okta.user-*',
 };
 
 const RELATED_USER_FIELD = 'related.user';

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -88,4 +88,4 @@ export const HISTORY_INDEX_PATTERN = `${getEntityIndexPattern({
   namespace: 'default',
 })}*`;
 
-export const ENTRA_SOURCE_INDEX = 'logs-entityanalytics_entra_id.entity-default';
+export const ENTRA_SOURCE_INDEX = 'logs-entityanalytics_entra_id.user-default';


### PR DESCRIPTION
## Summary

The `related.user` alias-resolution maintainer (default-off resolution rule) reads a person's identity-provider (Okta / Entra ID / Active Directory) source record to bridge cross-system aliases from the `related.user` list. It looked that record up in `logs-entityanalytics_<idp>.entity-*`.

That index pattern does not hold user identities in real environments:

- **v2+ integrations** (okta ≥2.0.0, entra_id, ad) collect into a generalised `entity` data stream, then their `routing_rules.yml` **reroutes** user identity documents — the ones carrying `related.user` — into the per-type `.user-*` data streams. The `.entity-*` stream keeps only non-user/non-device docs.
- **v1 integrations** wrote user identities directly to `.user-*` with no `entity` stream at all.

So in every integration version the maintainer matched **no** user identities and created **no** resolutions — matching the QA report in #275776 (resolution never created even after manually running the maintainer).

This change points the source-index lookup at `logs-entityanalytics_<idp>.user-*` for Active Directory, Entra ID, and Okta.


Related: 
- #275776
Fixes:
- https://github.com/elastic/kibana/issues/277766



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->