### PR TITLE
[Core] Add OTel telemetry for deferred (lazy) plugin initialization

### DIFF
--- a/src/core/packages/plugins/server-internal/moon.yml
+++ b/src/core/packages/plugins/server-internal/moon.yml
@@ -57,6 +57,7 @@ dependsOn:
   - '@kbn/lock-manager'
   - '@kbn/core-deferred-init-common'
   - '@kbn/core-http-router-server-mocks'
+  - '@kbn/tracing-utils'
 tags:
   - shared-server
   - package

--- a/src/core/packages/plugins/server-internal/src/deferred_init/TELEMETRY.md
+++ b/src/core/packages/plugins/server-internal/src/deferred_init/TELEMETRY.md
@@ -1,0 +1,245 @@
+# Deferred Plugin Initialization — Telemetry
+
+This document catalogs every OTel span and metric emitted by the deferred (lazy) plugin
+initialization subsystem. Each entry states the signal name, type, attributes, and the
+operational question it answers.
+
+---
+
+## Background
+
+Plugins that set `enableLazyInitialize: true` in their `kibana.jsonc` skip their
+Elasticsearch-backed work at boot. That work runs the first time the plugin is actually
+needed — driven by an incoming HTTP request, a cross-plugin contract call, or an explicit
+programmatic trigger. Core manages this lifecycle invisibly from the plugin author's
+perspective, but the timing, failure rate, and trigger paths are operationally significant
+and need to be observable.
+
+All signals live under the `kibana.plugins` OTel meter and carry a common set of
+attributes so they can be joined, sliced, and dashboarded together.
+
+---
+
+## Common attributes
+
+These attributes appear on every metric instrument and span described below.
+
+| Attribute | Values | Description |
+|---|---|---|
+| `plugin.id` | e.g. `securitySolution` | Plugin manifest id |
+| `plugin.source` | `oss` \| `x-pack` \| `external` | Where the plugin lives in the repo |
+| `outcome` | `available` \| `failed` \| `retry` | Result of a single run attempt |
+| `trigger.type` | `http_route` \| `contract` \| `explicit` | What caused lazy init to start |
+| `trigger.detail` | e.g. `/api/security/me`, `alerting`, `—` | Route path (http_route), caller plugin id (contract), or `—` (explicit) |
+
+`trigger.type` and `trigger.detail` are set at the moment the engine first kicks the
+deferred work and are **not** updated if a later retry is triggered from a different path.
+They answer "who first woke this plugin up", not "who last touched it".
+
+---
+
+## Spans
+
+### `kibana.plugin.setup`
+
+| | |
+|---|---|
+| **Type** | OTel span |
+| **Parent** | `server-setup` APM transaction |
+| **Emitted by** | `PluginsSystem.setupPlugins()` |
+
+One span per plugin per server boot, nested inside the existing `server-setup` APM
+transaction. Records the wall-clock time a plugin's `setup()` call occupies, including any
+async work it awaits before returning.
+
+**Attributes:** `plugin.id`, `plugin.source`
+
+**Questions answered:**
+- Which plugin's `setup()` is slowest at boot?
+- How does a plugin's setup time trend across releases?
+- What fraction of total boot time does `setup` account for across all plugins?
+
+---
+
+### `kibana.plugin.start`
+
+| | |
+|---|---|
+| **Type** | OTel span |
+| **Parent** | `server-start` APM transaction |
+| **Emitted by** | `PluginsSystem.startPlugins()` |
+
+One span per plugin per server boot, nested inside `server-start`. Records the time a
+plugin's `start()` occupies, including any async work. For lazy-init plugins this is
+typically fast (their ES-backed work is deferred to `lazyInitialize`), so a high value
+here on a `enableLazyInitialize` plugin is a signal the plugin is doing more eagerly than
+intended.
+
+**Attributes:** `plugin.id`, `plugin.source`
+
+**Questions answered:**
+- How much boot time does each plugin's `start()` consume?
+- For lazy-init plugins: is `start()` lightweight as expected, or is work leaking in?
+- Which plugins would benefit most from opting into lazy init (high `start` duration, non-critical path)?
+
+---
+
+### `kibana.plugin.deferred_init.run`
+
+| | |
+|---|---|
+| **Type** | OTel span |
+| **Parent** | Triggering HTTP request span (if http_route), otherwise root span |
+| **Emitted by** | `DeferredInitEngine.runGuarded()` |
+
+One span per actual execution of a plugin's `lazyInitialize()`. Covers the full
+`runGuarded` path: reading the saved-object state, acquiring the distributed lock, running
+the plugin's work, and persisting the outcome. The span is ended with `OK` on success or
+`ERROR` + exception recording on failure.
+
+**Attributes:** `plugin.id`, `plugin.source`, `outcome`, `trigger.type`, `trigger.detail`
+
+**Questions answered:**
+- What was the wall-clock cost of a specific lazy init run?
+- Which request (route path) first triggered initialization, and was that request slowed by it?
+- When init fails, which exception was thrown and from which trigger path?
+- Are retries converging or diverging (rising `outcome=failed` spans for the same plugin)?
+
+---
+
+## Metrics
+
+### `kibana.plugin.lifecycle.duration_ms`
+
+| | |
+|---|---|
+| **Type** | Histogram |
+| **Unit** | milliseconds |
+| **Emitted by** | `PluginsSystem.setupPlugins()`, `PluginsSystem.startPlugins()` |
+
+Records the duration of each plugin's `setup()` or `start()` call. One observation per
+plugin per lifecycle phase per boot.
+
+**Additional attribute:** `lifecycle` — `setup` or `start`
+
+**Questions answered:**
+- What is the p50/p95/p99 setup and start duration per plugin across the fleet?
+- Which plugins account for the most cumulative boot time?
+- For lazy-init plugins: is `start()` duration low (as expected) or suspiciously high?
+- How does boot time distribution shift as plugins are migrated to lazy init?
+
+---
+
+### `kibana.plugin.deferred_init.duration_ms`
+
+| | |
+|---|---|
+| **Type** | Histogram |
+| **Unit** | milliseconds |
+| **Emitted by** | `DeferredInitEngine.runGuarded()` |
+
+Records the wall-clock duration of each `lazyInitialize()` run, from when the lock is
+acquired until the runner returns (or throws). One observation per run attempt.
+
+**Questions answered:**
+- How long does each plugin's deferred init take in practice?
+- Is init time stable or is it growing over time (data growth, schema drift)?
+- How does init duration compare across plugins — who has the most expensive lazy work?
+- Does a plugin that fails (outcome=failed) consistently take longer before failing?
+
+---
+
+### `kibana.plugin.deferred_init.time_to_available_ms`
+
+| | |
+|---|---|
+| **Type** | Histogram |
+| **Unit** | milliseconds |
+| **Emitted by** | `DeferredInitEngine` — on first transition to `available` |
+
+Records the elapsed time from **process start** (i.e. when the `DeferredInitEngine` is
+constructed during `setup`) until a plugin first reaches the `available` state. Emitted
+exactly once per plugin per process lifetime.
+
+This is the headline metric for understanding how "lazy" a plugin actually is in
+production: a plugin initialized 2 seconds after boot is effectively eager; a plugin
+initialized 3 days after boot is genuinely deferring a large chunk of startup work.
+
+**Questions answered:**
+- How long after deployment does each plugin actually get used for the first time?
+- Which plugins are candidates for lazy init (rarely used, long time-to-available)?
+- For plugins already using lazy init: how much startup time is actually saved vs when they'd have been needed anyway?
+- Are any lazy-init plugins consistently initialized within seconds of boot (negating the lazy-init benefit)?
+- What is the p95 time between deployment and first use for each plugin across the fleet?
+
+---
+
+### `kibana.plugin.deferred_init.attempts_total`
+
+| | |
+|---|---|
+| **Type** | Counter |
+| **Unit** | count |
+| **Emitted by** | `DeferredInitEngine` — incremented on every run attempt |
+
+Counts the total number of `lazyInitialize()` run attempts per plugin per outcome. Resets
+to zero at process restart.
+
+**Questions answered:**
+- Is a plugin stuck in a retry loop (rising `outcome=failed` count)?
+- How many lock-race retries does a given plugin trigger across a multi-instance deployment?
+- What fraction of all init attempts succeed on the first try vs require retries?
+- Are failure rates correlated with deployment size (more instances → more lock races)?
+
+---
+
+## Trigger attribution
+
+Every metric and span includes `trigger.type` and `trigger.detail`. These are set on the
+first kick and carried through the full lifecycle of that run. The three trigger paths are:
+
+| `trigger.type` | When | `trigger.detail` |
+|---|---|---|
+| `http_route` | A gated HTTP route handler received a request while the plugin was `idle` | The route path, e.g. `/api/security/role` |
+| `contract` | Another plugin called `core.plugins.loadPluginContract()` for this plugin | The caller plugin's id |
+| `explicit` | `DeferredInitEngine.trigger()` was called directly (e.g. background job, test) | `—` |
+
+**Questions answered:**
+- Which route first woke up each plugin in production?
+- Are there plugins that are only ever triggered by a specific integration or background job?
+- Is a plugin's init being triggered by unexpected callers (cross-plugin contract races)?
+- Which routes see the most `503 Retry-After` responses because they triggered init?
+
+---
+
+## Before-and-after comparison
+
+With these signals in place, the operational story for migrating a plugin to lazy init looks
+like this:
+
+| Question | Before lazy init | After lazy init | Signal |
+|---|---|---|---|
+| How long does boot take? | Includes plugin's ES work | Reduced by plugin's `lazyInitialize` duration | `kibana.plugin.lifecycle.duration_ms` (start, p95) |
+| When is the plugin first used? | Always at boot | Measured in production | `kibana.plugin.deferred_init.time_to_available_ms` |
+| What triggered first use? | N/A (always boot) | Route / contract / explicit | `trigger.type` + `trigger.detail` on `deferred_init.run` span |
+| How long does the deferred work take? | Baked into `start()` span | Separate, standalone measurement | `kibana.plugin.deferred_init.duration_ms` |
+| How often does init fail? | Plugin prevented boot | Visible per-plugin, retryable | `kibana.plugin.deferred_init.attempts_total` (outcome=failed) |
+
+---
+
+## Dashboarding suggestions
+
+The signals above are designed to answer questions at multiple layers:
+
+**Fleet-wide, for platform owners:**
+- Total boot time saved across all lazy-init plugins: sum of `lifecycle.duration_ms{lifecycle=start}` for `enableLazyInitialize` plugins, compared against the same metric on branches where those plugins were eager
+- Distribution of `time_to_available_ms` across all lazy-init plugins: reveals which are truly lazy vs effectively eager
+
+**Per-plugin, for plugin owners:**
+- `deferred_init.duration_ms` histogram for their plugin: is init fast and stable?
+- `deferred_init.attempts_total{outcome=failed}` rate: are failures happening and resolving?
+- `deferred_init.run` span in APM: trace the exact init run end-to-end, see which request triggered it
+
+**Deployment health:**
+- `attempts_total{outcome=retry}` per instance: high lock-race retries may indicate instance count has grown beyond what the lock TTL accommodates
+- `time_to_available_ms` outliers: a plugin that takes unexpectedly long to reach `available` may have a slow `lazyInitialize` or be hitting a transient ES connectivity issue

