### PR TITLE
[9.3] Fix Bedrock Converse toolConfig handling (manual backport #245064)

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
@@ -40,6 +40,10 @@ export const bedrockClaudeAdapter: InferenceConnectorAdapter = {
     timeout,
   }) => {
     const noToolUsage = toolChoice === ToolChoiceType.none;
+    const hasToolUseMessages = messages.some(
+      (m) =>
+        m.role === MessageRole.Tool || (m.role === MessageRole.Assistant && m.toolCalls?.length)
+    );
 
     const converseMessages = messagesToBedrock(messages).map((message) => ({
       role: message.role,
@@ -48,14 +52,21 @@ export const bedrockClaudeAdapter: InferenceConnectorAdapter = {
     const systemMessage = noToolUsage
       ? [{ text: addNoToolUsageDirective(system) }]
       : [{ text: system }];
-    const bedRockTools = noToolUsage ? [] : toolsToConverseBedrock(tools, messages);
+    const bedRockTools =
+      noToolUsage && !hasToolUseMessages ? [] : toolsToConverseBedrock(tools, messages);
     const connector = executor.getConnector();
 
     const subActionParams = {
       system: systemMessage,
       messages: converseMessages,
       tools: bedRockTools?.length ? bedRockTools : undefined,
-      toolChoice: toolChoiceToConverse(toolChoice),
+      // Bedrock/Claude does not support a true "none" tool choice. If we include tool config
+      // (e.g. because the conversation contains tool use/result messages), we must still send a
+      // valid Bedrock toolChoice. The system directive prevents new tool usage in that case.
+      toolChoice:
+        noToolUsage && bedRockTools?.length
+          ? toolChoiceToConverse(ToolChoiceType.auto)
+          : toolChoiceToConverse(toolChoice),
       ...getTemperatureIfValid(temperature, { connector, modelName }),
       model: modelName,
       stopSequences: ['\n\nHuman:'],
@@ -100,7 +111,7 @@ export const bedrockClaudeAdapter: InferenceConnectorAdapter = {
 };
 
 const messagesToBedrock = (messages: Message[]): BedRockMessage[] => {
-  const converseMessages: BedRockMessage[] = messages.map((message): BedRockMessage => {
+  const converseMessages: BedRockMessage[] = messages.flatMap((message): BedRockMessage[] => {
     switch (message.role) {
       case MessageRole.User: {
         const rawContent: BedRockMessage['rawContent'] = [];
@@ -108,9 +119,13 @@ const messagesToBedrock = (messages: Message[]): BedRockMessage[] => {
           typeof message.content === 'string' ? [message.content] : message.content;
         for (const contentPart of contentArr) {
           if (typeof contentPart === 'string') {
-            rawContent.push({ text: contentPart });
+            if (contentPart.trim().length > 0) {
+              rawContent.push({ text: contentPart });
+            }
           } else if (contentPart.type === 'text') {
-            rawContent.push({ text: contentPart.text });
+            if (contentPart.text.trim().length > 0) {
+              rawContent.push({ text: contentPart.text });
+            }
           } else if (contentPart.source?.data && contentPart.source?.mimeType) {
             const format = contentPart.source.mimeType.split(
               '/'
@@ -125,14 +140,21 @@ const messagesToBedrock = (messages: Message[]): BedRockMessage[] => {
             });
           }
         }
-        return {
-          role: 'user',
-          rawContent,
-        };
+        // Bedrock requires at least one content block per message.
+        if (rawContent.length === 0) {
+          return [];
+        }
+
+        return [
+          {
+            role: 'user',
+            rawContent,
+          },
+        ];
       }
       case MessageRole.Assistant: {
         const rawContent: BedRockMessage['rawContent'] = [];
-        if (message.content) {
+        if (typeof message.content === 'string' && message.content.trim().length > 0) {
           rawContent.push({ text: message.content });
         }
         if (message.toolCalls) {
@@ -148,10 +170,17 @@ const messagesToBedrock = (messages: Message[]): BedRockMessage[] => {
             });
           }
         }
-        return {
-          role: 'assistant',
-          rawContent,
-        };
+        // Bedrock requires at least one content block per message.
+        if (rawContent.length === 0) {
+          return [];
+        }
+
+        return [
+          {
+            role: 'assistant',
+            rawContent,
+          },
+        ];
       }
       case MessageRole.Tool: {
         const contentArr: ToolResultContentBlock[] = [];
@@ -170,17 +199,19 @@ const messagesToBedrock = (messages: Message[]): BedRockMessage[] => {
           }
         }
 
-        return {
-          role: 'user',
-          rawContent: [
-            {
-              toolResult: {
-                toolUseId: message.toolCallId,
-                content: contentArr,
+        return [
+          {
+            role: 'user',
+            rawContent: [
+              {
+                toolResult: {
+                  toolUseId: message.toolCallId,
+                  content: contentArr,
+                },
               },
-            },
-          ],
-        };
+            ],
+          },
+        ];
       }
     }
   });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
@@ -61,14 +61,12 @@ const DEFAULT_PAYLOAD = {
 const DEFAULT_CONVERSE_REQUEST_PAYLOAD = {
   messages: DEFAULT_MESSAGES,
   inferenceConfig: { stopSequences: ['\n\nHuman:'] },
-  toolConfig: { toolChoice: {} },
   modelId: DEFAULT_MODEL,
 };
 
 const DEFAULT_CONVERSE_STREAM_REQUEST_PAYLOAD = {
   messages: DEFAULT_MESSAGES,
   inferenceConfig: { stopSequences: ['\n\nHuman:'] },
-  toolConfig: {},
   modelId: DEFAULT_MODEL,
 };
 
@@ -869,9 +867,6 @@ describe('BedrockConnector', () => {
                 },
               ],
               inferenceConfig: {},
-              toolConfig: {
-                toolChoice: {},
-              },
               system: [{ type: 'text', text: 'This is a system message' }],
               modelId: DEFAULT_MODEL,
             }),
@@ -934,9 +929,6 @@ describe('BedrockConnector', () => {
                 },
               ],
               inferenceConfig: {},
-              toolConfig: {
-                toolChoice: {},
-              },
               system: [{ type: 'text', text: 'This is a system message' }],
               modelId: DEFAULT_MODEL,
             }),
@@ -959,7 +951,6 @@ describe('BedrockConnector', () => {
             data: JSON.stringify({
               messages: [{ role: 'user', content: 'Hello world' }],
               inferenceConfig: { stopSequences: ['\n\nHuman:'] },
-              toolConfig: { toolChoice: {} },
               modelId: DEFAULT_MODEL,
             }),
             timeout,
@@ -1053,7 +1044,6 @@ describe('BedrockConnector', () => {
               inferenceConfig: {
                 stopSequences: ['\n\nHuman:'],
               },
-              toolConfig: {},
               modelId: DEFAULT_MODEL,
             }),
             timeout,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -540,6 +540,14 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     const currentModel = encodeURIComponent(decodeURIComponent(modelId));
     const path = `/model/${currentModel}/converse`;
 
+    const toolConfig =
+      tools !== undefined || toolChoice !== undefined
+        ? {
+            tools,
+            toolChoice: { auto: toolChoice },
+          }
+        : undefined;
+
     const request: ConverseRequest = {
       messages,
       inferenceConfig: {
@@ -547,10 +555,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
         stopSequences,
         maxTokens,
       },
-      toolConfig: {
-        tools,
-        toolChoice: { auto: toolChoice },
-      },
+      ...(toolConfig ? { toolConfig } : {}),
       system,
       modelId,
     };
@@ -590,6 +595,14 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     const currentModel = encodeURIComponent(decodeURIComponent(modelId));
     const path = `/model/${currentModel}/converse-stream`;
 
+    const toolConfig =
+      tools !== undefined || toolChoice !== undefined
+        ? {
+            tools,
+            toolChoice,
+          }
+        : undefined;
+
     const request: ConverseStreamRequest = {
       messages,
       inferenceConfig: {
@@ -597,10 +610,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
         stopSequences,
         maxTokens,
       },
-      toolConfig: {
-        tools,
-        toolChoice,
-      },
+      ...(toolConfig ? { toolConfig } : {}),
       system,
       modelId,
     };


### PR DESCRIPTION
## Summary

Manual backport to `9.3` of the AWS Bedrock **Converse** `toolConfig` fixes from #245064. Addresses elastic/sdh-kibana#6390, an already-fixed bug that shipped in 9.4/9.5/main but was never backported to 9.3.

Bedrock's Converse API surfaces the failure as a generic `400 – The provided request is not valid`. There are two related root causes, both fixed here:

1. **Empty `toolConfig: {}` rejected.** The Bedrock connector always sent `toolConfig`, even when `tools` and `toolChoice` were both `undefined`, producing `{}` on the wire, which Bedrock rejects.
2. **Missing `toolConfig` when tool blocks exist in history.** When `toolChoice: none` but the conversation contains `toolUse`/`toolResult` blocks, the inference adapter dropped tools and sent no `toolChoice`, so the connector omitted `toolConfig` entirely. Bedrock rejects that with *"The toolConfig field must be defined when using toolUse and toolResult content blocks"*. This is the deterministic failure hit by the Streams Significant Events / ES|QL generation flow.

This was done as a **manual backport** because both files have diverged from the source branch, so a clean cherry-pick conflicts:
- `stack_connectors` `bedrock.ts` still wraps `toolChoice: { auto: toolChoice }` on 9.3.
- The inference adapter on the source branch had an extra `stream` param not present on 9.3.

## Changes

- `stack_connectors/.../bedrock/bedrock.ts`: only include `toolConfig` when at least one of `tools`/`toolChoice` is defined (both `converse` and `converse-stream`).
- `inference/.../bedrock/bedrock_claude_adapter.ts`: keep Bedrock tools when the history contains tool use/result messages (`hasToolUseMessages`), send a valid `auto` `toolChoice` when tool config is included under `toolChoice: none` (the no-tool-usage system directive still suppresses new tool calls), and drop empty content blocks/messages (Bedrock requires at least one content block per message).
- Regression tests updated/added in both `bedrock.test.ts` files.

`prompts.ts` (`addNoToolUsageDirective`) already exists on 9.3, so no change was needed there.

## Test plan

- `node scripts/jest.js --config x-pack/platform/plugins/shared/stack_connectors/jest.config.js x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts` — 45/45 pass.
- `node scripts/jest.js --config x-pack/platform/plugins/shared/inference/jest.config.js x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.test.ts` — 15/15 pass.
- Type check passes for both `stack_connectors` and `inference` projects.

Relates to elastic/sdh-kibana#6390
Backport of #245064