### PR TITLE
fix: type in Scout config discovery test

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -393,6 +393,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
                 path: customPath,
                 exists: true,
                 sha1: 'custom123',
+                testChannels: [],
                 tests: [
                   {
                     id: 'customTest1',


### PR DESCRIPTION
Somehow missed by PR CI for https://github.com/elastic/kibana/pull/276667. 🤨