--- a/src/core/packages/plugins/server-internal/src/deferred_init/deferred_init_engine.ts
+++ b/src/core/packages/plugins/server-internal/src/deferred_init/deferred_init_engine.ts
@@ -8,10 +8,12 @@
  */
 
 import { BehaviorSubject, filter, firstValueFrom, type Observable } from 'rxjs';
+import { metrics, ValueType, type Counter, type Histogram } from '@opentelemetry/api';
 import type { Logger } from '@kbn/logging';
 import { withLock, isLockAcquisitionError } from '@kbn/lock-manager';
 import { DeferredInitializationError } from '@kbn/core-deferred-init-common';
 import type { InitState, LazyInitContext } from '@kbn/core-plugins-server';
+import { withActiveSpan } from '@kbn/tracing-utils';
 import { readDeferredInitState, writeDeferredInitOutcome } from './deferred_init_state';
 import {
   DEFERRED_INIT_BACKOFF_BASE_MS,
@@ -22,6 +24,18 @@ import {
 /** A plugin's deferred initialization work, bound to its {@link LazyInitContext}. */
 export type DeferredInitRunner = (ctx: LazyInitContext) => Promise<void>;
 
+/**
+ * What caused a plugin's deferred init to be kicked for the first time on this process.
+ * Recorded as span attributes and metric dimensions so teams can answer "which route/plugin
+ * first woke up our plugin in production".
+ *
+ * @public
+ */
+export type InitTrigger =
+  | { readonly type: 'http_route'; readonly path: string }
+  | { readonly type: 'contract'; readonly callerPlugin: string }
+  | { readonly type: 'explicit' };
+
 interface DeferredInitRecord {
   readonly state$: BehaviorSubject<InitState>;
   runner?: DeferredInitRunner;
@@ -30,11 +44,70 @@ interface DeferredInitRecord {
   lastError?: unknown;
   /** Consecutive failed runs since the last success; reset to 0 on success. */
   failedAttempts: number;
+  /** Set on the first kick; not updated on subsequent retries. */
+  firstTrigger?: InitTrigger;
+  /** process.hrtime.bigint() captured when the plugin first transitions to 'initializing'. */
+  initStartedAtNs?: bigint;
 }
 
 const LOCK_ID_PREFIX = 'deferred-init:';
+const METER_NAME = 'kibana.plugins';
 
 type GuardedRunOutcome = 'available' | 'retry';
+
+/** Lazily-initialized OTel instruments — created on first use so the global meter is ready. */
+interface DeferredInitInstruments {
+  readonly durationHistogram: Histogram;
+  readonly attemptsCounter: Counter;
+  readonly timeToAvailableHistogram: Histogram;
+}
+
+let instruments: DeferredInitInstruments | undefined;
+
+const getInstruments = (): DeferredInitInstruments => {
+  if (!instruments) {
+    const meter = metrics.getMeter(METER_NAME);
+    instruments = {
+      durationHistogram: meter.createHistogram('kibana.plugin.deferred_init.duration_ms', {
+        description:
+          'Wall-clock duration of a single lazyInitialize() run, from lock acquisition to runner return.',
+        unit: 'ms',
+        valueType: ValueType.DOUBLE,
+      }),
+      attemptsCounter: meter.createCounter('kibana.plugin.deferred_init.attempts_total', {
+        description: 'Cumulative count of lazyInitialize() run attempts, broken down by outcome.',
+        unit: '1',
+        valueType: ValueType.INT,
+      }),
+      timeToAvailableHistogram: meter.createHistogram(
+        'kibana.plugin.deferred_init.time_to_available_ms',
+        {
+          description:
+            'Elapsed time from process start until a plugin first reaches the available state. ' +
+            'A low value means the plugin is used immediately after boot (effectively eager); a ' +
+            'high value confirms the lazy-init benefit is real in production.',
+          unit: 'ms',
+          valueType: ValueType.DOUBLE,
+        }
+      ),
+    };
+  }
+  return instruments;
+};
+
+const triggerAttributes = (trigger: InitTrigger | undefined): Record<string, string> => {
+  if (!trigger) {
+    return { 'trigger.type': 'unknown', 'trigger.detail': '—' };
+  }
+  switch (trigger.type) {
+    case 'http_route':
+      return { 'trigger.type': 'http_route', 'trigger.detail': trigger.path };
+    case 'contract':
+      return { 'trigger.type': 'contract', 'trigger.detail': trigger.callerPlugin };
+    case 'explicit':
+      return { 'trigger.type': 'explicit', 'trigger.detail': '—' };
+  }
+};
 
 /**
  * Per-instance engine that tracks per-plugin deferred-init state and runs the work
@@ -57,6 +130,8 @@ type GuardedRunOutcome = 'available' | 'retry';
 export class DeferredInitEngine {
   private readonly records = new Map<string, DeferredInitRecord>();
   private readonly retryAttempts = new Map<string, number>();
+  /** Captured at construction (early in server boot) for time-to-available measurements. */
+  private readonly engineStartedAtNs = process.hrtime.bigint();
 
   constructor(private readonly log: Logger, private readonly kibanaVersion: string) {}
 
@@ -127,13 +202,13 @@ export class DeferredInitEngine {
    * `failed` plugin becomes auto-kickable again once its cooldown elapses and flips it back to
    * `idle`; an explicit {@link trigger} call can still force a sooner retry.
    */
-  public ensureInitialized(pluginId: string): InitState {
+  public ensureInitialized(pluginId: string, trigger?: InitTrigger): InitState {
     const record = this.records.get(pluginId);
     if (!record) {
       return 'idle';
     }
     if (record.state$.value === 'idle') {
-      this.kick(pluginId, record);
+      this.kick(pluginId, record, trigger);
     }
     return record.state$.value;
   }
@@ -142,16 +217,16 @@ export class DeferredInitEngine {
    * Explicitly kick the deferred work (if `idle`/`failed`) and return a promise that
    * resolves when the in-flight run settles. Used for programmatic triggers.
    */
-  public trigger(pluginId: string): Promise<void> {
+  public trigger(pluginId: string, trigger?: InitTrigger): Promise<void> {
     const record = this.ensureRecord(pluginId);
     const state = record.state$.value;
     if (state === 'idle' || state === 'failed') {
-      this.kick(pluginId, record);
+      this.kick(pluginId, record, trigger);
     }
     return record.inFlight ?? Promise.resolve();
   }
 
-  private kick(pluginId: string, record: DeferredInitRecord): void {
+  private kick(pluginId: string, record: DeferredInitRecord, trigger?: InitTrigger): void {
     if (record.inFlight) {
       return;
     }
@@ -162,14 +237,29 @@ export class DeferredInitEngine {
       return;
     }
 
+    // Only record the trigger that first woke up the plugin; retries inherit the original.
+    if (!record.firstTrigger && trigger) {
+      record.firstTrigger = trigger;
+    }
+
     const { runner, ctx } = record;
     record.state$.next('initializing');
+    record.initStartedAtNs = process.hrtime.bigint();
     this.log.info(`Deferred init for "${pluginId}" started.`);
 
-    record.inFlight = this.runGuarded(pluginId, runner, ctx).then(
+    record.inFlight = this.runGuarded(pluginId, runner, ctx, record.firstTrigger).then(
       (outcome) => {
         record.inFlight = undefined;
         if (outcome === 'available') {
+          const elapsedFromEngineStartMs =
+            Number(process.hrtime.bigint() - this.engineStartedAtNs) / 1e6;
+          const inst = getInstruments();
+          const commonAttrs = {
+            'plugin.id': pluginId,
+            ...triggerAttributes(record.firstTrigger),
+          };
+          inst.timeToAvailableHistogram.record(elapsedFromEngineStartMs, commonAttrs);
+
           this.retryAttempts.delete(pluginId);
           record.failedAttempts = 0;
           record.state$.next('available');
@@ -202,7 +292,7 @@ export class DeferredInitEngine {
    * `RuntimePluginContractResolver.loadPluginContract` to gate cross-plugin, in-process access to
    * a lazy plugin's `start()` contract.
    */
-  public async waitUntilAvailable(pluginId: string): Promise<void> {
+  public async waitUntilAvailable(pluginId: string, trigger?: InitTrigger): Promise<void> {
     const record = this.ensureRecord(pluginId);
 
     while (true) {
@@ -220,7 +310,7 @@ export class DeferredInitEngine {
         });
       }
       if (state === 'idle' || state === 'failed') {
-        this.kick(pluginId, record);
+        this.kick(pluginId, record, trigger);
       }
       await (record.inFlight ?? Promise.resolve());
 
@@ -248,64 +338,101 @@ export class DeferredInitEngine {
    *    than running unlocked.
    * 3. On success, persist `available`. On failure, re-check the state doc first so a slow
    *    failure can never clobber a peer's already-recorded success.
+   *
+   * Emits an OTel span (child of the triggering HTTP request span when available) and records
+   * duration + attempt-count metrics for every run.
    */
   private async runGuarded(
     pluginId: string,
     runner: DeferredInitRunner,
-    ctx: LazyInitContext
+    ctx: LazyInitContext,
+    trigger: InitTrigger | undefined
   ): Promise<GuardedRunOutcome> {
     const { savedObjects, elasticsearch, logger } = ctx;
+    const inst = getInstruments();
+    const commonAttrs = {
+      'plugin.id': pluginId,
+      ...triggerAttributes(trigger),
+    };
 
-    const existing = await readDeferredInitState(savedObjects, logger, pluginId);
-    // Only trust a stored `available` result if it was written by the same Kibana version.
-    // On upgrade the SO is migrated but attributes persist, so a stale `available` from the
-    // previous version must be treated as unknown and the runner re-executed.
-    if (existing?.status === 'available' && existing.kibanaVersion === this.kibanaVersion) {
-      return 'available';
-    }
+    return withActiveSpan(
+      'kibana.plugin.deferred_init.run',
+      { attributes: commonAttrs },
+      async () => {
+        const runStartNs = process.hrtime.bigint();
 
-    try {
-      await withLock(
-        { esClient: elasticsearch.client, logger, lockId: LOCK_ID_PREFIX + pluginId },
-        () => runner(ctx)
-      );
-    } catch (error) {
-      if (isLockAcquisitionError(error)) {
-        this.log.debug(
-          `Deferred init for "${pluginId}": lock held by another instance; will retry.`
+        const existing = await readDeferredInitState(savedObjects, logger, pluginId);
+        // Only trust a stored `available` result if it was written by the same Kibana version.
+        // On upgrade the SO is migrated but attributes persist, so a stale `available` from the
+        // previous version must be treated as unknown and the runner re-executed.
+        if (existing?.status === 'available' && existing.kibanaVersion === this.kibanaVersion) {
+          const durationMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+          const attrs = { ...commonAttrs, outcome: 'available' };
+          inst.durationHistogram.record(durationMs, attrs);
+          inst.attemptsCounter.add(1, attrs);
+          return 'available' as GuardedRunOutcome;
+        }
+
+        try {
+          await withLock(
+            { esClient: elasticsearch.client, logger, lockId: LOCK_ID_PREFIX + pluginId },
+            () => runner(ctx)
+          );
+        } catch (error) {
+          if (isLockAcquisitionError(error)) {
+            this.log.debug(
+              `Deferred init for "${pluginId}": lock held by another instance; will retry.`
+            );
+            const durationMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+            const attrs = { ...commonAttrs, outcome: 'retry' };
+            inst.durationHistogram.record(durationMs, attrs);
+            inst.attemptsCounter.add(1, attrs);
+            return 'retry' as GuardedRunOutcome;
+          }
+
+          // The runner threw. Before recording a cluster-wide failure, make sure a peer that
+          // raced us to completion didn't already succeed in the meantime.
+          const latest = await readDeferredInitState(savedObjects, logger, pluginId);
+          if (latest?.status === 'available' && latest.kibanaVersion === this.kibanaVersion) {
+            const durationMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+            const attrs = { ...commonAttrs, outcome: 'available' };
+            inst.durationHistogram.record(durationMs, attrs);
+            inst.attemptsCounter.add(1, attrs);
+            return 'available' as GuardedRunOutcome;
+          }
+          await writeDeferredInitOutcome(
+            savedObjects,
+            logger,
+            pluginId,
+            'failed',
+            latest?.attempts ?? existing?.attempts ?? 0,
+            this.kibanaVersion,
+            error
+          );
+          const durationMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+          const attrs = { ...commonAttrs, outcome: 'failed' };
+          inst.durationHistogram.record(durationMs, attrs);
+          inst.attemptsCounter.add(1, attrs);
+          throw error;
+        }
+
+        // Always safe to write `available` here even under a race: every concurrent writer
+        // converges on the same value.
+        await writeDeferredInitOutcome(
+          savedObjects,
+          logger,
+          pluginId,
+          'available',
+          existing?.attempts ?? 0,
+          this.kibanaVersion
         );
-        return 'retry';
+        const durationMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+        const attrs = { ...commonAttrs, outcome: 'available' };
+        inst.durationHistogram.record(durationMs, attrs);
+        inst.attemptsCounter.add(1, attrs);
+        return 'available' as GuardedRunOutcome;
       }
-
-      // The runner threw. Before recording a cluster-wide failure, make sure a peer that
-      // raced us to completion didn't already succeed in the meantime.
-      const latest = await readDeferredInitState(savedObjects, logger, pluginId);
-      if (latest?.status === 'available' && latest.kibanaVersion === this.kibanaVersion) {
-        return 'available';
-      }
-      await writeDeferredInitOutcome(
-        savedObjects,
-        logger,
-        pluginId,
-        'failed',
-        latest?.attempts ?? existing?.attempts ?? 0,
-        this.kibanaVersion,
-        error
-      );
-      throw error;
-    }
-
-    // Always safe to write `available` here even under a race: every concurrent writer
-    // converges on the same value.
-    await writeDeferredInitOutcome(
-      savedObjects,
-      logger,
-      pluginId,
-      'available',
-      existing?.attempts ?? 0,
-      this.kibanaVersion
-    );
-    return 'available';
+    ) as Promise<GuardedRunOutcome>;
   }
 
   /**

--- a/src/core/packages/plugins/server-internal/src/deferred_init/guarded_router.ts
+++ b/src/core/packages/plugins/server-internal/src/deferred_init/guarded_router.ts
@@ -49,6 +49,9 @@ const initializingResponse = (
  * route-registration methods are intercepted; everything else (routerPath, getRoutes, etc.)
  * passes through to the underlying router via the Proxy.
  *
+ * The route path from the triggering request is forwarded to the engine as the init trigger
+ * source, so metrics and spans record which route first woke the plugin up.
+ *
  * @internal
  */
 export function createGuardedRouter<Context extends RequestHandlerContextBase>(
@@ -60,7 +63,10 @@ export function createGuardedRouter<Context extends RequestHandlerContextBase>(
     handler: RequestHandler<P, Q, B, Context, Method>
   ): RequestHandler<P, Q, B, Context, Method> => {
     return (context, request, response) => {
-      const status = engine.ensureInitialized(pluginId);
+      const status = engine.ensureInitialized(pluginId, {
+        type: 'http_route',
+        path: request.route.path,
+      });
       if (status !== 'available') {
         return initializingResponse(response, status);
       }
@@ -102,7 +108,10 @@ function createGuardedVersionedRouter<Context extends RequestHandlerContextBase>
     addVersion: (options, handler) =>
       wrapVersionedRoute(
         route.addVersion(options, (context, request, response): MaybePromise<IKibanaResponse> => {
-          const status = engine.ensureInitialized(pluginId);
+          const status = engine.ensureInitialized(pluginId, {
+            type: 'http_route',
+            path: request.route.path,
+          });
           if (status !== 'available') {
             return initializingResponse(response, status);
           }

--- a/src/core/packages/plugins/server-internal/src/deferred_init/index.ts
+++ b/src/core/packages/plugins/server-internal/src/deferred_init/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { DeferredInitEngine } from './deferred_init_engine';
-export type { DeferredInitRunner } from './deferred_init_engine';
+export type { DeferredInitRunner, InitTrigger } from './deferred_init_engine';
 export { createGuardedRouter } from './guarded_router';
 export { registerDeferredInitStatusRoute } from './register_status_route';
 export { toServiceStatus } from './status_mapping';

--- a/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.test.ts
@@ -465,7 +465,10 @@ describe('RuntimePluginContractResolver', () => {
       await expect(resolver.loadPluginContract(SOURCE_PLUGIN, 'pluginA')).resolves.toBe(
         pluginAContract
       );
-      expect(engine.waitUntilAvailable).toHaveBeenCalledWith('pluginA');
+      expect(engine.waitUntilAvailable).toHaveBeenCalledWith('pluginA', {
+        type: 'contract',
+        callerPlugin: SOURCE_PLUGIN,
+      });
     });
 
     it('rejects if the engine ultimately fails to become available', async () => {

--- a/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_contract_resolver.ts
@@ -164,7 +164,10 @@ export class RuntimePluginContractResolver {
     }
 
     if (this.deferredInitEngine?.isRegistered(dependencyName)) {
-      await this.deferredInitEngine.waitUntilAvailable(dependencyName);
+      await this.deferredInitEngine.waitUntilAvailable(dependencyName, {
+        type: 'contract',
+        callerPlugin: pluginName,
+      });
     }
 
     return item.contract;

--- a/src/core/packages/plugins/server-internal/src/plugins_system.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.ts
@@ -9,6 +9,7 @@
 
 import { map } from 'rxjs';
 import pRetry from 'p-retry';
+import { metrics, ValueType, type Histogram } from '@opentelemetry/api';
 import { withTimeout, isPromise } from '@kbn/std';
 import type { DiscoveredPlugin, PluginName } from '@kbn/core-base-common';
 import type { CoreContext } from '@kbn/core-base-server-internal';
@@ -16,6 +17,7 @@ import type { Logger } from '@kbn/logging';
 import { PluginType } from '@kbn/core-base-common';
 import type { LazyInitContext } from '@kbn/core-plugins-server';
 import { isDeferredInitializationError } from '@kbn/core-deferred-init-common';
+import { withActiveSpan } from '@kbn/tracing-utils';
 import type { PluginWrapper } from './plugin';
 import { type PluginDependencies } from './types';
 import {
@@ -38,6 +40,21 @@ import {
 } from './deferred_init';
 
 const Sec = 1000;
+
+let lifecycleHistogram: Histogram | undefined;
+const getLifecycleHistogram = (): Histogram => {
+  if (!lifecycleHistogram) {
+    lifecycleHistogram = metrics
+      .getMeter('kibana.plugins')
+      .createHistogram('kibana.plugin.lifecycle.duration_ms', {
+        description:
+          'Wall-clock duration of each plugin setup() or start() call during server boot.',
+        unit: 'ms',
+        valueType: ValueType.DOUBLE,
+      });
+  }
+  return lifecycleHistogram;
+};
 /**
  * How many times to retry a plugin's `start()` when it fails because a dependency's deferred
  * init hasn't succeeded yet (a {@link DeferredInitializationError} with `retriable: true`). Any
@@ -183,8 +200,14 @@ export class PluginsSystem<T extends PluginType> {
         );
       }
 
+      const pluginAttrs = { 'plugin.id': pluginName, 'plugin.source': plugin.source };
       let contract: unknown;
-      const contractOrPromise = plugin.setup(pluginSetupContext, pluginDepContracts);
+      const setupStartNs = process.hrtime.bigint();
+      const contractOrPromise = withActiveSpan(
+        'kibana.plugin.setup',
+        { attributes: pluginAttrs },
+        () => plugin.setup(pluginSetupContext, pluginDepContracts)
+      );
       if (isPromise(contractOrPromise)) {
         if (this.coreContext.env.mode.dev) {
           this.log.warn(
@@ -206,6 +229,10 @@ export class PluginsSystem<T extends PluginType> {
       } else {
         contract = contractOrPromise;
       }
+      getLifecycleHistogram().record(Number(process.hrtime.bigint() - setupStartNs) / 1e6, {
+        ...pluginAttrs,
+        lifecycle: 'setup',
+      });
 
       contracts.set(pluginName, contract);
       this.satupPlugins.push(pluginName);
@@ -242,12 +269,17 @@ export class PluginsSystem<T extends PluginType> {
         return depContracts;
       }, {} as Record<PluginName, unknown>);
 
-      const contract = await this.startPluginWithRetry(
-        pluginName,
-        plugin,
-        deps,
-        pluginDepContracts
+      const pluginAttrs = { 'plugin.id': pluginName, 'plugin.source': plugin.source };
+      const startStartNs = process.hrtime.bigint();
+      const contract = await withActiveSpan(
+        'kibana.plugin.start',
+        { attributes: pluginAttrs },
+        () => this.startPluginWithRetry(pluginName, plugin, deps, pluginDepContracts)
       );
+      getLifecycleHistogram().record(Number(process.hrtime.bigint() - startStartNs) / 1e6, {
+        ...pluginAttrs,
+        lifecycle: 'start',
+      });
 
       // Attach the deferred-init runner before moving on to the next plugin. Dependencies start
       // before dependents (topological order), so a dependent that calls

--- a/src/core/packages/plugins/server-internal/tsconfig.json
+++ b/src/core/packages/plugins/server-internal/tsconfig.json
@@ -51,6 +51,7 @@
     "@kbn/lock-manager",
     "@kbn/core-deferred-init-common",
     "@kbn/core-http-router-server-mocks",
+    "@kbn/tracing-utils",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Before the lazy-init feature landed, there was no way to know how much boot time any individual plugin was actually responsible for, or whether moving a plugin to lazy init was making a real difference in practice. This PR wires up the observability layer so we can start answering those questions with data.

### Questions this answers

**Did lazy init actually help for this plugin?** The `kibana.plugin.deferred_init.time_to_available_ms` histogram measures elapsed time from server start to the moment a plugin first becomes available. If that number is consistently 3 days, the plugin is genuinely being deferred. If it's 4 seconds, the plugin is effectively eager and probably should not be in this category.

**Which plugin is making boot slow?** Per-plugin spans (`kibana.plugin.setup`, `kibana.plugin.start`) are now nested inside the existing `server-setup` and `server-start` APM transactions, so you can finally see the breakdown instead of just the total.

**What first triggered a lazy plugin to initialize?** Every metric and span carries a trigger source: the HTTP route path that hit the gate first, the plugin that called `loadPluginContract` on it, or an explicit programmatic kick. This tells you whether a plugin is being woken up by expected traffic, a background job, or a surprise cross-plugin dependency.

**Is a plugin stuck in a failure loop?** The `kibana.plugin.deferred_init.attempts_total` counter broken down by outcome (`available`, `failed`, `retry`) makes it immediately visible if a plugin is failing repeatedly and whether retries are converging or spinning.

**How long does the actual init work take once triggered?** The `kibana.plugin.deferred_init.duration_ms` histogram covers the full run: lock acquisition, the plugin's work, and persisting the outcome. Useful for spotting init that's quietly getting slower as data grows.

### What was added

OTel spans and metrics under the `kibana.plugins` meter, emitted from `deferred_init_engine.ts`, `plugins_system.ts`, `guarded_router.ts`, and `plugin_contract_resolver.ts`. The full signal reference including attribute names and dashboarding suggestions is in [`TELEMETRY.md`](src/core/packages/plugins/server-internal/src/deferred_init/TELEMETRY.md).

### Identify risks

None worth calling out. All instruments are created lazily on first use, consistent with how `kibana.feature-flags`, `kibana.os`, and others work, so a missing global meter is a no-op. The trigger argument added to `ensureInitialized`, `trigger()`, and `waitUntilAvailable()` is optional, so no existing call sites needed updating.