### PR TITLE
[Synthetics] Fix Test Now screenshots for long journeys

### DIFF
--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -53077,7 +53077,6 @@
     "xpack.synthetics.testRun.description": "Testen Sie Ihren Monitor und verifizieren Sie die Ergebnisse, bevor Sie speichern",
     "xpack.synthetics.testRun.invalid": "Der Monitor muss gültig sein, um den Test auszuführen. Bitte korrigieren Sie die oben genannten Pflichtfelder.",
     "xpack.synthetics.testRun.pushError": "Dieser Test kann zurzeit nicht ausgeführt werden. Versuchen Sie es später erneut.",
-    "xpack.synthetics.testRun.pushing.description": "Den Monitor in den Wartungsmodus versetzen ...",
     "xpack.synthetics.testRun.runErrorLabel": "Ich kann den Test jetzt nicht ausführen",
     "xpack.synthetics.testRun.runErrorLocation.reason": "Der Test konnte am Standort {locationName} nicht ausgeführt werden. {reason}",
     "xpack.synthetics.testRun.testErrorLabel": "Fehler beim Ausführen des Tests",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -52897,7 +52897,6 @@
     "xpack.synthetics.testRun.description": "Tester votre moniteur et vérifier les résultats avant d'enregistrer",
     "xpack.synthetics.testRun.invalid": "Le moniteur doit être valide pour exécuter le test, veuillez vérifier les champs requis ci-dessus.",
     "xpack.synthetics.testRun.pushError": "Ce test ne peut pas être exécuté pour l'instant. Réessayez plus tard.",
-    "xpack.synthetics.testRun.pushing.description": "Envoi du moniteur vers le service...",
     "xpack.synthetics.testRun.runErrorLabel": "Impossible d’exécuter le test maintenant",
     "xpack.synthetics.testRun.runErrorLocation.reason": "Impossible d'exécuter le moniteur sur l'emplacement {locationName} {reason}",
     "xpack.synthetics.testRun.testErrorLabel": "Erreur lors de l'exécution du test",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -53268,7 +53268,6 @@
     "xpack.synthetics.testRun.description": "モニターをテストし、保存する前に結果を検証します",
     "xpack.synthetics.testRun.invalid": "テストを実行するには、モニターが有効である必要があります。上記の必須フィールドを修正してください。",
     "xpack.synthetics.testRun.pushError": "このテストは現在実行できません。しばらくたってから再試行してください。",
-    "xpack.synthetics.testRun.pushing.description": "モニターをサービスにプッシュしています...",
     "xpack.synthetics.testRun.runErrorLabel": "今すぐテストを実行できません",
     "xpack.synthetics.testRun.runErrorLocation.reason": "場所{locationName}でテストを実行できませんでした。{reason}",
     "xpack.synthetics.testRun.testErrorLabel": "テストの実行エラー",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -53260,7 +53260,6 @@
     "xpack.synthetics.testRun.description": "请在保存前测试您的监测并验证结果",
     "xpack.synthetics.testRun.invalid": "监测必须有效才能运行测试，请修复以上必填字段。",
     "xpack.synthetics.testRun.pushError": "当前无法执行此测试。请稍后重试。",
-    "xpack.synthetics.testRun.pushing.description": "正在推送监测到服务......",
     "xpack.synthetics.testRun.runErrorLabel": "现在无法运行该测试",
     "xpack.synthetics.testRun.runErrorLocation.reason": "无法在位置 {locationName} 运行测试。{reason}",
     "xpack.synthetics.testRun.testErrorLabel": "运行测试时出错",

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/refresh_button.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/refresh_button.tsx
@@ -23,13 +23,16 @@ export function RefreshButton() {
   );
 }
 
