### PR TITLE
[flaky test runner] update scout manifests before discovery

### DIFF
--- a/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
@@ -17,5 +17,8 @@ export KBN_BOOTSTRAP_NO_PREBUILT=true
 # Injected as step env by the pipeline generator; require it so a missing value fails loudly.
 : "${SCOUT_DISCOVERY_TARGET:?SCOUT_DISCOVERY_TARGET must be set by the flaky pipeline generator}"
 
+echo '--- Update Scout Test Config Manifests'
+node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
+
 echo '--- Resolve requested configs and plan Scout flaky steps'
 ts-node .buildkite/pipelines/flaky_tests/pick_scout_flaky_run_order.ts


### PR DESCRIPTION
## Summary

Tests discovery relies on meta files and fails because for new config it can be missing (e.g. `src/platform/plugins/shared/discover/test/scout/.meta/ui/standard.json`).

Since we want a better UX and get the latest tests status, this PR update pipeline to match PR/on-merge one and run manifest update in advance.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->