### PR TITLE
[Security Solution][Flyout] add missing cell actions to new attack flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/attack_flyout_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/attack_flyout_wrapper.tsx
@@ -10,6 +10,7 @@ import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils';
+import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import { useAttackDetails } from '../../../flyout/attack_details/hooks/use_attack_details';
 import { AttackFlyout } from '.';
@@ -34,6 +35,10 @@ export interface AttackFlyoutWrapperProps {
    * having to close and re-open it.
    */
   onAttackUpdated: () => void;
+  /**
+   * Renderer for cell actions in nested alert flyouts opened from attack tools.
+   */
+  renderCellActions?: CellActionRenderer;
 }
 
 /**
@@ -44,7 +49,7 @@ export interface AttackFlyoutWrapperProps {
  * is reflected without re-opening the flyout.
  */
 export const AttackFlyoutWrapper = memo(
-  ({ attackId, indexName, onAttackUpdated }: AttackFlyoutWrapperProps) => {
+  ({ attackId, indexName, onAttackUpdated, renderCellActions }: AttackFlyoutWrapperProps) => {
     const { loading, searchHit, attack, refetch } = useAttackDetails({ attackId, indexName });
 
     const hit = useMemo(
@@ -77,7 +82,14 @@ export const AttackFlyoutWrapper = memo(
       );
     }
 
-    return <AttackFlyout hit={hit} attack={attack} onAttackUpdated={handleAttackUpdated} />;
+    return (
+      <AttackFlyout
+        hit={hit}
+        attack={attack}
+        onAttackUpdated={handleAttackUpdated}
+        renderCellActions={renderCellActions}
+      />
+    );
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/index.tsx
@@ -20,6 +20,7 @@ import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 import { flyoutProviders } from '../../shared/components/flyout_provider';
 import { JsonTab as SharedJsonTab } from '../../shared/components/json_tab';
@@ -71,6 +72,10 @@ export interface AttackFlyoutProps {
    * and notifies the surface that opened the flyout to refresh as well.
    */
   onAttackUpdated: () => void;
+  /**
+   * Renderer for cell actions in this flyout and nested alert flyouts.
+   */
+  renderCellActions?: CellActionRenderer;
 }
 
 /**
@@ -78,80 +83,86 @@ export interface AttackFlyoutProps {
  * from `AttackFlyoutWrapper` (which owns the single data fetch) and renders the
  * header, overview tab, and footer.
  */
-export const AttackFlyout = memo(({ hit, attack, onAttackUpdated }: AttackFlyoutProps) => {
-  const { services } = useKibana();
-  const { overlays } = services;
-  const store = useStore();
-  const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+export const AttackFlyout = memo(
+  ({ hit, attack, onAttackUpdated, renderCellActions = cellActionRenderer }: AttackFlyoutProps) => {
+    const { services } = useKibana();
+    const { overlays } = services;
+    const store = useStore();
+    const history = useHistory();
+    const isInSecurityApp = useIsInSecurityApp();
+    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
-  // The selected tab is persisted to localStorage, sharing the key with the legacy
-  // attack flyout so the user's preference carries across both implementations.
-  const { selectedTabId, setSelectedTabId } = useTabs<AttackFlyoutTabId>({
-    validTabIds: VALID_TAB_IDS,
-    storageKey: FLYOUT_STORAGE_KEYS.SELECTED_TAB,
-  });
+    // The selected tab is persisted to localStorage, sharing the key with the legacy
+    // attack flyout so the user's preference carries across both implementations.
+    const { selectedTabId, setSelectedTabId } = useTabs<AttackFlyoutTabId>({
+      validTabIds: VALID_TAB_IDS,
+      storageKey: FLYOUT_STORAGE_KEYS.SELECTED_TAB,
+    });
 
-  const onShowNotes = useCallback(() => {
-    overlays.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: <NotesDetails hit={hit} />,
-      }),
-      { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+    const onShowNotes = useCallback(() => {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <NotesDetails hit={hit} />,
+        }),
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+      );
+    }, [history, historyKey, hit, overlays, services, store]);
+
+    return (
+      <>
+        <EuiFlyoutHeader data-test-subj="attack-flyout-header">
+          <Header hit={hit} onAttackUpdated={onAttackUpdated} onShowNotes={onShowNotes} />
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody data-test-subj="attack-flyout-body">
+          <EuiTabs>
+            <EuiTab
+              isSelected={selectedTabId === 'overview'}
+              onClick={() => setSelectedTabId('overview')}
+              data-test-subj={OVERVIEW_TAB_TEST_ID}
+            >
+              {OVERVIEW_TAB_LABEL}
+            </EuiTab>
+            <EuiTab
+              isSelected={selectedTabId === 'table'}
+              onClick={() => setSelectedTabId('table')}
+              data-test-subj={TABLE_TAB_TEST_ID}
+            >
+              {TABLE_TAB_LABEL}
+            </EuiTab>
+            <EuiTab
+              isSelected={selectedTabId === 'json'}
+              onClick={() => setSelectedTabId('json')}
+              data-test-subj={JSON_TAB_TEST_ID}
+            >
+              {JSON_TAB_LABEL}
+            </EuiTab>
+          </EuiTabs>
+          <EuiSpacer size="m" />
+          {selectedTabId === 'table' ? (
+            <TableTab hit={hit} renderCellActions={renderCellActions} />
+          ) : selectedTabId === 'json' ? (
+            <SharedJsonTab
+              value={hit.raw as unknown as Record<string, unknown>}
+              showFooterOffset={false}
+              data-test-subj={JSON_TAB_CONTENT_TEST_ID}
+            />
+          ) : (
+            <OverviewTab
+              hit={hit}
+              onAttackUpdated={onAttackUpdated}
+              renderCellActions={renderCellActions}
+            />
+          )}
+        </EuiFlyoutBody>
+        <EuiFlyoutFooter data-test-subj="attack-flyout-footer">
+          <Footer attack={attack} hit={hit} onAttackUpdated={onAttackUpdated} />
+        </EuiFlyoutFooter>
+      </>
     );
-  }, [history, historyKey, hit, overlays, services, store]);
-
-  return (
-    <>
-      <EuiFlyoutHeader data-test-subj="attack-flyout-header">
-        <Header hit={hit} onAttackUpdated={onAttackUpdated} onShowNotes={onShowNotes} />
-      </EuiFlyoutHeader>
-      <EuiFlyoutBody data-test-subj="attack-flyout-body">
-        <EuiTabs>
-          <EuiTab
-            isSelected={selectedTabId === 'overview'}
-            onClick={() => setSelectedTabId('overview')}
-            data-test-subj={OVERVIEW_TAB_TEST_ID}
-          >
-            {OVERVIEW_TAB_LABEL}
-          </EuiTab>
-          <EuiTab
-            isSelected={selectedTabId === 'table'}
-            onClick={() => setSelectedTabId('table')}
-            data-test-subj={TABLE_TAB_TEST_ID}
-          >
-            {TABLE_TAB_LABEL}
-          </EuiTab>
-          <EuiTab
-            isSelected={selectedTabId === 'json'}
-            onClick={() => setSelectedTabId('json')}
-            data-test-subj={JSON_TAB_TEST_ID}
-          >
-            {JSON_TAB_LABEL}
-          </EuiTab>
-        </EuiTabs>
-        <EuiSpacer size="m" />
-        {selectedTabId === 'table' ? (
-          <TableTab hit={hit} renderCellActions={cellActionRenderer} />
-        ) : selectedTabId === 'json' ? (
-          <SharedJsonTab
-            value={hit.raw as unknown as Record<string, unknown>}
-            showFooterOffset={false}
-            data-test-subj={JSON_TAB_CONTENT_TEST_ID}
-          />
-        ) : (
-          <OverviewTab hit={hit} onAttackUpdated={onAttackUpdated} />
-        )}
-      </EuiFlyoutBody>
-      <EuiFlyoutFooter data-test-subj="attack-flyout-footer">
-        <Footer attack={attack} hit={hit} onAttackUpdated={onAttackUpdated} />
-      </EuiFlyoutFooter>
-    </>
-  );
-});
+  }
+);
 
 AttackFlyout.displayName = 'AttackFlyout';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.test.tsx
