### PR TITLE
Fix DoS via Playground Query Test

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.ts
@@ -465,7 +465,11 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
           sourceFields = parseSourceFields(chatContext.source_fields);
         } catch (e) {
           logger.error('Failed to parse the source fields', e);
-          throw Error(e);
+          return response.badRequest({
+            body: {
+              message: getErrorMessage(e),
+            },
+          });
         }
         const searchResponse = await client.asCurrentUser.search({
           ...searchQuery,

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/parse_source_fields.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/parse_source_fields.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { parseSourceFields } from './parse_source_fields';
+import { MAX_SOURCE_FIELDS_PER_INDEX, parseSourceFields } from './parse_source_fields';
 
 describe('parseSourceFields', () => {
   it('should parse source fields with multiple index fields', () => {
@@ -28,6 +28,45 @@ describe('parseSourceFields', () => {
     expect(result).toEqual({
       'index-002': 'content',
     });
+  });
+
+  it('should deduplicate source fields for an index', () => {
+    const sourceFields = JSON.stringify({
+      'index-001': ['body', 'name', 'body', 'name', 'body'],
+    });
+    const result = parseSourceFields(sourceFields);
+    expect(result).toEqual({
+      'index-001': ['body', 'name'],
+    });
+  });
+
+  it('should collapse a duplicated single field to a string', () => {
+    const sourceFields = JSON.stringify({
+      'index-001': Array(1000).fill('description'),
+    });
+    const result = parseSourceFields(sourceFields);
+    expect(result).toEqual({
+      'index-001': 'description',
+    });
+  });
+
+  it('should throw an error if unique source fields exceed the maximum per index', () => {
+    const fields = Array.from({ length: MAX_SOURCE_FIELDS_PER_INDEX + 1 }, (_, i) => `field-${i}`);
+    const sourceFields = JSON.stringify({
+      'index-001': fields,
+    });
+    expect(() => parseSourceFields(sourceFields)).toThrowError(
+      `source_fields for index "index-001" exceeds the maximum of ${MAX_SOURCE_FIELDS_PER_INDEX} fields`
+    );
+  });
+
+  it('should throw an error if source fields contain non-string values', () => {
+    const sourceFields = JSON.stringify({
+      'index-001': ['body', 123],
+    });
+    expect(() => parseSourceFields(sourceFields)).toThrowError(
+      'source_fields for index "index-001" must contain non-empty strings'
+    );
   });
 
   it('should throw an error if source fields index value is empty', () => {

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/parse_source_fields.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/parse_source_fields.ts
@@ -7,6 +7,21 @@
 
 import type { ElasticsearchRetrieverContentField } from '../types';
 
+export const MAX_SOURCE_FIELDS_PER_INDEX = 100;
+
+const sanitizeFieldList = (fields: string[], index: string): string[] => {
+  if (fields.some((field) => typeof field !== 'string' || field.length === 0)) {
+    throw new Error(`source_fields for index "${index}" must contain non-empty strings`);
+  }
+  const uniqueFields = [...new Set(fields as string[])];
+  if (uniqueFields.length > MAX_SOURCE_FIELDS_PER_INDEX) {
+    throw new Error(
+      `source_fields for index "${index}" exceeds the maximum of ${MAX_SOURCE_FIELDS_PER_INDEX} fields`
+    );
+  }
+  return uniqueFields;
+};
+
 export const parseSourceFields = (sourceFields: string): ElasticsearchRetrieverContentField => {
   const result: ElasticsearchRetrieverContentField = {};
   const parsedSourceFields = JSON.parse(sourceFields);
@@ -16,8 +31,12 @@ export const parseSourceFields = (sourceFields: string): ElasticsearchRetrieverC
   Object.entries(parsedSourceFields).forEach(([index, fields]) => {
     if (Array.isArray(fields)) {
       if (fields.length === 0) throw new Error('source_fields index value cannot be empty');
-      result[index] = fields.length > 1 ? fields : fields[0];
+      const uniqueFields = sanitizeFieldList(fields, index);
+      result[index] = uniqueFields.length > 1 ? uniqueFields : uniqueFields[0];
     } else if (typeof fields === 'string') {
+      if (fields.length === 0) {
+        throw new Error(`source_fields for index "${index}" must contain non-empty strings`);
+      }
       result[index] = fields;
     } else {
       throw new Error('source_fields index value must be an array or string');


### PR DESCRIPTION


## Summary

This PR: 

- Deduplicate and cap `source_fields` (max 100 unique fields per index) in `parseSourceFields`, so repeated/excessive fields can’t inflate `query_test` responses into a DoS.

- Reject invalid field entries (non-string / empty), and return 400 from `query_test `when parsing fails instead of throwing a 500.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->