### PR TITLE
[SigEvents][Discovery]: change point detection regression

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/rules/schedule.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/rules/schedule.test.ts
@@ -48,10 +48,10 @@ describe('Significant Events rule scheduling', () => {
       interval_minutes: 5,
       recent_activity_minutes: 10,
       bucket_interval: '5m',
-      lookback: 'now-110m',
-      lookback_minutes: 110,
-      quick_recovery_lookback: 'now-110m',
-      quick_recovery_lookback_minutes: 110,
+      lookback: 'now-125m',
+      lookback_minutes: 125,
+      quick_recovery_lookback: 'now-125m',
+      quick_recovery_lookback_minutes: 125,
       quiet_stationary_peak_min_alert_count: 6,
     });
   });

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/rules/schedule.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/rules/schedule.ts
@@ -17,7 +17,10 @@ export const RULE_LOOKBACK_OVERLAP_RATIO = 2;
 const CRITICAL_CHANGE_POINT_BUCKET_INTERVAL = '30s';
 const DEFAULT_CHANGE_POINT_LOOKBACK_MINUTES = 30;
 const DEFAULT_QUICK_RECOVERY_LOOKBACK_MINUTES = 11;
-const CHANGE_POINT_BUCKET_FLOOR = 22;
+// Histogram buckets to request per rule (`lookback = TARGET * interval` yields TARGET buckets).
+// ES `change_point` returns `indeterminable` below 22 buckets and consumes one fewer than the
+// histogram emits, so 25 keeps a safe margin above that floor at every cadence.
+const CHANGE_POINT_BUCKET_TARGET = 25;
 const RECENT_ACTIVITY_MINUTES_FLOOR = 5;
 const QUIET_STATIONARY_PEAK_ALERT_COUNT = 30;
 
@@ -72,10 +75,10 @@ export function getRuleDetectionSchedule(
   const isCriticalCadence = interval === CRITICAL_RULE_INTERVAL;
   const lookbackMinutes = isCriticalCadence
     ? DEFAULT_CHANGE_POINT_LOOKBACK_MINUTES
-    : Math.max(DEFAULT_CHANGE_POINT_LOOKBACK_MINUTES, CHANGE_POINT_BUCKET_FLOOR * intervalMinutes);
+    : Math.max(DEFAULT_CHANGE_POINT_LOOKBACK_MINUTES, CHANGE_POINT_BUCKET_TARGET * intervalMinutes);
   const quickRecoveryLookbackMinutes = isCriticalCadence
     ? DEFAULT_QUICK_RECOVERY_LOOKBACK_MINUTES
-    : CHANGE_POINT_BUCKET_FLOOR * intervalMinutes;
+    : CHANGE_POINT_BUCKET_TARGET * intervalMinutes;
 
   return {
     interval_minutes: intervalMinutes,


### PR DESCRIPTION
## Summary

Fixes a regression in the Significant Events change point detection rule where lookback windows were sized too tightly against Elasticsearch's `change_point` aggregation floor. ES returns `indeterminable` below 22 histogram buckets and effectively consumes one fewer bucket than the histogram emits, so the previous floor of exactly 22 buckets left no safety margin and could cause detections to silently degrade. The bucket target is raised to 25 to keep a safe margin above that floor at every rule cadence.


### How to test

Run the OLD query against the nightshift env to see some `indeterminable` change points

```sql
GET .rule-events/_search?filter_path=-aggregations.by_rule.buckets.over_time
{
  "size": 0,
  "query": {
    "bool": {
      "filter": [
        {
          "term": {
            "type": "signal"
          }
        },
        {
          "term": {
            "space_id": "default"
          }
        },
        {
          "range": {
            "@timestamp": {
              "gte": "now-30m"
            }
          }
        }
      ]
    }
  },
  "aggs": {
    "by_rule": {
      "terms": {
        "field": "rule.id",
        "size": 1000
      },
      "aggs": {
        "signal_count": {
          "cardinality": {
            "field": "group_hash"
          }
        },
        "over_time": {
          "date_histogram": {
            "field": "@timestamp",
            "fixed_interval": "5m",
            "min_doc_count": 0,
            "extended_bounds": {
              "min": "now-110m",
              "max": "now-5m"
            }
          }
        },
        "last_5m": {
          "filter": {
            "range": {
              "@timestamp": {
                "gte": "now-10m"
              }
            }
          },
          "aggs": {
            "signal_count": {
              "cardinality": {
                "field": "group_hash"
              }
            }
          }
        },
        "change_points": {
          "change_point": {
            "buckets_path": "over_time>_count"
          }
        },
        "last_floor_window": {
          "filter": {
            "range": {
              "@timestamp": {
                "gte": "now-20m"
              }
            }
          },
          "aggs": {
            "signal_count": {
              "cardinality": {
                "field": "group_hash"
              }
            }
          }
        }
      }
    }
  }
}
```

Compare with the fixed query

```sql
GET .rule-events/_search?filter_path=-aggregations.by_rule.buckets.over_time
{
  "size": 0,
  "query": {
    "bool": {
      "filter": [
        {
          "term": {
            "type": "signal"
          }
        },
        {
          "term": {
            "space_id": "default"
          }
        },
        {
          "range": {
            "@timestamp": {
              "gte": "now-30m"
            }
          }
        }
      ]
    }
  },
  "aggs": {
    "by_rule": {
      "terms": {
        "field": "rule.id",
        "size": 1000
      },
      "aggs": {
        "signal_count": {
          "cardinality": {
            "field": "group_hash"
          }
        },
        "over_time": {
          "date_histogram": {
            "field": "@timestamp",
            "fixed_interval": "5m",
            "min_doc_count": 0,
            "extended_bounds": {
              "min": "now-125m",
              "max": "now-5m"
            }
          }
        },
        "last_5m": {
          "filter": {
            "range": {
              "@timestamp": {
                "gte": "now-10m"
              }
            }
          },
          "aggs": {
            "signal_count": {
              "cardinality": {
                "field": "group_hash"
              }
            }
          }
        },
        "change_points": {
          "change_point": {
            "buckets_path": "over_time>_count"
          }
        },
        "last_floor_window": {
          "filter": {
            "range": {
              "@timestamp": {
                "gte": "now-20m"
              }
            }
          },
          "aggs": {
            "signal_count": {
              "cardinality": {
                "field": "group_hash"
              }
            }
          }
        }
      }
    }
  }
}
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