@@ -69,13 +69,16 @@ const buildHit = (extra: Record<string, unknown> = {}): DataTableRecord =>
 
 const renderTab = (
   hit: DataTableRecord,
-  { openSystemFlyout = jest.fn() }: { openSystemFlyout?: jest.Mock } = {}
+  {
+    openSystemFlyout = jest.fn(),
+    renderCellActions = jest.fn(),
+  }: { openSystemFlyout?: jest.Mock; renderCellActions?: jest.Mock } = {}
 ) => {
   const startServices = createStartServicesMock();
   startServices.overlays = { ...startServices.overlays, openSystemFlyout };
   return render(
     <TestProviders startServices={startServices}>
-      <OverviewTab hit={hit} onAttackUpdated={jest.fn()} />
+      <OverviewTab hit={hit} onAttackUpdated={jest.fn()} renderCellActions={renderCellActions} />
     </TestProviders>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/overview_tab.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useCallback } from 'react';
 import { EuiHorizontalRule } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { noopCellActionRenderer } from '../../../shared/components/cell_actions';
+import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 import { useFlyoutApi } from '../../../use_flyout_api';
 import { AISummarySection } from '../components/ai_summary_section';
 import { VisualizationsSection } from '../components/visualizations_section';
@@ -24,6 +24,10 @@ export interface OverviewTabProps {
    * Callback invoked after alert mutations to refresh the flyout content.
    */
   onAttackUpdated: () => void;
+  /**
+   * Renderer for cell actions in nested alert flyouts.
+   */
+  renderCellActions: CellActionRenderer;
 }
 
 /**
@@ -32,7 +36,7 @@ export interface OverviewTabProps {
  * the legacy attack details flyout. Owns the callbacks that open the Entities/Correlations tools
  * (and, from Correlations, an alert) as child flyouts via the new flyout system.
  */
-export const OverviewTab = memo(({ hit, onAttackUpdated }: OverviewTabProps) => {
+export const OverviewTab = memo(({ hit, onAttackUpdated, renderCellActions }: OverviewTabProps) => {
   const { openAttackCorrelations, openAttackEntities, openDocumentFlyoutFromIndexAsChild } =
     useFlyoutApi();
 
@@ -43,10 +47,10 @@ export const OverviewTab = memo(({ hit, onAttackUpdated }: OverviewTabProps) => 
       openDocumentFlyoutFromIndexAsChild({
         documentId: id,
         indexName,
-        renderCellActions: noopCellActionRenderer,
+        renderCellActions,
         onAlertUpdated: onAttackUpdated,
       }),
-    [openDocumentFlyoutFromIndexAsChild, onAttackUpdated]
+    [openDocumentFlyoutFromIndexAsChild, onAttackUpdated, renderCellActions]
   );
 
   const onShowCorrelations = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -15,6 +15,8 @@ import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser'
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useKibana } from '../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import type { CellActionRenderer } from '../shared/components/cell_actions';
+import { cellActionRenderer } from '../shared/components/cell_actions';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import {
@@ -42,6 +44,8 @@ export interface OpenAttackFlyoutParams {
   indexName: string;
   /** Invoked after the attack is mutated inside the flyout, to let the caller refresh. Defaults to a no-op. */
   onAttackUpdated?: () => void;
+  /** Renderer for cell actions in nested alert flyouts. Defaults to the standard `cellActionRenderer`. */
+  renderCellActions?: CellActionRenderer;
 }
 
 export interface OpenAttackCorrelationsParams {
@@ -117,12 +121,18 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
   );
 
   const openAttackFlyout = useCallback(
-    ({ attackId, indexName, onAttackUpdated = noop }: OpenAttackFlyoutParams) => {
+    ({
+      attackId,
+      indexName,
+      onAttackUpdated = noop,
+      renderCellActions = cellActionRenderer,
+    }: OpenAttackFlyoutParams) => {
       open(
         <AttackFlyoutWrapper
           attackId={attackId}
           indexName={indexName}
           onAttackUpdated={onAttackUpdated}
+          renderCellActions={renderCellActions}
         />,
         { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
       );
@@ -131,12 +141,18 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
   );
 
   const openAttackFlyoutAsChild = useCallback(
-    ({ attackId, indexName, onAttackUpdated = noop }: OpenAttackFlyoutParams) => {
+    ({
+      attackId,
+      indexName,
+      onAttackUpdated = noop,
+      renderCellActions = cellActionRenderer,
+    }: OpenAttackFlyoutParams) => {
       open(
         <AttackFlyoutWrapper
           attackId={attackId}
           indexName={indexName}
           onAttackUpdated={onAttackUpdated}
+          renderCellActions={renderCellActions}
         />,
         { ...defaultDocumentFlyoutProperties, historyKey, session: 'inherit' }
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/attack_flyout_overview_tab_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/attack_flyout_overview_tab_component/index.test.tsx
@@ -67,6 +67,7 @@ describe('AttackFlyoutOverviewTab', () => {
         hit={buildHit()}
         servicesPromise={new Promise<StartServices>(() => undefined)}
         storePromise={new Promise<ReturnType<typeof createStore>>(() => undefined) as never}
+        onAttackUpdated={jest.fn()}
       />
     );
 
@@ -81,6 +82,7 @@ describe('AttackFlyoutOverviewTab', () => {
         hit={buildHit()}
         servicesPromise={Promise.resolve(servicesMock)}
         storePromise={Promise.resolve(store as never)}
+        onAttackUpdated={jest.fn()}
       />
     );
 
@@ -104,6 +106,7 @@ describe('AttackFlyoutOverviewTab', () => {
         hit={buildHit()}
         servicesPromise={Promise.resolve(servicesMock)}
         storePromise={Promise.resolve(store as never)}
+        onAttackUpdated={jest.fn()}
       />
     );
 
@@ -123,6 +126,7 @@ describe('AttackFlyoutOverviewTab', () => {
         hit={buildHit()}
         servicesPromise={Promise.reject(new Error('services failed'))}
         storePromise={Promise.resolve(store as never)}
+        onAttackUpdated={jest.fn()}
       />
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/attack_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/attack_flyout_overview_tab_component/index.tsx
@@ -8,24 +8,55 @@
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { EuiSpacer } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
+import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import type { CellActionRenderer } from '../../flyout_v2/shared/components/cell_actions';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
 import { OverviewTab } from '../../flyout_v2/attack/main/tabs/overview_tab';
 import { DataViewManagerBootstrap } from '../alert_flyout_overview_tab_component/data_view_manager_bootstrap';
+import { DiscoverCellActions } from '../cell_actions';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 
 export interface AttackFlyoutOverviewTabProps {
   hit: DataTableRecord;
   servicesPromise: Promise<StartServices>;
   storePromise: Promise<SecurityAppStore>;
+  /** Callback invoked after attack mutations to refresh the Discover table. */
+  onAttackUpdated: () => void;
+  /** Current Discover columns shown in the doc viewer. */
+  columns?: DocViewRenderProps['columns'];
+  /** Discover filter callback used by flyout cell actions. */
+  filter?: DocViewRenderProps['filter'];
+  /** Callback used to add a column to the Discover table. */
+  onAddColumn?: DocViewRenderProps['onAddColumn'];
+  /** Callback used to remove a column from the Discover table. */
+  onRemoveColumn?: DocViewRenderProps['onRemoveColumn'];
 }
 
 export const AttackFlyoutOverviewTab = ({
   hit,
   servicesPromise,
   storePromise,
+  onAttackUpdated,
+  columns,
+  filter,
+  onAddColumn,
+  onRemoveColumn,
 }: AttackFlyoutOverviewTabProps) => {
+  const renderCellActions = useCallback<CellActionRenderer>(
+    (props) => (
+      <DiscoverCellActions
+        {...props}
+        columns={columns}
+        filter={filter}
+        onAddColumn={onAddColumn}
+        onRemoveColumn={onRemoveColumn}
+      />
+    ),
+    [columns, filter, onAddColumn, onRemoveColumn]
+  );
+
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
 
@@ -60,27 +91,43 @@ export const AttackFlyoutOverviewTab = ({
   return flyoutProviders({
     services,
     store,
-    children: <AttackFlyoutOverviewTabContent hit={hit} />,
+    children: (
+      <AttackFlyoutOverviewTabContent
+        hit={hit}
+        renderCellActions={renderCellActions}
+        onAttackUpdated={onAttackUpdated}
+      />
+    ),
   });
 };
 
 interface AttackFlyoutOverviewTabContentProps {
   hit: DataTableRecord;
+  /** Callback passed to the flyout content to render cell actions. */
+  renderCellActions: CellActionRenderer;
+  /** Callback invoked after attack mutations to refresh the Discover table. */
+  onAttackUpdated: () => void;
 }
 
 /**
  * Rendered inside flyoutProviders so it has access to Redux store and services.
  */
-const AttackFlyoutOverviewTabContent = ({ hit }: AttackFlyoutOverviewTabContentProps) => {
-  // In Discover there is no parent attack flyout to refresh after alert mutations.
-  const onAttackUpdated = useCallback(() => {}, []);
+const AttackFlyoutOverviewTabContent = ({
+  hit,
+  renderCellActions,
+  onAttackUpdated,
+}: AttackFlyoutOverviewTabContentProps) => {
   const isInSecurityApp = useIsInSecurityApp();
 
   return (
     <>
       {!isInSecurityApp && <DataViewManagerBootstrap />}
       <EuiSpacer size="m" />
-      <OverviewTab hit={hit} onAttackUpdated={onAttackUpdated} />
+      <OverviewTab
+        hit={hit}
+        onAttackUpdated={onAttackUpdated}
+        renderCellActions={renderCellActions}
+      />
     </>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -646,7 +646,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
 
     const attackFlyoutOverviewTabFeature: SecuritySolutionAttackFlyoutOverviewTabFeature = {
       id: 'security-solution-attack-flyout-overview-tab',
-      render: ({ hit }) => {
+      render: ({ hit, onAttackUpdated, columns, filter, onAddColumn, onRemoveColumn }) => {
         const servicesPromise = this.getDiscoverFlyoutServices(core);
         const storePromise = this.getDiscoverFlyoutStore(core);
 
@@ -656,6 +656,11 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
               hit={hit}
               servicesPromise={servicesPromise}
               storePromise={storePromise}
+              onAttackUpdated={onAttackUpdated}
+              columns={columns}
+              filter={filter}
+              onAddColumn={onAddColumn}
+              onRemoveColumn={onRemoveColumn}
             />
           </React.Suspense>
         );


### PR DESCRIPTION
## Summary

This PR adds the missing `renderCellActions` property to the new attack flyout, in Discover and in Security Solution.

On `main` currently when going to a attack tools flyout, the cell actions are not hooked up

https://github.com/user-attachments/assets/84eee274-83d9-4976-8891-dbdefe1363eb

With the changes on this PR we now have the correct cell actions

https://github.com/user-attachments/assets/d3bd4b43-2f29-4bdd-82a4-7a0d373b4218

The other cell actions in Discover and in Security Solution as working as before

https://github.com/user-attachments/assets/80f586e9-28f1-4cc1-9474-c121b86bd035

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->