### PR TITLE
First touch on merging duplicate tags

### DIFF
--- a/x-pack/platform/plugins/shared/saved_objects_tagging/README.md
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/README.md
@@ -60,3 +60,168 @@ export const tagUsageCollectorSchema: MakeSchemaFrom<TaggingUsageData> = {
 
 Edit the `taggableTypes` list in `x-pack/platform/plugins/shared/saved_objects_tagging/common/constants.ts` to add
 the name of the type you are adding.
+
+## Merge duplicate tags (internal)
+
+Internal-only workflow (`server/routes/merge`, `server/services/merge`, `server/tasks/tag_merge`) that lets a user
+consolidate tags that share the same name into one canonical tag: references on tagged saved objects are rewritten
+from one or more `fromIds` to a single `toId`, and the source tags can optionally be deleted once unreferenced.
+Not part of the `@kbn/saved-objects-tagging-oss-plugin` public contract, and not exposed on `/api/tags`.
+
+### Endpoints
+
+- `POST /internal/saved_objects_tagging/tags/merge/preview` — affected count (restricted to taggable types the
+  current user can update), plus `canStartMerge`/`canRequestDeleteSources` gate results.
+- `GET /internal/saved_objects_tagging/tags/merge/preview/objects` — paginated listing of the objects a merge would
+  touch.
+- `POST /internal/saved_objects_tagging/tags/merge` — starts the job (409 if one is already running in this space).
+- `GET /internal/saved_objects_tagging/tags/merge` — current job status for this space (`idle` if none exists).
+- `POST /internal/saved_objects_tagging/tags/merge/cancel` — requests cooperative cancellation.
+
+### Progress percent spans both phases when `deleteSources` is requested
+
+`GET .../tags/merge`'s `progress.percent` (`computePercent` in `status.ts`) is not simply
+`updatedCount / totalAffected`: when `deleteSources` is true, `finalizing` (deleting the source tags, which happens
+strictly after every saved object is updated) is real remaining work, so `updating` only accounts for the first
+half of the bar (0-50%) and `finalizing` the second half (50-100%, based on how many of `fromIds` have been
+checked/deleted so far) — otherwise the bar would read 100% while the source tags haven't been touched at all.
+When `deleteSources` is false, `updating` alone maps to the full 0-100% range, since there's no `finalizing` phase.
+
+### Per-user execution via Task Manager
+
+The merge itself runs asynchronously (`saved_objects_tagging:tag_merge` task type, `server/tasks/tag_merge`), after
+the HTTP request that started it has ended — but every reference rewrite must still be scoped to exactly what the
+*starting user* is authorized to change, not to an internal/system identity. The start route
+(`server/routes/merge/start.ts`) achieves this by passing the original `KibanaRequest` to `taskManager.schedule()`
+as `{ request }` in the *second* argument (`ApiKeyOptions`), not by granting a key itself. Task Manager grants an
+API key scoped to that request's own privileges internally and persists it as `apiKey`/`userScope` on the task —
+those fields are **only** ever set this way: setting them directly on the object passed as the first argument does
+nothing, because `taskInstanceToAttributes()` (in Task Manager's own `task_store.ts`) explicitly strips
+`apiKey`/`userScope`/`uiamApiKey` from it. (An earlier version of this code got that backwards — hand-granted the
+key and merged it onto the first argument — which silently scheduled tasks with no scoped request at all and
+failed at run time with "missing its scoped request".) The `task` saved object type already encrypts `apiKey` at
+rest, Task Manager rebuilds a scoped `fakeRequest` for every run and exposes it as `context.fakeRequest`, and it
+invalidates the key automatically once the task is removed (`userScope.apiKeyCreatedByUser: false` marks it as
+owned by the task, not the caller). No custom Encrypted Saved Objects type was needed for this — reuse this
+mechanism (`schedule(taskInstance, { request })`) rather than reinventing per-user execution for future background
+jobs in this plugin.
+
+### Gate 2a: source-tag deletion safety model
+
+Two independent authorization gates, both computed in `MergeService`:
+
+- **Baseline start gate** (`checkStartGate`): the user must be able to manage tag objects (update *and* delete the
+  `tag` type), and this specific merge must actually update at least one saved object the user can access —
+  gated on `affectedCount` (from `computeAffectedCount`, already scoped to `updatableTypes`), not on "the user can
+  update *some* taggable type somewhere." That distinction matters: a generic "can update at least one taggable
+  type" check is nearly always true for any active editor and doesn't correlate with whether *these specific*
+  `fromIds` are used by anything the user can actually update — a user who can only edit `dashboard` would pass
+  a generic check even if the tags being merged are only ever applied to `map`/`lens` objects the user can't
+  touch, letting them start a merge that provably does nothing. `affectedCount` is recomputed independently in
+  both `preview.ts` and `start.ts` (never trusting a client-supplied value from an earlier preview call) so this
+  can't drift or be bypassed. A merge with zero affected objects and no source deletion is a pure no-op anyway
+  (nothing rewritten, tags stay separate); cleaning up a truly-unused duplicate tag already has a simpler
+  existing path (the plain "Delete" row action), so this gate doesn't need a `deleteSources`-only carve-out.
+- **Gate 2a** (`checkDeleteSourcesGate`): deleting the source tags is only offered when the user can update *every
+  taggable type that actually has a live reference to `fromIds` right now* — not literally every taggable type
+  registered in the deployment. A dashboard-only editor can request deletion when the only tagged objects are
+  dashboards, even though they can't update `osquery-pack`/`slo_template`/etc. That `affectedTypes` set must come
+  from `core.savedObjects.getUnsafeInternalClient()` (an unscoped scan across all known taggable types), *not* the
+  per-user client: a per-user `find()` across multiple types silently narrows to the types the caller can `find`
+  rather than throwing on the rest (`api-server-internal/src/lib/apis/find.ts`), so computing `affectedTypes` from
+  a permission-scoped client would make this gate either trivially pass (if scoped to the caller's own
+  `updatableTypes`) or vacuous. `preview.ts` and `start.ts` both run this scan independently, same as
+  `affectedCount` above.
+
+Even when Gate 2a passes and `deleteSources: true`, the task's `finalizing` phase re-checks each `fromId`
+independently right before deleting it (`server/tasks/tag_merge/task_runner.ts`) — a tag is deleted only if a fresh
+scan finds zero remaining references, never based on the `updating` phase's earlier count. That scan also uses the
+unscoped internal client rather than the per-user one, for the same silent-narrowing reason as Gate 2a above: it's
+the only thing standing between "the merging user can't see every type" and actually deleting a tag some other,
+invisible-to-them object still references. The tag deletion call itself still goes through the user's own scoped
+client, so it's still bound by their own delete privilege on the `tag` type (part of the baseline gate) — only the
+*visibility* check for "is it safe to delete" is unscoped.
+
+### Cancellation semantics
+
+Cancellation is cooperative, not immediate. `POST .../cancel` only flips `state.cancelRequested` on the task (via
+`taskManager.bulkUpdateState`) and nudges the task with `runSoon` in case it's idle between self-reschedules; the
+task checks that flag itself at the start of every run. Concretely:
+
+- Any object reference already rewritten before the flag is observed stays rewritten — there is no rollback.
+- If canceled during `updating`, the job stops before finalizing (deleting source tags), even if `deleteSources`
+  was requested — so a partially-completed job never deletes tags mid-merge.
+- A timeout (`abortController.signal.aborted`) is handled the same way as an explicit cancel within a phase: the
+  `finalizing` phase's per-`fromId` loop is sequential specifically so it can stop between tags rather than firing
+  every delete concurrently and losing track of what happened.
+
+Because this task carries an encrypted `apiKey`/`userScope` (see "Per-user execution" above), **any**
+`taskManager.bulkUpdateState`/`bulkUpdateSchedules`/`bulkUpdate`-style call against it — not just `schedule()` — must
+pass `{ request }` in its options. `TaskStore.getSoClientForUpdate` throws synchronously otherwise ("Request is not
+defined but some of the tasks have API key or user scope..."), and since that throw happens before `cancelRequested`
+is ever persisted, the symptom is exactly "cancel returns a 500, and the merge just keeps running to completion as
+if cancel was never called." `cancel.ts` passes `req` for this reason.
+
+**Every terminal-state return (`canceled`, `success`, and the pre-work-abort bail-out) must still include a
+`runAt`.** This task has no `schedule`, and Task Manager's `TaskManagerRunner.processResultWhenDone` treats *any*
+run that returns without `runAt` as "this one-shot task is finished" — it deletes the task's saved object
+immediately, without ever persisting that run's returned `state`. Returning the terminal state without `runAt`
+therefore doesn't just skip a reschedule, it throws the terminal state away entirely: the next status poll finds no
+task at all and falls back to reporting `idle`, which reads as "merge failed" in the UI even though it actually
+succeeded or was cleanly canceled. The fix is for every phase to set a `runAt` (as usual) even on the run that
+transitions to a terminal state — the following no-op run (the `case 'complete'` branch in `task_runner.ts`, which
+correctly has no `runAt`) is what actually triggers cleanup, once the terminal state has had a chance to persist
+and be observed by at least one poll.
+
+### Singleton per space
+
+At most one merge job may run per Kibana space at a time. The `task` saved object type is namespace-`agnostic` (not
+space-aware), so the space id is encoded directly in the deterministic task id (`getTagMergeTaskId(spaceId)` →
+`saved_objects_tagging:tag_merge:<spaceId>`) rather than relying on saved-object space partitioning. The start route
+uses this id both to detect an in-progress job (409) and to clean up ("remove") a previous, already-finished job
+before scheduling a new one in the same space — there is no separate garbage-collection task for abandoned/finished
+jobs; the next `start` call in that space is what reclaims it.
+
+Because it's singleton per space, a job started for one duplicate-name group blocks starting a merge for any *other*
+group until it finishes — there's no per-group concurrency. This is an intentional scope cut, not an oversight
+(proposal.md's open questions explicitly flag the follow-on "job visibility and ownership across multiple users" as
+unresolved), but it has two UI-visible consequences that needed their own fixes:
+
+- **Reattaching to a running job.** The job keeps running server-side regardless of whether the flyout that started
+  it is still open — closing it, or navigating away, never stops or fails it. But since the job isn't tied to any
+  particular duplicate-name group, `MergeDuplicateTagsFlyout` checks `mergeClient.status()` on mount and jumps
+  straight to the `running` step if one is already in progress, rather than starting fresh at tag selection (which
+  would otherwise 409 on "Start merge" with no way to see the job that's actually blocking it). This is why `running`
+  and `done` never reference the flyout's own `tags` prop for anything — they only ever describe the actual running
+  job's `status.job`, which may belong to a different group than the one the flyout was opened for.
+- **Which tag is it merging into?** Since the running job's canonical tag may not be part of the flyout's own `tags`
+  prop, `MergeDuplicateTagsFlyout` also takes an `allTags` prop (every tag in the space) purely to resolve
+  `status.job.toId` to a name via `buildTagNameLookup` (`public/management/utils/tag_name_lookup.ts`) — otherwise
+  there'd be no way to tell the user which merge is actually running. `TagManagementPage` also polls
+  `mergeClient.status()` independently (`MergeInProgressCallout`), so a running job — and which tag it's merging
+  into — is visible on the page itself without opening the flyout at all.
+
+### Client-side cache invalidation
+
+A merge that deletes duplicate source tags does so server-side, inside the async Task Manager task — not through
+the browser's `TagsClient`. That means the shared `TagsCache` (`public/services/tags/tags_cache.ts`, used by tag
+pickers everywhere else in the app: Dashboard, Visualize, etc.) never learns about the deletion through its normal
+`onDidDelete` hook, which only fires on client-initiated deletes; without an explicit refresh, deleted tags would
+keep appearing in those pickers — and the now-stale duplicate-tags warning would keep showing on the Tag Management
+page itself — until the cache's own periodic refresh interval or a full page reload. `TagManagementPage`'s
+`refreshAfterMerge` (`public/management/tag_management_page.tsx`) works around this by calling both `fetchTags()`
+(refreshes this page's own `allTags`, so `DuplicateTagsCallout` recomputes correctly once a source tag is gone) and
+`tagClient.invalidateCache()` (refreshes the shared cache). `invalidateCache()` is a thin wrapper the
+`ITagInternalClient` interface adds around the existing (but oddly-named, for this purpose)
+`TagsClient.fetchAllFromNetwork()` — a method that already existed, but only as a dual-purpose "fetch tags *and*, as
+a side effect, sync the cache" primitive used by the cache's own periodic refresh (`public/plugin.ts`), which
+actually needs the returned tag list. `invalidateCache()` exists so a caller that only wants the side effect, and
+doesn't care about the return value, doesn't have to know that "fetch all tags from the network" is also how you
+refresh the cache.
+
+`refreshAfterMerge` has two triggers, and both are needed: the flyout's own `onMerged` callback (fires when the
+flyout that started or reattached to the job is open and reaches a terminal state), and the page's own
+`mergeClient.status()` poll detecting a transition from `in_progress` to anything else (fires even if no flyout was
+ever open to observe the job finish — e.g. the user started a merge, closed the flyout, and never reopened it).
+Relying on the flyout alone left the page showing a stale `DuplicateTagsCallout` warning for an already-deleted tag
+indefinitely whenever nothing was watching the job when it finished.

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/common/merge.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/common/merge.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Configuration of a tag merge job: rewrite references from `fromIds` to `toId`,
+ * optionally deleting `fromIds` once no references remain.
+ */
+export interface MergeJobConfig {
+  toId: string;
+  fromIds: string[];
+  deleteSources: boolean;
+}
+
+export type MergeJobPhase = 'scanning' | 'updating' | 'finalizing' | 'complete';
+
+export type MergeJobStatus = 'idle' | 'in_progress' | 'canceled' | 'success' | 'failed';
+
+export interface MergeJobProgress {
+  totalAffected?: number;
+  updatedCount: number;
+  percent?: number;
+}
+
+export interface MergeDeletionResult {
+  id: string;
+  deleted: boolean;
+  remainingReferences?: number;
+  error?: string;
+}
+
+export interface MergeErrorsSummary {
+  count: number;
+  samples: string[];
+}
+
+export interface MergeGateResult {
+  allowed: boolean;
+  reasons: string[];
+}
+
+export interface MergePreviewRequest {
+  toId: string;
+  fromIds: string[];
+}
+
+export interface MergePreviewResponse {
+  affectedCount: number;
+  byType: Record<string, number>;
+  canStartMerge: MergeGateResult;
+  canRequestDeleteSources: MergeGateResult;
+}
+
+export interface MergeAffectedObject {
+  type: string;
+  id: string;
+  title?: string;
+}
+
+export interface MergePreviewObjectsResponse {
+  objects: MergeAffectedObject[];
+  total: number;
+  page: number;
+  perPage: number;
+}
+
+export type MergeStartRequest = MergeJobConfig;
+
+export interface MergeStatusResponse {
+  status: MergeJobStatus;
+  phase: MergeJobPhase;
+  job?: MergeJobConfig & { startedAt: string };
+  progress: MergeJobProgress;
+  deletion: MergeDeletionResult[];
+  errors: MergeErrorsSummary;
+}

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/kibana.jsonc
@@ -17,11 +17,13 @@
     "requiredPlugins": [
       "features",
       "management",
-      "savedObjectsTaggingOss"
+      "savedObjectsTaggingOss",
+      "taskManager"
     ],
     "optionalPlugins": [
       "usageCollection",
-      "security"
+      "security",
+      "spaces"
     ],
     "requiredBundles": []
   }

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/duplicate_tags_callout.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/duplicate_tags_callout.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React from 'react';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink, EuiText, EuiSpacer } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import type { DuplicateTagGroup } from '../utils';
+
+export interface DuplicateTagsCalloutProps {
+  groups: DuplicateTagGroup[];
+  onMergeGroup: (group: DuplicateTagGroup) => void;
+}
+
+export const DuplicateTagsCallout: FC<DuplicateTagsCalloutProps> = ({ groups, onMergeGroup }) => {
+  if (groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        data-test-subj="tagsDuplicateTagsCallout"
+        title={i18n.translate('xpack.savedObjectsTagging.management.duplicates.calloutTitle', {
+          defaultMessage:
+            '{count, plural, one {1 duplicate tag name found} other {# duplicate tag names found}}',
+          values: { count: groups.length },
+        })}
+        color="warning"
+        iconType="alert"
+      >
+        <EuiFlexGroup direction="column" gutterSize="s">
+          {groups.map((group) => (
+            <EuiFlexItem key={group.normalizedName}>
+              <EuiText size="s">
+                <FormattedMessage
+                  id="xpack.savedObjectsTagging.management.duplicates.groupText"
+                  defaultMessage='{count} tags named "{name}"'
+                  values={{ count: group.tags.length, name: group.tags[0].name }}
+                />{' '}
+                <EuiLink
+                  data-test-subj={`tagsDuplicateTagsMergeLink-${group.normalizedName}`}
+                  onClick={() => onMergeGroup(group)}
+                >
+                  <FormattedMessage
+                    id="xpack.savedObjectsTagging.management.duplicates.mergeLink"
+                    defaultMessage="Merge"
+                  />
+                </EuiLink>
+              </EuiText>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      </EuiCallOut>
+      <EuiSpacer size="l" />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/index.ts
@@ -8,3 +8,6 @@
 export { Header } from './header';
 export { TagTable } from './table';
 export { ActionBar } from './action_bar';
+export { DuplicateTagsCallout } from './duplicate_tags_callout';
+export { MergeInProgressCallout } from './merge_in_progress_callout';
+export { MergeDuplicateTagsFlyout } from './merge_duplicate_tags_flyout';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/merge_duplicate_tags_flyout.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/merge_duplicate_tags_flyout.tsx
@@ -1,0 +1,815 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiTitle,
+  EuiSpacer,
+  EuiText,
+  EuiRadio,
+  EuiCheckbox,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiProgress,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiConfirmModal,
+  EuiLoadingSpinner,
+  EuiLink,
+  EuiIconTip,
+  EuiBasicTable,
+  EuiInMemoryTable,
+  type EuiBasicTableColumn,
+  type Criteria,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { TagWithRelations } from '../../../common/types';
+import type {
+  MergeJobPhase,
+  MergeAffectedObject,
+  MergePreviewObjectsResponse,
+  MergePreviewResponse,
+  MergeStatusResponse,
+} from '../../../common/merge';
+import type { IMergeClient } from '../../services';
+import { TagBadge } from '../../components';
+import { buildTagNameLookup } from '../utils';
+
+const POLL_INTERVAL_MS = 2000;
+const AFFECTED_OBJECTS_PAGE_SIZE = 10;
+
+type Step = 'select' | 'preview' | 'running' | 'done';
+
+export interface MergeDuplicateTagsFlyoutProps {
+  /** The duplicate-name group (2+ tags) to merge; may include managed tags (shown read-only). */
+  tags: TagWithRelations[];
+  /**
+   * Every tag in the space, used only to resolve the running/finished job's canonical tag id
+   * (`status.job.toId`) to a name. Merge jobs are singleton per space, so the job this flyout
+   * reattaches to on open may belong to a *different* duplicate-name group than `tags` — without
+   * this, there would be no way to tell the user which tag is actually being merged.
+   */
+  allTags: TagWithRelations[];
+  mergeClient: IMergeClient;
+  onClose: () => void;
+  /** Called when the flyout closes after a merge actually ran, so the tags list can be refreshed. */
+  onMerged: () => void;
+}
+
+const errorMessage = (e: unknown): string =>
+  (e as { body?: { message?: string } })?.body?.message ?? (e as Error).message;
+
+const affectedObjectsColumns: Array<EuiBasicTableColumn<MergeAffectedObject>> = [
+  {
+    field: 'title',
+    name: i18n.translate('xpack.savedObjectsTagging.management.merge.preview.table.title', {
+      defaultMessage: 'Title',
+    }),
+    render: (title: string | undefined, object: MergeAffectedObject) => title ?? object.id,
+  },
+  {
+    field: 'type',
+    name: i18n.translate('xpack.savedObjectsTagging.management.merge.preview.table.type', {
+      defaultMessage: 'Type',
+    }),
+  },
+];
+
+const phaseLabel = (phase: MergeJobPhase) => {
+  switch (phase) {
+    case 'scanning':
+      return i18n.translate('xpack.savedObjectsTagging.management.merge.phase.scanning', {
+        defaultMessage: 'Scanning for affected objects…',
+      });
+    case 'updating':
+      return i18n.translate('xpack.savedObjectsTagging.management.merge.phase.updating', {
+        defaultMessage: 'Updating tagged objects…',
+      });
+    case 'finalizing':
+      return i18n.translate('xpack.savedObjectsTagging.management.merge.phase.finalizing', {
+        defaultMessage: 'Deleting merged tags…',
+      });
+    case 'complete':
+    default:
+      return i18n.translate('xpack.savedObjectsTagging.management.merge.phase.complete', {
+        defaultMessage: 'Complete',
+      });
+  }
+};
+
+export const MergeDuplicateTagsFlyout: FC<MergeDuplicateTagsFlyoutProps> = ({
+  tags,
+  allTags,
+  mergeClient,
+  onClose,
+  onMerged,
+}) => {
+  const selectableTags = useMemo(() => tags.filter((tag) => !tag.managed), [tags]);
+
+  const getTagName = useMemo(() => buildTagNameLookup(allTags), [allTags]);
+  const runningJobTagName = (job: MergeStatusResponse['job']) =>
+    job ? getTagName(job.toId) ?? job.toId : undefined;
+  // For rendering an actual colored badge (not just a name) for a source tag that couldn't be
+  // deleted — it may not be in `tags` (the group this flyout was opened for) if this flyout
+  // reattached to a job for a different group, but it will still be in `allTags` since it wasn't
+  // actually deleted.
+  const getTagById = useMemo(() => new Map(allTags.map((tag) => [tag.id, tag])), [allTags]);
+
+  const [step, setStep] = useState<Step>('select');
+  const [canonicalId, setCanonicalId] = useState<string | undefined>(selectableTags[0]?.id);
+  const [deleteSources, setDeleteSources] = useState(false);
+  const [preview, setPreview] = useState<MergePreviewResponse | undefined>();
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [showAffectedObjects, setShowAffectedObjects] = useState(false);
+  const [affectedObjectsPage, setAffectedObjectsPage] = useState(0);
+  const [affectedObjects, setAffectedObjects] = useState<MergePreviewObjectsResponse | undefined>();
+  const [affectedObjectsLoading, setAffectedObjectsLoading] = useState(false);
+  const [status, setStatus] = useState<MergeStatusResponse | undefined>();
+  const [confirmingCancel, setConfirmingCancel] = useState(false);
+  const [ranMerge, setRanMerge] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [checkingExistingJob, setCheckingExistingJob] = useState(true);
+
+  const canonicalTag = selectableTags.find((tag) => tag.id === canonicalId);
+  const fromIds = useMemo(
+    () => selectableTags.filter((tag) => tag.id !== canonicalId).map((tag) => tag.id),
+    [selectableTags, canonicalId]
+  );
+
+  const goToPreview = useCallback(async () => {
+    if (!canonicalId) {
+      return;
+    }
+    setStep('preview');
+    setPreviewLoading(true);
+    setError(undefined);
+    try {
+      const result = await mergeClient.preview({ toId: canonicalId, fromIds });
+      setPreview(result);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [mergeClient, canonicalId, fromIds]);
+
+  const loadAffectedObjects = useCallback(
+    async (page: number) => {
+      if (!canonicalId) {
+        return;
+      }
+      setAffectedObjectsLoading(true);
+      try {
+        const result = await mergeClient.previewObjects({
+          toId: canonicalId,
+          fromIds,
+          page: page + 1,
+          perPage: AFFECTED_OBJECTS_PAGE_SIZE,
+        });
+        setAffectedObjects(result);
+        setAffectedObjectsPage(page);
+      } catch (e) {
+        setError(errorMessage(e));
+      } finally {
+        setAffectedObjectsLoading(false);
+      }
+    },
+    [mergeClient, canonicalId, fromIds]
+  );
+
+  const toggleAffectedObjects = useCallback(() => {
+    setShowAffectedObjects((shown) => {
+      const next = !shown;
+      if (next && !affectedObjects) {
+        loadAffectedObjects(0);
+      }
+      return next;
+    });
+  }, [affectedObjects, loadAffectedObjects]);
+
+  const startMerge = useCallback(async () => {
+    if (!canonicalId) {
+      return;
+    }
+    setError(undefined);
+    try {
+      await mergeClient.start({ toId: canonicalId, fromIds, deleteSources });
+      setRanMerge(true);
+      setStep('running');
+    } catch (e) {
+      setError(errorMessage(e));
+    }
+  }, [mergeClient, canonicalId, fromIds, deleteSources]);
+
+  // A merge job is singleton-per-space and runs entirely server-side, so closing this flyout
+  // (or navigating away) never stops or fails it. Reopening always started fresh at tag
+  // selection, with no way to see the still-running job — worse, trying to start a new one just
+  // 409'd. Check for an in-progress job on mount and reattach straight to `running` if there is
+  // one, regardless of which duplicate group this flyout instance was opened for (the `running`
+  // and `done` steps don't reference the local tag selection, so this is always safe to show).
+  useEffect(() => {
+    let cancelled = false;
+    mergeClient
+      .status()
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        if (result.status === 'in_progress') {
+          setStatus(result);
+          setRanMerge(true);
+          setStep('running');
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(errorMessage(e));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setCheckingExistingJob(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // deliberately run once on mount only: re-running this on every `mergeClient` identity
+    // change would fight with the user's own navigation through the select/preview steps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Poll job status while running; stop as soon as it's no longer in progress.
+  useEffect(() => {
+    if (step !== 'running') {
+      return;
+    }
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const result = await mergeClient.status();
+        if (cancelled) {
+          return;
+        }
+        setStatus(result);
+        if (result.status !== 'in_progress') {
+          setStep('done');
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(errorMessage(e));
+        }
+      }
+    };
+    poll();
+    const interval = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [step, mergeClient]);
+
+  const confirmCancel = useCallback(async () => {
+    setConfirmingCancel(false);
+    try {
+      await mergeClient.cancel();
+    } catch (e) {
+      setError(errorMessage(e));
+    }
+  }, [mergeClient]);
+
+  const handleClose = useCallback(() => {
+    if (ranMerge) {
+      onMerged();
+    }
+    onClose();
+  }, [ranMerge, onMerged, onClose]);
+
+  const errorCallout = error && (
+    <>
+      <EuiCallOut
+        color="danger"
+        title={i18n.translate('xpack.savedObjectsTagging.management.merge.errorTitle', {
+          defaultMessage: 'An error occurred',
+        })}
+      >
+        {error}
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+    </>
+  );
+
+  let body: React.ReactNode;
+  let footer: React.ReactNode;
+
+  if (checkingExistingJob) {
+    body = <EuiLoadingSpinner size="l" />;
+    footer = (
+      <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={onClose}>
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.cancelButton"
+              defaultMessage="Cancel"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  } else if (step === 'select') {
+    const selectColumns: Array<EuiBasicTableColumn<TagWithRelations>> = [
+      {
+        field: 'id',
+        name: '',
+        width: '32px',
+        render: (_id: string, tag: TagWithRelations) => (
+          <EuiRadio
+            id={`mergeDuplicateTagsRadio-${tag.id}`}
+            data-test-subj={`mergeDuplicateTagsRadio-${tag.id}`}
+            checked={tag.id === canonicalId}
+            disabled={tag.managed}
+            onChange={() => setCanonicalId(tag.id)}
+            aria-label={i18n.translate(
+              'xpack.savedObjectsTagging.management.merge.select.table.keepAriaLabel',
+              { defaultMessage: 'Keep the "{name}" tag', values: { name: tag.name } }
+            )}
+          />
+        ),
+      },
+      {
+        field: 'name',
+        name: i18n.translate('xpack.savedObjectsTagging.management.merge.select.table.tag', {
+          defaultMessage: 'Tag',
+        }),
+        sortable: true,
+        render: (_name: string, tag: TagWithRelations) => (
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <TagBadge tag={tag} />
+            </EuiFlexItem>
+            {tag.managed && (
+              <EuiFlexItem grow={false}>
+                <EuiIconTip
+                  type="lock"
+                  content={i18n.translate(
+                    'xpack.savedObjectsTagging.management.merge.select.table.managedTooltip',
+                    {
+                      defaultMessage: 'This tag is managed by Elastic and cannot be merged.',
+                    }
+                  )}
+                />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        ),
+      },
+      {
+        field: 'description',
+        name: i18n.translate(
+          'xpack.savedObjectsTagging.management.merge.select.table.description',
+          { defaultMessage: 'Description' }
+        ),
+        sortable: true,
+        render: (description: string) => description || null,
+      },
+      {
+        field: 'relationCount',
+        name: i18n.translate(
+          'xpack.savedObjectsTagging.management.merge.select.table.connections',
+          { defaultMessage: 'Connections' }
+        ),
+        sortable: true,
+        render: (count: number) =>
+          i18n.translate('xpack.savedObjectsTagging.management.merge.select.connectionCount', {
+            defaultMessage: '{count, plural, one {1 saved object} other {# saved objects}}',
+            values: { count },
+          }),
+      },
+    ];
+
+    const selectTableSorting = {
+      sort: { field: 'relationCount' as const, direction: 'desc' as const },
+    };
+
+    body = (
+      <>
+        {errorCallout}
+        <EuiText size="s">
+          <FormattedMessage
+            id="xpack.savedObjectsTagging.management.merge.select.description"
+            defaultMessage="Choose the tag to keep. All other tags with this name will be merged into it, and every saved object that references them will be updated to use the tag you keep."
+          />
+        </EuiText>
+        <EuiSpacer size="m" />
+        {selectableTags.length < 2 ? (
+          <EuiCallOut
+            color="danger"
+            title={i18n.translate(
+              'xpack.savedObjectsTagging.management.merge.select.notEnoughTags',
+              {
+                defaultMessage: 'Not enough non-managed tags in this group to merge.',
+              }
+            )}
+          />
+        ) : (
+          <EuiInMemoryTable
+            data-test-subj="mergeDuplicateTagsSelectTable"
+            items={tags}
+            columns={selectColumns}
+            sorting={selectTableSorting}
+            rowProps={(tag) =>
+              tag.managed
+                ? {}
+                : { onClick: () => setCanonicalId(tag.id), css: { cursor: 'pointer' } }
+            }
+          />
+        )}
+      </>
+    );
+
+    footer = (
+      <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={onClose}>
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.cancelButton"
+              defaultMessage="Cancel"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            data-test-subj="mergeDuplicateTagsNextButton"
+            fill
+            disabled={!canonicalId || selectableTags.length < 2}
+            onClick={goToPreview}
+          >
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.nextButton"
+              defaultMessage="Next"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  } else if (step === 'preview') {
+    body = (
+      <>
+        {errorCallout}
+        {previewLoading || !preview ? (
+          <EuiLoadingSpinner size="l" />
+        ) : (
+          <>
+            <EuiText size="s">
+              <FormattedMessage
+                id="xpack.savedObjectsTagging.management.merge.preview.affectedCount"
+                defaultMessage='{count, plural, one {1 saved object} other {# saved objects}} will be updated to use the "{name}" tag.'
+                values={{ count: preview.affectedCount, name: canonicalTag?.name }}
+              />{' '}
+              {preview.affectedCount > 0 && (
+                <EuiLink
+                  data-test-subj="mergeDuplicateTagsViewAffectedObjectsLink"
+                  onClick={toggleAffectedObjects}
+                >
+                  {showAffectedObjects
+                    ? i18n.translate(
+                        'xpack.savedObjectsTagging.management.merge.preview.hideAffectedObjects',
+                        { defaultMessage: 'Hide affected objects' }
+                      )
+                    : i18n.translate(
+                        'xpack.savedObjectsTagging.management.merge.preview.viewAffectedObjects',
+                        { defaultMessage: 'View affected objects' }
+                      )}
+                </EuiLink>
+              )}
+            </EuiText>
+            {showAffectedObjects && (
+              <>
+                <EuiSpacer size="s" />
+                <EuiBasicTable
+                  data-test-subj="mergeDuplicateTagsAffectedObjectsTable"
+                  loading={affectedObjectsLoading}
+                  items={affectedObjects?.objects ?? []}
+                  columns={affectedObjectsColumns}
+                  pagination={{
+                    pageIndex: affectedObjectsPage,
+                    pageSize: AFFECTED_OBJECTS_PAGE_SIZE,
+                    totalItemCount: affectedObjects?.total ?? 0,
+                    showPerPageOptions: false,
+                  }}
+                  onChange={({ page }: Criteria<MergeAffectedObject>) =>
+                    loadAffectedObjects(page?.index ?? 0)
+                  }
+                />
+              </>
+            )}
+            <EuiSpacer size="m" />
+            {!preview.canStartMerge.allowed && (
+              <>
+                <EuiCallOut
+                  color="danger"
+                  title={i18n.translate(
+                    'xpack.savedObjectsTagging.management.merge.preview.cannotStart',
+                    {
+                      defaultMessage: 'You cannot start this merge',
+                    }
+                  )}
+                >
+                  <ul>
+                    {preview.canStartMerge.reasons.map((reason) => (
+                      <li key={reason}>{reason}</li>
+                    ))}
+                  </ul>
+                </EuiCallOut>
+                <EuiSpacer size="m" />
+              </>
+            )}
+            <EuiCheckbox
+              id="mergeDuplicateTagsDeleteSources"
+              data-test-subj="mergeDuplicateTagsDeleteSourcesCheckbox"
+              checked={deleteSources}
+              disabled={!preview.canRequestDeleteSources.allowed}
+              onChange={(e) => setDeleteSources(e.target.checked)}
+              label={i18n.translate(
+                'xpack.savedObjectsTagging.management.merge.preview.deleteSources',
+                {
+                  defaultMessage:
+                    '{count, plural, one {Delete the duplicate tag} other {Delete the duplicate tags}} once the merge completes',
+                  values: { count: fromIds.length },
+                }
+              )}
+            />
+            {!preview.canRequestDeleteSources.allowed && (
+              <EuiText size="xs" color="subdued">
+                {preview.canRequestDeleteSources.reasons.join(' ')}
+              </EuiText>
+            )}
+          </>
+        )}
+      </>
+    );
+
+    footer = (
+      <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={() => setStep('select')}>
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.backButton"
+              defaultMessage="Back"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            data-test-subj="mergeDuplicateTagsStartButton"
+            fill
+            disabled={!preview || !preview.canStartMerge.allowed}
+            onClick={startMerge}
+          >
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.startButton"
+              defaultMessage="Start merge"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  } else if (step === 'running') {
+    const percent = status?.progress.percent;
+    const jobTagName = runningJobTagName(status?.job);
+    body = (
+      <>
+        {errorCallout}
+        {jobTagName && (
+          <>
+            <EuiText size="s">
+              <strong>
+                <FormattedMessage
+                  id="xpack.savedObjectsTagging.management.merge.running.mergingInto"
+                  defaultMessage='Merging duplicate tags into "{name}"'
+                  values={{ name: jobTagName }}
+                />
+              </strong>
+            </EuiText>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <EuiText size="s" color="subdued">
+          {phaseLabel(status?.phase ?? 'scanning')}
+        </EuiText>
+        <EuiSpacer size="s" />
+        {percent != null ? (
+          <EuiProgress value={percent} max={100} size="m" />
+        ) : (
+          <EuiProgress size="m" />
+        )}
+        <EuiSpacer size="s" />
+        <EuiText size="xs" color="subdued">
+          <FormattedMessage
+            id="xpack.savedObjectsTagging.management.merge.running.updatedCount"
+            defaultMessage="{updatedCount} of {totalAffected} saved objects updated"
+            values={{
+              updatedCount: status?.progress.updatedCount ?? 0,
+              totalAffected: status?.progress.totalAffected ?? '…',
+            }}
+          />
+        </EuiText>
+      </>
+    );
+
+    footer = (
+      <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            data-test-subj="mergeDuplicateTagsCancelJobButton"
+            color="danger"
+            onClick={() => setConfirmingCancel(true)}
+          >
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.cancelJobButton"
+              defaultMessage="Cancel merge"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  } else {
+    const success = status?.status === 'success';
+    const canceled = status?.status === 'canceled';
+    const jobTagName = runningJobTagName(status?.job);
+    const deletion = status?.deletion ?? [];
+    const deletedCount = deletion.filter((d) => d.deleted).length;
+    const notDeleted = deletion.filter((d) => !d.deleted);
+    const title = (defaultMessage: string) =>
+      jobTagName
+        ? i18n.translate('xpack.savedObjectsTagging.management.merge.done.titleWithTagName', {
+            defaultMessage: '{title} — merged into "{name}"',
+            values: { title: defaultMessage, name: jobTagName },
+          })
+        : defaultMessage;
+    body = (
+      <>
+        {errorCallout}
+        <EuiCallOut
+          data-test-subj="mergeDuplicateTagsResultCallout"
+          color={success ? 'success' : canceled ? 'warning' : 'danger'}
+          title={
+            success
+              ? title(
+                  i18n.translate('xpack.savedObjectsTagging.management.merge.done.successTitle', {
+                    defaultMessage: 'Merge complete',
+                  })
+                )
+              : canceled
+              ? title(
+                  i18n.translate('xpack.savedObjectsTagging.management.merge.done.canceledTitle', {
+                    defaultMessage: 'Merge canceled',
+                  })
+                )
+              : title(
+                  i18n.translate('xpack.savedObjectsTagging.management.merge.done.failedTitle', {
+                    defaultMessage: 'Merge failed',
+                  })
+                )
+          }
+        >
+          <FormattedMessage
+            id="xpack.savedObjectsTagging.management.merge.done.updatedCount"
+            defaultMessage="{updatedCount} saved objects were updated."
+            values={{ updatedCount: status?.progress.updatedCount ?? 0 }}
+          />
+          {status && status.errors.count > 0 && (
+            <>
+              {' '}
+              <FormattedMessage
+                id="xpack.savedObjectsTagging.management.merge.done.errorCount"
+                defaultMessage="{count, plural, one {1 object} other {# objects}} could not be updated."
+                values={{ count: status.errors.count }}
+              />
+            </>
+          )}
+          {deletedCount > 0 && (
+            <>
+              {' '}
+              <FormattedMessage
+                id="xpack.savedObjectsTagging.management.merge.done.deletedCount"
+                defaultMessage="{count, plural, one {1 duplicate tag} other {# duplicate tags}} deleted."
+                values={{ count: deletedCount }}
+              />
+            </>
+          )}
+        </EuiCallOut>
+        {notDeleted.length > 0 && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiFlexGroup direction="column" gutterSize="s">
+              {notDeleted.map((d) => {
+                const tag = getTagById.get(d.id);
+                const reason =
+                  d.remainingReferences != null
+                    ? i18n.translate(
+                        'xpack.savedObjectsTagging.management.merge.done.tagNotDeleted',
+                        {
+                          defaultMessage:
+                            'still referenced by {count, plural, one {1 object} other {# objects}}',
+                          values: { count: d.remainingReferences },
+                        }
+                      )
+                    : i18n.translate(
+                        'xpack.savedObjectsTagging.management.merge.done.tagDeleteError',
+                        {
+                          defaultMessage: 'could not be deleted: {error}',
+                          values: { error: d.error ?? 'unknown error' },
+                        }
+                      );
+                return (
+                  <EuiFlexItem key={d.id}>
+                    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                      <EuiFlexItem grow={false}>
+                        {tag ? <TagBadge tag={tag} /> : <EuiText size="s">{d.id}</EuiText>}
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiText size="s" color="subdued">
+                          {reason}
+                        </EuiText>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                );
+              })}
+            </EuiFlexGroup>
+          </>
+        )}
+      </>
+    );
+
+    footer = (
+      <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiButton data-test-subj="mergeDuplicateTagsCloseButton" fill onClick={handleClose}>
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.closeButton"
+              defaultMessage="Close"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <EuiFlyout
+      onClose={handleClose}
+      size="s"
+      data-test-subj="mergeDuplicateTagsFlyout"
+      aria-labelledby="mergeDuplicateTagsFlyoutTitle"
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id="mergeDuplicateTagsFlyoutTitle">
+            <FormattedMessage
+              id="xpack.savedObjectsTagging.management.merge.title"
+              defaultMessage="Merge duplicate tags"
+            />
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>{body}</EuiFlyoutBody>
+      <EuiFlyoutFooter>{footer}</EuiFlyoutFooter>
+      {confirmingCancel && (
+        <EuiConfirmModal
+          title={i18n.translate('xpack.savedObjectsTagging.management.merge.confirmCancel.title', {
+            defaultMessage: 'Cancel merge?',
+          })}
+          onCancel={() => setConfirmingCancel(false)}
+          onConfirm={confirmCancel}
+          cancelButtonText={i18n.translate(
+            'xpack.savedObjectsTagging.management.merge.confirmCancel.cancelButtonText',
+            { defaultMessage: 'Keep running' }
+          )}
+          confirmButtonText={i18n.translate(
+            'xpack.savedObjectsTagging.management.merge.confirmCancel.confirmButtonText',
+            { defaultMessage: 'Cancel merge' }
+          )}
+          buttonColor="danger"
+        >
+          <FormattedMessage
+            id="xpack.savedObjectsTagging.management.merge.confirmCancel.text"
+            defaultMessage="Objects already updated will keep the new tag. Objects not yet reached will keep their current tags."
+          />
+        </EuiConfirmModal>
+      )}
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/merge_in_progress_callout.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/merge_in_progress_callout.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React from 'react';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiButton, EuiSpacer } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+
+export interface MergeInProgressCalloutProps {
+  /** Name of the canonical tag the running job is merging into, if resolvable. */
+  tagName: string | undefined;
+  onViewProgress: () => void;
+}
+
+/**
+ * Merge jobs are singleton per space and run entirely server-side, so a job can still be running
+ * after the flyout that started it was closed (or started from another browser tab/session). This
+ * makes that discoverable from the Tag Management page itself, without having to reopen the
+ * flyout for a specific duplicate group first (which may 409 on "Start merge" without explaining
+ * why — see the flyout's own on-mount reattach check for the other half of this fix).
+ */
+export const MergeInProgressCallout: FC<MergeInProgressCalloutProps> = ({
+  tagName,
+  onViewProgress,
+}) => {
+  return (
+    <>
+      <EuiCallOut
+        data-test-subj="tagsMergeInProgressCallout"
+        color="primary"
+        iconType="clock"
+        title={
+          tagName
+            ? i18n.translate('xpack.savedObjectsTagging.management.mergeInProgress.titleWithName', {
+                defaultMessage: 'A tag merge into "{name}" is currently running.',
+                values: { name: tagName },
+              })
+            : i18n.translate('xpack.savedObjectsTagging.management.mergeInProgress.title', {
+                defaultMessage: 'A tag merge is currently running.',
+              })
+        }
+      >
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              data-test-subj="tagsMergeInProgressViewProgressButton"
+              onClick={onViewProgress}
+            >
+              <FormattedMessage
+                id="xpack.savedObjectsTagging.management.mergeInProgress.viewProgressButton"
+                defaultMessage="View progress"
+              />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiCallOut>
+      <EuiSpacer size="l" />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/mount_section.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/mount_section.tsx
@@ -12,13 +12,19 @@ import type { CoreSetup, ApplicationStart } from '@kbn/core/public';
 import type { ManagementAppMountParams } from '@kbn/management-plugin/public';
 import { getTagsCapabilities } from '../../common';
 import type { SavedObjectTaggingPluginStart } from '../types';
-import type { ITagInternalClient, ITagAssignmentService, ITagsCache } from '../services';
+import type {
+  ITagInternalClient,
+  ITagAssignmentService,
+  ITagsCache,
+  IMergeClient,
+} from '../services';
 import { TagManagementPage } from './tag_management_page';
 
 interface MountSectionParams {
   tagClient: ITagInternalClient;
   tagCache: ITagsCache;
   assignmentService: ITagAssignmentService;
+  mergeClient: IMergeClient;
   core: CoreSetup<{}, SavedObjectTaggingPluginStart>;
   mountParams: ManagementAppMountParams;
   title: string;
@@ -41,6 +47,7 @@ export const mountSection = async ({
   tagClient,
   tagCache,
   assignmentService,
+  mergeClient,
   core,
   mountParams,
   title,
@@ -60,6 +67,7 @@ export const mountSection = async ({
           tagClient={tagClient}
           tagCache={tagCache}
           assignmentService={assignmentService}
+          mergeClient={mergeClient}
           capabilities={capabilities}
           assignableTypes={assignableTypes}
         />

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/tag_management_page.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/tag_management_page.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useEffect, useCallback, useState, useMemo } from 'react';
+import React, { useEffect, useCallback, useState, useMemo, useRef } from 'react';
 import { Subject } from 'rxjs';
 import useMount from 'react-use/lib/useMount';
 import { Query } from '@elastic/eui';
@@ -15,13 +15,33 @@ import type { ChromeBreadcrumb, CoreStart } from '@kbn/core/public';
 import { EuiSpacer } from '@elastic/eui';
 import type { TagsCapabilities } from '../../common';
 import type { TagWithRelations } from '../../common/types';
+import type { MergeStatusResponse } from '../../common/merge';
 import { getCreateModalOpener } from '../components/edition_modal';
-import type { ITagInternalClient, ITagAssignmentService, ITagsCache } from '../services';
+import type {
+  ITagInternalClient,
+  ITagAssignmentService,
+  ITagsCache,
+  IMergeClient,
+} from '../services';
 import type { TagBulkAction } from './types';
-import { Header, TagTable, ActionBar } from './components';
+import {
+  Header,
+  TagTable,
+  ActionBar,
+  DuplicateTagsCallout,
+  MergeInProgressCallout,
+  MergeDuplicateTagsFlyout,
+} from './components';
 import { getTableActions } from './actions';
 import { getBulkActions } from './bulk_actions';
-import { getTagConnectionsUrl } from './utils';
+import {
+  getTagConnectionsUrl,
+  groupDuplicateTagsByName,
+  buildTagNameLookup,
+  type DuplicateTagGroup,
+} from './utils';
+
+const MERGE_STATUS_POLL_INTERVAL_MS = 5000;
 
 interface TagManagementPageParams {
   setBreadcrumbs: (crumbs: ChromeBreadcrumb[]) => void;
@@ -29,6 +49,7 @@ interface TagManagementPageParams {
   tagClient: ITagInternalClient;
   tagCache: ITagsCache;
   assignmentService: ITagAssignmentService;
+  mergeClient: IMergeClient;
   capabilities: TagsCapabilities;
   assignableTypes: string[];
 }
@@ -39,6 +60,7 @@ export const TagManagementPage: FC<TagManagementPageParams> = ({
   tagClient,
   tagCache,
   assignmentService,
+  mergeClient,
   capabilities,
   assignableTypes,
 }) => {
@@ -47,6 +69,8 @@ export const TagManagementPage: FC<TagManagementPageParams> = ({
   const [allTags, setAllTags] = useState<TagWithRelations[]>([]);
   const [selectedTags, setSelectedTags] = useState<TagWithRelations[]>([]);
   const [query, setQuery] = useState<Query | undefined>();
+  const [mergingGroup, setMergingGroup] = useState<DuplicateTagGroup | undefined>();
+  const [mergeStatus, setMergeStatus] = useState<MergeStatusResponse | undefined>();
 
   const filteredTags = useMemo(() => {
     return query ? Query.execute(query, allTags) : allTags;
@@ -72,9 +96,59 @@ export const TagManagementPage: FC<TagManagementPageParams> = ({
     setLoading(false);
   }, [tagClient]);
 
+  // A merge job deletes duplicate source tags server-side, via an async Task Manager task, not
+  // through this client — so the shared `TagsCache` (used by tag pickers elsewhere in the app)
+  // never sees it through its normal onDidDelete hook. Force a refresh so those pickers don't
+  // keep offering deleted tags until the cache's own periodic refresh or a page reload.
+  const refreshAfterMerge = useCallback(async () => {
+    await Promise.all([fetchTags(), tagClient.invalidateCache()]);
+  }, [fetchTags, tagClient]);
+
   useMount(() => {
     fetchTags();
   });
+
+  // Merge jobs are singleton per space and run entirely server-side, so one can still be running
+  // (or finish) even if the flyout that started it was never opened on this page load. Poll
+  // independently of the flyout so both the "in progress" banner and the tag list itself
+  // (including the now-stale duplicate-tags warning once source tags are deleted) stay correct
+  // even when nothing ever opened the flyout to trigger its own `onMerged` refresh.
+  const wasInProgressRef = useRef(false);
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const result = await mergeClient.status();
+        if (cancelled) {
+          return;
+        }
+        setMergeStatus(result);
+        if (wasInProgressRef.current && result.status !== 'in_progress') {
+          refreshAfterMerge();
+        }
+        wasInProgressRef.current = result.status === 'in_progress';
+      } catch (e) {
+        // best-effort awareness banner; a failed poll just tries again next interval.
+      }
+    };
+    poll();
+    const interval = setInterval(poll, MERGE_STATUS_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [mergeClient, refreshAfterMerge]);
+
+  const getTagName = useMemo(() => buildTagNameLookup(allTags), [allTags]);
+  const duplicateGroups = useMemo(() => groupDuplicateTagsByName(allTags), [allTags]);
+
+  const viewMergeProgress = useCallback(() => {
+    const runningToId = mergeStatus?.job?.toId;
+    const runningGroup = duplicateGroups.find((group) =>
+      group.tags.some((tag) => tag.id === runningToId)
+    );
+    setMergingGroup(runningGroup ?? { normalizedName: '', tags: [] });
+  }, [mergeStatus, duplicateGroups]);
 
   const createModalOpener = useMemo(
     () => getCreateModalOpener({ ...startServices, tagClient }),
@@ -199,6 +273,13 @@ export const TagManagementPage: FC<TagManagementPageParams> = ({
     <>
       <Header canCreate={capabilities.create} onCreate={openCreateModal} />
       <EuiSpacer size="l" />
+      {mergeStatus?.status === 'in_progress' && (
+        <MergeInProgressCallout
+          tagName={mergeStatus.job ? getTagName(mergeStatus.job.toId) : undefined}
+          onViewProgress={viewMergeProgress}
+        />
+      )}
+      <DuplicateTagsCallout groups={duplicateGroups} onMergeGroup={setMergingGroup} />
       <TagTable
         loading={loading}
         tags={filteredTags}
@@ -220,6 +301,15 @@ export const TagManagementPage: FC<TagManagementPageParams> = ({
           showTagRelations(tag);
         }}
       />
+      {mergingGroup && (
+        <MergeDuplicateTagsFlyout
+          tags={mergingGroup.tags}
+          allTags={allTags}
+          mergeClient={mergeClient}
+          onClose={() => setMergingGroup(undefined)}
+          onMerged={refreshAfterMerge}
+        />
+      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/group_duplicate_tags.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/group_duplicate_tags.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TagWithRelations } from '../../../common/types';
+import { groupDuplicateTagsByName } from './group_duplicate_tags';
+
+const createTag = (id: string, name: string, managed = false): TagWithRelations => ({
+  id,
+  name,
+  description: '',
+  color: '#FF0088',
+  managed,
+  relationCount: 0,
+});
+
+describe('groupDuplicateTagsByName', () => {
+  it('returns no groups when there are no duplicate names', () => {
+    const tags = [createTag('1', 'foo'), createTag('2', 'bar')];
+    expect(groupDuplicateTagsByName(tags)).toEqual([]);
+  });
+
+  it('groups tags sharing the exact same name', () => {
+    const tags = [createTag('1', 'foo'), createTag('2', 'foo'), createTag('3', 'bar')];
+    const groups = groupDuplicateTagsByName(tags);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].tags.map((t) => t.id)).toEqual(['1', '2']);
+  });
+
+  it('normalizes names by trimming and lowercasing before grouping', () => {
+    const tags = [createTag('1', 'Foo'), createTag('2', ' foo '), createTag('3', 'FOO')];
+    const groups = groupDuplicateTagsByName(tags);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].tags.map((t) => t.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('includes managed tags in a group alongside non-managed duplicates', () => {
+    const tags = [createTag('1', 'foo', true), createTag('2', 'foo')];
+    const groups = groupDuplicateTagsByName(tags);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].tags.map((t) => t.id)).toEqual(['1', '2']);
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/group_duplicate_tags.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/group_duplicate_tags.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TagWithRelations } from '../../../common/types';
+
+export interface DuplicateTagGroup {
+  normalizedName: string;
+  tags: TagWithRelations[];
+}
+
+/** trim + lowercase: matches the case-insensitive comparison `convertTagNameToId` already uses. */
+export const normalizeTagName = (name: string) => name.trim().toLowerCase();
+
+/** Groups of 2+ tags sharing the same normalized name. */
+export const groupDuplicateTagsByName = (tags: TagWithRelations[]): DuplicateTagGroup[] => {
+  const byName = new Map<string, TagWithRelations[]>();
+  for (const tag of tags) {
+    const key = normalizeTagName(tag.name);
+    const group = byName.get(key);
+    if (group) {
+      group.push(tag);
+    } else {
+      byName.set(key, [tag]);
+    }
+  }
+
+  return [...byName.entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([normalizedName, group]) => ({ normalizedName, tags: group }));
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/tag_name_lookup.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/tag_name_lookup.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TagWithRelations } from '../../../common/types';
+import { buildTagNameLookup } from './tag_name_lookup';
+
+const createTag = (id: string, name: string): TagWithRelations => ({
+  id,
+  name,
+  description: '',
+  color: '#FF0088',
+  managed: false,
+  relationCount: 0,
+});
+
+describe('buildTagNameLookup', () => {
+  it('resolves a known id to its tag name', () => {
+    const getName = buildTagNameLookup([createTag('1', 'foo'), createTag('2', 'bar')]);
+    expect(getName('1')).toEqual('foo');
+    expect(getName('2')).toEqual('bar');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    const getName = buildTagNameLookup([createTag('1', 'foo')]);
+    expect(getName('unknown')).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/tag_name_lookup.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/utils/tag_name_lookup.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TagWithRelations } from '../../../common/types';
+
+/** Builds an id → name lookup, e.g. to resolve a merge job's `toId` to a display name. */
+export const buildTagNameLookup = (tags: TagWithRelations[]) => {
+  const nameById = new Map(tags.map((tag) => [tag.id, tag.name]));
+  return (id: string): string | undefined => nameById.get(id);
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/plugin.ts
@@ -12,7 +12,7 @@ import type { SavedObjectTaggingOssPluginSetup } from '@kbn/saved-objects-taggin
 import { tagManagementSectionId } from '../common/constants';
 import { getTagsCapabilities } from '../common/capabilities';
 import type { SavedObjectTaggingPluginStart } from './types';
-import { TagsClient, TagsCache, TagAssignmentService } from './services';
+import { TagsClient, TagsCache, TagAssignmentService, MergeClient } from './services';
 import { getUiApi } from './ui_api';
 import type { SavedObjectsTaggingClientConfigRawType } from './config';
 import { SavedObjectsTaggingClientConfig } from './config';
@@ -28,6 +28,7 @@ export class SavedObjectTaggingPlugin
   private tagClient?: TagsClient;
   private tagCache?: TagsCache;
   private assignmentService?: TagAssignmentService;
+  private mergeClient?: MergeClient;
   private readonly config: SavedObjectsTaggingClientConfig;
 
   constructor(context: PluginInitializerContext) {
@@ -54,6 +55,7 @@ export class SavedObjectTaggingPlugin
           tagClient: this.tagClient!,
           tagCache: this.tagCache!,
           assignmentService: this.assignmentService!,
+          mergeClient: this.mergeClient!,
           core,
           mountParams,
           title,
@@ -81,6 +83,7 @@ export class SavedObjectTaggingPlugin
     });
 
     this.assignmentService = new TagAssignmentService({ http });
+    this.mergeClient = new MergeClient(http);
 
     // do not fetch tags on anonymous page
     if (!http.anonymousPaths.isAnonymous(window.location.pathname)) {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/index.ts
@@ -14,3 +14,5 @@ export type {
 export { TagsCache, TagsClient, isServerValidationError } from './tags';
 export type { ITagAssignmentService } from './assignments';
 export { TagAssignmentService } from './assignments';
+export type { IMergeClient } from './merge';
+export { MergeClient } from './merge';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/merge/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/merge/index.ts
@@ -5,7 +5,5 @@
  * 2.0.
  */
 
-export { getTagConnectionsUrl } from './get_tag_connections_url';
-export type { DuplicateTagGroup } from './group_duplicate_tags';
-export { groupDuplicateTagsByName } from './group_duplicate_tags';
-export { buildTagNameLookup } from './tag_name_lookup';
+export type { IMergeClient } from './merge_client';
+export { MergeClient } from './merge_client';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/merge/merge_client.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/merge/merge_client.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpSetup } from '@kbn/core/public';
+import type {
+  MergePreviewRequest,
+  MergePreviewResponse,
+  MergePreviewObjectsResponse,
+  MergeStartRequest,
+  MergeStatusResponse,
+} from '../../../common/merge';
+
+const BASE_PATH = '/internal/saved_objects_tagging/tags/merge';
+
+export interface IMergeClient {
+  preview(request: MergePreviewRequest): Promise<MergePreviewResponse>;
+  previewObjects(
+    request: MergePreviewRequest & { page: number; perPage: number }
+  ): Promise<MergePreviewObjectsResponse>;
+  start(request: MergeStartRequest): Promise<void>;
+  status(): Promise<MergeStatusResponse>;
+  cancel(): Promise<void>;
+}
+
+export class MergeClient implements IMergeClient {
+  constructor(private readonly http: HttpSetup) {}
+
+  public preview(request: MergePreviewRequest) {
+    return this.http.post<MergePreviewResponse>(`${BASE_PATH}/preview`, {
+      body: JSON.stringify(request),
+    });
+  }
+
+  public previewObjects({
+    toId,
+    fromIds,
+    page,
+    perPage,
+  }: MergePreviewRequest & { page: number; perPage: number }) {
+    return this.http.get<MergePreviewObjectsResponse>(`${BASE_PATH}/preview/objects`, {
+      query: { toId, fromIds, page, perPage },
+    });
+  }
+
+  public async start(request: MergeStartRequest) {
+    await this.http.post<{}>(BASE_PATH, { body: JSON.stringify(request) });
+  }
+
+  public status() {
+    return this.http.get<MergeStatusResponse>(BASE_PATH);
+  }
+
+  public async cancel() {
+    await this.http.post<{}>(`${BASE_PATH}/cancel`);
+  }
+}

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.mock.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.mock.ts
@@ -17,6 +17,7 @@ const createInternalClientMock = () => {
     find: jest.fn(),
     findByName: jest.fn(),
     bulkDelete: jest.fn(),
+    invalidateCache: jest.fn(),
   };
 
   return mock;

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.ts
@@ -67,6 +67,13 @@ const trapErrors = (fn: () => void) => {
 export interface ITagInternalClient extends ITagsClient {
   find(options: FindTagsOptions): Promise<FindTagsResponse>;
   bulkDelete(ids: string[]): Promise<void>;
+  /**
+   * Refreshes the shared `TagsCache` (if one is configured) from the server, so other consumers
+   * of that cache (tag pickers elsewhere in the app) see changes made outside this client — e.g.
+   * a tag deleted by an async, server-side job — without waiting for the cache's own periodic
+   * refresh or a full page reload.
+   */
+  invalidateCache(): Promise<void>;
 }
 
 export class TagsClient implements ITagInternalClient {
@@ -171,6 +178,11 @@ export class TagsClient implements ITagInternalClient {
     });
 
     return tags;
+  }
+
+  /** See {@link ITagInternalClient.invalidateCache}. */
+  public async invalidateCache() {
+    await this.fetchAllFromNetwork();
   }
 
   public async getAll(options: GetAllTagsOptions = {}) {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.test.ts
@@ -10,6 +10,7 @@ import { registerRoutesMock, createTagUsageCollectorMock } from './plugin.test.m
 import { coreMock } from '@kbn/core/server/mocks';
 import { featuresPluginMock } from '@kbn/features-plugin/server/mocks';
 import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { SavedObjectTaggingPlugin } from './plugin';
 import { savedObjectsTaggingFeature } from './features';
 
@@ -17,11 +18,15 @@ describe('SavedObjectTaggingPlugin', () => {
   let plugin: SavedObjectTaggingPlugin;
   let featuresPluginSetup: ReturnType<typeof featuresPluginMock.createSetup>;
   let usageCollectionSetup: ReturnType<typeof usageCollectionPluginMock.createSetupContract>;
+  let taskManagerSetup: ReturnType<typeof taskManagerMock.createSetup>;
+  let taskManagerStart: ReturnType<typeof taskManagerMock.createStart>;
 
   beforeEach(() => {
     plugin = new SavedObjectTaggingPlugin();
     featuresPluginSetup = featuresPluginMock.createSetup();
     usageCollectionSetup = usageCollectionPluginMock.createSetupContract();
+    taskManagerSetup = taskManagerMock.createSetup();
+    taskManagerStart = taskManagerMock.createStart();
     // `usageCollection` 'mocked' implementation use the real `CollectorSet` implementation
     // that throws when registering things that are not collectors.
     // We just want to assert that it was called here, so jest.fn is fine.
@@ -35,13 +40,16 @@ describe('SavedObjectTaggingPlugin', () => {
 
   describe('#setup', () => {
     it('registers routes', async () => {
-      await plugin.setup(coreMock.createSetup(), { features: featuresPluginSetup });
+      await plugin.setup(coreMock.createSetup(), {
+        features: featuresPluginSetup,
+        taskManager: taskManagerSetup,
+      });
       expect(registerRoutesMock).toHaveBeenCalledTimes(1);
     });
 
     it('registers the globalSearch route handler context', async () => {
       const coreSetup = coreMock.createSetup();
-      plugin.setup(coreSetup, { features: featuresPluginSetup });
+      plugin.setup(coreSetup, { features: featuresPluginSetup, taskManager: taskManagerSetup });
       expect(coreSetup.http.registerRouteHandlerContext).toHaveBeenCalledTimes(1);
       expect(coreSetup.http.registerRouteHandlerContext).toHaveBeenCalledWith(
         'tags',
@@ -50,7 +58,10 @@ describe('SavedObjectTaggingPlugin', () => {
     });
 
     it('registers the `savedObjectsTagging` feature', async () => {
-      plugin.setup(coreMock.createSetup(), { features: featuresPluginSetup });
+      plugin.setup(coreMock.createSetup(), {
+        features: featuresPluginSetup,
+        taskManager: taskManagerSetup,
+      });
       expect(featuresPluginSetup.registerKibanaFeature).toHaveBeenCalledTimes(1);
       expect(featuresPluginSetup.registerKibanaFeature).toHaveBeenCalledWith(
         savedObjectsTaggingFeature
@@ -64,6 +75,7 @@ describe('SavedObjectTaggingPlugin', () => {
       plugin.setup(coreMock.createSetup(), {
         features: featuresPluginSetup,
         usageCollection: usageCollectionSetup,
+        taskManager: taskManagerSetup,
       });
 
       expect(usageCollectionSetup.registerCollector).toHaveBeenCalledTimes(1);
@@ -73,8 +85,11 @@ describe('SavedObjectTaggingPlugin', () => {
 
   describe('#start', () => {
     it('returns the expected contract', () => {
-      plugin.setup(coreMock.createSetup(), { features: featuresPluginSetup });
-      const contract = plugin.start(coreMock.createStart(), {});
+      plugin.setup(coreMock.createSetup(), {
+        features: featuresPluginSetup,
+        taskManager: taskManagerSetup,
+      });
+      const contract = plugin.start(coreMock.createStart(), { taskManager: taskManagerStart });
 
       expect(contract).toEqual({
         createTagClient: expect.any(Function),

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.ts
@@ -9,6 +9,11 @@ import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { UsageCollectionSetup, UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
 import { savedObjectsTaggingFeature } from './features';
 import { tagType } from './saved_objects';
 import type {
@@ -19,6 +24,7 @@ import type {
 } from './types';
 import { TagsRequestHandlerContext } from './request_handler_context';
 import { registerRoutes } from './routes';
+import { registerTagMergeTaskType } from './tasks/tag_merge';
 import { createTagUsageCollector } from './usage';
 import { TagsClient, AssignmentService } from './services';
 import { convertTagNameToId, getTagsFromReferences, replaceTagReferences } from '../common';
@@ -27,10 +33,13 @@ interface SetupDeps {
   features: FeaturesPluginSetup;
   usageCollection?: UsageCollectionSetup;
   security?: SecurityPluginSetup;
+  spaces?: SpacesPluginSetup;
+  taskManager: TaskManagerSetupContract;
 }
 
 interface StartDeps {
   security?: SecurityPluginStart;
+  taskManager: TaskManagerStartContract;
 }
 
 export class SavedObjectTaggingPlugin
@@ -38,7 +47,7 @@ export class SavedObjectTaggingPlugin
 {
   public setup(
     { savedObjects, http, getStartServices }: CoreSetup<StartDeps, SavedObjectTaggingStart>,
-    { features, usageCollection, security }: SetupDeps
+    { features, usageCollection, security, spaces, taskManager }: SetupDeps
   ) {
     savedObjects.registerType(tagType);
 
@@ -46,7 +55,11 @@ export class SavedObjectTaggingPlugin
     const apiUsageCounter: UsageCounter | undefined = usageCollection?.createUsageCounter(
       'saved_objects_tagging_api'
     );
-    registerRoutes({ router, usageCounter: apiUsageCounter });
+    registerRoutes({
+      router,
+      usageCounter: apiUsageCounter,
+      mergeRouteDeps: { getStartServices, spacesService: spaces?.spacesService },
+    });
 
     http.registerRouteHandlerContext<TagsHandlerContext, 'tags'>(
       'tags',
@@ -56,6 +69,8 @@ export class SavedObjectTaggingPlugin
     );
 
     features.registerKibanaFeature(savedObjectsTaggingFeature);
+
+    registerTagMergeTaskType({ taskManager, getStartServices });
 
     if (usageCollection) {
       const getKibanaIndices = () =>

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/request_handler_context.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/request_handler_context.ts
@@ -9,11 +9,18 @@ import type { CoreRequestHandlerContext, KibanaRequest } from '@kbn/core/server'
 import type { SecurityPluginSetup } from '@kbn/security-plugin/server';
 import type { ITagsClient } from '../common/types';
 import type { ITagsRequestHandlerContext } from './types';
-import { TagsClient, type IAssignmentService, AssignmentService } from './services';
+import {
+  TagsClient,
+  type IAssignmentService,
+  AssignmentService,
+  type IMergeService,
+  MergeService,
+} from './services';
 
 export class TagsRequestHandlerContext implements ITagsRequestHandlerContext {
   #client?: ITagsClient;
   #assignmentService?: IAssignmentService;
+  #mergeService?: IMergeService;
 
   constructor(
     private readonly request: KibanaRequest,
@@ -38,5 +45,18 @@ export class TagsRequestHandlerContext implements ITagsRequestHandlerContext {
       });
     }
     return this.#assignmentService;
+  }
+
+  public get mergeService() {
+    if (this.#mergeService == null) {
+      this.#mergeService = new MergeService({
+        request: this.request,
+        client: this.coreContext.savedObjects.client,
+        typeRegistry: this.coreContext.savedObjects.typeRegistry,
+        tagsClient: this.tagsClient,
+        authorization: this.security?.authz,
+      });
+    }
+    return this.#mergeService;
   }
 }

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/index.ts
@@ -24,14 +24,24 @@ import {
   registerInternalBulkDeleteRoute,
   registerInternalGetAllTagsRoute,
 } from './internal';
+import {
+  registerMergePreviewRoute,
+  registerMergePreviewObjectsRoute,
+  registerMergeStartRoute,
+  registerMergeStatusRoute,
+  registerMergeCancelRoute,
+  type MergeRouteDeps,
+} from './merge';
 import type { TagsPluginRouter } from '../types';
 
 export const registerRoutes = ({
   router,
   usageCounter,
+  mergeRouteDeps,
 }: {
   router: TagsPluginRouter;
   usageCounter?: UsageCounter;
+  mergeRouteDeps: MergeRouteDeps;
 }) => {
   // public API
   registerApiRoutes(router, usageCounter);
@@ -50,4 +60,10 @@ export const registerRoutes = ({
   registerInternalFindTagsRoute(router);
   registerInternalBulkDeleteRoute(router);
   registerInternalGetAllTagsRoute(router);
+  // merge duplicate tags API
+  registerMergePreviewRoute(router, mergeRouteDeps);
+  registerMergePreviewObjectsRoute(router);
+  registerMergeStartRoute(router, mergeRouteDeps);
+  registerMergeStatusRoute(router, mergeRouteDeps);
+  registerMergeCancelRoute(router, mergeRouteDeps);
 };

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/cancel.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/cancel.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, coreMock } from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { registerMergeCancelRoute } from './cancel';
+
+describe('registerMergeCancelRoute', () => {
+  let router: { post: jest.Mock; handleLegacyErrors: jest.Mock };
+  let taskManager: ReturnType<typeof taskManagerMock.createStart>;
+
+  const getHandler = () => router.post.mock.calls[0][1];
+
+  beforeEach(() => {
+    router = {
+      post: jest.fn(),
+      handleLegacyErrors: jest.fn((fn) => fn),
+    };
+    taskManager = taskManagerMock.createStart();
+    taskManager.runSoon.mockResolvedValue(undefined as any);
+    taskManager.bulkUpdateState.mockResolvedValue({ tasks: [], errors: [] });
+
+    registerMergeCancelRoute(router as any, {
+      getStartServices: () =>
+        Promise.resolve([coreMock.createStart(), { taskManager, security: undefined }, undefined]),
+      spacesService: undefined,
+    });
+  });
+
+  const callHandler = async () => {
+    const req = httpServerMock.createKibanaRequest();
+    const res = httpServerMock.createResponseFactory();
+    await getHandler()({}, req, res);
+    return { req, res };
+  };
+
+  it('returns 404 when there is no merge job in this space', async () => {
+    taskManager.get.mockRejectedValue(new Error('not found'));
+
+    const { res } = await callHandler();
+
+    expect(res.notFound).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkUpdateState).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the job has already finished', async () => {
+    taskManager.get.mockResolvedValue(taskManagerMock.createTask({ state: { status: 'success' } }));
+
+    const { res } = await callHandler();
+
+    expect(taskManager.bulkUpdateState).not.toHaveBeenCalled();
+    expect(res.ok).toHaveBeenCalledWith({ body: {} });
+  });
+
+  it('flips `cancelRequested` and nudges the task to run soon when in progress', async () => {
+    // the cancel/status routes derive the task id from the space id, not from `task.id`
+    const taskId = 'saved_objects_tagging:tag_merge:default';
+    const task = taskManagerMock.createTask({ state: { status: 'in_progress' } });
+    taskManager.get.mockResolvedValue(task);
+
+    const { req, res } = await callHandler();
+
+    // `{ request: req }` is required: this task carries an encrypted apiKey/userScope, and
+    // TaskStore.getSoClientForUpdate throws synchronously if bulk-updating such a task without
+    // a request to build the decrypting SO client from (see cancel.ts's comment).
+    expect(taskManager.bulkUpdateState).toHaveBeenCalledWith([taskId], expect.any(Function), {
+      request: req,
+    });
+    const [, stateMapFn] = taskManager.bulkUpdateState.mock.calls[0];
+    expect(stateMapFn({ status: 'in_progress', cancelRequested: false }, taskId)).toEqual({
+      status: 'in_progress',
+      cancelRequested: true,
+    });
+    expect(taskManager.runSoon).toHaveBeenCalledWith(taskId);
+    expect(res.ok).toHaveBeenCalledWith({ body: {} });
+  });
+
+  it('does not fail the request if `runSoon` rejects', async () => {
+    taskManager.get.mockResolvedValue(
+      taskManagerMock.createTask({ id: 'task-1', state: { status: 'in_progress' } })
+    );
+    taskManager.runSoon.mockRejectedValue(new Error('task is not idle'));
+
+    const { res } = await callHandler();
+
+    expect(res.ok).toHaveBeenCalledWith({ body: {} });
+  });
+
+  it('reports a server error, and does not call `runSoon`, if `bulkUpdateState` failed to persist the flag', async () => {
+    // e.g. a persistent version conflict after task manager's own internal retries.
+    taskManager.get.mockResolvedValue(
+      taskManagerMock.createTask({ id: 'task-1', state: { status: 'in_progress' } })
+    );
+    taskManager.bulkUpdateState.mockResolvedValue({
+      tasks: [],
+      errors: [
+        {
+          id: 'task-1',
+          type: 'task',
+          error: { error: 'Conflict', message: 'Conflict', statusCode: 409 },
+        },
+      ],
+    });
+
+    const { res } = await callHandler();
+
+    expect(res.customError).toHaveBeenCalledWith({
+      statusCode: 500,
+      body: 'Failed to cancel the merge job: Conflict',
+    });
+    expect(taskManager.runSoon).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/cancel.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/cancel.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TagsPluginRouter } from '../../types';
+import { getTagMergeTaskId, type TagMergeTaskState } from '../../tasks/tag_merge';
+import { DEFAULT_SPACE_ID, type MergeRouteDeps } from './types';
+
+export const registerMergeCancelRoute = (
+  router: TagsPluginRouter,
+  { getStartServices, spacesService }: MergeRouteDeps
+) => {
+  router.post(
+    {
+      path: '/internal/saved_objects_tagging/tags/merge/cancel',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route only cancels the current user’s own merge job.',
+        },
+      },
+      validate: {},
+    },
+    router.handleLegacyErrors(async (ctx, req, res) => {
+      const spaceId = spacesService?.getSpaceId(req) ?? DEFAULT_SPACE_ID;
+      const taskId = getTagMergeTaskId(spaceId);
+      const [, { taskManager }] = await getStartServices();
+
+      const task = await taskManager.get(taskId).catch(() => undefined);
+      if (!task) {
+        return res.notFound({ body: 'No merge job found in this space' });
+      }
+      if ((task.state as TagMergeTaskState).status !== 'in_progress') {
+        // already finished; nothing to cancel
+        return res.ok({ body: {} });
+      }
+
+      // `{ request: req }` is required here, not optional: this task's state carries an
+      // encrypted `apiKey`/`userScope` (per-user execution, see start.ts), and
+      // `TaskStore.getSoClientForUpdate` throws synchronously if asked to bulk-update a task
+      // with encrypted fields without a request to build the decrypting SO client from.
+      const { errors } = await taskManager.bulkUpdateState(
+        [taskId],
+        (state) => ({ ...state, cancelRequested: true }),
+        { request: req }
+      );
+      if (errors.length > 0) {
+        // e.g. a persistent version conflict after task manager's own retries: cancelRequested
+        // was NOT persisted, so don't report success — the merge will keep running otherwise.
+        return res.customError({
+          statusCode: 500,
+          body: `Failed to cancel the merge job: ${errors[0].error.message}`,
+        });
+      }
+      // if the task is idle (between self-reschedules), nudge it to pick up the cancel promptly
+      await taskManager.runSoon(taskId).catch(() => {});
+
+      return res.ok({ body: {} });
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { registerMergePreviewRoute } from './preview';
+export { registerMergePreviewObjectsRoute } from './preview_objects';
+export { registerMergeStartRoute } from './start';
+export { registerMergeStatusRoute } from './status';
+export { registerMergeCancelRoute } from './cancel';
+export type { MergeRouteDeps, MergeRouteStartDeps } from './types';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, coreMock } from '@kbn/core/server/mocks';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { MergeError } from '../../services';
+import { registerMergePreviewRoute } from './preview';
+
+describe('registerMergePreviewRoute', () => {
+  let router: { post: jest.Mock; handleLegacyErrors: jest.Mock };
+  let mergeService: {
+    normalizeFromIds: jest.Mock;
+    assertTagsNotManaged: jest.Mock;
+    getUpdatableTaggableTypes: jest.Mock;
+    getKnownTaggableTypes: jest.Mock;
+    computeAffectedCount: jest.Mock;
+    checkStartGate: jest.Mock;
+    checkDeleteSourcesGate: jest.Mock;
+  };
+  let coreStart: ReturnType<typeof coreMock.createStart>;
+  let internalClient: jest.Mocked<SavedObjectsClientContract>;
+
+  const getHandler = () => router.post.mock.calls[0][1];
+
+  beforeEach(() => {
+    router = {
+      post: jest.fn(),
+      handleLegacyErrors: jest.fn((fn) => fn),
+    };
+    mergeService = {
+      normalizeFromIds: jest.fn((toId, fromIds) => fromIds.filter((id: string) => id !== toId)),
+      assertTagsNotManaged: jest.fn().mockResolvedValue(undefined),
+      getUpdatableTaggableTypes: jest.fn().mockResolvedValue(['dashboard']),
+      getKnownTaggableTypes: jest.fn().mockReturnValue(['dashboard', 'osquery-pack']),
+      computeAffectedCount: jest
+        .fn()
+        .mockResolvedValue({ affectedCount: 3, byType: { dashboard: 3 } }),
+      checkStartGate: jest.fn().mockResolvedValue({ allowed: true, reasons: [] }),
+      checkDeleteSourcesGate: jest.fn().mockResolvedValue({ allowed: true, reasons: [] }),
+    };
+
+    coreStart = coreMock.createStart();
+    internalClient = coreStart.savedObjects.getUnsafeInternalClient() as jest.Mocked<
+      typeof internalClient
+    >;
+    internalClient.find.mockResolvedValue({
+      saved_objects: [],
+      total: 3,
+      page: 1,
+      per_page: 0,
+    });
+
+    registerMergePreviewRoute(router as any, {
+      getStartServices: () =>
+        Promise.resolve([coreStart, { taskManager: taskManagerMock.createStart() }, undefined]),
+    });
+  });
+
+  const callHandler = async (body: object) => {
+    const req = httpServerMock.createKibanaRequest({ body });
+    const res = httpServerMock.createResponseFactory();
+    const ctx = { tags: Promise.resolve({ mergeService }) };
+    await getHandler()(ctx, req, res);
+    return res;
+  };
+
+  it('rejects when `fromIds` is empty after removing `toId`', async () => {
+    const res = await callHandler({ toId: 'to-1', fromIds: ['to-1'] });
+
+    expect(res.badRequest).toHaveBeenCalledTimes(1);
+    expect(mergeService.assertTagsNotManaged).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the MergeError status when a tag is managed', async () => {
+    mergeService.assertTagsNotManaged.mockRejectedValue(new MergeError('nope', 400));
+
+    const res = await callHandler({ toId: 'to-1', fromIds: ['from-1'] });
+
+    expect(res.customError).toHaveBeenCalledWith({ statusCode: 400, body: 'nope' });
+  });
+
+  it('rethrows non-MergeError errors from `assertTagsNotManaged`', async () => {
+    mergeService.assertTagsNotManaged.mockRejectedValue(new Error('boom'));
+
+    await expect(callHandler({ toId: 'to-1', fromIds: ['from-1'] })).rejects.toThrow('boom');
+  });
+
+  it('returns the affected count, byType breakdown, and gate results', async () => {
+    const res = await callHandler({ toId: 'to-1', fromIds: ['from-1'] });
+
+    expect(mergeService.computeAffectedCount).toHaveBeenCalledWith({
+      fromIds: ['from-1'],
+      types: ['dashboard'],
+    });
+    // `checkStartGate` is gated on the just-computed `affectedCount`, not a generic
+    // "can update any taggable type" signal — see merge_service.ts's doc comment.
+    expect(mergeService.checkStartGate).toHaveBeenCalledWith({ affectedCount: 3 });
+    expect(res.ok).toHaveBeenCalledWith({
+      body: {
+        affectedCount: 3,
+        byType: { dashboard: 3 },
+        canStartMerge: { allowed: true, reasons: [] },
+        canRequestDeleteSources: { allowed: true, reasons: [] },
+      },
+    });
+  });
+
+  it('gates deleteSources on the true (unscoped) set of affected types, not the caller-scoped one', async () => {
+    // Both known taggable types come back with references from the internal client, so Gate 2a
+    // must be checked against both — not just whatever the per-user client could see.
+    await callHandler({ toId: 'to-1', fromIds: ['from-1'] });
+
+    expect(coreStart.savedObjects.getUnsafeInternalClient).toHaveBeenCalled();
+    expect(internalClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'dashboard' })
+    );
+    expect(internalClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'osquery-pack' })
+    );
+    expect(mergeService.checkDeleteSourcesGate).toHaveBeenCalledWith({
+      updatableTypes: ['dashboard'],
+      affectedTypes: ['dashboard', 'osquery-pack'],
+    });
+  });
+
+  it('surfaces gate failures with their reasons', async () => {
+    mergeService.checkStartGate.mockResolvedValue({
+      allowed: false,
+      reasons: ['User cannot manage tag saved objects'],
+    });
+
+    const res = await callHandler({ toId: 'to-1', fromIds: ['from-1'] });
+
+    expect(res.ok).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          canStartMerge: { allowed: false, reasons: ['User cannot manage tag saved objects'] },
+        }),
+      })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { MergePreviewResponse } from '../../../common/merge';
+import type { TagsPluginRouter } from '../../types';
+import { MergeError, computeAffectedCount } from '../../services';
+import type { MergeRouteDeps } from './types';
+
+export const registerMergePreviewRoute = (
+  router: TagsPluginRouter,
+  { getStartServices }: MergeRouteDeps
+) => {
+  router.post(
+    {
+      path: '/internal/saved_objects_tagging/tags/merge/preview',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out from authorization as there is a separate authorization check within the merge service.',
+        },
+      },
+      validate: {
+        body: schema.object({
+          toId: schema.string(),
+          fromIds: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 50 }),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (ctx, req, res) => {
+      const { mergeService } = await ctx.tags;
+      const { toId, fromIds: rawFromIds } = req.body;
+
+      const fromIds = mergeService.normalizeFromIds(toId, rawFromIds);
+      if (fromIds.length === 0) {
+        return res.badRequest({
+          body: { message: '`fromIds` must contain at least one tag id other than `toId`' },
+        });
+      }
+
+      try {
+        await mergeService.assertTagsNotManaged([toId, ...fromIds]);
+      } catch (e) {
+        if (e instanceof MergeError) {
+          return res.customError({ statusCode: e.status, body: e.message });
+        }
+        throw e;
+      }
+
+      const updatableTypes = await mergeService.getUpdatableTaggableTypes();
+      const { affectedCount, byType } = await mergeService.computeAffectedCount({
+        fromIds,
+        types: updatableTypes,
+      });
+
+      // Gate 2a needs the *true* set of affected types, independent of what this caller can
+      // see — an internal repository bypasses per-user RBAC entirely (unlike the per-user client
+      // above, which would silently narrow to `updatableTypes` and make the gate vacuous).
+      const [core] = await getStartServices();
+      const internalClient = core.savedObjects.getUnsafeInternalClient();
+      const { byType: unrestrictedByType } = await computeAffectedCount(internalClient, {
+        fromIds,
+        types: mergeService.getKnownTaggableTypes(),
+      });
+      const affectedTypes = Object.entries(unrestrictedByType)
+        .filter(([, count]) => count > 0)
+        .map(([type]) => type);
+
+      const [canStartMerge, canRequestDeleteSources] = await Promise.all([
+        mergeService.checkStartGate({ affectedCount }),
+        mergeService.checkDeleteSourcesGate({ updatableTypes, affectedTypes }),
+      ]);
+
+      return res.ok({
+        body: {
+          affectedCount,
+          byType,
+          canStartMerge,
+          canRequestDeleteSources,
+        } as MergePreviewResponse,
+      });
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview_objects.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview_objects.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { registerMergePreviewObjectsRoute } from './preview_objects';
+
+describe('registerMergePreviewObjectsRoute', () => {
+  let router: { get: jest.Mock; handleLegacyErrors: jest.Mock };
+  let mergeService: {
+    normalizeFromIds: jest.Mock;
+    getUpdatableTaggableTypes: jest.Mock;
+    findAffectedObjects: jest.Mock;
+  };
+
+  const getHandler = () => router.get.mock.calls[0][1];
+
+  beforeEach(() => {
+    router = {
+      get: jest.fn(),
+      handleLegacyErrors: jest.fn((fn) => fn),
+    };
+    mergeService = {
+      normalizeFromIds: jest.fn((toId, fromIds) => fromIds.filter((id: string) => id !== toId)),
+      getUpdatableTaggableTypes: jest.fn().mockResolvedValue(['dashboard']),
+      findAffectedObjects: jest.fn().mockResolvedValue({
+        objects: [{ type: 'dashboard', id: 'obj-1', title: 'My dashboard' }],
+        total: 25,
+      }),
+    };
+
+    registerMergePreviewObjectsRoute(router as any);
+  });
+
+  const callHandler = async (query: object) => {
+    const req = httpServerMock.createKibanaRequest({ query });
+    const res = httpServerMock.createResponseFactory();
+    const ctx = { tags: Promise.resolve({ mergeService }) };
+    await getHandler()(ctx, req, res);
+    return res;
+  };
+
+  it('rejects when `fromIds` is empty after removing `toId`', async () => {
+    const res = await callHandler({ toId: 'to-1', fromIds: 'to-1', page: 1, perPage: 20 });
+
+    expect(res.badRequest).toHaveBeenCalledTimes(1);
+    expect(mergeService.findAffectedObjects).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a single-string `fromIds` query param into an array', async () => {
+    await callHandler({ toId: 'to-1', fromIds: 'from-1', page: 1, perPage: 20 });
+
+    expect(mergeService.normalizeFromIds).toHaveBeenCalledWith('to-1', ['from-1']);
+  });
+
+  it('passes pagination through and returns the objects/total/page/perPage', async () => {
+    const res = await callHandler({
+      toId: 'to-1',
+      fromIds: ['from-1', 'from-2'],
+      page: 3,
+      perPage: 5,
+    });
+
+    expect(mergeService.findAffectedObjects).toHaveBeenCalledWith({
+      fromIds: ['from-1', 'from-2'],
+      types: ['dashboard'],
+      page: 3,
+      perPage: 5,
+    });
+    expect(res.ok).toHaveBeenCalledWith({
+      body: {
+        objects: [{ type: 'dashboard', id: 'obj-1', title: 'My dashboard' }],
+        total: 25,
+        page: 3,
+        perPage: 5,
+      },
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview_objects.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/preview_objects.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { MergePreviewObjectsResponse } from '../../../common/merge';
+import type { TagsPluginRouter } from '../../types';
+
+export const registerMergePreviewObjectsRoute = (router: TagsPluginRouter) => {
+  router.get(
+    {
+      path: '/internal/saved_objects_tagging/tags/merge/preview/objects',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out from authorization as there is a separate authorization check within the merge service.',
+        },
+      },
+      validate: {
+        query: schema.object({
+          toId: schema.string(),
+          fromIds: schema.oneOf([
+            schema.string(),
+            schema.arrayOf(schema.string(), { minSize: 1, maxSize: 50 }),
+          ]),
+          page: schema.number({ min: 1, defaultValue: 1 }),
+          perPage: schema.number({ min: 1, max: 100, defaultValue: 20 }),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (ctx, req, res) => {
+      const { mergeService } = await ctx.tags;
+      const { toId, fromIds: rawFromIds, page, perPage } = req.query;
+
+      const fromIds = mergeService.normalizeFromIds(
+        toId,
+        typeof rawFromIds === 'string' ? [rawFromIds] : rawFromIds
+      );
+      if (fromIds.length === 0) {
+        return res.badRequest({
+          body: { message: '`fromIds` must contain at least one tag id other than `toId`' },
+        });
+      }
+
+      const updatableTypes = await mergeService.getUpdatableTaggableTypes();
+      const { objects, total } = await mergeService.findAffectedObjects({
+        fromIds,
+        types: updatableTypes,
+        page,
+        perPage,
+      });
+
+      return res.ok({
+        body: { objects, total, page, perPage } as MergePreviewObjectsResponse,
+      });
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/start.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/start.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, coreMock } from '@kbn/core/server/mocks';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { MergeError } from '../../services';
+import { TAG_MERGE_TASK_TYPE } from '../../tasks/tag_merge';
+import { registerMergeStartRoute } from './start';
+
+describe('registerMergeStartRoute', () => {
+  let router: { post: jest.Mock; handleLegacyErrors: jest.Mock };
+  let mergeService: {
+    normalizeFromIds: jest.Mock;
+    assertTagsNotManaged: jest.Mock;
+    getUpdatableTaggableTypes: jest.Mock;
+    getKnownTaggableTypes: jest.Mock;
+    computeAffectedCount: jest.Mock;
+    checkStartGate: jest.Mock;
+    checkDeleteSourcesGate: jest.Mock;
+  };
+  let taskManager: ReturnType<typeof taskManagerMock.createStart>;
+  let security: ReturnType<typeof securityMock.createStart>;
+  let coreStart: ReturnType<typeof coreMock.createStart>;
+  let internalClient: jest.Mocked<SavedObjectsClientContract>;
+
+  const getHandler = () => router.post.mock.calls[0][1];
+
+  beforeEach(() => {
+    router = {
+      post: jest.fn(),
+      handleLegacyErrors: jest.fn((fn) => fn),
+    };
+    mergeService = {
+      normalizeFromIds: jest.fn((toId, fromIds) => fromIds.filter((id: string) => id !== toId)),
+      assertTagsNotManaged: jest.fn().mockResolvedValue(undefined),
+      getUpdatableTaggableTypes: jest.fn().mockResolvedValue(['dashboard']),
+      getKnownTaggableTypes: jest.fn().mockReturnValue(['dashboard']),
+      computeAffectedCount: jest.fn().mockResolvedValue({ affectedCount: 1, byType: {} }),
+      checkStartGate: jest.fn().mockResolvedValue({ allowed: true, reasons: [] }),
+      checkDeleteSourcesGate: jest.fn().mockResolvedValue({ allowed: true, reasons: [] }),
+    };
+    taskManager = taskManagerMock.createStart();
+    taskManager.get.mockRejectedValue(new Error('not found'));
+    security = securityMock.createStart();
+    coreStart = coreMock.createStart();
+    internalClient = coreStart.savedObjects.getUnsafeInternalClient() as jest.Mocked<
+      typeof internalClient
+    >;
+    internalClient.find.mockResolvedValue({
+      saved_objects: [],
+      total: 1,
+      page: 1,
+      per_page: 0,
+    });
+
+    registerMergeStartRoute(router as any, {
+      getStartServices: () => Promise.resolve([coreStart, { taskManager, security }, undefined]),
+      spacesService: undefined,
+    });
+  });
+
+  const callHandler = async (body: object) => {
+    const req = httpServerMock.createKibanaRequest({ body });
+    const res = httpServerMock.createResponseFactory();
+    const ctx = { tags: Promise.resolve({ mergeService }) };
+    await getHandler()(ctx, req, res);
+    return { req, res };
+  };
+
+  it('rejects when `fromIds` is empty after removing `toId`', async () => {
+    const { res } = await callHandler({ toId: 'to-1', fromIds: ['to-1'], deleteSources: false });
+
+    expect(res.badRequest).toHaveBeenCalledTimes(1);
+    expect(mergeService.assertTagsNotManaged).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the MergeError status when a tag is managed', async () => {
+    mergeService.assertTagsNotManaged.mockRejectedValue(new MergeError('nope', 400));
+
+    const { res } = await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: false });
+
+    expect(res.customError).toHaveBeenCalledWith({ statusCode: 400, body: 'nope' });
+  });
+
+  it('is forbidden when the baseline start gate disallows it', async () => {
+    mergeService.checkStartGate.mockResolvedValue({ allowed: false, reasons: ['nope'] });
+
+    const { res } = await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: false });
+
+    expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'nope' } });
+    expect(taskManager.schedule).not.toHaveBeenCalled();
+  });
+
+  it('recomputes `affectedCount` independently (never trusts a client-supplied value) and gates on it', async () => {
+    mergeService.computeAffectedCount.mockResolvedValue({
+      affectedCount: 42,
+      byType: { dashboard: 42 },
+    });
+
+    await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: false });
+
+    expect(mergeService.computeAffectedCount).toHaveBeenCalledWith({
+      fromIds: ['from-1'],
+      types: ['dashboard'],
+    });
+    expect(mergeService.checkStartGate).toHaveBeenCalledWith({ affectedCount: 42 });
+  });
+
+  it('is forbidden when `deleteSources` is requested but Gate 2a disallows it', async () => {
+    mergeService.checkDeleteSourcesGate.mockResolvedValue({ allowed: false, reasons: ['nope'] });
+
+    const { res } = await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: true });
+
+    expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'nope' } });
+    expect(taskManager.schedule).not.toHaveBeenCalled();
+  });
+
+  it('does not check Gate 2a when `deleteSources` is false', async () => {
+    (coreStart.savedObjects.getUnsafeInternalClient as jest.Mock).mockClear();
+
+    await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: false });
+
+    expect(mergeService.checkDeleteSourcesGate).not.toHaveBeenCalled();
+    expect(coreStart.savedObjects.getUnsafeInternalClient).not.toHaveBeenCalled();
+  });
+
+  it('gates deleteSources on the true (unscoped) set of affected types, not the caller-scoped one', async () => {
+    mergeService.getKnownTaggableTypes.mockReturnValue(['dashboard', 'osquery-pack']);
+    (internalClient.find as jest.Mock)
+      .mockResolvedValueOnce({ saved_objects: [], total: 1, page: 1, per_page: 0 })
+      .mockResolvedValueOnce({ saved_objects: [], total: 0, page: 1, per_page: 0 });
+
+    await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: true });
+
+    expect(mergeService.checkDeleteSourcesGate).toHaveBeenCalledWith({
+      updatableTypes: ['dashboard'],
+      affectedTypes: ['dashboard'],
+    });
+  });
+
+  it('returns a 501 when the security plugin is unavailable', async () => {
+    registerMergeStartRoute(router as any, {
+      getStartServices: () =>
+        Promise.resolve([coreMock.createStart(), { taskManager, security: undefined }, undefined]),
+      spacesService: undefined,
+    });
+
+    const req = httpServerMock.createKibanaRequest({
+      body: { toId: 'to-1', fromIds: ['from-1'], deleteSources: false },
+    });
+    const res = httpServerMock.createResponseFactory();
+    const ctx = { tags: Promise.resolve({ mergeService }) };
+    await router.post.mock.calls[1][1](ctx, req, res);
+
+    expect(res.customError).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 501 }));
+  });
+
+  it('returns a 409 when a merge job is already in progress in this space', async () => {
+    taskManager.get.mockResolvedValue(
+      taskManagerMock.createTask({ state: { status: 'in_progress' } })
+    );
+
+    const { res } = await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: false });
+
+    expect(res.customError).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409 }));
+    expect(taskManager.schedule).not.toHaveBeenCalled();
+  });
+
+  it('removes a finished previous job before scheduling a new one', async () => {
+    taskManager.get.mockResolvedValue(taskManagerMock.createTask({ state: { status: 'success' } }));
+
+    await callHandler({ toId: 'to-1', fromIds: ['from-1'], deleteSources: false });
+
+    expect(taskManager.removeIfExists).toHaveBeenCalledTimes(1);
+    expect(taskManager.schedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules the task by passing `request` as the second `schedule()` argument (not a pre-built apiKey)', async () => {
+    // This is what makes the job per-user: Task Manager itself grants the scoped API key from
+    // `request` and persists it as `apiKey`/`userScope` on the task — setting those fields
+    // directly on the first argument does nothing, since `taskInstanceToAttributes` strips them.
+    const { req, res } = await callHandler({
+      toId: 'to-1',
+      fromIds: ['from-1'],
+      deleteSources: true,
+    });
+
+    expect(security.authc.apiKeys.grantAsInternalUser).not.toHaveBeenCalled();
+    expect(taskManager.schedule).toHaveBeenCalledTimes(1);
+    const [taskInstance, options] = taskManager.schedule.mock.calls[0];
+    expect(taskInstance).toEqual(
+      expect.objectContaining({
+        taskType: TAG_MERGE_TASK_TYPE,
+        params: { toId: 'to-1', fromIds: ['from-1'], deleteSources: true },
+      })
+    );
+    expect(taskInstance).not.toHaveProperty('apiKey');
+    expect(taskInstance).not.toHaveProperty('userScope');
+    expect(options).toEqual({ request: req });
+    expect(res.ok).toHaveBeenCalledWith({ body: {} });
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/start.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/start.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { TagsPluginRouter } from '../../types';
+import { MergeError, computeAffectedCount } from '../../services';
+import {
+  getTagMergeTaskId,
+  initialTagMergeTaskState,
+  TAG_MERGE_TASK_TYPE,
+} from '../../tasks/tag_merge';
+import { DEFAULT_SPACE_ID, type MergeRouteDeps } from './types';
+
+export const registerMergeStartRoute = (
+  router: TagsPluginRouter,
+  { getStartServices, spacesService }: MergeRouteDeps
+) => {
+  router.post(
+    {
+      path: '/internal/saved_objects_tagging/tags/merge',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out from authorization as there is a separate authorization check within the merge service.',
+        },
+      },
+      validate: {
+        body: schema.object({
+          toId: schema.string(),
+          fromIds: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 50 }),
+          deleteSources: schema.boolean({ defaultValue: false }),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (ctx, req, res) => {
+      const { mergeService } = await ctx.tags;
+      const { toId, fromIds: rawFromIds, deleteSources } = req.body;
+      const spaceId = spacesService?.getSpaceId(req) ?? DEFAULT_SPACE_ID;
+
+      const fromIds = mergeService.normalizeFromIds(toId, rawFromIds);
+      if (fromIds.length === 0) {
+        return res.badRequest({
+          body: { message: '`fromIds` must contain at least one tag id other than `toId`' },
+        });
+      }
+
+      try {
+        await mergeService.assertTagsNotManaged([toId, ...fromIds]);
+      } catch (e) {
+        if (e instanceof MergeError) {
+          return res.customError({ statusCode: e.status, body: e.message });
+        }
+        throw e;
+      }
+
+      const [core, { taskManager, security }] = await getStartServices();
+
+      const updatableTypes = await mergeService.getUpdatableTaggableTypes();
+      // Recomputed independently of whatever the client's earlier preview call showed — never
+      // trust a client-supplied or stale affected count for an authorization decision.
+      const { affectedCount } = await mergeService.computeAffectedCount({
+        fromIds,
+        types: updatableTypes,
+      });
+      const canStartMerge = await mergeService.checkStartGate({ affectedCount });
+      if (!canStartMerge.allowed) {
+        return res.forbidden({ body: { message: canStartMerge.reasons.join('; ') } });
+      }
+      if (deleteSources) {
+        // Gate 2a needs the *true* set of affected types, independent of what this caller can
+        // see — an internal client bypasses per-user RBAC entirely (unlike the per-user client
+        // above, which would silently narrow to `updatableTypes` and make the gate vacuous).
+        const internalClient = core.savedObjects.getUnsafeInternalClient();
+        const { byType: unrestrictedByType } = await computeAffectedCount(internalClient, {
+          fromIds,
+          types: mergeService.getKnownTaggableTypes(),
+        });
+        const affectedTypes = Object.entries(unrestrictedByType)
+          .filter(([, count]) => count > 0)
+          .map(([type]) => type);
+
+        const canRequestDeleteSources = await mergeService.checkDeleteSourcesGate({
+          updatableTypes,
+          affectedTypes,
+        });
+        if (!canRequestDeleteSources.allowed) {
+          return res.forbidden({ body: { message: canRequestDeleteSources.reasons.join('; ') } });
+        }
+      }
+
+      if (!security) {
+        return res.customError({
+          statusCode: 501,
+          body: 'The security plugin is required to run tag merge jobs',
+        });
+      }
+
+      const taskId = getTagMergeTaskId(spaceId);
+      const existing = await taskManager.get(taskId).catch(() => undefined);
+      if (existing?.state?.status === 'in_progress') {
+        return res.customError({
+          statusCode: 409,
+          body: 'A merge job is already in progress in this space',
+        });
+      }
+      if (existing) {
+        await taskManager.removeIfExists(taskId);
+      }
+
+      // Passing `request` here (not a pre-built apiKey) is what makes this per-user: Task
+      // Manager itself grants an API key scoped to `req`'s own privileges and persists it as
+      // `apiKey`/`userScope` on the task. Setting those fields directly on the task instance
+      // instead would silently do nothing — `taskInstanceToAttributes` strips them, since this
+      // `request`-based grant is the only supported way to populate them.
+      await taskManager.schedule(
+        {
+          id: taskId,
+          taskType: TAG_MERGE_TASK_TYPE,
+          params: { toId, fromIds, deleteSources },
+          state: initialTagMergeTaskState(),
+          scope: ['savedObjectsTagging'],
+        },
+        { request: req }
+      );
+
+      return res.ok({ body: {} });
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/status.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/status.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, coreMock } from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { registerMergeStatusRoute } from './status';
+
+describe('registerMergeStatusRoute', () => {
+  let router: { get: jest.Mock; handleLegacyErrors: jest.Mock };
+  let taskManager: ReturnType<typeof taskManagerMock.createStart>;
+
+  const getHandler = () => router.get.mock.calls[0][1];
+
+  beforeEach(() => {
+    router = {
+      get: jest.fn(),
+      handleLegacyErrors: jest.fn((fn) => fn),
+    };
+    taskManager = taskManagerMock.createStart();
+
+    registerMergeStatusRoute(router as any, {
+      getStartServices: () =>
+        Promise.resolve([coreMock.createStart(), { taskManager, security: undefined }, undefined]),
+      spacesService: undefined,
+    });
+  });
+
+  const callHandler = async () => {
+    const req = httpServerMock.createKibanaRequest();
+    const res = httpServerMock.createResponseFactory();
+    await getHandler()({}, req, res);
+    return res;
+  };
+
+  it('returns an idle status when there is no task for this space', async () => {
+    taskManager.get.mockRejectedValue(new Error('not found'));
+
+    const res = await callHandler();
+
+    expect(res.ok).toHaveBeenCalledWith({
+      body: {
+        status: 'idle',
+        phase: 'complete',
+        progress: { updatedCount: 0 },
+        deletion: [],
+        errors: { count: 0, samples: [] },
+      },
+    });
+  });
+
+  it('maps an in-progress task instance to the status response shape', async () => {
+    taskManager.get.mockResolvedValue(
+      taskManagerMock.createTask({
+        params: { toId: 'to-1', fromIds: ['from-1'], deleteSources: false },
+        state: {
+          status: 'in_progress',
+          phase: 'updating',
+          startedAt: '2024-01-01T00:00:00.000Z',
+          totalAffected: 200,
+          updatedCount: 50,
+          deletion: [],
+          errors: { count: 0, samples: [] },
+        },
+      })
+    );
+
+    const res = await callHandler();
+
+    expect(res.ok).toHaveBeenCalledWith({
+      body: {
+        status: 'in_progress',
+        phase: 'updating',
+        job: {
+          toId: 'to-1',
+          fromIds: ['from-1'],
+          deleteSources: false,
+          startedAt: '2024-01-01T00:00:00.000Z',
+        },
+        progress: { totalAffected: 200, updatedCount: 50, percent: 25 },
+        deletion: [],
+        errors: { count: 0, samples: [] },
+      },
+    });
+  });
+
+  describe('percent, when `deleteSources` is requested', () => {
+    // `finalizing` (deleting source tags) is real remaining work after every saved object has
+    // been updated, so `updating` only accounts for the first half of the bar and `finalizing`
+    // the second half — otherwise the bar would read 100% before source tags are even touched.
+    const baseParams = { toId: 'to-1', fromIds: ['from-1', 'from-2'], deleteSources: true };
+
+    it('caps the `updating` phase contribution at 50%, even once every object is updated', async () => {
+      taskManager.get.mockResolvedValue(
+        taskManagerMock.createTask({
+          params: baseParams,
+          state: {
+            status: 'in_progress',
+            phase: 'updating',
+            startedAt: '2024-01-01T00:00:00.000Z',
+            totalAffected: 200,
+            updatedCount: 200,
+            deletion: [],
+            errors: { count: 0, samples: [] },
+          },
+        })
+      );
+
+      const res = await callHandler();
+
+      expect(res.ok).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ progress: expect.objectContaining({ percent: 50 }) }),
+        })
+      );
+    });
+
+    it('reports 50-100% during `finalizing`, based on how many source tags have been checked', async () => {
+      taskManager.get.mockResolvedValue(
+        taskManagerMock.createTask({
+          params: baseParams,
+          state: {
+            status: 'in_progress',
+            phase: 'finalizing',
+            startedAt: '2024-01-01T00:00:00.000Z',
+            totalAffected: 200,
+            updatedCount: 200,
+            deletion: [{ id: 'from-1', deleted: true }], // 1 of 2 fromIds processed
+            errors: { count: 0, samples: [] },
+          },
+        })
+      );
+
+      const res = await callHandler();
+
+      expect(res.ok).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ progress: expect.objectContaining({ percent: 75 }) }),
+        })
+      );
+    });
+
+    it('reports 100% once the job reaches `complete`', async () => {
+      taskManager.get.mockResolvedValue(
+        taskManagerMock.createTask({
+          params: baseParams,
+          state: {
+            status: 'success',
+            phase: 'complete',
+            startedAt: '2024-01-01T00:00:00.000Z',
+            totalAffected: 200,
+            updatedCount: 200,
+            deletion: [
+              { id: 'from-1', deleted: true },
+              { id: 'from-2', deleted: true },
+            ],
+            errors: { count: 0, samples: [] },
+          },
+        })
+      );
+
+      const res = await callHandler();
+
+      expect(res.ok).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ progress: expect.objectContaining({ percent: 100 }) }),
+        })
+      );
+    });
+  });
+
+  it('omits `percent` when `totalAffected` is not yet known (still scanning)', async () => {
+    taskManager.get.mockResolvedValue(
+      taskManagerMock.createTask({
+        params: { toId: 'to-1', fromIds: ['from-1'], deleteSources: false },
+        state: {
+          status: 'in_progress',
+          phase: 'scanning',
+          startedAt: '2024-01-01T00:00:00.000Z',
+          updatedCount: 0,
+          deletion: [],
+          errors: { count: 0, samples: [] },
+        },
+      })
+    );
+
+    const res = await callHandler();
+
+    expect(res.ok).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          progress: { totalAffected: undefined, updatedCount: 0, percent: undefined },
+        }),
+      })
+    );
+  });
+
+  it('caps `percent` at 100 even if `updatedCount` exceeds `totalAffected`', async () => {
+    taskManager.get.mockResolvedValue(
+      taskManagerMock.createTask({
+        params: { toId: 'to-1', fromIds: ['from-1'], deleteSources: false },
+        state: {
+          status: 'in_progress',
+          phase: 'updating',
+          startedAt: '2024-01-01T00:00:00.000Z',
+          totalAffected: 10,
+          updatedCount: 15,
+          deletion: [],
+          errors: { count: 0, samples: [] },
+        },
+      })
+    );
+
+    const res = await callHandler();
+
+    expect(res.ok).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ progress: expect.objectContaining({ percent: 100 }) }),
+      })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/status.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/status.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MergeStatusResponse } from '../../../common/merge';
+import type { TagsPluginRouter } from '../../types';
+import {
+  getTagMergeTaskId,
+  type TagMergeTaskParams,
+  type TagMergeTaskState,
+} from '../../tasks/tag_merge';
+import { DEFAULT_SPACE_ID, type MergeRouteDeps } from './types';
+
+const idleStatus: MergeStatusResponse = {
+  status: 'idle',
+  phase: 'complete',
+  progress: { updatedCount: 0 },
+  deletion: [],
+  errors: { count: 0, samples: [] },
+};
+
+/**
+ * When `deleteSources` is requested, `finalizing` (deleting the source tags) is real remaining
+ * work after every saved object has been updated — so `updating` only accounts for the first
+ * half of the progress bar and `finalizing` the second half, rather than the bar reading 100%
+ * while source tags haven't been touched yet.
+ */
+const computePercent = (
+  state: TagMergeTaskState,
+  { deleteSources, fromIds }: TagMergeTaskParams
+): number | undefined => {
+  if (state.totalAffected == null) {
+    return undefined;
+  }
+  if (state.phase === 'complete') {
+    return 100;
+  }
+
+  const updatingFraction = Math.min(1, state.updatedCount / Math.max(state.totalAffected, 1));
+
+  if (!deleteSources) {
+    return Math.round(updatingFraction * 100);
+  }
+  if (state.phase === 'finalizing') {
+    const finalizingFraction = fromIds.length > 0 ? state.deletion.length / fromIds.length : 1;
+    return Math.round(50 + finalizingFraction * 50);
+  }
+  return Math.round(updatingFraction * 50);
+};
+
+export const registerMergeStatusRoute = (
+  router: TagsPluginRouter,
+  { getStartServices, spacesService }: MergeRouteDeps
+) => {
+  router.get(
+    {
+      path: '/internal/saved_objects_tagging/tags/merge',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route only exposes the current user’s own merge job status.',
+        },
+      },
+      validate: {},
+    },
+    router.handleLegacyErrors(async (ctx, req, res) => {
+      const spaceId = spacesService?.getSpaceId(req) ?? DEFAULT_SPACE_ID;
+      const taskId = getTagMergeTaskId(spaceId);
+      const [, { taskManager }] = await getStartServices();
+
+      const task = await taskManager.get(taskId).catch(() => undefined);
+      if (!task) {
+        return res.ok({ body: idleStatus });
+      }
+
+      const state = task.state as TagMergeTaskState;
+      const params = task.params as TagMergeTaskParams;
+      const percent = computePercent(state, params);
+
+      return res.ok({
+        body: {
+          status: state.status,
+          phase: state.phase,
+          job: {
+            toId: params.toId,
+            fromIds: params.fromIds,
+            deleteSources: params.deleteSources,
+            startedAt: state.startedAt,
+          },
+          progress: {
+            totalAffected: state.totalAffected,
+            updatedCount: state.updatedCount,
+            percent,
+          },
+          deletion: state.deletion,
+          errors: state.errors,
+        } as MergeStatusResponse,
+      });
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/types.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/merge/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { SpacesServiceSetup } from '@kbn/spaces-plugin/server';
+
+export interface MergeRouteStartDeps {
+  taskManager: TaskManagerStartContract;
+  security?: SecurityPluginStart;
+}
+
+export interface MergeRouteDeps {
+  getStartServices: () => Promise<[CoreStart, MergeRouteStartDeps, unknown]>;
+  spacesService?: SpacesServiceSetup;
+}
+
+export const DEFAULT_SPACE_ID = 'default';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/assignments/get_updatable_types.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/assignments/get_updatable_types.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { getUpdatableSavedObjectTypes } from './get_updatable_types';
+
+describe('getUpdatableSavedObjectTypes', () => {
+  let request: ReturnType<typeof httpServerMock.createKibanaRequest>;
+  let authorization: ReturnType<typeof securityMock.createSetup>['authz'];
+
+  beforeEach(() => {
+    request = httpServerMock.createKibanaRequest();
+    authorization = securityMock.createSetup().authz;
+    // the mock's `savedObject.get` is auto-mocked to always return `undefined`; give it the
+    // real implementation's shape so tests can distinguish privileges by type/action.
+    (authorization.actions.savedObject.get as jest.Mock).mockImplementation(
+      (type: string, action: string) => `saved_object:${type}/${action}`
+    );
+  });
+
+  it('returns all types unfiltered when RBAC is not enforced for the request', async () => {
+    authorization.mode.useRbacForRequest.mockReturnValue(false);
+
+    const result = await getUpdatableSavedObjectTypes({
+      request,
+      types: ['dashboard', 'map'],
+      authorization,
+    });
+
+    expect(result).toEqual(['dashboard', 'map']);
+    expect(authorization.checkPrivilegesDynamicallyWithRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all types unfiltered when no authorization service is provided', async () => {
+    const result = await getUpdatableSavedObjectTypes({
+      request,
+      types: ['dashboard', 'map'],
+      authorization: undefined,
+    });
+
+    expect(result).toEqual(['dashboard', 'map']);
+  });
+
+  it('checks the `update` action by default', async () => {
+    authorization.mode.useRbacForRequest.mockReturnValue(true);
+    const checkPrivileges = jest.fn().mockResolvedValue({ privileges: { kibana: [] } });
+    authorization.checkPrivilegesDynamicallyWithRequest.mockReturnValue(checkPrivileges);
+
+    await getUpdatableSavedObjectTypes({ request, types: ['dashboard'], authorization });
+
+    expect(checkPrivileges).toHaveBeenCalledWith({
+      kibana: [authorization.actions.savedObject.get('dashboard', 'update')],
+    });
+  });
+
+  it('checks a caller-supplied action instead, when provided', async () => {
+    authorization.mode.useRbacForRequest.mockReturnValue(true);
+    const checkPrivileges = jest.fn().mockResolvedValue({ privileges: { kibana: [] } });
+    authorization.checkPrivilegesDynamicallyWithRequest.mockReturnValue(checkPrivileges);
+
+    await getUpdatableSavedObjectTypes({
+      request,
+      types: ['tag'],
+      authorization,
+      action: 'delete',
+    });
+
+    expect(checkPrivileges).toHaveBeenCalledWith({
+      kibana: [authorization.actions.savedObject.get('tag', 'delete')],
+    });
+  });
+
+  it('filters out types the privilege check does not authorize', async () => {
+    authorization.mode.useRbacForRequest.mockReturnValue(true);
+    const updatePrivilege = authorization.actions.savedObject.get('dashboard', 'update');
+    const checkPrivileges = jest.fn().mockResolvedValue({
+      privileges: {
+        kibana: [
+          { privilege: updatePrivilege, authorized: true },
+          {
+            privilege: authorization.actions.savedObject.get('map', 'update'),
+            authorized: false,
+          },
+        ],
+      },
+    });
+    authorization.checkPrivilegesDynamicallyWithRequest.mockReturnValue(checkPrivileges);
+
+    const result = await getUpdatableSavedObjectTypes({
+      request,
+      types: ['dashboard', 'map'],
+      authorization,
+    });
+
+    expect(result).toEqual(['dashboard']);
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/assignments/get_updatable_types.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/assignments/get_updatable_types.ts
@@ -12,10 +12,13 @@ export const getUpdatableSavedObjectTypes = async ({
   request,
   types,
   authorization,
+  action = 'update',
 }: {
   types: string[];
   request: KibanaRequest;
   authorization?: SecurityPluginSetup['authz'];
+  /** The privilege action to check for each type. Defaults to `'update'`. */
+  action?: string;
 }) => {
   // Don't bother authorizing if the security plugin is disabled, or if security is disabled in ES
   const shouldAuthorize = authorization?.mode.useRbacForRequest(request) ?? false;
@@ -25,7 +28,7 @@ export const getUpdatableSavedObjectTypes = async ({
 
   // Each Saved Object type has a distinct privilege/action that we need to check
   const typeActionMap = types.reduce((acc, type) => {
-    acc[type] = authorization!.actions.savedObject.get(type, 'update');
+    acc[type] = authorization!.actions.savedObject.get(type, action);
     return acc;
   }, {} as Record<string, string>);
 

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/index.ts
@@ -8,3 +8,11 @@
 export { TagsClient, savedObjectToTag, TagValidationError } from './tags';
 export type { IAssignmentService } from './assignments';
 export { AssignmentService, AssignmentError } from './assignments';
+export type { IMergeService } from './merge';
+export {
+  MergeService,
+  MergeError,
+  computeAffectedCount,
+  findAffectedObjects,
+  rewriteTagReferences,
+} from './merge';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/errors.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/errors.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Error returned from {@link MergeService} when a merge request is invalid or forbidden.
+ */
+export class MergeError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+    Object.setPrototypeOf(this, MergeError.prototype);
+  }
+}

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { getTagConnectionsUrl } from './get_tag_connections_url';
-export type { DuplicateTagGroup } from './group_duplicate_tags';
-export { groupDuplicateTagsByName } from './group_duplicate_tags';
-export { buildTagNameLookup } from './tag_name_lookup';
+export type { IMergeService } from './merge_service';
+export { MergeService } from './merge_service';
+export { MergeError } from './errors';
+export { computeAffectedCount, findAffectedObjects, rewriteTagReferences } from './queries';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/merge_service.test.mocks.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/merge_service.test.mocks.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { getTagConnectionsUrl } from './get_tag_connections_url';
-export type { DuplicateTagGroup } from './group_duplicate_tags';
-export { groupDuplicateTagsByName } from './group_duplicate_tags';
-export { buildTagNameLookup } from './tag_name_lookup';
+export const getUpdatableSavedObjectTypesMock = jest.fn();
+jest.doMock('../assignments/get_updatable_types', () => ({
+  getUpdatableSavedObjectTypes: getUpdatableSavedObjectTypesMock,
+}));

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/merge_service.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/merge_service.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getUpdatableSavedObjectTypesMock } from './merge_service.test.mocks';
+import {
+  httpServerMock,
+  savedObjectsClientMock,
+  savedObjectsTypeRegistryMock,
+} from '@kbn/core/server/mocks';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { tagsClientMock } from '../tags/tags_client.mock';
+import { createTag } from '../../../common/test_utils';
+import { taggableTypes, tagSavedObjectTypeName } from '../../../common/constants';
+import { MergeError } from './errors';
+import { MergeService } from './merge_service';
+
+describe('MergeService', () => {
+  let service: MergeService;
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let request: ReturnType<typeof httpServerMock.createKibanaRequest>;
+  let authorization: ReturnType<typeof securityMock.createSetup>['authz'];
+  let typeRegistry: ReturnType<typeof savedObjectsTypeRegistryMock.create>;
+  let tagsClient: ReturnType<typeof tagsClientMock.create>;
+
+  beforeEach(() => {
+    request = httpServerMock.createKibanaRequest();
+    authorization = securityMock.createSetup().authz;
+    soClient = savedObjectsClientMock.create();
+    typeRegistry = savedObjectsTypeRegistryMock.create();
+    typeRegistry.getType.mockImplementation((type) => ({ name: type } as any));
+    tagsClient = tagsClientMock.create();
+
+    service = new MergeService({
+      request,
+      client: soClient,
+      typeRegistry,
+      tagsClient,
+      authorization,
+    });
+  });
+
+  afterEach(() => {
+    getUpdatableSavedObjectTypesMock.mockReset();
+  });
+
+  describe('#normalizeFromIds', () => {
+    it('dedupes and removes `toId`', () => {
+      expect(service.normalizeFromIds('to', ['a', 'b', 'a', 'to'])).toEqual(['a', 'b']);
+    });
+
+    it('returns an empty array when only `toId` is provided', () => {
+      expect(service.normalizeFromIds('to', ['to'])).toEqual([]);
+    });
+  });
+
+  describe('#getUpdatableTaggableTypes', () => {
+    it('calls `getUpdatableSavedObjectTypes` with the known taggable types', async () => {
+      getUpdatableSavedObjectTypesMock.mockResolvedValue(['dashboard']);
+
+      const result = await service.getUpdatableTaggableTypes();
+
+      expect(getUpdatableSavedObjectTypesMock).toHaveBeenCalledWith({
+        request,
+        types: taggableTypes,
+        authorization,
+      });
+      expect(result).toEqual(['dashboard']);
+    });
+
+    it('filters out types not registered in the type registry', async () => {
+      typeRegistry.getType.mockImplementation((type) =>
+        type === 'dashboard' ? ({ name: type } as any) : undefined
+      );
+      getUpdatableSavedObjectTypesMock.mockImplementation(({ types }) => Promise.resolve(types));
+
+      const result = await service.getUpdatableTaggableTypes();
+
+      expect(result).toEqual(['dashboard']);
+    });
+  });
+
+  describe('#assertTagsNotManaged', () => {
+    it('resolves when no tag is managed', async () => {
+      tagsClient.get.mockImplementation((id) => Promise.resolve(createTag({ id, managed: false })));
+
+      await expect(service.assertTagsNotManaged(['a', 'b'])).resolves.toBeUndefined();
+    });
+
+    it('throws a 400 MergeError naming the managed tag ids', async () => {
+      tagsClient.get.mockImplementation((id) =>
+        Promise.resolve(createTag({ id, managed: id === 'b' }))
+      );
+
+      const error = await service.assertTagsNotManaged(['a', 'b']).catch((e) => e);
+
+      expect(error).toBeInstanceOf(MergeError);
+      expect(error.message).toEqual('Managed tags cannot be merged: [b]');
+      expect(error.status).toEqual(400);
+    });
+  });
+
+  describe('#checkStartGate', () => {
+    it('is allowed when the user can manage tags and this merge affects at least one object', async () => {
+      getUpdatableSavedObjectTypesMock.mockResolvedValue([tagSavedObjectTypeName]);
+
+      const result = await service.checkStartGate({ affectedCount: 1 });
+
+      expect(result).toEqual({ allowed: true, reasons: [] });
+    });
+
+    it('is forbidden when the user cannot manage tag objects', async () => {
+      getUpdatableSavedObjectTypesMock.mockResolvedValue([]);
+
+      const result = await service.checkStartGate({ affectedCount: 1 });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reasons).toContain('User cannot manage tag saved objects');
+    });
+
+    it('is forbidden when this merge would not affect any object the user can access', async () => {
+      // even though the user can otherwise manage tags fine — a merge with 0 affected objects and
+      // no source deletion is a pure no-op, whether because nothing is tagged, or because what is
+      // tagged is outside this user's reach (`affectedCount` is already scoped to updatable types).
+      getUpdatableSavedObjectTypesMock.mockResolvedValue([tagSavedObjectTypeName]);
+
+      const result = await service.checkStartGate({ affectedCount: 0 });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reasons).toContain(
+        'This merge would not update any saved objects you have permission to update'
+      );
+    });
+  });
+
+  describe('#checkDeleteSourcesGate', () => {
+    it('is allowed (Gate 2a) when the user can update every type actually affected by this merge, even if that is not every taggable type registered in the deployment', async () => {
+      // e.g. a dashboard-only editor can request deletion when only dashboards are affected,
+      // even though they can't update every taggable type registered in the deployment
+      // (`taggableTypes` has 10 entries; the user here can only update one of them).
+      const result = await service.checkDeleteSourcesGate({
+        updatableTypes: [taggableTypes[0]],
+        affectedTypes: [taggableTypes[0]],
+      });
+
+      expect(result).toEqual({ allowed: true, reasons: [] });
+      expect(taggableTypes.length).toBeGreaterThan(1);
+    });
+
+    it('is forbidden and names the affected types the user cannot update', async () => {
+      const result = await service.checkDeleteSourcesGate({
+        updatableTypes: [taggableTypes[0]],
+        affectedTypes: [taggableTypes[0], taggableTypes[1]],
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.reasons[0]).toContain(taggableTypes[1]);
+    });
+  });
+
+  describe('#getKnownTaggableTypes', () => {
+    it('filters `taggableTypes` down to those registered in this deployment', () => {
+      typeRegistry.getType.mockImplementation((type) =>
+        type === taggableTypes[0] ? ({ name: type } as any) : undefined
+      );
+
+      expect(service.getKnownTaggableTypes()).toEqual([taggableTypes[0]]);
+    });
+  });
+
+  describe('#computeAffectedCount / #findAffectedObjects', () => {
+    it('delegates `computeAffectedCount` to the shared query primitive using the service client', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 3, page: 1, per_page: 0 });
+
+      const result = await service.computeAffectedCount({ fromIds: ['a'], types: ['dashboard'] });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'dashboard', hasReferenceOperator: 'OR' })
+      );
+      expect(result).toEqual({ affectedCount: 3, byType: { dashboard: 3 } });
+    });
+
+    it('delegates `findAffectedObjects` to the shared query primitive using the service client', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [
+          { id: 'obj-1', type: 'dashboard', references: [], attributes: {}, score: 0 },
+        ],
+        total: 1,
+        page: 2,
+        per_page: 10,
+      });
+
+      const result = await service.findAffectedObjects({
+        fromIds: ['a'],
+        types: ['dashboard'],
+        page: 2,
+        perPage: 10,
+      });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ type: ['dashboard'], page: 2, perPage: 10 })
+      );
+      expect(result).toEqual({ total: 1, objects: [{ id: 'obj-1', type: 'dashboard' }] });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/merge_service.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/merge_service.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { uniq, difference } from 'lodash';
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type {
+  SavedObjectsClientContract,
+  ISavedObjectTypeRegistry,
+  KibanaRequest,
+} from '@kbn/core/server';
+import type { SecurityPluginSetup } from '@kbn/security-plugin/server';
+import { taggableTypes, tagSavedObjectTypeName } from '../../../common/constants';
+import type { MergeGateResult } from '../../../common/merge';
+import type { ITagsClient } from '../../../common/types';
+import { getUpdatableSavedObjectTypes } from '../assignments/get_updatable_types';
+import { MergeError } from './errors';
+import { computeAffectedCount, findAffectedObjects } from './queries';
+
+interface MergeServiceOptions {
+  request: KibanaRequest;
+  client: SavedObjectsClientContract;
+  typeRegistry: ISavedObjectTypeRegistry;
+  tagsClient: ITagsClient;
+  authorization?: SecurityPluginSetup['authz'];
+}
+
+export type IMergeService = PublicMethodsOf<MergeService>;
+
+/**
+ * Server-side primitives shared by the merge-duplicate-tags preview/start routes and by
+ * the `tag_merge` Task Manager runner, so the "affected objects" definition and the
+ * authorization gates can't drift between preview and execution.
+ */
+export class MergeService {
+  private readonly request: KibanaRequest;
+  private readonly soClient: SavedObjectsClientContract;
+  private readonly typeRegistry: ISavedObjectTypeRegistry;
+  private readonly tagsClient: ITagsClient;
+  private readonly authorization?: SecurityPluginSetup['authz'];
+
+  constructor({ request, client, typeRegistry, tagsClient, authorization }: MergeServiceOptions) {
+    this.request = request;
+    this.soClient = client;
+    this.typeRegistry = typeRegistry;
+    this.tagsClient = tagsClient;
+    this.authorization = authorization;
+  }
+
+  /** Dedupe `fromIds` and drop `toId` if present. */
+  public normalizeFromIds(toId: string, fromIds: string[]): string[] {
+    return uniq(fromIds.filter((id) => id !== toId));
+  }
+
+  /** Taggable types registered in this deployment that the current user can update. */
+  public async getUpdatableTaggableTypes(): Promise<string[]> {
+    return getUpdatableSavedObjectTypes({
+      request: this.request,
+      types: this.getKnownTaggableTypes(),
+      authorization: this.authorization,
+    });
+  }
+
+  /** All `taggableTypes` registered in this deployment, unfiltered by the caller's permissions. */
+  public getKnownTaggableTypes(): string[] {
+    return taggableTypes.filter((type) => this.typeRegistry.getType(type) !== undefined);
+  }
+
+  /** Throws a 400 {@link MergeError} if any of the given tag ids is a managed tag. */
+  public async assertTagsNotManaged(tagIds: string[]): Promise<void> {
+    const tags = await Promise.all(tagIds.map((id) => this.tagsClient.get(id)));
+    const managedIds = tags.filter((tag) => tag.managed).map((tag) => tag.id);
+    if (managedIds.length > 0) {
+      throw new MergeError(`Managed tags cannot be merged: [${managedIds.join(', ')}]`, 400);
+    }
+  }
+
+  /**
+   * Count of objects, per updatable taggable type, that reference any of `fromIds` (OR).
+   * Delegates to {@link computeAffectedCount}, the same primitive the `tag_merge` Task Manager
+   * runner uses, so the "affected objects" definition can't drift between preview and execution.
+   */
+  public async computeAffectedCount(args: { fromIds: string[]; types: string[] }) {
+    return computeAffectedCount(this.soClient, args);
+  }
+
+  /** Paginated listing of objects referencing any of `fromIds` (OR), across `types`. */
+  public async findAffectedObjects(args: {
+    fromIds: string[];
+    types: string[];
+    page: number;
+    perPage: number;
+  }) {
+    return findAffectedObjects(this.soClient, this.typeRegistry, args);
+  }
+
+  /**
+   * Baseline gate: can manage tag objects AND this specific merge would actually update at least
+   * one saved object the user can access. Deliberately keyed on `affectedCount` (computed against
+   * `updatableTypes`, i.e. already scoped to what *this* user can update) rather than "the user
+   * can update *some* taggable type somewhere" — the latter is nearly always true for any active
+   * editor and doesn't correlate with whether these specific `fromIds` are used by anything this
+   * user could actually update. A merge with zero affected objects and no source deletion is a
+   * pure no-op (nothing rewritten, tags stay separate); cleaning up a truly-unused duplicate tag
+   * already has a simpler existing path (the plain "Delete" row action), so this gate doesn't need
+   * a `deleteSources`-only carve-out for that case.
+   */
+  public async checkStartGate({
+    affectedCount,
+  }: {
+    affectedCount: number;
+  }): Promise<MergeGateResult> {
+    const reasons: string[] = [];
+
+    if (!(await this.canManageTagObjects())) {
+      reasons.push('User cannot manage tag saved objects');
+    }
+    if (affectedCount === 0) {
+      reasons.push('This merge would not update any saved objects you have permission to update');
+    }
+
+    return { allowed: reasons.length === 0, reasons };
+  }
+
+  /**
+   * Gate 2a: source-tag deletion is only offered when the user can update every taggable type
+   * that *actually* has a live reference to `fromIds` right now — not every taggable type
+   * registered in the deployment. `affectedTypes` must come from an authoritative, unscoped scan
+   * (an internal repository, not the per-user client): a per-user `find()` call silently narrows
+   * to the types the caller can `find` rather than throwing on the rest, so computing
+   * `affectedTypes` from a permission-scoped client would make this gate either trivially pass
+   * (if scoped to the caller's own `updatableTypes`) or vacuous. See `preview.ts`/`start.ts` for
+   * where that scan happens.
+   */
+  public async checkDeleteSourcesGate({
+    updatableTypes,
+    affectedTypes,
+  }: {
+    updatableTypes: string[];
+    affectedTypes: string[];
+  }): Promise<MergeGateResult> {
+    const missingTypes = difference(affectedTypes, updatableTypes);
+
+    return {
+      allowed: missingTypes.length === 0,
+      reasons:
+        missingTypes.length === 0
+          ? []
+          : [`User cannot update all affected types: missing [${missingTypes.join(', ')}]`],
+    };
+  }
+
+  private async canManageTagObjects(): Promise<boolean> {
+    const [updatable, deletable] = await Promise.all([
+      getUpdatableSavedObjectTypes({
+        request: this.request,
+        types: [tagSavedObjectTypeName],
+        authorization: this.authorization,
+        action: 'update',
+      }),
+      getUpdatableSavedObjectTypes({
+        request: this.request,
+        types: [tagSavedObjectTypeName],
+        authorization: this.authorization,
+        action: 'delete',
+      }),
+    ]);
+    return updatable.includes(tagSavedObjectTypeName) && deletable.includes(tagSavedObjectTypeName);
+  }
+}

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/queries.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/queries.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock, savedObjectsTypeRegistryMock } from '@kbn/core/server/mocks';
+import { createReference, createTagReference } from '../../../common/test_utils';
+import { computeAffectedCount, findAffectedObjects, rewriteTagReferences } from './queries';
+
+describe('computeAffectedCount', () => {
+  let client: ReturnType<typeof savedObjectsClientMock.create>;
+
+  beforeEach(() => {
+    client = savedObjectsClientMock.create();
+  });
+
+  it('sums the per-type totals into the overall affected count', async () => {
+    client.find.mockImplementation(({ type }) =>
+      Promise.resolve({
+        saved_objects: [],
+        page: 1,
+        per_page: 0,
+        total: type === 'dashboard' ? 5 : 2,
+      })
+    );
+
+    const result = await computeAffectedCount(client, {
+      fromIds: ['from-1', 'from-2'],
+      types: ['dashboard', 'map'],
+    });
+
+    expect(result).toEqual({ affectedCount: 7, byType: { dashboard: 5, map: 2 } });
+  });
+
+  it('queries each type with an OR over all `fromIds` references', async () => {
+    client.find.mockResolvedValue({ saved_objects: [], page: 1, per_page: 0, total: 0 });
+
+    await computeAffectedCount(client, { fromIds: ['from-1', 'from-2'], types: ['dashboard'] });
+
+    expect(client.find).toHaveBeenCalledWith({
+      type: 'dashboard',
+      hasReference: [createTagReference('from-1'), createTagReference('from-2')],
+      hasReferenceOperator: 'OR',
+      perPage: 0,
+    });
+  });
+
+  it('returns zero when no type has any matches', async () => {
+    client.find.mockResolvedValue({ saved_objects: [], page: 1, per_page: 0, total: 0 });
+
+    const result = await computeAffectedCount(client, {
+      fromIds: ['from-1'],
+      types: ['dashboard'],
+    });
+
+    expect(result).toEqual({ affectedCount: 0, byType: { dashboard: 0 } });
+  });
+});
+
+describe('findAffectedObjects', () => {
+  let client: ReturnType<typeof savedObjectsClientMock.create>;
+  let typeRegistry: ReturnType<typeof savedObjectsTypeRegistryMock.create>;
+
+  beforeEach(() => {
+    client = savedObjectsClientMock.create();
+    typeRegistry = savedObjectsTypeRegistryMock.create();
+  });
+
+  it('passes pagination params through to the client and maps the results', async () => {
+    typeRegistry.getType.mockReturnValue({
+      management: { getTitle: (obj: any) => `title-${obj.id}` },
+    } as any);
+    client.find.mockResolvedValue({
+      saved_objects: [
+        { id: 'obj-1', type: 'dashboard', references: [], attributes: {}, score: 0 },
+        { id: 'obj-2', type: 'map', references: [], attributes: {}, score: 0 },
+      ],
+      total: 42,
+      page: 3,
+      per_page: 5,
+    });
+
+    const result = await findAffectedObjects(client, typeRegistry, {
+      fromIds: ['from-1'],
+      types: ['dashboard', 'map'],
+      page: 3,
+      perPage: 5,
+    });
+
+    expect(client.find).toHaveBeenCalledWith({
+      type: ['dashboard', 'map'],
+      hasReference: [createTagReference('from-1')],
+      hasReferenceOperator: 'OR',
+      page: 3,
+      perPage: 5,
+    });
+    expect(result).toEqual({
+      total: 42,
+      objects: [
+        { id: 'obj-1', type: 'dashboard', title: 'title-obj-1' },
+        { id: 'obj-2', type: 'map', title: 'title-obj-2' },
+      ],
+    });
+  });
+
+  it('omits `title` when the type has no title getter registered', async () => {
+    typeRegistry.getType.mockReturnValue(undefined);
+    client.find.mockResolvedValue({
+      saved_objects: [{ id: 'obj-1', type: 'dashboard', references: [], attributes: {}, score: 0 }],
+      total: 1,
+      page: 1,
+      per_page: 20,
+    });
+
+    const result = await findAffectedObjects(client, typeRegistry, {
+      fromIds: ['from-1'],
+      types: ['dashboard'],
+      page: 1,
+      perPage: 20,
+    });
+
+    expect(result.objects).toEqual([{ id: 'obj-1', type: 'dashboard', title: undefined }]);
+  });
+});
+
+describe('rewriteTagReferences', () => {
+  it('replaces all `fromIds` references with `toId`, leaving non-tag references untouched', () => {
+    const objects = [
+      {
+        id: 'obj-1',
+        type: 'dashboard',
+        references: [
+          createReference('dashboard', 'other-dash'),
+          createTagReference('from-1'),
+          createTagReference('from-2'),
+        ],
+      },
+    ];
+
+    const result = rewriteTagReferences(objects, { toId: 'to-1', fromIds: ['from-1', 'from-2'] });
+
+    expect(result).toEqual([
+      {
+        id: 'obj-1',
+        type: 'dashboard',
+        attributes: {},
+        references: [createReference('dashboard', 'other-dash'), createTagReference('to-1')],
+      },
+    ]);
+  });
+
+  it('dedupes when the object already references `toId` alongside a `fromId`', () => {
+    const objects = [
+      {
+        id: 'obj-1',
+        type: 'dashboard',
+        references: [createTagReference('to-1'), createTagReference('from-1')],
+      },
+    ];
+
+    const result = rewriteTagReferences(objects, { toId: 'to-1', fromIds: ['from-1'] });
+
+    expect(result[0].references).toEqual([createTagReference('to-1')]);
+  });
+
+  it('leaves objects with no matching tag references unchanged beyond the empty attributes', () => {
+    const objects = [
+      { id: 'obj-1', type: 'dashboard', references: [createReference('dashboard', 'other')] },
+    ];
+
+    const result = rewriteTagReferences(objects, { toId: 'to-1', fromIds: ['from-1'] });
+
+    expect(result[0].references).toEqual([
+      createReference('dashboard', 'other'),
+      createTagReference('to-1'),
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/queries.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/services/merge/queries.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  SavedObjectsClientContract,
+  SavedObjectsBulkUpdateObject,
+  ISavedObjectTypeRegistry,
+  SavedObject,
+} from '@kbn/core/server';
+import { tagIdToReference, updateTagReferences } from '../../../common/references';
+import type { MergeAffectedObject } from '../../../common/merge';
+
+/**
+ * Count of objects, per taggable type, that reference any of `fromIds` (OR). The overall
+ * affected count is the sum across types, since every saved object has exactly one type.
+ *
+ * Plain function (no request/auth context needed): shared as-is by the preview route (using a
+ * per-user-scoped client) and the `tag_merge` Task Manager runner (using the job's own
+ * user-scoped client), so the "affected objects" definition can't drift between the two.
+ */
+export const computeAffectedCount = async (
+  client: SavedObjectsClientContract,
+  { fromIds, types }: { fromIds: string[]; types: string[] }
+): Promise<{ affectedCount: number; byType: Record<string, number> }> => {
+  const hasReference = fromIds.map(tagIdToReference);
+
+  const byType: Record<string, number> = {};
+  await Promise.all(
+    types.map(async (type) => {
+      const { total } = await client.find({
+        type,
+        hasReference,
+        hasReferenceOperator: 'OR',
+        perPage: 0,
+      });
+      byType[type] = total;
+    })
+  );
+
+  const affectedCount = Object.values(byType).reduce((sum, count) => sum + count, 0);
+  return { affectedCount, byType };
+};
+
+/** Paginated listing of objects referencing any of `fromIds` (OR), across `types`. */
+export const findAffectedObjects = async (
+  client: SavedObjectsClientContract,
+  typeRegistry: ISavedObjectTypeRegistry,
+  {
+    fromIds,
+    types,
+    page,
+    perPage,
+  }: { fromIds: string[]; types: string[]; page: number; perPage: number }
+): Promise<{ objects: MergeAffectedObject[]; total: number }> => {
+  const { saved_objects: objects, total } = await client.find({
+    type: types,
+    hasReference: fromIds.map(tagIdToReference),
+    hasReferenceOperator: 'OR',
+    page,
+    perPage,
+  });
+
+  return {
+    total,
+    objects: objects.map((object) => ({
+      type: object.type,
+      id: object.id,
+      title: typeRegistry.getType(object.type)?.management?.getTitle?.(object),
+    })),
+  };
+};
+
+/** Rewrite `fromIds` tag references to `toId` on the given objects, deduping per object. */
+export const rewriteTagReferences = (
+  objects: Array<Pick<SavedObject, 'id' | 'type' | 'references'>>,
+  { toId, fromIds }: { toId: string; fromIds: string[] }
+): SavedObjectsBulkUpdateObject[] =>
+  objects.map((object) => ({
+    id: object.id,
+    type: object.type,
+    // partial update: empty attributes leaves attributes untouched, only references change.
+    attributes: {},
+    references: updateTagReferences({
+      references: object.references,
+      toAdd: [toId],
+      toRemove: fromIds,
+    }),
+  }));

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/constants.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/constants.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TAG_MERGE_TASK_TYPE = 'saved_objects_tagging:tag_merge';
+
+/** Number of referencing objects rewritten per `updating`-phase run. */
+export const TAG_MERGE_BATCH_SIZE = 100;
+
+/** Cap on retained sample error messages in the job's error summary. */
+export const TAG_MERGE_MAX_ERROR_SAMPLES = 20;
+
+/** Delay before a self-rescheduled run, to avoid monopolizing a Task Manager capacity slot. */
+export const TAG_MERGE_RESCHEDULE_DELAY_MS = 3000;
+
+/**
+ * Deterministic id, unique per space: enforces "at most one merge job per space" since
+ * scheduling a task at an id that already exists conflicts (the `task` saved object type is
+ * namespace-agnostic, so the space must be encoded directly in the id).
+ */
+export const getTagMergeTaskId = (spaceId: string) => `${TAG_MERGE_TASK_TYPE}:${spaceId}`;

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { getTagConnectionsUrl } from './get_tag_connections_url';
-export type { DuplicateTagGroup } from './group_duplicate_tags';
-export { groupDuplicateTagsByName } from './group_duplicate_tags';
-export { buildTagNameLookup } from './tag_name_lookup';
+export { registerTagMergeTaskType } from './register';
+export { getTagMergeTaskId, TAG_MERGE_TASK_TYPE } from './constants';
+export { initialTagMergeTaskState } from './schemas';
+export type { TagMergeTaskParams, TagMergeTaskState } from './schemas';

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/register.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/register.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/server';
+import { TaskCost, type TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
+import { TAG_MERGE_TASK_TYPE } from './constants';
+import { tagMergeTaskParamsSchema, tagMergeTaskStateSchemaByVersion } from './schemas';
+import { createTagMergeTaskRunner } from './task_runner';
+
+export const registerTagMergeTaskType = ({
+  taskManager,
+  getStartServices,
+}: {
+  taskManager: TaskManagerSetupContract;
+  getStartServices: () => Promise<[CoreStart, unknown, unknown]>;
+}) => {
+  taskManager.registerTaskDefinitions({
+    [TAG_MERGE_TASK_TYPE]: {
+      title: 'Merge duplicate tags',
+      description:
+        "Rewrites saved object references from one or more duplicate tags to a canonical tag, optionally deleting the sources once they're unreferenced.",
+      timeout: '2m',
+      cost: TaskCost.Normal,
+      paramsSchema: tagMergeTaskParamsSchema,
+      stateSchemaByVersion: tagMergeTaskStateSchemaByVersion,
+      createTaskRunner: createTagMergeTaskRunner(() => getStartServices().then(([core]) => core)),
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/schemas.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/schemas.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, type TypeOf } from '@kbn/config-schema';
+
+export const tagMergeTaskParamsSchema = schema.object({
+  toId: schema.string(),
+  fromIds: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 50 }),
+  deleteSources: schema.boolean(),
+});
+
+export type TagMergeTaskParams = TypeOf<typeof tagMergeTaskParamsSchema>;
+
+const mergeDeletionResultSchema = schema.object({
+  id: schema.string(),
+  deleted: schema.boolean(),
+  remainingReferences: schema.maybe(schema.number()),
+  error: schema.maybe(schema.string()),
+});
+
+const tagMergeTaskStateSchemaV1 = schema.object({
+  status: schema.oneOf([
+    schema.literal('in_progress'),
+    schema.literal('canceled'),
+    schema.literal('success'),
+    schema.literal('failed'),
+  ]),
+  phase: schema.oneOf([
+    schema.literal('scanning'),
+    schema.literal('updating'),
+    schema.literal('finalizing'),
+    schema.literal('complete'),
+  ]),
+  startedAt: schema.string(),
+  totalAffected: schema.maybe(schema.number()),
+  updatedCount: schema.number({ defaultValue: 0 }),
+  cancelRequested: schema.boolean({ defaultValue: false }),
+  deletion: schema.arrayOf(mergeDeletionResultSchema, { defaultValue: [] }),
+  errors: schema.object({
+    count: schema.number({ defaultValue: 0 }),
+    samples: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  }),
+});
+
+export type TagMergeTaskState = TypeOf<typeof tagMergeTaskStateSchemaV1>;
+
+export const tagMergeTaskStateSchemaByVersion = {
+  1: {
+    schema: tagMergeTaskStateSchemaV1,
+    up: (state: Record<string, unknown>) => state,
+  },
+};
+
+export const initialTagMergeTaskState = (): TagMergeTaskState => ({
+  status: 'in_progress',
+  phase: 'scanning',
+  startedAt: new Date().toISOString(),
+  updatedCount: 0,
+  cancelRequested: false,
+  deletion: [],
+  errors: { count: 0, samples: [] },
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/task_runner.test.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  coreMock,
+  httpServerMock,
+  savedObjectsClientMock,
+  savedObjectsTypeRegistryMock,
+} from '@kbn/core/server/mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { taggableTypes, tagSavedObjectTypeName } from '../../../common/constants';
+import { createTagMergeTaskRunner } from './task_runner';
+import {
+  initialTagMergeTaskState,
+  type TagMergeTaskParams,
+  type TagMergeTaskState,
+} from './schemas';
+
+interface MergeRunResult {
+  state: TagMergeTaskState;
+  runAt?: Date;
+}
+
+describe('createTagMergeTaskRunner', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let internalClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let typeRegistry: ReturnType<typeof savedObjectsTypeRegistryMock.create>;
+  let getCoreStart: jest.Mock;
+
+  const params: TagMergeTaskParams = {
+    toId: 'to-1',
+    fromIds: ['from-1', 'from-2'],
+    deleteSources: false,
+  };
+
+  const runWith = async (
+    state: TagMergeTaskState,
+    overrides: Parameters<typeof taskManagerMock.createRunContext>[0] = {}
+  ): Promise<MergeRunResult> => {
+    const context = taskManagerMock.createRunContext({
+      taskInstance: taskManagerMock.createTask({ params, state }),
+      fakeRequest: httpServerMock.createKibanaRequest(),
+      ...overrides,
+    });
+    const result = await createTagMergeTaskRunner(getCoreStart)(context).run();
+    // production code always returns a full result; the wider `RunResult | undefined | void`
+    // signature only accommodates task types that legitimately return nothing.
+    return result as MergeRunResult;
+  };
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    internalClient = savedObjectsClientMock.create();
+    typeRegistry = savedObjectsTypeRegistryMock.create();
+    // pretend every known taggable type is registered in this deployment
+    typeRegistry.getType.mockImplementation((type) => ({ name: type } as any));
+
+    const core = coreMock.createStart();
+    core.savedObjects.getScopedClient.mockReturnValue(soClient);
+    core.savedObjects.getUnsafeInternalClient.mockReturnValue(internalClient);
+    core.savedObjects.getTypeRegistry.mockReturnValue(typeRegistry);
+    getCoreStart = jest.fn().mockResolvedValue(core);
+  });
+
+  describe('top-level guards', () => {
+    it('throws an unrecoverable error when no `fakeRequest` was provided', async () => {
+      await expect(runWith(initialTagMergeTaskState(), { fakeRequest: undefined })).rejects.toThrow(
+        /missing its scoped request/
+      );
+      expect(getCoreStart).not.toHaveBeenCalled();
+    });
+
+    it('cancels immediately, without touching the saved objects client, when cancelRequested', async () => {
+      const state: TagMergeTaskState = {
+        ...initialTagMergeTaskState(),
+        phase: 'updating',
+        cancelRequested: true,
+      };
+
+      const result = await runWith(state);
+
+      // `runAt` is required here: a terminal state returned without it is never persisted at
+      // all (Task Manager deletes the task immediately instead), so the next status poll would
+      // never observe `canceled` — see the comment on this branch in task_runner.ts.
+      expect(result.state).toEqual({ ...state, status: 'canceled', phase: 'complete' });
+      expect(result.runAt).toBeInstanceOf(Date);
+      expect(getCoreStart).not.toHaveBeenCalled();
+    });
+
+    it('retries shortly, rather than being deleted, when the abort signal is already tripped', async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      const state = initialTagMergeTaskState();
+
+      const result = await runWith(state, { abortController });
+
+      // No `runAt` here would get this task deleted outright (see task_runner.ts's comment) even
+      // though a transient abort isn't a terminal state — so this must still reschedule.
+      expect(result.state).toEqual(state);
+      expect(result.runAt).toBeInstanceOf(Date);
+      expect(getCoreStart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scanning phase', () => {
+    it('sums per-type totals into `totalAffected` and advances to `updating`', async () => {
+      soClient.find.mockImplementation(({ type }) =>
+        Promise.resolve({
+          saved_objects: [],
+          page: 1,
+          per_page: 0,
+          total: type === 'dashboard' ? 4 : 1,
+        })
+      );
+
+      const result = await runWith(initialTagMergeTaskState());
+
+      expect(result.state.totalAffected).toEqual(4 + (taggableTypes.length - 1) * 1);
+      expect(result.state.phase).toEqual('updating');
+      expect(result.runAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('updating phase', () => {
+    const updatingState: TagMergeTaskState = {
+      ...initialTagMergeTaskState(),
+      phase: 'updating',
+      totalAffected: 10,
+    };
+
+    it('rewrites references for the next batch and increments `updatedCount`', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [
+          { id: 'obj-1', type: 'dashboard', references: [], attributes: {}, score: 0 },
+          { id: 'obj-2', type: 'dashboard', references: [], attributes: {}, score: 0 },
+        ],
+        total: 2,
+        page: 1,
+        per_page: 100,
+      });
+      soClient.bulkUpdate.mockResolvedValue({
+        saved_objects: [
+          { id: 'obj-1', type: 'dashboard', references: [], attributes: {} },
+          { id: 'obj-2', type: 'dashboard', references: [], attributes: {} },
+        ],
+      });
+
+      const result = await runWith(updatingState);
+
+      expect(soClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(result.state.updatedCount).toEqual(2);
+      expect(result.state.phase).toEqual('updating');
+      expect(result.runAt).toBeInstanceOf(Date);
+    });
+
+    it('records per-object failures from `bulkUpdate` in the error summary without failing the run', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [
+          { id: 'obj-1', type: 'dashboard', references: [], attributes: {}, score: 0 },
+        ],
+        total: 1,
+        page: 1,
+        per_page: 100,
+      });
+      soClient.bulkUpdate.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'obj-1',
+            type: 'dashboard',
+            error: { statusCode: 409, message: 'conflict', error: 'Conflict' },
+          } as any,
+        ],
+      });
+
+      const result = await runWith(updatingState);
+
+      expect(result.state.updatedCount).toEqual(0);
+      expect(result.state.errors.count).toEqual(1);
+      expect(result.state.errors.samples[0]).toContain('conflict');
+    });
+
+    it('advances to `complete`/`success` once the batch is empty and `deleteSources` is false', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, page: 1, per_page: 100 });
+
+      const result = await runWith(updatingState);
+
+      expect(result.state.phase).toEqual('complete');
+      expect(result.state.status).toEqual('success');
+    });
+
+    it('advances to `finalizing` once the batch is empty and `deleteSources` is true', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, page: 1, per_page: 100 });
+
+      const context = taskManagerMock.createRunContext({
+        taskInstance: taskManagerMock.createTask({
+          params: { ...params, deleteSources: true },
+          state: updatingState,
+        }),
+        fakeRequest: httpServerMock.createKibanaRequest(),
+      });
+      const result = (await createTagMergeTaskRunner(getCoreStart)(
+        context
+      ).run()) as MergeRunResult;
+
+      expect(result.state.phase).toEqual('finalizing');
+      expect(result.state.status).toEqual('in_progress');
+    });
+
+    it('cancels via the top-level guard before entering the phase at all, once cancelRequested is set', async () => {
+      // The next run after `cancelRequested` is set (by the cancel route) sees it via the
+      // top-level `run()` guard, which fires before `runUpdatingPhase` — so no further batch is
+      // ever processed once cancellation is requested, regardless of which phase the job was in.
+      const result = await runWith({ ...updatingState, cancelRequested: true });
+
+      expect(result.state.status).toEqual('canceled');
+      expect(result.state.phase).toEqual('complete');
+      // one more reschedule so the `canceled` state has a chance to persist and be observed
+      // before the following no-op run lets Task Manager clean up the task; see task_runner.ts.
+      expect(result.runAt).toBeInstanceOf(Date);
+      expect(soClient.find).not.toHaveBeenCalled();
+      expect(soClient.bulkUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('finalizing phase', () => {
+    const finalizingState: TagMergeTaskState = {
+      ...initialTagMergeTaskState(),
+      phase: 'finalizing',
+    };
+    const finalizingParams: TagMergeTaskParams = { ...params, deleteSources: true };
+
+    const runFinalizing = async (
+      state: TagMergeTaskState,
+      overrides = {}
+    ): Promise<MergeRunResult> => {
+      const context = taskManagerMock.createRunContext({
+        taskInstance: taskManagerMock.createTask({ params: finalizingParams, state }),
+        fakeRequest: httpServerMock.createKibanaRequest(),
+        ...overrides,
+      });
+      const result = await createTagMergeTaskRunner(getCoreStart)(context).run();
+      return result as MergeRunResult;
+    };
+
+    it('runs a fresh per-fromId scan and deletes only ids with zero remaining references', async () => {
+      // Deliberately on `internalClient`, not `soClient`: the remaining-references safety check
+      // must use the unscoped client so it can't under-count references in types the merging
+      // user can't `find` — see the comment on this in task_runner.ts.
+      internalClient.find.mockImplementation(({ hasReference }) => {
+        const id = (hasReference as Array<{ id: string }>)[0].id;
+        return Promise.resolve({
+          saved_objects: [],
+          page: 1,
+          per_page: 0,
+          total: id === 'from-1' ? 0 : 3,
+        });
+      });
+
+      const result = await runFinalizing(finalizingState);
+
+      expect(soClient.removeReferencesTo).toHaveBeenCalledWith(tagSavedObjectTypeName, 'from-1');
+      expect(soClient.delete).toHaveBeenCalledWith(tagSavedObjectTypeName, 'from-1');
+      expect(soClient.delete).not.toHaveBeenCalledWith(tagSavedObjectTypeName, 'from-2');
+      expect(result.state.deletion).toEqual([
+        { id: 'from-1', deleted: true },
+        { id: 'from-2', deleted: false, remainingReferences: 3 },
+      ]);
+      expect(result.state.phase).toEqual('complete');
+      expect(result.state.status).toEqual('success');
+      // `runAt` is required here too: without it this terminal state is never persisted (Task
+      // Manager deletes the task immediately instead) — same landmine as the cancel branch.
+      expect(result.runAt).toBeInstanceOf(Date);
+    });
+
+    it('treats a not-found error on delete as already-deleted (idempotent re-run)', async () => {
+      internalClient.find.mockResolvedValue({ saved_objects: [], page: 1, per_page: 0, total: 0 });
+      soClient.delete.mockRejectedValue(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(tagSavedObjectTypeName, 'from-1')
+      );
+
+      const result = await runFinalizing(finalizingState);
+
+      expect(result.state.deletion.every((d) => d.deleted)).toBe(true);
+    });
+
+    it('records a real delete error without treating it as success', async () => {
+      internalClient.find.mockResolvedValue({ saved_objects: [], page: 1, per_page: 0, total: 0 });
+      soClient.delete.mockRejectedValue(new Error('cluster unavailable'));
+
+      const result = await runFinalizing(finalizingState);
+
+      expect(
+        result.state.deletion.every((d) => !d.deleted && d.error === 'cluster unavailable')
+      ).toBe(true);
+    });
+
+    it('stops at the current id when aborted and reschedules a fresh (idempotent) re-run', async () => {
+      const abortController = new AbortController();
+      let calls = 0;
+      internalClient.find.mockImplementation(() => {
+        calls += 1;
+        if (calls === 1) {
+          abortController.abort();
+        }
+        return Promise.resolve({ saved_objects: [], page: 1, per_page: 0, total: 0 });
+      });
+
+      const result = await runFinalizing(finalizingState, { abortController });
+
+      expect(result.state.deletion).toHaveLength(1); // stopped after the first id
+      expect(result.state.phase).toEqual('finalizing'); // not yet complete
+      expect(result.runAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/task_runner.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/tasks/tag_merge/task_runner.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CoreStart,
+  SavedObjectsClientContract,
+  ISavedObjectTypeRegistry,
+} from '@kbn/core/server';
+import { isSavedObjectErrorResult, SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { RunContext, TaskRunCreatorFunction } from '@kbn/task-manager-plugin/server';
+import { throwUnrecoverableError } from '@kbn/task-manager-plugin/server';
+import { taggableTypes } from '../../../common/constants';
+import { tagIdToReference } from '../../../common/references';
+import { computeAffectedCount, rewriteTagReferences, TagsClient } from '../../services';
+import {
+  TAG_MERGE_BATCH_SIZE,
+  TAG_MERGE_MAX_ERROR_SAMPLES,
+  TAG_MERGE_RESCHEDULE_DELAY_MS,
+} from './constants';
+import type { TagMergeTaskParams, TagMergeTaskState } from './schemas';
+
+interface PhaseArgs {
+  soClient: SavedObjectsClientContract;
+  internalClient: SavedObjectsClientContract;
+  typeRegistry: ISavedObjectTypeRegistry;
+  params: TagMergeTaskParams;
+  state: TagMergeTaskState;
+  knownTaggableTypes: string[];
+  abortController: AbortController;
+}
+
+const addErrorSamples = (
+  errors: TagMergeTaskState['errors'],
+  messages: string[]
+): TagMergeTaskState['errors'] => ({
+  count: errors.count + messages.length,
+  samples: [...errors.samples, ...messages].slice(0, TAG_MERGE_MAX_ERROR_SAMPLES),
+});
+
+const runScanningPhase = async ({ soClient, params, state, knownTaggableTypes }: PhaseArgs) => {
+  const { affectedCount } = await computeAffectedCount(soClient, {
+    fromIds: params.fromIds,
+    types: knownTaggableTypes,
+  });
+
+  return {
+    state: { ...state, totalAffected: affectedCount, phase: 'updating' as const },
+    runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS),
+  };
+};
+
+const runUpdatingPhase = async ({ soClient, params, state, knownTaggableTypes }: PhaseArgs) => {
+  const { toId, fromIds } = params;
+  const hasReference = fromIds.map(tagIdToReference);
+
+  const { saved_objects: batch } = await soClient.find({
+    type: knownTaggableTypes,
+    hasReference,
+    hasReferenceOperator: 'OR',
+    perPage: TAG_MERGE_BATCH_SIZE,
+  });
+
+  if (batch.length === 0) {
+    const nextPhase = params.deleteSources ? ('finalizing' as const) : ('complete' as const);
+    return {
+      state: {
+        ...state,
+        phase: nextPhase,
+        status: nextPhase === 'complete' ? ('success' as const) : state.status,
+      },
+      runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS),
+    };
+  }
+
+  const updates = rewriteTagReferences(batch, { toId, fromIds });
+  const result = await soClient.bulkUpdate(updates);
+  const failures = result.saved_objects.filter(isSavedObjectErrorResult);
+  const succeeded = batch.length - failures.length;
+
+  const nextState: TagMergeTaskState = {
+    ...state,
+    updatedCount: state.updatedCount + succeeded,
+    errors: addErrorSamples(
+      state.errors,
+      failures.map((f) => `[${f.type}/${f.id}] ${f.error!.message}`)
+    ),
+  };
+
+  // Cancellation is handled by `run()`'s top-level guard before the next batch starts, not here.
+  return { state: nextState, runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS) };
+};
+
+const runFinalizingPhase = async ({
+  soClient,
+  internalClient,
+  params,
+  state,
+  knownTaggableTypes,
+  abortController,
+}: PhaseArgs) => {
+  const { fromIds } = params;
+  const tagsClient = new TagsClient({ client: soClient });
+
+  // Sequential (not Promise.all): each iteration checks the abort signal, so a timeout stops
+  // deleting further source tags immediately rather than firing all deletes concurrently.
+  const deletion: TagMergeTaskState['deletion'] = [];
+  for (const id of fromIds) {
+    if (abortController.signal.aborted) break;
+
+    // Deliberately the unscoped `internalClient`, not the per-user `soClient`: a per-user
+    // `find()` silently narrows to types the merging user can `find` rather than throwing on
+    // the rest, so this safety check would otherwise under-count real remaining references (and
+    // delete a source tag still in use) whenever the merging user can't see every taggable type.
+    const { total } = await internalClient.find({
+      type: knownTaggableTypes,
+      hasReference: [tagIdToReference(id)],
+      perPage: 0,
+    });
+    if (total > 0) {
+      deletion.push({ id, deleted: false, remainingReferences: total });
+      continue;
+    }
+    try {
+      await tagsClient.delete(id);
+      deletion.push({ id, deleted: true });
+    } catch (e) {
+      // a re-run (e.g. after an abort below) may re-delete an id already removed on a prior run.
+      deletion.push(
+        SavedObjectsErrorHelpers.isNotFoundError(e)
+          ? { id, deleted: true }
+          : { id, deleted: false, error: e.message }
+      );
+    }
+  }
+
+  if (abortController.signal.aborted) {
+    // partial progress only; re-run `finalizing` from scratch (idempotent) to cover the rest.
+    return {
+      state: { ...state, deletion },
+      runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS),
+    };
+  }
+
+  return {
+    state: { ...state, phase: 'complete' as const, status: 'success' as const, deletion },
+    // See the top-level guard's comment: a terminal state returned without `runAt` is never
+    // persisted at all (Task Manager deletes the task instead), so this still needs one.
+    runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS),
+  };
+};
+
+export const createTagMergeTaskRunner =
+  (getCoreStart: () => Promise<CoreStart>): TaskRunCreatorFunction =>
+  (context: RunContext) => {
+    const { taskInstance, fakeRequest, abortController } = context;
+
+    return {
+      run: async () => {
+        const params = taskInstance.params as TagMergeTaskParams;
+        const state = taskInstance.state as TagMergeTaskState;
+
+        if (!fakeRequest) {
+          throwUnrecoverableError(
+            new Error(
+              'Tag merge task is missing its scoped request: no apiKey/userScope was set when it was scheduled'
+            )
+          );
+        }
+
+        // Cooperative cancellation: checked at the start of every run, before doing more work.
+        //
+        // `runAt` here is required, not optional: a one-shot task (no `schedule`) that returns
+        // WITHOUT `runAt` is treated by Task Manager as finished and its saved object is deleted
+        // immediately (`processResultWhenDone`, task_manager's task_runner.ts) — the returned
+        // `state` is never written first. Omitting `runAt` on a terminal-state transition means
+        // that state (`canceled`, here) is silently thrown away, and the next status poll finds
+        // no task at all and falls back to reporting `idle`. The one further no-op run this
+        // causes (hitting the `case 'complete'` branch below, which correctly has no `runAt`)
+        // is what actually triggers cleanup, once the terminal state has had a chance to persist
+        // and be observed.
+        if (state.cancelRequested && state.status === 'in_progress') {
+          return {
+            state: { ...state, status: 'canceled' as const, phase: 'complete' as const },
+            runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS),
+          };
+        }
+
+        // Already timed out before this run got a chance to start any work: retry shortly
+        // rather than returning without `runAt`, which (per the comment above) would get this
+        // task deleted outright — a transient abort here isn't a terminal state.
+        if (abortController.signal.aborted) {
+          return { state, runAt: new Date(Date.now() + TAG_MERGE_RESCHEDULE_DELAY_MS) };
+        }
+
+        const core = await getCoreStart();
+        const soClient = core.savedObjects.getScopedClient(fakeRequest!);
+        const internalClient = core.savedObjects.getUnsafeInternalClient();
+        const typeRegistry = core.savedObjects.getTypeRegistry();
+        const knownTaggableTypes = taggableTypes.filter(
+          (type) => typeRegistry.getType(type) !== undefined
+        );
+        const phaseArgs: PhaseArgs = {
+          soClient,
+          internalClient,
+          typeRegistry,
+          params,
+          state,
+          knownTaggableTypes,
+          abortController,
+        };
+
+        switch (state.phase) {
+          case 'scanning':
+            return runScanningPhase(phaseArgs);
+          case 'updating':
+            return runUpdatingPhase(phaseArgs);
+          case 'finalizing':
+            return runFinalizingPhase(phaseArgs);
+          case 'complete':
+          default:
+            // No `runAt`: this is the no-op run that lets Task Manager clean up the task,
+            // now that the terminal state set on the previous run has had a chance to persist.
+            return { state };
+        }
+      },
+    };
+  };

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/types.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/types.ts
@@ -12,11 +12,12 @@ import type {
   SavedObjectReference,
 } from '@kbn/core/server';
 import type { ITagsClient, Tag } from '../common/types';
-import type { IAssignmentService } from './services';
+import type { IAssignmentService, IMergeService } from './services';
 
 export interface ITagsRequestHandlerContext {
   tagsClient: ITagsClient;
   assignmentService: IAssignmentService;
+  mergeService: IMergeService;
 }
 
 /** @public */

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json
@@ -26,7 +26,9 @@
     "@kbn/as-code-shared-schemas",
     "@kbn/core-http-server",
     "@kbn/core-http-browser",
-    "@kbn/as-code-shared-telemetry"
+    "@kbn/as-code-shared-telemetry",
+    "@kbn/task-manager-plugin",
+    "@kbn/spaces-plugin"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
__Warning: Vibe-coded. Needs human review__

## Summary

Adds an internal-only workflow to merge duplicate-named tags in Saved Objects Tagging. Because saved objects reference tags by immutable ID (not name), duplicate tag names accumulate over time (migrations, imports, race conditions before create/update validation tightened) and users have no safe way to consolidate them without breaking references or accidentally detaching tags from objects.

This adds, from Tag Management:
1. Detection of duplicate tag names, surfaced as a callout grouping them.
2. A flyout to pick a canonical tag from a duplicate-name group (table view, sortable by description/connection count, managed tags shown read-only).
3. A preview step showing the count of affected saved objects (with a paginated drill-down) and whether the merge/deletion can proceed for the current user.
4. An async merge, run via Task Manager, that rewrites tag references from the duplicate ("from") tags to the canonical ("to") tag in batches, then optionally deletes the now-unused source tags.
5. Live progress (phase, percent, per-object error samples), cancellation, and reattachment — closing the flyout mid-merge and reopening it (or navigating away and back) picks the running job back up rather than losing status.

**Key design points:**
- **Per-user execution**: the merge task runs with a Saved Objects client scoped to the user who started it, via Task Manager's built-in per-request API key grant (`schedule(taskInstance, { request })`) — not a custom Encrypted Saved Objects type.
- **Singleton per space**: at most one merge job runs at a time per space; the UI surfaces which duplicate-name group is currently merging via a page-level banner, independent of whether the flyout is open.
- **Two authorization gates**:
  - Baseline: user must be able to manage tag objects (update+delete `tag` SOs) and this specific merge must actually affect at least one object the user can update (gated on a freshly recomputed `affectedCount`, not a generic "can update some taggable type" signal).
  - Delete-sources gate: user must be able to update every taggable type that *actually* has a live reference to the tags being merged right now — determined via an unscoped internal scan, so a dashboard-only editor can delete sources when only dashboards are affected, without needing access to every registered taggable type in the deployment.
- **Deletion safety**: before deleting a source tag, the task re-scans (via the same unscoped internal client, not the per-user one) for zero remaining references — never trusting the earlier preview/update-phase counts. This also closes a subtler issue: a per-user-scoped `find()` across multiple types silently narrows to types the caller can see rather than erroring, so using it for this safety check could have under-counted real references and deleted a tag still in use elsewhere.
- **Best-effort, not fail-fast**: per-object update/delete failures are recorded (count + sampled messages) without aborting the batch or the job.

New internal routes under `/internal/saved_objects_tagging/tags/merge`: preview, preview-objects (paginated drill-down), start, status, cancel. New Task Manager task type `saved_objects_tagging:tag_merge`.

Out of scope: public `/api/tags` merge support, cross-space merges, rollback/undo of a partially completed merge, automatic canonical-tag selection.

<!-- add a screenshot/gif of the flyout flow here before publishing -->

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials — see the plugin `README.md` for the merge workflow, authorization model, and cancellation semantics
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker) — N/A, no config keys added
- [x] This was checked for breaking HTTP API changes — N/A, all new endpoints are `internal` (not part of the public `/api/tags` surface)
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels

### Identify risks

- **Deletion safety under partial permissions**: deleting a source tag is only safe if the pre-deletion "any remaining references?" check can see every reference, regardless of what the merging user can see. Mitigated by using an unscoped internal Saved Objects client for that specific check (and for computing which types gate `deleteSources`), rather than the per-user client, which would otherwise silently under-count references in types the user lacks `find` privilege on. Covered by unit tests in `task_runner.test.ts` and `merge_service.test.ts`.
- **Long-running background job correctness**: the task carries an encrypted `apiKey`/`userScope`; several Task Manager terminal-state and cancellation edge cases (missing `runAt` causing silent task deletion, `bulkUpdateState` needing `{ request }`) were non-obvious and are called out explicitly in the README and in code comments to avoid regressions.
- **No rollback**: reference rewrites already applied before a cancel or failure are not undone. This is a deliberate, documented tradeoff (see proposal's "Out of scope"), but worth reviewer awareness since it affects user-visible behavior if a merge is canceled partway through.
- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
