### PR TITLE
[Security Solution][Flyout] toggle between legacy and new entity flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/generic/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/generic/main/index.tsx
@@ -15,14 +15,9 @@ import {
 import { css } from '@emotion/react';
 import { EuiEmptyPrompt, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { buildEntityNameFilter } from '../../../../../common/search_strategy';
 import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
 import type { Refetch } from '../../../../common/types';
-import { useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { FIRST_RECORD_PAGINATION } from '../../../../entity_analytics/common';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
@@ -42,16 +37,7 @@ import { GenericEntityFlyoutHeader } from '../../../../flyout/entity_details/gen
 import { GenericEntityFlyoutContent } from '../../../../flyout/entity_details/generic_right/content';
 import { GenericEntityFlyoutFooter } from '../../../../flyout/entity_details/generic_right/footer';
 import { GENERIC_FLYOUT_STORAGE_KEYS } from '../../../../flyout/entity_details/generic_right/constants';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../../../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { FieldsTableTool } from '../../shared/tools/fields_table';
-import { MisconfigurationInsights } from '../../shared/tools/misconfiguration_insights';
-import { AlertsInsights } from '../../shared/tools/alerts_insights';
-import { VulnerabilityInsights } from '../../host/tools/vulnerability_insights';
+import { useFlyoutApi } from '../../../use_flyout_api';
 
 export type GenericEntityProps = {
   scopeId: string;
@@ -59,22 +45,22 @@ export type GenericEntityProps = {
 } & UseGetGenericEntityParams;
 
 /**
- * Standalone generic-entity details flyout content (for use with `overlays.openSystemFlyout`).
+ * Standalone generic-entity details flyout content (for use with the entity flyout API).
  *
  * Runs the same data hooks as the v1 `GenericEntityPanel`, but without the expandable-flyout
  * navigation or preview-mode handling. Detail panels (fields table, CSP insights) open as separate
- * system flyouts via `overlays.openSystemFlyout`.
+ * system flyouts via `useFlyoutApi`.
  */
 export const GenericEntity: FC<GenericEntityProps> = memo(function GenericEntity(params) {
   const { scopeId } = params;
   const { euiTheme } = useEuiTheme();
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const {
+    openGenericEntityFlyoutAsChild,
+    openEntityFieldsTable,
+    openEntityMisconfigurationInsights,
+    openEntityVulnerabilityInsights,
+    openEntityAlertsInsights,
+  } = useFlyoutApi();
 
   const { getGenericEntity } = useGetGenericEntity(params);
   const genericInsightsValue = getGenericEntity.data?._source?.entity.id;
@@ -125,77 +111,52 @@ export const GenericEntity: FC<GenericEntityProps> = memo(function GenericEntity
   }, [getGenericEntity.data?._id]);
 
   const onShowGeneric = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <GenericEntity {...params} />,
-      }),
-      { ...defaultDocumentFlyoutProperties, historyKey, session: 'inherit' }
-    );
-  }, [overlays, services, store, history, params, historyKey, defaultDocumentFlyoutProperties]);
+    openGenericEntityFlyoutAsChild({ ...params });
+  }, [openGenericEntityFlyoutAsChild, params]);
 
   const openDetailsPanel = useCallback(
     (path: EntityDetailsPath) => {
-      const common = {
-        ...defaultToolsFlyoutProperties,
-        historyKey,
-        session: 'start' as const,
-      };
-      const wrap = (children: React.ReactNode) =>
-        overlays.openSystemFlyout(flyoutProviders({ services, store, history, children }), common);
-
       const value = genericInsightsValue || '';
 
       switch (path.tab) {
         case EntityDetailsLeftPanelTab.FIELDS_TABLE:
-          return wrap(
-            <FieldsTableTool
-              document={(getGenericEntity.data?._source ?? {}) as Record<string, unknown>}
-              tableStorageKey={GENERIC_FLYOUT_STORAGE_KEYS.OVERVIEW_FIELDS_TABLE_PINS}
-              entityName={value}
-              onShowEntity={onShowGeneric}
-            />
-          );
+          return openEntityFieldsTable({
+            document: (getGenericEntity.data?._source ?? {}) as Record<string, unknown>,
+            tableStorageKey: GENERIC_FLYOUT_STORAGE_KEYS.OVERVIEW_FIELDS_TABLE_PINS,
+            entityName: value,
+            onShowEntity: onShowGeneric,
+          });
         case EntityDetailsLeftPanelTab.CSP_INSIGHTS:
           switch (path.subTab) {
             case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
-              return wrap(
-                <MisconfigurationInsights
-                  entityType={EntityType.generic}
-                  value={value}
-                  entityId={genericInsightsValue}
-                  onShowEntity={onShowGeneric}
-                />
-              );
+              return openEntityMisconfigurationInsights({
+                entityType: EntityType.generic,
+                value,
+                entityId: genericInsightsValue,
+                onShowEntity: onShowGeneric,
+              });
             case CspInsightLeftPanelSubTab.VULNERABILITIES:
-              return wrap(
-                <VulnerabilityInsights
-                  value={value}
-                  entityId={genericInsightsValue}
-                  entityType={EntityType.generic}
-                  onShowHost={onShowGeneric}
-                />
-              );
+              return openEntityVulnerabilityInsights({
+                value,
+                entityId: genericInsightsValue,
+                entityType: EntityType.generic,
+                onShowHost: onShowGeneric,
+              });
             case CspInsightLeftPanelSubTab.ALERTS:
-              return wrap(
-                <AlertsInsights
-                  entityType={EntityType.generic}
-                  value={value}
-                  entityId={genericInsightsValue}
-                  onShowEntity={onShowGeneric}
-                />
-              );
+              return openEntityAlertsInsights({
+                entityType: EntityType.generic,
+                value,
+                entityId: genericInsightsValue,
+                onShowEntity: onShowGeneric,
+              });
           }
       }
     },
     [
-      overlays,
-      services,
-      store,
-      history,
-      historyKey,
+      openEntityFieldsTable,
+      openEntityMisconfigurationInsights,
+      openEntityVulnerabilityInsights,
+      openEntityAlertsInsights,
       genericInsightsValue,
       getGenericEntity.data?._source,
       onShowGeneric,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
@@ -8,12 +8,9 @@
 import type { FC } from 'react';
 import React, { memo, useCallback, useMemo } from 'react';
 import { noop } from 'lodash/fp';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { EuiFlyoutHeader, EuiFlyoutBody, EuiSpacer, EuiFlyoutFooter } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { useUpdateAssetCriticality } from '../../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useAssetCriticalityPrivileges } from '../../../../entity_analytics/components/asset_criticality/use_asset_criticality';
 import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
@@ -25,26 +22,12 @@ import { useQueryInspector } from '../../../../common/components/page/manage_que
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { buildHostNamesFilter, type RiskSeverity } from '../../../../../common/search_strategy';
 import { useUiSetting, useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import type { EntityDetailsPath } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
 import {
   CspInsightLeftPanelSubTab,
   EntityDetailsLeftPanelTab,
 } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../../../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { RiskInputs } from '../../shared/tools/risk_inputs';
-import { MisconfigurationInsights } from '../../shared/tools/misconfiguration_insights';
-import { VulnerabilityInsights } from '../tools/vulnerability_insights';
-import { AlertsInsights } from '../../shared/tools/alerts_insights';
-import { GraphView } from '../../shared/tools/graph_view';
-import { Resolution } from '../../shared/tools/resolution';
-import { renderEntityDetails } from '../../shared/render_entity_details';
-import { AnomalyInsights } from '../../shared/tools/anomaly_insights';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { Header } from './header';
 import { Content } from './content';
 import { Footer } from './footer';
@@ -105,11 +88,11 @@ const FIRST_RECORD_PAGINATION = {
 };
 
 /**
- * Standalone host details flyout content (for use with `overlays.openSystemFlyout`).
+ * Standalone host details flyout content (for use with the entity flyout API).
  *
  * Runs the same data hooks as the v1 `HostPanel`, but without the expandable-flyout
  * navigation or preview-mode handling. Detail panels (risk inputs, graph view, etc.)
- * open as separate system flyouts via `overlays.openSystemFlyout`.
+ * open as separate system flyouts via `useFlyoutApi`.
  */
 export const Host: FC<HostProps> = memo(function Host({
   hostName,
@@ -119,10 +102,19 @@ export const Host: FC<HostProps> = memo(function Host({
   contextID,
 }) {
   const { services } = useKibana();
-  const { uiSettings, overlays } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { uiSettings } = services;
   const euidApi = useEntityStoreEuidApi();
+  const {
+    openHostFlyoutAsChild,
+    openEntityDetailsAsChild,
+    openEntityRiskInputs,
+    openEntityAnomalyInsights,
+    openEntityVulnerabilityInsights,
+    openEntityAlertsInsights,
+    openEntityMisconfigurationInsights,
+    openEntityGraphView,
+    openEntityResolution,
+  } = useFlyoutApi();
 
   // Compute entityId from hit when provided, otherwise use the prop
   const entityId = useMemo(
@@ -131,9 +123,6 @@ export const Host: FC<HostProps> = memo(function Host({
   );
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
   const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2);
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
   const safeContextID = contextID ?? scopeId ?? 'host-panel';
   const { setQuery, deleteQuery, isInitializing } = useGlobalTime();
@@ -273,26 +262,8 @@ export const Host: FC<HostProps> = memo(function Host({
   ) : undefined;
 
   const onShowHost = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <Host hostName={hostName} entityId={entityId} scopeId={scopeId} />,
-      }),
-      { ...defaultDocumentFlyoutProperties, title: hostName, historyKey, session: 'inherit' }
-    );
-  }, [
-    overlays,
-    services,
-    store,
-    history,
-    historyKey,
-    hostName,
-    entityId,
-    scopeId,
-    defaultDocumentFlyoutProperties,
-  ]);
+    openHostFlyoutAsChild({ hostName, entityId, scopeId, title: hostName });
+  }, [openHostFlyoutAsChild, hostName, entityId, scopeId]);
 
   const onShowRelatedEntity = useCallback(
     (params: {
@@ -300,114 +271,93 @@ export const Host: FC<HostProps> = memo(function Host({
       entityId: string;
       entityName: string | undefined;
     }) =>
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: renderEntityDetails({ ...params, scopeId }),
-        }),
-        {
-          ...defaultDocumentFlyoutProperties,
-          title: params.entityName ?? params.entityId,
-          historyKey,
-          session: 'inherit',
-        }
-      ),
-    [overlays, services, store, history, scopeId, historyKey, defaultDocumentFlyoutProperties]
+      openEntityDetailsAsChild({
+        engineType: params.engineType,
+        entityId: params.entityId,
+        entityName: params.entityName,
+        scopeId,
+        title: params.entityName ?? params.entityId,
+      }),
+    [openEntityDetailsAsChild, scopeId]
   );
 
   const openDetailsPanel = useCallback(
     (path: EntityDetailsPath) => {
-      const common = {
-        ...defaultToolsFlyoutProperties,
-        title: hostName,
-        historyKey,
-        session: 'start' as const,
-      };
-      const wrap = (children: React.ReactNode) =>
-        overlays.openSystemFlyout(flyoutProviders({ services, store, history, children }), common);
-
       switch (path.tab) {
         case EntityDetailsLeftPanelTab.RISK_INPUTS:
-          return wrap(
-            <RiskInputs
-              entityType={EntityType.host}
-              entityName={hostName}
-              entityId={entityStoreEntityId}
-              onShowEntity={onShowHost}
-            />
-          );
+          return openEntityRiskInputs({
+            entityType: EntityType.host,
+            entityName: hostName,
+            entityId: entityStoreEntityId,
+            onShowEntity: onShowHost,
+            title: hostName,
+          });
         case EntityDetailsLeftPanelTab.ANOMALIES:
-          return wrap(
-            <AnomalyInsights
-              entityType={EntityType.host}
-              value={hostName}
-              entityId={entityStoreEntityId}
-              onOpenEntity={onShowHost}
-            />
-          );
+          return openEntityAnomalyInsights({
+            entityType: EntityType.host,
+            value: hostName,
+            entityId: entityStoreEntityId,
+            onOpenEntity: onShowHost,
+            title: hostName,
+          });
         case EntityDetailsLeftPanelTab.CSP_INSIGHTS:
           switch (path.subTab) {
             case CspInsightLeftPanelSubTab.VULNERABILITIES:
-              return wrap(
-                <VulnerabilityInsights
-                  value={hostName}
-                  entityId={panelDisplayEntityId}
-                  onShowHost={onShowHost}
-                />
-              );
+              return openEntityVulnerabilityInsights({
+                value: hostName,
+                entityId: panelDisplayEntityId,
+                onShowHost,
+                title: hostName,
+              });
             case CspInsightLeftPanelSubTab.ALERTS:
-              return wrap(
-                <AlertsInsights
-                  entityType={EntityType.host}
-                  value={hostName}
-                  entityId={panelDisplayEntityId}
-                  onShowEntity={onShowHost}
-                />
-              );
+              return openEntityAlertsInsights({
+                entityType: EntityType.host,
+                value: hostName,
+                entityId: panelDisplayEntityId,
+                onShowEntity: onShowHost,
+                title: hostName,
+              });
             case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
-              return wrap(
-                <MisconfigurationInsights
-                  entityType={EntityType.host}
-                  value={hostName}
-                  entityId={panelDisplayEntityId}
-                  onShowEntity={onShowHost}
-                />
-              );
+              return openEntityMisconfigurationInsights({
+                entityType: EntityType.host,
+                value: hostName,
+                entityId: panelDisplayEntityId,
+                onShowEntity: onShowHost,
+                title: hostName,
+              });
           }
           return;
         case EntityDetailsLeftPanelTab.GRAPH_VIEW:
           if (!entityStoreEntityId) return;
-          return wrap(
-            <GraphView
-              entityId={entityStoreEntityId}
-              scopeId={scopeId}
-              entityName={hostName}
-              onShowEntity={onShowRelatedEntity}
-              onShowOriginatingEntity={onShowHost}
-            />
-          );
+          return openEntityGraphView({
+            entityId: entityStoreEntityId,
+            scopeId,
+            entityName: hostName,
+            onShowEntity: onShowRelatedEntity,
+            onShowOriginatingEntity: onShowHost,
+            title: hostName,
+          });
         case EntityDetailsLeftPanelTab.RESOLUTION_GROUP:
           if (!entityStoreEntityId) return;
-          return wrap(
-            <Resolution
-              entityId={entityStoreEntityId}
-              entityType="host"
-              entityName={hostName}
-              scopeId={scopeId}
-              onShowEntity={onShowHost}
-              onShowRelatedEntity={onShowRelatedEntity}
-            />
-          );
+          return openEntityResolution({
+            entityId: entityStoreEntityId,
+            entityType: 'host',
+            entityName: hostName,
+            scopeId,
+            onShowEntity: onShowHost,
+            onShowRelatedEntity,
+            title: hostName,
+          });
       }
     },
     [
-      overlays,
-      services,
-      store,
-      history,
-      historyKey,
+      openEntityRiskInputs,
+      openEntityAnomalyInsights,
+      openEntityVulnerabilityInsights,
+      openEntityAlertsInsights,
+      openEntityMisconfigurationInsights,
+      openEntityGraphView,
+      openEntityResolution,
       hostName,
       scopeId,
       panelDisplayEntityId,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
@@ -7,19 +7,14 @@
 
 import type { FC } from 'react';
 import React, { memo, useCallback, useMemo } from 'react';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { css } from '@emotion/react';
 import { EuiSpacer, useEuiTheme } from '@elastic/eui';
 import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { CriticalityLevelWithUnassigned } from '../../../../../common/entity_analytics/asset_criticality/types';
 import type { ESQuery } from '../../../../../common/typed_json';
 import { buildEntityNameFilter, type RiskSeverity } from '../../../../../common/search_strategy';
 import { EntityType } from '../../../../../common/entity_analytics/types';
 import type { Refetch } from '../../../../common/types';
-import { useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
@@ -47,16 +42,7 @@ import { ServicePanelContent } from '../../../../flyout/entity_details/service_r
 import { ServicePanelHeader } from '../../../../flyout/entity_details/service_right/header';
 import { ServicePanelFooter } from '../../../../flyout/entity_details/service_right/footer';
 import { useObservedService } from '../../../../flyout/entity_details/service_right/hooks/use_observed_service';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../../../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { RiskInputs } from '../../shared/tools/risk_inputs';
-import { GraphView } from '../../shared/tools/graph_view';
-import { Resolution } from '../../shared/tools/resolution';
-import { renderEntityDetails } from '../../shared/render_entity_details';
+import { useFlyoutApi } from '../../../use_flyout_api';
 
 export interface ServiceProps {
   /** Display name from the source row / document (typically `service.name`). */
@@ -75,11 +61,11 @@ const FIRST_RECORD_PAGINATION = {
 };
 
 /**
- * Standalone service details flyout content (for use with `overlays.openSystemFlyout`).
+ * Standalone service details flyout content (for use with the entity flyout API).
  *
  * Runs the same data hooks as the v1 `ServicePanel`, but without the expandable-flyout navigation
  * or preview-mode handling. Detail panels (risk inputs, graph view, resolution) open as separate
- * system flyouts via `overlays.openSystemFlyout`.
+ * system flyouts via `useFlyoutApi`.
  */
 export const Service: FC<ServiceProps> = memo(function Service({
   serviceName,
@@ -88,13 +74,13 @@ export const Service: FC<ServiceProps> = memo(function Service({
   contextID,
 }) {
   const { euiTheme } = useEuiTheme();
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const {
+    openServiceFlyoutAsChild,
+    openEntityDetailsAsChild,
+    openEntityRiskInputs,
+    openEntityGraphView,
+    openEntityResolution,
+  } = useFlyoutApi();
 
   const safeContextID = contextID ?? scopeId ?? 'service-panel';
 
@@ -177,26 +163,8 @@ export const Service: FC<ServiceProps> = memo(function Service({
     : undefined;
 
   const onShowService = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <Service serviceName={serviceName} entityId={entityId} scopeId={scopeId} />,
-      }),
-      { ...defaultDocumentFlyoutProperties, title: serviceName, historyKey, session: 'inherit' }
-    );
-  }, [
-    overlays,
-    services,
-    store,
-    history,
-    serviceName,
-    entityId,
-    scopeId,
-    historyKey,
-    defaultDocumentFlyoutProperties,
-  ]);
+    openServiceFlyoutAsChild({ serviceName, entityId, scopeId, title: serviceName });
+  }, [openServiceFlyoutAsChild, serviceName, entityId, scopeId]);
 
   const onShowRelatedEntity = useCallback(
     (params: {
@@ -204,78 +172,57 @@ export const Service: FC<ServiceProps> = memo(function Service({
       entityId: string;
       entityName: string | undefined;
     }) =>
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: renderEntityDetails({ ...params, scopeId }),
-        }),
-        {
-          ...defaultDocumentFlyoutProperties,
-          title: params.entityName ?? params.entityId,
-          historyKey,
-          session: 'inherit',
-        }
-      ),
-    [overlays, services, store, history, scopeId, historyKey, defaultDocumentFlyoutProperties]
+      openEntityDetailsAsChild({
+        engineType: params.engineType,
+        entityId: params.entityId,
+        entityName: params.entityName,
+        scopeId,
+        title: params.entityName ?? params.entityId,
+      }),
+    [openEntityDetailsAsChild, scopeId]
   );
 
   const openDetailsPanel = useCallback(
     (path: EntityDetailsPath) => {
-      const common = {
-        ...defaultToolsFlyoutProperties,
-        title: serviceName,
-        historyKey,
-        session: 'start' as const,
-      };
-      const wrap = (children: React.ReactNode) =>
-        overlays.openSystemFlyout(flyoutProviders({ services, store, history, children }), common);
-
       switch (path.tab) {
         case EntityDetailsLeftPanelTab.RISK_INPUTS:
-          return wrap(
-            <RiskInputs
-              entityType={EntityType.service}
-              entityName={serviceName}
-              entityId={entityStoreEntityId}
-              onShowEntity={onShowService}
-            />
-          );
+          return openEntityRiskInputs({
+            entityType: EntityType.service,
+            entityName: serviceName,
+            entityId: entityStoreEntityId,
+            onShowEntity: onShowService,
+            title: serviceName,
+          });
         case EntityDetailsLeftPanelTab.GRAPH_VIEW:
           if (!entityStoreEntityId) return;
-          return wrap(
-            <GraphView
-              entityId={entityStoreEntityId}
-              scopeId={scopeId}
-              entityName={serviceName}
-              onShowEntity={onShowRelatedEntity}
-              onShowOriginatingEntity={onShowService}
-            />
-          );
+          return openEntityGraphView({
+            entityId: entityStoreEntityId,
+            scopeId,
+            entityName: serviceName,
+            onShowEntity: onShowRelatedEntity,
+            onShowOriginatingEntity: onShowService,
+            title: serviceName,
+          });
         case EntityDetailsLeftPanelTab.RESOLUTION_GROUP:
           if (!entityStoreEntityId) return;
-          return wrap(
-            <Resolution
-              entityId={entityStoreEntityId}
-              entityType="service"
-              entityName={serviceName}
-              scopeId={scopeId}
-              onShowEntity={onShowService}
-              onShowRelatedEntity={onShowRelatedEntity}
-            />
-          );
+          return openEntityResolution({
+            entityId: entityStoreEntityId,
+            entityType: 'service',
+            entityName: serviceName,
+            scopeId,
+            onShowEntity: onShowService,
+            onShowRelatedEntity,
+            title: serviceName,
+          });
       }
     },
     [
-      overlays,
-      services,
-      store,
-      history,
+      openEntityRiskInputs,
+      openEntityGraphView,
+      openEntityResolution,
       serviceName,
       scopeId,
       entityStoreEntityId,
-      historyKey,
       onShowService,
       onShowRelatedEntity,
     ]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.mock.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityFlyoutApi } from './use_entity_flyout_api';
+
+/**
+ * Returns a `useEntityFlyoutApi` return value with every method stubbed as a `jest.fn()`.
+ * Use with `jest.mocked(useEntityFlyoutApi).mockReturnValue(createEntityFlyoutApiMock())`
+ * and assert against the individual method you care about.
+ */
+export const createEntityFlyoutApiMock = (): jest.Mocked<EntityFlyoutApi> => ({
+  openHostFlyout: jest.fn(),
+  openHostFlyoutAsChild: jest.fn(),
+  openUserFlyout: jest.fn(),
+  openUserFlyoutAsChild: jest.fn(),
+  openServiceFlyout: jest.fn(),
+  openServiceFlyoutAsChild: jest.fn(),
+  openGenericEntityFlyout: jest.fn(),
+  openGenericEntityFlyoutAsChild: jest.fn(),
+  openEntityDetailsAsChild: jest.fn(),
+  openEntityRiskInputs: jest.fn(),
+  openEntityAnomalyInsights: jest.fn(),
+  openEntityAlertsInsights: jest.fn(),
+  openEntityMisconfigurationInsights: jest.fn(),
+  openEntityVulnerabilityInsights: jest.fn(),
+  openEntityGraphView: jest.fn(),
+  openEntityResolution: jest.fn(),
+  openEntityEntraInsights: jest.fn(),
+  openEntityOktaInsights: jest.fn(),
+  openEntityFieldsTable: jest.fn(),
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { useEntityFlyoutApi } from './use_entity_flyout_api';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: jest.fn(() => ({})),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({})),
+}));
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/is_in_security_app');
+jest.mock('../shared/components/flyout_provider', () => ({
+  flyoutProviders: jest.fn(() => 'FLYOUT_CONTENT'),
+}));
+jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: jest.fn(() => ({ size: 's' })),
+  defaultToolsFlyoutProperties: { size: 'm' },
+}));
+
+const mockOpenSystemFlyout = jest.fn();
+
+describe('useEntityFlyoutApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { overlays: { openSystemFlyout: mockOpenSystemFlyout } },
+    });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  it('openHostFlyout opens a system flyout as a new session with the document properties', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openHostFlyout({ hostName: 'host-1' });
+
+    expect(flyoutProviders).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openHostFlyoutAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openHostFlyoutAsChild({ hostName: 'host-1' });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].session).toBe('inherit');
+  });
+
+  it('openUserFlyout opens a system flyout as a new session with the document properties', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openUserFlyout({ userName: 'user-1' });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'start', historyKey: documentFlyoutHistoryKey })
+    );
+  });
+
+  it('openUserFlyoutAsChild opens a system flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openUserFlyoutAsChild({ userName: 'user-1' });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].session).toBe('inherit');
+  });
+
+  it('openEntityDetailsAsChild opens the matching entity flyout that inherits the current session', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityDetailsAsChild({
+      engineType: 'host',
+      entityId: 'entity-1',
+      entityName: 'host-1',
+      scopeId: 'scopeId',
+    });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 's', session: 'inherit' })
+    );
+  });
+
+  it.each([
+    'openEntityRiskInputs',
+    'openEntityAnomalyInsights',
+    'openEntityAlertsInsights',
+    'openEntityMisconfigurationInsights',
+    'openEntityVulnerabilityInsights',
+    'openEntityGraphView',
+    'openEntityResolution',
+    'openEntityEntraInsights',
+    'openEntityOktaInsights',
+    'openEntityFieldsTable',
+  ] as const)('%s opens a tools flyout as a new session', (method) => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    // The tool params differ per method; the hook only spreads them onto the (unrendered, mocked)
+    // component, so a permissive object is fine for asserting the flyout properties.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result.current[method] as (params: any) => void)({
+      entityType: 'host',
+      value: 'x',
+      entityName: 'x',
+      hostName: 'x',
+      entityId: 'entity-1',
+      scopeId: '',
+      document: {},
+      managedUser: {},
+    });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+  });
+
+  it('uses the doc-viewer history key when outside the security app', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openHostFlyout({ hostName: 'host-1' });
+
+    expect(mockOpenSystemFlyout.mock.calls[0][1].historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -1,0 +1,379 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import { useKibana } from '../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { flyoutProviders } from '../shared/components/flyout_provider';
+import { FlyoutLoading } from '../shared/components/flyout_loading';
+import {
+  defaultToolsFlyoutProperties,
+  useDefaultDocumentFlyoutProperties,
+} from '../shared/hooks/use_default_flyout_properties';
+import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import type { HostProps } from './host/main';
+import type { UserProps } from './user/main';
+import type { ServiceProps } from './service/main';
+import type { GenericEntityProps } from './generic/main';
+import type { VulnerabilityInsightsProps } from './host/tools/vulnerability_insights';
+import type { EntraInsightsProps } from './user/tools/entra_insights';
+import type { OktaInsightsProps } from './user/tools/okta_insights';
+import type { AlertsInsightsProps } from './shared/tools/alerts_insights';
+import type { RiskInputsProps } from './shared/tools/risk_inputs';
+import type { MisconfigurationInsightsProps } from './shared/tools/misconfiguration_insights';
+import type { AnomalyInsightsProps } from './shared/tools/anomaly_insights';
+import type { FieldsTableToolProps } from './shared/tools/fields_table';
+import type { ResolutionProps } from './shared/tools/resolution';
+import type { GraphViewProps } from './shared/tools/graph_view';
+
+// Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
+// bundle; each chunk only loads when the corresponding flyout is actually opened.
+const Host = lazy(() => import('./host/main').then((m) => ({ default: m.Host })));
+const User = lazy(() => import('./user/main').then((m) => ({ default: m.User })));
+const Service = lazy(() => import('./service/main').then((m) => ({ default: m.Service })));
+const GenericEntity = lazy(() =>
+  import('./generic/main').then((m) => ({ default: m.GenericEntity }))
+);
+const VulnerabilityInsights = lazy(() =>
+  import('./host/tools/vulnerability_insights').then((m) => ({ default: m.VulnerabilityInsights }))
+);
+const EntraInsights = lazy(() =>
+  import('./user/tools/entra_insights').then((m) => ({ default: m.EntraInsights }))
+);
+const OktaInsights = lazy(() =>
+  import('./user/tools/okta_insights').then((m) => ({ default: m.OktaInsights }))
+);
+const AlertsInsights = lazy(() =>
+  import('./shared/tools/alerts_insights').then((m) => ({ default: m.AlertsInsights }))
+);
+const RiskInputs = lazy(() =>
+  import('./shared/tools/risk_inputs').then((m) => ({ default: m.RiskInputs }))
+);
+const MisconfigurationInsights = lazy(() =>
+  import('./shared/tools/misconfiguration_insights').then((m) => ({
+    default: m.MisconfigurationInsights,
+  }))
+);
+const AnomalyInsights = lazy(() =>
+  import('./shared/tools/anomaly_insights').then((m) => ({ default: m.AnomalyInsights }))
+);
+const FieldsTableTool = lazy(() =>
+  import('./shared/tools/fields_table').then((m) => ({ default: m.FieldsTableTool }))
+);
+const Resolution = lazy(() =>
+  import('./shared/tools/resolution').then((m) => ({ default: m.Resolution }))
+);
+const GraphView = lazy(() =>
+  import('./shared/tools/graph_view').then((m) => ({ default: m.GraphView }))
+);
+
+/** An optional flyout header title (typically the entity name), shown for entity flyouts. */
+interface WithTitle {
+  title?: string;
+}
+
+// Main entity flyouts — each reuses the component's own props, plus an optional title.
+export type OpenHostFlyoutParams = HostProps & WithTitle;
+export type OpenUserFlyoutParams = UserProps & WithTitle;
+export type OpenServiceFlyoutParams = ServiceProps & WithTitle;
+export type OpenGenericEntityFlyoutParams = GenericEntityProps & WithTitle;
+
+export interface OpenEntityDetailsParams extends WithTitle {
+  /** Entity Store engine type (`host` | `user` | `service` | other → generic). */
+  engineType: string | undefined;
+  /** Canonical Entity Store v2 id (`entity.id`). */
+  entityId: string;
+  /** Display name of the entity. */
+  entityName: string | undefined;
+  /** Scope id for downstream containers and queries. */
+  scopeId: string;
+}
+
+// Entity tool flyouts — each reuses the tool component's own props, plus an optional title.
+export type OpenEntityRiskInputsParams = RiskInputsProps & WithTitle;
+export type OpenEntityAnomalyInsightsParams = AnomalyInsightsProps & WithTitle;
+export type OpenEntityAlertsInsightsParams = AlertsInsightsProps & WithTitle;
+export type OpenEntityMisconfigurationInsightsParams = MisconfigurationInsightsProps & WithTitle;
+export type OpenEntityVulnerabilityInsightsParams = VulnerabilityInsightsProps & WithTitle;
+export type OpenEntityGraphViewParams = GraphViewProps & WithTitle;
+export type OpenEntityResolutionParams = ResolutionProps & WithTitle;
+export type OpenEntityEntraInsightsParams = EntraInsightsProps & WithTitle;
+export type OpenEntityOktaInsightsParams = OktaInsightsProps & WithTitle;
+export type OpenEntityFieldsTableParams = FieldsTableToolProps & WithTitle;
+
+export interface EntityFlyoutApi {
+  /** Opens the host entity details flyout as a new, top-level flyout (fresh session). */
+  openHostFlyout: (params: OpenHostFlyoutParams) => void;
+  /** Opens the host entity details flyout as a child of the currently open flyout. */
+  openHostFlyoutAsChild: (params: OpenHostFlyoutParams) => void;
+  /** Opens the user entity details flyout as a new, top-level flyout (fresh session). */
+  openUserFlyout: (params: OpenUserFlyoutParams) => void;
+  /** Opens the user entity details flyout as a child of the currently open flyout. */
+  openUserFlyoutAsChild: (params: OpenUserFlyoutParams) => void;
+  /** Opens the service entity details flyout as a new, top-level flyout (fresh session). */
+  openServiceFlyout: (params: OpenServiceFlyoutParams) => void;
+  /** Opens the service entity details flyout as a child of the currently open flyout. */
+  openServiceFlyoutAsChild: (params: OpenServiceFlyoutParams) => void;
+  /** Opens the generic entity details flyout as a new, top-level flyout (fresh session). */
+  openGenericEntityFlyout: (params: OpenGenericEntityFlyoutParams) => void;
+  /** Opens the generic entity details flyout as a child of the currently open flyout. */
+  openGenericEntityFlyoutAsChild: (params: OpenGenericEntityFlyoutParams) => void;
+  /**
+   * Opens the matching entity details flyout (host/user/service/generic, by `engineType`) as a
+   * child of the currently open flyout. Use for related-entity navigation (graph, resolution).
+   */
+  openEntityDetailsAsChild: (params: OpenEntityDetailsParams) => void;
+  /** Opens the entity Risk Inputs tool flyout. */
+  openEntityRiskInputs: (params: OpenEntityRiskInputsParams) => void;
+  /** Opens the entity Anomalies tool flyout. */
+  openEntityAnomalyInsights: (params: OpenEntityAnomalyInsightsParams) => void;
+  /** Opens the entity Alerts insights tool flyout. */
+  openEntityAlertsInsights: (params: OpenEntityAlertsInsightsParams) => void;
+  /** Opens the entity Misconfigurations insights tool flyout. */
+  openEntityMisconfigurationInsights: (params: OpenEntityMisconfigurationInsightsParams) => void;
+  /** Opens the host Vulnerabilities insights tool flyout. */
+  openEntityVulnerabilityInsights: (params: OpenEntityVulnerabilityInsightsParams) => void;
+  /** Opens the entity Graph view tool flyout. */
+  openEntityGraphView: (params: OpenEntityGraphViewParams) => void;
+  /** Opens the entity Resolution tool flyout. */
+  openEntityResolution: (params: OpenEntityResolutionParams) => void;
+  /** Opens the user Entra insights tool flyout. */
+  openEntityEntraInsights: (params: OpenEntityEntraInsightsParams) => void;
+  /** Opens the user Okta insights tool flyout. */
+  openEntityOktaInsights: (params: OpenEntityOktaInsightsParams) => void;
+  /** Opens the generic entity Fields table tool flyout. */
+  openEntityFieldsTable: (params: OpenEntityFieldsTableParams) => void;
+}
+
+/**
+ * Developer-facing API to open the new (EUI-based) entity flyouts (host / user / service / generic)
+ * and their tool flyouts, in the same mindset as `useExpandableFlyoutApi`, `useDocumentFlyoutApi`,
+ * etc. It encapsulates the provider wiring (`flyoutProviders` + `overlays.openSystemFlyout`) and the
+ * per-flyout properties so call sites don't repeat them.
+ *
+ * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
+ * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
+ * legacy flyout when it is off.
+ *
+ * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
+ */
+export const useEntityFlyoutApi = (): EntityFlyoutApi => {
+  const { services } = useKibana();
+  const { overlays } = services;
+  const store = useStore();
+  const history = useHistory();
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+  const open = useCallback(
+    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+        }),
+        properties
+      );
+    },
+    [overlays, services, store, history]
+  );
+
+  // The entity flyouts differ only in their base properties (document vs tools size) and session;
+  // both are kept private here so callers never reason about them — they pick the method they want.
+  const mainProperties = useCallback(
+    (
+      session: OverlaySystemFlyoutOpenOptions['session'],
+      title?: string
+    ): OverlaySystemFlyoutOpenOptions => ({
+      ...defaultDocumentFlyoutProperties,
+      historyKey,
+      session,
+      ...(title !== undefined ? { title } : {}),
+    }),
+    [defaultDocumentFlyoutProperties, historyKey]
+  );
+
+  const toolProperties = useCallback(
+    (title?: string): OverlaySystemFlyoutOpenOptions => ({
+      ...defaultToolsFlyoutProperties,
+      historyKey,
+      session: 'start',
+      ...(title !== undefined ? { title } : {}),
+    }),
+    [historyKey]
+  );
+
+  // Main entity flyouts.
+  const openHostFlyout = useCallback(
+    ({ title, ...props }: OpenHostFlyoutParams) =>
+      open(<Host {...props} />, mainProperties('start', title)),
+    [open, mainProperties]
+  );
+  const openHostFlyoutAsChild = useCallback(
+    ({ title, ...props }: OpenHostFlyoutParams) =>
+      open(<Host {...props} />, mainProperties('inherit', title)),
+    [open, mainProperties]
+  );
+  const openUserFlyout = useCallback(
+    ({ title, ...props }: OpenUserFlyoutParams) =>
+      open(<User {...props} />, mainProperties('start', title)),
+    [open, mainProperties]
+  );
+  const openUserFlyoutAsChild = useCallback(
+    ({ title, ...props }: OpenUserFlyoutParams) =>
+      open(<User {...props} />, mainProperties('inherit', title)),
+    [open, mainProperties]
+  );
+  const openServiceFlyout = useCallback(
+    ({ title, ...props }: OpenServiceFlyoutParams) =>
+      open(<Service {...props} />, mainProperties('start', title)),
+    [open, mainProperties]
+  );
+  const openServiceFlyoutAsChild = useCallback(
+    ({ title, ...props }: OpenServiceFlyoutParams) =>
+      open(<Service {...props} />, mainProperties('inherit', title)),
+    [open, mainProperties]
+  );
+  const openGenericEntityFlyout = useCallback(
+    ({ title, ...props }: OpenGenericEntityFlyoutParams) =>
+      open(<GenericEntity {...props} />, mainProperties('start', title)),
+    [open, mainProperties]
+  );
+  const openGenericEntityFlyoutAsChild = useCallback(
+    ({ title, ...props }: OpenGenericEntityFlyoutParams) =>
+      open(<GenericEntity {...props} />, mainProperties('inherit', title)),
+    [open, mainProperties]
+  );
+
+  const openEntityDetailsAsChild = useCallback(
+    ({ engineType, entityId, entityName, scopeId, title }: OpenEntityDetailsParams) => {
+      let children: ReactNode;
+      switch (engineType) {
+        case 'host':
+          children = <Host hostName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />;
+          break;
+        case 'user':
+          children = <User userName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />;
+          break;
+        case 'service':
+          children = (
+            <Service serviceName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />
+          );
+          break;
+        default:
+          children = <GenericEntity entityId={entityId} scopeId={scopeId} />;
+      }
+      open(children, mainProperties('inherit', title));
+    },
+    [open, mainProperties]
+  );
+
+  // Entity tool flyouts.
+  const openEntityRiskInputs = useCallback(
+    ({ title, ...props }: OpenEntityRiskInputsParams) =>
+      open(<RiskInputs {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityAnomalyInsights = useCallback(
+    ({ title, ...props }: OpenEntityAnomalyInsightsParams) =>
+      open(<AnomalyInsights {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityAlertsInsights = useCallback(
+    ({ title, ...props }: OpenEntityAlertsInsightsParams) =>
+      open(<AlertsInsights {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityMisconfigurationInsights = useCallback(
+    ({ title, ...props }: OpenEntityMisconfigurationInsightsParams) =>
+      open(<MisconfigurationInsights {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityVulnerabilityInsights = useCallback(
+    ({ title, ...props }: OpenEntityVulnerabilityInsightsParams) =>
+      open(<VulnerabilityInsights {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityGraphView = useCallback(
+    ({ title, ...props }: OpenEntityGraphViewParams) =>
+      open(<GraphView {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityResolution = useCallback(
+    ({ title, ...props }: OpenEntityResolutionParams) =>
+      open(<Resolution {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityEntraInsights = useCallback(
+    ({ title, ...props }: OpenEntityEntraInsightsParams) =>
+      open(<EntraInsights {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityOktaInsights = useCallback(
+    ({ title, ...props }: OpenEntityOktaInsightsParams) =>
+      open(<OktaInsights {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+  const openEntityFieldsTable = useCallback(
+    ({ title, ...props }: OpenEntityFieldsTableParams) =>
+      open(<FieldsTableTool {...props} />, toolProperties(title)),
+    [open, toolProperties]
+  );
+
+  return useMemo(
+    () => ({
+      openHostFlyout,
+      openHostFlyoutAsChild,
+      openUserFlyout,
+      openUserFlyoutAsChild,
+      openServiceFlyout,
+      openServiceFlyoutAsChild,
+      openGenericEntityFlyout,
+      openGenericEntityFlyoutAsChild,
+      openEntityDetailsAsChild,
+      openEntityRiskInputs,
+      openEntityAnomalyInsights,
+      openEntityAlertsInsights,
+      openEntityMisconfigurationInsights,
+      openEntityVulnerabilityInsights,
+      openEntityGraphView,
+      openEntityResolution,
+      openEntityEntraInsights,
+      openEntityOktaInsights,
+      openEntityFieldsTable,
+    }),
+    [
+      openHostFlyout,
+      openHostFlyoutAsChild,
+      openUserFlyout,
+      openUserFlyoutAsChild,
+      openServiceFlyout,
+      openServiceFlyoutAsChild,
+      openGenericEntityFlyout,
+      openGenericEntityFlyoutAsChild,
+      openEntityDetailsAsChild,
+      openEntityRiskInputs,
+      openEntityAnomalyInsights,
+      openEntityAlertsInsights,
+      openEntityMisconfigurationInsights,
+      openEntityVulnerabilityInsights,
+      openEntityGraphView,
+      openEntityResolution,
+      openEntityEntraInsights,
+      openEntityOktaInsights,
+      openEntityFieldsTable,
+    ]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
@@ -8,12 +8,9 @@
 import type { FC } from 'react';
 import React, { memo, useCallback, useMemo } from 'react';
 import { noop } from 'lodash/fp';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { EuiFlyoutHeader, EuiFlyoutBody, EuiSpacer, EuiFlyoutFooter } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { useUpdateAssetCriticality } from '../../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useAssetCriticalityPrivileges } from '../../../../entity_analytics/components/asset_criticality/use_asset_criticality';
 import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
@@ -26,27 +23,12 @@ import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { buildUserNamesFilter, type RiskSeverity } from '../../../../../common/search_strategy';
 import { ManagedUserDatasetKey } from '../../../../../common/search_strategy/security_solution/users/managed_details';
 import { useUiSetting, useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import type { EntityDetailsPath } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
 import {
   CspInsightLeftPanelSubTab,
   EntityDetailsLeftPanelTab,
 } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
-import { flyoutProviders } from '../../../shared/components/flyout_provider';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../../../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
-import { RiskInputs } from '../../shared/tools/risk_inputs';
-import { MisconfigurationInsights } from '../../shared/tools/misconfiguration_insights';
-import { AlertsInsights } from '../../shared/tools/alerts_insights';
-import { AnomalyInsights } from '../../shared/tools/anomaly_insights';
-import { OktaInsights } from '../tools/okta_insights';
-import { EntraInsights } from '../tools/entra_insights';
-import { GraphView } from '../../shared/tools/graph_view';
-import { Resolution } from '../../shared/tools/resolution';
-import { renderEntityDetails } from '../../shared/render_entity_details';
+import { useFlyoutApi } from '../../../use_flyout_api';
 import { Header } from './header';
 import { Content } from './content';
 import { Footer } from './footer';
@@ -110,7 +92,7 @@ const FIRST_RECORD_PAGINATION = {
 /**
  * Runs the same data hooks as the v1 `UserPanel`, but without the expandable-flyout
  * navigation or preview-mode handling. Detail panels (risk inputs, Okta, Entra, etc.)
- * open as separate system flyouts via `overlays.openSystemFlyout`.
+ * open as separate system flyouts via `useFlyoutApi`.
  */
 export const User: FC<UserProps> = memo(function User({
   userName,
@@ -120,10 +102,20 @@ export const User: FC<UserProps> = memo(function User({
   contextID,
 }) {
   const { services } = useKibana();
-  const { uiSettings, overlays } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { uiSettings } = services;
   const euidApi = useEntityStoreEuidApi();
+  const {
+    openUserFlyoutAsChild,
+    openEntityDetailsAsChild,
+    openEntityRiskInputs,
+    openEntityAnomalyInsights,
+    openEntityAlertsInsights,
+    openEntityMisconfigurationInsights,
+    openEntityGraphView,
+    openEntityResolution,
+    openEntityOktaInsights,
+    openEntityEntraInsights,
+  } = useFlyoutApi();
 
   const entityId = useMemo(
     () => (hit ? euidApi?.euid?.getEuidFromObject('user', hit.flattened) : entityIdProp),
@@ -131,9 +123,6 @@ export const User: FC<UserProps> = memo(function User({
   );
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
   const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2);
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
   const safeContextID = contextID ?? scopeId ?? 'user-panel';
   const { setQuery, deleteQuery, isInitializing } = useGlobalTime();
@@ -275,26 +264,8 @@ export const User: FC<UserProps> = memo(function User({
   ) : undefined;
 
   const onOpenUser = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <User userName={userName} entityId={entityId} scopeId={scopeId} />,
-      }),
-      { ...defaultDocumentFlyoutProperties, title: userName, historyKey, session: 'inherit' }
-    );
-  }, [
-    overlays,
-    services,
-    store,
-    history,
-    historyKey,
-    userName,
-    entityId,
-    scopeId,
-    defaultDocumentFlyoutProperties,
-  ]);
+    openUserFlyoutAsChild({ userName, entityId, scopeId, title: userName });
+  }, [openUserFlyoutAsChild, userName, entityId, scopeId]);
 
   const onShowRelatedEntity = useCallback(
     (params: {
@@ -302,133 +273,112 @@ export const User: FC<UserProps> = memo(function User({
       entityId: string;
       entityName: string | undefined;
     }) =>
-      overlays.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: renderEntityDetails({ ...params, scopeId }),
-        }),
-        {
-          ...defaultDocumentFlyoutProperties,
-          title: params.entityName ?? params.entityId,
-          historyKey,
-          session: 'inherit',
-        }
-      ),
-    [overlays, services, store, history, scopeId, historyKey, defaultDocumentFlyoutProperties]
+      openEntityDetailsAsChild({
+        engineType: params.engineType,
+        entityId: params.entityId,
+        entityName: params.entityName,
+        scopeId,
+        title: params.entityName ?? params.entityId,
+      }),
+    [openEntityDetailsAsChild, scopeId]
   );
 
   const openDetailsPanel = useCallback(
     (path: EntityDetailsPath) => {
-      const common = {
-        ...defaultToolsFlyoutProperties,
-        title: userName,
-        historyKey,
-        session: 'start' as const,
-      };
-      const wrap = (children: React.ReactNode) =>
-        overlays.openSystemFlyout(flyoutProviders({ services, store, history, children }), common);
-
       switch (path.tab) {
         case EntityDetailsLeftPanelTab.RISK_INPUTS:
-          return wrap(
-            <RiskInputs
-              entityType={EntityType.user}
-              entityName={userName}
-              entityId={entityStoreEntityId}
-              onShowEntity={onOpenUser}
-            />
-          );
+          return openEntityRiskInputs({
+            entityType: EntityType.user,
+            entityName: userName,
+            entityId: entityStoreEntityId,
+            onShowEntity: onOpenUser,
+            title: userName,
+          });
         case EntityDetailsLeftPanelTab.ANOMALIES:
-          return wrap(
-            <AnomalyInsights
-              entityType={EntityType.user}
-              value={userName}
-              entityId={entityStoreEntityId}
-              onOpenEntity={onOpenUser}
-            />
-          );
+          return openEntityAnomalyInsights({
+            entityType: EntityType.user,
+            value: userName,
+            entityId: entityStoreEntityId,
+            onOpenEntity: onOpenUser,
+            title: userName,
+          });
         case EntityDetailsLeftPanelTab.CSP_INSIGHTS:
           switch (path.subTab) {
             case CspInsightLeftPanelSubTab.ALERTS:
-              return wrap(
-                <AlertsInsights
-                  entityType={EntityType.user}
-                  value={userName}
-                  entityId={panelDisplayEntityId}
-                  onShowEntity={onOpenUser}
-                />
-              );
+              return openEntityAlertsInsights({
+                entityType: EntityType.user,
+                value: userName,
+                entityId: panelDisplayEntityId,
+                onShowEntity: onOpenUser,
+                title: userName,
+              });
             case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
-              return wrap(
-                <MisconfigurationInsights
-                  entityType={EntityType.user}
-                  value={userName}
-                  entityId={panelDisplayEntityId}
-                  onShowEntity={onOpenUser}
-                />
-              );
+              return openEntityMisconfigurationInsights({
+                entityType: EntityType.user,
+                value: userName,
+                entityId: panelDisplayEntityId,
+                onShowEntity: onOpenUser,
+                title: userName,
+              });
           }
           break;
         case EntityDetailsLeftPanelTab.GRAPH_VIEW:
           if (!entityStoreEntityId) return;
-          return wrap(
-            <GraphView
-              entityId={entityStoreEntityId}
-              scopeId={scopeId}
-              entityName={userName}
-              onShowEntity={onShowRelatedEntity}
-              onShowOriginatingEntity={onOpenUser}
-            />
-          );
+          return openEntityGraphView({
+            entityId: entityStoreEntityId,
+            scopeId,
+            entityName: userName,
+            onShowEntity: onShowRelatedEntity,
+            onShowOriginatingEntity: onOpenUser,
+            title: userName,
+          });
         case EntityDetailsLeftPanelTab.RESOLUTION_GROUP:
           if (!entityStoreEntityId) return;
-          return wrap(
-            <Resolution
-              entityId={entityStoreEntityId}
-              entityType="user"
-              entityName={userName}
-              scopeId={scopeId}
-              onShowEntity={onOpenUser}
-              onShowRelatedEntity={onShowRelatedEntity}
-            />
-          );
+          return openEntityResolution({
+            entityId: entityStoreEntityId,
+            entityType: 'user',
+            entityName: userName,
+            scopeId,
+            onShowEntity: onOpenUser,
+            onShowRelatedEntity,
+            title: userName,
+          });
         // TODO: currently dead (v1 accessed through left pane tabs, need to perhaps add preview?)
         case EntityDetailsLeftPanelTab.OKTA: {
           const oktaManagedUser = managedUser.data?.[ManagedUserDatasetKey.OKTA];
           if (oktaManagedUser) {
-            return wrap(
-              <OktaInsights
-                managedUser={oktaManagedUser}
-                value={userName}
-                onOpenUser={onOpenUser}
-              />
-            );
+            return openEntityOktaInsights({
+              managedUser: oktaManagedUser,
+              value: userName,
+              onOpenUser,
+              title: userName,
+            });
           }
           break;
         }
         case EntityDetailsLeftPanelTab.ENTRA: {
           const entraManagedUser = managedUser.data?.[ManagedUserDatasetKey.ENTRA];
           if (entraManagedUser) {
-            return wrap(
-              <EntraInsights
-                managedUser={entraManagedUser}
-                value={userName}
-                onOpenUser={onOpenUser}
-              />
-            );
+            return openEntityEntraInsights({
+              managedUser: entraManagedUser,
+              value: userName,
+              onOpenUser,
+              title: userName,
+            });
           }
           break;
         }
       }
     },
     [
-      overlays,
-      services,
-      store,
-      history,
-      historyKey,
+      openEntityRiskInputs,
+      openEntityAnomalyInsights,
+      openEntityAlertsInsights,
+      openEntityMisconfigurationInsights,
+      openEntityGraphView,
+      openEntityResolution,
+      openEntityOktaInsights,
+      openEntityEntraInsights,
       userName,
       scopeId,
       panelDisplayEntityId,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.mock.ts
@@ -11,6 +11,7 @@ import { createDocumentFlyoutApiMock } from './document/use_document_flyout_api.
 import { createIocFlyoutApiMock } from './ioc/use_ioc_flyout_api.mock';
 import { createNetworkFlyoutApiMock } from './network/use_network_flyout_api.mock';
 import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
+import { createEntityFlyoutApiMock } from './entity/use_entity_flyout_api.mock';
 
 /**
  * Returns a `useFlyoutApi` return value with every method stubbed as a `jest.fn()`.
@@ -21,6 +22,7 @@ import { createRuleFlyoutApiMock } from './rule/use_rule_flyout_api.mock';
 export const createFlyoutApiMock = (): jest.Mocked<FlyoutApi> => ({
   ...createDocumentFlyoutApiMock(),
   ...createAttackFlyoutApiMock(),
+  ...createEntityFlyoutApiMock(),
   ...createIocFlyoutApiMock(),
   ...createNetworkFlyoutApiMock(),
   ...createRuleFlyoutApiMock(),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.test.tsx
@@ -13,6 +13,8 @@ import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { createAttackFlyoutApiMock } from './attack/use_attack_flyout_api.mock';
 import { useDocumentFlyoutApi } from './document/use_document_flyout_api';
 import { createDocumentFlyoutApiMock } from './document/use_document_flyout_api.mock';
+import { useEntityFlyoutApi } from './entity/use_entity_flyout_api';
+import { createEntityFlyoutApiMock } from './entity/use_entity_flyout_api.mock';
 import { useIocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import { createIocFlyoutApiMock } from './ioc/use_ioc_flyout_api.mock';
 import { useNetworkFlyoutApi } from './network/use_network_flyout_api';
@@ -23,6 +25,7 @@ import { useFlyoutApi } from './use_flyout_api';
 
 jest.mock('./attack/use_attack_flyout_api');
 jest.mock('./document/use_document_flyout_api');
+jest.mock('./entity/use_entity_flyout_api');
 jest.mock('./ioc/use_ioc_flyout_api');
 jest.mock('./network/use_network_flyout_api');
 jest.mock('./rule/use_rule_flyout_api');
@@ -32,14 +35,16 @@ describe('useFlyoutApi', () => {
     jest.clearAllMocks();
   });
 
-  it('exposes document, attack, IOC, network, and rule methods from composed hooks', () => {
+  it('exposes document, attack, entity, IOC, network, and rule methods from composed per-type hooks', () => {
     const documentApi = createDocumentFlyoutApiMock();
     const attackApi = createAttackFlyoutApiMock();
+    const entityApi = createEntityFlyoutApiMock();
     const iocApi = createIocFlyoutApiMock();
     const networkApi = createNetworkFlyoutApiMock();
     const ruleApi = createRuleFlyoutApiMock();
     jest.mocked(useDocumentFlyoutApi).mockReturnValue(documentApi);
     jest.mocked(useAttackFlyoutApi).mockReturnValue(attackApi);
+    jest.mocked(useEntityFlyoutApi).mockReturnValue(entityApi);
     jest.mocked(useIocFlyoutApi).mockReturnValue(iocApi);
     jest.mocked(useNetworkFlyoutApi).mockReturnValue(networkApi);
     jest.mocked(useRuleFlyoutApi).mockReturnValue(ruleApi);
@@ -48,6 +53,8 @@ describe('useFlyoutApi', () => {
 
     const fromIndexParams = { documentId: '1', indexName: 'index' };
     const attackParams = { attackId: 'attack-1', indexName: '.alerts-security' };
+    const hostParams = { hostName: 'host-1' };
+    const userParams = { userName: 'user-1' };
     const iocParams = { indicator: { _id: 'ioc-1', fields: {} } as unknown as Indicator };
     const networkParams = { ip: '1.2.3.4', flowTarget: FlowTargetSourceDest.source };
     const ruleParams = { ruleId: 'rule-1' };
@@ -58,6 +65,16 @@ describe('useFlyoutApi', () => {
     result.current.openNotes({ hit });
     result.current.openAttackFlyout(attackParams);
     result.current.openAttackFlyoutAsChild(attackParams);
+    result.current.openHostFlyout(hostParams);
+    result.current.openHostFlyoutAsChild(hostParams);
+    result.current.openUserFlyout(userParams);
+    result.current.openUserFlyoutAsChild(userParams);
+    result.current.openEntityGraphView({
+      entityId: 'entity-1',
+      scopeId: '',
+      entityName: 'host-1',
+      onShowEntity: jest.fn(),
+    });
     result.current.openIocFlyout(iocParams);
     result.current.openIocFlyoutAsChild(iocParams);
     result.current.openNetworkFlyout(networkParams);
@@ -70,6 +87,11 @@ describe('useFlyoutApi', () => {
     expect(documentApi.openNotes).toHaveBeenCalledWith({ hit });
     expect(attackApi.openAttackFlyout).toHaveBeenCalledWith(attackParams);
     expect(attackApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(attackParams);
+    expect(entityApi.openHostFlyout).toHaveBeenCalledWith(hostParams);
+    expect(entityApi.openHostFlyoutAsChild).toHaveBeenCalledWith(hostParams);
+    expect(entityApi.openUserFlyout).toHaveBeenCalledWith(userParams);
+    expect(entityApi.openUserFlyoutAsChild).toHaveBeenCalledWith(userParams);
+    expect(entityApi.openEntityGraphView).toHaveBeenCalled();
     expect(iocApi.openIocFlyout).toHaveBeenCalledWith(iocParams);
     expect(iocApi.openIocFlyoutAsChild).toHaveBeenCalledWith(iocParams);
     expect(networkApi.openNetworkFlyout).toHaveBeenCalledWith(networkParams);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/use_flyout_api.tsx
@@ -10,6 +10,8 @@ import type { AttackFlyoutApi } from './attack/use_attack_flyout_api';
 import { useAttackFlyoutApi } from './attack/use_attack_flyout_api';
 import type { DocumentFlyoutApi } from './document/use_document_flyout_api';
 import { useDocumentFlyoutApi } from './document/use_document_flyout_api';
+import type { EntityFlyoutApi } from './entity/use_entity_flyout_api';
+import { useEntityFlyoutApi } from './entity/use_entity_flyout_api';
 import type { IocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import { useIocFlyoutApi } from './ioc/use_ioc_flyout_api';
 import type { NetworkFlyoutApi } from './network/use_network_flyout_api';
@@ -39,6 +41,7 @@ import { useRuleFlyoutApi } from './rule/use_rule_flyout_api';
  */
 export type FlyoutApi = DocumentFlyoutApi &
   AttackFlyoutApi &
+  EntityFlyoutApi &
   IocFlyoutApi &
   NetworkFlyoutApi &
   RuleFlyoutApi;
@@ -46,6 +49,7 @@ export type FlyoutApi = DocumentFlyoutApi &
 export const useFlyoutApi = (): FlyoutApi => {
   const documentApi = useDocumentFlyoutApi();
   const attack = useAttackFlyoutApi();
+  const entity = useEntityFlyoutApi();
   const ioc = useIocFlyoutApi();
   const network = useNetworkFlyoutApi();
   const rule = useRuleFlyoutApi();
@@ -54,10 +58,11 @@ export const useFlyoutApi = (): FlyoutApi => {
     () => ({
       ...documentApi,
       ...attack,
+      ...entity,
       ...ioc,
       ...network,
       ...rule,
     }),
-    [documentApi, attack, ioc, network, rule]
+    [documentApi, attack, entity, ioc, network, rule]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
@@ -16,9 +16,10 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createEntityFlyoutApiMock } from '../../../../../flyout_v2/entity/use_entity_flyout_api.mock';
 
 const mockOpenFlyout = jest.fn();
-const mockOpenSystemFlyout = jest.fn();
 
 jest.mock('@kbn/expandable-flyout');
 
@@ -30,43 +31,21 @@ jest.mock('../../../../../common/components/draggables', () => ({
   DefaultDraggable: () => <div data-test-subj="DefaultDraggable" />,
 }));
 
-jest.mock('../../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-jest.mock('../../../../../flyout_v2/shared/hooks/use_default_flyout_properties', () => ({
-  useDefaultDocumentFlyoutProperties: () => ({ size: 'm' }),
-}));
-
-jest.mock('../../../../../flyout_v2/entity/host/main', () => ({
-  Host: () => <div data-test-subj="mockHostPanel" />,
-}));
-
-// Keep the real kibana services (HostDetailsLink relies on them) but inject openSystemFlyout.
-jest.mock('../../../../../common/lib/kibana', () => {
-  const actual = jest.requireActual('../../../../../common/lib/kibana');
-  return {
-    ...actual,
-    useKibana: () => {
-      const kibana = actual.useKibana();
-      return {
-        ...kibana,
-        services: {
-          ...kibana.services,
-          overlays: { ...kibana.services.overlays, openSystemFlyout: mockOpenSystemFlyout },
-        },
-      };
-    },
-  };
-});
+jest.mock('../../../../../flyout_v2/use_flyout_api');
 
 describe('HostName', () => {
+  let flyoutApi: ReturnType<typeof createEntityFlyoutApiMock>;
+
   beforeEach(() => {
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
     jest.mocked(useExpandableFlyoutApi).mockReturnValue({
       ...createExpandableFlyoutApiMock(),
       openFlyout: mockOpenFlyout,
     });
+    flyoutApi = createEntityFlyoutApiMock();
+    jest
+      .mocked(useFlyoutApi)
+      .mockReturnValue(flyoutApi as unknown as ReturnType<typeof useFlyoutApi>);
   });
 
   afterEach(() => {
@@ -231,12 +210,12 @@ describe('HostName', () => {
 
     wrapper.find('[data-test-subj="host-details-button"]').last().simulate('click');
     await waitFor(() => {
-      expect(mockOpenSystemFlyout).toHaveBeenCalledTimes(1);
+      expect(flyoutApi.openHostFlyout).toHaveBeenCalledTimes(1);
     });
-    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ session: 'start' })
-    );
+    expect(flyoutApi.openHostFlyout).toHaveBeenCalledWith({
+      hostName: props.value,
+      entityId: undefined,
+    });
     expect(mockOpenFlyout).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.tsx
@@ -9,21 +9,14 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import type { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
 import { isString } from 'lodash/fp';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { HostPanelKey } from '../../../../../flyout/entity_details/shared/constants';
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
 import { HostDetailsLink } from '../../../../../common/components/links';
 import { getEmptyTagValue } from '../../../../../common/components/empty_value';
 import { TruncatableText } from '../../../../../common/components/truncatable_text';
 import { useIsInSecurityApp } from '../../../../../common/hooks/is_in_security_app';
-import { useKibana } from '../../../../../common/lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
-import { Host } from '../../../../../flyout_v2/entity/host/main';
-import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 
 interface Props {
   contextId: string;
@@ -45,16 +38,10 @@ const HostNameComponent: React.FC<Props> = ({
   entityId,
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { openHostFlyout } = useFlyoutApi();
   const newFlyoutSystemEnabled = useIsNewFlyoutEnabled();
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
   const isInSecurityApp = useIsInSecurityApp();
-
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
   const eventContext = useContext(StatefulEventContext);
   const hostName = `${value}`;
@@ -73,19 +60,7 @@ const HostNameComponent: React.FC<Props> = ({
       }
 
       if (newFlyoutSystemEnabled) {
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: <Host hostName={hostName} entityId={entityId} />,
-          }),
-          {
-            ...defaultDocumentFlyoutProperties,
-            historyKey,
-            session: 'start',
-          }
-        );
+        openHostFlyout({ hostName, entityId });
       } else {
         const { timelineID } = eventContext;
         openFlyout({
@@ -110,12 +85,7 @@ const HostNameComponent: React.FC<Props> = ({
       openFlyout,
       contextId,
       newFlyoutSystemEnabled,
-      overlays,
-      services,
-      store,
-      history,
-      historyKey,
-      defaultDocumentFlyoutProperties,
+      openHostFlyout,
     ]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.test.tsx
@@ -16,6 +16,8 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
+import { createEntityFlyoutApiMock } from '../../../../../flyout_v2/entity/use_entity_flyout_api.mock';
 
 const mockOpenFlyout = jest.fn();
 
@@ -28,35 +30,21 @@ jest.mock('../../../../../common/components/draggables', () => ({
   DefaultDraggable: () => <div data-test-subj="DefaultDraggable" />,
 }));
 
-const mockOpenSystemFlyout = jest.fn();
-jest.mock('../../../../../common/lib/kibana', () => {
-  const original = jest.requireActual('../../../../../common/lib/kibana');
-  return {
-    ...original,
-    useKibana: () => ({
-      ...original.useKibana(),
-      services: {
-        ...original.useKibana().services,
-        overlays: {
-          ...original.useKibana().services.overlays,
-          openSystemFlyout: mockOpenSystemFlyout,
-        },
-      },
-    }),
-  };
-});
-
-jest.mock('../../../../../flyout_v2/shared/components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => children,
-}));
+jest.mock('../../../../../flyout_v2/use_flyout_api');
 
 describe('UserName', () => {
+  let flyoutApi: ReturnType<typeof createEntityFlyoutApiMock>;
+
   beforeEach(() => {
     jest.mocked(useExpandableFlyoutApi).mockReturnValue({
       ...createExpandableFlyoutApiMock(),
       openFlyout: mockOpenFlyout,
     });
     jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    flyoutApi = createEntityFlyoutApiMock();
+    jest
+      .mocked(useFlyoutApi)
+      .mockReturnValue(flyoutApi as unknown as ReturnType<typeof useFlyoutApi>);
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -196,7 +184,7 @@ describe('UserName', () => {
 
     wrapper.find('[data-test-subj="users-link-anchor"]').last().simulate('click');
     await waitFor(() => {
-      expect(mockOpenSystemFlyout).toHaveBeenCalled();
+      expect(flyoutApi.openUserFlyout).toHaveBeenCalled();
       expect(mockOpenFlyout).not.toHaveBeenCalled();
     });
   });
@@ -211,7 +199,7 @@ describe('UserName', () => {
 
     wrapper.find('[data-test-subj="users-link-anchor"]').last().simulate('click');
     await waitFor(() => {
-      expect(mockOpenSystemFlyout).not.toHaveBeenCalled();
+      expect(flyoutApi.openUserFlyout).not.toHaveBeenCalled();
       expect(mockOpenFlyout).not.toHaveBeenCalled();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.tsx
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import React, { lazy, Suspense, useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import type { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
 import { isString } from 'lodash/fp';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 import { UserPanelKey } from '../../../../../flyout/entity_details/shared/constants';
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
@@ -19,19 +16,10 @@ import { getEmptyTagValue } from '../../../../../common/components/empty_value';
 import { UserDetailsLink } from '../../../../../common/components/links';
 import { TruncatableText } from '../../../../../common/components/truncatable_text';
 import { useIsInSecurityApp } from '../../../../../common/hooks/is_in_security_app';
-import { useKibana, useUiSetting } from '../../../../../common/lib/kibana';
+import { useUiSetting } from '../../../../../common/lib/kibana';
 import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_flyout_enabled';
 import { useEntityFromStore } from '../../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
-import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
-import { FlyoutLoading } from '../../../../../flyout_v2/shared/components/flyout_loading';
-import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../../../flyout_v2/shared/constants/flyout_history';
-
-// Lazy-loaded to keep the heavy v2 entity flyout out of the timeline row renderer's static import
-// graph, which would otherwise create a require cycle back through the row renderers barrel.
-const User = lazy(() =>
-  import('../../../../../flyout_v2/entity/user/main').then((module) => ({ default: module.User }))
-);
+import { useFlyoutApi } from '../../../../../flyout_v2/use_flyout_api';
 
 interface Props {
   contextId: string;
@@ -53,14 +41,9 @@ const UserNameComponent: React.FC<Props> = ({
   entityId,
 }) => {
   const { openFlyout } = useExpandableFlyoutApi();
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
+  const { openUserFlyout } = useFlyoutApi();
   const newFlyoutSystemEnabled = useIsNewFlyoutEnabled();
-  const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
   const eventContext = useContext(StatefulEventContext);
   const userName = `${value}`;
@@ -88,19 +71,7 @@ const UserNameComponent: React.FC<Props> = ({
       }
 
       if (newFlyoutSystemEnabled) {
-        overlays.openSystemFlyout(
-          flyoutProviders({
-            services,
-            store,
-            history,
-            children: (
-              <Suspense fallback={<FlyoutLoading />}>
-                <User userName={userName} entityId={resolvedEntityId} />
-              </Suspense>
-            ),
-          }),
-          { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
-        );
+        openUserFlyout({ userName, entityId: resolvedEntityId });
       } else {
         const { timelineID } = eventContext;
         openFlyout({
@@ -125,12 +96,7 @@ const UserNameComponent: React.FC<Props> = ({
       userName,
       resolvedEntityId,
       newFlyoutSystemEnabled,
-      overlays,
-      services,
-      store,
-      history,
-      historyKey,
-      defaultDocumentFlyoutProperties,
+      openUserFlyout,
     ]
   );
 


### PR DESCRIPTION
## Summary

We've been working on migrating the legacy expandable flyout to the new flyout system. During development, we had added a few entry points that would toggle between the 2 depending on a feature flag and more recently depending on an advanced setting.
There were many places where the legacy expandable flyout was still the only one that could be opened.

> [!NOTE]
> This PR is only focusing on the network flyout. A couple of follow up PRs will take care of the other flyouts.

The PR also introduces single developer-facing APIs to open the new ioc flyout, so call sites no longer hand-roll the `overlays.openSystemFlyout(flyoutProviders(...))` wiring:
- `useFlyoutApi()`: that is inernally calling the entity flyout specific api `useEntityFlyoutApi()`

> [!TIP]
> Developers should use - unless not possible - the `useFlyoutApi()` to open all of their flyouts

Every external entry point that opened one of these legacy flyouts now routes through the matching API when the new flyout is enabled.

> [!WARNING]
> No legacy flyout behavior change introduced! Only toggling between the legacy and new flyout based off the advanced setting.

#### Advanced setting off (default)

https://github.com/user-attachments/assets/26d6872c-06dc-460a-9928-3eded7ea4190

#### Advanced setting on

https://github.com/user-attachments/assets/ec178d85-ab53-4625-b3d5-0e4aa453f3f7

### How to test

1. Turn on the new flyout: set the `securitySolution:enableNewFlyout` advanced setting to on (dev: enable the `newFlyoutSystemEnabled` feature flag first so the setting is registered).
2. With it **on**, confirm the new flyout/tool opens from each surface.
3. With the setting **off**, repeat a couple of the above and confirm the **legacy** flyout opens instead (no behavior change).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->