### PR TITLE
[ResponseOps][Alerting v2] Preserve error code and details in error responses

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/base_alerting_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/base_alerting_route.test.ts
@@ -80,6 +80,7 @@ describe('BaseAlertingRoute', () => {
           error: 'Service Unavailable',
           message: 'Alerting is disabled.',
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -96,6 +97,21 @@ describe('BaseAlertingRoute', () => {
   });
 
   describe('onError', () => {
+    it('sets bypassErrorFormat so the flat { code, error, message, details? } body reaches the client verbatim', async () => {
+      route.executeFn.mockRejectedValue(
+        Boom.notFound('Rule "abc" not found.', {
+          code: 'RULE_NOT_FOUND',
+          details: { rule_id: 'abc' },
+        })
+      );
+
+      await route.handle();
+
+      expect(response.customError).toHaveBeenCalledWith(
+        expect.objectContaining({ bypassErrorFormat: true })
+      );
+    });
+
     it('returns { code, error, message } for plain Boom errors (no data attached)', async () => {
       route.executeFn.mockRejectedValue(Boom.notFound('rule not found'));
 
@@ -108,6 +124,7 @@ describe('BaseAlertingRoute', () => {
           error: 'Not Found',
           message: 'rule not found',
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -125,6 +142,7 @@ describe('BaseAlertingRoute', () => {
           error: 'Not Found',
           message: 'Rule "abc" not found.',
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -146,6 +164,7 @@ describe('BaseAlertingRoute', () => {
           message: 'Rule "abc" not found.',
           details: { rule_id: 'abc' },
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -164,6 +183,7 @@ describe('BaseAlertingRoute', () => {
           message: 'Invalid input',
           details: {},
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -181,6 +201,7 @@ describe('BaseAlertingRoute', () => {
           error: 'Internal Server Error',
           message: 'An internal server error occurred',
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -196,6 +217,7 @@ describe('BaseAlertingRoute', () => {
           error: "I'm a teapot",
           message: 'teapot',
         },
+        bypassErrorFormat: true,
       });
     });
 
@@ -211,6 +233,7 @@ describe('BaseAlertingRoute', () => {
           error: 'Internal Server Error',
           message: 'An internal server error occurred',
         },
+        bypassErrorFormat: true,
       });
     });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/base_alerting_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/base_alerting_route.ts
@@ -157,9 +157,15 @@ export abstract class BaseAlertingRoute implements RouteHandler {
       ...(data?.details ? { details: data.details } : {}),
     };
 
+    // `bypassErrorFormat` sends `body` verbatim. Without it, Kibana core's
+    // `HapiResponseAdapter.toError` rebuilds the response from a bare Boom
+    // envelope (`{ statusCode, error, message }`) and drops every extra field,
+    // stripping our `code` / `details`. Bypassing keeps the response aligned
+    // with `errorResponseSchema`, the single source of truth for the OAS.
     return this.ctx.response.customError({
       statusCode: boom.output.statusCode,
       body,
+      bypassErrorFormat: true,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/error_response_contract.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/error_response_contract.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * End-to-end contract for the alerting v2 error envelope.
+ *
+ * Every alerting v2 route funnels its errors through
+ * `BaseAlertingRoute.onError`, which serializes them to the flat
+ * `{ code, error, message, details? }` shape declared by `errorResponseSchema`
+ * and sets `bypassErrorFormat: true` so Kibana core sends that body verbatim.
+ *
+ * Because the serialization is centralized, one representative route is enough
+ * to prove the wire shape for all of them: we drive a `RULE_NOT_FOUND` 404
+ * (it carries both a stable `code` and structured `details`) and assert the
+ * envelope survives to the client.
+ *
+ * Per `errorResponseSchema`, only `code` is a stable/contractual value (changing
+ * it is a breaking change) and `details` is structured context clients consume
+ * programmatically. `error` and `message` are documented as "subject to change
+ * without notice", so we assert their presence and type but never their wording.
+ */
+
+import { expect } from '@kbn/scout/api';
+import type { RoleApiCredentials } from '@kbn/scout';
+import { ALERTING_V2_RULES_READ_ROLE, apiTest, getRuleUrl } from '../fixtures';
+
+apiTest.describe('Alerting v2 error response contract', { tag: '@local-stateful-classic' }, () => {
+  let readerCredentials: RoleApiCredentials;
+  let readerHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ requestAuth }) => {
+    readerCredentials = await requestAuth.getApiKeyForCustomRole(ALERTING_V2_RULES_READ_ROLE);
+    readerHeaders = { ...readerCredentials.apiKeyHeader };
+  });
+
+  apiTest(
+    'delivers the flat { code, error, message, details } body verbatim (no Boom re-wrap)',
+    async ({ apiClient }) => {
+      const missingRuleId = 'error-contract-missing-rule';
+
+      const response = await apiClient.get(getRuleUrl(missingRuleId), {
+        headers: readerHeaders,
+      });
+
+      expect(response).toHaveStatusCode(404);
+
+      // Only `code` is a stable, machine-readable field: per `errorResponseSchema`,
+      // changing its value is a breaking change, so it is the only value we pin.
+      expect(response.body.code).toBe('RULE_NOT_FOUND');
+
+      expect(response.body.details).toMatchObject({ rule_id: missingRuleId });
+
+      expect(typeof response.body.error).toBe('string');
+      expect(response.body.error.length).toBeGreaterThan(0);
+      expect(typeof response.body.message).toBe('string');
+      expect(response.body.message.length).toBeGreaterThan(0);
+
+      // `statusCode` is not part of the contract. It is added by Kibana core's
+      // `HapiResponseAdapter.toError` method. If there is a bug in our code, it will be present.
+      expect(response.body.statusCode).toBeUndefined();
+    }
+  );
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/delete_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/delete_action_policy.spec.ts
@@ -65,6 +65,7 @@ apiTest.describe('Delete action policy API', { tag: '@local-stateful-classic' },
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest(
@@ -83,6 +84,7 @@ apiTest.describe('Delete action policy API', { tag: '@local-stateful-classic' },
         headers: { ...testData.COMMON_HEADERS, ...writerHeaders },
       });
       expect(secondDelete).toHaveStatusCode(404);
+      expect(secondDelete.body.code).toBe('ACTION_POLICY_NOT_FOUND');
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/disable_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/disable_action_policy.spec.ts
@@ -105,6 +105,7 @@ apiTest.describe('Disable action policy API', { tag: '@local-stateful-classic' }
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects id over the maximum length', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/enable_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/enable_action_policy.spec.ts
@@ -107,6 +107,7 @@ apiTest.describe('Enable action policy API', { tag: '@local-stateful-classic' },
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects id over the maximum length', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/get_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/get_action_policy.spec.ts
@@ -128,6 +128,7 @@ apiTest.describe('Get action policy API', { tag: '@local-stateful-classic' }, ()
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects id over the maximum length', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/snooze_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/snooze_action_policy.spec.ts
@@ -117,6 +117,7 @@ apiTest.describe('Snooze action policy API', { tag: '@local-stateful-classic' },
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects an invalid date string', async ({ apiClient, apiServices }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/unsnooze_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/unsnooze_action_policy.spec.ts
@@ -109,6 +109,7 @@ apiTest.describe('Unsnooze action policy API', { tag: '@local-stateful-classic' 
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects id over the maximum length', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/update_action_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/update_action_policy.spec.ts
@@ -362,6 +362,7 @@ apiTest.describe('Update action policy API', { tag: '@local-stateful-classic' },
       body: { name: 'second-update', version: staleVersion },
     });
     expect(secondUpdate).toHaveStatusCode(409);
+    expect(secondUpdate.body.code).toBe('ACTION_POLICY_VERSION_CONFLICT');
   });
 
   apiTest('not found: returns 404 for a non-existent id', async ({ apiClient }) => {
@@ -376,6 +377,7 @@ apiTest.describe('Update action policy API', { tag: '@local-stateful-classic' },
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects empty destinations array', async ({ apiClient, apiServices }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/update_action_policy_api_key.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/action_policies/update_action_policy_api_key.spec.ts
@@ -96,6 +96,7 @@ apiTest.describe('Update action policy API key API', { tag: '@local-stateful-cla
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ACTION_POLICY_NOT_FOUND');
   });
 
   apiTest('validation: rejects id over the maximum length', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_ack_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_ack_alert_action.spec.ts
@@ -118,6 +118,7 @@ apiTest.describe('Create ack alert action API', { tag: '@local-stateful-classic'
       body: { episode_id: 'unknown-episode' },
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(
@@ -137,6 +138,7 @@ apiTest.describe('Create ack alert action API', { tag: '@local-stateful-classic'
         body: { episode_id: 'unknown-episode' },
       });
       expect(response).toHaveStatusCode(404);
+      expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_activate_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_activate_alert_action.spec.ts
@@ -174,6 +174,7 @@ apiTest.describe('Create activate alert action API', { tag: '@local-stateful-cla
       body: { reason: 'valid reason' },
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(
@@ -199,6 +200,7 @@ apiTest.describe('Create activate alert action API', { tag: '@local-stateful-cla
       });
 
       expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_EPISODE_STATE_TRANSITION');
 
       const ruleEvents = await apiServices.alertingV2.ruleEvents.find(ruleId);
       expect(ruleEvents).toHaveLength(1);

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_assign_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_assign_alert_action.spec.ts
@@ -178,6 +178,7 @@ apiTest.describe('Create assign alert action API', { tag: '@local-stateful-class
       body: { episode_id: 'unknown-episode', assignee_uid: 'u_someone' },
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(
@@ -197,6 +198,7 @@ apiTest.describe('Create assign alert action API', { tag: '@local-stateful-class
         body: { episode_id: 'unknown-episode', assignee_uid: 'u_someone' },
       });
       expect(response).toHaveStatusCode(404);
+      expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_deactivate_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_deactivate_alert_action.spec.ts
@@ -177,6 +177,7 @@ apiTest.describe('Create deactivate alert action API', { tag: '@local-stateful-c
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(
@@ -202,6 +203,7 @@ apiTest.describe('Create deactivate alert action API', { tag: '@local-stateful-c
       });
 
       expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_EPISODE_STATE_TRANSITION');
 
       const ruleEvents = await apiServices.alertingV2.ruleEvents.find(ruleId);
       expect(ruleEvents).toHaveLength(1);

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_snooze_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_snooze_alert_action.spec.ts
@@ -140,6 +140,7 @@ apiTest.describe('Create snooze alert action API', { tag: '@local-stateful-class
       body: {},
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_tag_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_tag_alert_action.spec.ts
@@ -161,6 +161,7 @@ apiTest.describe('Create tag alert action API', { tag: '@local-stateful-classic'
       body: { tags: ['production'] },
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_unack_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_unack_alert_action.spec.ts
@@ -111,6 +111,7 @@ apiTest.describe('Create unack alert action API', { tag: '@local-stateful-classi
       body: { episode_id: 'unknown-episode' },
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(
@@ -130,6 +131,7 @@ apiTest.describe('Create unack alert action API', { tag: '@local-stateful-classi
         body: { episode_id: 'unknown-episode' },
       });
       expect(response).toHaveStatusCode(404);
+      expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_unsnooze_alert_action.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/alert_actions/create_unsnooze_alert_action.spec.ts
@@ -96,6 +96,7 @@ apiTest.describe('Create unsnooze alert action API', { tag: '@local-stateful-cla
     });
 
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('ALERT_EVENT_NOT_FOUND');
   });
 
   apiTest(

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/delete_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/delete_rule.spec.ts
@@ -55,6 +55,7 @@ apiTest.describe('Delete rule API', { tag: '@local-stateful-classic' }, () => {
       headers: writerHeaders,
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('RULE_NOT_FOUND');
   });
 
   apiTest('validation: rejects ids longer than ID_MAX_LENGTH with a 400', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/find_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/find_rules.spec.ts
@@ -350,6 +350,7 @@ apiTest.describe('Find rules API', { tag: '@local-stateful-classic' }, () => {
       );
 
       expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_FILTER_FIELD');
       expect(response.body).toMatchObject({
         statusCode: 400,
         error: 'Bad Request',

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/find_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/find_rules.spec.ts
@@ -351,14 +351,6 @@ apiTest.describe('Find rules API', { tag: '@local-stateful-classic' }, () => {
 
       expect(response).toHaveStatusCode(400);
       expect(response.body.code).toBe('INVALID_FILTER_FIELD');
-      expect(response.body).toMatchObject({
-        statusCode: 400,
-        error: 'Bad Request',
-        // `stringContaining('')` matches any string — the Scout API expect
-        // doesn't expose `expect.any(String)`. We just want to assert that the
-        // server returned a human-readable message field.
-        message: expect.stringContaining(''),
-      });
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rule.spec.ts
@@ -58,6 +58,7 @@ apiTest.describe('Get rule API', { tag: '@local-stateful-classic' }, () => {
       headers: readerHeaders,
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('RULE_NOT_FOUND');
   });
 
   apiTest(

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rule_tags.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rule_tags.spec.ts
@@ -155,6 +155,7 @@ apiTest.describe('Get rule tags API', { tag: '@local-stateful-classic' }, () => 
       });
 
       expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_FILTER_FIELD');
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rules_bulk.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rules_bulk.spec.ts
@@ -123,6 +123,7 @@ apiTest.describe('Bulk get rules API', { tag: '@local-stateful-classic' }, () =>
       });
 
       expect(response).toHaveStatusCode(404);
+      expect(response.body.code).toBe('NOT_FOUND');
     }
   );
 
@@ -135,6 +136,7 @@ apiTest.describe('Bulk get rules API', { tag: '@local-stateful-classic' }, () =>
       });
 
       expect(response).toHaveStatusCode(404);
+      expect(response.body.code).toBe('NOT_FOUND');
     }
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
@@ -272,6 +272,7 @@ apiTest.describe('Update rule API', { tag: '@local-stateful-classic' }, () => {
         body: { version: created.version, metadata: { name: 'second-rename' } },
       });
       expect(staleUpdate).toHaveStatusCode(409);
+      expect(staleUpdate.body.code).toBe('RULE_VERSION_CONFLICT');
     }
   );
 
@@ -305,6 +306,7 @@ apiTest.describe('Update rule API', { tag: '@local-stateful-classic' }, () => {
       body: { metadata: { name: 'whatever' } },
     });
     expect(response).toHaveStatusCode(404);
+    expect(response.body.code).toBe('RULE_NOT_FOUND');
   });
 
   apiTest(

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/upsert_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/upsert_rule.spec.ts
@@ -139,6 +139,7 @@ apiTest.describe('Upsert rule API', { tag: '@local-stateful-classic' }, () => {
         }),
       });
       expect(response).toHaveStatusCode(409);
+      expect(response.body.code).toBe('IMMUTABLE_FIELDS_CHANGED');
       // Verify the rule was not modified.
       const stored = await apiServices.alertingV2.rules.get(id);
       expect(stored.kind).toBe(created.kind);


### PR DESCRIPTION
## Summary

Fixes a bug where the alerting v2 error response schema is not respected by the Core's router.

Before the fix:

```
{
    "statusCode": 404,
    "error": "Not Found",
    "message": "Rule with id \"foo\" not found"
}
```

After the fix:

```
{
    "code": "RULE_NOT_FOUND",
    "error": "Not Found",
    "message": "Rule with id \"foo\" not found",
    "details": {
        "rule_id": "foo"
    }
}
```

Closes #274951

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->