### PR TITLE
[SigEvents] Fix triage auto-investigation trigger missing required message input

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
@@ -231,6 +231,20 @@ steps:
       and steps.store_significant_events.output.significant_events != null }}
     foreach: '${{ steps.store_significant_events.output.significant_events }}'
     steps:
+      # Look up the full discovery finding for this promoted event so trigger_investigation
+      # below can build the `message` the investigation workflow requires. The judge's
+      # structured output only echoes discovery_slug/event_id/status/written; the finding's
+      # title/summary/root_cause/stream_names still live in collect_discoveries' output.
+      - name: resolve_promoted_finding
+        type: data.set
+        if: '${{ foreach.item.status == "promoted" and foreach.item.written }}'
+        with:
+          finding: >-
+            ${{ steps.collect_discoveries.output.findings
+              | where: 'discovery_slug', foreach.item.discovery_slug
+              | first
+              | default: {} }}
+
       # Fire-and-forget a root-cause investigation for each newly-promoted event.
       # Async so triage (30m) never blocks on the investigation (60m).
       # concurrency_key per slug ensures a re-promotion cancels the prior in-progress
@@ -242,10 +256,19 @@ steps:
         with:
           workflow-id: 'system-significant-events-investigation'
           inputs:
+            message: |
+              {{ steps.resolve_promoted_finding.output.finding.title }}
+
+              {{ steps.resolve_promoted_finding.output.finding.summary }}
+
+              Probable cause: {{ steps.resolve_promoted_finding.output.finding.root_cause }}
+            stream_names: '${{ steps.resolve_promoted_finding.output.finding.stream_names | default: [] }}'
             concurrency_key: '{{ foreach.item.discovery_slug }}'
             context:
+              source: 'significant_event'
               event_id: '{{ foreach.item.event_id }}'
               discovery_slug: '{{ foreach.item.discovery_slug }}'
+              status: '{{ foreach.item.status }}'
         on-failure:
           continue: true
 

--- a/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
@@ -18,9 +18,7 @@ import {
   SIGNIFICANT_EVENTS_SCHEDULED_REVIEW_WORKFLOW_ID,
 } from './definitions';
 import type { ManagedWorkflowDefinition, ManagedWorkflowTemplateValues } from './types';
-import { getInputsFromDefinition } from '../spec/lib/field_conversion';
 import { WorkflowSchemaBase } from '../spec/schema';
-import type { WorkflowYaml } from '../spec/schema';
 
 const ManagedWorkflowSchema = WorkflowSchemaBase.extend({
   triggers: z.array(z.object({ type: z.string().min(1) }).passthrough()).min(1),
@@ -119,103 +117,6 @@ function assertWorkflowYamlIsValid(workflowId: string, yamlContent: string): voi
   }
 }
 
