### PR TITLE
[Lens] Fix ES|QL chart filtering.

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/expressions/defs/map_to_columns/types.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/defs/map_to_columns/types.ts
@@ -20,6 +20,8 @@ export type OriginalColumn = {
 } & (
   | { operationType: 'date_histogram'; sourceField: string; interval: number }
   | { operationType: string; sourceField?: string; interval: never }
+  // text-based ES|QL columns
+  | { operationType?: undefined; sourceField?: string }
 );
 
 export type MapToColumnsExpressionFunction = ExpressionFunctionDefinition<

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/convert_to_text_based_layer.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/convert_to_text_based_layer.ts
@@ -115,7 +115,8 @@ function buildTextBasedState(
         column.customLabel = true; // set always to true so we can use the default label as a custom label
         if (hasCustomLabel) {
           column.label = sourceColumn.label;
-        } else {
+          // This is a sanity check to satisfy TS for the incoming form based column.
+        } else if ('operationType' in sourceColumn && sourceColumn.operationType) {
           // use the generated default label
           column.label = operationDefinitionMap[sourceColumn.operationType].getDefaultLabel(
             layer.columns[sourceColumn.id],

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.test.ts
@@ -1166,7 +1166,7 @@ describe('Textbased Data Source', () => {
             Object {
               "arguments": Object {
                 "idMap": Array [
-                  "{\\"Test 1\\":[{\\"id\\":\\"a\\",\\"label\\":\\"Test 1\\",\\"dataType\\":\\"number\\",\\"operationType\\":\\"literal\\"}],\\"Test 2\\":[{\\"id\\":\\"b\\",\\"label\\":\\"Test 2\\",\\"dataType\\":\\"number\\",\\"operationType\\":\\"literal\\"}]}",
+                  "{\\"Test 1\\":[{\\"id\\":\\"a\\",\\"label\\":\\"Test 1\\",\\"dataType\\":\\"number\\"}],\\"Test 2\\":[{\\"id\\":\\"b\\",\\"label\\":\\"Test 2\\",\\"dataType\\":\\"number\\"}]}",
                 ],
                 "isTextBased": Array [
                   true,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.test.ts
@@ -58,7 +58,6 @@ describe('toExpression', () => {
       id: 'a',
       label: '@timestamp',
       dataType: 'date',
-      operationType: 'literal',
     });
     expect(idMap['@timestamp'][0]).not.toHaveProperty('dropPartials');
   });
@@ -84,7 +83,6 @@ describe('toExpression', () => {
       label: '@timestamp',
       dropPartials: false,
       dataType: 'date',
-      operationType: 'literal',
     });
   });
 
@@ -109,7 +107,6 @@ describe('toExpression', () => {
       label: '@timestamp',
       dropPartials: true,
       dataType: 'date',
-      operationType: 'literal',
     });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
@@ -25,7 +25,7 @@ function getExpressionForLayer(
   layer.columns.forEach((col) => {
     // Only pick fields that OriginalColumn declares; the Omit<> drops the
     // `interval: never` discriminant that doesn't apply to text-based columns.
-    const entry = {
+    const entry: OriginalColumn = {
       id: col.columnId,
       label: col.customLabel ? col.label ?? col.fieldName : col.fieldName,
       variable: col.variable,
@@ -33,8 +33,9 @@ function getExpressionForLayer(
       format: col.params?.format,
       dataType: col.meta?.type as OriginalColumn['dataType'],
       customLabel: col.customLabel,
-      operationType: 'literal',
-    } as OriginalColumn;
+      // no operation type for text-based columns
+      operationType: undefined,
+    };
     if (idMapper[col.fieldName]) {
       idMapper[col.fieldName].push(entry);
     } else {


### PR DESCRIPTION
## Summary

Fixes ES|QL chart click filtering which produced `exists` filters instead of value-matching `match_phrase` filters.

The text-based datasource `to_expression.ts` set `operationType: 'literal'` on every ES|QL column in the idMap. Downstream, `createFilterESQL` uses `operationType` as a routing discriminator:

- `'date_histogram'` / `'histogram'` → range filter ✅
- `undefined` → phrase filter via raw column path ✅
- any other string (including `'literal'`) → `buildSimpleExistFilter` ❌

The `'literal'` value was introduced as a type-satisfying placeholder when the `OriginalColumn` discriminated union required `operationType: string`. The runtime code in `mapToOriginalColumnsTextBased` already guarded with `'operationType' in originalColumn`, so absence was already handled — the type just did not reflect it.

**Changes:**
- Add a third union variant to `OriginalColumn` (`operationType?: undefined`) for text-based columns that have no aggregation operation
- Remove `operationType: 'literal'` from `to_expression.ts`
- Guard `convert_to_text_based_layer.ts` against `undefined` operationType
- Update test expectations

This is a follow-up bugfix to https://github.com/elastic/kibana/pull/272499

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk: type change to `OriginalColumn` adds a new union variant — all existing consumers already handle the `undefined` case at runtime

### Release note

Fixes an issue where clicking a value in an ES|QL chart to filter data created an incorrect filter that matched any document containing the field, instead of filtering to the specific clicked value. This fix is only applicable to serverless deployments.




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->