### PR TITLE
[Entity Analytics] Workaround for ES|QL filter in Recent Anomalies

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import {
+  useRecentAnomaliesTopRowsEsqlSource,
+  useRecentAnomaliesDataEsqlSource,
+} from './recent_anomalies_esql_source_query_hooks';
+
+jest.mock('@kbn/entity-store/public', () => ({ useEntityStoreEuidApi: jest.fn() }));
+jest.mock('@kbn/entity-store/common', () => ({
+  getLatestEntitiesIndexName: jest.fn(() => '.entities.v2.latest.security_default'),
+}));
+jest.mock('../anomaly_heatmap_interval', () => ({ useIntervalForHeatmap: jest.fn(() => 3) }));
+
+const mockUseEntityStoreEuidApi = useEntityStoreEuidApi as jest.Mock;
+
+const TIME_RANGE_WHERE = '| WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend';
+
+describe('recent anomalies ES|QL sources', () => {
+  beforeEach(() => {
+    mockUseEntityStoreEuidApi.mockReturnValue({
+      euid: {
+        esql: {
+          getFieldEvaluations: (entityType: string) =>
+            `${entityType}_field = TO_STRING(${entityType}.name)`,
+          getEuidEvaluation: (entityType: string, target: string) =>
+            `${target} = CONCAT("${entityType}:", ${entityType}.name)`,
+        },
+      },
+    });
+  });
+
+  const expectTimeRangeBeforeLookupJoin = (source: string | undefined) => {
+    expect(source).toBeDefined();
+    expect(source).toContain(TIME_RANGE_WHERE);
+    expect(source!.indexOf(TIME_RANGE_WHERE)).toBeLessThan(source!.indexOf('LOOKUP JOIN'));
+  };
+
+  it.each(['entity', 'jobId'] as const)(
+    'top rows source (%s mode) filters the time range inside the query text',
+    (viewBy) => {
+      const { result } = renderHook(() =>
+        useRecentAnomaliesTopRowsEsqlSource({
+          anomalyBands: [],
+          viewBy,
+          spaceId: 'default',
+          rowsLimit: 5,
+        })
+      );
+      expectTimeRangeBeforeLookupJoin(result.current);
+    }
+  );
+
+  it.each(['entity', 'jobId'] as const)(
+    'anomaly data source (%s mode) filters the time range inside the query text',
+    (viewBy) => {
+      const { result } = renderHook(() =>
+        useRecentAnomaliesDataEsqlSource({
+          anomalyBands: [],
+          viewBy,
+          spaceId: 'default',
+          rowLabels: ['row-1'],
+        })
+      );
+      expectTimeRangeBeforeLookupJoin(result.current);
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
@@ -24,6 +24,17 @@ export type ViewByMode = 'entity' | 'jobId';
  */
 const BASE_RECORD_FILTER = `| WHERE result_type == "record" AND is_interim == false AND record_score >= 1`;
 
+/**
+ * Time-range filter applied inside the query text via ?_tstart/?_tend named
+ * params (populated by getESQLResults when given a timeRange) instead of the
+ * request-level `filter` DSL. A request-level filter that matches no data
+ * makes the FROM pattern resolve to zero indices, which trips an
+ * Elasticsearch bug in LOOKUP JOIN lookup-index resolution and fails the
+ * query with a misleading "Lookup Join requires a single lookup mode index"
+ * error instead of returning an empty result (elastic/kibana#277613).
+ */
+const TIME_RANGE_FILTER = `| WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend`;
+
 const ANOMALY_ENTITY_TYPES = ['user', 'host', 'service'] as const;
 
 /** The entity name field (e.g. user.name) used as the display name for each entity type. */
@@ -132,6 +143,7 @@ export const useRecentAnomaliesTopRowsEsqlSource = ({
     return `SET unmapped_fields="nullify";
     FROM ${ML_ANOMALIES_INDEX}
     ${BASE_RECORD_FILTER}
+    ${TIME_RANGE_FILTER}
     ${getJobIdsFilter(jobIds)}
     ${getEuidEvaluationBlock(euidApi.euid)}
     | WHERE entity_id IS NOT NULL
@@ -148,6 +160,7 @@ export const useRecentAnomaliesTopRowsEsqlSource = ({
   return `SET unmapped_fields="nullify";
     FROM ${ML_ANOMALIES_INDEX}
     ${BASE_RECORD_FILTER}
+    ${TIME_RANGE_FILTER}
     ${getJobIdsFilter(jobIds)}
     ${getEuidEvaluationBlock(euidApi.euid)}
     | WHERE entity_id IS NOT NULL
@@ -181,6 +194,7 @@ export const useRecentAnomaliesDataEsqlSource = ({
     return `SET unmapped_fields="nullify";
     FROM ${ML_ANOMALIES_INDEX}
     ${BASE_RECORD_FILTER} AND job_id IN (${formattedLabels})
+    ${TIME_RANGE_FILTER}
     ${getEuidEvaluationBlock(euidApi.euid)}
     | WHERE entity_id IS NOT NULL
     ${getEntityIdsFilter(entityIds)}
@@ -201,6 +215,7 @@ export const useRecentAnomaliesDataEsqlSource = ({
   return `SET unmapped_fields="nullify";
     FROM ${ML_ANOMALIES_INDEX}
     ${BASE_RECORD_FILTER}
+    ${TIME_RANGE_FILTER}
     ${getJobIdsFilter(jobIds)}
     ${getEuidEvaluationBlock(euidApi.euid)}
     | WHERE entity_id IN (${formattedLabels})

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.test.ts
@@ -16,7 +16,6 @@ import {
 } from './recent_anomalies_esql_source_query_hooks';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useGlobalFilterQuery } from '../../../../common/hooks/use_global_filter_query';
-import { useEsqlTimeRangeFilter } from '../../../../common/hooks/esql/use_esql_global_filter';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useSecurityMlModuleJobIds } from '../../../../common/components/ml/hooks/use_security_ml_module_job_ids';
 
@@ -34,9 +33,6 @@ jest.mock('../../../../common/lib/kibana', () => ({ useKibana: jest.fn() }));
 jest.mock('../../../../common/hooks/use_global_filter_query', () => ({
   useGlobalFilterQuery: jest.fn(),
 }));
-jest.mock('../../../../common/hooks/esql/use_esql_global_filter', () => ({
-  useEsqlTimeRangeFilter: jest.fn(),
-}));
 jest.mock('../../../../common/containers/use_global_time', () => ({ useGlobalTime: jest.fn() }));
 jest.mock('../../../../common/components/ml/hooks/use_security_ml_module_job_ids', () => ({
   useSecurityMlModuleJobIds: jest.fn(),
@@ -50,13 +46,11 @@ const mockTopRowsSource = useRecentAnomaliesTopRowsEsqlSource as jest.Mock;
 const mockDataSource = useRecentAnomaliesDataEsqlSource as jest.Mock;
 const mockUseKibana = useKibana as jest.Mock;
 const mockUseGlobalFilterQuery = useGlobalFilterQuery as jest.Mock;
-const mockUseEsqlTimeRangeFilter = useEsqlTimeRangeFilter as jest.Mock;
 const mockUseGlobalTime = useGlobalTime as jest.Mock;
 const mockUseSecurityJobIds = useSecurityMlModuleJobIds as jest.Mock;
 
 const TOP_ROWS_SQL = 'TOP_ROWS_SQL';
 const DATA_SQL = 'DATA_SQL';
-const TIME_FILTER = 'TIME_FILTER';
 const EMPTY_BOOL = { bool: { must: [], filter: [], should: [], must_not: [] } };
 const ACTIVE_BOOL = {
   bool: {
@@ -107,7 +101,6 @@ describe('useRecentAnomaliesQuery', () => {
     });
     mockUseGlobalTime.mockReturnValue({ from: 'global-from', to: 'global-to' });
     mockUseSecurityJobIds.mockReturnValue({ jobIds: ['security-job-01'], loading: false });
-    mockUseEsqlTimeRangeFilter.mockReturnValue(TIME_FILTER);
     mockUseGlobalFilterQuery.mockReturnValue({ filterQuery: EMPTY_BOOL });
     mockGetLatestEntitiesIndexName.mockReturnValue('entities-latest-default');
     mockTopRowsSource.mockReturnValue(TOP_ROWS_SQL);
@@ -139,18 +132,26 @@ describe('useRecentAnomaliesQuery', () => {
     });
   });
 
-  describe('time range filter', () => {
-    it('uses the fixed time range when one is provided', () => {
+  describe('time range', () => {
+    it('passes the fixed time range to the query as named params input', async () => {
       renderHook(() => useRecentAnomaliesQuery(baseParams));
-      expect(mockUseEsqlTimeRangeFilter).toHaveBeenCalledWith('now-30d', 'now');
+
+      await topRowsCall()![1]({ signal: undefined });
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ timeRange: { from: 'now-30d', to: 'now' } })
+      );
     });
 
-    it('falls back to the global date picker range when no time range is provided', () => {
+    it('falls back to the global date picker range when no time range is provided', async () => {
       renderHook(() => useRecentAnomaliesQuery({ ...baseParams, timeRange: undefined }));
-      expect(mockUseEsqlTimeRangeFilter).toHaveBeenCalledWith('global-from', 'global-to');
+
+      await topRowsCall()![1]({ signal: undefined });
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ timeRange: { from: 'global-from', to: 'global-to' } })
+      );
     });
 
-    it('applies only the time filter to the anomaly query, not the search bar filters', async () => {
+    it('does not send a request-level filter with the anomaly queries (elastic/kibana#277613)', async () => {
       mockUseGlobalFilterQuery.mockReturnValue({ filterQuery: ACTIVE_BOOL });
       resolvedEntityIds = ['host:test_host_01'];
       topRowsRecords = [{ entity_id: 'host:test_host_01', entity_name: 'h1', entity_type: 'host' }];
@@ -158,9 +159,8 @@ describe('useRecentAnomaliesQuery', () => {
       renderHook(() => useRecentAnomaliesQuery(baseParams));
 
       await topRowsCall()![1]({ signal: undefined });
-      expect(mockGetESQLResults).toHaveBeenCalledWith(
-        expect.objectContaining({ filter: TIME_FILTER })
-      );
+      const callArgs = mockGetESQLResults.mock.calls.at(-1)![0];
+      expect(callArgs.filter).toBeUndefined();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -13,7 +13,6 @@ import { useMemo } from 'react';
 import { getLatestEntitiesIndexName } from '@kbn/entity-store/common';
 import { ML_ANOMALIES_INDEX } from '../../../../../common/constants';
 import type { ESBoolQuery } from '../../../../../common/typed_json';
-import { useEsqlTimeRangeFilter } from '../../../../common/hooks/esql/use_esql_global_filter';
 import { useGlobalFilterQuery } from '../../../../common/hooks/use_global_filter_query';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { esqlResponseToRecords } from '../../../../common/utils/esql';
@@ -45,16 +44,25 @@ interface FixedTimeRange {
 const MAX_FILTERED_ENTITIES = 1000;
 
 /**
- * Time-range-only ES|QL filter for the ML anomalies source. The search bar on
+ * Time-range-only resolver for the ML anomalies source. The search bar on
  * the Entity Analytics home page targets the entity store data view, so its
  * field filters cannot be applied as a pre-filter on the ML anomalies index;
  * they are resolved separately via {@link useFilteredEntityIds}.
+ *
+ * The time range is applied inside the query text as ?_tstart/?_tend named
+ * params (via getESQLResults' timeRange option) rather than the request-level
+ * `filter` DSL. A request-level filter that matches no data makes the FROM
+ * pattern resolve to zero indices, triggering an Elasticsearch bug in LOOKUP
+ * JOIN lookup-index resolution (elastic/kibana#277613).
  */
-const useRecentAnomaliesTimeFilter = (timeRange?: FixedTimeRange): ESBoolQuery => {
+const useRecentAnomaliesTimeRange = (timeRange?: FixedTimeRange): FixedTimeRange => {
   const { from: globalFrom, to: globalTo } = useGlobalTime();
-  const from = timeRange?.from ?? globalFrom;
-  const to = timeRange?.to ?? globalTo;
-  return useEsqlTimeRangeFilter(from, to);
+  const fixedFrom = timeRange?.from;
+  const fixedTo = timeRange?.to;
+  return useMemo(
+    () => ({ from: fixedFrom ?? globalFrom, to: fixedTo ?? globalTo }),
+    [fixedFrom, fixedTo, globalFrom, globalTo]
+  );
 };
 
 const hasActiveFilter = (query?: ESBoolQuery): boolean => {
@@ -172,7 +180,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
   timeRange?: FixedTimeRange;
 }) => {
   const search = useKibana().services.data.search.search;
-  const timeFilter = useRecentAnomaliesTimeFilter(params.timeRange);
+  const timeRange = useRecentAnomaliesTimeRange(params.timeRange);
   const { entityIds, isLoading: isEntityIdsLoading } = useFilteredEntityIds(params.spaceId);
   const { jobIds: securityJobIds, isLoading: isSecurityJobIdsLoading } = useSecurityJobIds();
   const { indexExists: mlIndexExists, isLoading: isMlIndexLoading } = useMlAnomaliesIndexExists();
@@ -188,7 +196,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
   });
 
   const { isLoading, data, isError } = useQuery(
-    [timeFilter, topRowsEsqlSource, entityIds, securityJobIds, mlIndexExists],
+    [timeRange, topRowsEsqlSource, entityIds, securityJobIds, mlIndexExists],
     async ({ signal }) => {
       if (!topRowsEsqlSource || noFilterMatches || noSecurityJobs || !mlIndexExists) {
         return { records: [], rawResponse: undefined };
@@ -197,7 +205,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
         esqlQuery: topRowsEsqlSource,
         search,
         signal,
-        filter: timeFilter,
+        timeRange,
       });
       return {
         records: esqlResponseToRecords<Record<string, string>>(esqlResult?.response),
@@ -246,7 +254,7 @@ export const useRecentAnomaliesQuery = (params: {
   timeRange?: FixedTimeRange;
 }) => {
   const search = useKibana().services.data.search.search;
-  const timeFilter = useRecentAnomaliesTimeFilter(params.timeRange);
+  const timeRange = useRecentAnomaliesTimeRange(params.timeRange);
   const { entityIds, isLoading: isEntityIdsLoading } = useFilteredEntityIds(params.spaceId);
   const { jobIds: securityJobIds, isLoading: isSecurityJobIdsLoading } = useSecurityJobIds();
   const noFilterMatches = entityIds !== undefined && entityIds.length === 0;
@@ -282,7 +290,7 @@ export const useRecentAnomaliesQuery = (params: {
     rowLabels: string[];
     rawResponse?: ESQLSearchResponse;
   }>(
-    [timeFilter, anomalyDataEsqlSource, rowLabels, entityIds, securityJobIds],
+    [timeRange, anomalyDataEsqlSource, rowLabels, entityIds, securityJobIds],
     async ({ signal }) => {
       if (!anomalyDataEsqlSource || !hasAnomaliesData || noFilterMatches || noSecurityJobs) {
         return { anomalyRecords: [], rowLabels: [] };
@@ -291,7 +299,7 @@ export const useRecentAnomaliesQuery = (params: {
         esqlQuery: anomalyDataEsqlSource,
         search,
         signal,
-        filter: timeFilter,
+        timeRange,
       });
       const anomalyRecords = esqlResponseToRecords<Record<string, string | number>>(
         esqlResult.response


### PR DESCRIPTION
## Summary

This is a workaround, switching _Recent Anomalies_ query to use `WHERE @timestamp >= _tstart AND @timestamp <= _tend` instead of the broken `filter` parameter.
See the explanation in https://github.com/elastic/kibana/issues/277613#issuecomment-4960155053

Towards https://github.com/elastic/kibana/issues/277613

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->