### PR TITLE
[Security Solution][Flyout] add flyout session context to open the correct session

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -24,6 +24,7 @@ import {
   useDefaultDocumentFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the attack flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the attack flyout graph into their
 // bundle; the chunk only loads when the flyout (or one of its tools) is actually opened.
@@ -101,23 +102,32 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // The main/child flyout and the tools differ only in their properties (base size + session). Both
   // are kept private here so callers never reason about them: they pick the method they want and
   // this helper opens the system flyout with the given properties.
   const open = useCallback(
-    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+    (
+      children: ReactNode,
+      properties: OverlaySystemFlyoutOpenOptions,
+      propagatedMainFlyoutSessionMode = mainFlyoutSessionMode
+    ) => {
       overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider value={propagatedMainFlyoutSessionMode}>
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history]
+    [overlays, services, store, history, mainFlyoutSessionMode]
   );
 
   const openAttackFlyout = useCallback(
@@ -134,10 +144,10 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           onAttackUpdated={onAttackUpdated}
           renderCellActions={renderCellActions}
         />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
+        { ...defaultDocumentFlyoutProperties, historyKey, session: mainFlyoutSessionMode }
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey]
+    [open, defaultDocumentFlyoutProperties, historyKey, mainFlyoutSessionMode]
   );
 
   const openAttackFlyoutAsChild = useCallback(
@@ -154,7 +164,8 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           onAttackUpdated={onAttackUpdated}
           renderCellActions={renderCellActions}
         />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: 'inherit' }
+        { ...defaultDocumentFlyoutProperties, historyKey, session: 'inherit' },
+        'inherit'
       );
     },
     [open, defaultDocumentFlyoutProperties, historyKey]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
@@ -18,8 +18,9 @@ import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context';
 import type { MisconfigurationProps } from './misconfiguration/main';
-import type { VulnerabilityProps } from './vulnerability/main';
+import type { VulnerabilityProps } from './vulnerability/main'; // Lazy-loaded so consumers of this hook don't statically pull the CSP finding flyout graph into
 
 // Lazy-loaded so consumers of this hook don't statically pull the CSP finding flyout graph into
 // their bundle; the chunk only loads when a finding is actually opened.
