### PR TITLE
Add AI-assisted contribution guidelines

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,15 @@
+# AI-assisted contributions
+
+We welcome contributions made with the help of AI. Some of the best pull requests we've seen were written with an assistant, and they tend to share a few things in common. The person behind them talked to us first, kept the work focused, understood every line they submitted, and used AI to move faster on something they genuinely owned. Here's what that looks like in practice.
+
+**Talk to us before you build.** Open an issue, or comment on an existing one, to let us know what you're planning. A quick conversation early on helps us point you toward the right approach and saves you from pouring effort into something that won't land. A surprise PR is much harder for everyone than a shared plan.
+
+**Keep it scoped.** The contributions that work best are the ones you can validate from end to end, like a specific bug fix, a documentation improvement, a missing test, or an accessibility fix. Sweeping changes you can't fully verify yourself are tough to review and tougher to trust.
+
+**Know what you're submitting.** Read your own diff, run the code, and make sure you can explain why each change is there. If you can't explain it, please don't submit it. AI is a great way to speed up work you understand, not a shortcut around understanding it.
+
+**Speak for yourself.** When you're discussing your work in an issue or PR, use your own words. Pasting generated replies into the conversation makes it hard to have a real discussion, and we'd genuinely rather talk with you.
+
+**Aim for quality over volume.** One thoughtful, well-tested PR is worth far more than a pile of generated ones. Low-quality contributions are hard to review and end up costing everyone time.
+
+Do these things and we'd love to have your work. We want more of it.


### PR DESCRIPTION
## Summary

Adds a top-level `AI.md` with guidelines for AI-assisted contributions to Kibana.

We welcome AI-assisted contributions, and the best ones share a few traits: the contributor engaged with the team early, scoped the work so it could be validated end to end, understood the change deeply, and used AI to move faster on work they genuinely owned. This document captures that in a short, welcoming form.

It covers engaging with the team before building, keeping changes well-scoped, understanding what you submit, communicating in your own words, and favoring quality over quantity.

The tone is intentionally warm and written as natural prose rather than dense bullet lists.
