### PR TITLE
[Index Management] Fix bug when assigning a policy to an index without aliases

### DIFF
--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.test.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+
+import type { Index, PolicyFromES } from '../../../common/types';
+import { loadPolicies } from '../../application/services/api';
+import { AddLifecyclePolicyConfirmModal } from './add_lifecycle_confirm_modal';
+
+jest.mock('../../application/services/api', () => ({
+  loadPolicies: jest.fn(),
+  addLifecyclePolicyToIndex: jest.fn(),
+}));
+
+jest.mock('../../application/services/api_errors', () => ({
+  showApiError: jest.fn(),
+}));
+
+jest.mock('../../application/services/notification', () => ({
+  toasts: { addSuccess: jest.fn() },
+}));
+
+const rolloverPolicy: PolicyFromES = {
+  name: 'rollover-policy',
+  version: 1,
+  modifiedDate: '2020-01-01T00:00:00.000Z',
+  policy: {
+    name: 'rollover-policy',
+    phases: {
+      hot: {
+        min_age: '0ms',
+        actions: { rollover: { max_age: '30d' } },
+      },
+    },
+  },
+};
+
+const getUrlForApp = (appId: string, options?: { path?: string }) =>
+  `${appId}/${options?.path ?? ''}`;
+
+const renderModal = (index: Index) =>
+  renderWithI18n(
+    <AddLifecyclePolicyConfirmModal
+      indexName={index.name}
+      index={index}
+      closeModal={jest.fn()}
+      reloadIndices={jest.fn()}
+      getUrlForApp={getUrlForApp}
+    />
+  );
+
+const selectRolloverPolicy = async () => {
+  // The policy select is the only combobox until a rollover policy is selected.
+  const policySelect = await screen.findByRole('combobox');
+  fireEvent.change(policySelect, { target: { value: rolloverPolicy.name } });
+};
+
+describe('AddLifecyclePolicyConfirmModal', () => {
+  beforeEach(() => {
+    (loadPolicies as jest.Mock).mockReset();
+    (loadPolicies as jest.Mock).mockResolvedValue([rolloverPolicy]);
+  });
+
+  it('does not crash and warns when aliases is undefined and a rollover policy is selected', async () => {
+    renderModal({ name: 'index-without-aliases' });
+
+    await selectRolloverPolicy();
+
+    expect(await screen.findByText('Index has no aliases')).toBeInTheDocument();
+  });
+
+  it('warns when aliases is the "none" sentinel and a rollover policy is selected', async () => {
+    renderModal({ name: 'index-without-aliases', aliases: 'none' });
+
+    await selectRolloverPolicy();
+
+    expect(await screen.findByText('Index has no aliases')).toBeInTheDocument();
+  });
+
+  it('renders the rollover alias selector when the index has aliases', async () => {
+    renderModal({ name: 'index-with-aliases', aliases: ['my-alias'] });
+
+    await selectRolloverPolicy();
+
+    expect(await screen.findByText('Index rollover alias')).toBeInTheDocument();
+    expect(screen.queryByText('Index has no aliases')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.tsx
@@ -112,7 +112,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
       return null;
     }
     const { aliases } = index;
-    if (aliases === 'none') {
+    if (!Array.isArray(aliases) || aliases.length === 0) {
       return (
         <Fragment>
           <EuiSpacer size="m" />
@@ -140,7 +140,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
         </Fragment>
       );
     }
-    const aliasOptions = (aliases as string[]).map((alias: string) => {
+    const aliasOptions = aliases.map((alias: string) => {
       return {
         text: alias,
         value: alias,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/277765

## Summary
Opening the "Add lifecycle policy" dialog for an index and selecting a policy configured for rollover crashed the whole Index Management page when the index had no aliases (for example a data stream backing index such as `.ds-.alert-actions-*`).

Root cause: introduced in #246276 ([index management] Faster index list loading), which changed the index list data contract. For indices without aliases the new `GET /api/index_management/indices_get` endpoint now omits the `aliases` field entirely (so `index.aliases` is `undefined`) and `Index.aliases` became optional. Previously the server always returned the sentinel string `'none'`. `AddLifecyclePolicyConfirmModal` still assumed the old contract: it only special-cased `aliases === 'none'` and otherwise called `aliases.map(...)`, which threw on `undefined` and crashed the page (caught by the Kibana error boundary).

The modal now treats a missing/empty `aliases` value the same as "no aliases" and shows the existing "Index has no aliases" callout instead of crashing.

- Guard changed from `aliases === 'none'` to `!Array.isArray(aliases) || aliases.length === 0`, which also covers the legacy `'none'` value and lets us drop an unsafe `as string[]` cast.
- No server/API changes; behavior for indices that do have aliases is unchanged.

### Test plan
- Manual:
  1. Go to Stack Management → Index Management → Indices.
  2. Select an index without aliases (e.g. a data stream backing index `.ds-...`), and assign a policy configured for rollover.
     - **Before**: the page crashes with a React error boundary ("The above error occurred in AddLifecyclePolicyConfirmModal").
     - **After**: no crash; the modal shows the "Index has no aliases" warning ("Policy … is configured for rollover, but index … does not have an alias, which is required for rollover.").
- Automated: added `add_lifecycle_confirm_modal.test.tsx` (no unit test existed for this component before) covering three cases: `aliases` undefined (regression for this issue), the legacy `aliases: 'none'` value, and an index with aliases showing the rollover alias selector. Run with `node scripts/jest x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.test.tsx` (3 passed).

### Evidence 

https://github.com/user-attachments/assets/637a1053-6a4b-452b-bcb3-d68903a94848



<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->