@@ -87,6 +88,7 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` (and, for child flyouts, an optional history `title`) are the only things that differ
   // between a main and a child open. Kept private here so callers never reason about them: they pick
@@ -104,18 +106,33 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider
+              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+            >
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         { ...defaultDocumentFlyoutProperties, historyKey, session, title }
       );
       return { close: () => flyoutRef.close(), onClose: flyoutRef.onClose };
     },
-    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+    [
+      overlays,
+      services,
+      store,
+      history,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      mainFlyoutSessionMode,
+    ]
   );
 
   const openMisconfigurationFinding = useCallback(
-    (params: MisconfigurationProps) => open(<Misconfiguration {...params} />, 'start'),
-    [open]
+    (params: MisconfigurationProps) =>
+      open(<Misconfiguration {...params} />, mainFlyoutSessionMode),
+    [open, mainFlyoutSessionMode]
   );
 
   const openMisconfigurationFindingAsChild = useCallback(
@@ -125,8 +142,8 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
   );
 
   const openVulnerabilityFinding = useCallback(
-    (params: VulnerabilityProps) => open(<Vulnerability {...params} />, 'start'),
-    [open]
+    (params: VulnerabilityProps) => open(<Vulnerability {...params} />, mainFlyoutSessionMode),
+    [open, mainFlyoutSessionMode]
   );
 
   const openVulnerabilityFindingAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
@@ -25,7 +25,6 @@ import { EntitiesOverview } from './entities_overview';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
-import { HOST_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 
 export const INSIGHTS_SECTION_TEST_ID = `${PREFIX}InsightsSection` as const;
 
@@ -117,9 +116,7 @@ export const InsightsSection = memo(
     );
 
     const renderFlyoutLink = useCallback(
-      (props: OpenFlyoutLinkProps) => (
-        <OpenFlyoutLink {...props} asParent={props.field === HOST_NAME_FIELD_NAME} />
-      ),
+      (props: OpenFlyoutLinkProps) => <OpenFlyoutLink {...props} />,
       []
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.test.tsx
@@ -236,7 +236,7 @@ describe('InvestigationSection', () => {
     );
   });
 
-  it('renders a rule link keyed by the rule UUID and opening as a new parent flyout', () => {
+  it('renders a rule link keyed by the rule UUID', () => {
     mockUseExpandSection.mockReturnValue(true);
     const ruleUuid = '28f4bc3f-5795-46e3-b5ca-d73cd4ab3e5c';
     const ruleHit = createMockHit({
@@ -261,9 +261,9 @@ describe('InvestigationSection', () => {
       children: <span />,
     }) as React.ReactElement;
 
-    // The link target is the UUID (not the displayed name), and it opens as a new main flyout.
+    // The link target is the UUID (not the displayed name).
     expect(element.props.value).toBe(ruleUuid);
-    expect(element.props.asParent).toBe(true);
+    expect(element.props.asParent).toBeUndefined();
   });
 
   it('falls back to plain children for a rule field when the rule UUID is unavailable', () => {
@@ -291,7 +291,7 @@ describe('InvestigationSection', () => {
     expect(element.props.children).toBeDefined();
   });
 
-  it('opens a non-rule entity field (host) as a new parent flyout', () => {
+  it('keeps non-rule entity fields (host) as direct flyout links', () => {
     mockUseExpandSection.mockReturnValue(true);
 
     render(
@@ -311,9 +311,7 @@ describe('InvestigationSection', () => {
       children: <span />,
     }) as React.ReactElement;
 
-    // Host keeps its value as-is and opens as a parent.
     expect(element.props.value).toBe('host-1');
-    expect(element.props.asParent).toBe(true);
   });
 
   it('uses Security history key when opening flyout inside Security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/investigation_section.tsx
@@ -24,10 +24,8 @@ import { useRuleWithFallback } from '../../../../detection_engine/rule_managemen
 import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
 import {
-  HOST_NAME_FIELD_NAME,
   LEGACY_SIGNAL_RULE_NAME_FIELD_NAME,
   SIGNAL_RULE_NAME_FIELD_NAME,
-  USER_NAME_FIELD_NAME,
 } from '../../../../timelines/components/timeline/body/renderers/constants';
 
 export const INVESTIGATION_SECTION_TEST_ID = `${PREFIX}InvestigationSection` as const;
@@ -108,14 +106,9 @@ export const InvestigationSection = memo(
           if (!ruleId) {
             return <>{props.children}</>;
           }
-          return <OpenFlyoutLink {...props} value={ruleId} asParent />;
+          return <OpenFlyoutLink {...props} value={ruleId} />;
         }
-        return (
-          <OpenFlyoutLink
-            {...props}
-            asParent={props.field === HOST_NAME_FIELD_NAME || props.field === USER_NAME_FIELD_NAME}
-          />
-        );
+        return <OpenFlyoutLink {...props} />;
       },
       [ruleId]
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -35,10 +35,7 @@ import { useFlyoutApi } from '../../use_flyout_api';
 import type { OpenFlyoutLinkProps } from '../../shared/components/open_flyout_link';
 import { OpenFlyoutLink } from '../../shared/components/open_flyout_link';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
-import { getEcsField } from '../../shared/components/table_field_name_cell';
 import {
-  HOST_NAME_FIELD_NAME,
-  IP_FIELD_TYPE,
   LEGACY_SIGNAL_RULE_NAME_FIELD_NAME,
   SIGNAL_RULE_NAME_FIELD_NAME,
 } from '../../../timelines/components/timeline/body/renderers/constants';
@@ -138,13 +135,9 @@ export const DocumentFlyout = memo(
           if (!ruleId) {
             return <>{props.children}</>;
           }
-          return <OpenFlyoutLink {...props} value={ruleId} asParent />;
+          return <OpenFlyoutLink {...props} value={ruleId} />;
         }
-        // Host and IP fields open as a new flyout (parent) rather than a child of the current one.
-        const isIpField = getEcsField(props.field)?.type === IP_FIELD_TYPE;
-        return (
-          <OpenFlyoutLink {...props} asParent={props.field === HOST_NAME_FIELD_NAME || isIpField} />
-        );
+        return <OpenFlyoutLink {...props} />;
       },
       [ruleId]
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
@@ -32,6 +32,7 @@ import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { useFlyoutApi } from '../../../use_flyout_api';
 import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
+import { FlyoutSessionContextProvider } from '../../../session_context';
 
 export const GRAPH_TOOLS_TEST_ID = `${PREFIX}GraphTools` as const;
 
@@ -107,12 +108,14 @@ export const GraphDetails = memo(
             store,
             history,
             children: (
-              <GraphGroupedNodePreviewPanel
-                {...params}
-                scopeId={GRAPH_SCOPE_ID}
-                onShowDocument={onShowDocument}
-                onShowEntity={onShowEntity}
-              />
+              <FlyoutSessionContextProvider value="inherit">
+                <GraphGroupedNodePreviewPanel
+                  {...params}
+                  scopeId={GRAPH_SCOPE_ID}
+                  onShowDocument={onShowDocument}
+                  onShowEntity={onShowEntity}
+                />
+              </FlyoutSessionContextProvider>
             ),
           }),
           { ...defaultFlyoutProperties, historyKey, session: 'inherit' }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/index.tsx
@@ -25,6 +25,7 @@ import { useSessionViewConfig } from './hooks/use_session_view_config';
 import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { SessionViewDetails } from './components/session_view_details';
+import { FlyoutSessionContextProvider } from '../../../session_context';
 
 export const SESSION_VIEW_TEST_ID = `${PREFIX}SessionView` as const;
 
@@ -138,16 +139,18 @@ export const SessionView: FC<SessionViewProps> = memo(
             store,
             history,
             children: (
-              <SessionViewDetails
-                selectedProcess={selectedProcess}
-                index={sessionViewConfig.index}
-                sessionEntityId={sessionViewConfig.sessionEntityId}
-                sessionStartTime={sessionViewConfig.sessionStartTime}
-                investigatedAlertId={sessionViewConfig.investigatedAlertId}
-                renderCellActions={renderCellActions}
-                onJumpToEvent={handleJumpToEvent}
-                onAlertUpdated={onAlertUpdated}
-              />
+              <FlyoutSessionContextProvider value="inherit">
+                <SessionViewDetails
+                  selectedProcess={selectedProcess}
+                  index={sessionViewConfig.index}
+                  sessionEntityId={sessionViewConfig.sessionEntityId}
+                  sessionStartTime={sessionViewConfig.sessionStartTime}
+                  investigatedAlertId={sessionViewConfig.investigatedAlertId}
+                  renderCellActions={renderCellActions}
+                  onJumpToEvent={handleJumpToEvent}
+                  onAlertUpdated={onAlertUpdated}
+                />
+              </FlyoutSessionContextProvider>
             ),
           }),
           {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -25,6 +25,7 @@ import {
   useDefaultDocumentFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
 
 // Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
 // tool graph into their bundle; the chunk only loads when a flyout is actually opened.
@@ -194,20 +195,29 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   const open = useCallback(
-    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+    (
+      children: ReactNode,
+      properties: OverlaySystemFlyoutOpenOptions,
+      propagatedMainFlyoutSessionMode = mainFlyoutSessionMode
+    ) => {
       overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider value={propagatedMainFlyoutSessionMode}>
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history]
+    [overlays, services, store, history, mainFlyoutSessionMode]
   );
 
   // Builds the document flyout content (resolved from a concrete `_index`), shared by both the main
@@ -235,19 +245,29 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       open(buildFromIndexContent(params), {
         ...defaultDocumentFlyoutProperties,
         historyKey,
-        session: 'start',
+        session: mainFlyoutSessionMode,
       });
     },
-    [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey]
+    [
+      open,
+      buildFromIndexContent,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      mainFlyoutSessionMode,
+    ]
   );
 
   const openDocumentFlyoutFromIndexAsChild = useCallback(
     (params: OpenDocumentFlyoutParams) => {
-      open(buildFromIndexContent(params), {
-        ...defaultDocumentFlyoutProperties,
-        historyKey,
-        session: 'inherit',
-      });
+      open(
+        buildFromIndexContent(params),
+        {
+          ...defaultDocumentFlyoutProperties,
+          historyKey,
+          session: 'inherit',
+        },
+        'inherit'
+      );
     },
     [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey]
   );
@@ -266,10 +286,10 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           renderCellActions={renderCellActions}
           onAlertUpdated={onAlertUpdated}
         />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: 'start' }
+        { ...defaultDocumentFlyoutProperties, historyKey, session: mainFlyoutSessionMode }
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey]
+    [open, defaultDocumentFlyoutProperties, historyKey, mainFlyoutSessionMode]
   );
 
   const openAnalyzer = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/components/observed_data_section_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/components/observed_data_section_content.tsx
@@ -147,9 +147,7 @@ export const ObservedDataSectionContent = memo((props: ObservedDataSectionProps)
   const observedFields = entityType === EntityType.host ? hostFields : userFields;
 
   const renderFlyoutLink = useCallback(
-    (flyoutLinkProps: OpenFlyoutLinkProps) => (
-      <OpenFlyoutLink {...flyoutLinkProps} asParent={false} />
-    ),
+    (flyoutLinkProps: OpenFlyoutLinkProps) => <OpenFlyoutLink {...flyoutLinkProps} />,
     []
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
@@ -26,6 +26,7 @@ import { useFlyoutApi } from '../../../../use_flyout_api';
 import { cellActionRenderer } from '../../../../shared/components/cell_actions';
 import { ToolsFlyoutHeader } from '../../../../shared/components/tools_flyout_header';
 import { GraphVisualization } from '../../../../document/tools/graph/components/graph_visualization';
+import { FlyoutSessionContextProvider } from '../../../../session_context';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.entityDetails.graphView.title', {
   defaultMessage: 'Graph',
@@ -93,12 +94,14 @@ export const GraphView = memo(
             store,
             history,
             children: (
-              <GraphGroupedNodePreviewPanel
-                {...params}
-                scopeId={scopeId}
-                onShowDocument={onShowDocument}
-                onShowEntity={onShowEntity}
-              />
+              <FlyoutSessionContextProvider value="inherit">
+                <GraphGroupedNodePreviewPanel
+                  {...params}
+                  scopeId={scopeId}
+                  onShowDocument={onShowDocument}
+                  onShowEntity={onShowEntity}
+                />
+              </FlyoutSessionContextProvider>
             ),
           }),
           { ...defaultFlyoutProperties, historyKey, session: 'inherit' }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -20,6 +20,7 @@ import {
   useDefaultDocumentFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context';
 import type { HostProps } from './host/main';
 import type { UserProps } from './user/main';
 import type { ServiceProps } from './service/main';
@@ -33,7 +34,7 @@ import type { MisconfigurationInsightsProps } from './shared/tools/misconfigurat
 import type { AnomalyInsightsProps } from './shared/tools/anomaly_insights';
 import type { FieldsTableToolProps } from './shared/tools/fields_table';
 import type { ResolutionProps } from './shared/tools/resolution';
-import type { GraphViewProps } from './shared/tools/graph_view';
+import type { GraphViewProps } from './shared/tools/graph_view'; // Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
 // bundle; each chunk only loads when the corresponding flyout is actually opened.
@@ -174,35 +175,41 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   const open = useCallback(
-    (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
+    (
+      children: ReactNode,
+      properties: OverlaySystemFlyoutOpenOptions,
+      propagatedMainFlyoutSessionMode = mainFlyoutSessionMode
+    ) => {
       overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider value={propagatedMainFlyoutSessionMode}>
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history]
+    [overlays, services, store, history, mainFlyoutSessionMode]
   );
 
   // The entity flyouts differ only in their base properties (document vs tools size) and session;
   // both are kept private here so callers never reason about them — they pick the method they want.
   const mainProperties = useCallback(
-    (
-      session: OverlaySystemFlyoutOpenOptions['session'],
-      title?: string
-    ): OverlaySystemFlyoutOpenOptions => ({
+    (session = mainFlyoutSessionMode, title?: string): OverlaySystemFlyoutOpenOptions => ({
       ...defaultDocumentFlyoutProperties,
       historyKey,
       session,
       ...(title !== undefined ? { title } : {}),
     }),
-    [defaultDocumentFlyoutProperties, historyKey]
+    [defaultDocumentFlyoutProperties, historyKey, mainFlyoutSessionMode]
   );
 
   const toolProperties = useCallback(
@@ -218,42 +225,42 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   // Main entity flyouts.
   const openHostFlyout = useCallback(
     ({ title, ...props }: OpenHostFlyoutParams) =>
-      open(<Host {...props} />, mainProperties('start', title)),
+      open(<Host {...props} />, mainProperties(undefined, title)),
     [open, mainProperties]
   );
   const openHostFlyoutAsChild = useCallback(
     ({ title, ...props }: OpenHostFlyoutParams) =>
-      open(<Host {...props} />, mainProperties('inherit', title)),
+      open(<Host {...props} />, mainProperties('inherit', title), 'inherit'),
     [open, mainProperties]
   );
   const openUserFlyout = useCallback(
     ({ title, ...props }: OpenUserFlyoutParams) =>
-      open(<User {...props} />, mainProperties('start', title)),
+      open(<User {...props} />, mainProperties(undefined, title)),
     [open, mainProperties]
   );
   const openUserFlyoutAsChild = useCallback(
     ({ title, ...props }: OpenUserFlyoutParams) =>
-      open(<User {...props} />, mainProperties('inherit', title)),
+      open(<User {...props} />, mainProperties('inherit', title), 'inherit'),
     [open, mainProperties]
   );
   const openServiceFlyout = useCallback(
     ({ title, ...props }: OpenServiceFlyoutParams) =>
-      open(<Service {...props} />, mainProperties('start', title)),
+      open(<Service {...props} />, mainProperties(undefined, title)),
     [open, mainProperties]
   );
   const openServiceFlyoutAsChild = useCallback(
     ({ title, ...props }: OpenServiceFlyoutParams) =>
-      open(<Service {...props} />, mainProperties('inherit', title)),
+      open(<Service {...props} />, mainProperties('inherit', title), 'inherit'),
     [open, mainProperties]
   );
   const openGenericEntityFlyout = useCallback(
     ({ title, ...props }: OpenGenericEntityFlyoutParams) =>
-      open(<GenericEntity {...props} />, mainProperties('start', title)),
+      open(<GenericEntity {...props} />, mainProperties(undefined, title)),
     [open, mainProperties]
   );
   const openGenericEntityFlyoutAsChild = useCallback(
     ({ title, ...props }: OpenGenericEntityFlyoutParams) =>
-      open(<GenericEntity {...props} />, mainProperties('inherit', title)),
+      open(<GenericEntity {...props} />, mainProperties('inherit', title), 'inherit'),
     [open, mainProperties]
   );
 
@@ -275,7 +282,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         default:
           children = <GenericEntity entityId={entityId} scopeId={scopeId} />;
       }
-      open(children, mainProperties('inherit', title));
+      open(children, mainProperties('inherit', title), 'inherit');
     },
     [open, mainProperties]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
@@ -21,6 +21,7 @@ import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the IOC flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the IOC flyout graph into their
 // bundle; the chunk only loads when the flyout is actually opened.
@@ -66,6 +67,7 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` is the only thing that differs between a main and a child flyout. It is kept private
   // here so callers never have to reason about it: they pick `openIocFlyout` (main) or
