### PR TITLE
Fix flaky spaces grid loading & test

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
@@ -228,6 +228,57 @@ describe('SpacesGridPage', () => {
     ]);
   });
 
+  it('re-applies an in-flight search when loadGrid resolves', async () => {
+    let resolveSpaces: (value: typeof spaces) => void = () => {};
+    const spacesPromise = new Promise<typeof spaces>((resolve) => {
+      resolveSpaces = resolve;
+    });
+
+    const deferredSpacesManager = spacesManagerMock.create();
+    deferredSpacesManager.getSpaces = jest.fn().mockReturnValue(spacesPromise);
+    deferredSpacesManager.getActiveSpace.mockResolvedValue(spaces[0]);
+
+    const wrapper = shallowWithIntl(
+      <SpacesGridPage
+        spacesManager={deferredSpacesManager}
+        getFeatures={featuresStart.getFeatures}
+        notifications={notificationServiceMock.createStartContract()}
+        getUrlForApp={getUrlForApp}
+        history={history}
+        capabilities={{
+          navLinks: {},
+          management: {},
+          catalogue: {},
+          spaces: { manage: true },
+        }}
+        allowSolutionVisibility={false}
+        {...spacesGridCommonProps}
+      />
+    );
+
+    const page = wrapper.instance() as SpacesGridPage;
+    act(() => {
+      page.onQueryChange({
+        query: { text: 'Custom 1' },
+      } as Parameters<SpacesGridPage['onQueryChange']>[0]);
+    });
+    wrapper.update();
+
+    await act(async () => {
+      resolveSpaces(spaces);
+      await spacesPromise;
+    });
+    wrapper.update();
+
+    expect(wrapper.find('EuiInMemoryTable').prop('items')).toEqual([
+      {
+        id: 'custom-1',
+        name: 'Custom 1',
+        disabledFeatures: [],
+      },
+    ]);
+  });
+
   it('renders a "current" badge for the current space', async () => {
     const spacesWithCurrent = [
       { id: 'default', name: 'Default', disabledFeatures: [], _reserved: true },

--- a/x-pack/platform/plugins/shared/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -65,6 +65,7 @@ interface Props {
 interface State {
   spaces: Space[];
   spacesFiltered: Space[];
+  queryText: string;
   activeSpace: Space | null;
   features: KibanaFeature[];
   loading: boolean;
@@ -78,6 +79,7 @@ export class SpacesGridPage extends Component<Props, State> {
     this.state = {
       spaces: [],
       spacesFiltered: [],
+      queryText: '',
       activeSpace: null,
       features: [],
       loading: true,
@@ -119,19 +121,24 @@ export class SpacesGridPage extends Component<Props, State> {
     );
   }
 
-  public onQueryChange = ({ query }: EuiSearchBarOnChangeArgs) => {
-    const text = query?.text?.toLowerCase() || '';
+  private filterSpacesByQuery = (spaces: Space[], queryText: string): Space[] => {
+    if (!queryText) {
+      return spaces;
+    }
 
-    this.setState({ loading: true });
-
-    const spacesFiltered = this.state.spaces.filter(
+    return spaces.filter(
       (space) =>
-        space.name.toLowerCase().includes(text) || space.description?.toLowerCase().includes(text)
+        space.name.toLowerCase().includes(queryText) ||
+        space.description?.toLowerCase().includes(queryText)
     );
+  };
+
+  public onQueryChange = ({ query }: EuiSearchBarOnChangeArgs) => {
+    const queryText = query?.text?.toLowerCase() || '';
 
     this.setState({
-      spacesFiltered,
-      loading: false,
+      queryText,
+      spacesFiltered: this.filterSpacesByQuery(this.state.spaces, queryText),
     });
   };
 
@@ -261,13 +268,16 @@ export class SpacesGridPage extends Component<Props, State> {
         getActiveSpace,
         getFeatures(),
       ]);
-      this.setState({
+      // Re-apply any query typed while load was in flight; otherwise an early
+      // filter is wiped when this resolves and the table shows every space
+      // while the search box still shows the query text.
+      this.setState((state) => ({
         loading: false,
         spaces,
-        spacesFiltered: spaces,
+        spacesFiltered: this.filterSpacesByQuery(spaces, state.queryText),
         activeSpace,
         features,
-      });
+      }));
     } catch (error) {
       this.setState({
         loading: false,

--- a/x-pack/platform/plugins/shared/spaces/test/scout/ui/fixtures/page_objects/spaces.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/ui/fixtures/page_objects/spaces.ts
@@ -74,7 +74,9 @@ export class SpacesPage {
 
   async gotoSpacesGrid() {
     await this.page.gotoApp('management/kibana/spaces');
-    await this.gridPageLocator().waitFor({ state: 'visible' });
+    await this.page.testSubj.locator('spacesListTableRow-default').waitFor({
+      state: 'visible',
+    });
   }
 
   async gotoManagement() {
@@ -122,8 +124,8 @@ export class SpacesPage {
   async filterSpacesGrid(searchText: string) {
     const searchBox = this.page.testSubj.locator('spacesListTableSearchBox');
     await searchBox.fill(searchText);
-    // The grid's EuiSearchBar is non-incremental: it only runs the query on
-    // submit, so a bare fill leaves the table unfiltered.
+    // Search is incremental (debounced 200ms); Enter forces an immediate apply
+    // so callers don't race the debounce before asserting row counts.
     await searchBox.press('Enter');
   }
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/277923

Addresses a flaky test, and flaky search behavior for the Spaces grid page.
The flaky test is addressed by waiting for the grid page to load the default space, as this is a much more stable identifier that the search has completed successfully.

The flaky search behavior was addressed by ensuring that the grid page re-filters search results when the list of spaces is returned to the client.