### PR TITLE
[9.3] [EDR Workflows] Endpoint response actions search strategy maintenance (#277586)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/factory/response_actions/results/query.action_results.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/factory/response_actions/results/query.action_results.dsl.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ActionResponsesRequestOptions } from '../../../../../../common/search_strategy/endpoint/response_actions';
+import { buildActionResultsQuery } from './query.action_results.dsl';
+
+describe('buildActionResultsQuery', () => {
+  const options = {
+    actionId: 'action-1',
+    sort: { field: '@timestamp', order: 'desc' },
+  } as unknown as ActionResponsesRequestOptions;
+
+  it('only projects the completion timestamp instead of the whole document', () => {
+    const { fields } = buildActionResultsQuery(options);
+
+    expect(fields).toEqual([{ field: 'EndpointActions.completed_at' }]);
+  });
+
+  it('does not request wildcard fields (would leak response output)', () => {
+    const { fields } = buildActionResultsQuery(options);
+
+    expect(JSON.stringify(fields)).not.toContain('*');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/factory/response_actions/results/query.action_results.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/factory/response_actions/results/query.action_results.dsl.ts
@@ -13,7 +13,8 @@ export const buildActionResultsQuery = ({
   actionId,
   sort,
 }: ActionResponsesRequestOptions): ISearchRequestParams => {
-  const fields = [{ field: '*' }, { field: 'EndpointActions.*', include_unmapped: true }];
+  // Only the completion timestamp is consumed from the hits (see `useGetAutomatedActionResponseList`)
+  const fields = [{ field: 'EndpointActions.completed_at' }];
   const dslQuery = {
     allow_no_indices: true,
     index: [ENDPOINT_ACTION_RESPONSES_INDEX],

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/index.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lastValueFrom, of } from 'rxjs';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { KbnServerError } from '@kbn/kibana-utils-plugin/server';
+import type { PluginStart, SearchStrategyDependencies } from '@kbn/data-plugin/server';
+
+import type { EndpointAuthz } from '../../../common/endpoint/types/authz';
+import { getEndpointAuthzInitialStateMock } from '../../../common/endpoint/service/authz/mocks';
+import { ResponseActionsQueries } from '../../../common/search_strategy/endpoint/response_actions';
+import type { EndpointAppContext } from '../../endpoint/types';
+import { endpointSearchStrategyProvider } from '.';
+
+describe('endpointSearchStrategyProvider', () => {
+  type SearchArgs = Parameters<ReturnType<typeof endpointSearchStrategyProvider>['search']>;
+
+  const buildProvider = (authzOverrides: Partial<EndpointAuthz> = {}) => {
+    const search = jest.fn().mockReturnValue(of({ rawResponse: { hits: { total: 0, hits: [] } } }));
+    const data = {
+      search: { searchAsInternalUser: { search } },
+    } as unknown as PluginStart;
+    const getEndpointAuthz = jest
+      .fn()
+      .mockResolvedValue(getEndpointAuthzInitialStateMock(authzOverrides));
+    const isCcsEnabled = jest.fn().mockResolvedValue(false);
+    const endpointContext = {
+      service: { getEndpointAuthz, isCcsEnabled },
+    } as unknown as EndpointAppContext;
+
+    return { provider: endpointSearchStrategyProvider(data, endpointContext), search };
+  };
+
+  const deps = {
+    request: httpServerMock.createKibanaRequest(),
+  } as unknown as SearchStrategyDependencies;
+  const options = {} as unknown as SearchArgs[1];
+  const request = {
+    factoryQueryType: ResponseActionsQueries.actions,
+    alertIds: ['alert-1'],
+    sort: { field: '@timestamp', order: 'desc' as const },
+  } as unknown as SearchArgs[0];
+
+  it('rejects with a 403 when the caller cannot access endpoint actions log management', async () => {
+    const { provider, search } = buildProvider({ canAccessEndpointActionsLogManagement: false });
+
+    await expect(lastValueFrom(provider.search(request, options, deps))).rejects.toBeInstanceOf(
+      KbnServerError
+    );
+    await expect(lastValueFrom(provider.search(request, options, deps))).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('runs the query when the caller can access endpoint actions log management', async () => {
+    const { provider, search } = buildProvider({ canAccessEndpointActionsLogManagement: true });
+
+    await lastValueFrom(provider.search(request, options, deps));
+
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/endpoint/index.ts
@@ -8,6 +8,7 @@
 import { map, mergeMap, from } from 'rxjs';
 import type { ISearchStrategy, PluginStart } from '@kbn/data-plugin/server';
 import { shimHitsTotal } from '@kbn/data-plugin/server';
+import { KbnServerError } from '@kbn/kibana-utils-plugin/server';
 import type {
   EndpointStrategyParseResponseType,
   EndpointStrategyRequestType,
@@ -17,6 +18,7 @@ import type {
 import type { EndpointFactory } from './factory/types';
 
 import type { EndpointAppContext } from '../../endpoint/types';
+import { ENDPOINT_AUTHZ_ERROR_MESSAGE } from '../../endpoint/errors';
 import { endpointFactory } from './factory';
 
 export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTypes>(
@@ -35,6 +37,10 @@ export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTyp
       }
       return from(endpointContext.service.getEndpointAuthz(deps.request)).pipe(
         mergeMap((authz) => {
+          if (!authz.canAccessEndpointActionsLogManagement) {
+            throw new KbnServerError(ENDPOINT_AUTHZ_ERROR_MESSAGE, 403);
+          }
+
           const queryFactory: EndpointFactory<T> = endpointFactory[request.factoryQueryType];
           const strictRequest = {
             factoryQueryType: request.factoryQueryType,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[EDR Workflows] Endpoint response actions search strategy maintenance (#277586)](https://github.com/elastic/kibana/pull/277586)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":277586,"url":"https://github.com/elastic/kibana/pull/277586","title":"[EDR Workflows] Endpoint response actions search strategy maintenance"},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"sourceCommit":{"sha":"d6117626e9350e665bfe84a45ffd88fdc961da8f"}}] BACKPORT-->