@@ -82,12 +84,26 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider
+              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+            >
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+    [
+      overlays,
+      services,
+      store,
+      history,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      mainFlyoutSessionMode,
+    ]
   );
 
   // Builds the flyout content (an `IOCDetails` element with a record derived from the indicator),
@@ -105,8 +121,8 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
   );
 
   const openIocFlyout = useCallback(
-    (params: OpenIocFlyoutParams) => open(buildContent(params), 'start'),
-    [open, buildContent]
+    (params: OpenIocFlyoutParams) => open(buildContent(params), mainFlyoutSessionMode),
+    [open, buildContent, mainFlyoutSessionMode]
   );
 
   const openIocFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
@@ -18,6 +18,7 @@ import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the network flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the network flyout graph into their
 // bundle; the chunk only loads when the flyout is actually opened.
@@ -64,6 +65,7 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` is the only thing that differs between a main and a child flyout. It is kept private
   // here so callers never have to reason about it: they pick `openNetworkFlyout` (main) or
@@ -80,19 +82,33 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider
+              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+            >
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+    [
+      overlays,
+      services,
+      store,
+      history,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      mainFlyoutSessionMode,
+    ]
   );
 
   const openNetworkFlyout = useCallback(
     ({ ip, flowTarget }: OpenNetworkFlyoutParams) => {
-      open(<Network ip={ip} flowTarget={flowTarget} />, 'start');
+      open(<Network ip={ip} flowTarget={flowTarget} />, mainFlyoutSessionMode);
     },
-    [open]
+    [open, mainFlyoutSessionMode]
   );
 
   const openNetworkFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
@@ -17,6 +17,7 @@ import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the rule flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the rule flyout graph into their
 // bundle; the chunk only loads when the flyout is actually opened.
@@ -61,6 +62,7 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` is the only thing that differs between a main and a child flyout. It is kept private
   // here so callers never have to reason about it: they pick `openRuleFlyout` (main) or
