### PR TITLE
[AgentBuilder] Scope graph-creation skill to inline topology visualization

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/graph_creation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/graph_creation_skill.ts
@@ -14,17 +14,19 @@ export const graphCreationSkill = defineSkillType({
   name: 'graph-creation',
   basePath: 'skills/platform/visualization',
   description:
-    'Create graph attachments by transforming raw data into valid React Flow nodes and edges.',
+    'Visualize topology, node/entity relationships, or dependency graphs inline in the conversation by rendering data as React Flow nodes and edges. Not for charts, metrics, or dashboard panels.',
   content: `## When to Use This Skill
 
-Use this skill when:
-- A user asks for relationship/dependency/topology/entity-link visualization.
-- You need to represent raw records as nodes and edges and render them in-chat.
-- You need a reusable graph attachment id for follow-up updates or comparisons.
+Use this skill **only** when the user specifically asks to visualize topology, nodes, or entity relationships **inline in the conversation**, for example:
+- "Show a node graph / topology of ..." rendered in-chat.
+- Represent raw records as connected nodes and edges (services, hosts, users, processes, dependencies) as an in-chat graph attachment.
+- Reuse or update a graph attachment id created earlier in this conversation.
 
 Do **not** use this skill when:
-- A chart/table/metric is more appropriate than a graph.
+- The user wants a chart, metric, trend, breakdown, or distribution — use the **visualization-creation** skill, even if the data is relational.
+- The conversation is about a **dashboard or dashboard panels** (creating a dashboard, adding a panel, laying out, or editing panels) — use the **dashboard-management** skill. Be especially cautious here: a request to add a diagram/graph/"workflow" chart *to a dashboard* is a dashboard/panel task, not an inline graph attachment.
 - There is no meaningful relationship data to connect entities.
+- A chart/table/metric is a more appropriate representation than a node graph.
 
 ## Available Tool
 


### PR DESCRIPTION
The `graph-creation` Agent Builder skill (React Flow node/edge graph attachments rendered in-chat) had a generic `description` and broad "When to Use" triggers, so skill selection over-picked it whenever a user wanted a chart or a dashboard panel. It shares `basePath: skills/platform/visualization` with `visualization-creation` and sits next to `dashboard-management`, which made the clash more likely, especially for requests phrased around dashboard panels or "workflow" charts.

This narrows the skill so it only activates for inline topology/node/relationship visualizations and explicitly hands off the neighbouring cases, using the same named cross-reference convention the sibling skills already rely on to disambiguate.

- Rewrites the `description` to emphasize inline/in-chat topology and node/relationship graphs and to state it is not for charts, metrics, or dashboard panels.
- Restricts the "Use this skill" triggers to explicit inline topology/node requests.
- Adds "Do not use" guidance that routes chart/metric/trend requests to the `visualization-creation` skill and dashboard/panel requests to the `dashboard-management` skill, with an explicit caution that adding a diagram/graph to a dashboard is a panel task rather than an inline graph attachment.

This is a prompt-text-only change; the skill's schema, workflow steps, and examples are untouched. I intentionally left the skill-selection benchmark dataset alone in this PR.
