### PR TITLE
[9.3] Update API Key Fix (#276087)

### DIFF
--- a/src/core/packages/security/server/src/authentication/api_keys/api_keys.ts
+++ b/src/core/packages/security/server/src/authentication/api_keys/api_keys.ts
@@ -138,6 +138,7 @@ export interface CreateCrossClusterAPIKeyParams {
     }>;
     replication?: Array<{
       names: string[];
+      allow_restricted_indices?: boolean;
     }>;
   };
 }
@@ -246,6 +247,7 @@ export interface UpdateCrossClusterAPIKeyParams {
     }>;
     replication?: Array<{
       names: string[];
+      allow_restricted_indices?: boolean;
     }>;
   };
 }

--- a/x-pack/platform/packages/shared/security/plugin_types_common/src/api_keys/api_key.ts
+++ b/x-pack/platform/packages/shared/security/plugin_types_common/src/api_keys/api_key.ts
@@ -65,7 +65,10 @@ type CrossClusterApiKeySearch = Pick<
 >;
 
 // TODO: Remove this type when `@elastic/elasticsearch` has been updated.
-type CrossClusterApiKeyReplication = Pick<estypes.SecurityIndicesPrivileges, 'names'>;
+type CrossClusterApiKeyReplication = Pick<
+  estypes.SecurityIndicesPrivileges,
+  'names' | 'allow_restricted_indices'
+>;
 
 export type ApiKeyRoleDescriptors = Record<string, estypes.SecurityRoleDescriptor>;
 

--- a/x-pack/platform/packages/shared/security/plugin_types_server/src/authentication/api_keys/api_keys.ts
+++ b/x-pack/platform/packages/shared/security/plugin_types_server/src/authentication/api_keys/api_keys.ts
@@ -57,6 +57,7 @@ export const crossClusterApiKeySchema = schema.object({
         schema.arrayOf(
           schema.object({
             names: schema.arrayOf(schema.string()),
+            allow_restricted_indices: schema.maybe(schema.boolean()),
           })
         )
       ),
@@ -96,6 +97,7 @@ export const updateCrossClusterApiKeySchema = schema.object({
         schema.arrayOf(
           schema.object({
             names: schema.arrayOf(schema.string()),
+            allow_restricted_indices: schema.maybe(schema.boolean()),
           })
         )
       ),

--- a/x-pack/platform/test/api_integration/apis/security/api_keys.ts
+++ b/x-pack/platform/test/api_integration/apis/security/api_keys.ts
@@ -348,6 +348,36 @@ export default function ({ getService }: FtrProviderContext) {
             })
             .expect(400);
         });
+
+        it('should allow allow_restricted_indices in replication entries', async () => {
+          const createResult = await supertest
+            .post('/internal/security/api_key')
+            .set('kbn-xsrf', 'xxx')
+            .send({
+              type: 'cross_cluster',
+              name: 'test_cc_api_key_replication_restricted',
+              metadata: {},
+              access: {
+                replication: [{ names: ['logs*'], allow_restricted_indices: true }],
+              },
+            })
+            .expect(200);
+
+          const updateResult = await supertest
+            .put('/internal/security/api_key')
+            .set('kbn-xsrf', 'xxx')
+            .send({
+              type: 'cross_cluster',
+              id: createResult.body.id,
+              metadata: {},
+              access: {
+                replication: [{ names: ['logs*'], allow_restricted_indices: false }],
+              },
+            })
+            .expect(200);
+
+          expect(updateResult.body.updated).to.be(true);
+        });
       }
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Update API Key Fix (#276087)](https://github.com/elastic/kibana/pull/276087)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryan","email":"ryan.godfrey@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T14:14:06Z","message":"Update API Key Fix (#276087)\n\nCloses: https://github.com/elastic/kibana/issues/276046\n\n## Summary\nAdds alllow_restricted_indices to the API key schema definition to fix a\nbug preventing users from updating cross-cluster api keys after they are\ncreated.\n\nAfter creating an api key, alllow_restricted_indices is added to the\nreplication privileges associated to the api key. This prevents the user\nfrom updating it after it is created even if they don't make any\nchanges.\n\n## Steps to test\n1. create a new cross-cluster API key\n2. attempt to update the key without making any changes\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6f493b03a0f4a8ad5d512b37d3b0d1a9bc2d5763","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Security","Feature:Users/Roles/API Keys","release_note:skip","backport:all-open","v9.5.0","v9.6.0"],"title":"Update API Key Fix","number":276087,"url":"https://github.com/elastic/kibana/pull/276087","mergeCommit":{"message":"Update API Key Fix (#276087)\n\nCloses: https://github.com/elastic/kibana/issues/276046\n\n## Summary\nAdds alllow_restricted_indices to the API key schema definition to fix a\nbug preventing users from updating cross-cluster api keys after they are\ncreated.\n\nAfter creating an api key, alllow_restricted_indices is added to the\nreplication privileges associated to the api key. This prevents the user\nfrom updating it after it is created even if they don't make any\nchanges.\n\n## Steps to test\n1. create a new cross-cluster API key\n2. attempt to update the key without making any changes\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6f493b03a0f4a8ad5d512b37d3b0d1a9bc2d5763"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277804","number":277804,"state":"MERGED","mergeCommit":{"sha":"19223160e8086392aadbae5692acc984a49335a6","message":"[9.5] Update API Key Fix (#276087) (#277804)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [Update API Key Fix\n(#276087)](https://github.com/elastic/kibana/pull/276087)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryan <ryan.godfrey@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276087","number":276087,"mergeCommit":{"message":"Update API Key Fix (#276087)\n\nCloses: https://github.com/elastic/kibana/issues/276046\n\n## Summary\nAdds alllow_restricted_indices to the API key schema definition to fix a\nbug preventing users from updating cross-cluster api keys after they are\ncreated.\n\nAfter creating an api key, alllow_restricted_indices is added to the\nreplication privileges associated to the api key. This prevents the user\nfrom updating it after it is created even if they don't make any\nchanges.\n\n## Steps to test\n1. create a new cross-cluster API key\n2. attempt to update the key without making any changes\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6f493b03a0f4a8ad5d512b37d3b0d1a9bc2d5763"}},{"url":"https://github.com/elastic/kibana/pull/277803","number":277803,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->