### PR TITLE
[Infra] Fix test failure on polluted scout lanes

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/sequential_hosts_synthtrace.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/sequential_hosts_synthtrace.ts
@@ -64,6 +64,88 @@ const unwrapSynthtraceClient = <TClientName extends SynthtraceClientName, TClien
   return value as TClient;
 };
 
+/**
+ * Name of the shadow composable index template installed before ingesting fixed-date
+ * host metrics. The template uses priority 500 (> Fleet's 200) and omits
+ * `index.mode: time_series`, ensuring `metrics-system.*` data streams are created as
+ * standard (non-TSDS) streams that accept historical timestamps.
+ */
+const NON_TSDS_SHADOW_TEMPLATE_NAME = 'synthtrace-hosts-flyout-metrics-system-non-tsds';
+
+/**
+ * Upserts a priority-500 shadow index template for `metrics-system.*` that deliberately
+ * omits `index.mode: time_series`. This overrides any Fleet-installed TSDS template
+ * (priority 200) so the data streams accept fixed historical dates used in these tests.
+ */
+export const ensureNonTsdsSystemTemplate = async (
+  esClient: EsClient,
+  log: ScoutLogger
+): Promise<void> => {
+  try {
+    await esClient.indices.putIndexTemplate({
+      name: NON_TSDS_SHADOW_TEMPLATE_NAME,
+      index_patterns: ['metrics-system.*'],
+      data_stream: {},
+      priority: 500,
+      template: {
+        mappings: {
+          dynamic: true,
+          // Map all strings as keyword so `terms` aggregations on fields like
+          // `host.name` work correctly — `dynamic: true` alone would auto-map
+          // them as `text`, breaking the infra hosts API aggregation.
+          dynamic_templates: [
+            {
+              strings_as_keyword: {
+                match_mapping_type: 'string',
+                mapping: { type: 'keyword', ignore_above: 1024 },
+              },
+            },
+          ],
+          properties: {
+            '@timestamp': { type: 'date' },
+          },
+        },
+      },
+    });
+    log.info(
+      `Installed shadow index template "${NON_TSDS_SHADOW_TEMPLATE_NAME}" (priority 500, no TSDS) for metrics-system.*`
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warning(
+      `Failed to install shadow index template "${NON_TSDS_SHADOW_TEMPLATE_NAME}": ${message}`
+    );
+    throw error;
+  }
+};
+
+/**
+ * Removes the shadow index template installed by `ensureNonTsdsSystemTemplate`.
+ * Ignores 404 (already removed).
+ */
+export const cleanNonTsdsSystemTemplate = async (
+  esClient: EsClient,
+  log: ScoutLogger
+): Promise<void> => {
+  try {
+    await esClient.indices.deleteIndexTemplate({ name: NON_TSDS_SHADOW_TEMPLATE_NAME });
+    log.info(`Removed shadow index template "${NON_TSDS_SHADOW_TEMPLATE_NAME}"`);
+  } catch (error: unknown) {
+    const statusCode = (error as { statusCode?: number })?.statusCode;
+    if (statusCode === 404) {
+      log.debug(
+        `Shadow index template "${NON_TSDS_SHADOW_TEMPLATE_NAME}" not found — already removed`
+      );
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    log.warning(
+      `Failed to remove shadow index template "${NON_TSDS_SHADOW_TEMPLATE_NAME}": ${message}`
+    );
+    throw error;
+  }
+};
+
 const indexInfra = async (
   deps: SequentialSynthtraceWorkerDeps,
   events: SynthtraceGenerator<InfraDocument>

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_flyout.spec.ts
@@ -18,17 +18,27 @@ import {
 } from '../../fixtures/constants';
 import {
   cleanHostsFlyoutSynthtraceData,
+  cleanNonTsdsSystemTemplate,
+  ensureNonTsdsSystemTemplate,
   ingestHostsFlyoutSynthtraceData,
 } from '../../fixtures/sequential_hosts_synthtrace';
 
 const CUSTOM_DASHBOARDS_SETTING = 'observability:enableInfrastructureAssetCustomDashboards';
 
-// Failing: See https://github.com/elastic/kibana/issues/267130
-test.describe.skip(
+test.describe(
   'Hosts Page - Flyout',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     test.beforeAll(async ({ esClient, kbnUrl, log, config, kbnClient }) => {
+      // Install a shadow template that ensures metrics-system.* data streams have the expected settings for data ingestion.
+      log.info('Sequential suite: installing non-TSDS shadow template for metrics-system.*');
+      await ensureNonTsdsSystemTemplate(esClient, log);
+
+      // Delete any existing data streams so they are re-created under the shadow template
+      // (clean reset also prevents row-count pollution from previous runs).
+      log.info('Sequential suite: resetting existing synthtrace data before ingest');
+      await cleanHostsFlyoutSynthtraceData({ esClient, kbnUrl, log, config });
+
       log.info('Sequential suite: ingesting ECS hosts + logs + APM services for flyout tests');
       await ingestHostsFlyoutSynthtraceData({ esClient, kbnUrl, log, config });
 
@@ -83,8 +93,12 @@ test.describe.skip(
     });
 
     test.afterAll(async ({ esClient, kbnUrl, log, config }) => {
+      // Delete data streams first, then the shadow template — so no window opens where
+      // a stream could be re-created against a template before the stream is gone.
       log.info('Sequential suite: cleaning synthtrace data for flyout tests');
       await cleanHostsFlyoutSynthtraceData({ esClient, kbnUrl, log, config });
+      log.info('Sequential suite: removing non-TSDS shadow template for metrics-system.*');
+      await cleanNonTsdsSystemTemplate(esClient, log);
     });
 
     test('Overview Tab - KPI charts and collapsible sections', async ({


### PR DESCRIPTION
## Summary

The `hosts_flyout.spec.ts` sequential suite ingests host metrics using **fixed historical dates** (March 2023). The suite passes `skipInstallation: true` to avoid installing the Fleet `system` package — this prevents the suite from _adding_ Fleet templates, but it cannot undo Fleet templates that **already exist in the shared ES cluster**.

In CI, multiple test suites share the same Elasticsearch cluster within a lane. Any suite that installs the Fleet `system` package configures `metrics-system.*` data streams as **TSDS (Time Series Data Stream)**, which enforces a rolling wall-clock window for `@timestamp`. Once that priority-200 composable index template is present in the cluster — regardless of how — any new `metrics-system.*` data stream is created in TSDS mode. Documents with 2023 timestamps fall outside the allowed window and are **silently rejected** by Elasticsearch (dropped via `onDrop` in the bulk helper). The infra hosts API then finds fewer than 6 hosts and the readiness poll times out.

## Fix

Before ingesting, we install a **priority-500 composable index template** covering `metrics-system.*` that explicitly omits `index.mode: time_series`:

```
synthtrace-hosts-flyout-metrics-system-non-tsds  (priority 500)
  index_patterns: ['metrics-system.*']
  data_stream: {}
  mappings:
    dynamic: true
    dynamic_templates: [{ strings_as_keyword }]   ← maps all strings as keyword
    properties: { @timestamp: date }
```

Because ES applies the highest-priority matching template, our priority-500 template wins over Fleet's priority-200 TSDS template. Any `metrics-system.*` data stream created while our template is active is a **standard (non-TSDS) stream** that accepts the fixed 2023 dates. The `strings_as_keyword` dynamic template ensures all string fields (including `host.name`) are indexed as `keyword`, which is required for the `terms` aggregation in the infra hosts API — without it, `dynamic: true` alone would map strings as `text`, silently breaking aggregations.

The `beforeAll` order is:

1. Install shadow template (upsert — idempotent, self-heals any stale leftover)
2. Delete existing `metrics-system.*` data streams so they are **re-created** under the shadow template
3. Ingest host metrics
4. Wait for the infra API to return ≥ 6 hosts

## Cleanup

`afterAll` reverses everything in the safe order:

1. Delete the data streams first
2. Remove the shadow template with `deleteIndexTemplate` (404-tolerant)

Deleting data streams before the template ensures there is no window where the template is gone but a stream could still receive writes and accidentally be re-created under a TSDS template. Once both steps complete, the ES cluster is in exactly the state it was before the suite ran — no pollution for any subsequent suite in the lane.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->