### PR TITLE
[Entity Analytics] Fix inconsistent entity identifier in flyout "Add to chat"

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -344,7 +344,11 @@ export const HostPanel = memo(function HostPanel({
       {!isPreviewMode && assetInventoryEnabled && (
         <EuiFlyoutFooter>
           <EuiPanel color="transparent">
-            <Footer identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+            <Footer
+              hostName={hostName}
+              identityFields={documentEntityIdentifiers}
+              entity={entityFromStore}
+            />
           </EuiPanel>
         </EuiFlyoutFooter>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx
@@ -39,7 +39,9 @@ jest.mock('../shared/components/take_action', () => ({
 }));
 
 jest.mock('../../../entity_analytics/components/ai_assistant_button/ai_assistant_button', () => ({
-  AiAssistantButton: () => <div data-test-subj="mockAiAssistantButton" />,
+  AiAssistantButton: ({ entityName }: { entityName: string }) => (
+    <div data-test-subj="mockAiAssistantButton">{entityName}</div>
+  ),
 }));
 
 // Render the real menu items but with minimal markup — footer tests only care about presence.
@@ -63,7 +65,8 @@ const renderFooter = (
   entityAttachmentsEnabled: boolean,
   attachmentsEnabled: boolean,
   entity?: EntityStoreRecord,
-  identityFields = SERVICE_IDENTITY_FIELDS
+  identityFields = SERVICE_IDENTITY_FIELDS,
+  serviceName = 'service-alice'
 ) => {
   mockUseIsExperimentalFeatureEnabled.mockReturnValue(entityAttachmentsEnabled);
   mockUseKibana.mockReturnValue({
@@ -79,7 +82,11 @@ const renderFooter = (
 
   return render(
     <TestProviders>
-      <ServicePanelFooter identityFields={identityFields} entity={entity} />
+      <ServicePanelFooter
+        serviceName={serviceName}
+        identityFields={identityFields}
+        entity={entity}
+      />
     </TestProviders>
   );
 };
@@ -120,5 +127,24 @@ describe('ServicePanelFooter – entity attachment actions', () => {
 
     expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
     expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+  });
+});
+
+describe('ServicePanelFooter – AiAssistantButton entity name', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes the raw serviceName prop, not a value derived from identityFields', () => {
+    // Consistency regression alongside host/user (security-team/kibana#277619): "Add to chat"
+    // must send the same display name the risk-score tab's AiAssistantButton sends, not
+    // whatever identityFields happens to resolve to.
+    renderFooter(
+      true,
+      true,
+      ENTITY_STORE_RECORD,
+      { 'service.id': 'svc-uuid-1234' },
+      'service-alice'
+    );
+
+    expect(screen.getByTestId('mockAiAssistantButton')).toHaveTextContent('service-alice');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx
@@ -65,7 +65,7 @@ const renderFooter = (
   entityAttachmentsEnabled: boolean,
   attachmentsEnabled: boolean,
   entity?: EntityStoreRecord,
-  identityFields = SERVICE_IDENTITY_FIELDS,
+  identityFields: Record<string, string> = SERVICE_IDENTITY_FIELDS,
   serviceName = 'service-alice'
 ) => {
   mockUseIsExperimentalFeatureEnabled.mockReturnValue(entityAttachmentsEnabled);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.tsx
@@ -19,11 +19,18 @@ import type { EntityToAttach } from '../../../cases/attachments/entity';
 import { useEntityCaseTakeActionItems } from '../../../cases/attachments/entity/hooks/use_entity_case_take_action_items';
 
 export const ServicePanelFooter = ({
+  serviceName,
   identityFields,
   entity,
   flyoutFooterProps,
   panelProps,
 }: {
+  /**
+   * Display name the flyout was opened with. Used for the "Add to chat" attachment so it
+   * matches the identifier the risk-score tab's AiAssistantButton sends for the same entity,
+   * rather than a value derived from `identityFields`.
+   */
+  serviceName: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
@@ -37,7 +44,7 @@ export const ServicePanelFooter = ({
    */
   panelProps?: React.ComponentProps<typeof EuiPanel>;
 }) => {
-  const serviceName = useMemo(
+  const identityServiceName = useMemo(
     () =>
       identityFields[EntityIdentifierFields.serviceName] || Object.values(identityFields)[0] || '',
     [identityFields]
@@ -57,8 +64,14 @@ export const ServicePanelFooter = ({
   const riskScore = risk?.calculated_score_norm;
 
   const entityToAttach = useMemo<EntityToAttach>(
-    () => ({ id: entityStoreId ?? '', name: serviceName, type: 'service', riskLevel, riskScore }),
-    [entityStoreId, serviceName, riskLevel, riskScore]
+    () => ({
+      id: entityStoreId ?? '',
+      name: identityServiceName,
+      type: 'service',
+      riskLevel,
+      riskScore,
+    }),
+    [entityStoreId, identityServiceName, riskLevel, riskScore]
   );
   const additionalItems = useEntityCaseTakeActionItems(entityToAttach);
 
@@ -75,8 +88,8 @@ export const ServicePanelFooter = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <TakeAction
-              isDisabled={!serviceName}
-              kqlQuery={euidEntityFilter ?? `service.name: "${serviceName}"`}
+              isDisabled={!identityServiceName}
+              kqlQuery={euidEntityFilter ?? `service.name: "${identityServiceName}"`}
               additionalItems={additionalItems}
             />
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -241,6 +241,7 @@ export const ServicePanel = memo(function ServicePanel({
       </FlyoutBody>
       {!isPreviewMode && (
         <ServicePanelFooter
+          serviceName={serviceName}
           identityFields={documentEntityIdentifiers}
           entity={
             entityStoreV2Enabled ? entityFromStoreResult.entityRecord ?? undefined : undefined

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -346,7 +346,11 @@ export const UserPanel = memo(function UserPanel({
       {!isPreviewMode && assetInventoryEnabled && (
         <EuiFlyoutFooter>
           <EuiPanel color="transparent">
-            <Footer identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+            <Footer
+              userName={userName}
+              identityFields={documentEntityIdentifiers}
+              entity={entityFromStore}
+            />
           </EuiPanel>
         </EuiFlyoutFooter>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx
@@ -72,7 +72,7 @@ const renderFooter = (
   entityAttachmentsEnabled: boolean,
   attachmentsEnabled: boolean,
   entity?: EntityStoreRecord,
-  identityFields = HOST_IDENTITY_FIELDS,
+  identityFields: Record<string, string> = HOST_IDENTITY_FIELDS,
   hostName = 'host-alice'
 ) => {
   mockUseIsExperimentalFeatureEnabled.mockReturnValue(entityAttachmentsEnabled);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx
@@ -45,7 +45,9 @@ jest.mock('../../../../flyout/entity_details/shared/components/take_action', () 
 jest.mock(
   '../../../../entity_analytics/components/ai_assistant_button/ai_assistant_button',
   () => ({
-    AiAssistantButton: () => <div data-test-subj="mockAiAssistantButton" />,
+    AiAssistantButton: ({ entityName }: { entityName: string }) => (
+      <div data-test-subj="mockAiAssistantButton">{entityName}</div>
+    ),
   })
 );
 
@@ -70,7 +72,8 @@ const renderFooter = (
   entityAttachmentsEnabled: boolean,
   attachmentsEnabled: boolean,
   entity?: EntityStoreRecord,
-  identityFields = HOST_IDENTITY_FIELDS
+  identityFields = HOST_IDENTITY_FIELDS,
+  hostName = 'host-alice'
 ) => {
   mockUseIsExperimentalFeatureEnabled.mockReturnValue(entityAttachmentsEnabled);
   mockUseKibana.mockReturnValue({
@@ -86,7 +89,7 @@ const renderFooter = (
 
   return render(
     <TestProviders>
-      <Footer identityFields={identityFields} entity={entity} />
+      <Footer hostName={hostName} identityFields={identityFields} entity={entity} />
     </TestProviders>
   );
 };
@@ -127,5 +130,25 @@ describe('Footer – entity attachment actions', () => {
 
     expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
     expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+  });
+});
+
+describe('Footer – AiAssistantButton entity name', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes the raw hostName prop, not a value derived from identityFields', () => {
+    // Regression for security-team/kibana#277619: when identityFields resolves to a
+    // higher-ranked EUID field (e.g. host.id) with no host.name key at all, the footer must
+    // still send the flyout's display name to "Add to chat" — the same value the risk-score
+    // tab's AiAssistantButton sends for this entity — not the id.
+    renderFooter(
+      true,
+      true,
+      ENTITY_STORE_RECORD,
+      { 'host.id': 'f47ac10b-58cc-4372-a567-0e02b2c3d479' },
+      'host-alice'
+    );
+
+    expect(screen.getByTestId('mockAiAssistantButton')).toHaveTextContent('host-alice');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.tsx
@@ -20,6 +20,13 @@ import type { EntityToAttach } from '../../../../cases/attachments/entity';
 import { useEntityCaseTakeActionItems } from '../../../../cases/attachments/entity/hooks/use_entity_case_take_action_items';
 
 export interface FooterProps {
+  /**
+   * Display name the flyout was opened with. Used for the "Add to chat" attachment so it
+   * matches the identifier the risk-score tab's AiAssistantButton sends for the same entity —
+   * `identityFields` can resolve to a bare id when the entity's higher-ranked EUID field
+   * (e.g. host.id) is populated, which would make the two "Add to chat" buttons disagree.
+   */
+  hostName: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
@@ -28,9 +35,9 @@ export interface FooterProps {
 /**
  * Footer for the host details flyout containing the asset-inventory TakeAction button.
  */
-export const Footer = ({ identityFields, entity }: FooterProps) => {
+export const Footer = ({ hostName, identityFields, entity }: FooterProps) => {
   const isInSecurityApp = useIsInSecurityApp();
-  const hostName = useMemo(
+  const identityHostName = useMemo(
     () => identityFields[EntityIdentifierFields.hostName] || Object.values(identityFields)[0] || '',
     [identityFields]
   );
@@ -49,8 +56,8 @@ export const Footer = ({ identityFields, entity }: FooterProps) => {
   const riskScore = risk?.calculated_score_norm;
 
   const entityToAttach = useMemo<EntityToAttach>(
-    () => ({ id: entityStoreId ?? '', name: hostName, type: 'host', riskLevel, riskScore }),
-    [entityStoreId, hostName, riskLevel, riskScore]
+    () => ({ id: entityStoreId ?? '', name: identityHostName, type: 'host', riskLevel, riskScore }),
+    [entityStoreId, identityHostName, riskLevel, riskScore]
   );
   const additionalItems = useEntityCaseTakeActionItems(entityToAttach);
 
@@ -65,8 +72,8 @@ export const Footer = ({ identityFields, entity }: FooterProps) => {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <TakeAction
-          isDisabled={!hostName || !isInSecurityApp}
-          kqlQuery={euidEntityFilter ?? `host.name: "${hostName}"`}
+          isDisabled={!identityHostName || !isInSecurityApp}
+          kqlQuery={euidEntityFilter ?? `host.name: "${identityHostName}"`}
           additionalItems={additionalItems}
         />
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
@@ -468,7 +468,11 @@ export const Host: FC<HostProps> = memo(function Host({
       </EuiFlyoutBody>
       {assetInventoryEnabled && (
         <EuiFlyoutFooter>
-          <Footer identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+          <Footer
+            hostName={hostName}
+            identityFields={documentEntityIdentifiers}
+            entity={entityFromStore}
+          />
         </EuiFlyoutFooter>
       )}
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
@@ -343,6 +343,7 @@ export const Service: FC<ServiceProps> = memo(function Service({
         )}
       </FlyoutBody>
       <ServicePanelFooter
+        serviceName={serviceName}
         identityFields={documentEntityIdentifiers}
         entity={entityFromStoreResult.entityRecord ?? undefined}
         flyoutFooterProps={{

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx
@@ -72,7 +72,7 @@ const renderFooter = (
   entityAttachmentsEnabled: boolean,
   attachmentsEnabled: boolean,
   entity?: EntityStoreRecord,
-  identityFields = USER_IDENTITY_FIELDS,
+  identityFields: Record<string, string> = USER_IDENTITY_FIELDS,
   userName = 'alice'
 ) => {
   mockUseIsExperimentalFeatureEnabled.mockReturnValue(entityAttachmentsEnabled);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx
@@ -45,7 +45,9 @@ jest.mock('../../../../flyout/entity_details/shared/components/take_action', () 
 jest.mock(
   '../../../../entity_analytics/components/ai_assistant_button/ai_assistant_button',
   () => ({
-    AiAssistantButton: () => <div data-test-subj="mockAiAssistantButton" />,
+    AiAssistantButton: ({ entityName }: { entityName: string }) => (
+      <div data-test-subj="mockAiAssistantButton">{entityName}</div>
+    ),
   })
 );
 
@@ -70,7 +72,8 @@ const renderFooter = (
   entityAttachmentsEnabled: boolean,
   attachmentsEnabled: boolean,
   entity?: EntityStoreRecord,
-  identityFields = USER_IDENTITY_FIELDS
+  identityFields = USER_IDENTITY_FIELDS,
+  userName = 'alice'
 ) => {
   mockUseIsExperimentalFeatureEnabled.mockReturnValue(entityAttachmentsEnabled);
   mockUseKibana.mockReturnValue({
@@ -86,7 +89,7 @@ const renderFooter = (
 
   return render(
     <TestProviders>
-      <Footer identityFields={identityFields} entity={entity} />
+      <Footer userName={userName} identityFields={identityFields} entity={entity} />
     </TestProviders>
   );
 };
@@ -127,5 +130,19 @@ describe('Footer – entity attachment actions', () => {
 
     expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
     expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+  });
+});
+
+describe('Footer – AiAssistantButton entity name', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes the raw userName prop, not a value derived from identityFields', () => {
+    // Regression for security-team/kibana#277619: for non-local users, identityFields can
+    // resolve to user.email (ranked above user.name) with no user.name key at all. The footer
+    // must still send the flyout's display name to "Add to chat" — the same value the
+    // risk-score tab's AiAssistantButton sends for this entity — not the email.
+    renderFooter(true, true, ENTITY_STORE_RECORD, { 'user.email': 'alice@example.com' }, 'alice');
+
+    expect(screen.getByTestId('mockAiAssistantButton')).toHaveTextContent('alice');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.tsx
@@ -20,14 +20,22 @@ import type { EntityToAttach } from '../../../../cases/attachments/entity';
 import { useEntityCaseTakeActionItems } from '../../../../cases/attachments/entity/hooks/use_entity_case_take_action_items';
 
 export interface FooterProps {
+  /**
+   * Display name the flyout was opened with. Used for the "Add to chat" attachment so it
+   * matches the identifier the risk-score tab's AiAssistantButton sends for the same entity —
+   * `identityFields` can resolve to a non-name field (e.g. user.email for non-local users)
+   * when the entity's higher-ranked EUID field is populated, which would make the two
+   * "Add to chat" buttons disagree.
+   */
+  userName: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
 }
 
-export const Footer = ({ identityFields, entity }: FooterProps) => {
+export const Footer = ({ userName, identityFields, entity }: FooterProps) => {
   const isInSecurityApp = useIsInSecurityApp();
-  const userName = useMemo(
+  const identityUserName = useMemo(
     () => identityFields[EntityIdentifierFields.userName] || Object.values(identityFields)[0] || '',
     [identityFields]
   );
@@ -46,8 +54,8 @@ export const Footer = ({ identityFields, entity }: FooterProps) => {
   const riskScore = risk?.calculated_score_norm;
 
   const entityToAttach = useMemo<EntityToAttach>(
-    () => ({ id: entityStoreId ?? '', name: userName, type: 'user', riskLevel, riskScore }),
-    [entityStoreId, userName, riskLevel, riskScore]
+    () => ({ id: entityStoreId ?? '', name: identityUserName, type: 'user', riskLevel, riskScore }),
+    [entityStoreId, identityUserName, riskLevel, riskScore]
   );
   const additionalItems = useEntityCaseTakeActionItems(entityToAttach);
 
@@ -62,8 +70,8 @@ export const Footer = ({ identityFields, entity }: FooterProps) => {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <TakeAction
-          isDisabled={!userName || !isInSecurityApp}
-          kqlQuery={euidEntityFilter ?? `user.name: "${userName}"`}
+          isDisabled={!identityUserName || !isInSecurityApp}
+          kqlQuery={euidEntityFilter ?? `user.name: "${identityUserName}"`}
           additionalItems={additionalItems}
         />
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
@@ -491,7 +491,11 @@ export const User: FC<UserProps> = memo(function User({
       </EuiFlyoutBody>
       {assetInventoryEnabled && (
         <EuiFlyoutFooter>
-          <Footer identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+          <Footer
+            userName={userName}
+            identityFields={documentEntityIdentifiers}
+            entity={entityFromStore}
+          />
         </EuiFlyoutFooter>
       )}
     </>


### PR DESCRIPTION
## Summary

Both "Add to chat" buttons in the host/user/service entity flyout render the same `AiAssistantButton`, which sends whatever `entityName` it's given as the literal chat identifier. The footer button and the risk-score tab's button fed it differently:

- The risk-score tab passes the flyout's raw display name straight through.
- The footer instead derived a name from EUID-ranked `identityFields`, which returns only the highest-ranked *populated* identity field. Host's ranking puts `host.id` above `host.name`, so whenever a host record had an id (almost always), the footer's lookup returned `{ 'host.id': <uuid> }` — no `host.name` key at all — and silently fell through to the id. Non-local users have the same exposure via `user.email` outranking `user.name`.

Fix: thread the raw `hostName`/`userName`/`serviceName` prop into each footer and use it directly for `AiAssistantButton`, instead of deriving anything from `identityFields`. This guarantees both "Add to chat" buttons send the identical identifier by construction, not by two independently-derived values that happened to usually agree. `identityFields` is left untouched for its other job in each footer — the EUID-based KQL filter used by the "Take Action" button.

Applied to host and user (both reproducible) and service (same latent pattern, not currently reproducible since service identity is single-field — included for consistency).

Note: the issue also asks whether there should be one "Add to chat" button instead of two — that's a product question for @iryna-krasilchuk, not addressed here.

## How to test

1. Open a host entity flyout for a host whose entity-store record has `host.id` populated (most hosts with an entity-store record).
2. Click **Add to chat** in the footer, then expand the flyout and click **Add to chat** in the **Risk score** tab.
3. Both should now reference the entity by the same name. Before this fix, the footer's reference could resolve to the host's id instead.

Unit tests:
```
node scripts/jest x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.test.tsx x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.test.tsx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->