### PR TITLE
[9.5] [Alerting] [Bug] Fix rule form data view picker fetching fields for every data view on mount (#277571)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/rule_types/degraded_docs/rule_form/rule_form.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/rule_types/degraded_docs/rule_form/rule_form.tsx
@@ -50,7 +50,11 @@ export const RuleForm: React.FunctionComponent<
   RuleTypeParamsExpressionProps<DegradedDocsRuleParams, { adHocDataViewList: DataView[] }>
 > = (props) => {
   const {
-    services: { dataViews, dataViewEditor },
+    services: {
+      dataViews,
+      dataViewEditor,
+      notifications: { toasts },
+    },
   } = useKibanaContextForPlugin();
 
   const { setRuleParams, ruleParams, errors, metadata, onChangeMetaData } = props;
@@ -211,7 +215,7 @@ export const RuleForm: React.FunctionComponent<
       <EuiSpacer size="s" />
 
       <DataViewSelectPopover
-        dependencies={{ dataViews, dataViewEditor }}
+        dependencies={{ dataViews, dataViewEditor, toasts }}
         dataView={dataView}
         metadata={{ adHocDataViewList: adHocDataViews }}
         onSelectDataView={onSelectDataView}

--- a/x-pack/platform/plugins/shared/stack_alerts/moon.yml
+++ b/x-pack/platform/plugins/shared/stack_alerts/moon.yml
@@ -64,6 +64,7 @@ dependsOn:
   - '@kbn/response-ops-rule-params'
   - '@kbn/object-utils'
   - '@kbn/kql'
+  - '@kbn/core-notifications-browser-mocks'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.test.tsx
@@ -6,28 +6,45 @@
  */
 
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithI18n } from '@kbn/test-jest-helpers';
 import type { DataViewSelectPopoverProps } from './data_view_select_popover';
 import { DataViewSelectPopover } from './data_view_select_popover';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import type { DataView } from '@kbn/data-views-plugin/public';
+import type { DataView, DataViewListItem } from '@kbn/data-views-plugin/public';
 import { indexPatternEditorPluginMock as dataViewEditorPluginMock } from '@kbn/data-view-editor-plugin/public/mocks';
 import { ESQL_TYPE } from '@kbn/data-view-utils';
+import type { ToastsStart } from '@kbn/core/public';
 
 // Mock DataViewSelector to avoid expensive EuiTextTruncate rendering in jsdom
-const MockedDataViewSelector = jest.fn(({ dataViewsList }) => (
-  <div data-test-subj="dataViewSelector-mock">
-    {dataViewsList?.map((dv: { id: string; title: string }) => (
-      <div key={dv.id} data-test-subj={`dataViewOption-${dv.id}`}>
-        {dv.title}
-      </div>
-    ))}
-  </div>
-));
+const MockedDataViewSelector = jest.fn(
+  ({
+    dataViewsList,
+    onChangeDataView,
+  }: {
+    dataViewsList: Array<{ id: string; title: string }>;
+    onChangeDataView: (id: string) => void;
+  }) => (
+    <div data-test-subj="dataViewSelector-mock">
+      {dataViewsList?.map((dv) => (
+        <button
+          key={dv.id}
+          type="button"
+          data-test-subj={`dataViewOption-${dv.id}`}
+          onClick={() => onChangeDataView(dv.id)}
+        >
+          {dv.title}
+        </button>
+      ))}
+    </div>
+  )
+);
 jest.mock('@kbn/unified-search-plugin/public', () => ({
-  DataViewSelector: (props: Record<string, unknown>) => MockedDataViewSelector(props),
+  DataViewSelector: (props: {
+    dataViewsList: Array<{ id: string; title: string }>;
+    onChangeDataView: (id: string) => void;
+  }) => MockedDataViewSelector(props),
 }));
 
 const selectedDataView = {
@@ -39,24 +56,37 @@ const selectedDataView = {
   getName: () => 'kibana_sample_data_logs',
 } as unknown as DataView;
 
-const dataViewIds = [
-  'mock-data-logs-id',
-  'mock-ecommerce-id',
-  'mock-test-id',
-  'mock-ad-hoc-id',
-  'mock-ad-hoc-esql-id',
+const dataViewListItems: DataViewListItem[] = [
+  {
+    id: 'mock-data-logs-id',
+    namespaces: ['default'],
+    title: 'kibana_sample_data_logs',
+  },
+  {
+    id: 'mock-ecommerce-id',
+    namespaces: ['default'],
+    title: 'kibana_sample_data_ecommerce',
+  },
+  {
+    id: 'mock-test-id',
+    namespaces: ['default'],
+    title: 'test',
+  },
+  {
+    id: 'mock-ad-hoc-id',
+    namespaces: ['default'],
+    title: 'ad-hoc data view',
+  },
+  {
+    id: 'mock-ad-hoc-esql-id',
+    namespaces: ['default'],
+    title: 'ad-hoc data view esql',
+    type: ESQL_TYPE,
+  },
 ];
 
 const dataViewOptions = [
   selectedDataView,
-  {
-    id: 'mock-flyghts-id',
-    namespaces: ['default'],
-    title: 'kibana_sample_data_flights',
-    isTimeBased: jest.fn(),
-    isPersisted: jest.fn(() => true),
-    getName: () => 'kibana_sample_data_flights',
-  },
   {
     id: 'mock-ecommerce-id',
     namespaces: ['default'],
@@ -96,18 +126,24 @@ const dataViewOptions = [
   },
 ];
 
+const mockAddDanger = jest.fn();
+
 const mount = () => {
   const dataViewsMock = dataViewPluginMocks.createStartContract();
-  dataViewsMock.getIds = jest.fn().mockImplementation(() => Promise.resolve(dataViewIds));
+  dataViewsMock.getIdsWithTitle = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(dataViewListItems));
   dataViewsMock.get = jest
     .fn()
     .mockImplementation((id: string) =>
       Promise.resolve(dataViewOptions.find((current) => current.id === id))
     );
   const dataViewEditorMock = dataViewEditorPluginMock.createStartContract();
+  const onSelectDataView = jest.fn();
+  const toasts = { addDanger: mockAddDanger } as unknown as ToastsStart;
   const props: DataViewSelectPopoverProps = {
-    dependencies: { dataViews: dataViewsMock, dataViewEditor: dataViewEditorMock },
-    onSelectDataView: () => {},
+    dependencies: { dataViews: dataViewsMock, dataViewEditor: dataViewEditorMock, toasts },
+    onSelectDataView,
     onChangeMetaData: () => {},
     dataView: selectedDataView,
   };
@@ -115,36 +151,41 @@ const mount = () => {
   return {
     result: renderWithI18n(<DataViewSelectPopover {...props} />),
     dataViewsMock,
+    onSelectDataView,
   };
 };
 
 describe('DataViewSelectPopover', () => {
-  test('renders properly', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockedDataViewSelector.mockClear();
+  });
+
+  test('renders properly and loads list metadata without hydrating each data view', async () => {
     const { dataViewsMock } = mount();
 
     await waitFor(() => {
-      expect(dataViewsMock.getIds).toHaveBeenCalled();
+      expect(dataViewsMock.getIdsWithTitle).toHaveBeenCalledWith(true);
     });
 
     expect(screen.getByTestId('selectDataViewExpression')).toBeInTheDocument();
+    expect(dataViewsMock.get).not.toHaveBeenCalled();
 
-    const getIdsResult = await dataViewsMock.getIds.mock.results[0].value;
-    expect(getIdsResult).toBe(dataViewIds);
+    const getIdsWithTitleResult = await dataViewsMock.getIdsWithTitle.mock.results[0].value;
+    expect(getIdsWithTitleResult).toBe(dataViewListItems);
   });
 
   test('should open a popover on click and display loaded data views', async () => {
     const { dataViewsMock } = mount();
 
     await waitFor(() => {
-      expect(dataViewsMock.getIds).toHaveBeenCalled();
+      expect(dataViewsMock.getIdsWithTitle).toHaveBeenCalled();
     });
 
     await userEvent.click(screen.getByTestId('selectDataViewExpression'));
 
     await screen.findByTestId('chooseDataViewPopoverContent');
 
-    // Verify the DataViewSelector received the correct filtered data views
-    // (excludes flights which isn't in dataViewIds)
     const lastCall = MockedDataViewSelector.mock.calls.at(-1)![0];
     const dataViewTitles = lastCall.dataViewsList.map((dv: { title: string }) => dv.title);
     expect(dataViewTitles).toEqual([
@@ -154,6 +195,54 @@ describe('DataViewSelectPopover', () => {
       'ad-hoc data view',
       'ad-hoc data view esql',
     ]);
-    expect(dataViewTitles).not.toContain('kibana_sample_data_flights');
+  });
+
+  test('hydrates a data view only when one is selected', async () => {
+    const { dataViewsMock, onSelectDataView } = mount();
+
+    await waitFor(() => {
+      expect(dataViewsMock.getIdsWithTitle).toHaveBeenCalled();
+    });
+
+    await userEvent.click(screen.getByTestId('selectDataViewExpression'));
+    await screen.findByTestId('chooseDataViewPopoverContent');
+
+    const { onChangeDataView } = MockedDataViewSelector.mock.calls.at(-1)![0];
+    await act(async () => {
+      await onChangeDataView('mock-ecommerce-id');
+    });
+
+    expect(dataViewsMock.get).toHaveBeenCalledTimes(1);
+    expect(dataViewsMock.get).toHaveBeenCalledWith('mock-ecommerce-id', false);
+    expect(onSelectDataView).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'mock-ecommerce-id' })
+    );
+  });
+
+  test('shows a specific toast when the selected data view fails to load', async () => {
+    const { dataViewsMock, onSelectDataView } = mount();
+    dataViewsMock.get = jest
+      .fn()
+      .mockRejectedValue(new Error('index_not_found_exception: no such index'));
+
+    await waitFor(() => {
+      expect(dataViewsMock.getIdsWithTitle).toHaveBeenCalled();
+    });
+
+    await userEvent.click(screen.getByTestId('selectDataViewExpression'));
+    await screen.findByTestId('chooseDataViewPopoverContent');
+
+    const { onChangeDataView } = MockedDataViewSelector.mock.calls.at(-1)![0];
+    await act(async () => {
+      await onChangeDataView('mock-test-id');
+    });
+
+    expect(mockAddDanger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Data view 'test' could not be loaded",
+        text: 'index_not_found_exception: no such index',
+      })
+    );
+    expect(onSelectDataView).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/components/data_view_select_popover.tsx
@@ -27,9 +27,11 @@ import {
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
 import type {
   DataView,
+  DataViewListItem,
   DataViewSpec,
   DataViewsPublicPluginStart,
 } from '@kbn/data-views-plugin/public';
+import type { ToastsStart } from '@kbn/core/public';
 import { DataViewSelector } from '@kbn/unified-search-plugin/public';
 import type { DataViewListItemEnhanced } from '@kbn/unified-search-plugin/public/dataview_picker/dataview_list';
 import type { EsQueryRuleMetaData } from '../es_query/types';
@@ -41,6 +43,7 @@ export interface DataViewSelectPopoverProps {
   dependencies: {
     dataViews: DataViewsPublicPluginStart;
     dataViewEditor: DataViewEditorStart;
+    toasts: ToastsStart;
   };
   dataView?: DataView;
   metadata?: EsQueryRuleMetaData;
@@ -58,8 +61,13 @@ const toDataViewListItem = (dataView: DataView): DataViewListItemEnhanced => {
   };
 };
 
+const toPersistedDataViewListItem = (dataView: DataViewListItem): DataViewListItemEnhanced => ({
+  ...dataView,
+  isAdhoc: false,
+});
+
 export const DataViewSelectPopover: React.FunctionComponent<DataViewSelectPopoverProps> = ({
-  dependencies: { dataViews, dataViewEditor },
+  dependencies: { dataViews, dataViewEditor, toasts },
   metadata,
   dataView,
   onSelectDataView,
@@ -93,20 +101,37 @@ export const DataViewSelectPopover: React.FunctionComponent<DataViewSelectPopove
 
   const onChangeDataView = useCallback(
     async (selectedDataViewId: string) => {
-      const selectedDataView = await dataViews.get(selectedDataViewId);
-      onSelectDataView(selectedDataView);
-      closeDataViewPopover();
+      try {
+        // Suppress the data views service toast so we can show a specific message
+        // for the data view the user actually selected.
+        const selectedDataView = await dataViews.get(selectedDataViewId, false);
+        onSelectDataView(selectedDataView);
+        closeDataViewPopover();
+      } catch (error) {
+        const listItem = allDataViewItems.find((item) => item.id === selectedDataViewId);
+        const dataViewName = listItem?.name || listItem?.title || selectedDataViewId;
+        toasts.addDanger({
+          title: i18n.translate(
+            'xpack.stackAlerts.components.ui.dataViewSelectPopover.loadDataViewErrorTitle',
+            {
+              defaultMessage: "Data view ''{dataViewName}'' could not be loaded",
+              values: { dataViewName },
+            }
+          ),
+          text: error instanceof Error ? error.message : String(error),
+        });
+      }
     },
-    [closeDataViewPopover, dataViews, onSelectDataView]
+    [allDataViewItems, closeDataViewPopover, dataViews, onSelectDataView, toasts]
   );
 
   const loadPersistedDataViews = useCallback(async () => {
     setLoadingDataViews(true);
     try {
-      // Calling getIds with refresh = true to make sure we don't get stale data
-      const ids = await dataViews.getIds(true);
-      const dataViewsList = await Promise.all(ids.map((id) => dataViews.get(id)));
-      setDataViewsItems(dataViewsList.map(toDataViewListItem));
+      // Use getIdsWithTitle so the picker list does not hydrate fields for every
+      // data view in the space. refresh=true avoids stale saved object cache data.
+      const dataViewsList = await dataViews.getIdsWithTitle(true);
+      setDataViewsItems(dataViewsList.map(toPersistedDataViewListItem));
     } catch (e) {
       // Error fetching data views
     }

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/expression.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/expression.test.tsx
@@ -11,6 +11,7 @@ import { renderWithI18n } from '@kbn/test-jest-helpers';
 import React, { useState } from 'react';
 import { docLinksServiceMock } from '@kbn/core/public/mocks';
 import { httpServiceMock } from '@kbn/core/public/mocks';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
@@ -152,6 +153,7 @@ const dataViewsMock = {
   getIndices: jest.fn().mockResolvedValue([]),
 };
 const dataViewEditorMock = dataViewEditorPluginMock.createStartContract();
+const notificationsMock = notificationServiceMock.createStartContract();
 
 (dataMock.search.searchSource.create as jest.Mock).mockImplementation(() =>
   Promise.resolve(searchSourceMock)
@@ -236,6 +238,7 @@ const setup = (
         http: httpMock,
         unifiedSearch: unifiedSearchMock,
         dataViewEditor: dataViewEditorMock,
+        notifications: notificationsMock,
       }}
     >
       <Wrapper ruleParams={ruleParams} metadata={metadata} />

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/search_source_expression.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/search_source_expression.test.tsx
@@ -23,6 +23,7 @@ import { copyToClipboard } from '@elastic/eui';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { indexPatternEditorPluginMock as dataViewEditorPluginMock } from '@kbn/data-view-editor-plugin/public/mocks';
 import type { DataPlugin } from '@kbn/data-plugin/public';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
@@ -254,6 +255,7 @@ describe('SearchSourceAlertTypeExpression', () => {
       searchConfiguration: [],
     };
     const dataViewEditorMock = dataViewEditorPluginMock.createStartContract();
+    const notificationsMock = notificationServiceMock.createStartContract();
 
     return render(
       <KibanaContextProvider
@@ -263,6 +265,7 @@ describe('SearchSourceAlertTypeExpression', () => {
           uiSettings: uiSettingsMock,
           dataViewEditor: dataViewEditorMock,
           unifiedSearch: unifiedSearchMock,
+          notifications: notificationsMock,
         }}
       >
         <SearchSourceExpression

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/search_source_expression_form.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/search_source_expression_form.tsx
@@ -83,7 +83,7 @@ const isSearchSourceParam = (action: LocalStateAction): action is SearchSourcePa
 export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProps) => {
   const services = useTriggerUiActionServices();
   const unifiedSearch = services.unifiedSearch;
-  const { dataViews, dataViewEditor, isServerless } = useTriggerUiActionServices();
+  const { dataViews, dataViewEditor, isServerless, notifications } = useTriggerUiActionServices();
   const { searchSource, errors, initialSavedQuery, setParam, ruleParams } = props;
   const [savedQuery, setSavedQuery] = useState<SavedQuery>();
 
@@ -312,7 +312,7 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
         }
       >
         <DataViewSelectPopover
-          dependencies={{ dataViews, dataViewEditor }}
+          dependencies={{ dataViews, dataViewEditor, toasts: notifications.toasts }}
           dataView={dataView}
           metadata={props.metadata}
           onSelectDataView={onSelectDataView}

--- a/x-pack/platform/plugins/shared/stack_alerts/tsconfig.json
+++ b/x-pack/platform/plugins/shared/stack_alerts/tsconfig.json
@@ -52,6 +52,7 @@
     "@kbn/response-ops-rule-params",
     "@kbn/object-utils",
     "@kbn/kql",
+    "@kbn/core-notifications-browser-mocks",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/custom_threshold_rule_expression.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/custom_threshold_rule_expression.tsx
@@ -206,6 +206,7 @@ export default function Expressions(props: CustomThresholdRuleExpressionProps) {
     data,
     dataViews,
     dataViewEditor,
+    notifications: { toasts },
 
     unifiedSearch: {
       ui: { SearchBar },
@@ -636,7 +637,7 @@ export default function Expressions(props: CustomThresholdRuleExpressionProps) {
         </EuiCallOut>
       ) : (
         <DataViewSelectPopover
-          dependencies={{ dataViews, dataViewEditor }}
+          dependencies={{ dataViews, dataViewEditor, toasts }}
           dataView={dataView}
           metadata={{ adHocDataViewList: metadata?.adHocDataViewList || [] }}
           onSelectDataView={onSelectDataView}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Alerting] [Bug] Fix rule form data view picker fetching fields for every data view on mount (#277571)](https://github.com/elastic/kibana/pull/277571)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Anna Davydova","email":"ana.davydova@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T07:54:49Z","message":"[Alerting] [Bug] Fix rule form data view picker fetching fields for every data view on mount (#277571)\n\nCloses #276539 \n\n- Fixes the rule-form data view picker (`DataViewSelectPopover`) so it\nloads the list with `getIdsWithTitle()` instead of hydrating every data\nview via `get()` on mount. This removes the parallel\n`/internal/data_views/fields` request storm in spaces with many data\nviews.\n- Fully hydrates a data view only when the user selects one (`get(id,\nfalse)`), and shows a single clear toast if that load fails.\n- Applies to all consumers of the shared picker: Elasticsearch Query\n(KQL/Lucene), Custom Threshold, and Dataset Quality (Degraded docs).\n\n## Test plan\n- [ ] In a space with multiple data views (including one broken /\nunresolved index pattern), open **Create rule → Elasticsearch query →\nKQL or Lucene**\n- [ ] Confirm Network does **not** fire one\n`/internal/data_views/fields` request per data view on mount\n- [ ] Confirm the picker still lists all data views\n- [ ] Select a healthy data view → form updates; only that data view is\nhydrated\n- [ ] Select a data view that fails to load → one toast: `Data view\n'<name>' could not be loaded` (with underlying error text)\n- [ ] Spot-check **Custom Threshold** and **Dataset Quality** rule forms\nfor the same mount behavior\n- [ ] Unit tests: `data_view_select_popover.test.tsx`, related ES Query\nexpression tests\n\nCo-authored-by: Jason Rhodes <jason.rhodes@elastic.co>","sha":"f571025991154e5cfcd990842d64c86eff7cecb6","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","author:actionable-obs","closes:rna","v9.5.0","bug-fixer","v9.6.0"],"title":"[Alerting] [Bug] Fix rule form data view picker fetching fields for every data view on mount","number":277571,"url":"https://github.com/elastic/kibana/pull/277571","mergeCommit":{"message":"[Alerting] [Bug] Fix rule form data view picker fetching fields for every data view on mount (#277571)\n\nCloses #276539 \n\n- Fixes the rule-form data view picker (`DataViewSelectPopover`) so it\nloads the list with `getIdsWithTitle()` instead of hydrating every data\nview via `get()` on mount. This removes the parallel\n`/internal/data_views/fields` request storm in spaces with many data\nviews.\n- Fully hydrates a data view only when the user selects one (`get(id,\nfalse)`), and shows a single clear toast if that load fails.\n- Applies to all consumers of the shared picker: Elasticsearch Query\n(KQL/Lucene), Custom Threshold, and Dataset Quality (Degraded docs).\n\n## Test plan\n- [ ] In a space with multiple data views (including one broken /\nunresolved index pattern), open **Create rule → Elasticsearch query →\nKQL or Lucene**\n- [ ] Confirm Network does **not** fire one\n`/internal/data_views/fields` request per data view on mount\n- [ ] Confirm the picker still lists all data views\n- [ ] Select a healthy data view → form updates; only that data view is\nhydrated\n- [ ] Select a data view that fails to load → one toast: `Data view\n'<name>' could not be loaded` (with underlying error text)\n- [ ] Spot-check **Custom Threshold** and **Dataset Quality** rule forms\nfor the same mount behavior\n- [ ] Unit tests: `data_view_select_popover.test.tsx`, related ES Query\nexpression tests\n\nCo-authored-by: Jason Rhodes <jason.rhodes@elastic.co>","sha":"f571025991154e5cfcd990842d64c86eff7cecb6"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277571","number":277571,"mergeCommit":{"message":"[Alerting] [Bug] Fix rule form data view picker fetching fields for every data view on mount (#277571)\n\nCloses #276539 \n\n- Fixes the rule-form data view picker (`DataViewSelectPopover`) so it\nloads the list with `getIdsWithTitle()` instead of hydrating every data\nview via `get()` on mount. This removes the parallel\n`/internal/data_views/fields` request storm in spaces with many data\nviews.\n- Fully hydrates a data view only when the user selects one (`get(id,\nfalse)`), and shows a single clear toast if that load fails.\n- Applies to all consumers of the shared picker: Elasticsearch Query\n(KQL/Lucene), Custom Threshold, and Dataset Quality (Degraded docs).\n\n## Test plan\n- [ ] In a space with multiple data views (including one broken /\nunresolved index pattern), open **Create rule → Elasticsearch query →\nKQL or Lucene**\n- [ ] Confirm Network does **not** fire one\n`/internal/data_views/fields` request per data view on mount\n- [ ] Confirm the picker still lists all data views\n- [ ] Select a healthy data view → form updates; only that data view is\nhydrated\n- [ ] Select a data view that fails to load → one toast: `Data view\n'<name>' could not be loaded` (with underlying error text)\n- [ ] Spot-check **Custom Threshold** and **Dataset Quality** rule forms\nfor the same mount behavior\n- [ ] Unit tests: `data_view_select_popover.test.tsx`, related ES Query\nexpression tests\n\nCo-authored-by: Jason Rhodes <jason.rhodes@elastic.co>","sha":"f571025991154e5cfcd990842d64c86eff7cecb6"}}]}] BACKPORT-->