### PR TITLE
[CI] Increase disk size for ES snapshot build

### DIFF
--- a/.buildkite/pipelines/es_snapshots/build.yml
+++ b/.buildkite/pipelines/es_snapshots/build.yml
@@ -9,4 +9,4 @@ steps:
       localSsds: 1
       localSsdInterface: nvme
       machineType: c2-standard-8
-      diskSizeGb: 135
+      diskSizeGb: 130

--- a/.buildkite/pipelines/es_snapshots/build.yml
+++ b/.buildkite/pipelines/es_snapshots/build.yml
@@ -9,4 +9,4 @@ steps:
       localSsds: 1
       localSsdInterface: nvme
       machineType: c2-standard-8
-      diskSizeGb: 130
+      diskSizeGb: 135

--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
+echo "--- Cleaning up cached images"
+clean_cached_images
+
 echo "--- Cloning Elasticsearch and preparing workspace"
 
 cd ..


### PR DESCRIPTION
## Summary
We're seeing disk size depletion during ES snapshot builds (specifically at the ES docker image build step).

This PR cleans up cached docker images to make disk space available for the build. 

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->