### PR TITLE
[Synthetics] Validate monitor status rule down threshold

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { syntheticsMonitorStatusRuleParamsSchema } from './v1';
+
+describe('syntheticsMonitorStatusRuleParamsSchema', () => {
+  it('accepts a down threshold within the number of checks', () => {
+    expect(() =>
+      syntheticsMonitorStatusRuleParamsSchema.validate({
+        condition: { downThreshold: 3, window: { numberOfChecks: 5 } },
+      })
+    ).not.toThrow();
+  });
+
+  it('accepts a down threshold equal to the number of checks', () => {
+    expect(() =>
+      syntheticsMonitorStatusRuleParamsSchema.validate({
+        condition: { downThreshold: 5, window: { numberOfChecks: 5 } },
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a down threshold greater than the number of checks', () => {
+    expect(() =>
+      syntheticsMonitorStatusRuleParamsSchema.validate({
+        condition: { downThreshold: 5, window: { numberOfChecks: 1 } },
+      })
+    ).toThrowError(/cannot be greater than the number of checks/);
+  });
+
+  it('does not constrain the down threshold for time window conditions', () => {
+    expect(() =>
+      syntheticsMonitorStatusRuleParamsSchema.validate({
+        condition: { downThreshold: 50, window: { time: { unit: 'm', size: 5 } } },
+      })
+    ).not.toThrow();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.ts
@@ -28,34 +28,48 @@ const NumberOfChecksSchema = schema.object({
   }),
 });
 
-const StatusRuleConditionSchema = schema.object({
-  groupBy: schema.maybe(
-    schema.string({
-      defaultValue: 'locationId',
-    })
-  ),
-  downThreshold: schema.maybe(
-    schema.number({
-      defaultValue: 3,
-    })
-  ),
-  locationsThreshold: schema.maybe(
-    schema.number({
-      defaultValue: 1,
-    })
-  ),
-  window: schema.oneOf([
-    schema.object({
-      time: TimeWindowSchema,
-    }),
-    NumberOfChecksSchema,
-  ]),
-  includeRetests: schema.maybe(schema.boolean()),
-  alertOnNoData: schema.maybe(schema.boolean()),
-  recoveryStrategy: schema.maybe(
-    schema.oneOf([schema.literal('firstUp'), schema.literal('conditionNotMet')])
-  ),
-});
+const StatusRuleConditionSchema = schema.object(
+  {
+    groupBy: schema.maybe(
+      schema.string({
+        defaultValue: 'locationId',
+      })
+    ),
+    downThreshold: schema.maybe(
+      schema.number({
+        defaultValue: 3,
+      })
+    ),
+    locationsThreshold: schema.maybe(
+      schema.number({
+        defaultValue: 1,
+      })
+    ),
+    window: schema.oneOf([
+      schema.object({
+        time: TimeWindowSchema,
+      }),
+      NumberOfChecksSchema,
+    ]),
+    includeRetests: schema.maybe(schema.boolean()),
+    alertOnNoData: schema.maybe(schema.boolean()),
+    recoveryStrategy: schema.maybe(
+      schema.oneOf([schema.literal('firstUp'), schema.literal('conditionNotMet')])
+    ),
+  },
+  {
+    // In "within the last N checks" mode the down threshold can never exceed the
+    // number of checks, otherwise the rule can never fire (see issue #214831).
+    validate: ({ downThreshold, window }) => {
+      if (window && 'numberOfChecks' in window && downThreshold !== undefined) {
+        const { numberOfChecks } = window;
+        if (downThreshold > numberOfChecks) {
+          return `[downThreshold]: cannot be greater than the number of checks (${numberOfChecks})`;
+        }
+      }
+    },
+  }
+);
 
 export const syntheticsMonitorStatusRuleParamsSchema = schema.object(
   {

--- a/x-pack/solutions/observability/plugins/synthetics/common/rules/status_rule.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/rules/status_rule.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { getConditionType } from './status_rule';
+import {
+  getConditionType,
+  getDownThresholdExceedsChecksError,
+  validateStatusRuleParams,
+} from './status_rule';
 
 describe('Status Rule', () => {
   it('should return the correct condition type for empty', () => {
@@ -34,5 +38,35 @@ describe('Status Rule', () => {
     });
     expect(useTimeWindow).toBe(true);
     expect(useLatestChecks).toBe(false);
+  });
+});
+
+describe('validateStatusRuleParams', () => {
+  it('returns no errors when down threshold is within the number of checks', () => {
+    expect(validateStatusRuleParams({ downThreshold: 3, window: { numberOfChecks: 5 } })).toEqual(
+      {}
+    );
+  });
+
+  it('returns no errors when down threshold equals the number of checks', () => {
+    expect(validateStatusRuleParams({ downThreshold: 5, window: { numberOfChecks: 5 } })).toEqual(
+      {}
+    );
+  });
+
+  it('returns an error when down threshold exceeds the number of checks', () => {
+    expect(validateStatusRuleParams({ downThreshold: 5, window: { numberOfChecks: 1 } })).toEqual({
+      downThreshold: [getDownThresholdExceedsChecksError(5, 1)],
+    });
+  });
+
+  it('does not validate down threshold for time window conditions', () => {
+    expect(
+      validateStatusRuleParams({ downThreshold: 50, window: { time: { unit: 'm', size: 5 } } })
+    ).toEqual({});
+  });
+
+  it('returns no errors when condition is undefined', () => {
+    expect(validateStatusRuleParams(undefined)).toEqual({});
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/common/rules/status_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/rules/status_rule.ts
@@ -9,6 +9,7 @@ import type {
   StatusRuleCondition,
   TimeWindow,
 } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
+import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 
 export const getConditionType = (condition?: StatusRuleCondition) => {
@@ -48,4 +49,36 @@ export const getConditionType = (condition?: StatusRuleCondition) => {
     downThreshold: condition?.downThreshold ?? 1,
     isDefaultRule: isEmpty(condition),
   };
+};
+
+export const getDownThresholdExceedsChecksError = (downThreshold: number, numberOfChecks: number) =>
+  i18n.translate('xpack.synthetics.statusRule.downThresholdExceedsChecksError', {
+    defaultMessage:
+      'The number of down checks ({downThreshold}) cannot be greater than the number of checks ({numberOfChecks}).',
+    values: { downThreshold, numberOfChecks },
+  });
+
+export interface StatusRuleParamsErrors {
+  downThreshold?: string[];
+}
+
+/**
+ * In "within the last N checks" mode a monitor can be down at most N times, so a
+ * down threshold greater than N describes a condition that can never fire (#214831).
+ */
+export const validateStatusRuleParams = (
+  condition?: StatusRuleCondition
+): StatusRuleParamsErrors => {
+  const errors: StatusRuleParamsErrors = {};
+
+  if (condition?.window && 'numberOfChecks' in condition.window) {
+    const { numberOfChecks } = condition.window;
+    const downThreshold = condition.downThreshold ?? 1;
+
+    if (numberOfChecks > 0 && downThreshold > numberOfChecks) {
+      errors.downThreshold = [getDownThresholdExceedsChecksError(downThreshold, numberOfChecks)];
+    }
+  }
+
+  return errors;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_expression.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_expression.tsx
@@ -27,11 +27,13 @@ import { LocationsValueExpression } from './common/condition_locations_value';
 interface Props {
   ruleParams: StatusRuleParamsProps['ruleParams'];
   setRuleParams: StatusRuleParamsProps['setRuleParams'];
+  errors?: StatusRuleParamsProps['errors'];
 }
 
-export const StatusRuleExpression: React.FC<Props> = ({ ruleParams, setRuleParams }) => {
+export const StatusRuleExpression: React.FC<Props> = ({ ruleParams, setRuleParams, errors }) => {
   const condition = ruleParams.condition ?? DEFAULT_CONDITION;
   const downThreshold = condition?.downThreshold ?? DEFAULT_CONDITION.downThreshold;
+  const downThresholdErrors = Array.isArray(errors?.downThreshold) ? errors.downThreshold : [];
 
   const locationsThreshold = condition?.locationsThreshold ?? DEFAULT_CONDITION.locationsThreshold;
 
@@ -132,7 +134,7 @@ export const StatusRuleExpression: React.FC<Props> = ({ ruleParams, setRuleParam
               onThresholdChange(val);
             }}
             description={StatusTranslations.isDownDescription}
-            errors={[]}
+            errors={downThresholdErrors}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_ui.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_ui.tsx
@@ -20,7 +20,8 @@ export type StatusRuleParamsProps = RuleTypeParamsExpressionProps<StatusRulePara
 export const StatusRuleComponent: React.FC<{
   ruleParams: StatusRuleParamsProps['ruleParams'];
   setRuleParams: StatusRuleParamsProps['setRuleParams'];
-}> = ({ ruleParams, setRuleParams }) => {
+  errors?: StatusRuleParamsProps['errors'];
+}> = ({ ruleParams, setRuleParams, errors }) => {
   const onFiltersChange = useCallback(
     (val: { kqlQuery?: string; filters?: Filter[] }) => {
       setRuleParams('kqlQuery', val.kqlQuery);
@@ -35,7 +36,7 @@ export const StatusRuleComponent: React.FC<{
       <FieldFilters ruleParams={ruleParams} setRuleParams={setRuleParams} />
       <StatusRuleViz ruleParams={ruleParams} />
       <EuiSpacer size="m" />
-      <StatusRuleExpression ruleParams={ruleParams} setRuleParams={setRuleParams} />
+      <StatusRuleExpression ruleParams={ruleParams} setRuleParams={setRuleParams} errors={errors} />
     </>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/monitor_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/monitor_status.tsx
@@ -47,7 +47,11 @@ export default function MonitorStatusAlert({ coreStart, plugins, params }: Props
             )}
 
             {(!params.id || !isEmpty(ruleParams)) && (
-              <StatusRuleComponent ruleParams={ruleParams} setRuleParams={params.setRuleParams} />
+              <StatusRuleComponent
+                ruleParams={ruleParams}
+                setRuleParams={params.setRuleParams}
+                errors={params.errors}
+              />
             )}
 
             <EuiSpacer size="m" />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
@@ -13,6 +13,7 @@ import type { ObservabilityRuleTypeModel } from '@kbn/observability-plugin/publi
 import type { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
 import type { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
 import { getSyntheticsErrorRouteFromMonitorId } from '../../../../../common/utils/get_synthetics_monitor_url';
+import { validateStatusRuleParams } from '../../../../../common/rules/status_rule';
 import { STATE_ID } from '../../../../../common/field_names';
 import { SyntheticsMonitorStatusTranslations } from '../../../../../common/rules/synthetics/translations';
 import type { AlertTypeInitializer } from './types';
@@ -36,8 +37,8 @@ export const initMonitorStatusAlertType: AlertTypeInitializer = ({
   ruleParamsExpression: (paramProps: RuleTypeParamsExpressionProps<StatusRuleParams>) => (
     <MonitorStatusAlert coreStart={core} plugins={plugins} params={paramProps} />
   ),
-  validate: (_ruleParams: StatusRuleParams) => {
-    return { errors: {} };
+  validate: (ruleParams: StatusRuleParams) => {
+    return { errors: validateStatusRuleParams(ruleParams.condition) };
   },
   defaultActionMessage,
   defaultRecoveryMessage,

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/ui/tests/custom_status_alert.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/ui/tests/custom_status_alert.spec.ts
@@ -72,4 +72,31 @@ test.describe('CustomStatusAlert', { tag: tags.stateful.classic }, () => {
       await expect(page.getByText('Synthetics monitor status rule')).toBeVisible();
     });
   });
+
+  test('flags an impossible down threshold vs number of checks', async ({
+    pageObjects,
+    page,
+    browserAuth,
+  }) => {
+    await test.step('login and navigate to overview', async () => {
+      await browserAuth.loginAsPrivilegedUser();
+      await pageObjects.syntheticsApp.navigateToOverview(15);
+    });
+
+    await test.step('open the create status rule form', async () => {
+      await pageObjects.syntheticsApp.openManageStatusRule();
+      await page.testSubj.click('createNewStatusRule');
+      await expect(page.testSubj.locator('valueExpression')).toBeVisible();
+    });
+
+    await test.step('set a down threshold greater than the number of checks', async () => {
+      // Default condition uses 5 checks, so 10 down checks can never happen.
+      await page.testSubj.click('valueExpression');
+      await page.testSubj.fill('valueFieldNumber', '10');
+
+      await expect(
+        page.getByText('The number of down checks (10) cannot be greater than the number of checks')
+      ).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The Monitor Status rule let users configure a down threshold greater than the number of checks in "within the last N checks" mode (e.g. `is down 5 times` `within the last 1 checks`). Such a rule saves fine but can **never fire**, since a monitor can be down at most N times within N checks.

This PR adds validation at every layer so the impossible case is flagged and rejected:

- **Shared helper** `validateStatusRuleParams` in `common/rules/status_rule.ts`.
- **Client-side**: the rule model `validate` now uses the helper and the error is surfaced on the "is down {X} times" input.
- **Server-side**: cross-field `validate` on `StatusRuleConditionSchema` so API-created rules can't bypass the UI.

Time-window mode is intentionally not constrained (there the down threshold is compared against pings in a time range, not bounded by the number of checks).

Closes #214831

## Test plan

- [ ] Unit tests: `validateStatusRuleParams` and schema validation (added).
- [ ] Scout UI: `custom_status_alert.spec.ts` asserts the error shows when down threshold (10) > checks (5).
- [ ] Manual: create a Monitor Status rule, set "is down" higher than "within the last N checks" → the input is flagged and the rule can't be saved; verify the same via the alerting API returns a 400.

Made with [Cursor](https://cursor.com)