@@ -77,19 +79,33 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider
+              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+            >
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey]
+    [
+      overlays,
+      services,
+      store,
+      history,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      mainFlyoutSessionMode,
+    ]
   );
 
   const openRuleFlyout = useCallback(
     ({ ruleId }: OpenRuleFlyoutParams) => {
-      open(<RuleDetails ruleId={ruleId} />, 'start');
+      open(<RuleDetails ruleId={ruleId} />, mainFlyoutSessionMode);
     },
-    [open]
+    [open, mainFlyoutSessionMode]
   );
 
   const openRuleFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_context.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC, PropsWithChildren } from 'react';
+import React, { createContext, useContext } from 'react';
+
+export type MainFlyoutSession = 'start' | 'inherit';
+
+const DEFAULT_FLYOUT_SESSION: MainFlyoutSession = 'start';
+
+const FlyoutSessionContext = createContext<MainFlyoutSession>(DEFAULT_FLYOUT_SESSION);
+
+export const FlyoutSessionContextProvider: FC<PropsWithChildren<{ value: MainFlyoutSession }>> = ({
+  value,
+  children,
+}) => <FlyoutSessionContext.Provider value={value}>{children}</FlyoutSessionContext.Provider>;
+
+export const useFlyoutSessionContext = (): MainFlyoutSession => useContext(FlyoutSessionContext);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.test.tsx
@@ -86,13 +86,13 @@ describe('<OpenFlyoutLink />', () => {
       expect(mockOpenSystemFlyout).toHaveBeenCalled();
     });
 
