### PR TITLE
Fix Scout config fixture

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -393,6 +393,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
                 path: customPath,
                 exists: true,
                 sha1: 'custom123',
+                testChannels: [],
                 tests: [
                   {
                     id: 'customTest1',


### PR DESCRIPTION
## Summary
Fix the missing `testChannels` field introduced by https://github.com/elastic/kibana/pull/276667.

## Test plan
- `node scripts/type_check --project src/platform/packages/shared/kbn-scout/tsconfig.json`

Made with [Cursor](https://cursor.com)