-const WORKFLOW_EXECUTE_STEP_TYPES = new Set(['workflow.execute', 'workflow.executeAsync']);
-
-interface WorkflowExecuteStepNode {
-  name?: unknown;
-  type: string;
-  with?: {
-    'workflow-id'?: unknown;
-    inputs?: Record<string, unknown>;
-  };
-}
-
-function isWorkflowExecuteStepNode(node: unknown): node is WorkflowExecuteStepNode {
-  return (
-    typeof node === 'object' &&
-    node !== null &&
-    typeof (node as { type?: unknown }).type === 'string' &&
-    WORKFLOW_EXECUTE_STEP_TYPES.has((node as { type: string }).type)
-  );
-}
-
-/**
- * Recursively walks a parsed workflow's `steps` tree (including steps nested under
- * `foreach`/`if`/etc.) and collects every `workflow.execute` / `workflow.executeAsync` step,
- * regardless of nesting depth or the container step type that holds it.
- */
-function collectWorkflowExecuteSteps(
-  node: unknown,
-  results: WorkflowExecuteStepNode[] = []
-): WorkflowExecuteStepNode[] {
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      collectWorkflowExecuteSteps(item, results);
-    }
-    return results;
-  }
-
-  if (node && typeof node === 'object') {
-    if (isWorkflowExecuteStepNode(node)) {
-      results.push(node);
-    }
-    for (const value of Object.values(node)) {
-      collectWorkflowExecuteSteps(value, results);
-    }
-  }
-
-  return results;
-}
-
-/**
- * For every workflow.execute / workflow.executeAsync step that targets another managed
- * workflow (by id, resolvable at build time), asserts the step's `with.inputs` covers all of
- * the target workflow's required manual-trigger inputs. Steps targeting a workflow id that
- * isn't in the managed registry (e.g. a user-authored workflow) are skipped, since their
- * required inputs can't be resolved statically.
- *
- * Guards against drift like a caller only ever exercising a subset of the target's required
- * inputs, which manual/UI-triggered calls to the same workflow can mask.
- */
-function assertWorkflowExecuteStepsSupplyRequiredInputs(
-  sourceWorkflowId: string,
-  steps: WorkflowExecuteStepNode[]
-): void {
-  const resolvableStepTargetPairs = steps
-    .map((step) => {
-      const targetId = step.with?.['workflow-id'];
-      const targetEntry =
-        typeof targetId === 'string'
-          ? managedDefinitionsById.find(([defId]) => defId === targetId)
-          : undefined;
-
-      return targetEntry ? { step, targetId, targetDefinition: targetEntry[1] } : undefined;
-    })
-    .filter((pair): pair is NonNullable<typeof pair> => pair !== undefined);
-
-  for (const { step, targetId, targetDefinition } of resolvableStepTargetPairs) {
-    const targetYaml = renderWorkflowYaml(targetDefinition);
-    const targetParsed = parse(targetYaml) as WorkflowYaml;
-    const inputsSchema = getInputsFromDefinition(targetParsed);
-    const requiredInputNames = inputsSchema?.required ?? [];
-
-    const providedInputNames = Object.keys(step.with?.inputs ?? {});
-    const missingInputNames = requiredInputNames.filter(
-      (name) => !providedInputNames.includes(name)
-    );
-
-    if (missingInputNames.length > 0) {
-      throw new Error(
-        `Managed workflow '${sourceWorkflowId}' step '${String(
-          step.name
-        )}' calls '${targetId}' via workflow.execute(Async) but does not supply its required input(s): ${missingInputNames.join(
-          ', '
-        )}. The target workflow will reject this call at runtime with an InputValidationError.`
-      );
-    }
-  }
-}
-
 describe('managedWorkflowDefinitions', () => {
   it('contains unique workflow ids', () => {
     const ids = managedWorkflowDefinitions.map(({ id }) => id);
@@ -284,19 +185,6 @@ describe('managedWorkflowDefinitions', () => {
       expect(renderedYaml.trim()).not.toHaveLength(0);
       expect(renderedYaml).not.toContain('undefined');
       assertWorkflowYamlIsValid(id, renderedYaml);
-    }
-  );
-});
-
-describe('managed workflow cross-references', () => {
-  it.each(managedDefinitionsById)(
-    '%s workflow.execute/executeAsync steps supply every required input of their target managed workflow',
-    (id, definition) => {
-      const renderedYaml = renderWorkflowYaml(definition);
-      const parsedYaml = parse(renderedYaml) as { steps?: unknown };
-      const executeSteps = collectWorkflowExecuteSteps(parsedYaml.steps);
-
-      assertWorkflowExecuteStepsSupplyRequiredInputs(id, executeSteps);
     }
   );
 });

--- a/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
@@ -18,7 +18,9 @@ import {
   SIGNIFICANT_EVENTS_SCHEDULED_REVIEW_WORKFLOW_ID,
 } from './definitions';
 import type { ManagedWorkflowDefinition, ManagedWorkflowTemplateValues } from './types';
+import { getInputsFromDefinition } from '../spec/lib/field_conversion';
 import { WorkflowSchemaBase } from '../spec/schema';
+import type { WorkflowYaml } from '../spec/schema';
 
 const ManagedWorkflowSchema = WorkflowSchemaBase.extend({
   triggers: z.array(z.object({ type: z.string().min(1) }).passthrough()).min(1),
@@ -117,6 +119,103 @@ function assertWorkflowYamlIsValid(workflowId: string, yamlContent: string): voi
   }
 }
 
+const WORKFLOW_EXECUTE_STEP_TYPES = new Set(['workflow.execute', 'workflow.executeAsync']);
+
+interface WorkflowExecuteStepNode {
+  name?: unknown;
+  type: string;
+  with?: {
+    'workflow-id'?: unknown;
+    inputs?: Record<string, unknown>;
+  };
+}
+
+function isWorkflowExecuteStepNode(node: unknown): node is WorkflowExecuteStepNode {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    typeof (node as { type?: unknown }).type === 'string' &&
+    WORKFLOW_EXECUTE_STEP_TYPES.has((node as { type: string }).type)
+  );
+}
+
+/**
+ * Recursively walks a parsed workflow's `steps` tree (including steps nested under
+ * `foreach`/`if`/etc.) and collects every `workflow.execute` / `workflow.executeAsync` step,
+ * regardless of nesting depth or the container step type that holds it.
+ */
+function collectWorkflowExecuteSteps(
+  node: unknown,
+  results: WorkflowExecuteStepNode[] = []
+): WorkflowExecuteStepNode[] {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectWorkflowExecuteSteps(item, results);
+    }
+    return results;
+  }
+
+  if (node && typeof node === 'object') {
+    if (isWorkflowExecuteStepNode(node)) {
+      results.push(node);
+    }
+    for (const value of Object.values(node)) {
+      collectWorkflowExecuteSteps(value, results);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * For every workflow.execute / workflow.executeAsync step that targets another managed
+ * workflow (by id, resolvable at build time), asserts the step's `with.inputs` covers all of
+ * the target workflow's required manual-trigger inputs. Steps targeting a workflow id that
+ * isn't in the managed registry (e.g. a user-authored workflow) are skipped, since their
+ * required inputs can't be resolved statically.
+ *
+ * Guards against drift like a caller only ever exercising a subset of the target's required
+ * inputs, which manual/UI-triggered calls to the same workflow can mask.
+ */
+function assertWorkflowExecuteStepsSupplyRequiredInputs(
+  sourceWorkflowId: string,
+  steps: WorkflowExecuteStepNode[]
+): void {
+  const resolvableStepTargetPairs = steps
+    .map((step) => {
+      const targetId = step.with?.['workflow-id'];
+      const targetEntry =
+        typeof targetId === 'string'
+          ? managedDefinitionsById.find(([defId]) => defId === targetId)
+          : undefined;
+
+      return targetEntry ? { step, targetId, targetDefinition: targetEntry[1] } : undefined;
+    })
+    .filter((pair): pair is NonNullable<typeof pair> => pair !== undefined);
+
+  for (const { step, targetId, targetDefinition } of resolvableStepTargetPairs) {
+    const targetYaml = renderWorkflowYaml(targetDefinition);
+    const targetParsed = parse(targetYaml) as WorkflowYaml;
+    const inputsSchema = getInputsFromDefinition(targetParsed);
+    const requiredInputNames = inputsSchema?.required ?? [];
+
+    const providedInputNames = Object.keys(step.with?.inputs ?? {});
+    const missingInputNames = requiredInputNames.filter(
+      (name) => !providedInputNames.includes(name)
+    );
+
+    if (missingInputNames.length > 0) {
+      throw new Error(
+        `Managed workflow '${sourceWorkflowId}' step '${String(
+          step.name
+        )}' calls '${targetId}' via workflow.execute(Async) but does not supply its required input(s): ${missingInputNames.join(
+          ', '
+        )}. The target workflow will reject this call at runtime with an InputValidationError.`
+      );
+    }
+  }
+}
+
 describe('managedWorkflowDefinitions', () => {
   it('contains unique workflow ids', () => {
     const ids = managedWorkflowDefinitions.map(({ id }) => id);
@@ -185,6 +284,19 @@ describe('managedWorkflowDefinitions', () => {
       expect(renderedYaml.trim()).not.toHaveLength(0);
       expect(renderedYaml).not.toContain('undefined');
       assertWorkflowYamlIsValid(id, renderedYaml);
+    }
+  );
+});
+
+describe('managed workflow cross-references', () => {
+  it.each(managedDefinitionsById)(
+    '%s workflow.execute/executeAsync steps supply every required input of their target managed workflow',
+    (id, definition) => {
+      const renderedYaml = renderWorkflowYaml(definition);
+      const parsedYaml = parse(renderedYaml) as { steps?: unknown };
+      const executeSteps = collectWorkflowExecuteSteps(parsedYaml.steps);
+
+      assertWorkflowExecuteStepsSupplyRequiredInputs(id, executeSteps);
     }
   );
 });


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/276207/changes#diff-0a468a33c6870e3a15519f2ddf327eb5aa5a2ff89c9333632451f81bb9839377 removed the required `message` field from the investigation trigger step, which broke auto-investigation for newly discovered promoted sig events. This change fixes that.