### PR TITLE
[Security Solution] Fix prototype-collision crash in index fields formatting

### DIFF
--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/index_fields/index.test.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/index_fields/index.test.ts
@@ -167,6 +167,45 @@ describe('Index Fields', () => {
       );
     });
   });
+  describe('prototype-collision safety', () => {
+    const protoNames = ['constructor', 'toString', 'hasOwnProperty', '__proto__'];
+
+    test.each(protoNames)(
+      'field named %s resolves without throwing and is included in results',
+      async (fieldName) => {
+        const fieldSpec = [
+          {
+            name: fieldName,
+            type: 'keyword',
+            searchable: true,
+            aggregatable: true,
+            readFromDocValues: true,
+            esTypes: ['keyword'] as string[],
+          },
+        ];
+        const result = await formatIndexFields(beatFields, [fieldSpec], ['test-index']);
+        const match = result.find((f) => f.name === fieldName);
+        expect(match).toBeDefined();
+        expect(match!.name).toBe(fieldName);
+      }
+    );
+
+    test('calling formatIndexFields with a constructor-named field does not mutate the global Object constructor', async () => {
+      const fieldSpec = [
+        {
+          name: 'constructor',
+          type: 'keyword',
+          searchable: true,
+          aggregatable: true,
+          readFromDocValues: true,
+          esTypes: ['keyword'] as string[],
+        },
+      ];
+      await formatIndexFields(beatFields, [fieldSpec], ['test-index']);
+      expect(Object.prototype.hasOwnProperty.call(Object, 'category')).toBe(false);
+    });
+  });
+
   describe('createFieldItem', () => {
     test('Basic functionality', () => {
       const item = createFieldItem(

--- a/x-pack/solutions/security/plugins/timelines/server/search_strategy/index_fields/index.ts
+++ b/x-pack/solutions/security/plugins/timelines/server/search_strategy/index_fields/index.ts
@@ -17,6 +17,7 @@ import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import { DELETED_SECURITY_SOLUTION_DATA_VIEW } from '../../../common/constants';
 import type {
   BeatFields,
+  FieldInfo,
   IndexField,
   IndexFieldsStrategyRequest,
   IndexFieldsStrategyResponse,
@@ -270,13 +271,14 @@ export const createFieldItem = (
     splitIndexName[splitIndexName.length - 1] === 'text'
       ? splitIndexName.slice(0, splitIndexName.length - 1).join('.')
       : index.name;
-  const beatIndex = beatFields[indexName] ?? {};
-  if (isEmpty(beatIndex.category)) {
-    beatIndex.category = splitIndexName[0];
-  }
+  const beatIndex: Partial<FieldInfo> = Object.prototype.hasOwnProperty.call(beatFields, indexName)
+    ? beatFields[indexName]
+    : {};
+  const category = isEmpty(beatIndex.category) ? splitIndexName[0] : (beatIndex.category as string);
   return {
     ...beatIndex,
     ...index,
+    category,
     // the format type on FieldSpec is SerializedFieldFormat
     // and is a string on beatIndex
     format: index.format?.id ?? beatIndex.format,
@@ -307,14 +309,14 @@ export const formatIndexFields = async (
 ): Promise<IndexField[]> => {
   return new Promise((resolve) => {
     setTimeout(() => {
-      const indexFieldNameHash: Record<string, number> = {};
+      const indexFieldNameHash = new Map<string, number>();
       resolve(
         responsesFieldSpec.reduce(
           (accumulator: IndexField[], fieldSpec: FieldSpec[], indexesAliasId: number) => {
             const indexesAliasIdx = responsesFieldSpec.length > 1 ? indexesAliasId : null;
             missingFields.concat(fieldSpec).forEach((index) => {
               const item = createFieldItem(beatFields, indexesAlias, index, indexesAliasIdx);
-              const alreadyExistingIndexField = indexFieldNameHash[item.name];
+              const alreadyExistingIndexField = indexFieldNameHash.get(item.name);
               if (alreadyExistingIndexField != null) {
                 const existingIndexField = accumulator[alreadyExistingIndexField];
                 if (isEmpty(accumulator[alreadyExistingIndexField].description)) {
@@ -332,7 +334,7 @@ export const formatIndexFields = async (
                 return;
               }
               accumulator.push(item);
-              indexFieldNameHash[item.name] = accumulator.length - 1;
+              indexFieldNameHash.set(item.name, accumulator.length - 1);
             });
             return accumulator;
           },


### PR DESCRIPTION
## Summary

### 🛑 Problem

`formatIndexFields` and `createFieldItem` in the timelines plugin's index fields search strategy used plain objects (`Record<string, number>` / index-name-keyed lookup) as hash maps keyed by user-controlled field/index names. A field or index named `constructor` (or another `Object.prototype` property like `toString`, `hasOwnProperty`, `__proto__`) resolves through the prototype chain instead of returning `undefined`/absent, which crashes `formatIndexFields` and lets `createFieldItem` silently mutate the global `Object` constructor.

### 💡 Solution

Replaced the plain-object hash (`indexFieldNameHash`) in `formatIndexFields` with a `Map`, so `.get('constructor')` correctly returns `undefined` instead of resolving through `Object.prototype`. In `createFieldItem`, guarded the `beatFields[indexName]` lookup with `Object.prototype.hasOwnProperty.call` so reserved prototype names fall through to a fresh `{}` rather than the global `Object` constructor. Added regression tests covering `constructor`, `toString`, `hasOwnProperty`, and `__proto__` field names, including an explicit assertion that `Object` itself is never mutated as a side effect.

### 🧠 Notes

- No GitHub issue is linked — this was reported outside the public tracker.
- Backport scope hasn't been decided yet; no `backport:*` label has been applied.

### ✅ How to verify

Run the updated unit tests:
```
node scripts/jest x-pack/solutions/security/plugins/timelines/server/search_strategy/index_fields/index.test.ts
```
All cases in the new `prototype-collision safety` describe block should pass, including the assertion that `Object` is not mutated.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->