### PR TITLE
[Agent Builder] Add type narrowing for guard functions in allow_lists

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -111,11 +111,11 @@ export const AGENT_BUILDER_BUILTIN_AGENTS = [
 
 export type AgentBuilderBuiltinAgent = (typeof AGENT_BUILDER_BUILTIN_AGENTS)[number];
 
-export const isAllowedBuiltinTool = (toolName: string) => {
+export const isAllowedBuiltinTool = (toolName: string): toolName is AgentBuilderBuiltinTool => {
   return (AGENT_BUILDER_BUILTIN_TOOLS as readonly string[]).includes(toolName);
 };
 
-export const isAllowedBuiltinAgent = (agentName: string) => {
+export const isAllowedBuiltinAgent = (agentName: string): agentName is AgentBuilderBuiltinAgent => {
   return (AGENT_BUILDER_BUILTIN_AGENTS as readonly string[]).includes(agentName);
 };
 
@@ -127,7 +127,7 @@ export const AGENT_BUILDER_AGENT_TYPES = [chatAgentTypeId] as const;
 
 export type AgentBuilderAgentType = (typeof AGENT_BUILDER_AGENT_TYPES)[number];
 
-export const isAllowedAgentType = (typeId: string) => {
+export const isAllowedAgentType = (typeId: string): typeId is AgentBuilderAgentType => {
   return (AGENT_BUILDER_AGENT_TYPES as readonly string[]).includes(typeId);
 };
 
@@ -211,7 +211,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
 
 export type AgentBuilderBuiltinSkill = (typeof AGENT_BUILDER_BUILTIN_SKILLS)[number];
 
-export const isAllowedBuiltinSkill = (skillId: string) => {
+export const isAllowedBuiltinSkill = (skillId: string): skillId is AgentBuilderBuiltinSkill => {
   return (AGENT_BUILDER_BUILTIN_SKILLS as readonly string[]).includes(skillId);
 };
 
@@ -223,7 +223,7 @@ export const AGENT_BUILDER_BUILTIN_PLUGINS = [] as const;
 
 export type AgentBuilderBuiltinPlugin = (typeof AGENT_BUILDER_BUILTIN_PLUGINS)[number];
 
-export const isAllowedBuiltinPlugin = (pluginId: string) => {
+export const isAllowedBuiltinPlugin = (pluginId: string): pluginId is AgentBuilderBuiltinPlugin => {
   return (AGENT_BUILDER_BUILTIN_PLUGINS as readonly string[]).includes(pluginId);
 };
 
@@ -296,6 +296,8 @@ export const AGENT_BUILDER_BUILTIN_ATTACHMENTS = [
 
 export type AgentBuilderBuiltinAttachment = (typeof AGENT_BUILDER_BUILTIN_ATTACHMENTS)[number];
 
-export const isAllowedBuiltinAttachment = (attachmentTypeId: string) => {
+export const isAllowedBuiltinAttachment = (
+  attachmentTypeId: string
+): attachmentTypeId is AgentBuilderBuiltinAttachment => {
   return (AGENT_BUILDER_BUILTIN_ATTACHMENTS as readonly string[]).includes(attachmentTypeId);
 };


### PR DESCRIPTION
## Summary

Adds type narrowing to Agent Builder's `allow_lists` guard functions.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.