### PR TITLE
[Security Solution] Remove Technical Preview badge from rule changes history

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_changes_history/rule_change_history_page_header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_changes_history/rule_change_history_page_header.tsx
@@ -8,7 +8,6 @@
 import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { HeaderPage } from '../../../../common/components/header_page';
-import { TechnicalPreviewBadge } from '../../../../common/components/technical_preview_badge';
 import { SecurityPageName } from '../../../../app/types';
 import { getRuleDetailsTabUrl } from '../../../../common/components/link_to/redirect_to_detection_engine';
 import type { RuleResponse } from '../../../../../common/api/detection_engine/model/rule_schema';
@@ -53,11 +52,7 @@ export const RuleChangesHistoryPageHeader = memo(function RuleChangesHistoryPage
 
   return (
     <HeaderPage
-      title={
-        <>
-          {rule?.name ?? ''} <TechnicalPreviewBadge label="" />
-        </>
-      }
+      title={rule?.name ?? ''}
       subtitle={subTitle}
       subtitle2={statusInfo}
       backOptions={{

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -242,7 +242,7 @@ export const RuleDetailsPage = connector(
     );
     const [ruleChangesHistoryAdvancedSetting] = useUiSetting$<boolean>(
       ENABLE_RULE_CHANGES_HISTORY_SETTING,
-      false
+      true
     );
     const isRuleChangesHistoryEnabled =
       ruleChangesHistoryFFEnabled && ruleChangesHistoryAdvancedSetting;

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/rule_actions_overflow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/rule_actions_overflow/index.tsx
@@ -109,7 +109,7 @@ const RuleActionsOverflowComponent = ({
   const ruleChangesHistoryFFEnabled = useIsExperimentalFeatureEnabled('ruleChangesHistoryEnabled');
   const [ruleChangesHistoryAdvancedSetting] = useUiSetting$<boolean>(
     ENABLE_RULE_CHANGES_HISTORY_SETTING,
-    false
+    true
   );
   const isRuleChangesHistoryEnabled =
     ruleChangesHistoryFFEnabled && ruleChangesHistoryAdvancedSetting;

--- a/x-pack/solutions/security/plugins/security_solution/public/rules/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules/routes.tsx
@@ -205,7 +205,7 @@ const RulesContainerComponent: React.FC = () => {
   const ruleChangesHistoryFFEnabled = useIsExperimentalFeatureEnabled('ruleChangesHistoryEnabled');
   const [ruleChangesHistoryAdvancedSetting] = useUiSetting$<boolean>(
     ENABLE_RULE_CHANGES_HISTORY_SETTING,
-    false
+    true
   );
   const isRuleChangesHistoryEnabled =
     ruleChangesHistoryFFEnabled && ruleChangesHistoryAdvancedSetting;

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -148,7 +148,7 @@ describe('initUiSettings', () => {
     expect(registeredSettings[ENABLE_RULE_CHANGES_HISTORY_SETTING]).toEqual(
       expect.objectContaining({
         name: 'Enable detection rule changes history',
-        value: false,
+        value: true,
         type: 'boolean',
         requiresPageReload: true,
       })

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -357,7 +357,7 @@ export const initUiSettings = (
           }
         ),
         type: 'boolean',
-        value: false,
+        value: true,
         category: [APP_ID],
         requiresPageReload: true,
         schema: schema.boolean(),

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -362,7 +362,6 @@ export const initUiSettings = (
         requiresPageReload: true,
         schema: schema.boolean(),
         solutionViews: ['classic', 'security'],
-        technicalPreview: true,
       },
     }),
     [NEWS_FEED_URL_SETTING]: {


### PR DESCRIPTION
## Summary

Removes the "Technical Preview" messaging from the rule changes history feature, following up on [#276307](https://github.com/elastic/kibana/pull/276307).

## Changes

- Removed the `TechnicalPreviewBadge` (and its import) from the rule changes history page header (`rule_change_history_page_header.tsx`).
- Dropped the `technicalPreview: true` flag from the `securitySolution:enableRuleChangesHistory` advanced setting (`ui_settings.ts`), so it no longer renders a "Technical Preview" badge in Advanced Settings.

## Test plan

- [ ] Rule changes history page header no longer shows the "Technical Preview" badge.
- [ ] The `securitySolution:enableRuleChangesHistory` advanced setting no longer shows a "Technical Preview" badge in Stack Management > Advanced Settings.

Made with [Cursor](https://cursor.com)