### PR TITLE
[core] Cross-check solution nav-tree link references against declared deps

### DIFF
--- a/src/core/packages/chrome/browser-internal-types/index.ts
+++ b/src/core/packages/chrome/browser-internal-types/index.ts
@@ -100,8 +100,23 @@ export interface InternalChromeStart extends ChromeStart {
       ChildrenId extends string = Id
     >(
       id: SolutionId,
-      navigationTree$: Observable<NavigationTreeDefinition<LinkId, Id, ChildrenId>>
+      navigationTree$: Observable<NavigationTreeDefinition<LinkId, Id, ChildrenId>>,
+      /**
+       * Id of the plugin that owns the navigation tree. Enables the dev-mode
+       * navigation-dependency cross-check for the tree's `link` references.
+       */
+      ownerPluginId?: string
     ): void;
+
+    /**
+     * Emits the `link` targets referenced by the current project navigation tree,
+     * along with the id of the plugin that owns the tree. Only emits when an owner
+     * was provided to {@link initNavigation}. Consumed by Core to warn about
+     * undeclared cross-plugin navigation dependencies.
+     *
+     * @internal
+     */
+    getNavTreeDependencies$(): Observable<{ ownerPluginId: string; linkTargets: string[] }>;
 
     /** Get an observable of the resolved project navigation tree and active nodes. */
     getNavigation$(): Observable<{

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -70,11 +70,12 @@ export function createChromeApi({
   const project: InternalChromeStart['project'] = {
     setCloudUrls: projectNavigation.setCloudUrls.bind(projectNavigation),
     setKibanaName: projectNavigation.setKibanaName.bind(projectNavigation),
-    initNavigation: (id, navigationTree$) => {
+    initNavigation: (id, navigationTree$, ownerPluginId) => {
       validateProjectStyle();
-      projectNavigation.initNavigation(id, navigationTree$);
+      projectNavigation.initNavigation(id, navigationTree$, ownerPluginId);
     },
     getNavigation$: () => projectNavigation.getNavigation$(),
+    getNavTreeDependencies$: () => projectNavigation.getNavTreeDependencies$(),
     setBreadcrumbs: (breadcrumbs, params) =>
       projectNavigation.setProjectBreadcrumbs(breadcrumbs, params),
     getBreadcrumbs$: () => projectNavigation.getProjectBreadcrumbs$(),

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
@@ -1019,3 +1019,40 @@ describe('getActiveSolutionNavId$()', () => {
     expect(activeId).toBe('oblt');
   });
 });
+
+describe('getNavTreeDependencies$()', () => {
+  test('emits the owner and every link target when the tree declares an owner', async () => {
+    const { projectNavigation } = setup();
+
+    projectNavigation.initNavigation<any>(
+      'es',
+      of({
+        body: [
+          {
+            id: 'group',
+            children: [{ link: 'discover' }, { link: 'management:transform' }],
+          },
+        ],
+        footer: [{ link: 'dev_tools' }],
+      }),
+      'enterpriseSearch'
+    );
+
+    await expect(firstValueFrom(projectNavigation.getNavTreeDependencies$())).resolves.toEqual({
+      ownerPluginId: 'enterpriseSearch',
+      linkTargets: ['discover', 'management:transform', 'dev_tools'],
+    });
+  });
+
+  test('does not emit when the tree has no owner', async () => {
+    const { projectNavigation } = setup();
+    const onEmit = jest.fn();
+    const subscription = projectNavigation.getNavTreeDependencies$().subscribe(onEmit);
+
+    projectNavigation.initNavigation<any>('es', of({ body: [{ link: 'discover' }] }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onEmit).not.toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+});

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
@@ -31,6 +31,7 @@ import {
   skipWhile,
   filter,
   of,
+  EMPTY,
   switchMap,
   shareReplay,
   catchError,
@@ -39,7 +40,7 @@ import type { Location, History } from 'history';
 import deepEqual from 'react-fast-compare';
 import type { Logger } from '@kbn/logging';
 
-import { findActiveNodes, stripQueryParams } from './utils';
+import { collectNavTreeLinks, findActiveNodes, stripQueryParams } from './utils';
 import { buildBreadcrumbs } from './breadcrumbs';
 import { getCloudLinks } from './cloud_links';
 import { applyCustomization, type ParsedNavigation } from './apply_customization';
@@ -77,6 +78,7 @@ export class ProjectNavigationService {
     const currentNavSource$ = new BehaviorSubject<{
       id: SolutionId;
       navTreeDefinition$: Observable<NavigationTreeDefinition>;
+      ownerPluginId?: string;
     } | null>(null);
     const kibanaName$ = new BehaviorSubject<string | undefined>(undefined);
     const cloudLinks$ = new BehaviorSubject<CloudLinks>({});
@@ -146,6 +148,21 @@ export class ProjectNavigationService {
       shareReplay(1)
     );
 
+    // Raw `link` targets referenced by the active nav tree, tagged with the owning
+    // plugin. Only produced when a source declares an owner; consumed by Core's
+    // dev-mode navigation-dependency cross-check.
+    const navTreeDependencies$ = currentNavSource$.pipe(
+      switchMap((source) => {
+        if (!source?.ownerPluginId) return EMPTY;
+        const { ownerPluginId } = source;
+        return source.navTreeDefinition$.pipe(
+          map((def) => ({ ownerPluginId, linkTargets: collectNavTreeLinks(def) }))
+        );
+      }),
+      takeUntil(this.stop$),
+      shareReplay(1)
+    );
+
     // Reset custom breadcrumbs when the active navigation path changes
     navigation$
       .pipe(
@@ -187,7 +204,8 @@ export class ProjectNavigationService {
       },
       initNavigation: <LinkId extends AppDeepLinkId = AppDeepLinkId>(
         id: SolutionId,
-        navTreeDefinition$: Observable<NavigationTreeDefinition<LinkId>>
+        navTreeDefinition$: Observable<NavigationTreeDefinition<LinkId>>,
+        ownerPluginId?: string
       ) => {
         if (currentNavSource$.getValue()?.id === id) return;
         // Customization has a single writer: the navigation plugin, which seeds
@@ -195,9 +213,11 @@ export class ProjectNavigationService {
         currentNavSource$.next({
           id,
           navTreeDefinition$: navTreeDefinition$ as Observable<NavigationTreeDefinition>,
+          ownerPluginId,
         });
       },
       getNavigation$: () => navigation$,
+      getNavTreeDependencies$: () => navTreeDependencies$,
       setProjectBreadcrumbs: (
         breadcrumbs: ChromeBreadcrumb | ChromeBreadcrumb[],
         params?: Partial<ChromeSetProjectBreadcrumbsParams>

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.test.ts
@@ -13,7 +13,7 @@ import type {
   ChromeProjectNavigationNode,
   NavigationTreeDefinition,
 } from '@kbn/core-chrome-browser/src';
-import { flattenNav, findActiveNodes, parseNavigationTree } from './utils';
+import { collectNavTreeLinks, flattenNav, findActiveNodes, parseNavigationTree } from './utils';
 
 const getDeepLink = (id: string, path: string, title = ''): ChromeNavLink => ({
   id,
@@ -463,5 +463,40 @@ describe('findActiveNodes', () => {
         },
       ],
     ]);
+  });
+});
+
+describe('collectNavTreeLinks', () => {
+  test('collects link targets from body and footer, recursing into children', () => {
+    const navTree: NavigationTreeDefinition = {
+      body: [
+        {
+          id: 'group',
+          title: 'Group',
+          children: [
+            { link: 'discover' },
+            { link: 'management:transform' },
+            { id: 'no-link', title: 'No link' },
+          ],
+        },
+        { link: 'dashboards' },
+      ],
+      footer: [{ link: 'dev_tools' }],
+    };
+
+    expect(collectNavTreeLinks(navTree)).toEqual([
+      'discover',
+      'management:transform',
+      'dashboards',
+      'dev_tools',
+    ]);
+  });
+
+  test('returns an empty array when no nodes declare a link', () => {
+    const navTree: NavigationTreeDefinition = {
+      body: [{ id: 'group', title: 'Group', children: [{ id: 'child', title: 'Child' }] }],
+    };
+
+    expect(collectNavTreeLinks(navTree)).toEqual([]);
   });
 });

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.ts
@@ -406,3 +406,26 @@ export const parseNavigationTree = (
 
   return { navigationTree, navigationTreeUI };
 };
+
+/**
+ * Recursively collect every `link` target declared in a navigation tree definition.
+ * Targets are either an appId (`"discover"`) or a deep-link id (`"management:transform"`).
+ * Used by the navigation-dependency cross-check to attribute nav references to apps.
+ */
+export const collectNavTreeLinks = (navTree: NavigationTreeDefinition): string[] => {
+  const links: string[] = [];
+
+  const walk = (nodes?: Array<NodeDefinition<AppDeepLinkId, string, string>>): void => {
+    nodes?.forEach((node) => {
+      if (typeof node.link === 'string') {
+        links.push(node.link);
+      }
+      walk(node.children);
+    });
+  };
+
+  walk(navTree.body);
+  walk(navTree.footer);
+
+  return links;
+};

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, EMPTY, of } from 'rxjs';
 import type { Observable } from 'rxjs';
 import type { MountPoint } from '@kbn/core-mount-utils-browser';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
@@ -132,6 +132,7 @@ const createStartContractMock = () => {
       setCloudUrls: jest.fn(),
       setKibanaName: jest.fn(),
       initNavigation: jest.fn(),
+      getNavTreeDependencies$: jest.fn().mockReturnValue(EMPTY),
       setBreadcrumbs: jest.fn(),
       getBreadcrumbs$: jest.fn().mockReturnValue(new BehaviorSubject([])),
       getNavigation$: jest.fn().mockReturnValue(new BehaviorSubject({} as any)),

--- a/src/core/packages/chrome/browser/src/project_navigation.ts
+++ b/src/core/packages/chrome/browser/src/project_navigation.ts
@@ -274,6 +274,13 @@ export interface SolutionNavigationDefinition<LinkId extends AppDeepLinkId = App
   navigationTree$: Observable<NavigationTreeDefinition<LinkId>>;
   /** Optional icon for the solution navigation to render in the select dropdown. */
   icon?: IconType;
+  /**
+   * Id of the plugin that owns this navigation tree. When provided, Core cross-checks
+   * (in dev builds) that every app referenced by the tree's `link` nodes is owned by a
+   * plugin declared as a dependency of `ownerPluginId`, surfacing implicit navigation
+   * dependencies (see https://github.com/elastic/kibana/issues/66682).
+   */
+  ownerPluginId?: string;
 }
 
 export type SolutionNavigationDefinitions = {

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -7,10 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Subscription } from 'rxjs';
 import type { CoreService, CoreContext } from '@kbn/core-base-browser-internal';
 import type { PluginName, PluginOpaqueId } from '@kbn/core-base-common';
 import type { InjectedMetadataPlugin } from '@kbn/core-injected-metadata-common-internal';
 import type { InternalCoreSetup, InternalCoreStart } from '@kbn/core-lifecycle-browser-internal';
+import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-types';
 import { PluginWrapper } from './plugin';
 import {
   createPluginInitializerContext,
@@ -50,6 +52,7 @@ export class PluginsService
   private readonly pluginDependencies = new Map<PluginName, PluginName[]>();
 
   private readonly satupPlugins: PluginName[] = [];
+  private navDependenciesSubscription?: Subscription;
 
   constructor(private readonly coreContext: CoreContext, plugins: InjectedMetadataPlugin[]) {
     // Generate opaque ids
@@ -138,6 +141,43 @@ export class PluginsService
         })
       : undefined;
 
+    // Apply the same cross-check to solution side-navigation trees: their `link` nodes
+    // reference apps from other plugins without any manifest dependency (the implicit nav
+    // dependencies of https://github.com/elastic/kibana/issues/66682). Chrome tags each
+    // tree with its owning plugin so we can attribute the references.
+    if (reportNavDependency) {
+      const getDeclaredDependencies = (pluginId: PluginName): Set<PluginName> | undefined => {
+        const wrapper = this.plugins.get(pluginId);
+        if (!wrapper) return undefined;
+        return new Set<PluginName>([
+          ...wrapper.requiredPlugins,
+          ...wrapper.optionalPlugins,
+          ...wrapper.runtimePluginDependencies,
+        ]);
+      };
+
+      // `InternalCoreStart` exposes the public `ChromeStart`; the project navigation APIs
+      // (including the nav-tree dependency stream) live on the internal contract.
+      const chrome = deps.chrome as InternalChromeStart;
+      this.navDependenciesSubscription = chrome.project
+        .getNavTreeDependencies$()
+        .subscribe(
+          ({
+            ownerPluginId,
+            linkTargets,
+          }: {
+            ownerPluginId: PluginName;
+            linkTargets: string[];
+          }) => {
+            const declaredDependencies = getDeclaredDependencies(ownerPluginId);
+            if (!declaredDependencies) return;
+            linkTargets.forEach((target) =>
+              reportNavDependency(ownerPluginId, declaredDependencies, target)
+            );
+          }
+        );
+    }
+
     // Setup each plugin with required and optional plugin contracts
     const contracts = new Map<string, unknown>();
     for (const [pluginName, plugin] of this.plugins.entries()) {
@@ -174,6 +214,7 @@ export class PluginsService
   }
 
   public async stop() {
+    this.navDependenciesSubscription?.unsubscribe();
     // Stop plugins in reverse topological order.
     for (const pluginName of this.satupPlugins.reverse()) {
       this.plugins.get(pluginName)!.stop();

--- a/src/core/packages/plugins/browser-internal/tsconfig.json
+++ b/src/core/packages/plugins/browser-internal/tsconfig.json
@@ -30,6 +30,7 @@
     "@kbn/core-application-browser-mocks",
     "@kbn/core-overlays-browser-mocks",
     "@kbn/core-chrome-browser-mocks",
+    "@kbn/core-chrome-browser-internal-types",
     "@kbn/core-fatal-errors-browser-mocks",
     "@kbn/core-ui-settings-browser-mocks",
     "@kbn/core-http-browser-mocks",

--- a/src/platform/plugins/shared/navigation/public/plugin.tsx
+++ b/src/platform/plugins/shared/navigation/public/plugin.tsx
@@ -193,7 +193,11 @@ export class NavigationPublicPlugin
     if (!this.activeSolutionId || !this.chrome) return;
     const def = this.solutionNavDefinitions.get(this.activeSolutionId);
     if (!def) return;
-    this.chrome.project.initNavigation(this.activeSolutionId, def.navigationTree$);
+    this.chrome.project.initNavigation(
+      this.activeSolutionId,
+      def.navigationTree$,
+      def.ownerPluginId
+    );
   }
 
   private initiateChromeStyleAndSideNav(

--- a/x-pack/platform/plugins/shared/serverless/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/serverless/public/plugin.tsx
@@ -64,8 +64,8 @@ export class ServerlessPlugin
     });
 
     return {
-      initNavigation: (id, navigationTree$) => {
-        project.initNavigation(id, navigationTree$);
+      initNavigation: (id, navigationTree$, ownerPluginId) => {
+        project.initNavigation(id, navigationTree$, ownerPluginId);
       },
       setBreadcrumbs: (breadcrumbs, params) => project.setBreadcrumbs(breadcrumbs, params),
       getNavigationCards$: (roleManagementEnabled, extendCardNavDefinitions) => {

--- a/x-pack/platform/plugins/shared/serverless/public/types.ts
+++ b/x-pack/platform/plugins/shared/serverless/public/types.ts
@@ -23,7 +23,15 @@ export interface ServerlessPluginStart {
     breadcrumbs: ChromeBreadcrumb | ChromeBreadcrumb[],
     params?: Partial<ChromeSetProjectBreadcrumbsParams>
   ) => void;
-  initNavigation(id: SolutionId, navigationTree$: Observable<NavigationTreeDefinition>): void;
+  initNavigation(
+    id: SolutionId,
+    navigationTree$: Observable<NavigationTreeDefinition>,
+    /**
+     * Id of the plugin that owns the navigation tree. Enables Core's dev-mode
+     * navigation-dependency cross-check for the tree's `link` references.
+     */
+    ownerPluginId?: string
+  ): void;
   getNavigationCards$(
     roleManagementEnabled?: boolean,
     extendCardNavDefinitions?: Record<string, CardNavExtensionDefinition>


### PR DESCRIPTION
## Summary

Extends the cross-plugin navigation cross-check to solution side-navigation trees, whose `link:` nodes reference other plugins' apps with no manifest dependency (addresses #66682).

- `addSolutionNavigation` / `serverless.initNavigation` accept an optional `ownerPluginId`, threaded through chrome's internal `project.initNavigation`.
- Chrome exposes the active tree's `link` targets tagged with the owner via internal `project.getNavTreeDependencies$()`.
- The browser `PluginsService` reuses the report-mode reporter to warn (dev only) when a referenced app's owner isn't declared in the owning plugin's manifest.

All new surface is `@internal`. Dormant until callers pass `ownerPluginId`, so this is a behavioral no-op on its own.

## Test plan
- [x] `collectNavTreeLinks` + `getNavTreeDependencies$` unit tests
- [x] chrome `browser-internal` (36) + `plugins/browser-internal` (52) suites green
- [x] typecheck: chrome, plugins/browser-internal, navigation, serverless