### PR TITLE
[Dashboards in Chat] Align tag cloud and data table chart type values

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
@@ -40,8 +40,8 @@ export interface ToolResultMixin<TType extends string = string, TData extends Ob
   data: TType extends ToolResultType.other
     ? TData
     : TType extends ToolResultType
-      ? ToolResultDataOf<TType>
-      : TData;
+    ? ToolResultDataOf<TType>
+    : TData;
 }
 
 type UnknownToolType<T extends string> = T extends ToolResultType ? never : T;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
@@ -40,8 +40,8 @@ export interface ToolResultMixin<TType extends string = string, TData extends Ob
   data: TType extends ToolResultType.other
     ? TData
     : TType extends ToolResultType
-    ? ToolResultDataOf<TType>
-    : TData;
+      ? ToolResultDataOf<TType>
+      : TData;
 }
 
 type UnknownToolType<T extends string> = T extends ToolResultType ? never : T;
@@ -113,11 +113,11 @@ export type QueryResult = ToolResultMixin<ToolResultType.query>;
 export enum SupportedChartType {
   Metric = 'metric',
   Gauge = 'gauge',
-  Tagcloud = 'tagcloud',
+  Tagcloud = 'tag_cloud',
   XY = 'xy',
   RegionMap = 'region_map',
   Heatmap = 'heatmap',
-  Datatable = 'datatable',
+  Datatable = 'data_table',
   Pie = 'pie',
   Treemap = 'treemap',
   Waffle = 'waffle',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/lens/chart_type_registry.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/lens/chart_type_registry.ts
@@ -155,7 +155,7 @@ export const chartTypeRegistry: Record<SupportedChartType, ChartTypeRegistryEntr
         description:
           'For displaying word frequency or categorical data where text size represents value. Best for showing top terms, keywords, categories, or text-based aggregations (e.g., "show top error messages", "display most common tags").',
         guideline:
-          "Choose 'tagcloud' when visualizing text/categorical data where frequency or count determines size",
+          "Choose 'tag_cloud' when visualizing text/categorical data where frequency or count determines size",
       },
     },
   },
@@ -177,7 +177,7 @@ export const chartTypeRegistry: Record<SupportedChartType, ChartTypeRegistryEntr
         description:
           'For displaying data in a structured table format with sortable columns. Best for showing detailed records, precise numeric comparisons, or multi-dimensional breakdowns where exact values matter more than visual patterns (e.g., "list top 20 hosts by CPU usage", "show error counts by service and status code").',
         guideline:
-          "Choose 'datatable' when the user needs precise values, sortable columns, or a spreadsheet-like view of the data",
+          "Choose 'data_table' when the user needs precise values, sortable columns, or a spreadsheet-like view of the data",
       },
       config: {
         options: {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations/shared/get_visualization_dimensions.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations/shared/get_visualization_dimensions.ts
@@ -77,7 +77,6 @@ export const getVisualizationDimensionsFromLensConfig = (
       return METRIC_DIMENSIONS;
 
     case SupportedChartType.Datatable:
-    case 'data_table':
       return DATATABLE_DIMENSIONS;
 
     case SupportedChartType.Gauge: {

--- a/x-pack/platform/plugins/shared/agent_builder_visualizations/server/lens_reference.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_visualizations/server/lens_reference.test.ts
@@ -67,14 +67,14 @@ describe('lens_reference helpers', () => {
   });
 
   describe('toSupportedChartType', () => {
-    it.each(['xy', 'metric', 'pie', 'heatmap', 'datatable', 'region_map'])(
+    it.each(['xy', 'metric', 'pie', 'heatmap', 'data_table', 'tag_cloud', 'region_map'])(
       'returns %s unchanged for a supported chart type',
       (type) => {
         expect(toSupportedChartType(type)).toBe(type);
       }
     );
 
-    it.each(['lnsXY', 'lnsPie', 'bar', 'line', 'area', 'unknown', ''])(
+    it.each(['lnsXY', 'lnsPie', 'bar', 'line', 'area', 'datatable', 'tagcloud', 'unknown', ''])(
       'returns undefined for the unsupported value %p',
       (type) => {
         expect(toSupportedChartType(type)).toBeUndefined();


### PR DESCRIPTION
## Summary

Fixes the `SupportedChartType.Tagcloud` and `SupportedChartType.Datatable` enum values (`tag_cloud`, `data_table`) so they match the chart type identifiers already expected elsewhere in the visualization code, instead of the mismatched `tagcloud`/`datatable` strings.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->