### PR TITLE
[Synthetics] Return focus to monitor error icon after closing error popover

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_error_icon.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_error_icon.tsx
@@ -14,7 +14,13 @@ import { css } from '@emotion/react';
 import { useSyntheticsSettingsContext } from '../../../../../contexts';
 import { selectErrorPopoverState, toggleErrorPopoverOpen } from '../../../../../state';
 
-export const MetricErrorIcon = ({ configIdByLocation }: { configIdByLocation: string }) => {
+export const MetricErrorIcon = ({
+  configIdByLocation,
+  buttonRef,
+}: {
+  configIdByLocation: string;
+  buttonRef?: React.Ref<HTMLButtonElement>;
+}) => {
   const isPopoverOpen = useSelector(selectErrorPopoverState);
   const dispatch = useDispatch();
 
@@ -77,6 +83,7 @@ export const MetricErrorIcon = ({ configIdByLocation }: { configIdByLocation: st
     >
       <EuiToolTip content={ERROR_DETAILS} disableScreenReaderOutput>
         <EuiButtonIcon
+          buttonRef={buttonRef}
           data-test-subj="syntheticsMetricItemIconButton"
           iconType="warning"
           color="danger"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_icon.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_icon.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render } from '../../../../../utils/testing/rtl_helpers';
+import { MetricItemIcon } from './metric_item_icon';
+import type { OverviewStatusMetaData } from '../../../../../../../../common/runtime_types';
+
+jest.mock('./use_latest_error', () => ({
+  useLatestError: () => ({
+    loading: false,
+    latestPing: { error: { message: 'Something went wrong' } },
+  }),
+}));
+
+jest.mock('../../../hooks/use_monitor_mws', () => ({
+  useMonitorMWs: () => ({ activeMWs: [] }),
+}));
+
+jest.mock('../../../../common/links/error_details_link', () => ({
+  useErrorDetailsLink: () => '/app/synthetics/error-details',
+}));
+
+jest.mock('../../../../../../../hooks/use_date_format', () => ({
+  useDateFormat: () => (timestamp?: string) => timestamp ?? '',
+}));
+
+describe('MetricItemIcon', () => {
+  const configIdByLocation = 'test-config-us_central';
+
+  const monitor = {
+    configId: 'test-config',
+    locations: [{ id: 'us_central', label: 'US Central' }],
+    monitorQueryId: 'test-config',
+  } as unknown as OverviewStatusMetaData;
+
+  const renderIcon = () =>
+    render(
+      <MetricItemIcon
+        monitor={monitor}
+        status="down"
+        configIdByLocation={configIdByLocation}
+        timestamp="2026-01-01T00:00:00.000Z"
+      />,
+      { useRealStore: true }
+    );
+
+  it('returns focus to the trigger icon after the error popover is closed', async () => {
+    const { getByRole, getByLabelText } = renderIcon();
+
+    const triggerButton = getByRole('button', { name: 'Error details' });
+    fireEvent.click(triggerButton);
+
+    const closeButton = getByLabelText('Close popover');
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(triggerButton);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_icon.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_icon.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import {
   EuiLoadingSpinner,
   EuiToolTip,
@@ -81,6 +82,21 @@ export const MetricItemIcon = ({
   const testTime = formatter(timestamp);
   const metricItemPopoverTitleId = useGeneratedHtmlId();
 
+  const errorIconButtonRef = useRef<HTMLButtonElement | null>(null);
+  const isErrorPopoverForItemOpen = configIdByLocation === isPopoverOpen;
+  const wasErrorPopoverForItemOpen = useRef(isErrorPopoverForItemOpen);
+
+  useEffect(() => {
+    // When this monitor's error popover closes (Escape, close button, or an
+    // outside click), return keyboard focus to the trigger icon so keyboard and
+    // screen reader users aren't dropped at the top of the page (WCAG 2.4.3).
+    // Skip when focus has moved to another monitor's popover.
+    if (wasErrorPopoverForItemOpen.current && !isErrorPopoverForItemOpen && !isPopoverOpen) {
+      errorIconButtonRef.current?.focus();
+    }
+    wasErrorPopoverForItemOpen.current = isErrorPopoverForItemOpen;
+  }, [isErrorPopoverForItemOpen, isPopoverOpen]);
+
   if (inProgress) {
     return (
       <Container>
@@ -134,13 +150,19 @@ export const MetricItemIcon = ({
     return (
       <Container>
         <EuiPopover
-          button={<MetricErrorIcon configIdByLocation={configIdByLocation} />}
-          isOpen={configIdByLocation === isPopoverOpen}
+          button={
+            <MetricErrorIcon
+              configIdByLocation={configIdByLocation}
+              buttonRef={errorIconButtonRef}
+            />
+          }
+          isOpen={isErrorPopoverForItemOpen}
           closePopover={closePopover}
           anchorPosition="upCenter"
           panelStyle={{
             outline: 'none',
           }}
+          focusTrapProps={{ returnFocus: false }}
           aria-labelledby={metricItemPopoverTitleId}
         >
           <EuiPopoverTitle id={metricItemPopoverTitleId}>


### PR DESCRIPTION
## Summary

On the **Observability → Synthetics → Monitors → Overview** page, opening a monitor's error popover and then closing it dropped keyboard focus to the top of the page instead of returning it to the monitor's error icon. This forced keyboard and screen reader users to navigate back down to regain context (WCAG 2.4.3 Focus Order).

The popover's open/close state lives in Redux, and `EuiPopover`'s built-in return-focus could not reliably restore focus to the trigger. This PR manages focus restoration explicitly:

- Forward a `buttonRef` through `MetricErrorIcon` to the underlying trigger `EuiButtonIcon`.
- Disable `EuiPopover`'s own `returnFocus` and, when this monitor's error popover transitions from open → closed (Escape, close button, or outside click), return focus to the trigger icon. Focus is not stolen when the user switches to another monitor's popover.

Closes #255833

## Test plan

- [ ] Added a Jest test asserting focus returns to the trigger icon after the error popover closes.
- [ ] Manual: on the Monitors Overview page, tab to an erroring monitor's error icon, open the error popover, close it (Esc / close button / click outside), and confirm focus returns to the error icon rather than the top of the page.

Made with [Cursor](https://cursor.com)