### PR TITLE
Fix run_quick_checks.test.ts triggering CLI at import

### DIFF
--- a/src/dev/run_quick_checks.test.ts
+++ b/src/dev/run_quick_checks.test.ts
@@ -7,6 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// The module under test invokes `run()` at import time to bootstrap the CLI.
+// Mock it out so importing the module for unit tests does not execute the CLI
+// against Jest's own argv (which fails with "Unknown flag(s)").
+jest.mock('@kbn/dev-cli-runner', () => ({
+  run: jest.fn(),
+}));
+
 import { REPO_ROOT } from '@kbn/repo-info';
 import { buildPipelineAnnotation } from './run_quick_checks';
 


### PR DESCRIPTION
The test imports from `run_quick_checks.ts`, which calls `run()` from `@kbn/dev-cli-runner` at module top level. Importing it executed the CLI against Jest's argv, erroring with "Unknown flag(s)" and failing `src/dev/jest.config.js` on-merge despite all tests passing.

Mock @kbn/dev-cli-runner so the import is a no-op, matching how the sibling r`un_check.test.ts` already handles the same pattern.

Introduced by #276096.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->