### PR TITLE
[One Workflow] Don't render provided workflow inputs as Liquid templates during input validation

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.test.ts
@@ -404,6 +404,34 @@ describe('applyInputDefaults', () => {
     });
   });
 
+  it('should pass the value source (default vs provided) to the renderer', () => {
+    const inputsSchema = normalizeFieldsToJsonSchema({
+      properties: {
+        greeting: { type: 'string', default: '{{ default_greeting }}' },
+        name: { type: 'string' },
+        settings: {
+          type: 'object',
+          properties: {
+            theme: { type: 'string', default: '{{ default_theme }}' },
+            locale: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const renderer = jest.fn((value: unknown) => value);
+    applyInputDefaults(
+      { name: '{{ user }}', settings: { locale: '{{ locale }}' } },
+      inputsSchema,
+      renderer
+    );
+
+    expect(renderer).toHaveBeenCalledWith('{{ default_greeting }}', 'default');
+    expect(renderer).toHaveBeenCalledWith('{{ user }}', 'provided');
+    expect(renderer).toHaveBeenCalledWith('{{ default_theme }}', 'default');
+    expect(renderer).toHaveBeenCalledWith('{{ locale }}', 'provided');
+  });
+
   it('should apply defaults for nested objects', () => {
     const inputsSchema = normalizeFieldsToJsonSchema({
       properties: {

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/field_conversion.ts
@@ -27,10 +27,21 @@ export type NormalizableFieldSchema =
   | JsonModelSchemaType
   | Array<LegacyWorkflowInput | WorkflowOutput>;
 
-export type RenderInputValue = (value: unknown) => unknown;
+/**
+ * Indicates where an input value being rendered came from:
+ * - 'default': a default defined in the workflow's input schema (author-controlled)
+ * - 'provided': a value supplied by the caller at execution time (runtime data)
+ */
+export type RenderInputValueSource = 'default' | 'provided';
 
-function renderValue(value: unknown, renderInputValue?: RenderInputValue): unknown {
-  return renderInputValue ? renderInputValue(value) : value;
+export type RenderInputValue = (value: unknown, source: RenderInputValueSource) => unknown;
+
+function renderValue(
+  value: unknown,
+  renderInputValue: RenderInputValue | undefined,
+  source: RenderInputValueSource
+): unknown {
+  return renderInputValue ? renderInputValue(value, source) : value;
 }
 
 /**
@@ -224,7 +235,7 @@ function applyDefaultToObjectProperty(
 ): unknown {
   if (currentValue === undefined) {
     if (prop.default !== undefined) {
-      return renderValue(prop.default, renderInputValue);
+      return renderValue(prop.default, renderInputValue, 'default');
     }
     if (prop.type === 'object' && prop.properties) {
       return applyDefaultFromSchema(prop, undefined, inputsSchema, renderInputValue);
@@ -241,7 +252,7 @@ function applyDefaultToObjectProperty(
     return applyDefaultFromSchema(prop, currentValue, inputsSchema, renderInputValue);
   }
 
-  return renderValue(currentValue, renderInputValue);
+  return renderValue(currentValue, renderInputValue, 'provided');
 }
 
 /**
@@ -414,12 +425,12 @@ function applyDefaultFromSchema(
         renderInputValue
       );
     }
-    return renderValue(value, renderInputValue);
+    return renderValue(value, renderInputValue, 'provided');
   }
 
   // If value is not provided, use default if available
   if (schema.default !== undefined) {
-    return renderValue(schema.default, renderInputValue);
+    return renderValue(schema.default, renderInputValue, 'default');
   }
 
   // For objects, create object with defaults for required properties or properties with defaults

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
@@ -295,7 +295,7 @@ describe('validateWorkflowInputs', () => {
     });
   });
 
-  it('should render provided input values before validation', async () => {
+  it('should render provided input values using the explicit expression form before validation', async () => {
     setInputsSchema({
       properties: {
         severity: { type: 'string', enum: ['low', 'medium', 'high'] },
@@ -304,7 +304,7 @@ describe('validateWorkflowInputs', () => {
     });
 
     const workflowExecution = createWorkflowExecution(
-      { inputs: { severity: '{{ consts.default_severity }}' } },
+      { inputs: { severity: '${{ consts.default_severity }}' } },
       {
         workflowDefinition: {
           ...stubWorkflowExecution.workflowDefinition,
@@ -323,6 +323,63 @@ describe('validateWorkflowInputs', () => {
       id: executionId,
       context: { inputs: { severity: 'high' } },
     });
+  });
+
+  it('should pass through provided values whose text is not valid Liquid instead of failing', async () => {
+    setInputsSchema({
+      properties: {
+        summary_markdown: { type: 'string' },
+      },
+      required: ['summary_markdown'],
+    });
+
+    // Attack discovery markdown uses `{{ field.name value }}` field-reference syntax,
+    // which is not valid Liquid (`field.name value` is not a Liquid expression).
+    const fieldSyntaxMarkdown =
+      'Malware on {{ host.name SRVWIN07 }} run by {{ user.name James_01 }}';
+
+    const workflowExecution = createWorkflowExecution({
+      inputs: { summary_markdown: fieldSyntaxMarkdown },
+    });
+
+    const result = await callValidate(workflowExecution);
+
+    expect(result).toBe(true);
+    expect(workflowExecution.context.inputs).toEqual({
+      summary_markdown: fieldSyntaxMarkdown,
+    });
+    expect(mockRepository.updateWorkflowExecution).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: ExecutionStatus.FAILED })
+    );
+  });
+
+  it('should pass through provided values nested in arrays and objects when not valid Liquid', async () => {
+    setInputsSchema({
+      properties: {
+        attack_discoveries: {
+          type: 'array',
+          items: { type: 'object', additionalProperties: true },
+        },
+      },
+      required: ['attack_discoveries'],
+    });
+
+    const discoveries = [
+      {
+        title: 'Credential theft',
+        details_markdown: '- {{ process.name mimikatz.exe }} on {{ host.name SRVWIN07 }}',
+        entity_summary_markdown: '{{ host.name SRVWIN07 }} {{ user.name James_01 }}',
+      },
+    ];
+
+    const workflowExecution = createWorkflowExecution({
+      inputs: { attack_discoveries: discoveries },
+    });
+
+    const result = await callValidate(workflowExecution);
+
+    expect(result).toBe(true);
+    expect(workflowExecution.context.inputs).toEqual({ attack_discoveries: discoveries });
   });
 
   it('should return false and mark execution as FAILED when a default input template is invalid', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
@@ -53,10 +53,41 @@ export const validateWorkflowInputs = async (
   const templateEngine = new WorkflowTemplatingEngine({
     liquidSettings: workflowExecution.workflowDefinition.settings?.liquid,
   });
+
+  // Provided input values are runtime data, not workflow-authored templates. They may
+  // legitimately contain text resembling Liquid syntax (e.g. attack discovery markdown
+  // using `{{ field.name value }}` field references), which must be passed through
+  // verbatim: rendering it would either fail to parse (e.g. 'expected "|" before filter')
+  // or silently resolve unknown variables to empty strings, corrupting the data.
+  // Only the explicit `${{ ... }}` expression form is evaluated, as an unambiguous
+  // opt-in for dynamic provided values.
+  const renderProvidedValue = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return value.startsWith('${{') && value.endsWith('}}')
+        ? templateEngine.render(value, renderContext)
+        : value;
+    }
+    if (Array.isArray(value)) {
+      return value.map(renderProvidedValue);
+    }
+    if (value !== null && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, nested]) => [key, renderProvidedValue(nested)])
+      );
+    }
+    return value;
+  };
+
   let inputsWithDefaults: Record<string, unknown> | undefined;
   try {
-    inputsWithDefaults = applyInputDefaults(renderContext.inputs, normalizedSchema, (value) =>
-      templateEngine.render(value, renderContext)
+    inputsWithDefaults = applyInputDefaults(
+      renderContext.inputs,
+      normalizedSchema,
+      (value, source) =>
+        source === 'default'
+          ? // Schema defaults are author-controlled templates; render them fully.
+            templateEngine.render(value, renderContext)
+          : renderProvidedValue(value)
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Fixes a bug where workflow executions fail (or have their inputs silently corrupted) when any **provided input value** contains text that resembles Liquid syntax.

Since #272494, `validateWorkflowInputs` renders **all** input values through the Liquid engine before validation — both schema-defined defaults and caller-provided values. That works well for defaults, but treating provided values as templates is unsafe, because provided inputs are runtime *data*, not workflow-authored templates:

1. **Hard failure:** if a provided string contains `{{ ... }}` text that doesn't parse as Liquid, the execution fails before it starts with an opaque error such as:

   ```
   Workflow input validation failed: expected "|" before filter
   ```

2. **Silent data corruption:** if the text *does* parse (e.g. `{{ some.thing }}`), unknown variables resolve to empty strings (`strictVariables: false`), so legitimate content is quietly stripped from the input before the workflow ever sees it.

This affects any workflow whose inputs carry user- or system-generated content: alert/document payloads, markdown, code snippets, log lines, Mustache/Handlebars/Jinja templates being passed as data, etc. A concrete in-product example is Security's Attack Discovery custom validation hook, where discovery markdown uses the `{{ field.name value }}` field-reference syntax — passing discoveries as a workflow input currently fails validation (or strips the references) through no fault of the workflow author.

### What changed

- `applyInputDefaults` (`@kbn/workflows`) now tells the render callback where each value came from, via a new `source` argument: `'default'` (author-controlled schema default) vs `'provided'` (caller-supplied runtime value).
- `validateWorkflowInputs` (workflows execution engine) now renders the two differently:
  - **Defaults** are rendered fully as Liquid, exactly as before. Dynamic defaults like `{{ 'now' | date: '%Y-%m-%dT%H:%M:%SZ' }}` keep working, and an invalid default template still fails the run (it's a workflow-authoring error).
  - **Provided values** are treated as data and passed through verbatim, recursively across nested objects/arrays. Only strings in the explicit `${{ ... }}` expression form are evaluated — matching the templating engine's existing opt-in convention for expressions — so dynamic provided values remain possible but require unambiguous opt-in.

### Behavior change

Provided input values that relied on *implicit* `{{ ... }}` rendering must now use the explicit `${{ ... }}` form (e.g. `severity: "${{ consts.default_severity }}"` instead of `severity: "{{ consts.default_severity }}"`). This is the intended trade-off: the ambiguity between "template to render" and "data containing braces" was the root cause, and there is no way to distinguish the two for implicit `{{ ... }}` strings. Schema **defaults** are unaffected and keep implicit rendering.

### Testing

- New unit tests in `validate_workflow_inputs.test.ts`: field-syntax markdown passes through unchanged; nested arrays/objects pass through unchanged; `${{ ... }}` provided values still render; invalid default templates still fail the run.
- New unit test in `field_conversion.test.ts` asserting the correct `source` is passed for defaults vs provided values at both top level and nested levels.
- `node scripts/jest` green for both suites; ESLint and type check pass.

### How to reproduce (before this fix)

Create a workflow with a manual trigger input, then run it with a value containing brace-like text:

```yaml
triggers:
  - type: manual
    inputs:
      properties:
        note: { type: string }
```

```json
{ "note": "escalate if {{ host.name web-01 }} reappears" }
```

Before: execution fails with `Workflow input validation failed: expected "|" before filter`.
After: the input passes through verbatim and the workflow runs.

## Release note

Fixed workflow input validation failing or corrupting provided input values that contain text resembling Liquid template syntax.

Made with [Cursor](https://cursor.com)