### PR TITLE
[Cases] Preserve pending template field edits

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -73,6 +73,8 @@ export interface ConditionRenderProps {
   maxLength?: number;
   /** When provided, the control renders inline confirm/cancel buttons and only calls this on confirm. */
   onConfirm?: () => void;
+  isSaving?: boolean;
+  isSaveDisabled?: boolean;
 }
 
 const BaseFieldSchema = z.object({

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -79,6 +79,7 @@ const defaultProps = {
 describe('TemplateFields', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    onUpdateField.mockImplementation(({ onSuccess }) => onSuccess?.());
     mockUseGetTemplate.mockReturnValue({ data: mockTemplate, isLoading: false });
     mockUseGetFieldDefinitions.mockReturnValue({
       data: { fieldDefinitions: [] },
@@ -184,18 +185,31 @@ describe('TemplateFields', () => {
     const getSummaryInput = (): HTMLInputElement =>
       within(screen.getByTestId('template-field-summary')).getByRole('textbox') as HTMLInputElement;
 
-    it('does NOT show confirm/cancel buttons before the field is focused', () => {
+    it('does NOT show confirm/cancel buttons before the field is changed', () => {
       render(<TemplateFields {...defaultProps} />);
 
       expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
       expect(screen.queryByTestId('template-field-cancel-summary')).not.toBeInTheDocument();
     });
 
-    it('shows confirm and cancel buttons when the text field is focused', async () => {
+    it('does NOT show confirm/cancel buttons from focus alone, without a change', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
       await user.click(getSummaryInput());
+
+      expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-summary')).not.toBeInTheDocument();
+    });
+
+    it('shows confirm and cancel buttons after the user types a change', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
 
       expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
       expect(screen.getByTestId('template-field-cancel-summary')).toBeInTheDocument();
@@ -217,11 +231,50 @@ describe('TemplateFields', () => {
       });
       const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
       expect(lastCall.key).toBe('extended_fields');
-      expect(lastCall.value).toEqual(
-        expect.objectContaining({
-          summary_as_keyword: 'updated summary',
-        })
-      );
+      expect(lastCall.value).toEqual({ summary_as_keyword: 'updated summary' });
+    });
+
+    it('does NOT include other unconfirmed fields when confirming a single field', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
+
+      const notes = within(screen.getByTestId('template-field-notes')).getByRole(
+        'textbox'
+      ) as HTMLTextAreaElement;
+      await user.click(notes);
+      await user.clear(notes);
+      await user.type(notes, 'unconfirmed notes edit');
+
+      await user.click(screen.getByTestId('template-field-confirm-summary'));
+
+      await waitFor(() => {
+        expect(onUpdateField).toHaveBeenCalled();
+      });
+      const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
+      expect(lastCall.value).toEqual({ summary_as_keyword: 'updated summary' });
+      expect(lastCall.value).not.toHaveProperty('notes_as_keyword');
+
+      expect(notes.value).toBe('unconfirmed notes edit');
+      expect(screen.getByTestId('template-field-confirm-notes')).toBeInTheDocument();
+    });
+
+    it('keeps the field dirty when the update fails', async () => {
+      onUpdateField.mockImplementation(({ onError }) => onError?.());
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const summary = getSummaryInput();
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
+      await user.click(screen.getByTestId('template-field-confirm-summary'));
+
+      expect(summary.value).toBe('updated summary');
+      expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
     });
 
     it('does NOT call onUpdateField when cancel button is clicked', async () => {
@@ -260,7 +313,10 @@ describe('TemplateFields', () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
-      await user.click(getSummaryInput());
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
       expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
 
       await user.click(screen.getByTestId('template-field-confirm-summary'));
@@ -274,7 +330,10 @@ describe('TemplateFields', () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
-      await user.click(getSummaryInput());
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
       expect(screen.getByTestId('template-field-cancel-summary')).toBeInTheDocument();
 
       await user.click(screen.getByTestId('template-field-cancel-summary'));
@@ -298,21 +357,20 @@ describe('TemplateFields', () => {
       expect(onUpdateField).not.toHaveBeenCalled();
     });
 
-    it('hides confirm/cancel buttons when the field loses focus (tab away)', async () => {
+    it('keeps confirm/cancel buttons visible when the field loses focus (tab away) while dirty', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
-      await user.click(getSummaryInput());
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
       expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
 
       await user.tab();
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(screen.queryByTestId('template-field-cancel-summary')).not.toBeInTheDocument();
-      });
+      expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-summary')).toBeInTheDocument();
     });
   });
 
@@ -322,18 +380,31 @@ describe('TemplateFields', () => {
         'textbox'
       ) as HTMLTextAreaElement;
 
-    it('does NOT show confirm/cancel buttons before the field is focused', () => {
+    it('does NOT show confirm/cancel buttons before the field is changed', () => {
       render(<TemplateFields {...defaultProps} />);
 
       expect(screen.queryByTestId('template-field-confirm-notes')).not.toBeInTheDocument();
       expect(screen.queryByTestId('template-field-cancel-notes')).not.toBeInTheDocument();
     });
 
-    it('shows confirm and cancel buttons when the textarea is focused', async () => {
+    it('does NOT show confirm/cancel buttons from focus alone, without a change', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
       await user.click(getNotesInput());
+
+      expect(screen.queryByTestId('template-field-confirm-notes')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-notes')).not.toBeInTheDocument();
+    });
+
+    it('shows confirm and cancel buttons after the user types a change', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const notes = getNotesInput();
+      await user.click(notes);
+      await user.clear(notes);
+      await user.type(notes, 'updated notes');
 
       expect(screen.getByTestId('template-field-confirm-notes')).toBeInTheDocument();
       expect(screen.getByTestId('template-field-cancel-notes')).toBeInTheDocument();
@@ -377,21 +448,20 @@ describe('TemplateFields', () => {
       });
     });
 
-    it('hides confirm/cancel buttons when the textarea loses focus', async () => {
+    it('keeps confirm/cancel buttons visible when the textarea loses focus while dirty', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
-      await user.click(getNotesInput());
+      const notes = getNotesInput();
+      await user.click(notes);
+      await user.clear(notes);
+      await user.type(notes, 'updated notes');
       expect(screen.getByTestId('template-field-confirm-notes')).toBeInTheDocument();
 
       await user.tab();
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('template-field-confirm-notes')).not.toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(screen.queryByTestId('template-field-cancel-notes')).not.toBeInTheDocument();
-      });
+      expect(screen.getByTestId('template-field-confirm-notes')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-notes')).toBeInTheDocument();
     });
   });
 
@@ -401,18 +471,31 @@ describe('TemplateFields', () => {
         'spinbutton'
       ) as HTMLInputElement;
 
-    it('does NOT show confirm/cancel buttons before the field is focused', () => {
+    it('does NOT show confirm/cancel buttons before the field is changed', () => {
       render(<TemplateFields {...defaultProps} />);
 
       expect(screen.queryByTestId('template-field-confirm-effort')).not.toBeInTheDocument();
       expect(screen.queryByTestId('template-field-cancel-effort')).not.toBeInTheDocument();
     });
 
-    it('shows confirm and cancel buttons when the number field is focused', async () => {
+    it('does NOT show confirm/cancel buttons from focus alone, without a change', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
       await user.click(getEffortInput());
+
+      expect(screen.queryByTestId('template-field-confirm-effort')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-effort')).not.toBeInTheDocument();
+    });
+
+    it('shows confirm and cancel buttons after the user types a change', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const effort = getEffortInput();
+      await user.click(effort);
+      await user.clear(effort);
+      await user.type(effort, '10');
 
       expect(screen.getByTestId('template-field-confirm-effort')).toBeInTheDocument();
       expect(screen.getByTestId('template-field-cancel-effort')).toBeInTheDocument();
@@ -454,21 +537,20 @@ describe('TemplateFields', () => {
       });
     });
 
-    it('hides confirm/cancel buttons when the number field loses focus', async () => {
+    it('keeps confirm/cancel buttons visible when the number field loses focus while dirty', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
 
-      await user.click(getEffortInput());
+      const effort = getEffortInput();
+      await user.click(effort);
+      await user.clear(effort);
+      await user.type(effort, '10');
       expect(screen.getByTestId('template-field-confirm-effort')).toBeInTheDocument();
 
       await user.tab();
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('template-field-confirm-effort')).not.toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(screen.queryByTestId('template-field-cancel-effort')).not.toBeInTheDocument();
-      });
+      expect(screen.getByTestId('template-field-confirm-effort')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-effort')).toBeInTheDocument();
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { CaseUI } from '../../../../common';
@@ -232,6 +232,36 @@ describe('TemplateFields', () => {
       const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
       expect(lastCall.key).toBe('extended_fields');
       expect(lastCall.value).toEqual({ summary_as_keyword: 'updated summary' });
+    });
+
+    it('disables the confirm action and shows a spinner while saving', async () => {
+      let completeUpdate: (() => void) | undefined;
+      onUpdateField.mockImplementation(({ onSuccess }) => {
+        completeUpdate = onSuccess;
+      });
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const summary = getSummaryInput();
+      await user.clear(summary);
+      await user.type(summary, 'updated summary');
+      const notes = within(screen.getByTestId('template-field-notes')).getByRole('textbox');
+      await user.clear(notes);
+      await user.type(notes, 'pending notes');
+      await user.click(screen.getByTestId('template-field-confirm-summary'));
+
+      const confirmButton = screen.getByTestId('template-field-confirm-summary');
+      expect(confirmButton).toBeDisabled();
+      expect(within(confirmButton).getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-summary')).toBeDisabled();
+      expect(screen.getByTestId('template-field-confirm-notes')).toBeDisabled();
+      expect(screen.getByTestId('template-field-cancel-notes')).toBeEnabled();
+
+      act(() => completeUpdate?.());
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
+      });
     });
 
     it('does NOT include other unconfirmed fields when confirming a single field', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -253,6 +253,8 @@ describe('TemplateFields', () => {
       const confirmButton = screen.getByTestId('template-field-confirm-summary');
       expect(confirmButton).toBeDisabled();
       expect(within(confirmButton).getByRole('progressbar')).toBeInTheDocument();
+      expect(summary).toBeDisabled();
+      expect(notes).toBeEnabled();
       expect(screen.getByTestId('template-field-cancel-summary')).toBeDisabled();
       expect(screen.getByTestId('template-field-confirm-notes')).toBeDisabled();
       expect(screen.getByTestId('template-field-cancel-notes')).toBeEnabled();
@@ -262,6 +264,7 @@ describe('TemplateFields', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
       });
+      expect(summary).toBeEnabled();
     });
 
     it('does NOT include other unconfirmed fields when confirming a single field', async () => {
@@ -461,6 +464,19 @@ describe('TemplateFields', () => {
       );
     });
 
+    it('disables the textarea while saving', async () => {
+      onUpdateField.mockImplementation(() => {});
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const notes = getNotesInput();
+      await user.clear(notes);
+      await user.type(notes, 'updated notes');
+      await user.click(screen.getByTestId('template-field-confirm-notes'));
+
+      expect(notes).toBeDisabled();
+    });
+
     it('does NOT call onUpdateField and reverts value when cancel is clicked', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
@@ -550,6 +566,19 @@ describe('TemplateFields', () => {
       expect(lastCall.value).toEqual(expect.objectContaining({ effort_as_integer: '10' }));
     });
 
+    it('disables the number input while saving', async () => {
+      onUpdateField.mockImplementation(() => {});
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const effort = getEffortInput();
+      await user.clear(effort);
+      await user.type(effort, '10');
+      await user.click(screen.getByTestId('template-field-confirm-effort'));
+
+      expect(effort).toBeDisabled();
+    });
+
     it('does NOT call onUpdateField and reverts value when cancel is clicked', async () => {
       const user = userEvent.setup();
       render(<TemplateFields {...defaultProps} />);
@@ -620,6 +649,18 @@ describe('TemplateFields', () => {
       const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
       expect(lastCall.key).toBe('extended_fields');
       expect(lastCall.value).toEqual(expect.objectContaining({ priority_as_keyword: 'high' }));
+    });
+
+    it('disables the select while saving', async () => {
+      onUpdateField.mockImplementation(() => {});
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const priority = getPrioritySelect();
+      await user.selectOptions(priority, 'high');
+      await user.click(screen.getByTestId('template-field-confirm-priority'));
+
+      expect(priority).toBeDisabled();
     });
 
     it('does NOT call onUpdateField and reverts value when cancel is clicked', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -307,7 +307,8 @@ describe('TemplateFields', () => {
       await user.click(screen.getByTestId('template-field-confirm-summary'));
 
       expect(summary.value).toBe('updated summary');
-      expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
+      expect(summary).toBeEnabled();
+      expect(screen.getByTestId('template-field-confirm-summary')).toBeEnabled();
     });
 
     it('does NOT call onUpdateField when cancel button is clicked', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields_form_ready.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields_form_ready.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
 import type { InlineField } from '../../../../common/types/domain/template/fields';
@@ -42,9 +42,11 @@ export const TemplateFieldsFormReady: FC<{
   }, [initialDefaultValues, form]);
 
   const inflightRef = useRef(false);
+  const [savingFieldKey, setSavingFieldKey] = useState<string>();
 
   const releaseLock = useCallback(() => {
     inflightRef.current = false;
+    setSavingFieldKey(undefined);
   }, []);
 
   const persist = useCallback(
@@ -52,6 +54,7 @@ export const TemplateFieldsFormReady: FC<{
       if (inflightRef.current) return;
       inflightRef.current = true;
       const snakeKey = getFieldSnakeKey(fieldName, fieldType);
+      setSavingFieldKey(snakeKey);
       const path = `${CASE_EXTENDED_FIELDS}.${snakeKey}`;
       const isValid = await form.trigger(path).catch(() => false);
       if (!isValid) {
@@ -75,7 +78,11 @@ export const TemplateFieldsFormReady: FC<{
   return (
     <FormProvider {...form}>
       <div data-test-subj="template-fields-form">
-        <FieldsRenderer resolvedFields={resolvedFields} onFieldConfirm={persist} />
+        <FieldsRenderer
+          resolvedFields={resolvedFields}
+          onFieldConfirm={persist}
+          savingFieldKey={savingFieldKey}
+        />
       </div>
     </FormProvider>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields_form_ready.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields_form_ready.tsx
@@ -37,10 +37,8 @@ export const TemplateFieldsFormReady: FC<{
     mode: 'onBlur',
   });
 
-  // Reset to fresh defaults whenever the underlying case data changes — e.g.
-  // after a successful save the parent re-renders with new extendedFields.
   useEffect(() => {
-    form.reset(initialDefaultValues);
+    form.reset(initialDefaultValues, { keepDirtyValues: true });
   }, [initialDefaultValues, form]);
 
   const inflightRef = useRef(false);
@@ -49,25 +47,30 @@ export const TemplateFieldsFormReady: FC<{
     inflightRef.current = false;
   }, []);
 
-  const persist = useCallback(async () => {
-    if (inflightRef.current) return;
-    // Claim the lock synchronously before awaiting so a second invocation
-    // can't race past the guard above.
-    inflightRef.current = true;
-    const isValid = await form.trigger().catch(() => false);
-    if (!isValid) {
-      releaseLock();
-      return;
-    }
-    const values =
-      (form.getValues() as Record<string, Record<string, unknown>>)?.[CASE_EXTENDED_FIELDS] ?? {};
-    onUpdateField({
-      key: CASE_EXTENDED_FIELDS,
-      value: values,
-      onSuccess: releaseLock,
-      onError: releaseLock,
-    });
-  }, [form, onUpdateField, releaseLock]);
+  const persist = useCallback(
+    async (fieldName: string, fieldType: string) => {
+      if (inflightRef.current) return;
+      inflightRef.current = true;
+      const snakeKey = getFieldSnakeKey(fieldName, fieldType);
+      const path = `${CASE_EXTENDED_FIELDS}.${snakeKey}`;
+      const isValid = await form.trigger(path).catch(() => false);
+      if (!isValid) {
+        releaseLock();
+        return;
+      }
+      const value = form.getValues(path);
+      onUpdateField({
+        key: CASE_EXTENDED_FIELDS,
+        value: { [snakeKey]: value },
+        onSuccess: () => {
+          form.resetField(path, { defaultValue: value });
+          releaseLock();
+        },
+        onError: releaseLock,
+      });
+    },
+    [form, onUpdateField, releaseLock]
+  );
 
   return (
     <FormProvider {...form}>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.test.tsx
@@ -18,6 +18,7 @@ interface FormWrapperProps {
   isRequired?: boolean;
   initialValue?: string[];
   onConfirm?: () => void;
+  isSaving?: boolean;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -25,6 +26,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   isRequired,
   initialValue,
   onConfirm,
+  isSaving,
   onSubmitResult,
 }) => {
   const form = useForm({
@@ -54,6 +56,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
         isRequired={isRequired}
         metadata={{ options: OPTIONS }}
         onConfirm={onConfirm}
+        isSaving={isSaving}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -73,6 +76,14 @@ describe('CheckboxGroup', () => {
       render(<FormWrapper onSubmitResult={jest.fn()} />);
       for (const option of OPTIONS) {
         expect(screen.getByLabelText(option)).toBeInTheDocument();
+      }
+    });
+
+    it('disables every option while saving', () => {
+      render(<FormWrapper isSaving onSubmitResult={jest.fn()} />);
+
+      for (const option of OPTIONS) {
+        expect(screen.getByLabelText(option)).toBeDisabled();
       }
     });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.test.tsx
@@ -17,10 +17,16 @@ const OPTIONS = ['frontend', 'backend', 'database'];
 interface FormWrapperProps {
   isRequired?: boolean;
   initialValue?: string[];
+  onConfirm?: () => void;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
-const FormWrapper: React.FC<FormWrapperProps> = ({ isRequired, initialValue, onSubmitResult }) => {
+const FormWrapper: React.FC<FormWrapperProps> = ({
+  isRequired,
+  initialValue,
+  onConfirm,
+  onSubmitResult,
+}) => {
   const form = useForm({
     defaultValues: {
       [CASE_EXTENDED_FIELDS]: initialValue
@@ -47,6 +53,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({ isRequired, initialValue, onS
         label="Affected systems"
         isRequired={isRequired}
         metadata={{ options: OPTIONS }}
+        onConfirm={onConfirm}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -127,6 +134,44 @@ describe('CheckboxGroup', () => {
       expect(screen.getByLabelText('frontend')).toBeChecked();
       expect(screen.getByLabelText('backend')).not.toBeChecked();
       expect(screen.getByLabelText('database')).toBeChecked();
+    });
+
+    it('shows actions only while the field is dirty', async () => {
+      render(<FormWrapper onConfirm={jest.fn()} onSubmitResult={jest.fn()} />);
+
+      expect(
+        screen.queryByTestId('template-field-confirm-affected_systems')
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText('backend'));
+
+      expect(screen.getByTestId('template-field-confirm-affected_systems')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-affected_systems')).toBeInTheDocument();
+    });
+
+    it('confirms the pending value', async () => {
+      const onConfirm = jest.fn();
+      render(<FormWrapper onConfirm={onConfirm} onSubmitResult={jest.fn()} />);
+
+      await userEvent.click(screen.getByLabelText('backend'));
+      await userEvent.click(screen.getByTestId('template-field-confirm-affected_systems'));
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels the pending value and hides the actions', async () => {
+      render(
+        <FormWrapper initialValue={['frontend']} onConfirm={jest.fn()} onSubmitResult={jest.fn()} />
+      );
+
+      await userEvent.click(screen.getByLabelText('backend'));
+      await userEvent.click(screen.getByTestId('template-field-cancel-affected_systems'));
+
+      expect(screen.getByLabelText('frontend')).toBeChecked();
+      expect(screen.getByLabelText('backend')).not.toBeChecked();
+      expect(
+        screen.queryByTestId('template-field-confirm-affected_systems')
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
@@ -44,6 +44,8 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
   metadata,
   isRequired,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -101,7 +103,13 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
               />
             </EuiFormRow>
             {fieldState.isDirty && onConfirm && (
-              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+              <InlineFieldActions
+                name={name}
+                onConfirm={onConfirm}
+                onCancel={handleCancel}
+                isLoading={isSaving}
+                isDisabled={isSaveDisabled}
+              />
             )}
           </>
         );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiCheckboxGroup, EuiFormRow } from '@elastic/eui';
 import { InlineFieldActions } from './inline_field_actions';
@@ -46,7 +46,6 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
   onConfirm,
 }) => {
   const { control, resetField } = useFormContext();
-  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const options = useMemo(
@@ -65,33 +64,34 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
     };
   }, [isRequired]);
 
-  const showInlineActions = hasPendingChange && onConfirm != null;
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   return (
-    <>
-      <Controller
-        key={name}
-        name={path}
-        control={control}
-        rules={rules}
-        defaultValue={defaultValue}
-        render={({ field, fieldState }) => {
-          const selected = toArray(field.value);
-          const handleChange = (id: string) => {
-            const next = selected.includes(id)
-              ? selected.filter((s) => s !== id)
-              : [...selected, id];
-            field.onChange(JSON.stringify(next));
-            field.onBlur();
-            setHasPendingChange(true);
-          };
+    <Controller
+      key={name}
+      name={path}
+      control={control}
+      rules={rules}
+      defaultValue={defaultValue}
+      render={({ field, fieldState }) => {
+        const selected = toArray(field.value);
+        const handleChange = (id: string) => {
+          const next = selected.includes(id)
+            ? selected.filter((selectedId) => selectedId !== id)
+            : [...selected, id];
+          field.onChange(JSON.stringify(next));
+          field.onBlur();
+        };
 
-          return (
+        return (
+          <>
             <EuiFormRow
               label={label}
               labelAppend={!isRequired ? OptionalFieldLabel : undefined}
               error={fieldState.error?.message}
-              isInvalid={!!fieldState.error}
+              isInvalid={Boolean(fieldState.error)}
               fullWidth
             >
               <EuiCheckboxGroup
@@ -100,23 +100,13 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
                 onChange={handleChange}
               />
             </EuiFormRow>
-          );
-        }}
-      />
-      {showInlineActions && (
-        <InlineFieldActions
-          name={name}
-          onConfirm={() => {
-            setHasPendingChange(false);
-            onConfirm();
-          }}
-          onCancel={() => {
-            setHasPendingChange(false);
-            resetField(path);
-          }}
-        />
-      )}
-    </>
+            {fieldState.isDirty && onConfirm && (
+              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            )}
+          </>
+        );
+      }}
+    />
   );
 };
 CheckboxGroup.displayName = 'CheckboxGroup';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
@@ -100,6 +100,7 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
                 options={options}
                 idToSelectedMap={Object.fromEntries(selected.map((id) => [id, true]))}
                 onChange={handleChange}
+                disabled={isSaving}
               />
             </EuiFormRow>
             {fieldState.isDirty && onConfirm && (

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.test.tsx
@@ -18,6 +18,7 @@ interface FormWrapperProps {
   showTime?: boolean;
   timezone?: 'utc' | 'local';
   initialValue?: string;
+  onConfirm?: () => void;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -26,6 +27,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   showTime,
   timezone,
   initialValue,
+  onConfirm,
   onSubmitResult,
 }) => {
   const form = useForm({
@@ -56,6 +58,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
             ? { show_time: showTime, timezone }
             : undefined
         }
+        onConfirm={onConfirm}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -154,6 +157,21 @@ describe('DatePicker', () => {
 
       // react-datepicker renders a time input only when showTimeSelect is true
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('inline actions', () => {
+    it('shows actions after the date changes and confirms it', async () => {
+      const onConfirm = jest.fn();
+      render(<FormWrapper onConfirm={onConfirm} onSubmitResult={jest.fn()} />);
+
+      const input = screen.getByRole('textbox');
+      await userEvent.type(input, '07/15/2026');
+      await userEvent.tab();
+
+      await userEvent.click(screen.getByTestId('template-field-confirm-due_date'));
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.test.tsx
@@ -19,6 +19,7 @@ interface FormWrapperProps {
   timezone?: 'utc' | 'local';
   initialValue?: string;
   onConfirm?: () => void;
+  isSaving?: boolean;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -28,6 +29,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   timezone,
   initialValue,
   onConfirm,
+  isSaving,
   onSubmitResult,
 }) => {
   const form = useForm({
@@ -59,6 +61,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
             : undefined
         }
         onConfirm={onConfirm}
+        isSaving={isSaving}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -81,6 +84,12 @@ describe('DatePicker', () => {
       render(<FormWrapper onSubmitResult={onSubmitResult} />);
 
       expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('disables the input while saving', () => {
+      render(<FormWrapper isSaving onSubmitResult={jest.fn()} />);
+
+      expect(screen.getByRole('textbox')).toBeDisabled();
     });
 
     it('shows Optional label when isRequired is false', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -88,6 +88,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               showTimeSelect={metadata?.show_time ?? false}
               utcOffset={isLocal ? undefined : 0}
               isInvalid={Boolean(fieldState.error)}
+              disabled={isSaving}
               fullWidth
             />
           </EuiFormRow>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -8,7 +8,7 @@
 import type { z } from '@kbn/zod/v4';
 import type { Moment } from 'moment';
 import moment from 'moment-timezone';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiDatePicker, EuiFormRow } from '@elastic/eui';
 import { InlineFieldActions } from './inline_field_actions';
@@ -44,7 +44,6 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   onConfirm,
 }) => {
   const { control, resetField } = useFormContext();
-  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
   const isLocal = metadata?.timezone === 'local';
 
@@ -58,22 +57,24 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     };
   }, [isRequired]);
 
-  const showInlineActions = hasPendingChange && onConfirm != null;
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   return (
-    <>
-      <Controller
-        key={name}
-        name={path}
-        control={control}
-        rules={rules}
-        defaultValue=""
-        render={({ field, fieldState }) => (
+    <Controller
+      key={name}
+      name={path}
+      control={control}
+      rules={rules}
+      defaultValue=""
+      render={({ field, fieldState }) => (
+        <>
           <EuiFormRow
             label={label}
             labelAppend={!isRequired ? OptionalFieldLabel : undefined}
             error={fieldState.error?.message}
-            isInvalid={!!fieldState.error}
+            isInvalid={Boolean(fieldState.error)}
             fullWidth
           >
             <EuiDatePicker
@@ -81,30 +82,19 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               onChange={(date) => {
                 field.onChange(toIsoString(date, isLocal));
                 field.onBlur();
-                setHasPendingChange(true);
               }}
               showTimeSelect={metadata?.show_time ?? false}
               utcOffset={isLocal ? undefined : 0}
-              isInvalid={!!fieldState.error}
+              isInvalid={Boolean(fieldState.error)}
               fullWidth
             />
           </EuiFormRow>
-        )}
-      />
-      {showInlineActions && (
-        <InlineFieldActions
-          name={name}
-          onConfirm={() => {
-            setHasPendingChange(false);
-            onConfirm();
-          }}
-          onCancel={() => {
-            setHasPendingChange(false);
-            resetField(path);
-          }}
-        />
+          {fieldState.isDirty && onConfirm && (
+            <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+          )}
+        </>
       )}
-    </>
+    />
   );
 };
 DatePicker.displayName = 'DatePicker';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -42,6 +42,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   metadata,
   isRequired,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -90,7 +92,13 @@ export const DatePicker: React.FC<DatePickerProps> = ({
             />
           </EuiFormRow>
           {fieldState.isDirty && onConfirm && (
-            <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            <InlineFieldActions
+              name={name}
+              onConfirm={onConfirm}
+              onCancel={handleCancel}
+              isLoading={isSaving}
+              isDisabled={isSaveDisabled}
+            />
           )}
         </>
       )}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/inline_field_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/inline_field_actions.tsx
@@ -7,7 +7,7 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import * as i18n from '../../translations';
 
 interface InlineFieldActionsProps {
@@ -16,28 +16,37 @@ interface InlineFieldActionsProps {
   onCancel: () => void;
 }
 
-export const InlineFieldActions: FC<InlineFieldActionsProps> = ({ name, onConfirm, onCancel }) => (
-  <EuiFlexGroup gutterSize="xs" justifyContent="flexEnd" responsive={false}>
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="check"
-        color="success"
-        aria-label={i18n.CONFIRM_FIELD_EDIT}
-        data-test-subj={`template-field-confirm-${name}`}
-        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault()}
-        onClick={onConfirm}
-      />
-    </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="cross"
-        color="danger"
-        aria-label={i18n.CANCEL_FIELD_EDIT}
-        data-test-subj={`template-field-cancel-${name}`}
-        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault()}
-        onClick={onCancel}
-      />
-    </EuiFlexItem>
-  </EuiFlexGroup>
+const preventMouseDownDefault = (event: React.MouseEvent<HTMLButtonElement>) =>
+  event.preventDefault();
+
+export const InlineFieldActions: FC<InlineFieldActionsProps> = React.memo(
+  ({ name, onConfirm, onCancel }) => (
+    <EuiFlexGroup gutterSize="xs" justifyContent="flexEnd" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={i18n.CONFIRM_FIELD_EDIT} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="check"
+            color="success"
+            aria-label={i18n.CONFIRM_FIELD_EDIT}
+            data-test-subj={`template-field-confirm-${name}`}
+            onMouseDown={preventMouseDownDefault}
+            onClick={onConfirm}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={i18n.CANCEL_FIELD_EDIT} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="cross"
+            color="danger"
+            aria-label={i18n.CANCEL_FIELD_EDIT}
+            data-test-subj={`template-field-cancel-${name}`}
+            onMouseDown={preventMouseDownDefault}
+            onClick={onCancel}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  )
 );
 InlineFieldActions.displayName = 'InlineFieldActions';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/inline_field_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/inline_field_actions.tsx
@@ -14,13 +14,15 @@ interface InlineFieldActionsProps {
   name: string;
   onConfirm: () => void;
   onCancel: () => void;
+  isLoading?: boolean;
+  isDisabled?: boolean;
 }
 
 const preventMouseDownDefault = (event: React.MouseEvent<HTMLButtonElement>) =>
   event.preventDefault();
 
 export const InlineFieldActions: FC<InlineFieldActionsProps> = React.memo(
-  ({ name, onConfirm, onCancel }) => (
+  ({ name, onConfirm, onCancel, isLoading = false, isDisabled = false }) => (
     <EuiFlexGroup gutterSize="xs" justifyContent="flexEnd" responsive={false}>
       <EuiFlexItem grow={false}>
         <EuiToolTip content={i18n.CONFIRM_FIELD_EDIT} disableScreenReaderOutput>
@@ -31,6 +33,8 @@ export const InlineFieldActions: FC<InlineFieldActionsProps> = React.memo(
             data-test-subj={`template-field-confirm-${name}`}
             onMouseDown={preventMouseDownDefault}
             onClick={onConfirm}
+            isLoading={isLoading}
+            isDisabled={isDisabled}
           />
         </EuiToolTip>
       </EuiFlexItem>
@@ -43,6 +47,7 @@ export const InlineFieldActions: FC<InlineFieldActionsProps> = React.memo(
             data-test-subj={`template-field-cancel-${name}`}
             onMouseDown={preventMouseDownDefault}
             onClick={onCancel}
+            isDisabled={isLoading}
           />
         </EuiToolTip>
       </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -97,6 +97,7 @@ export const InputNumber = ({
                 onChange={field.onChange}
                 onBlur={field.onBlur}
                 isInvalid={Boolean(fieldState.error)}
+                disabled={isSaving}
                 fullWidth
               />
             </EuiFormRow>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFieldNumber, EuiFormRow } from '@elastic/eui';
 import { InlineFieldActions } from './inline_field_actions';
@@ -38,8 +38,11 @@ export const InputNumber = ({
   onConfirm,
 }: InputNumberProps) => {
   const { control, resetField } = useFormContext();
-  const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
+
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   const rules = useMemo(() => {
     const validate: Record<string, (value: unknown) => true | string> = {};
@@ -67,8 +70,6 @@ export const InputNumber = ({
     return { validate };
   }, [isRequired, min, max]);
 
-  const showInlineActions = isFocused && onConfirm != null;
-
   return (
     <Controller
       key={name}
@@ -76,44 +77,33 @@ export const InputNumber = ({
       control={control}
       rules={rules}
       defaultValue=""
-      render={({ field, fieldState }) => (
-        <>
-          <EuiFormRow
-            label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-            isInvalid={!!fieldState.error}
-            error={fieldState.error?.message}
-            fullWidth
-          >
-            <EuiFieldNumber
-              inputRef={field.ref}
-              name={field.name}
-              value={(field.value as string | number | undefined) ?? ''}
-              onChange={(e) => field.onChange(e.target.value)}
-              onBlur={() => {
-                field.onBlur();
-                setIsFocused(false);
-              }}
-              onFocus={() => setIsFocused(true)}
-              isInvalid={!!fieldState.error}
+      render={({ field, fieldState }) => {
+        const showInlineActions = fieldState.isDirty && onConfirm != null;
+        return (
+          <>
+            <EuiFormRow
+              label={label}
+              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              isInvalid={Boolean(fieldState.error)}
+              error={fieldState.error?.message}
               fullWidth
-            />
-          </EuiFormRow>
-          {showInlineActions && (
-            <InlineFieldActions
-              name={name}
-              onConfirm={() => {
-                setIsFocused(false);
-                onConfirm();
-              }}
-              onCancel={() => {
-                setIsFocused(false);
-                resetField(path);
-              }}
-            />
-          )}
-        </>
-      )}
+            >
+              <EuiFieldNumber
+                inputRef={field.ref}
+                name={field.name}
+                value={(field.value as string | number | undefined) ?? ''}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                isInvalid={Boolean(fieldState.error)}
+                fullWidth
+              />
+            </EuiFormRow>
+            {showInlineActions && onConfirm && (
+              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            )}
+          </>
+        );
+      }}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -36,6 +36,8 @@ export const InputNumber = ({
   min,
   max,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }: InputNumberProps) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -99,7 +101,13 @@ export const InputNumber = ({
               />
             </EuiFormRow>
             {showInlineActions && onConfirm && (
-              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+              <InlineFieldActions
+                name={name}
+                onConfirm={onConfirm}
+                onCancel={handleCancel}
+                isLoading={isSaving}
+                isDisabled={isSaveDisabled}
+              />
             )}
           </>
         );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -36,6 +36,8 @@ export const InputText = ({
   minLength,
   maxLength,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }: InputTextProps) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -106,7 +108,13 @@ export const InputText = ({
               />
             </EuiFormRow>
             {showInlineActions && onConfirm && (
-              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+              <InlineFieldActions
+                name={name}
+                onConfirm={onConfirm}
+                onCancel={handleCancel}
+                isLoading={isSaving}
+                isDisabled={isSaveDisabled}
+              />
             )}
           </>
         );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFieldText, EuiFormRow } from '@elastic/eui';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
@@ -38,7 +38,6 @@ export const InputText = ({
   onConfirm,
 }: InputTextProps) => {
   const { control, resetField } = useFormContext();
-  const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const rules = useMemo(() => {
@@ -74,7 +73,9 @@ export const InputText = ({
     return { validate };
   }, [isRequired, patternValidation, minLength, maxLength]);
 
-  const showInlineActions = isFocused && onConfirm != null;
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   return (
     <Controller
@@ -83,44 +84,33 @@ export const InputText = ({
       control={control}
       rules={rules}
       defaultValue=""
-      render={({ field, fieldState }) => (
-        <>
-          <EuiFormRow
-            label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-            isInvalid={!!fieldState.error}
-            error={fieldState.error?.message}
-            fullWidth
-          >
-            <EuiFieldText
-              inputRef={field.ref}
-              name={field.name}
-              value={(field.value as string) ?? ''}
-              onChange={(e) => field.onChange(e.target.value)}
-              onBlur={() => {
-                field.onBlur();
-                setIsFocused(false);
-              }}
-              onFocus={() => setIsFocused(true)}
-              isInvalid={!!fieldState.error}
+      render={({ field, fieldState }) => {
+        const showInlineActions = fieldState.isDirty && onConfirm != null;
+        return (
+          <>
+            <EuiFormRow
+              label={label}
+              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              isInvalid={Boolean(fieldState.error)}
+              error={fieldState.error?.message}
               fullWidth
-            />
-          </EuiFormRow>
-          {showInlineActions && (
-            <InlineFieldActions
-              name={name}
-              onConfirm={() => {
-                setIsFocused(false);
-                onConfirm();
-              }}
-              onCancel={() => {
-                setIsFocused(false);
-                resetField(path);
-              }}
-            />
-          )}
-        </>
-      )}
+            >
+              <EuiFieldText
+                inputRef={field.ref}
+                name={field.name}
+                value={(field.value as string) ?? ''}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                isInvalid={Boolean(fieldState.error)}
+                fullWidth
+              />
+            </EuiFormRow>
+            {showInlineActions && onConfirm && (
+              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            )}
+          </>
+        );
+      }}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -104,6 +104,7 @@ export const InputText = ({
                 onChange={field.onChange}
                 onBlur={field.onBlur}
                 isInvalid={Boolean(fieldState.error)}
+                disabled={isSaving}
                 fullWidth
               />
             </EuiFormRow>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.test.tsx
@@ -18,6 +18,7 @@ interface FormWrapperProps {
   isRequired?: boolean;
   initialValue?: string;
   defaultOption?: string;
+  onConfirm?: () => void;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -25,6 +26,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   isRequired,
   initialValue,
   defaultOption,
+  onConfirm,
   onSubmitResult,
 }) => {
   const form = useForm({
@@ -52,6 +54,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
         label="Severity"
         isRequired={isRequired}
         metadata={{ options: OPTIONS, default: defaultOption }}
+        onConfirm={onConfirm}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -135,6 +138,38 @@ describe('RadioGroup', () => {
       );
       expect(checkedOptions).toHaveLength(1);
       expect(checkedOptions[0]).toBe('high');
+    });
+
+    it('shows actions only while the field is dirty', async () => {
+      render(<FormWrapper onConfirm={jest.fn()} onSubmitResult={jest.fn()} />);
+
+      expect(screen.queryByTestId('template-field-confirm-severity')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText('critical'));
+
+      expect(screen.getByTestId('template-field-confirm-severity')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-severity')).toBeInTheDocument();
+    });
+
+    it('confirms the pending value', async () => {
+      const onConfirm = jest.fn();
+      render(<FormWrapper onConfirm={onConfirm} onSubmitResult={jest.fn()} />);
+
+      await userEvent.click(screen.getByLabelText('critical'));
+      await userEvent.click(screen.getByTestId('template-field-confirm-severity'));
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels the pending value and hides the actions', async () => {
+      render(<FormWrapper defaultOption="low" onConfirm={jest.fn()} onSubmitResult={jest.fn()} />);
+
+      await userEvent.click(screen.getByLabelText('high'));
+      await userEvent.click(screen.getByTestId('template-field-cancel-severity'));
+
+      expect(screen.getByLabelText('low')).toBeChecked();
+      expect(screen.getByLabelText('high')).not.toBeChecked();
+      expect(screen.queryByTestId('template-field-confirm-severity')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.test.tsx
@@ -19,6 +19,7 @@ interface FormWrapperProps {
   initialValue?: string;
   defaultOption?: string;
   onConfirm?: () => void;
+  isSaving?: boolean;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -27,6 +28,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   initialValue,
   defaultOption,
   onConfirm,
+  isSaving,
   onSubmitResult,
 }) => {
   const form = useForm({
@@ -55,6 +57,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
         isRequired={isRequired}
         metadata={{ options: OPTIONS, default: defaultOption }}
         onConfirm={onConfirm}
+        isSaving={isSaving}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -74,6 +77,14 @@ describe('RadioGroup', () => {
       render(<FormWrapper onSubmitResult={jest.fn()} />);
       for (const option of OPTIONS) {
         expect(screen.getByLabelText(option)).toBeInTheDocument();
+      }
+    });
+
+    it('disables every option while saving', () => {
+      render(<FormWrapper isSaving onSubmitResult={jest.fn()} />);
+
+      for (const option of OPTIONS) {
+        expect(screen.getByLabelText(option)).toBeDisabled();
       }
     });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
@@ -28,6 +28,8 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   metadata,
   isRequired,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }) => {
   const { control, setValue, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -78,7 +80,13 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
             setValue={setValue}
           />
           {fieldState.isDirty && onConfirm && (
-            <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            <InlineFieldActions
+              name={name}
+              onConfirm={onConfirm}
+              onCancel={handleCancel}
+              isLoading={isSaving}
+              isDisabled={isSaveDisabled}
+            />
           )}
         </>
       )}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFormRow, EuiRadioGroup } from '@elastic/eui';
 import { InlineFieldActions } from './inline_field_actions';
@@ -30,7 +30,6 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   onConfirm,
 }) => {
   const { control, setValue, resetField } = useFormContext();
-  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
   const firstOption = metadata.options[0];
   const defaultValue = metadata.default ?? firstOption;
@@ -49,17 +48,19 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
     };
   }, [isRequired]);
 
-  const showInlineActions = hasPendingChange && onConfirm != null;
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   return (
-    <>
-      <Controller
-        key={name}
-        name={path}
-        control={control}
-        rules={rules}
-        defaultValue={defaultValue}
-        render={({ field, fieldState }) => (
+    <Controller
+      key={name}
+      name={path}
+      control={control}
+      rules={rules}
+      defaultValue={defaultValue}
+      render={({ field, fieldState }) => (
+        <>
           <RadioGroupRender
             name={name}
             path={path}
@@ -68,31 +69,20 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
             options={options}
             firstOption={firstOption}
             value={typeof field.value === 'string' ? field.value : ''}
-            isInvalid={!!fieldState.error}
+            isInvalid={Boolean(fieldState.error)}
             errorMessage={fieldState.error?.message}
             onChange={(id) => {
               field.onChange(id);
               field.onBlur();
-              setHasPendingChange(true);
             }}
             setValue={setValue}
           />
-        )}
-      />
-      {showInlineActions && (
-        <InlineFieldActions
-          name={name}
-          onConfirm={() => {
-            setHasPendingChange(false);
-            onConfirm();
-          }}
-          onCancel={() => {
-            setHasPendingChange(false);
-            resetField(path);
-          }}
-        />
+          {fieldState.isDirty && onConfirm && (
+            <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+          )}
+        </>
       )}
-    </>
+    />
   );
 };
 RadioGroup.displayName = 'RadioGroup';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
@@ -73,6 +73,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
             value={typeof field.value === 'string' ? field.value : ''}
             isInvalid={Boolean(fieldState.error)}
             errorMessage={fieldState.error?.message}
+            isDisabled={isSaving}
             onChange={(id) => {
               field.onChange(id);
               field.onBlur();
@@ -105,6 +106,7 @@ interface RadioGroupRenderProps {
   value: string;
   isInvalid: boolean;
   errorMessage?: string;
+  isDisabled?: boolean;
   onChange: (next: string) => void;
   setValue: ReturnType<typeof useFormContext>['setValue'];
 }
@@ -119,6 +121,7 @@ const RadioGroupRender: React.FC<RadioGroupRenderProps> = ({
   value,
   isInvalid,
   errorMessage,
+  isDisabled,
   onChange,
   setValue,
 }) => {
@@ -142,7 +145,13 @@ const RadioGroupRender: React.FC<RadioGroupRenderProps> = ({
       isInvalid={isInvalid}
       fullWidth
     >
-      <EuiRadioGroup name={name} options={options} idSelected={idSelected} onChange={onChange} />
+      <EuiRadioGroup
+        name={name}
+        options={options}
+        idSelected={idSelected}
+        onChange={onChange}
+        disabled={isDisabled}
+      />
     </EuiFormRow>
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
@@ -28,6 +28,8 @@ export const SelectBasic = ({
   type,
   isRequired,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }: SelectBasicProps) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -83,7 +85,13 @@ export const SelectBasic = ({
             />
           </EuiFormRow>
           {fieldState.isDirty && onConfirm && (
-            <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            <InlineFieldActions
+              name={name}
+              onConfirm={onConfirm}
+              onCancel={handleCancel}
+              isLoading={isSaving}
+              isDisabled={isSaveDisabled}
+            />
           )}
         </>
       )}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
@@ -81,6 +81,7 @@ export const SelectBasic = ({
               onBlur={field.onBlur}
               hasNoInitialSelection={!field.value}
               isInvalid={Boolean(fieldState.error)}
+              disabled={isSaving}
               fullWidth
             />
           </EuiFormRow>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { z } from '@kbn/zod/v4';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFormRow, EuiSelect } from '@elastic/eui';
@@ -30,7 +30,6 @@ export const SelectBasic = ({
   onConfirm,
 }: SelectBasicProps) => {
   const { control, resetField } = useFormContext();
-  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const options = useMemo(
@@ -48,21 +47,23 @@ export const SelectBasic = ({
     };
   }, [isRequired]);
 
-  const showInlineActions = hasPendingChange && onConfirm != null;
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   return (
-    <>
-      <Controller
-        key={name}
-        name={path}
-        control={control}
-        rules={rules}
-        defaultValue=""
-        render={({ field, fieldState }) => (
+    <Controller
+      key={name}
+      name={path}
+      control={control}
+      rules={rules}
+      defaultValue=""
+      render={({ field, fieldState }) => (
+        <>
           <EuiFormRow
             label={label}
             labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-            isInvalid={!!fieldState.error}
+            isInvalid={Boolean(fieldState.error)}
             error={fieldState.error?.message}
             fullWidth
           >
@@ -74,30 +75,19 @@ export const SelectBasic = ({
               onChange={(e) => {
                 field.onChange(e.target.value);
                 field.onBlur();
-                setHasPendingChange(true);
               }}
               onBlur={field.onBlur}
               hasNoInitialSelection={!field.value}
-              isInvalid={!!fieldState.error}
+              isInvalid={Boolean(fieldState.error)}
               fullWidth
             />
           </EuiFormRow>
-        )}
-      />
-      {showInlineActions && (
-        <InlineFieldActions
-          name={name}
-          onConfirm={() => {
-            setHasPendingChange(false);
-            onConfirm();
-          }}
-          onCancel={() => {
-            setHasPendingChange(false);
-            resetField(path);
-          }}
-        />
+          {fieldState.isDirty && onConfirm && (
+            <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+          )}
+        </>
       )}
-    </>
+    />
   );
 };
 SelectBasic.displayName = 'SelectBasic';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.test.tsx
@@ -19,11 +19,13 @@ jest.mock('@elastic/eui', () => {
     EuiMarkdownEditor: ({
       value,
       onChange,
+      readOnly,
       'aria-label': ariaLabel,
       'data-test-subj': dataTestSubj,
     }: {
       value: string;
       onChange: (value: string) => void;
+      readOnly?: boolean;
       'aria-label': string;
       'data-test-subj': string;
     }) => (
@@ -32,6 +34,7 @@ jest.mock('@elastic/eui', () => {
         aria-label={ariaLabel}
         value={value}
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+        disabled={readOnly}
       />
     ),
   };
@@ -44,6 +47,7 @@ interface FormWrapperProps {
   patternValidation?: { regex: string; message?: string };
   minLengthValue?: number;
   maxLengthValue?: number;
+  isSaving?: boolean;
   onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -54,6 +58,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   patternValidation,
   minLengthValue,
   maxLengthValue,
+  isSaving,
   onSubmitResult,
 }) => {
   const form = useForm({
@@ -83,6 +88,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
         patternValidation={patternValidation}
         minLength={minLengthValue}
         maxLength={maxLengthValue}
+        isSaving={isSaving}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -99,6 +105,12 @@ describe('Textarea', () => {
 
       expect(screen.getByRole('textbox')).toBeInTheDocument();
       expect(screen.queryByTestId('template-field-markdown-editor')).not.toBeInTheDocument();
+    });
+
+    it('disables the textarea while saving', () => {
+      render(<FormWrapper isSaving onSubmitResult={jest.fn()} />);
+
+      expect(screen.getByRole('textbox')).toBeDisabled();
     });
 
     it('renders the label', () => {
@@ -146,6 +158,12 @@ describe('Textarea', () => {
       render(<FormWrapper markdown onSubmitResult={onSubmitResult} />);
 
       expect(screen.getByTestId('template-field-markdown-editor')).toBeInTheDocument();
+    });
+
+    it('makes the markdown editor read-only while saving', () => {
+      render(<FormWrapper markdown isSaving onSubmitResult={jest.fn()} />);
+
+      expect(screen.getByTestId('template-field-markdown-editor')).toBeDisabled();
     });
 
     it('renders EuiTextArea when metadata.markdown is false', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -37,6 +37,8 @@ export const Textarea = ({
   minLength,
   maxLength,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }: TextareaProps) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -118,7 +120,13 @@ export const Textarea = ({
               )}
             </EuiFormRow>
             {showInlineActions && onConfirm && (
-              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+              <InlineFieldActions
+                name={name}
+                onConfirm={onConfirm}
+                onCancel={handleCancel}
+                isLoading={isSaving}
+                isDisabled={isSaveDisabled}
+              />
             )}
           </>
         );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFormRow, EuiTextArea, EuiMarkdownEditor } from '@elastic/eui';
 import { InlineFieldActions } from './inline_field_actions';
@@ -39,9 +39,12 @@ export const Textarea = ({
   onConfirm,
 }: TextareaProps) => {
   const { control, resetField } = useFormContext();
-  const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
   const isMarkdown = metadata?.markdown === true;
+
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   const rules = useMemo(() => {
     const validate: Record<string, (value: unknown) => true | string> = {};
@@ -76,8 +79,6 @@ export const Textarea = ({
     return { validate };
   }, [isRequired, patternValidation, minLength, maxLength]);
 
-  const showInlineActions = isFocused && onConfirm != null;
-
   return (
     <Controller
       key={name}
@@ -85,57 +86,43 @@ export const Textarea = ({
       control={control}
       rules={rules}
       defaultValue=""
-      render={({ field, fieldState }) => (
-        <>
-          <EuiFormRow
-            label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-            isInvalid={!!fieldState.error}
-            error={fieldState.error?.message}
-            fullWidth
-          >
-            {isMarkdown ? (
-              <EuiMarkdownEditor
-                value={(field.value as string) ?? ''}
-                onChange={(value) => {
-                  field.onChange(value);
-                  if (!isFocused) setIsFocused(true);
-                }}
-                aria-label={typeof label === 'string' ? label : name}
-                editorId={path}
-                data-test-subj="template-field-markdown-editor"
-              />
-            ) : (
-              <EuiTextArea
-                inputRef={field.ref}
-                name={field.name}
-                value={(field.value as string) ?? ''}
-                onChange={(e) => field.onChange(e.target.value)}
-                onBlur={() => {
-                  field.onBlur();
-                  setIsFocused(false);
-                }}
-                onFocus={() => setIsFocused(true)}
-                isInvalid={!!fieldState.error}
-                fullWidth
-              />
+      render={({ field, fieldState }) => {
+        const showInlineActions = fieldState.isDirty && onConfirm != null;
+        return (
+          <>
+            <EuiFormRow
+              label={label}
+              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              isInvalid={Boolean(fieldState.error)}
+              error={fieldState.error?.message}
+              fullWidth
+            >
+              {isMarkdown ? (
+                <EuiMarkdownEditor
+                  value={(field.value as string) ?? ''}
+                  onChange={field.onChange}
+                  aria-label={typeof label === 'string' ? label : name}
+                  editorId={path}
+                  data-test-subj="template-field-markdown-editor"
+                />
+              ) : (
+                <EuiTextArea
+                  inputRef={field.ref}
+                  name={field.name}
+                  value={(field.value as string) ?? ''}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  isInvalid={Boolean(fieldState.error)}
+                  fullWidth
+                />
+              )}
+            </EuiFormRow>
+            {showInlineActions && onConfirm && (
+              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
             )}
-          </EuiFormRow>
-          {showInlineActions && (
-            <InlineFieldActions
-              name={name}
-              onConfirm={() => {
-                setIsFocused(false);
-                onConfirm();
-              }}
-              onCancel={() => {
-                setIsFocused(false);
-                resetField(path);
-              }}
-            />
-          )}
-        </>
-      )}
+          </>
+        );
+      }}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -106,6 +106,7 @@ export const Textarea = ({
                   aria-label={typeof label === 'string' ? label : name}
                   editorId={path}
                   data-test-subj="template-field-markdown-editor"
+                  readOnly={isSaving}
                 />
               ) : (
                 <EuiTextArea
@@ -115,6 +116,7 @@ export const Textarea = ({
                   onChange={field.onChange}
                   onBlur={field.onBlur}
                   isInvalid={Boolean(fieldState.error)}
+                  disabled={isSaving}
                   fullWidth
                 />
               )}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.test.tsx
@@ -39,6 +39,7 @@ interface FormWrapperProps {
   multiple?: boolean;
   initialUsers?: Array<{ uid: string; name: string }>;
   onConfirm?: () => void;
+  isSaving?: boolean;
   onSubmitResult?: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -47,6 +48,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   multiple,
   initialUsers,
   onConfirm,
+  isSaving,
   onSubmitResult = jest.fn(),
 }) => {
   const serialized = JSON.stringify(initialUsers ?? []);
@@ -75,6 +77,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
         isRequired={isRequired}
         metadata={multiple !== undefined ? { multiple } : undefined}
         onConfirm={onConfirm}
+        isSaving={isSaving}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -110,6 +113,12 @@ describe('UserPicker', () => {
     it('renders the combobox input', () => {
       render(<FormWrapper />);
       expect(screen.getByTestId('template-user-picker-assignee')).toBeInTheDocument();
+    });
+
+    it('disables the combobox while saving', () => {
+      render(<FormWrapper isSaving />);
+
+      expect(screen.getByRole('combobox')).toBeDisabled();
     });
 
     it('renders in multi-select mode by default', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.test.tsx
@@ -38,6 +38,7 @@ interface FormWrapperProps {
   isRequired?: boolean;
   multiple?: boolean;
   initialUsers?: Array<{ uid: string; name: string }>;
+  onConfirm?: () => void;
   onSubmitResult?: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
 }
 
@@ -45,6 +46,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
   isRequired,
   multiple,
   initialUsers,
+  onConfirm,
   onSubmitResult = jest.fn(),
 }) => {
   const serialized = JSON.stringify(initialUsers ?? []);
@@ -72,6 +74,7 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
         label="Assignee"
         isRequired={isRequired}
         metadata={multiple !== undefined ? { multiple } : undefined}
+        onConfirm={onConfirm}
       />
       <button type="button" onClick={handleSubmit}>
         {'Submit'}
@@ -133,6 +136,18 @@ describe('UserPicker', () => {
       // No pill/badge rendered
       expect(screen.queryByRole('option', { selected: true })).not.toBeInTheDocument();
     });
+
+    it('loads selected users missing from the suggestions', () => {
+      useSuggestUserProfilesMock.mockReturnValue({
+        data: [alice],
+        isLoading: false,
+        isFetching: false,
+      });
+
+      render(<FormWrapper initialUsers={[{ uid: bob.uid, name: 'Physical Dinosaur' }]} />);
+
+      expect(useBulkGetUserProfilesMock).toHaveBeenCalledWith({ uids: [bob.uid] });
+    });
   });
 
   describe('search behaviour', () => {
@@ -155,6 +170,25 @@ describe('UserPicker', () => {
       });
       render(<FormWrapper />);
       expect(screen.getByTestId('template-user-picker-assignee')).toBeInTheDocument();
+    });
+  });
+
+  describe('inline actions', () => {
+    it('shows actions after the selection changes and confirms it', async () => {
+      const onConfirm = jest.fn();
+      useBulkGetUserProfilesMock.mockReturnValue({
+        data: new Map(),
+        isFetching: false,
+      });
+      render(<FormWrapper onConfirm={onConfirm} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+      await userEvent.click(await screen.findByText('Damaged Raccoon'));
+
+      await userEvent.click(screen.getByTestId('template-field-confirm-assignee'));
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -111,6 +111,7 @@ export const UserPicker: React.FC<UserPickerProps> = ({
               isLoading={isLoading}
               isMultiple={isMultiple}
               isRequired={isRequired ?? false}
+              isDisabled={isSaving}
               selectedUsers={selectedUsers}
               suggestedProfiles={suggestedProfiles}
               missingUids={missingUids}
@@ -146,6 +147,7 @@ interface UserPickerComboboxWithProfilesProps {
   isLoading: boolean;
   isMultiple: boolean;
   isRequired: boolean;
+  isDisabled?: boolean;
   selectedUsers: SelectedUser[];
   suggestedProfiles: UserProfileWithAvatar[];
   missingUids: string[];

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -39,9 +39,8 @@ export const UserPicker: React.FC<UserPickerProps> = ({
   isRequired,
   onConfirm,
 }) => {
-  const { control, resetField, getFieldState, formState } = useFormContext();
+  const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
-  const { isDirty } = getFieldState(path, formState);
 
   const { owner: owners } = useCasesContext();
   const availableOwners = useAvailableCasesOwners(getAllPermissionsExceptFrom('delete'));
@@ -63,6 +62,10 @@ export const UserPicker: React.FC<UserPickerProps> = ({
 
   const isLoading = isLoadingSuggest || isFetchingSuggest || isUserTyping;
   const isMultiple = metadata?.multiple !== false;
+  const suggestedUids = useMemo(
+    () => new Set(suggestedProfiles.map(({ uid }) => uid)),
+    [suggestedProfiles]
+  );
 
   const rules = useUserPickerValidators({ isRequired: isRequired ?? false, security });
 
@@ -78,27 +81,30 @@ export const UserPicker: React.FC<UserPickerProps> = ({
     [onContentChange]
   );
 
-  const showInlineActions = isDirty && onConfirm != null;
+  const handleCancel = useCallback(() => {
+    resetField(path);
+  }, [path, resetField]);
 
   return (
-    <>
-      <Controller
-        key={name}
-        name={path}
-        control={control}
-        rules={rules}
-        defaultValue={defaultValue}
-        render={({ field, fieldState }) => {
-          const selectedUsers = toSelectedUsers(field.value);
-          const missingUids = selectedUsers
-            .filter((u) => !suggestedProfiles.some((p) => p.uid === u.uid))
-            .map((u) => u.uid);
+    <Controller
+      key={name}
+      name={path}
+      control={control}
+      rules={rules}
+      defaultValue={defaultValue}
+      render={({ field, fieldState }) => {
+        const selectedUsers = toSelectedUsers(field.value);
+        const missingUids = selectedUsers.reduce<string[]>((uids, { uid }) => {
+          if (!suggestedUids.has(uid)) uids.push(uid);
+          return uids;
+        }, []);
 
-          return (
+        return (
+          <>
             <UserPickerComboboxWithProfiles
               label={label}
               name={name}
-              isInvalid={!!fieldState.error}
+              isInvalid={Boolean(fieldState.error)}
               errorMessage={fieldState.error?.message ?? null}
               isLoading={isLoading}
               isMultiple={isMultiple}
@@ -112,13 +118,13 @@ export const UserPicker: React.FC<UserPickerProps> = ({
                 field.onBlur();
               }}
             />
-          );
-        }}
-      />
-      {showInlineActions && (
-        <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={() => resetField(path)} />
-      )}
-    </>
+            {fieldState.isDirty && onConfirm && (
+              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+            )}
+          </>
+        );
+      }}
+    />
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -38,6 +38,8 @@ export const UserPicker: React.FC<UserPickerProps> = ({
   metadata,
   isRequired,
   onConfirm,
+  isSaving,
+  isSaveDisabled,
 }) => {
   const { control, resetField } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
@@ -119,7 +121,13 @@ export const UserPicker: React.FC<UserPickerProps> = ({
               }}
             />
             {fieldState.isDirty && onConfirm && (
-              <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={handleCancel} />
+              <InlineFieldActions
+                name={name}
+                onConfirm={onConfirm}
+                onCancel={handleCancel}
+                isLoading={isSaving}
+                isDisabled={isSaveDisabled}
+              />
             )}
           </>
         );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker_combobox.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker_combobox.tsx
@@ -32,6 +32,7 @@ export interface UserPickerComboboxProps {
   isLoadingBulk: boolean;
   isMultiple: boolean;
   isRequired: boolean;
+  isDisabled?: boolean;
   selectedUsers: SelectedUser[];
   allKnownProfiles: UserProfileWithAvatar[];
   onChange: (next: SelectedUser[]) => void;
@@ -47,6 +48,7 @@ export const UserPickerCombobox: React.FC<UserPickerComboboxProps> = ({
   isLoadingBulk,
   isMultiple,
   isRequired,
+  isDisabled,
   selectedUsers,
   allKnownProfiles,
   onChange,
@@ -132,6 +134,7 @@ export const UserPickerCombobox: React.FC<UserPickerComboboxProps> = ({
         isInvalid={isInvalid}
         fullWidth
         async
+        isDisabled={isDisabled}
         isLoading={isLoading || isLoadingBulk}
         options={options}
         selectedOptions={selectedOptions}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.test.tsx
@@ -10,11 +10,17 @@ import { parse as parseYaml } from 'yaml';
 import { render, renderHook, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, useFormContext } from 'react-hook-form';
 import { ParsedTemplateDefinitionSchema } from '../../../../common/types/domain/template/latest';
 import { CASE_EXTENDED_FIELDS } from '../../../../common/constants';
-import { isInlineField } from '../../../../common/types/domain/template/fields';
+import {
+  FieldType,
+  type InlineField,
+  isInlineField,
+} from '../../../../common/types/domain/template/fields';
+import { getFieldSnakeKey } from '../../../../common/utils';
 import { FieldsRenderer, TemplateFieldRenderer } from './field_renderer';
+import { controlRegistry } from './field_types_registry';
 
 jest.mock('../../field_library/hooks/use_resolved_fields', () => ({
   useResolvedFields: (fields: Array<Record<string, unknown>>) => ({
@@ -279,5 +285,90 @@ describe('FieldsRenderer — hidden required fields', () => {
     await waitFor(() => {
       expect(onSubmitResult).toHaveBeenCalledWith(false);
     });
+  });
+});
+
+describe('FieldsRenderer — field isolation', () => {
+  const fields: InlineField[] = [
+    { name: 'first', control: FieldType.INPUT_TEXT, type: 'keyword' },
+    { name: 'second', control: FieldType.INPUT_TEXT, type: 'keyword' },
+  ];
+  const renderCounts: Record<string, number> = {};
+  const originalInputText = controlRegistry[FieldType.INPUT_TEXT];
+
+  const TestControl: React.FC<{
+    name: string;
+    type: string;
+    onConfirm?: () => void;
+  }> = ({ name, type, onConfirm }) => {
+    renderCounts[name] = (renderCounts[name] ?? 0) + 1;
+    const { register } = useFormContext();
+    const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
+
+    return (
+      <>
+        <input aria-label={name} {...register(path)} />
+        {onConfirm && (
+          <button type="button" onClick={onConfirm}>
+            {`Confirm ${name}`}
+          </button>
+        )}
+      </>
+    );
+  };
+
+  const TestForm: React.FC<{
+    onFieldConfirm?: (fieldName: string, fieldType: string) => void;
+  }> = ({ onFieldConfirm }) => {
+    const form = useForm({
+      defaultValues: {
+        [CASE_EXTENDED_FIELDS]: {
+          first_as_keyword: '',
+          second_as_keyword: '',
+        },
+      },
+    });
+
+    return (
+      <FormProvider {...form}>
+        <FieldsRenderer resolvedFields={fields} onFieldConfirm={onFieldConfirm} />
+      </FormProvider>
+    );
+  };
+
+  beforeEach(() => {
+    renderCounts.first = 0;
+    renderCounts.second = 0;
+    controlRegistry[FieldType.INPUT_TEXT] = TestControl as typeof originalInputText;
+  });
+
+  afterEach(() => {
+    controlRegistry[FieldType.INPUT_TEXT] = originalInputText;
+  });
+
+  it('does not re-render a sibling control when a field value changes', async () => {
+    render(<TestForm />);
+    renderCounts.first = 0;
+    renderCounts.second = 0;
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'first' }), 'updated');
+
+    expect(renderCounts.first).toBeGreaterThan(0);
+    expect(renderCounts.second).toBe(0);
+  });
+
+  it('binds confirmation to the field name and type', async () => {
+    const onFieldConfirm = jest.fn();
+    render(<TestForm onFieldConfirm={onFieldConfirm} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm second' }));
+
+    expect(onFieldConfirm).toHaveBeenCalledWith('second', 'keyword');
+  });
+
+  it('does not expose confirmation when no handler is provided', () => {
+    render(<TestForm />);
+
+    expect(screen.queryByRole('button', { name: /Confirm/ })).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
@@ -35,12 +35,23 @@ interface TemplateFieldRowProps {
   value: unknown;
   isRequired: boolean;
   onFieldConfirm?: (fieldName: string, fieldType: string) => void;
+  isSaving: boolean;
+  isSaveDisabled: boolean;
   marginBottom: string;
 }
 
 /** Prevents a field value change from re-rendering sibling controls. */
 const TemplateFieldRow: FC<TemplateFieldRowProps> = React.memo(
-  ({ field, Control, value, isRequired, onFieldConfirm, marginBottom }) => {
+  ({
+    field,
+    Control,
+    value,
+    isRequired,
+    onFieldConfirm,
+    isSaving,
+    isSaveDisabled,
+    marginBottom,
+  }) => {
     const handleConfirm = useCallback(() => {
       onFieldConfirm?.(field.name, field.type);
     }, [onFieldConfirm, field.name, field.type]);
@@ -56,6 +67,8 @@ const TemplateFieldRow: FC<TemplateFieldRowProps> = React.memo(
       minLength: field.validation?.min_length,
       maxLength: field.validation?.max_length,
       onConfirm: onFieldConfirm ? handleConfirm : undefined,
+      isSaving,
+      isSaveDisabled,
     };
 
     return (
@@ -70,7 +83,8 @@ TemplateFieldRow.displayName = 'TemplateFieldRow';
 export const FieldsRenderer: FC<{
   resolvedFields: InlineField[];
   onFieldConfirm?: (fieldName: string, fieldType: string) => void;
-}> = ({ resolvedFields, onFieldConfirm }) => {
+  savingFieldKey?: string;
+}> = ({ resolvedFields, onFieldConfirm, savingFieldKey }) => {
   const { euiTheme } = useEuiTheme();
   const { control } = useFormContext();
 
@@ -130,6 +144,8 @@ export const FieldsRenderer: FC<{
             value={fieldValues[field.name]}
             isRequired={isRequired}
             onFieldConfirm={onFieldConfirm}
+            isSaving={savingFieldKey === getFieldSnakeKey(field.name, field.type)}
+            isSaveDisabled={savingFieldKey != null}
             marginBottom={euiTheme.size.m}
           />
         );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import type { z } from '@kbn/zod/v4';
 import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { useEuiTheme } from '@elastic/eui';
@@ -29,9 +29,47 @@ export interface TemplateFieldRendererProps {
   onFieldDefaultChange?: (fieldName: string, value: string, control: string) => void;
 }
 
+interface TemplateFieldRowProps {
+  field: InlineField;
+  Control: FC<Record<string, unknown>>;
+  value: unknown;
+  isRequired: boolean;
+  onFieldConfirm?: (fieldName: string, fieldType: string) => void;
+  marginBottom: string;
+}
+
+/** Prevents a field value change from re-rendering sibling controls. */
+const TemplateFieldRow: FC<TemplateFieldRowProps> = React.memo(
+  ({ field, Control, value, isRequired, onFieldConfirm, marginBottom }) => {
+    const handleConfirm = useCallback(() => {
+      onFieldConfirm?.(field.name, field.type);
+    }, [onFieldConfirm, field.name, field.type]);
+
+    const controlProps = {
+      ...field,
+      label: field.label ?? field.name,
+      value,
+      isRequired,
+      patternValidation: field.validation?.pattern,
+      min: field.validation?.min,
+      max: field.validation?.max,
+      minLength: field.validation?.min_length,
+      maxLength: field.validation?.max_length,
+      onConfirm: onFieldConfirm ? handleConfirm : undefined,
+    };
+
+    return (
+      <div data-test-subj={`template-field-${field.name}`} css={{ marginBottom }}>
+        <Control {...controlProps} />
+      </div>
+    );
+  }
+);
+TemplateFieldRow.displayName = 'TemplateFieldRow';
+
 export const FieldsRenderer: FC<{
   resolvedFields: InlineField[];
-  onFieldConfirm?: () => void;
+  onFieldConfirm?: (fieldName: string, fieldType: string) => void;
 }> = ({ resolvedFields, onFieldConfirm }) => {
   const { euiTheme } = useEuiTheme();
   const { control } = useFormContext();
@@ -84,27 +122,16 @@ export const FieldsRenderer: FC<{
         const Control = controlRegistry[field.control] as unknown as FC<Record<string, unknown>>;
         if (!Control) return null;
 
-        const controlProps = {
-          ...field,
-          label: field.label ?? field.name,
-          value: fieldValues[field.name],
-          isRequired,
-          patternValidation: field.validation?.pattern,
-          min: field.validation?.min,
-          max: field.validation?.max,
-          minLength: field.validation?.min_length,
-          maxLength: field.validation?.max_length,
-          onConfirm: onFieldConfirm,
-        };
-
         return (
-          <div
+          <TemplateFieldRow
             key={field.name}
-            data-test-subj={`template-field-${field.name}`}
-            css={{ marginBottom: euiTheme.size.m }}
-          >
-            <Control {...controlProps} />
-          </div>
+            field={field}
+            Control={Control}
+            value={fieldValues[field.name]}
+            isRequired={isRequired}
+            onFieldConfirm={onFieldConfirm}
+            marginBottom={euiTheme.size.m}
+          />
         );
       })}
     </>


### PR DESCRIPTION
## What & Why

Fixes Cases template fields so unsaved changes remain actionable after blur and each field saves independently. Save progress is visible, concurrent confirmations are blocked, and the active field is locked until its update completes.

https://github.com/user-attachments/assets/f0742c39-d29a-4ed8-b5bf-fdf09cdf117e


## How to Test

1. Open a case containing a template with several field types.
2. Edit a field and blur it; verify Save and Cancel remain visible.
3. Edit multiple fields, save one, and verify the others remain pending.
4. Throttle the network and save; verify the active Save shows a spinner, all Save buttons are disabled, and the active field cannot be edited.
5. Verify controls unlock after either a successful or failed update.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->