### PR TITLE
Declare owning plugin for solution navigation trees

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -714,6 +714,7 @@ export const createDefinition = (
   id: 'oblt',
   title,
   icon: 'logoObservability',
+  ownerPluginId: 'observability',
   navigationTree$: combineLatest([
     pluginsStart.streams?.navigationStatus$ || of({ status: 'disabled' as const }),
     coreStart.settings.client.get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE),

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/plugin.ts
@@ -64,7 +64,7 @@ export class ServerlessObservabilityPlugin
         });
       })
     );
-    serverless.initNavigation('oblt', navigationTree$);
+    serverless.initNavigation('oblt', navigationTree$, 'serverlessObservability');
 
     if (workflowsManagement && !core.pricing.isFeatureAvailable('observability:workflows')) {
       workflowsManagement.setUnavailableInServerlessTier({

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -63,6 +63,7 @@ export const getNavigationTreeDefinition = ({
   return {
     icon,
     id: 'es',
+    ownerPluginId: 'enterpriseSearch',
     navigationTree$: dynamicItems$.pipe(
       debounceTime(10),
       map(() => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -147,7 +147,7 @@ export class ServerlessSearchPlugin
         });
       })
     );
-    serverless.initNavigation('es', navigationTree$);
+    serverless.initNavigation('es', navigationTree$, 'serverlessSearch');
 
     this.managementCardsSubscription = serverless
       .getNavigationCards$(

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/solution_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/solution_navigation.ts
@@ -37,5 +37,6 @@ export const registerSolutionNavigation = async (services: Services) => {
     title: SOLUTION_NAME,
     icon: 'logoSecurity',
     navigationTree$,
+    ownerPluginId: 'securitySolutionEss',
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
@@ -53,5 +53,9 @@ export const registerSolutionNavigation = async (
 
   services.securitySolution.setSolutionNavigationTree(navigationTree);
 
-  services.serverless.initNavigation('security', Rx.of(navigationTree));
+  services.serverless.initNavigation(
+    'security',
+    Rx.of(navigationTree),
+    'securitySolutionServerless'
+  );
 };

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/plugin.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/plugin.ts
@@ -84,7 +84,7 @@ export class ServerlessVectordbPlugin
         });
       })
     );
-    serverless.initNavigation('vectordb', navigationTree$);
+    serverless.initNavigation('vectordb', navigationTree$, 'serverlessVectordb');
     return {};
   }
 

--- a/x-pack/solutions/workplaceai/plugins/serverless_workplace_ai/public/plugin.ts
+++ b/x-pack/solutions/workplaceai/plugins/serverless_workplace_ai/public/plugin.ts
@@ -40,7 +40,7 @@ export class WorkplaceAIServerlessPlugin
   ): WorkplaceAIServerlessPluginStart {
     const navigationTree$ = of(createNavigationTree(core));
 
-    serverless.initNavigation('workplaceai', navigationTree$);
+    serverless.initNavigation('workplaceai', navigationTree$, 'serverlessWorkplaceAI');
 
     return {};
   }


### PR DESCRIPTION
## Summary

Enables the nav-tree cross-check by passing `ownerPluginId` when each solution registers its side-navigation tree, so Core can attribute the tree's `link:` references to the registering plugin (addresses #66682).

Covers all stateful (`addSolutionNavigation`) and serverless (`serverless.initNavigation`) registrations across the security, search, observability, workplaceai and vectordb solutions.

Each change is a one-line, behavior-neutral addition — the warnings are dev-only and non-fatal.

## Test plan
- [x] typecheck `serverlessSearch` (exercises 3-arg `serverless.initNavigation`)
- [x] eslint clean on all 8 call sites
- [ ] CI typecheck across the remaining solution plugins