### PR TITLE
feat(agent-builder-sml): rename SML data index to .context-idx-sml-data

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.test.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { smlIndexName } from './sml_storage';
+
+describe('smlIndexName', () => {
+  it('is the context-idx-sml-data index', () => {
+    expect(smlIndexName).toBe('.context-idx-sml-data');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_sml/server/services/sml/sml_storage.ts
@@ -8,10 +8,9 @@
 import type { Logger, ElasticsearchClient } from '@kbn/core/server';
 import type { IndexStorageSettings } from '@kbn/storage-adapter';
 import { StorageIndexAdapter, types } from '@kbn/storage-adapter';
-import { chatSystemIndex } from '../../../common/indices';
 import type { SmlDocument } from './types';
 
-export const smlIndexName = chatSystemIndex('sml-data');
+export const smlIndexName = '.context-idx-sml-data';
 
 const SEMANTIC_MULTI_FIELD = {
   semantic: types.semantic_text({}),


### PR DESCRIPTION
## Summary

Renames the SML data index from `.chat-sml-data` (covered by the `.chat-*`
`SystemIndexDescriptor` in `KibanaPlugin.java`) to `.context-idx-sml-data`,
a plain non-system index, satisfying the product requirement that KI data is
customer-queryable directly via ES|QL.

The change is a one-line constant rename. `StorageIndexAdapter` (already in use)
handles the rest automatically on first write:
- Registers an index template matching `.context-idx-sml-data-*`
- Creates `.context-idx-sml-data-000001` as the physical backing index
- Exposes `.context-idx-sml-data` as a write alias

The alias-backed structure is intentional future-proofing: a future breaking
mapping change can roll over to `-000002` without renaming the alias that all
callers reference.

**No data migration.** This feature is experimental and feature-flagged;
developer environments are expected to re-index from scratch.

`.chat-sml-crawler-state` is intentionally not renamed.


### Prerequisites / stacking

- [x] **Stacks on #277253** (`sean/agent-builder-sml-rename-and-prune`) — must merge first; this PR's base will be rebased to `main` once that lands.
- [x] **Blocked on elastic/elasticsearch#153525** — grants `kibana_system` index
  privileges on `.context-idx-sml-data` and `.context-idx-sml-data-*`. Without
  it, `StorageIndexAdapter`'s lazy template registration and index creation will
  receive a 403 from ES. Safe to merge this Kibana PR first; the feature flag
  prevents production writes until the ES side lands.

### Future composability note

`StorageIndexAdapter` owns the full template for `.context-idx-sml-data-*` and
does not use `composed_of`. When search-team#15201 eventually builds a shared
`context-ki-mappings` component template, that effort will need to coordinate
with this template rather than assuming pattern-based composition works
automatically.


🤖 Generated with [Claude Code](https://claude.com/claude-code)