### PR TITLE
Fix visualization filters when adding alerts histogram to cases

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/legend_config.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/legend_config.ts
@@ -132,6 +132,14 @@ export const legendConfigFunction: LegendConfigFn = {
       options: [LegendLayout.List],
       strict: true,
     },
+    canFilterOnClick: {
+      types: ['boolean'],
+      default: false,
+      help: i18n.translate('expressionXY.legendConfig.canFilterOnClick.help', {
+        defaultMessage:
+          'Specifies whether clicking a legend item filters by that series, instead of toggling its visibility.',
+      }),
+    },
   },
   async fn(input, args, handlers) {
     const { legendConfigFn } = await import('./expression_module');

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/types/expression_functions.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/types/expression_functions.ts
@@ -233,6 +233,11 @@ export interface LegendConfig {
   layout?: LegendLayout;
   title?: string;
   isTitleVisible?: boolean;
+  /**
+   * Flag whether clicking a legend item should filter by that series, instead of the
+   * default @elastic/charts behaviour of toggling that series' visibility.
+   */
+  canFilterOnClick?: boolean;
 }
 
 // Arguments to XY chart expression, with computed properties

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/legend_action.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/legend_action.tsx
@@ -9,14 +9,7 @@
 
 import React from 'react';
 import type { LegendAction, XYChartSeriesIdentifier } from '@elastic/charts';
-import {
-  getAccessorByDimension,
-  isFilterableColumnSet,
-  getFilterDrilldownWarningMessage,
-} from '@kbn/chart-expressions-common';
-import type { CellValueContext } from '@kbn/embeddable-plugin/public';
-import { ESQL_TABLE_TYPE } from '@kbn/data-plugin/common';
-import type { LayerCellValueActions, FilterEvent } from '../types';
+import type { LayerCellValueActions } from '../types';
 import type { CommonXYDataLayerConfig } from '../../common';
 import type { LegendCellValueActions } from './legend_action_popover';
 import { LegendActionPopover } from './legend_action_popover';
@@ -25,11 +18,13 @@ import type {
   LayersAccessorsTitles,
   LayersFieldFormats,
 } from '../helpers';
-import { getSeriesName, hasMultipleLayersWithSplits } from '../helpers';
+import { getSeriesName, hasMultipleLayersWithSplits, getLegendSeriesFilterData } from '../helpers';
 
 export const getLegendAction = (
   dataLayers: CommonXYDataLayerConfig[],
-  onFilter: (data: FilterEvent['data']) => void,
+  // Same callback direct legend item clicks dispatch through (see `filterBySeries` in xy_chart.tsx),
+  // so "Filter for"/"Filter out" and a raw legend click always resolve to the same filter.
+  onFilter: (series: XYChartSeriesIdentifier, negate?: boolean) => void,
   layerCellValueActions: LayerCellValueActions,
   fieldFormats: LayersFieldFormats,
   formattedDatatables: DatatablesWithFormatInfo,
@@ -38,66 +33,24 @@ export const getLegendAction = (
 ): LegendAction =>
   React.memo(({ series: [xySeries] }) => {
     const series = xySeries as XYChartSeriesIdentifier;
-    const layerIndex = dataLayers.findIndex((l) =>
-      series.seriesKeys.some((key: string | number) =>
-        l.accessors.some(
-          (accessor) => getAccessorByDimension(accessor, l.table.columns) === key.toString()
-        )
-      )
-    );
     const allYAccessors = dataLayers.flatMap((dataLayer) => dataLayer.accessors);
 
-    if (layerIndex === -1) {
+    const seriesFilterData = getLegendSeriesFilterData(series, dataLayers, formattedDatatables);
+
+    if (!seriesFilterData) {
       return null;
     }
+
+    const { layerIndex, cellValueActionData, isFilterable, warningMessage } = seriesFilterData;
 
     const layer = dataLayers[layerIndex];
-    if (!layer || !layer.splitAccessors || !layer.splitAccessors.length) {
+    if (!layer?.splitAccessors?.length) {
       return null;
     }
-
-    const { table } = layer;
-    const isEsqlMode = table?.meta?.type === ESQL_TABLE_TYPE;
-
-    const filterActionData: FilterEvent['data']['data'] = [];
-    const cellValueActionData: CellValueContext['data'] = [];
-
-    series.splitAccessors.forEach((value, accessor) => {
-      const rowIndex = formattedDatatables[layer.layerId].table.rows.findIndex((row) => {
-        return row[accessor] === value;
-      });
-      const columnIndex = table.columns.findIndex((column) => column.id === accessor);
-
-      if (rowIndex >= 0 && columnIndex >= 0) {
-        filterActionData.push({
-          row: rowIndex,
-          column: columnIndex,
-          value: table.rows[rowIndex][accessor],
-          table,
-        });
-
-        cellValueActionData.push({
-          value: table.rows[rowIndex][accessor],
-          columnMeta: table.columns[columnIndex].meta,
-        });
-      }
-    });
-
-    if (filterActionData.length === 0) {
-      return null;
-    }
-
-    const filterableColumns = filterActionData.map((data) => data.table.columns[data.column]);
-    // isFilterable gates the action (disabled state + whether it runs); warningMessage is
-    // display-only and can be suppressed (e.g. for dates) without affecting isFilterable.
-    const isFilterable = !isEsqlMode || isFilterableColumnSet(filterableColumns);
-    const warningMessage = isEsqlMode
-      ? getFilterDrilldownWarningMessage(filterableColumns)
-      : undefined;
 
     const filterHandler = ({ negate }: { negate?: boolean } = {}) => {
       if (isFilterable) {
-        onFilter({ data: filterActionData, negate });
+        onFilter(series, negate);
       }
     };
 
@@ -113,7 +66,7 @@ export const getLegendAction = (
         {
           splitAccessors: layer.splitAccessors,
           accessorsCount: singleTable ? allYAccessors.length : layer.accessors.length,
-          columns: table.columns,
+          columns: layer.table.columns,
           splitAccessorsFormats: fieldFormats[layer.layerId].splitSeriesAccessors,
           alreadyFormattedColumns: formattedDatatables[layer.layerId].formattedColumns,
           columnToLabelMap: layer.columnToLabel ? JSON.parse(layer.columnToLabel) : {},

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -18,6 +18,7 @@ import type {
   RecursivePartial,
   XYChartElementEvent,
   XYChartSeriesIdentifier,
+  SeriesIdentifier,
   SettingsProps,
   TooltipValue,
   PointerValue,
@@ -97,6 +98,7 @@ import {
   validateExtent,
   getOriginalAxisPosition,
   getDecimalsFromFormat,
+  getLegendSeriesFilterData,
 } from '../helpers';
 import { getXDomain, XyEndzones } from './x_domain';
 import { getLegendAction } from './legend_action';
@@ -675,6 +677,23 @@ export function XYChart({
     onClickValue(context);
   };
 
+  // Single filter dispatch shared by the legend action popover's "Filter for"/"Filter out"
+  // buttons and direct legend item clicks (only wired up as the latter when
+  // `legend.canFilterOnClick` is enabled, since it replaces @elastic/charts' default legend
+  // behaviour of toggling series visibility).
+  const filterBySeries = (series: XYChartSeriesIdentifier, negate?: boolean) => {
+    const seriesFilterData = getLegendSeriesFilterData(series, dataLayers, formattedDatatables);
+
+    if (!seriesFilterData?.isFilterable) {
+      return;
+    }
+
+    onClickValue({ data: seriesFilterData.filterActionData, negate });
+  };
+
+  const legendClickFilterHandler = ([xySeries]: SeriesIdentifier[]) =>
+    filterBySeries(xySeries as XYChartSeriesIdentifier);
+
   const brushHandler = ({ x }: XYBrushEvent) => {
     if (!x) {
       return;
@@ -931,11 +950,14 @@ export function XYChart({
               // enable brushing only for time charts, for both ES|QL and DSL queries
               onBrushEnd={interactive ? (brushHandler as BrushEndListener) : undefined}
               onElementClick={interactive ? clickHandler : undefined}
+              onLegendItemClick={
+                interactive && legend.canFilterOnClick ? legendClickFilterHandler : undefined
+              }
               legendAction={
                 interactive
                   ? getLegendAction(
                       dataLayers,
-                      onClickValue,
+                      filterBySeries,
                       layerCellValueActions,
                       fieldFormats,
                       formattedDatatables,

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/data_layers.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/data_layers.tsx
@@ -21,12 +21,18 @@ import { ColorVariant, ScaleType } from '@elastic/charts';
 import type { IFieldFormat } from '@kbn/field-formats-plugin/common';
 import type { PersistedState } from '@kbn/visualizations-common';
 import type { Datatable } from '@kbn/expressions-plugin/common';
-import { getAccessorByDimension } from '@kbn/chart-expressions-common';
+import {
+  getAccessorByDimension,
+  isFilterableColumnSet,
+  getFilterDrilldownWarningMessage,
+} from '@kbn/chart-expressions-common';
 import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common';
 import type { PaletteRegistry, SeriesLayer } from '@kbn/coloring';
 import { getColorCategories } from '@kbn/chart-expressions-common';
 import type { KbnPalettes } from '@kbn/palettes';
 import { MULTI_FIELD_KEY_SEPARATOR, type RawValue } from '@kbn/data-plugin/common';
+import type { CellValueContext } from '@kbn/embeddable-plugin/public';
+import { ESQL_TABLE_TYPE } from '@kbn/data-plugin/common';
 import { isDataLayer } from '../../common/utils/layer_types_guards';
 import type {
   CommonXYDataLayerConfig,
@@ -35,7 +41,7 @@ import type {
   PointVisibility,
 } from '../../common';
 import { AxisModes, SeriesTypes } from '../../common/constants';
-import type { FormatFactory } from '../types';
+import type { FormatFactory, FilterEvent } from '../types';
 import { getSeriesColor } from './state';
 import type { ColorAssignments } from './color_assignment';
 import type { GroupsConfiguration } from './axes_configuration';
@@ -233,6 +239,84 @@ export const getFormattedTablesByLayers = (
     }),
     {}
   );
+
+export interface LegendSeriesFilterData {
+  layerIndex: number;
+  filterActionData: FilterEvent['data']['data'];
+  cellValueActionData: CellValueContext['data'];
+  isFilterable: boolean;
+  warningMessage?: string;
+}
+
+/**
+ * Resolves the split-series filter data for a legend item, shared between the
+ * legend action popover ("Filter for"/"Filter out") and direct legend item clicks
+ * (see `filterBySeries` in `xy_chart.tsx`, the single callback both paths dispatch through).
+ * Returns `null` when the series can't be mapped to a filterable split layer.
+ */
+export const getLegendSeriesFilterData = (
+  series: XYChartSeriesIdentifier,
+  dataLayers: CommonXYDataLayerConfig[],
+  formattedDatatables: DatatablesWithFormatInfo
+): LegendSeriesFilterData | null => {
+  const layerIndex = dataLayers.findIndex((l) =>
+    series.seriesKeys.some((key: string | number) =>
+      l.accessors.some(
+        (accessor) => getAccessorByDimension(accessor, l.table.columns) === key.toString()
+      )
+    )
+  );
+
+  if (layerIndex === -1) {
+    return null;
+  }
+
+  const layer = dataLayers[layerIndex];
+  if (!layer || !layer.splitAccessors || !layer.splitAccessors.length) {
+    return null;
+  }
+
+  const { table } = layer;
+  const isEsqlMode = table?.meta?.type === ESQL_TABLE_TYPE;
+
+  const filterActionData: FilterEvent['data']['data'] = [];
+  const cellValueActionData: CellValueContext['data'] = [];
+
+  series.splitAccessors.forEach((value, accessor) => {
+    const rowIndex = formattedDatatables[layer.layerId].table.rows.findIndex((row) => {
+      return row[accessor] === value;
+    });
+    const columnIndex = table.columns.findIndex((column) => column.id === accessor);
+
+    if (rowIndex >= 0 && columnIndex >= 0) {
+      filterActionData.push({
+        row: rowIndex,
+        column: columnIndex,
+        value: table.rows[rowIndex][accessor],
+        table,
+      });
+
+      cellValueActionData.push({
+        value: table.rows[rowIndex][accessor],
+        columnMeta: table.columns[columnIndex].meta,
+      });
+    }
+  });
+
+  if (filterActionData.length === 0) {
+    return null;
+  }
+
+  const filterableColumns = filterActionData.map((data) => data.table.columns[data.column]);
+  // isFilterable gates the action (disabled state + whether it runs); warningMessage is
+  // display-only and can be suppressed (e.g. for dates) without affecting isFilterable.
+  const isFilterable = !isEsqlMode || isFilterableColumnSet(filterableColumns);
+  const warningMessage = isEsqlMode
+    ? getFilterDrilldownWarningMessage(filterableColumns)
+    : undefined;
+
+  return { layerIndex, filterActionData, cellValueActionData, isFilterable, warningMessage };
+};
 
 function getSplitValues(
   splitAccessorsMap: XYChartSeriesIdentifier['splitAccessors'],

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/to_expression.ts
@@ -316,6 +316,7 @@ export const buildXYExpression = (
     legendStats: state.legend.legendStats,
     title: state.legend.title,
     isTitleVisible: state.legend.isTitleVisible,
+    canFilterOnClick: state.legend.canFilterOnClick,
     shouldTruncate:
       state.legend.shouldTruncate ??
       getDefaultVisualValuesForLayer(state, datasourceLayers).truncateText,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_histogram.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_histogram.test.ts.snap
@@ -174,6 +174,7 @@ Object {
         },
       ],
       "legend": Object {
+        "canFilterOnClick": true,
         "isVisible": true,
         "legendSize": "xlarge",
         "legendStats": Array [
@@ -347,6 +348,7 @@ Object {
         },
       ],
       "legend": Object {
+        "canFilterOnClick": true,
         "isVisible": true,
         "legendSize": "xlarge",
         "legendStats": Array [

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.ts
@@ -27,6 +27,7 @@ export const getAlertsHistogramLensAttributes: GetLensAttributes = ({
           position: 'right',
           legendSize: 'xlarge',
           legendStats: ['currentAndLastValue'],
+          canFilterOnClick: true,
         },
         valueLabels: 'hide',
         preferredSeriesType: 'bar_stacked',


### PR DESCRIPTION
## What & Why
Fixes alerts histogram legend filters not persisting when a visualization is added to a case. Legend clicks now use the same filtering path as the existing “Filter for” and “Filter out” actions.
https://github.com/elastic/kibana/issues/224466
Before

https://github.com/user-attachments/assets/874cd7a5-dec7-4c34-93f7-01b29b7cbe38

after 

https://github.com/user-attachments/assets/f897c7b3-fa50-4fc4-8384-9dae7c5505a5


## How to Test
1. Open an alerts histogram with multiple legend series.
2. Click a legend item and verify the chart filters to that series.
3. Add the filtered visualization to a case.
4. Open the case and verify the visualization retains the selected filter.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)