### PR TITLE
[Task Manager] Prototype: build API-key-scoped ES clients in Task Manager

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/es_service/tokens.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/es_service/tokens.ts
@@ -6,11 +6,23 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { TaskScopedClusterClients } from '@kbn/task-manager-plugin/server';
 import type { ServiceIdentifier } from 'inversify';
 
 export const EsServiceInternalToken = Symbol.for(
   'alerting_v2.EsServiceInternal'
 ) as ServiceIdentifier<ElasticsearchClient>;
+
+/**
+ * Elasticsearch clients built by Task Manager for a task execution, scoped to the task's API key.
+ * Bound (as a `Global`) into the per-task DI scope by the task runner factory when the run context
+ * carries them. When present, the request-scoped ES tokens below resolve from these clients instead
+ * of building their own via `elasticsearch.client.asScoped(request)`. Unbound outside task
+ * execution (e.g. HTTP routes), where the ES tokens fall back to the request-based clients.
+ */
+export const TaskManagerEsClientsToken = Symbol.for(
+  'alerting_v2.TaskManagerEsClients'
+) as ServiceIdentifier<TaskScopedClusterClients>;
 
 export const EsServiceScopedToken = Symbol.for(
   'alerting_v2.EsServiceScoped'

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
@@ -15,6 +15,7 @@ import type {
   TaskRunCreatorFunction,
 } from '@kbn/task-manager-plugin/server/task';
 import type { ServiceIdentifier } from 'inversify';
+import { TaskManagerEsClientsToken } from '../es_service/tokens';
 
 type TaskRunnerConstructor<T> = new (...args: never[]) => T;
 
@@ -86,7 +87,7 @@ export function createTaskRunnerFactory({
   getInjection: () => CoreDiServiceStart;
 }): TaskRunnerFactory {
   return ({ taskRunnerClass, taskType, requiresFakeRequest = true }) => {
-    return ({ taskInstance, abortController, fakeRequest }: RunContext) => ({
+    return ({ taskInstance, abortController, fakeRequest, esClient }: RunContext) => ({
       run: async () => {
         if (requiresFakeRequest && !fakeRequest) {
           throw new Error(
@@ -99,6 +100,15 @@ export function createTaskRunnerFactory({
         if (fakeRequest) {
           scope.bind(Request).toConstantValue(fakeRequest);
           scope.bind(Global).toConstantValue(Request);
+
+          // Task Manager already built the Elasticsearch clients scoped to this task's API key,
+          // so bind them (as a Global, like Request) and let the ES service tokens resolve from
+          // them instead of calling `elasticsearch.client.asScoped(request)` ourselves.
+          if (esClient) {
+            scope.bind(TaskManagerEsClientsToken).toConstantValue(esClient);
+            scope.bind(Global).toConstantValue(TaskManagerEsClientsToken);
+          }
+
           scope.bind(taskRunnerClass).toSelf().inRequestScope();
         } else {
           scope.bind(taskRunnerClass).toSelf().inTransientScope();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.test.ts
@@ -15,6 +15,7 @@ import {
   EsServiceInternalToken,
   EsServiceScopedToken,
   EsServiceScopedSpaceRoutingToken,
+  TaskManagerEsClientsToken,
 } from '../lib/services/es_service/tokens';
 import {
   QueryServiceScopedToken,
@@ -44,37 +45,65 @@ describe('bindServices - Elasticsearch client routing', () => {
     expect(elasticsearch.client.asScoped).not.toHaveBeenCalled();
   });
 
-  it('binds the scoped client to asCurrentUser without project routing (local)', () => {
-    const client = container.get(EsServiceScopedToken);
+  describe('HTTP route path (request-scoped, no Task Manager)', () => {
+    it('binds the scoped client to asCurrentUser without project routing (local)', () => {
+      const client = container.get(EsServiceScopedToken);
 
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request);
-    expect(client).toBe(elasticsearch.client.asScoped.mock.results[0].value.asCurrentUser);
-  });
-
-  it("binds the space-routed scoped client with projectRouting: 'space'", () => {
-    const client = container.get(EsServiceScopedSpaceRoutingToken);
-
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request, {
-      projectRouting: 'space',
+      expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
+      expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request);
+      expect(client).toBe(elasticsearch.client.asScoped.mock.results[0].value.asCurrentUser);
     });
-    expect(client).toBe(elasticsearch.client.asScoped.mock.results[0].value.asCurrentUser);
+
+    it('wires the scoped QueryService to the origin-only (local) client', () => {
+      container.get(QueryServiceScopedToken);
+
+      expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
+      expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request);
+    });
   });
 
-  it('wires the scoped QueryService to the origin-only (local) client', () => {
-    container.get(QueryServiceScopedToken);
+  describe('rule-executor task path (API-key clients built by Task Manager)', () => {
+    let taskManagerEsClients: {
+      scoped: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+      scopedWithSpaceRouting: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+    };
 
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request);
+    beforeEach(() => {
+      taskManagerEsClients = {
+        scoped: elasticsearchServiceMock.createScopedClusterClient(),
+        scopedWithSpaceRouting: elasticsearchServiceMock.createScopedClusterClient(),
+      };
+      container.bind(TaskManagerEsClientsToken).toConstantValue(taskManagerEsClients);
+    });
+
+    it('resolves the space-routed token from the Task Manager client and never scopes the request itself', () => {
+      const client = container.get(EsServiceScopedSpaceRoutingToken);
+
+      expect(client).toBe(taskManagerEsClients.scopedWithSpaceRouting.asCurrentUser);
+      expect(elasticsearch.client.asScoped).not.toHaveBeenCalled();
+    });
+
+    it('wires the space-routed QueryService to the Task Manager client (no local asScoped call)', () => {
+      container.get(QueryServiceScopedSpaceRoutingToken);
+
+      expect(elasticsearch.client.asScoped).not.toHaveBeenCalled();
+    });
+
+    it('still builds the route-path scoped token from the request', () => {
+      const client = container.get(EsServiceScopedToken);
+
+      expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
+      expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request);
+      expect(client).toBe(elasticsearch.client.asScoped.mock.results[0].value.asCurrentUser);
+    });
   });
 
-  it("wires the space-routed scoped QueryService with projectRouting: 'space'", () => {
-    container.get(QueryServiceScopedSpaceRoutingToken);
-
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledTimes(1);
-    expect(elasticsearch.client.asScoped).toHaveBeenCalledWith(request, {
-      projectRouting: 'space',
+  describe('EsServiceScopedSpaceRoutingToken outside task execution', () => {
+    it('throws because Task Manager did not provide the API-key clients', () => {
+      expect(() => container.get(EsServiceScopedSpaceRoutingToken)).toThrow(
+        'only available during task execution'
+      );
+      expect(elasticsearch.client.asScoped).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -31,6 +31,7 @@ import {
   EsServiceInternalToken,
   EsServiceScopedToken,
   EsServiceScopedSpaceRoutingToken,
+  TaskManagerEsClientsToken,
 } from '../lib/services/es_service/tokens';
 import { EventLogService } from '../lib/services/event_log_service/event_log_service';
 import { EventLogServiceToken } from '../lib/services/event_log_service/tokens';
@@ -145,6 +146,9 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
     })
     .inSingletonScope();
 
+  // Request-scoped current-user client for the HTTP route path (matcher suggestions, resource
+  // reset, alert action writes). Built from the live user request — Task Manager is not involved
+  // in the HTTP request lifecycle, so this stays here.
   bind(EsServiceScopedToken)
     .toDynamicValue(({ get }) => {
       const request = get(Request);
@@ -153,13 +157,19 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
     })
     .inRequestScope();
 
+  // API-key-scoped current-user client for rule execution (user-data ES|QL). This client is now
+  // built by Task Manager from the task's API key and handed to us on the run context, so
+  // alerting_v2 no longer constructs it via `elasticsearch.client.asScoped(...)`. It is only
+  // resolvable during task execution, where Task Manager binds `TaskManagerEsClientsToken`.
   bind(EsServiceScopedSpaceRoutingToken)
     .toDynamicValue(({ get }) => {
-      const request = get(Request);
-      const elasticsearch = get(CoreStart('elasticsearch'));
-      // `projectRouting: 'space'` scopes rule-execution queries to the originating space/project
-      // when CPS is enabled, matching alerting v1 behavior. Only `asCurrentUser` honors the option.
-      return elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser;
+      const taskManagerEsClients = get(TaskManagerEsClientsToken, { optional: true });
+      if (!taskManagerEsClients) {
+        throw new Error(
+          'EsServiceScopedSpaceRoutingToken is only available during task execution, where Task Manager provides the API-key-scoped Elasticsearch clients.'
+        );
+      }
+      return taskManagerEsClients.scopedWithSpaceRouting.asCurrentUser;
     })
     .inRequestScope();
 

--- a/x-pack/platform/plugins/shared/task_manager/server/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/index.ts
@@ -20,6 +20,7 @@ export type {
   ConcreteTaskInstance,
   TaskRunCreatorFunction,
   RunContext,
+  TaskScopedClusterClients,
   IntervalSchedule,
 } from './task';
 

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -466,6 +466,7 @@ export class TaskManagerPlugin
         apiKeyStrategy,
         eventLogger: this.taskEventLogger!,
         enrichFakeRequest,
+        elasticsearchClient: elasticsearch.client,
       });
     }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -26,6 +26,7 @@ import type { Err, Ok } from './lib/result_type';
 import { asOk, isErr, isOk } from './lib/result_type';
 import { FillPoolResult } from './lib/fill_pool';
 import { executionContextServiceMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { TaskCost } from './task';
 import type { TaskEventLogger } from './task';
 import { ApiKeyType, CLAIM_STRATEGY_MGET, DEFAULT_KIBANAS_PER_PARTITION } from './config';
@@ -139,6 +140,7 @@ describe('TaskPollingLifecycle', () => {
     }),
     apiKeyStrategy: new EsApiKeyStrategy(),
     eventLogger: eventLoggerMock,
+    elasticsearchClient: elasticsearchServiceMock.createClusterClient(),
   };
 
   beforeEach(() => {

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -12,7 +12,7 @@ import { pipe } from 'fp-ts/pipeable';
 import { map as mapOptional, none } from 'fp-ts/Option';
 import { tap } from 'rxjs';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
-import type { Logger, ExecutionContextStart } from '@kbn/core/server';
+import type { Logger, ExecutionContextStart, IClusterClient } from '@kbn/core/server';
 import type { FakeRequestEnricher } from '@kbn/core-security-server';
 
 import type { Result } from './lib/result_type';
@@ -84,6 +84,7 @@ export interface TaskPollingLifecycleOpts {
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
   enrichFakeRequest?: FakeRequestEnricher;
+  elasticsearchClient: IClusterClient;
 }
 
 export type TaskLifecycleEvent =
@@ -126,6 +127,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
   private apiKeyStrategy: ApiKeyStrategy;
   private currentTmUtilization$ = new BehaviorSubject<number>(0);
   private enrichFakeRequest?: FakeRequestEnricher;
+  private elasticsearchClient: IClusterClient;
 
   private eventLogger: TaskEventLogger;
 
@@ -149,6 +151,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     apiKeyStrategy,
     eventLogger,
     enrichFakeRequest,
+    elasticsearchClient,
   }: TaskPollingLifecycleOpts) {
     this.logger = logger;
     this.middleware = middleware;
@@ -159,6 +162,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     this.config = config;
     this.apiKeyStrategy = apiKeyStrategy;
     this.enrichFakeRequest = enrichFakeRequest;
+    this.elasticsearchClient = elasticsearchClient;
     const { poll_interval: pollInterval, claim_strategy: claimStrategy } = config;
     this.currentPollInterval = pollInterval;
     this.eventLogger = eventLogger;
@@ -287,6 +291,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
       apiKeyStrategy: this.apiKeyStrategy,
       eventLogger: this.eventLogger,
       enrichFakeRequest: this.enrichFakeRequest,
+      elasticsearchClient: this.elasticsearchClient,
     });
   };
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -10,7 +10,7 @@
 import type { ObjectType, TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { isNumber } from 'lodash';
-import type { KibanaRequest } from '@kbn/core/server';
+import type { IScopedClusterClient, KibanaRequest } from '@kbn/core/server';
 import type { IntervalSchedule, RruleSchedule } from '@kbn/response-ops-scheduling-types';
 import { isErr, tryAsResult } from './lib/result_type';
 import { isInterval, parseIntervalAsMillisecond } from './lib/intervals';
@@ -79,6 +79,30 @@ export const getTaskCostFromInstance = (cost?: InstanceTaskCost): number | undef
 type Require<T extends object, P extends keyof T> = Omit<T, P> & Required<Pick<T, P>>;
 
 /**
+ * Elasticsearch cluster clients built by Task Manager for a single task execution and
+ * authenticated with the task's API key (via its `fakeRequest`). Handed to task runners on
+ * the {@link RunContext} so consumers no longer have to call
+ * `elasticsearch.client.asScoped(fakeRequest)` themselves.
+ *
+ * Only present when the task has an API key (i.e. `fakeRequest` is set on the run context).
+ */
+export interface TaskScopedClusterClients {
+  /**
+   * Scoped cluster client authenticated with the task's API key using origin-only routing.
+   * Use `asCurrentUser` to query as the originating user and `asInternalUser` for the Kibana
+   * system user.
+   */
+  scoped: IScopedClusterClient;
+
+  /**
+   * Same as {@link TaskScopedClusterClients.scoped} but with CPS space project-routing enabled
+   * (reads `request.spaceId`), matching alerting rule-execution behavior in CPS-enabled
+   * Serverless environments. Falls back to local routing when CPS is disabled.
+   */
+  scopedWithSpaceRouting: IScopedClusterClient;
+}
+
+/**
  * The run context is passed into a task's run function as its sole argument.
  */
 export interface RunContext {
@@ -92,6 +116,14 @@ export interface RunContext {
    * is generated using the API key and passed as part of the run context.
    */
   fakeRequest?: KibanaRequest;
+
+  /**
+   * Elasticsearch clients scoped to the task's API key, built by Task Manager. Present only
+   * when the task has an API key (same condition as {@link RunContext.fakeRequest}). Lets task
+   * runners query Elasticsearch as the originating user without building scoped clients from
+   * `fakeRequest` themselves. See {@link TaskScopedClusterClients}.
+   */
+  esClient?: TaskScopedClusterClients;
   abortController: AbortController;
 
   /**

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/es_client_factory.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/es_client_factory.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IClusterClient, KibanaRequest } from '@kbn/core/server';
+import type { TaskScopedClusterClients } from '../task';
+
+interface BuildTaskEsClientsOpts {
+  clusterClient: IClusterClient;
+  fakeRequest?: KibanaRequest;
+}
+
+/**
+ * Builds the Elasticsearch clients handed to a task runner via the run context. The clients are
+ * scoped to the task's API key through its `fakeRequest`, so task runners can query Elasticsearch
+ * as the originating user without having to call `elasticsearch.client.asScoped(fakeRequest)`
+ * themselves.
+ *
+ * Returns `undefined` when there is no `fakeRequest` (i.e. the task was scheduled without an API
+ * key), matching the condition under which `fakeRequest` is populated on the run context.
+ *
+ * `asScoped` is cheap: the underlying per-user child clients are created lazily on first access of
+ * `asCurrentUser` / `asInternalUser`, so tasks that never touch Elasticsearch pay nothing.
+ */
+export const buildTaskEsClients = ({
+  clusterClient,
+  fakeRequest,
+}: BuildTaskEsClientsOpts): TaskScopedClusterClients | undefined => {
+  if (!fakeRequest) return;
+
+  return {
+    scoped: clusterClient.asScoped(fakeRequest),
+    // `projectRouting: 'space'` scopes rule-execution queries to the originating space/project
+    // when CPS is enabled, matching alerting behavior. Falls back to local routing otherwise.
+    scopedWithSpaceRouting: clusterClient.asScoped(fakeRequest, { projectRouting: 'space' }),
+  };
+};

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -35,6 +35,7 @@ import apm from 'elastic-apm-node';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { tracing } from '@elastic/opentelemetry-node/sdk';
 import { executionContextServiceMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
 import { bufferedTaskStoreMock } from '../buffered_task_store.mock';
 import {
@@ -4116,6 +4117,7 @@ describe('TaskManagerRunner', () => {
       apiKeyStrategy: new EsApiKeyStrategy(),
       eventLogger: eventLoggerMock,
       enrichFakeRequest: opts.enrichFakeRequest,
+      elasticsearchClient: elasticsearchServiceMock.createClusterClient(),
     });
 
     if (stage === TaskRunningStage.READY_TO_RUN) {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -16,11 +16,12 @@ import { withActiveSpan } from '@kbn/tracing-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { addSpanLabels, withSpan } from '@kbn/apm-utils';
 import { flow, identity, omit } from 'lodash';
-import type { ExecutionContextStart, Logger } from '@kbn/core/server';
+import type { ExecutionContextStart, IClusterClient, Logger } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { FakeRequestEnricher } from '@kbn/core-security-server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { buildChildRequestEnricher, buildTaskFakeRequest } from './fake_request_factory';
+import { buildTaskEsClients } from './es_client_factory';
 import type { Middleware } from '../lib/middleware';
 import type { Result } from '../lib/result_type';
 import {
@@ -133,6 +134,7 @@ type Opts = {
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
   enrichFakeRequest?: FakeRequestEnricher;
+  elasticsearchClient: IClusterClient;
 } & Pick<Middleware, 'beforeRun' | 'beforeMarkRunning'>;
 
 export enum TaskRunResult {
@@ -191,6 +193,7 @@ export class TaskManagerRunner implements TaskRunner {
   private eventLogger: TaskEventLogger;
   private isCancelled = false;
   private readonly enrichFakeRequest?: FakeRequestEnricher;
+  private readonly elasticsearchClient: IClusterClient;
 
   /**
    * Creates an instance of TaskManagerRunner.
@@ -220,6 +223,7 @@ export class TaskManagerRunner implements TaskRunner {
     apiKeyStrategy,
     eventLogger,
     enrichFakeRequest,
+    elasticsearchClient,
   }: Opts) {
     this.instance = asPending(sanitizeInstance(instance));
     this.definitions = definitions;
@@ -243,6 +247,7 @@ export class TaskManagerRunner implements TaskRunner {
     this.apiKeyStrategy = apiKeyStrategy;
     this.eventLogger = eventLogger;
     this.enrichFakeRequest = enrichFakeRequest;
+    this.elasticsearchClient = elasticsearchClient;
   }
 
   /**
@@ -458,6 +463,14 @@ export class TaskManagerRunner implements TaskRunner {
             enrichFakeRequest: this.enrichFakeRequest,
           });
 
+          // Build the Elasticsearch clients scoped to the task's API key here, so task runners
+          // receive ready-to-use clients on the run context instead of having to call
+          // `elasticsearch.client.asScoped(fakeRequest)` themselves.
+          const esClient = buildTaskEsClients({
+            clusterClient: this.elasticsearchClient,
+            fakeRequest,
+          });
+
           const enrichRequest = buildChildRequestEnricher({
             userProfileId,
             userName,
@@ -469,6 +482,7 @@ export class TaskManagerRunner implements TaskRunner {
           this.task = definition.createTaskRunner({
             taskInstance: sanitizedTaskInstance,
             fakeRequest,
+            esClient,
             abortController,
             enrichRequest,
             executionUuid: this.uuid,


### PR DESCRIPTION
## Summary

> [!WARNING]
> **Prototype / exploration — not intended to merge as-is.**

Explores what it would look like if **Task Manager** built the API-key-scoped Elasticsearch clients for a task run, instead of each consumer (here, `alerting_v2`) calling `elasticsearch.client.asScoped(fakeRequest)` itself.

### Task Manager (produces the clients)
- New `TaskScopedClusterClients` type + `esClient` field on `RunContext` (`server/task.ts`), exported from the plugin's public server entry.
- New `buildTaskEsClients` helper builds the scoped cluster clients from the task's `fakeRequest` (`scoped` = origin-only routing, `scopedWithSpaceRouting` = CPS space routing). `asScoped` is lazy, so tasks that never touch ES pay nothing.
- `TaskManagerRunner.run()` builds `esClient` right after `fakeRequest` and passes it into `createTaskRunner(...)`. The `IClusterClient` is threaded `plugin.start()` → `TaskPollingLifecycle` → `TaskManagerRunner`.

### alerting_v2 (consumes the clients)
- New `TaskManagerEsClientsToken`; the task-runner factory binds the run-context clients into the per-task DI scope (as a `Global`, mirroring how `fakeRequest`/`Request` already flow).
- The rule-executor's API-key ES client (`EsServiceScopedSpaceRoutingToken`) is now sourced **purely from Task Manager** — the local `elasticsearch.client.asScoped(request, { projectRouting: 'space' })` construction is deleted. It throws if resolved outside task execution (that path is task-only).
- The HTTP route-path client (`EsServiceScopedToken`) stays request-based: it's derived from the live user request, and Task Manager is not part of the HTTP request lifecycle.

## Test plan
- [x] `node scripts/type_check` for `task_manager` and `alerting_v2`
- [x] `bind_services.test.ts` — space-routing token resolves from TM's client (never calls `asScoped`), throws outside a task, route-path token still builds from the request
- [x] Task Manager `task_runner` + `polling_lifecycle` unit tests
- [x] alerting_v2 `rule_executor` suite
- [ ] End-to-end: verify a v2 rule executes and queries ES as the originating user via the TM-provided client

## Notes / open questions
- `TaskScopedClusterClients` keeps a non-space-routed `scoped` client for generality even though alerting_v2's rule executor only uses `scopedWithSpaceRouting` — open to trimming.
- Internal (`asInternalUser`) client left as-is; only the API-key-scoped clients are the focus.

Made with [Cursor](https://cursor.com)