### PR TITLE
[Fleet] Migrate server setup to core deferred (lazy) initialization

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/fleet/kibana.jsonc
@@ -51,6 +51,7 @@
       "kibanaUtils",
       "usageCollection"
     ],
-    "extraPublicDirs": ["common"]
+    "extraPublicDirs": ["common"],
+    "enableLazyInitialize": true
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { of } from 'rxjs';
+
+import {
+  coreMock,
+  elasticsearchServiceMock,
+  savedObjectsRepositoryMock,
+  loggingSystemMock,
+} from '@kbn/core/server/mocks';
+import type { CoreStart, LazyInitContext } from '@kbn/core/server';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
+
+import type { FleetConfigType } from '../common/types';
+
+import { FleetPlugin } from './plugin';
+import { setupFleet } from './services/setup';
+import { appContextService } from './services';
+import { createAppContextStartContractMock } from './mocks';
+
+jest.mock('./services/setup', () => {
+  return {
+    ...jest.requireActual('./services/setup'),
+    setupFleet: jest.fn(),
+  };
+});
+
+const mockedSetupFleet = setupFleet as jest.MockedFunction<typeof setupFleet>;
+
+interface PluginPrivates {
+  core: CoreStart;
+  fleetStatus$: { getValue: () => { summary: string } };
+  setupCompletedPromise: Promise<void>;
+  initializeUninstallTokens: () => Promise<void>;
+}
+
+// `lazyInitialize` only needs `this.core` (captured during `start()`) plus the plugin instance's
+// own constructor-initialized fields (`fleetStatus$`, `setupCompletedPromise`). Fleet's real
+// `start()` constructs ~15+ unrelated services/tasks, so rather than mocking all of those to call
+// it for real, this test constructs the plugin normally and pokes the one field `start()` would
+// have set - the "isolate the slice" approach flagged as acceptable in
+// docs/specs/2026-07-13-fleet-lazy-init-licensing-contract.md's handoff addendum.
+//
+// `plugin` and `privates` are two separately-cast views of the same instance: intersecting
+// `FleetPlugin` with a type that re-declares its private fields (`FleetPlugin & PluginPrivates`)
+// collapses to `never` under `tsc`, so public methods are called through `plugin` and private
+// fields are poked/read through `privates` instead.
+function createPlugin() {
+  const initializerContext = coreMock.createPluginInitializerContext<FleetConfigType>(
+    {} as FleetConfigType
+  );
+  const plugin = new FleetPlugin(initializerContext);
+  const privates = plugin as unknown as PluginPrivates;
+  const core = coreMock.createStart();
+  privates.core = core;
+  jest.spyOn(privates, 'initializeUninstallTokens').mockResolvedValue(undefined);
+  return { plugin, privates, core };
+}
+
+const createLazyInitContext = (): LazyInitContext => ({
+  elasticsearch: { client: elasticsearchServiceMock.createElasticsearchClient() },
+  savedObjects: savedObjectsRepositoryMock.create(),
+  logger: loggingSystemMock.create().get(),
+});
+
+const mockLicensingContract = (available: boolean): LicensingPluginStart =>
+  ({
+    license$: of({
+      getFeature: () => ({ isEnabled: available, isAvailable: available }),
+    }),
+  } as unknown as LicensingPluginStart);
+
+describe('FleetPlugin#lazyInitialize', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  afterEach(() => {
+    appContextService.stop();
+  });
+
+  it('loads the licensing contract via core.plugins.loadPluginContract, then runs setupFleet using core (not ctx) savedObjects', async () => {
+    const { plugin, core } = createPlugin();
+    jest.mocked(core.plugins.loadPluginContract).mockResolvedValue(mockLicensingContract(true));
+    mockedSetupFleet.mockResolvedValue({ isInitialized: true, nonFatalErrors: [] });
+
+    const ctx = createLazyInitContext();
+    await plugin.lazyInitialize(ctx);
+
+    expect(core.plugins.loadPluginContract).toHaveBeenCalledWith('licensing');
+    expect(mockedSetupFleet).toHaveBeenCalledWith(
+      core.savedObjects.getUnsafeInternalClient(),
+      ctx.elasticsearch.client
+    );
+  });
+
+  it('resolves fleetSetupCompleted() once setup succeeds', async () => {
+    const { plugin, privates, core } = createPlugin();
+    jest.mocked(core.plugins.loadPluginContract).mockResolvedValue(mockLicensingContract(true));
+    mockedSetupFleet.mockResolvedValue({ isInitialized: true, nonFatalErrors: [] });
+
+    await plugin.lazyInitialize(createLazyInitContext());
+
+    await expect(privates.setupCompletedPromise).resolves.toBeUndefined();
+  });
+
+  it('propagates a genuinely fatal setupFleet failure out of lazyInitialize, but still resolves fleetSetupCompleted()', async () => {
+    const { plugin, privates, core } = createPlugin();
+    jest.mocked(core.plugins.loadPluginContract).mockResolvedValue(mockLicensingContract(true));
+    const failure = new Error('SO method mocked to throw');
+    mockedSetupFleet.mockRejectedValue(failure);
+
+    const lazyInitializePromise = plugin.lazyInitialize(createLazyInitContext());
+    await expect(lazyInitializePromise).rejects.toBe(failure);
+
+    expect(privates.fleetStatus$.getValue().summary).toBe('Fleet setup failed');
+
+    // fleetSetupCompleted() resolves regardless of success/failure, same as the old
+    // fleetSetupPromise semantics - it must not reject just because lazyInitialize did.
+    await expect(privates.setupCompletedPromise).resolves.toBeUndefined();
+  });
+
+  it('propagates a loadPluginContract rejection (licensing contract unavailable) out of lazyInitialize', async () => {
+    const { plugin, core } = createPlugin();
+    const failure = new Error('licensing contract unavailable');
+    jest.mocked(core.plugins.loadPluginContract).mockRejectedValue(failure);
+
+    await expect(plugin.lazyInitialize(createLazyInitContext())).rejects.toBe(failure);
+    expect(mockedSetupFleet).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { backOff } from 'exponential-backoff';
 import type { Observable } from 'rxjs';
 import { BehaviorSubject } from 'rxjs';
 import { filter, take } from 'rxjs';
@@ -17,6 +16,7 @@ import type {
   ElasticsearchServiceStart,
   HttpServiceSetup,
   KibanaRequest,
+  LazyInitContext,
   Logger,
   Plugin,
   PluginInitializerContext,
@@ -362,6 +362,15 @@ export class FleetPlugin
   private policyWatcher?: PolicyWatcher;
   private fetchUsage?: (abortController: AbortController) => Promise<FleetUsage | undefined>;
   private lockManagerService?: LockManagerService;
+  // `LazyInitContext` has no `core`/`plugins` field, so this is captured here, during `start()`,
+  // purely so `lazyInitialize` below can reach `core.plugins.loadPluginContract` later.
+  private core?: CoreStart;
+  private setupCompletedResolve!: () => void;
+  // Resolves once the current (or most recent) `lazyInitialize` run has settled, regardless of
+  // whether it succeeded or failed - mirrors the old `fleetSetupPromise`'s semantics.
+  private setupCompletedPromise: Promise<void> = new Promise((resolve) => {
+    this.setupCompletedResolve = resolve;
+  });
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.config$ = this.initializerContext.config.create<FleetConfigType>();
@@ -800,6 +809,7 @@ export class FleetPlugin
   }
 
   public start(core: CoreStart, plugins: FleetStartDeps): FleetStartContract {
+    this.core = core;
     this.spacesPluginsStart = plugins.spaces;
 
     const messageSigningService = new MessageSigningService(
@@ -896,96 +906,6 @@ export class FleetPlugin
 
     this.policyWatcher.start(licenseService);
 
-    const setupAttempts = this.configInitialValue.internal?.retrySetupOnBoot ? 25 : 1;
-
-    const fleetSetupPromise = (async () => {
-      try {
-        // Fleet remains `available` during setup as to excessively delay Kibana's boot process.
-        // This should be reevaluated as Fleet's setup process is optimized and stabilized.
-        this.fleetStatus$.next({
-          level: ServiceStatusLevels.available,
-          summary: 'Fleet is setting up',
-        });
-
-        // We need to wait for the licence feature to be available,
-        // to have our internal saved object client with encrypted saved object working properly
-        await plugins.licensing.license$
-          .pipe(
-            filter(
-              (licence) =>
-                licence.getFeature('security').isEnabled &&
-                licence.getFeature('security').isAvailable
-            ),
-            take(1)
-          )
-          .toPromise();
-
-        const randomIntFromInterval = (min: number, max: number) => {
-          return Math.floor(Math.random() * (max - min + 1) + min);
-        };
-
-        // Retry Fleet setup w/ backoff
-        await backOff(
-          async () => {
-            await setupFleet(
-              core.savedObjects.getUnsafeInternalClient({
-                excludedExtensions: [SPACES_EXTENSION_ID],
-              }),
-              core.elasticsearch.client.asInternalUser,
-              { useLock: true }
-            );
-          },
-          {
-            numOfAttempts: setupAttempts,
-            delayFirstAttempt: true,
-            // 1s initial backoff
-            startingDelay: randomIntFromInterval(100, 1000),
-            // 5m max backoff
-            maxDelay: 60000 * 5,
-            timeMultiple: 2,
-            // avoid HA contention with other Kibana instances
-            jitter: 'full',
-            retry: (error: any, attemptCount: number) => {
-              const summary = `Fleet setup attempt ${attemptCount} failed, will retry after backoff`;
-              logger.warn(summary, { error });
-
-              this.fleetStatus$.next({
-                level: ServiceStatusLevels.available,
-                summary,
-                meta: {
-                  attemptCount,
-                  error,
-                },
-              });
-              return true;
-            },
-          }
-        );
-
-        // initialize (generate/encrypt/validate) Uninstall Tokens asynchronously
-        this.initializeUninstallTokens().catch(() => {});
-
-        this.fleetStatus$.next({
-          level: ServiceStatusLevels.available,
-          summary: 'Fleet is available',
-        });
-      } catch (error) {
-        logger.warn(`Fleet setup failed after ${setupAttempts} attempts`, {
-          error,
-        });
-
-        this.fleetStatus$.next({
-          // As long as Fleet has a dependency on EPR, we can't reliably set Kibana status to `unavailable` here.
-          // See https://github.com/elastic/kibana/issues/120237
-          level: ServiceStatusLevels.available,
-          summary: 'Fleet setup failed',
-          meta: {
-            error: error.message,
-          },
-        });
-      }
-    })();
-
     const internalSoClient = core.savedObjects.getUnsafeInternalClient({
       excludedExtensions: [SPACES_EXTENSION_ID],
     });
@@ -996,7 +916,7 @@ export class FleetPlugin
       agentless: {
         enabled: this.configInitialValue.agentless?.enabled ?? false,
       },
-      fleetSetupCompleted: () => fleetSetupPromise,
+      fleetSetupCompleted: () => this.setupCompletedPromise,
       packageService: this.setupPackageService(
         core.elasticsearch.client.asInternalUser,
         internalSoClient
@@ -1038,6 +958,78 @@ export class FleetPlugin
       cloudConnectorService,
       runWithCache,
     };
+  }
+
+  /**
+   * Deferred-init runner, gated by core's lazy-init framework (`enableLazyInitialize` in
+   * `kibana.jsonc`): runs Fleet's setup pipeline the first time something needs it instead of
+   * unconditionally at boot. Replaces the old `fleetSetupPromise` IIFE - core now owns
+   * cross-instance locking and retry-with-backoff (see `docs/design-doc.md`), so this only needs
+   * to run `setupFleet()` once per invocation and let genuinely fatal errors throw; the engine
+   * decides if/when to retry a failed run.
+   */
+  public async lazyInitialize(ctx: LazyInitContext): Promise<void> {
+    const { logger, elasticsearch } = ctx;
+
+    this.setupCompletedPromise = new Promise((resolve) => {
+      this.setupCompletedResolve = resolve;
+    });
+
+    try {
+      // Fleet remains `available` during setup as to not excessively delay Kibana's boot process.
+      // This should be reevaluated as Fleet's setup process is optimized and stabilized.
+      this.fleetStatus$.next({
+        level: ServiceStatusLevels.available,
+        summary: 'Fleet is setting up',
+      });
+
+      // We need to wait for the licence feature to be available,
+      // to have our internal saved object client with encrypted saved object working properly
+      const licensing = await this.core!.plugins.loadPluginContract<LicensingPluginStart>(
+        'licensing'
+      );
+      await licensing.license$
+        .pipe(
+          filter(
+            (licence) =>
+              licence.getFeature('security').isEnabled && licence.getFeature('security').isAvailable
+          ),
+          take(1)
+        )
+        .toPromise();
+
+      // Use `this.core` (not `ctx.savedObjects`) so setup keeps the same encrypted-saved-objects
+      // and security SO extensions it relies on today - the context's repository has none of them.
+      await setupFleet(
+        this.core!.savedObjects.getUnsafeInternalClient({
+          excludedExtensions: [SPACES_EXTENSION_ID],
+        }),
+        elasticsearch.client
+      );
+
+      // initialize (generate/encrypt/validate) Uninstall Tokens asynchronously
+      this.initializeUninstallTokens().catch(() => {});
+
+      this.fleetStatus$.next({
+        level: ServiceStatusLevels.available,
+        summary: 'Fleet is available',
+      });
+    } catch (error) {
+      logger.warn('Fleet setup failed', { error });
+
+      this.fleetStatus$.next({
+        // As long as Fleet has a dependency on EPR, we can't reliably set Kibana status to `unavailable` here.
+        // See https://github.com/elastic/kibana/issues/120237
+        level: ServiceStatusLevels.available,
+        summary: 'Fleet setup failed',
+        meta: {
+          error: error.message,
+        },
+      });
+      throw error;
+    } finally {
+      this.setupCompletedResolve();
+    }
   }
 
   public stop() {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/bump_migrated_agent_policies_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/bump_migrated_agent_policies_task.ts
@@ -124,10 +124,14 @@ export async function _updatePackagePoliciesThatNeedBump(
 }
 
 export async function scheduleBumpMigratedAgentPoliciesTask(
-  taskManagerStart: TaskManagerStartContract
+  taskManagerStart: TaskManagerStartContract,
+  // Callers that may be retried from scratch (e.g. Fleet's own setup pipeline) should pass a
+  // stable suffix so `ensureScheduled` coalesces repeated calls into a single pending task,
+  // instead of scheduling a fresh duplicate on every retry.
+  taskIdSuffix: string = uuidv4()
 ) {
   await taskManagerStart.ensureScheduled({
-    id: `${TASK_TYPE}:${uuidv4()}`,
+    id: `${TASK_TYPE}:${taskIdSuffix}`,
     scope: ['fleet'],
     params: {},
     taskType: TASK_TYPE,

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.test.ts
@@ -9,7 +9,6 @@ import { errors } from '@elastic/elasticsearch';
 
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
-import { LockAcquisitionError } from '@kbn/lock-manager';
 
 import { MessageSigningError } from '../../common/errors';
 import { createAppContextStartContractMock, xpackMocks } from '../mocks';
@@ -20,7 +19,7 @@ import { appContextService } from './app_context';
 import { getInstallations } from './epm/packages';
 import { setupUpgradeManagedPackagePolicies } from './setup/managed_package_policies';
 import { getPreconfiguredDeleteUnenrolledAgentsSettingFromConfig } from './preconfiguration/delete_unenrolled_agent_setting';
-import { _runSetupWithLock, setupFleet } from './setup';
+import { setupFleet } from './setup';
 import { isPackageInstalled } from './epm/packages/install';
 import { upgradeAgentPolicySchemaVersion } from './setup/upgrade_agent_policy_schema_version';
 import { createCCSIndexPatterns } from './setup/fleet_synced_integrations';
@@ -243,44 +242,5 @@ describe('setupFleet', () => {
         },
       ],
     });
-  });
-});
-
-describe('_runSetupWithLock', () => {
-  let mockedWithLock: jest.Mock<any, any, any>;
-  beforeEach(() => {
-    mockedWithLock = jest.fn();
-    mockedAppContextService.getLockManagerService.mockReturnValue({
-      withLock: mockedWithLock as any,
-    } as any);
-  });
-  it('should retry on lock acquisition error', async () => {
-    mockedWithLock
-      .mockImplementationOnce(async () => {
-        throw new LockAcquisitionError('test');
-      })
-      .mockImplementationOnce(async (id, fn) => {
-        return fn();
-      });
-
-    const setupFn = jest.fn();
-    await _runSetupWithLock(setupFn);
-
-    expect(setupFn).toHaveBeenCalled();
-    expect(mockedWithLock).toHaveBeenCalledTimes(2);
-  });
-
-  it('should not retry on setupFn error', async () => {
-    mockedWithLock.mockImplementation(async (id, fn) => {
-      return fn();
-    });
-
-    const setupFn = jest.fn();
-    setupFn.mockRejectedValue(new Error('test'));
-
-    await expect(_runSetupWithLock(setupFn)).rejects.toThrow(/test/);
-
-    expect(setupFn).toHaveBeenCalled();
-    expect(mockedWithLock).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
@@ -12,11 +12,8 @@ import { withActiveSpan } from '@kbn/tracing-utils';
 
 import { compact } from 'lodash';
 
-import pRetry from 'p-retry';
-
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
-import { LockAcquisitionError } from '@kbn/lock-manager';
 
 import { MessageSigningError } from '../../common/errors';
 
@@ -81,26 +78,9 @@ export interface SetupStatus {
   >;
 }
 
-export async function _runSetupWithLock(setupFn: () => Promise<SetupStatus>) {
-  return await pRetry(
-    () => appContextService.getLockManagerService()!.withLock('fleet-setup', () => setupFn()),
-    {
-      onFailedAttempt: async (error) => {
-        if (!(error instanceof LockAcquisitionError)) {
-          throw error;
-        }
-      },
-      maxRetryTime: 5 * 60 * 1000, // Retry for 5 minute to get the lock
-    }
-  );
-}
-
 export async function setupFleet(
   soClient: SavedObjectsClientContract,
-  esClient: ElasticsearchClient,
-  options: {
-    useLock: boolean;
-  } = { useLock: false }
+  esClient: ElasticsearchClient
 ): Promise<SetupStatus> {
   return withActiveSpan(
     'fleet-setup',
@@ -112,13 +92,7 @@ export async function setupFleet(
     async () => {
       const t = apm.startTransaction('fleet-setup', 'fleet');
       try {
-        if (options.useLock) {
-          return _runSetupWithLock(() =>
-            awaitIfPending(async () => createSetupSideEffects(soClient, esClient))
-          );
-        } else {
-          return await awaitIfPending(async () => createSetupSideEffects(soClient, esClient));
-        }
+        return await awaitIfPending(async () => createSetupSideEffects(soClient, esClient));
       } catch (error) {
         apm.captureError(error);
         t.setOutcome('failure');
@@ -279,8 +253,14 @@ async function createSetupSideEffects(
 
   // Bump the revision of agent policies whose package policies were flagged for a bump by a
   // saved object migration (no span: this only schedules a background task).
+  // Fixed suffix: Fleet's setup pipeline reruns from scratch on every invocation (including
+  // lazy-init retries), so repeated calls should coalesce into one pending task via
+  // `ensureScheduled` rather than piling up a duplicate per retry.
   logger.debug('Scheduling agent policy revision bump for migrated package policies');
-  await scheduleBumpMigratedAgentPoliciesTask(appContextService.getTaskManagerStart()!);
+  await scheduleBumpMigratedAgentPoliciesTask(
+    appContextService.getTaskManagerStart()!,
+    'fleet-setup'
+  );
 
   stepSpan = apm.startSpan('Set up enrollment keys for preconfigured policies', 'preconfiguration');
   logger.debug(


### PR DESCRIPTION
## Summary

Migrates Fleet's server-side setup to core's new **deferred (lazy) initialization** framework.

Previously Fleet ran its full setup pipeline unconditionally at boot via a `fleetSetupPromise` IIFE inside `start()`, owning its own cross-instance lock (`_runSetupWithLock`) and retry/backoff (`exponential-backoff` / `retrySetupOnBoot`). This PR opts Fleet into core's lazy-init framework so setup runs on first demand and core owns locking + retry.

**Changes**
- `kibana.jsonc`: opt in with `"enableLazyInitialize": true`.
- `plugin.ts`: replace the boot-time `fleetSetupPromise` IIFE with a `lazyInitialize(ctx)` runner that core invokes on first demand. It runs `setupFleet()` once and lets genuinely fatal errors throw; core decides if/when to retry. Licensing is loaded lazily via `core.plugins.loadPluginContract('licensing')`, and `fleetSetupCompleted()` semantics are preserved via `setupCompletedPromise`.
- `setup.ts`: drop Fleet's internal lock/retry machinery (`_runSetupWithLock`, the `useLock` option, `p-retry`, `LockAcquisitionError`) — core now owns cross-instance locking and retry-with-backoff.
- `setup.test.ts`: remove the now-obsolete `_runSetupWithLock` tests.
- `plugin.test.ts`: new unit tests for the `lazyInitialize` runner.
- `bump_migrated_agent_policies_task.ts` + `setup.ts`: the migrated-policy revision bump scheduled during setup now takes a stable `taskIdSuffix` (`'fleet-setup'`), so repeated setup runs (including lazy-init retries) coalesce into a single pending task via `ensureScheduled` instead of piling up a duplicate per retry.

> ⚠️ **Stacked on #277893** ("Add lazy (deferred) plugin initialization support to core"). This branch is based on `lazy_init_pr`, so until #277893 merges the diff here also includes that PR's changes. Review the last commit only, or merge #277893 first.

### Identify risks

- **Setup timing change** — Fleet setup now runs on first demand instead of unconditionally at boot. Severity: medium. Mitigation: core's lazy-init gating + retry/backoff; `fleetSetupCompleted()` semantics preserved so downstream awaiters are unaffected.
- **Locking/retry ownership moved to core** — Fleet's internal `_runSetupWithLock`/backoff removed. Severity: low. Behavior is consolidated into core, not removed.

Replaces #277793 (recreated from a branch on origin instead of a fork, to enable proper PR stacking on #277893).