-export function RefreshContextItem() {
+export function RefreshContextItem({ closePopover }: { closePopover?: () => void }) {
   const { refreshApp } = useSyntheticsRefreshContext();
   return (
     <EuiContextMenuItem
       data-test-subj="syntheticsRefreshContextItem"
       icon="refresh"
-      onClick={() => refreshApp()}
+      onClick={() => {
+        refreshApp();
+        closePopover?.();
+      }}
     >
       {REFRESH_LABEL}
     </EuiContextMenuItem>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
@@ -46,6 +46,8 @@ interface Props {
   showExpand?: boolean;
   testNowMode?: boolean;
   showLastSuccessful?: boolean;
+  /** Whether the journey run has concluded. Only relevant in "Run Once" / "Test Now" mode. */
+  isJourneyCompleted?: boolean;
 }
 
 export function isStepEnd(step: JourneyStep) {
@@ -70,6 +72,7 @@ function mapStepIds(steps: JourneyStep[]) {
 }
 
 const MAX_STEPS_TO_SHOW = 5;
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
 
 export const BrowserStepsList = ({
   steps,
@@ -81,8 +84,10 @@ export const BrowserStepsList = ({
   compressed = true,
   showExpand = true,
   testNowMode = false,
+  isJourneyCompleted,
 }: Props) => {
   const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(MAX_STEPS_TO_SHOW);
 
   const allStepEnds: JourneyStep[] = steps.filter(isStepEnd);
   const failedStep = allStepEnds.find((step) => step.synthetics.step?.status === 'failed');
@@ -91,23 +96,25 @@ export const BrowserStepsList = ({
 
   const stepEnds = shouldPaginate
     ? allStepEnds.slice(
-        pageIndex * MAX_STEPS_TO_SHOW,
-        Math.min(pageIndex * MAX_STEPS_TO_SHOW + MAX_STEPS_TO_SHOW, allStepEnds.length)
+        pageIndex * pageSize,
+        Math.min(pageIndex * pageSize + pageSize, allStepEnds.length)
       )
     : allStepEnds;
 
   const pagination: Pagination | undefined = shouldPaginate
     ? {
         pageIndex,
-        pageSize: MAX_STEPS_TO_SHOW,
+        pageSize,
         totalItemCount: allStepEnds.length,
-        showPerPageOptions: false,
+        pageSizeOptions: PAGE_SIZE_OPTIONS,
+        showPerPageOptions: true,
       }
     : undefined;
 
   const onTableChange = ({ page }: Criteria<JourneyStep>) => {
     if (page) {
       setPageIndex(page.index);
+      setPageSize(page.size);
     }
   };
   /**
@@ -210,6 +217,7 @@ export const BrowserStepsList = ({
           retryFetchOnRevisit={true}
           size={screenshotImageSize}
           testNowMode={testNowMode}
+          isJourneyCompleted={isJourneyCompleted}
           timestamp={timestamp}
         />
       ),
@@ -222,6 +230,7 @@ export const BrowserStepsList = ({
             showLastSuccessful={showLastSuccessful}
             isExpanded={Boolean(expandedMap[step._id])}
             isTestNowMode={testNowMode}
+            isJourneyCompleted={isJourneyCompleted}
             euiTheme={euiTheme}
           />
         ),
@@ -375,6 +384,7 @@ const MobileRowDetails = ({
   stepsLoading,
   isExpanded,
   isTestNowMode,
+  isJourneyCompleted,
   euiTheme,
 }: {
   journeyStep: JourneyStep;
@@ -383,6 +393,7 @@ const MobileRowDetails = ({
   stepsLoading: boolean;
   isExpanded: boolean;
   isTestNowMode: boolean;
+  isJourneyCompleted?: boolean;
   euiTheme: EuiThemeComputed;
 }) => {
   return (
@@ -405,6 +416,8 @@ const MobileRowDetails = ({
           allStepsLoaded={!stepsLoading}
           retryFetchOnRevisit={true}
           size={THUMBNAIL_SCREENSHOT_SIZE_MOBILE}
+          testNowMode={isTestNowMode}
+          isJourneyCompleted={isJourneyCompleted}
           timestamp={journeyStep?.['@timestamp']}
         />
         <div>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/journey_screenshot_preview.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/journey_screenshot_preview.tsx
@@ -25,6 +25,7 @@ export interface StepImagePopoverProps {
   maxSteps: number | undefined;
   isStepFailed: boolean;
   isLoading: boolean;
+  isPending?: boolean;
   size: ScreenshotImageSize;
   unavailableMessage?: string;
   borderRadius?: string | number;
@@ -39,6 +40,7 @@ export const JourneyScreenshotPreview: React.FC<StepImagePopoverProps> = ({
   maxSteps,
   isStepFailed,
   isLoading,
+  isPending,
   size,
   unavailableMessage,
   borderRadius,
@@ -92,6 +94,7 @@ export const JourneyScreenshotPreview: React.FC<StepImagePopoverProps> = ({
       })}
       imgSrc={imgSrc}
       isLoading={isLoading}
+      isPending={isPending}
       size={screenshotSize}
       unavailableMessage={unavailableMessage}
       borderColor={isStepFailed ? euiTheme.colors.danger : undefined}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/use_retrieve_step_image.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/use_retrieve_step_image.ts
@@ -35,6 +35,7 @@ export const useRetrieveStepImage = ({
   imgPath,
   testNowMode,
   retryFetchOnRevisit,
+  isJourneyCompleted,
 }: {
   timestamp?: string;
   checkGroup: string | undefined;
@@ -51,6 +52,14 @@ export const useRetrieveStepImage = ({
    *
    */
   retryFetchOnRevisit: boolean;
+
+  /**
+   * In "Run Once" / "Test Now" mode the agent only indexes step screenshots once the
+   * whole journey has concluded. A single backoff cycle can therefore expire before the
+   * images exist for long journeys (see issue #215222). When this flips to `true` we run
+   * one more fetch so the screenshot populates instead of getting stuck on the placeholder.
+   */
+  isJourneyCompleted?: boolean;
 }) => {
   const [imgState, setImgState] = useState<ImageDataResult>({});
   const skippedStep = stepStatus === 'skipped';
@@ -60,7 +69,17 @@ export const useRetrieveStepImage = ({
 
   const shouldFetch = useMemo(() => {
     const shouldRetry = retryFetchOnRevisit || !(imgState[imgPath]?.attempts ?? 0 > 0);
-    return !skippedStep && hasIntersected && !isImageUrlAvailable && shouldRetry && checkGroup;
+    // In Run Once / Test Now mode screenshots are only indexed once the journey concludes, so
+    // fetching earlier just produces guaranteed-404 backoff storms. Wait for completion instead.
+    const waitingForJourney = Boolean(testNowMode) && isJourneyCompleted === false;
+    return (
+      !skippedStep &&
+      hasIntersected &&
+      !isImageUrlAvailable &&
+      shouldRetry &&
+      !waitingForJourney &&
+      checkGroup
+    );
   }, [
     checkGroup,
     hasIntersected,
@@ -69,6 +88,8 @@ export const useRetrieveStepImage = ({
     isImageUrlAvailable,
     retryFetchOnRevisit,
     skippedStep,
+    testNowMode,
+    isJourneyCompleted,
   ]);
 
   useEffect(() => {
@@ -100,7 +121,9 @@ export const useRetrieveStepImage = ({
       }
     }
     run();
-  }, [imgPath, shouldFetch, testNowMode]);
+    // `isJourneyCompleted` is included so we re-attempt once the journey finishes, since
+    // screenshots for long journeys are only indexed after the run concludes.
+  }, [imgPath, shouldFetch, testNowMode, isJourneyCompleted]);
 
   return imageResult;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/empty_thumbnail.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/empty_thumbnail.test.tsx
@@ -11,6 +11,7 @@ import {
   EmptyThumbnail,
   SCREENSHOT_LOADING_ARIA_LABEL,
   SCREENSHOT_NOT_AVAILABLE,
+  SCREENSHOT_PENDING_MESSAGE,
 } from './empty_thumbnail';
 import { THUMBNAIL_SCREENSHOT_SIZE } from './screenshot_size';
 
@@ -31,6 +32,22 @@ describe('EmptyThumbnail', () => {
 
     expect(queryByTestId('stepScreenshotPlaceholderLoading')).not.toBeInTheDocument();
     expect(getByLabelText(SCREENSHOT_NOT_AVAILABLE));
+  });
+
+  it('renders a pending state (not loading or error) while the journey is running', () => {
+    const { getByTestId, queryByTestId, getByLabelText } = render(
+      <EmptyThumbnail
+        isLoading={false}
+        isPending={true}
+        animateLoading={true}
+        size={THUMBNAIL_SCREENSHOT_SIZE}
+      />
+    );
+
+    expect(getByTestId('stepScreenshotPending')).toBeInTheDocument();
+    expect(queryByTestId('stepScreenshotPlaceholderLoading')).not.toBeInTheDocument();
+    expect(queryByTestId('stepScreenshotNotAvailable')).not.toBeInTheDocument();
+    expect(getByLabelText(SCREENSHOT_PENDING_MESSAGE));
   });
 
   it('renders the provided unavailable message instead of default', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/empty_thumbnail.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/empty_thumbnail.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { useEuiTheme, EuiIcon, EuiText, EuiSkeletonRectangle } from '@elastic/eui';
+import { useEuiTheme, EuiIcon, EuiIconTip, EuiText, EuiSkeletonRectangle } from '@elastic/eui';
 
 import type { ScreenshotImageSize } from './screenshot_size';
 import { getConfinedScreenshotSize, THUMBNAIL_SCREENSHOT_SIZE } from './screenshot_size';
@@ -24,12 +24,14 @@ export const thumbnailStyle = {
 
 export const EmptyThumbnail = ({
   isLoading = false,
+  isPending = false,
   animateLoading,
   size = THUMBNAIL_SCREENSHOT_SIZE,
   unavailableMessage,
   borderRadius,
 }: {
   isLoading: boolean;
+  isPending?: boolean;
   animateLoading: boolean;
   size: ScreenshotImageSize | [number, number];
   unavailableMessage?: string;
@@ -38,14 +40,19 @@ export const EmptyThumbnail = ({
   const { euiTheme } = useEuiTheme();
   const { width, height } = getConfinedScreenshotSize(size);
   const noDataMessage = unavailableMessage ?? SCREENSHOT_NOT_AVAILABLE;
+  const ariaLabel = isPending
+    ? SCREENSHOT_PENDING_MESSAGE
+    : isLoading
+    ? SCREENSHOT_LOADING_ARIA_LABEL
+    : noDataMessage;
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <div
       data-test-subj="stepScreenshotPlaceholder"
       role="img"
-      aria-label={isLoading ? SCREENSHOT_LOADING_ARIA_LABEL : noDataMessage}
-      title={isLoading ? SCREENSHOT_LOADING_ARIA_LABEL : noDataMessage}
+      aria-label={ariaLabel}
+      title={isPending ? undefined : ariaLabel}
       style={{
         ...thumbnailStyle,
         width,
@@ -64,7 +71,15 @@ export const EmptyThumbnail = ({
         e.stopPropagation();
       }}
     >
-      {isLoading && animateLoading ? (
+      {isPending ? (
+        <EuiIconTip
+          type="clock"
+          color={euiTheme.colors.textSubdued}
+          content={SCREENSHOT_PENDING_MESSAGE}
+          aria-label={SCREENSHOT_PENDING_MESSAGE}
+          iconProps={{ 'data-test-subj': 'stepScreenshotPending' }}
+        />
+      ) : isLoading && animateLoading ? (
         <EuiSkeletonRectangle
           data-test-subj="stepScreenshotPlaceholderLoading"
           isLoading={isLoading}
@@ -118,5 +133,12 @@ export const SCREENSHOT_NOT_AVAILABLE = i18n.translate(
   'xpack.synthetics.monitor.step.screenshot.notAvailable',
   {
     defaultMessage: 'Step screenshot is not available.',
+  }
+);
+
+export const SCREENSHOT_PENDING_MESSAGE = i18n.translate(
+  'xpack.synthetics.monitor.step.screenshot.pending',
+  {
+    defaultMessage: 'Screenshots become available after the journey has completed.',
   }
 );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/journey_step_screenshot_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/journey_step_screenshot_container.tsx
@@ -26,6 +26,8 @@ interface Props {
   retryFetchOnRevisit?: boolean; // Set to `true` for "Run Once" / "Test Now" modes
   size?: ScreenshotImageSize;
   testNowMode?: boolean;
+  /** Whether the journey run has concluded. Only relevant in "Run Once" / "Test Now" mode. */
+  isJourneyCompleted?: boolean;
   unavailableMessage?: string;
   borderRadius?: number | string;
 }
@@ -38,6 +40,7 @@ export const JourneyStepScreenshotContainer = ({
   initialStepNumber = 1,
   retryFetchOnRevisit = false,
   testNowMode,
+  isJourneyCompleted,
   size = THUMBNAIL_SCREENSHOT_SIZE,
   unavailableMessage,
   borderRadius,
@@ -71,10 +74,15 @@ export const JourneyStepScreenshotContainer = ({
     retryFetchOnRevisit,
     checkGroup,
     testNowMode,
+    isJourneyCompleted,
     timestamp,
   });
 
   const { url, loading, stepName, maxSteps } = imageResult?.[imgPath] ?? {};
+
+  // In Run Once / Test Now mode step screenshots are only indexed once the journey concludes.
+  // Until then show a calm "pending" state (not a spinner or the "unavailable" error). See issue #215222.
+  const isPending = Boolean(testNowMode && isJourneyCompleted === false && !url);
 
   return (
     <div ref={intersectionRef}>
@@ -85,7 +93,8 @@ export const JourneyStepScreenshotContainer = ({
         stepNumber={initialStepNumber}
         isStepFailed={stepStatus === 'failed'}
         maxSteps={maxSteps}
-        isLoading={Boolean(loading || !allStepsLoaded)}
+        isLoading={Boolean((loading || !allStepsLoaded) && !isPending)}
+        isPending={isPending}
         size={size}
         unavailableMessage={unavailableMessage}
         borderRadius={borderRadius}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/screenshot_image.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/screenshot_image.tsx
@@ -20,6 +20,8 @@ type ScreenshotImageCallback = (e: { stopPropagation(): void }) => void;
 export interface ScreenshotImageProps {
   label?: string;
   isLoading: boolean;
+  /** Journey still running: screenshot not indexed yet, show a calm pending state instead of loading/error. */
+  isPending?: boolean;
   animateLoading?: boolean;
   size?: ScreenshotImageSize;
   unavailableMessage?: string;
@@ -35,6 +37,7 @@ export const ScreenshotImage: React.FC<ScreenshotImageProps & { imgSrc?: string 
   label,
   imgSrc,
   isLoading,
+  isPending = false,
   animateLoading = true,
   unavailableMessage,
   borderColor,
@@ -89,6 +92,7 @@ export const ScreenshotImage: React.FC<ScreenshotImageProps & { imgSrc?: string 
   ) : (
     <EmptyThumbnail
       isLoading={isLoading}
+      isPending={isPending}
       size={size === 'full' ? naturalSize : size}
       unavailableMessage={unavailableMessage}
       borderRadius={borderRadius}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/actions.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/actions.test.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitForElementToBeRemoved } from '@testing-library/react';
 import { Actions } from './actions';
+import { SyntheticsRefreshContext } from '../../contexts/synthetics_refresh_context';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useParams, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -94,6 +95,23 @@ describe('Actions Component', () => {
     expect(screen.getByText('Edit monitor')).toBeInTheDocument();
     expect(screen.getByText('Refresh')).toBeInTheDocument();
     expect(screen.getByText('Run test manually')).toBeInTheDocument();
+  });
+
+  it('closes the actions popover after an action is selected', async () => {
+    const refreshApp = jest.fn();
+    render(
+      <SyntheticsRefreshContext.Provider value={{ refreshApp } as any}>
+        <Actions />
+      </SyntheticsRefreshContext.Provider>
+    );
+
+    fireEvent.click(screen.getByTestId('monitorDetailsHeaderControlActionsButton'));
+    expect(screen.getByTestId('syntheticsRefreshContextItem')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('syntheticsRefreshContextItem'));
+
+    expect(refreshApp).toHaveBeenCalled();
+    await waitForElementToBeRemoved(() => screen.queryByTestId('syntheticsRefreshContextItem'));
   });
 
   describe('remote (CCS) monitor', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/actions.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/actions.tsx
@@ -44,9 +44,17 @@ export function Actions() {
     >
       <EuiContextMenuPanel
         items={[
-          <EditMonitorContextItem key="edit-monitor" isRemote={isRemote} />,
-          <RefreshContextItem key="refresh-monitor" />,
-          <RunTestManuallyContextItem key="run-test-manually" isRemote={isRemote} />,
+          <EditMonitorContextItem
+            key="edit-monitor"
+            isRemote={isRemote}
+            closePopover={closePopover}
+          />,
+          <RefreshContextItem key="refresh-monitor" closePopover={closePopover} />,
+          <RunTestManuallyContextItem
+            key="run-test-manually"
+            isRemote={isRemote}
+            closePopover={closePopover}
+          />,
         ]}
       />
     </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/edit_monitor_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/edit_monitor_link.tsx
@@ -48,7 +48,13 @@ export const EditMonitorLink = () => {
   );
 };
 
-export const EditMonitorContextItem = ({ isRemote = false }: { isRemote?: boolean }) => {
+export const EditMonitorContextItem = ({
+  isRemote = false,
+  closePopover,
+}: {
+  isRemote?: boolean;
+  closePopover?: () => void;
+}) => {
   const { basePath } = useSyntheticsSettingsContext();
   const { monitorId } = useParams<{ monitorId: string }>();
   const { remoteName, spaceId } = useGetUrlParams();
@@ -77,6 +83,7 @@ export const EditMonitorContextItem = ({ isRemote = false }: { isRemote?: boolea
         data-test-subj="syntheticsEditMonitorContextItem"
         href={remoteEditUrl}
         target={remoteEditUrl ? '_blank' : undefined}
+        onClick={closePopover}
         disabled={hasUndefinedRemoteKibanaUrl}
         toolTipContent={
           hasUndefinedRemoteKibanaUrl
@@ -105,6 +112,7 @@ export const EditMonitorContextItem = ({ isRemote = false }: { isRemote?: boolea
       icon={'pencil'}
       data-test-subj="syntheticsEditMonitorContextItem"
       {...linkProps}
+      onClick={closePopover}
       disabled={isLinkDisabled}
     >
       {EDIT_MONITOR}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -110,7 +110,9 @@ export const RunTestManuallyContextItem = ({
               <EuiIcon type="flask" size="s" aria-hidden={true} />
             )}
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>{<span>{RUN_TEST_LABEL}</span>}</EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <span>{testInProgress ? VIEW_TEST_RUN_LABEL : RUN_TEST_LABEL}</span>
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiContextMenuItem>
     </NoPermissionsTooltip>
@@ -119,6 +121,10 @@ export const RunTestManuallyContextItem = ({
 
 const RUN_TEST_LABEL = i18n.translate('xpack.synthetics.monitorSummary.runTestManually', {
   defaultMessage: 'Run test manually',
+});
+
+const VIEW_TEST_RUN_LABEL = i18n.translate('xpack.synthetics.monitorSummary.viewTestRun', {
+  defaultMessage: 'View test run in progress',
 });
 
 const NOT_AVAILABLE_FOR_REMOTE_MONITORS = i18n.translate(

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -25,6 +25,7 @@ import { useSelectedMonitor } from './hooks/use_selected_monitor';
 import {
   manualTestMonitorAction,
   manualTestRunInProgressSelector,
+  toggleTestNowFlyoutAction,
 } from '../../state/manual_test_runs';
 
 export const RunTestManuallyContextItem = ({
@@ -83,14 +84,20 @@ export const RunTestManuallyContextItem = ({
         disabled={!canUsePublicLocations || !canSave}
         onClick={() => {
           if (monitor) {
-            const spaceId = 'spaceId' in monitor ? (monitor.spaceId as string) : undefined;
-            dispatch(
-              manualTestMonitorAction.get({
-                configId: monitor.config_id,
-                name: monitor.name,
-                ...(spaceId && spaceId !== space?.id ? { spaceId } : {}),
-              })
-            );
+            // A run is already in progress for this monitor: re-open its flyout instead of
+            // kicking off a second run (the user likely closed it while the test was running).
+            if (testInProgress) {
+              dispatch(toggleTestNowFlyoutAction(monitor.config_id));
+            } else {
+              const spaceId = 'spaceId' in monitor ? (monitor.spaceId as string) : undefined;
+              dispatch(
+                manualTestMonitorAction.get({
+                  configId: monitor.config_id,
+                  name: monitor.name,
+                  ...(spaceId && spaceId !== space?.id ? { spaceId } : {}),
+                })
+              );
+            }
           }
           closePopover?.();
         }}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -27,7 +27,13 @@ import {
   manualTestRunInProgressSelector,
 } from '../../state/manual_test_runs';
 
-export const RunTestManuallyContextItem = ({ isRemote = false }: { isRemote?: boolean }) => {
+export const RunTestManuallyContextItem = ({
+  isRemote = false,
+  closePopover,
+}: {
+  isRemote?: boolean;
+  closePopover?: () => void;
+}) => {
   const dispatch = useDispatch();
 
   const { monitor } = useSelectedMonitor();
@@ -86,6 +92,7 @@ export const RunTestManuallyContextItem = ({ isRemote = false }: { isRemote?: bo
               })
             );
           }
+          closePopover?.();
         }}
       >
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -24,12 +24,12 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../../../../../../../common/embeddables/monitors_overview/constants';
 import { getSyntheticsCcsIndex } from '../../../../../../../common/get_synthetics_indices';
 import { useCreateSLO } from '../../hooks/use_create_slo';
-import { TEST_SCHEDULED_LABEL } from '../../../monitor_add_edit/form/run_test_btn';
 import { useCanUsePublicLocById } from '../../hooks/use_can_use_public_loc_id';
 import { toggleStatusAlert } from '../../../../../../../common/runtime_types/monitor_management/alert_config';
 import {
   manualTestMonitorAction,
   manualTestRunInProgressSelector,
+  toggleTestNowFlyoutAction,
 } from '../../../../state/manual_test_runs';
 import { useMonitorAlertEnable } from '../../../../hooks/use_monitor_alert_enable';
 import type { OverviewStatusMetaData } from '../../../../../../../common/runtime_types';
@@ -294,27 +294,29 @@ export function ActionsPopover({
     {
       name: isRemote ? (
         runTestManually
-      ) : testInProgress ? (
-        <EuiToolTip content={TEST_SCHEDULED_LABEL}>
-          <span tabIndex={0}>{runTestManually}</span>
-        </EuiToolTip>
       ) : (
         <NoPermissionsTooltip
           canUsePublicLocations={canUsePublicLocations}
           canEditSynthetics={canEditSynthetics}
         >
-          {runTestManually}
+          {testInProgress ? viewTestRun : runTestManually}
         </NoPermissionsTooltip>
       ),
-      icon: 'flask',
-      disabled: isRemote || testInProgress || !canUsePublicLocations || !isServiceAllowed,
+      // Show a spinner while a run is in progress; clicking then re-opens its flyout
+      // rather than starting a second run.
+      icon: testInProgress ? <EuiLoadingSpinner size="s" /> : 'flask',
+      disabled: isRemote || !canUsePublicLocations || !isServiceAllowed,
       toolTipContent: isRemote ? NOT_AVAILABLE_FOR_REMOTE_MONITORS : undefined,
       onClick: isRemote
         ? undefined
         : () => {
-            dispatch(
-              manualTestMonitorAction.get({ configId: monitor.configId, name: monitor.name })
-            );
+            if (testInProgress) {
+              dispatch(toggleTestNowFlyoutAction(monitor.configId));
+            } else {
+              dispatch(
+                manualTestMonitorAction.get({ configId: monitor.configId, name: monitor.name })
+              );
+            }
             dispatch(setFlyoutConfig(null));
             setIsPopoverOpen(false);
           },
@@ -511,6 +513,10 @@ const quickInspectName = i18n.translate('xpack.synthetics.overview.actions.quick
 
 const runTestManually = i18n.translate('xpack.synthetics.overview.actions.runTestManually.title', {
   defaultMessage: 'Run test manually',
+});
+
+const viewTestRun = i18n.translate('xpack.synthetics.overview.actions.viewTestRun.title', {
+  defaultMessage: 'View test run in progress',
 });
 
 const openActionsMenuAria = i18n.translate(

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
@@ -132,6 +132,7 @@ export const BrowserTestRunResult = ({ expectPings, onDone, testRunId }: Props) 
                   compressed={true}
                   testNowMode={true}
                   showLastSuccessful={false}
+                  isJourneyCompleted={Boolean(summaryDoc)}
                 />
               </>
             )}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiButtonEmpty,
-  EuiCallOut,
+  EuiEmptyPrompt,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -66,12 +66,15 @@ export function TestNowModeFlyout({
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <KibanaSectionErrorBoundary sectionName="xpack.synthetics.monitorManagement.testNowFlyout.body">
-          {isPushing && (
-            <EuiCallOut announceOnMount color="primary">
-              {PushingLabel} <EuiLoadingSpinner />
-            </EuiCallOut>
-          )}
-          {testRun ? (
+          {isPushing ? (
+            <EuiEmptyPrompt
+              data-test-subj="syntheticsTestRunStarting"
+              icon={<EuiLoadingSpinner size="xl" aria-label={STARTING_TEST_LABEL} />}
+              title={<h3>{STARTING_TEST_LABEL}</h3>}
+              titleSize="xs"
+              body={<p>{STARTING_TEST_DESCRIPTION}</p>}
+            />
+          ) : testRun ? (
             <TestNowMode
               isPushing={isPushing}
               errors={errors}
@@ -80,7 +83,7 @@ export function TestNowModeFlyout({
               onDone={onDone}
             />
           ) : (
-            !isPushing && <LoadingState />
+            <LoadingState />
           )}
         </KibanaSectionErrorBoundary>
       </EuiFlyoutBody>
@@ -112,6 +115,10 @@ const CLOSE_LABEL = i18n.translate('xpack.synthetics.monitorManagement.closeButt
   defaultMessage: 'Close',
 });
 
-const PushingLabel = i18n.translate('xpack.synthetics.testRun.pushing.description', {
-  defaultMessage: 'Pushing the monitor to service...',
+const STARTING_TEST_LABEL = i18n.translate('xpack.synthetics.testRun.starting.title', {
+  defaultMessage: 'Starting test run',
+});
+
+const STARTING_TEST_DESCRIPTION = i18n.translate('xpack.synthetics.testRun.starting.description', {
+  defaultMessage: 'Scheduling your monitor to run. This may take a few moments.',
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
@@ -13,6 +13,7 @@ import { TestNowModeFlyout } from './test_now_mode_flyout';
 import { ManualTestRunMode } from './manual_test_run_mode/manual_test_run_mode';
 import { useSyntheticsRefreshContext } from '../../contexts';
 import {
+  hideTestNowFlyoutAction,
   manualTestRunUpdateAction,
   testNowRunsSelector,
   TestRunStatus,
@@ -63,15 +64,22 @@ export function TestNowModeFlyoutContainer() {
       : undefined;
   }, [flyoutOpenTestRun, monitor]);
 
+  // Open the flyout as soon as the run is initiated (status `loading`) so it shows the
+  // "Pushing the monitor to service..." state immediately, rather than waiting for the
+  // trigger-test API to return a `testRunId`. `TestNowModeFlyout` handles the missing `testRun`.
   const flyout =
-    flyoutOpenTestRun && testRun && monitor ? (
+    flyoutOpenTestRun && monitor ? (
       <TestNowModeFlyout
         testRun={testRun}
         name={monitor.name}
         inProgress={
           flyoutOpenTestRun.status === 'in-progress' || flyoutOpenTestRun.status === 'loading'
         }
-        onClose={() => handleFlyoutClose(flyoutOpenTestRun.testRunId)}
+        onClose={() =>
+          flyoutOpenTestRun.testRunId
+            ? handleFlyoutClose(flyoutOpenTestRun.testRunId)
+            : dispatch(hideTestNowFlyoutAction())
+        }
         onDone={onDone}
         isPushing={flyoutOpenTestRun.status === 'loading'}
         errors={flyoutOpenTestRun.errors ?? []}
@@ -81,8 +89,14 @@ export function TestNowModeFlyoutContainer() {
   return (
     <>
       {Object.values(testNowRuns)
+        // Exclude the run currently shown in the flyout: it already polls via the flyout's
+        // `BrowserTestRunResult`, so rendering it here too would double every journey/steps
+        // request. `ManualTestRunMode` is only for background runs (progress toasts).
         .filter(
-          (val) => val.testRunId && (val.status === 'in-progress' || val.status === 'loading')
+          (val) =>
+            val.testRunId &&
+            !val.isTestNowFlyoutOpen &&
+            (val.status === 'in-progress' || val.status === 'loading')
         )
         .map((manualTestRun) => (
           <ManualTestRunMode

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
@@ -65,26 +65,28 @@ export function TestNowModeFlyoutContainer() {
   }, [flyoutOpenTestRun, monitor]);
 
   // Open the flyout as soon as the run is initiated (status `loading`) so it shows the
-  // "Starting test run" state immediately, rather than waiting for the trigger-test API to
-  // return a `testRunId`. `TestNowModeFlyout` handles the missing `testRun`.
-  const flyout =
-    flyoutOpenTestRun && monitor ? (
-      <TestNowModeFlyout
-        testRun={testRun}
-        name={monitor.name}
-        inProgress={
-          flyoutOpenTestRun.status === 'in-progress' || flyoutOpenTestRun.status === 'loading'
-        }
-        onClose={() =>
-          flyoutOpenTestRun.testRunId
-            ? handleFlyoutClose(flyoutOpenTestRun.testRunId)
-            : dispatch(hideTestNowFlyoutAction())
-        }
-        onDone={onDone}
-        isPushing={flyoutOpenTestRun.status === 'loading'}
-        errors={flyoutOpenTestRun.errors ?? []}
-      />
-    ) : null;
+  // "Starting test run" state immediately. We don't wait for the trigger-test API to return
+  // a `testRunId`, nor for the full monitor to be fetched (which adds a visible delay when
+  // launched from the overview list, where the monitor isn't loaded yet) — the stored run
+  // `name` is enough for the header until the monitor resolves. `TestNowModeFlyout` handles
+  // the missing `testRun`.
+  const flyout = flyoutOpenTestRun ? (
+    <TestNowModeFlyout
+      testRun={testRun}
+      name={monitor?.name ?? flyoutOpenTestRun.name ?? ''}
+      inProgress={
+        flyoutOpenTestRun.status === 'in-progress' || flyoutOpenTestRun.status === 'loading'
+      }
+      onClose={() =>
+        flyoutOpenTestRun.testRunId
+          ? handleFlyoutClose(flyoutOpenTestRun.testRunId)
+          : dispatch(hideTestNowFlyoutAction())
+      }
+      onDone={onDone}
+      isPushing={flyoutOpenTestRun.status === 'loading'}
+      errors={flyoutOpenTestRun.errors ?? []}
+    />
+  ) : null;
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
@@ -65,8 +65,8 @@ export function TestNowModeFlyoutContainer() {
   }, [flyoutOpenTestRun, monitor]);
 
   // Open the flyout as soon as the run is initiated (status `loading`) so it shows the
-  // "Pushing the monitor to service..." state immediately, rather than waiting for the
-  // trigger-test API to return a `testRunId`. `TestNowModeFlyout` handles the missing `testRun`.
+  // "Starting test run" state immediately, rather than waiting for the trigger-test API to
+  // return a `testRunId`. `TestNowModeFlyout` handles the missing `testRun`.
   const flyout =
     flyoutOpenTestRun && monitor ? (
       <TestNowModeFlyout

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/index.ts
@@ -34,6 +34,7 @@ export const isTestRunning = (testRun?: ManualTestRun) =>
 
 export interface ManualTestRun {
   configId: string;
+  name?: string;
   testRunId?: string;
   status: TestRunStatus;
   errors?: ServiceLocationErrors;
@@ -63,6 +64,7 @@ export const manualTestRunsReducer = createReducer(initialState, (builder) => {
 
         state[action.payload.configId] = {
           configId: action.payload.configId,
+          name: action.payload.name,
           status: TestRunStatus.LOADING,
           isTestNowFlyoutOpen: true,
         };
@@ -73,6 +75,7 @@ export const manualTestRunsReducer = createReducer(initialState, (builder) => {
       (state: Draft<ManualTestRunsState>, { payload }: PayloadAction<EnrichedTestNowResponse>) => {
         state[payload.configId] = {
           configId: payload.configId,
+          name: state[payload.configId]?.name,
           testRunId: payload.testRunId,
           status: TestRunStatus.IN_PROGRESS,
           errors: payload.errors,


### PR DESCRIPTION
## Summary

Fixes screenshot previews never appearing in the **Run Once / Test Now** flyout for long browser journeys, plus a handful of related UX papercuts in that flow.

The Synthetics agent only indexes step screenshots **after the whole journey concludes**. For long journeys the UI's exponential-backoff retry budget (~51s) expired before the images existed, so every step was left showing the "screenshot unavailable" error placeholder.

### Changes

- **Screenshot fetch timing** — skip screenshot fetches while a test-now journey is still running, and run one more fetch once it completes. Threaded via a new `isJourneyCompleted` prop through `BrowserStepsList` → `JourneyStepScreenshotContainer` → `useRetrieveStepImage`. This also stops the guaranteed-404 backoff storms during the run.
- **Pending state** — while the journey is in progress, show a calm "pending" state (clock icon + tooltip _"Screenshots become available after the journey has completed."_) instead of a spinner or the error placeholder.
- **Steps table page size** — add per-page size options (5 / 10 / 20 / 50) to the browser steps table.
- **Actions popover** — close the monitor-details Actions popover when an item (Edit / Refresh / Run test manually) is selected.
- **Instant flyout** — open the Test Now flyout immediately (showing its "Pushing the monitor to service…" state) instead of waiting for the trigger-test API to return a `testRunId`.
- **Duplicate polling** — stop the background `ManualTestRunMode` from double-polling the run that is already being polled by the open flyout's `BrowserTestRunResult`.

Closes #215222

## Test plan

- [x] `node scripts/type_check --project x-pack/solutions/observability/plugins/synthetics/tsconfig.json`
- [x] `node scripts/eslint` on changed files
- [x] `node scripts/i18n_check`
- [x] Jest: `empty_thumbnail`, `journey_step_screenshot_container`, `browser_steps_list`, `actions` (17 passed)
- [ ] Manual: trigger a long browser journey via Run Once / Test Now and confirm screenshots populate once the run completes, with the pending state shown while in progress.