-    it('should open as child flyout by default', () => {
+    it('should follow the default session context when no override is provided', () => {
       const { getByTestId } = renderOpenFlyoutLink();
 
       getByTestId(OPEN_FLYOUT_LINK_TEST_ID).click();
       expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ session: 'inherit', outsideClickCloses: false })
+        expect.objectContaining({ session: 'start', outsideClickCloses: true })
       );
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.tsx
@@ -13,15 +13,13 @@ import { useStore } from 'react-redux';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { flyoutProviders } from './flyout_provider';
-import {
-  defaultToolsFlyoutProperties,
-  useDefaultDocumentFlyoutProperties,
-} from '../hooks/use_default_flyout_properties';
+import { useDefaultDocumentFlyoutProperties } from '../hooks/use_default_flyout_properties';
 import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { documentFlyoutHistoryKey } from '../constants/flyout_history';
 import { OPEN_FLYOUT_LINK_TEST_ID } from './test_ids';
 import { buildFlyoutContent } from '../utils/build_flyout_content';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../session_context';
 
 export interface OpenFlyoutLinkProps {
   /**
@@ -37,8 +35,8 @@ export interface OpenFlyoutLinkProps {
    */
   hit?: DataTableRecord;
   /**
-   * When true, opens as a parent flyout starting a new session.
-   * When false (default), opens as a child flyout inheriting the parent session.
+   * Optional override to force opening as a new top-level flyout (`session: 'start'`).
+   * By default, the link inherits the current main-flyout session mode.
    */
   asParent?: boolean;
   /**
@@ -79,38 +77,42 @@ export const OpenFlyoutLink: FC<OpenFlyoutLinkProps> = ({
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   const flyoutContent = useMemo(() => buildFlyoutContent(field, value, hit), [field, value, hit]);
 
   const onClick = useCallback(() => {
     if (flyoutContent) {
-      const baseFlyoutProperties = asParent
-        ? defaultToolsFlyoutProperties
-        : defaultDocumentFlyoutProperties;
+      const resolvedSession = asParent ? 'start' : mainFlyoutSessionMode;
       overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
           history,
-          children: flyoutContent,
+          children: (
+            <FlyoutSessionContextProvider value={resolvedSession}>
+              {flyoutContent}
+            </FlyoutSessionContextProvider>
+          ),
         }),
         {
-          ...baseFlyoutProperties,
+          ...defaultDocumentFlyoutProperties,
           historyKey,
-          session: asParent ? 'start' : 'inherit',
-          outsideClickCloses: asParent,
+          session: resolvedSession,
+          outsideClickCloses: resolvedSession === 'start',
         }
       );
     }
   }, [
     defaultDocumentFlyoutProperties,
+    history,
+    flyoutContent,
+    historyKey,
+    mainFlyoutSessionMode,
     overlays,
     services,
     store,
-    history,
-    flyoutContent,
     asParent,
-    historyKey,
   ]);
 
   if (!flyoutContent) {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -25,6 +25,7 @@ import { useDefaultDocumentFlyoutProperties } from './use_default_flyout_propert
 import { documentFlyoutHistoryKey } from '../constants/flyout_history';
 import { DocumentSeverity } from '../../document/main/components/severity';
 import { Timestamp } from '../components/timestamp';
+import { FlyoutSessionContextProvider } from '../../session_context';
 
 export interface UseDocumentFlyoutTitleOptions {
   /** The source document to derive display values from. */
@@ -78,11 +79,13 @@ export const useDocumentFlyoutTitle = ({
         store,
         history,
         children: (
-          <DocumentFlyout
-            hit={hit}
-            renderCellActions={renderCellActions}
-            onAlertUpdated={onAlertUpdated}
-          />
+          <FlyoutSessionContextProvider value="inherit">
+            <DocumentFlyout
+              hit={hit}
+              renderCellActions={renderCellActions}
+              onAlertUpdated={onAlertUpdated}
+            />
+          </FlyoutSessionContextProvider>
         ),
       }),
       { ...defaultFlyoutProperties, historyKey, session: 'inherit' }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.test.tsx
@@ -45,7 +45,7 @@ describe('useSharedToolsFlyoutApi', () => {
 
   const getProperties = () => mockOpenSystemFlyout.mock.calls[0][1];
 
-  it('openNotes opens a tools flyout without a session (inherits the parent)', () => {
+  it('openNotes opens a tools flyout as a new tools session', () => {
     const { result } = renderHook(() => useSharedToolsFlyoutApi());
     result.current.openNotes({ hit });
 
@@ -54,7 +54,7 @@ describe('useSharedToolsFlyoutApi', () => {
       'FLYOUT_CONTENT',
       expect.objectContaining({ size: 'm', historyKey: documentFlyoutHistoryKey })
     );
-    expect(getProperties().session).toBeUndefined();
+    expect(getProperties().session).toBe('start');
   });
 
   it('uses the doc-viewer history key when outside the security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
@@ -18,6 +18,7 @@ import { flyoutProviders } from '../components/flyout_provider';
 import { FlyoutLoading } from '../components/flyout_loading';
 import { defaultToolsFlyoutProperties } from '../hooks/use_default_flyout_properties';
 import { documentFlyoutHistoryKey } from '../constants/flyout_history';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the shared tool graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the shared tool graph into their
 // bundle; the chunk only loads when the tool is actually opened.
@@ -53,6 +54,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
   const history = useHistory();
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   const open = useCallback(
     (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
@@ -61,17 +63,25 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
           services,
           store,
           history,
-          children: <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>,
+          children: (
+            <FlyoutSessionContextProvider value={mainFlyoutSessionMode}>
+              <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
+            </FlyoutSessionContextProvider>
+          ),
         }),
         properties
       );
     },
-    [overlays, services, store, history]
+    [overlays, services, store, history, mainFlyoutSessionMode]
   );
 
   const openNotes = useCallback(
     ({ hit }: OpenNotesParams) => {
-      open(<NotesDetails hit={hit} />, { ...defaultToolsFlyoutProperties, historyKey });
+      open(<NotesDetails hit={hit} />, {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      });
     },
     [open, historyKey]
   );


### PR DESCRIPTION
## Summary

This PR adds an internal flyout session context to `flyout_v2` so main flyouts open with the correct session (`start` vs `inherit`) based on where they are opened from, while tools flyouts always open with `session: 'start'`.

The goal is to make this behavior transparent for developers using `useFlyoutApi()` and per-flyout APIs, without requiring callsites to manually decide session mode in most cases.

### Why

Before this change, session behavior for main flyouts was often hardcoded per callsite (`start` or `inherit`), which made parent/child flow behavior inconsistent and required developers to reason about flyout internals.

### Changes

- Introduced an internal session context at
- Updated flyout APIs to propagate and consume session mode:
- `openXAsChild` methods are always using `inherit`
-  `openX` behavior are now context-aware
- tools flyouts are always using `session: 'start'`

#### Before

https://github.com/user-attachments/assets/07322364-b49c-45b6-ac3b-775afa9b2461

#### After

https://github.com/user-attachments/assets/3a37b611-91a7-4d4c-b25f-5782bc758f5e

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->