### PR TITLE
[Dashboards in chat] Add Fast mode in the dashboard preview

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/moon.yml
@@ -46,6 +46,7 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/test-jest-helpers'
   - '@kbn/esql-utils'
+  - '@kbn/presentation-publishing'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -411,7 +411,7 @@ describe('DashboardCanvasAttachment', () => {
     );
   });
 
-  it('configures Fast mode for the full-screen dashboard preview', async () => {
+  it('configures Fast mode for the dashboard preview', async () => {
     const { mockApi } = await renderDashboardCanvasAttachment();
 
     expect(getLatestSearchBarProps()?.esqlApproximation).toEqual(
@@ -443,12 +443,6 @@ describe('DashboardCanvasAttachment', () => {
     expect(getLatestSearchBarProps()?.esqlApproximation).toEqual(
       expect.objectContaining({ isApproximate: true })
     );
-  });
-
-  it('does not configure Fast mode for a sidebar dashboard preview', async () => {
-    await renderDashboardCanvasAttachment({ isSidebar: true });
-
-    expect(getLatestSearchBarProps()?.esqlApproximation).toBeUndefined();
   });
 
   it('updates dashboard query and time range from the preview search bar', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -38,20 +38,26 @@ describe('DashboardCanvasAttachment', () => {
   const createMockDashboardApi = (
     overrides: Partial<Pick<DashboardApi, 'isManaged' | 'isEditableByUser'>> = {}
   ): DashboardApi & {
+    children$: BehaviorSubject<Record<string, unknown>>;
     dataViews$: BehaviorSubject<any[]>;
+    isApproximate$: BehaviorSubject<boolean>;
   } => {
+    const children$ = new BehaviorSubject<Record<string, unknown>>({});
     const dataViews$ = new BehaviorSubject<any[]>([]);
     const filters$ = new BehaviorSubject<Filter[]>([]);
+    const isApproximate$ = new BehaviorSubject(false);
     const query$ = new BehaviorSubject<Query | undefined>(undefined);
     const timeRange$ = new BehaviorSubject({ from: 'now-15m', to: 'now' });
 
     return {
+      children$,
       locator: {
         navigate: jest.fn().mockResolvedValue(undefined),
       },
       dataViews$,
       filters$,
       forceRefresh: jest.fn(),
+      isApproximate$,
       query$,
       isEditableByUser: true,
       isManaged: false,
@@ -59,6 +65,7 @@ describe('DashboardCanvasAttachment', () => {
       runInteractiveSave: jest.fn().mockResolvedValue({ id: 'new-dashboard-id' }),
       savedObjectId$: new BehaviorSubject<string | undefined>(undefined),
       setFilters: jest.fn((nextFilters?: Filter[]) => filters$.next(nextFilters ?? [])),
+      setEsqlApproximation: jest.fn((isApproximate: boolean) => isApproximate$.next(isApproximate)),
       setQuery: jest.fn((nextQuery?: Query) => query$.next(nextQuery)),
       setViewMode: jest.fn(),
       setTimeRange: jest.fn((nextTimeRange?: { from: string; to: string }) => {
@@ -69,7 +76,9 @@ describe('DashboardCanvasAttachment', () => {
       timeRange$,
       ...overrides,
     } as unknown as DashboardApi & {
+      children$: BehaviorSubject<Record<string, unknown>>;
       dataViews$: BehaviorSubject<any[]>;
+      isApproximate$: BehaviorSubject<boolean>;
     };
   };
 
@@ -400,6 +409,46 @@ describe('DashboardCanvasAttachment', () => {
         useDefaultBehaviors: false,
       })
     );
+  });
+
+  it('configures Fast mode for the full-screen dashboard preview', async () => {
+    const { mockApi } = await renderDashboardCanvasAttachment();
+
+    expect(getLatestSearchBarProps()?.esqlApproximation).toEqual(
+      expect.objectContaining({
+        isApproximate: false,
+        disabled: true,
+      })
+    );
+
+    act(() => {
+      mockApi.children$.next({
+        'esql-panel': {
+          usesEsql$: new BehaviorSubject(true),
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(getLatestSearchBarProps()?.esqlApproximation).toEqual(
+        expect.objectContaining({ disabled: false })
+      );
+    });
+
+    act(() => {
+      getLatestSearchBarProps()?.esqlApproximation.onChange(true);
+    });
+
+    expect(mockApi.setEsqlApproximation).toHaveBeenCalledWith(true);
+    expect(getLatestSearchBarProps()?.esqlApproximation).toEqual(
+      expect.objectContaining({ isApproximate: true })
+    );
+  });
+
+  it('does not configure Fast mode for a sidebar dashboard preview', async () => {
+    await renderDashboardCanvasAttachment({ isSidebar: true });
+
+    expect(getLatestSearchBarProps()?.esqlApproximation).toBeUndefined();
   });
 
   it('updates dashboard query and time range from the preview search bar', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -56,6 +56,7 @@ export const DashboardCanvasContent = ({
   dashboardLocator,
   searchBarComponent: SearchBar,
   data,
+  isSidebar,
   checkSavedDashboardExist,
   canWriteDashboards,
 }: AttachmentRenderProps<DashboardAttachment> & {
@@ -109,6 +110,7 @@ export const DashboardCanvasContent = ({
     dashboardApi,
     dashboardState,
     data,
+    isSidebar,
   });
 
   const getCreationOptions = useCallback(

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -56,7 +56,6 @@ export const DashboardCanvasContent = ({
   dashboardLocator,
   searchBarComponent: SearchBar,
   data,
-  isSidebar,
   checkSavedDashboardExist,
   canWriteDashboards,
 }: AttachmentRenderProps<DashboardAttachment> & {
@@ -110,7 +109,6 @@ export const DashboardCanvasContent = ({
     dashboardApi,
     dashboardState,
     data,
-    isSidebar,
   });
 
   const getCreationOptions = useCallback(

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -27,7 +27,6 @@ interface UseDashboardPreviewUnifiedSearchParams {
   dashboardApi: DashboardApi | undefined;
   dashboardState: DashboardState;
   data: DataPublicPluginStart;
-  isSidebar: boolean;
 }
 
 const DEFAULT_EMPTY_QUERY: Query = { query: '', language: 'kuery' };
@@ -48,7 +47,6 @@ export const useDashboardPreviewUnifiedSearch = ({
   dashboardApi,
   dashboardState,
   data,
-  isSidebar,
 }: UseDashboardPreviewUnifiedSearchParams) => {
   const { filterManager } = data.query;
   const { timefilter } = data.query.timefilter;
@@ -208,21 +206,19 @@ export const useDashboardPreviewUnifiedSearch = ({
       displayStyle: 'inPage' as const,
       disableSubscribingToGlobalDataServices: true,
       enableDateRangePicker: true,
-      esqlApproximation: isSidebar
-        ? undefined
-        : {
-            isApproximate,
-            onChange: (nextIsApproximate: boolean) =>
-              dashboardApi?.setEsqlApproximation(nextIsApproximate),
-            disabled: !hasEsqlPanel,
-            additionalText: i18n.translate(
-              'agentBuilderDashboards.esqlApproximationToggle.additionalText',
-              {
-                defaultMessage:
-                  'Fast mode requires at least one ES|QL visualization that uses STATS in the dashboard.',
-              }
-            ),
-          },
+      esqlApproximation: {
+        isApproximate,
+        onChange: (nextIsApproximate: boolean) =>
+          dashboardApi?.setEsqlApproximation(nextIsApproximate),
+        disabled: !hasEsqlPanel,
+        additionalText: i18n.translate(
+          'agentBuilderDashboards.esqlApproximationToggle.additionalText',
+          {
+            defaultMessage:
+              'Fast mode requires at least one ES|QL visualization that uses STATS in the dashboard.',
+          }
+        ),
+      },
     }),
     [
       dashboardApi,
@@ -231,7 +227,6 @@ export const useDashboardPreviewUnifiedSearch = ({
       filters,
       hasEsqlPanel,
       isApproximate,
-      isSidebar,
       onFiltersUpdated,
       onQuerySubmit,
       onRefresh,

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -6,12 +6,19 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { distinctUntilChanged, map } from 'rxjs';
 import { toStoredFilters } from '@kbn/as-code-filters-transforms';
 import { toStoredQuery } from '@kbn/as-code-shared-transforms';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { isOfQueryType, type Filter, type Query, type TimeRange } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import {
+  apiPublishesEsqlUsage,
+  combineCompatibleChildrenApis,
+  type PublishesEsqlUsage,
+} from '@kbn/presentation-publishing';
 import { isEqual } from 'lodash';
 import type { DashboardState } from '@kbn/dashboard-plugin/server';
 import { DEFAULT_TIME_RANGE } from '@kbn/agent-builder-dashboards-common';
@@ -20,6 +27,7 @@ interface UseDashboardPreviewUnifiedSearchParams {
   dashboardApi: DashboardApi | undefined;
   dashboardState: DashboardState;
   data: DataPublicPluginStart;
+  isSidebar: boolean;
 }
 
 const DEFAULT_EMPTY_QUERY: Query = { query: '', language: 'kuery' };
@@ -40,6 +48,7 @@ export const useDashboardPreviewUnifiedSearch = ({
   dashboardApi,
   dashboardState,
   data,
+  isSidebar,
 }: UseDashboardPreviewUnifiedSearchParams) => {
   const { filterManager } = data.query;
   const { timefilter } = data.query.timefilter;
@@ -50,6 +59,8 @@ export const useDashboardPreviewUnifiedSearch = ({
   const [query, setQuery] = useState<Query>(normalizeQuery(toStoredQuery(dashboardState.query)));
   const [filters, setFilters] = useState<Filter[]>(toStoredFilters(dashboardState.filters) ?? []);
   const [dataViews, setDataViews] = useState<DataView[]>([]);
+  const [isApproximate, setIsApproximate] = useState(false);
+  const [hasEsqlPanel, setHasEsqlPanel] = useState(false);
 
   useEffect(() => {
     if (!dashboardApi) {
@@ -97,6 +108,32 @@ export const useDashboardPreviewUnifiedSearch = ({
       querySubscription.unsubscribe();
       dataViewsSubscription.unsubscribe();
       timeRangeSubscription.unsubscribe();
+    };
+  }, [dashboardApi]);
+
+  useEffect(() => {
+    if (!dashboardApi) {
+      setIsApproximate(false);
+      setHasEsqlPanel(false);
+      return;
+    }
+
+    const approximationSubscription = dashboardApi.isApproximate$.subscribe(setIsApproximate);
+    const esqlUsageSubscription = combineCompatibleChildrenApis<PublishesEsqlUsage, boolean[]>(
+      dashboardApi,
+      'usesEsql$',
+      apiPublishesEsqlUsage,
+      []
+    )
+      .pipe(
+        map((usesEsqlValues) => usesEsqlValues.some(Boolean)),
+        distinctUntilChanged()
+      )
+      .subscribe(setHasEsqlPanel);
+
+    return () => {
+      approximationSubscription.unsubscribe();
+      esqlUsageSubscription.unsubscribe();
     };
   }, [dashboardApi]);
 
@@ -171,12 +208,30 @@ export const useDashboardPreviewUnifiedSearch = ({
       displayStyle: 'inPage' as const,
       disableSubscribingToGlobalDataServices: true,
       enableDateRangePicker: true,
+      esqlApproximation: isSidebar
+        ? undefined
+        : {
+            isApproximate,
+            onChange: (nextIsApproximate: boolean) =>
+              dashboardApi?.setEsqlApproximation(nextIsApproximate),
+            disabled: !hasEsqlPanel,
+            additionalText: i18n.translate(
+              'agentBuilderDashboards.esqlApproximationToggle.additionalText',
+              {
+                defaultMessage:
+                  'Fast mode requires at least one ES|QL visualization that uses STATS in the dashboard.',
+              }
+            ),
+          },
     }),
     [
       dashboardApi,
       dashboardState.title,
       dataViews,
       filters,
+      hasEsqlPanel,
+      isApproximate,
+      isSidebar,
       onFiltersUpdated,
       onQuerySubmit,
       onRefresh,

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/data-views-plugin",
     "@kbn/test-jest-helpers",
     "@kbn/esql-utils",
+    "@kbn/presentation-publishing",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

- Expose the existing ES|QL Fast mode control in full-screen Agent Builder dashboard previews
- Reuse dashboard approximation state and ES|QL panel eligibility logic from the main dashboard search bar
- Keep sidebar chat previews unchanged
<img width="1268" height="703" alt="Screenshot 2026-07-14 at 13 56 05" src="https://github.com/user-attachments/assets/5f033669-2f85-40c4-a07b-0aabd25bbb2e" />

Closes #278008

## Test plan

- [x] Added unit tests for full-screen Fast mode visibility, sidebar omission, enable/disable behavior, and toggle wiring
- [x] `node scripts/jest x-pack/platform/plugins/shared/agent_builder_dashboards/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx`
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder_dashboards/tsconfig.json`
- [x] `node scripts/eslint` on modified files
- [ ] Manual: open a dashboard preview from full-screen chat and verify Fast mode appears and toggles ES|QL approximation
- [ ] Manual: confirm sidebar chat preview does not show Fast mode

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->