### PR TITLE
[chore] update types/chance to 1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1967,7 +1967,7 @@
     "@types/aws4": "1.11.3",
     "@types/byte-size": "8.1.2",
     "@types/cache-manager-fs-hash": "0.0.5",
-    "@types/chance": "1.1.7",
+    "@types/chance": "1.1.8",
     "@types/chroma-js": "2.1.3",
     "@types/chrome-remote-interface": "0.31.14",
     "@types/chromedriver": "81.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14797,10 +14797,10 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/chance@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.7.tgz#388c19748fe97bbe60552c83a056001a3c973082"
-  integrity sha512-40you9610GTQPJyvjMBgmj9wiDO6qXhbfjizNYod/fmvLSfUUxURAJMTD8tjmbcZSsyYE5iEUox61AAcCjW/wQ==
+"@types/chance@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.8.tgz#cc37c430382992ea1af6b2b55748fcbcf3485a4c"
+  integrity sha512-isycXjm4a88/zl3n9lfgMcEClR9wUi+m72lkE9MvEbkgZDQrKzolWbonBiUqDNAJFIwO9GKjzmJFq79qtKVTAQ==
 
 "@types/cheerio@*", "@types/cheerio@^0.22.22":
   version "0.22.28"


### PR DESCRIPTION
## Summary

Updating `@types/chance` to the latest version

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->