### PR TITLE
[Cases] Rename template fieldNames to fieldDefinitions, fix v1 schema bug

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -83587,7 +83587,7 @@ components:
         fieldCount:
           description: The number of fields defined in the template.
           type: integer
-        fieldNames:
+        fieldDefinitions:
           description: Metadata about each field defined in the template.
           items:
             type: object

--- a/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
+++ b/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
@@ -1155,7 +1155,7 @@ export const TemplateV2Response = lazySchema(() =>
     /**
      * Metadata about each field defined in the template.
      */
-    fieldNames: z
+    fieldDefinitions: z
       .array(
         z.object({
           name: z.string().max(256),

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
@@ -90,7 +90,7 @@ export const TemplateSchema = z.object({
   /**
    * Array of field metadata used for tooltips and label-to-storage-key resolution at search time
    */
-  fieldNames: z
+  fieldDefinitions: z
     .array(
       z.object({
         name: z.string(),

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
@@ -3196,7 +3196,7 @@ components:
         fieldCount:
           type: integer
           description: The number of fields defined in the template.
-        fieldNames:
+        fieldDefinitions:
           type: array
           description: Metadata about each field defined in the template.
           items:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/template_v2_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/template_v2_response.yaml
@@ -53,7 +53,7 @@ properties:
   fieldCount:
     type: integer
     description: The number of fields defined in the template.
-  fieldNames:
+  fieldDefinitions:
     type: array
     description: Metadata about each field defined in the template.
     items:

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/confirm_change_template_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/confirm_change_template_modal.test.tsx
@@ -14,12 +14,12 @@ import { renderWithTestingProviders } from '../../../../../common/mock';
 
 const oldTemplate = {
   name: 'Security Template',
-  fieldNames: [{ name: 'priority', label: 'Priority' }],
+  fieldDefinitions: [{ name: 'priority', label: 'Priority' }],
 };
 
 const newTemplate = {
   name: 'Observability Template',
-  fieldNames: [{ name: 'severity', label: 'Severity' }],
+  fieldDefinitions: [{ name: 'severity', label: 'Severity' }],
 };
 
 describe('ConfirmChangeTemplateModal', () => {
@@ -115,7 +115,7 @@ describe('ConfirmChangeTemplateModal', () => {
         screen.getByTestId('confirm-change-template-modal-fields-tooltip')
       ).toBeInTheDocument();
     });
-    expect(screen.getByText(newTemplate.fieldNames[0].label)).toBeInTheDocument();
+    expect(screen.getByText(newTemplate.fieldDefinitions[0].label)).toBeInTheDocument();
   });
 
   it('does not render a fields icon when a template has no fields', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/confirm_change_template_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/confirm_change_template_modal.tsx
@@ -25,7 +25,7 @@ export interface TemplateFieldSummary {
 
 export interface TemplateSummary {
   name: string;
-  fieldNames?: TemplateFieldSummary[];
+  fieldDefinitions?: TemplateFieldSummary[];
 }
 
 export interface ConfirmChangeTemplateModalProps {
@@ -45,7 +45,7 @@ const TemplateNameWithFields: FC<{ template: TemplateSummary }> = ({ template })
   return (
     <EuiText component="span" style={{ fontWeight: euiTheme.font.weight.bold }}>
       {template.name}{' '}
-      {template.fieldNames && template.fieldNames.length > 0 ? (
+      {template.fieldDefinitions && template.fieldDefinitions.length > 0 ? (
         <EuiIconTip
           type="list"
           size="s"
@@ -54,7 +54,7 @@ const TemplateNameWithFields: FC<{ template: TemplateSummary }> = ({ template })
           anchorProps={{ 'data-test-subj': 'confirm-change-template-modal-fields-icon' }}
           content={
             <div data-test-subj="confirm-change-template-modal-fields-tooltip">
-              {template.fieldNames.map((field, idx) => (
+              {template.fieldDefinitions.map((field, idx) => (
                 <div key={`${field.name}-${idx}`}>{field.label}</div>
               ))}
             </div>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/template_settings_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/template_settings_popover.test.tsx
@@ -32,14 +32,18 @@ const appliedTemplate = {
   templateId: 'template-1',
   name: 'Security Template',
   templateVersion: 1,
-  fieldNames: [{ name: 'priority', label: 'Priority', type: 'keyword', control: 'INPUT_TEXT' }],
+  fieldDefinitions: [
+    { name: 'priority', label: 'Priority', type: 'keyword', control: 'INPUT_TEXT' },
+  ],
 };
 
 const otherTemplate = {
   templateId: 'template-2',
   name: 'Observability Template',
   templateVersion: 1,
-  fieldNames: [{ name: 'severity', label: 'Severity', type: 'keyword', control: 'INPUT_TEXT' }],
+  fieldDefinitions: [
+    { name: 'severity', label: 'Severity', type: 'keyword', control: 'INPUT_TEXT' },
+  ],
 };
 
 const appliedParsedTemplate = {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/template_settings_popover.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/template_settings_popover.tsx
@@ -85,7 +85,7 @@ export const TemplateSettingsPopover: FC<TemplateSettingsPopoverProps> = ({
   const oldTemplateSummary: TemplateSummary | undefined = useMemo(
     () =>
       appliedTemplateData
-        ? { name: appliedTemplateData.name, fieldNames: appliedTemplateData.fieldNames }
+        ? { name: appliedTemplateData.name, fieldDefinitions: appliedTemplateData.fieldDefinitions }
         : undefined,
     [appliedTemplateData]
   );
@@ -95,7 +95,9 @@ export const TemplateSettingsPopover: FC<TemplateSettingsPopoverProps> = ({
       return undefined;
     }
     const template = templatesData?.templates.find((t) => t.templateId === pendingTemplateId);
-    return template ? { name: template.name, fieldNames: template.fieldNames } : undefined;
+    return template
+      ? { name: template.name, fieldDefinitions: template.fieldDefinitions }
+      : undefined;
   }, [pendingTemplateId, templatesData?.templates]);
 
   const isPendingNewTemplateDataReady =

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/api/sample_data.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/api/sample_data.ts
@@ -20,7 +20,7 @@ export const MOCK_TEMPLATES: Template[] = [
     tags: ['security', 'incident', 'critical'],
     author: 'john.doe',
     fieldCount: 8,
-    fieldNames: [
+    fieldDefinitions: [
       { name: 'severity', label: 'Severity', type: 'keyword', control: 'SELECT_BASIC' },
       { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
       {
@@ -50,7 +50,7 @@ export const MOCK_TEMPLATES: Template[] = [
     tags: ['observability', 'monitoring', 'alerts'],
     author: 'jane.smith',
     fieldCount: 5,
-    fieldNames: [
+    fieldDefinitions: [
       { name: 'service', label: 'Service', type: 'keyword', control: 'INPUT_TEXT' },
       { name: 'environment', label: 'Environment', type: 'keyword', control: 'SELECT_BASIC' },
       { name: 'alert_type', label: 'Alert Type', type: 'keyword', control: 'SELECT_BASIC' },
@@ -72,7 +72,7 @@ export const MOCK_TEMPLATES: Template[] = [
     tags: ['support', 'general'],
     author: 'bob.wilson',
     fieldCount: 4,
-    fieldNames: [
+    fieldDefinitions: [
       { name: 'category', label: 'Category', type: 'keyword', control: 'SELECT_BASIC' },
       { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
       { name: 'customer_id', label: 'Customer ID', type: 'keyword', control: 'INPUT_TEXT' },
@@ -93,7 +93,7 @@ export const MOCK_TEMPLATES: Template[] = [
     tags: ['security', 'malware', 'threat'],
     author: 'john.doe',
     fieldCount: 12,
-    fieldNames: [
+    fieldDefinitions: [
       { name: 'malware_type', label: 'Malware Type', type: 'keyword', control: 'SELECT_BASIC' },
       { name: 'file_hash', label: 'File Hash', type: 'keyword', control: 'INPUT_TEXT' },
       { name: 'file_name', label: 'File Name', type: 'keyword', control: 'INPUT_TEXT' },

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.test.tsx
@@ -148,7 +148,7 @@ describe('useTemplatesActions', () => {
     });
   });
 
-  it('handleClone does not pass author, fieldCount, fieldNames, or isDefault', () => {
+  it('handleClone does not pass author, fieldCount, fieldDefinitions, or isDefault', () => {
     const { result } = renderHook(() => useTemplatesActions(), { wrapper });
 
     act(() => {
@@ -158,7 +158,7 @@ describe('useTemplatesActions', () => {
     const { template } = cloneTemplateMock.mock.calls[0][0];
     expect(template).not.toHaveProperty('author');
     expect(template).not.toHaveProperty('fieldCount');
-    expect(template).not.toHaveProperty('fieldNames');
+    expect(template).not.toHaveProperty('fieldDefinitions');
     expect(template).not.toHaveProperty('isDefault');
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_columns.test.tsx
@@ -292,12 +292,12 @@ describe('useTemplatesColumns', () => {
       expect(screen.getByTestId('template-column-fields')).toHaveTextContent('5');
     });
 
-    it('shows beacon alongside tooltip when fieldNames are present', () => {
+    it('shows beacon alongside tooltip when fieldDefinitions are present', () => {
       const column = getFieldCountColumn();
       const template = {
         ...baseTemplate,
         fieldCount: 2,
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'severity', label: 'Severity', type: 'keyword', control: 'TEXT' },
           { name: 'hostname', label: 'Hostname', type: 'keyword', control: 'TEXT' },
         ],

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_columns.tsx
@@ -229,7 +229,7 @@ export const useTemplatesColumns = ({
             return getEmptyCellValue();
           }
 
-          const fieldNames = template.fieldNames;
+          const fieldDefinitions = template.fieldDefinitions;
           const content = (
             <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
@@ -247,13 +247,13 @@ export const useTemplatesColumns = ({
             </EuiFlexGroup>
           );
 
-          if (fieldNames && fieldNames.length > 0) {
+          if (fieldDefinitions && fieldDefinitions.length > 0) {
             return (
               <EuiToolTip
                 position="top"
                 content={
                   <div data-test-subj="template-column-fields-tooltip">
-                    {fieldNames.map((field, idx) => (
+                    {fieldDefinitions.map((field, idx) => (
                       <div key={`${field.name}-${idx}`}>{field.label}</div>
                     ))}
                   </div>

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/__test_helpers__/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/__test_helpers__/index.ts
@@ -125,23 +125,23 @@ export const makeUserAction = (
 
 /**
  * Build a `cases-templates` SO with the persisted shape the
- * analytics-v2 data view service reads. Only `attributes.fieldNames`
+ * analytics-v2 data view service reads. Only `attributes.fieldDefinitions`
  * is consumed, so the factory leaves everything else minimal.
  */
 export interface TemplateLike {
-  fieldNames?: Array<{ name: string; label?: string; type: string; control?: string }>;
+  fieldDefinitions?: Array<{ name: string; label?: string; type: string; control?: string }>;
 }
 
 export const makeTemplate = (
   id: string,
-  fieldNames: NonNullable<TemplateLike['fieldNames']>
+  fieldDefinitions: NonNullable<TemplateLike['fieldDefinitions']>
 ): SavedObject<TemplateLike> =>
   ({
     type: CASE_TEMPLATE_SAVED_OBJECT,
     id,
     namespaces: ['default'],
     references: [],
-    attributes: { fieldNames },
+    attributes: { fieldDefinitions },
   } as unknown as SavedObject<TemplateLike>);
 
 // ----- SO client `find` stub -----

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
@@ -73,8 +73,8 @@ describe('CasesAnalyticsV2DataViewService', () => {
   };
 
   describe('ensureForSpace', () => {
-    it('reads template field metadata from attributes.fieldNames (not the YAML definition string)', async () => {
-      // The persisted contract is `attributes.fieldNames`; reaching for
+    it('reads template field metadata from attributes.fieldDefinitions (not the YAML definition string)', async () => {
+      // The persisted contract is `attributes.fieldDefinitions`; reaching for
       // `attributes.definition.fields` would be `undefined` (definition
       // is a YAML string), silently emptying the runtime field map.
       const { service, dvService, deps } = setup([
@@ -306,7 +306,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
      * runtime fields forever and the data view would accumulate
      * ghost fields silently.
      */
-    it('filters templates by isLatest=true AND deletedAt=null and only requests the fieldNames attribute', async () => {
+    it('filters templates by isLatest=true AND deletedAt=null and only requests the fieldDefinitions attribute', async () => {
       const { service, dvService, deps, internalSoClient } = setup([]);
       stubMissingDataView(dvService);
 
@@ -316,7 +316,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
         expect.objectContaining({
           type: CASE_TEMPLATE_SAVED_OBJECT,
           namespaces: [spaceId],
-          fields: ['fieldNames'],
+          fields: ['fieldDefinitions'],
           filter: expect.stringContaining('isLatest: true'),
         })
       );

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
@@ -100,8 +100,8 @@ interface EnsureForSpaceDeps {
 /**
  * Subset of the template SO this service reads. Persisted
  * `attributes.definition` is the raw YAML the user submitted; structured
- * field metadata lives on `attributes.fieldNames`, populated at create /
- * update time by `toFieldNames(parsedDefinition.fields)` (see
+ * field metadata lives on `attributes.fieldDefinitions`, populated at create /
+ * update time by `toFieldDefinitions(parsedDefinition.fields)` (see
  * `services/templates/index.ts`).
  *
  * Typed loosely with `unknown` per element so a future template-field type
@@ -109,7 +109,7 @@ interface EnsureForSpaceDeps {
  * read can land without changing this interface.
  */
 interface TemplateAttributesLike {
-  fieldNames?: Array<{ name?: unknown; type?: unknown }>;
+  fieldDefinitions?: Array<{ name?: unknown; type?: unknown }>;
 }
 
 /**
@@ -421,7 +421,7 @@ export class CasesAnalyticsV2DataViewService {
   /**
    * Pages through every active template SO in the given space and extracts
    * `<name>_as_<type>` snake-keys from each template's persisted
-   * `attributes.fieldNames` array. `attributes.definition` is YAML on
+   * `attributes.fieldDefinitions` array. `attributes.definition` is YAML on
    * disk; structured `{ name, type }` only exists as transient parser
    * output during create / update.
    *
@@ -432,10 +432,10 @@ export class CasesAnalyticsV2DataViewService {
    *   - `isLatest: true` excludes old versions that a renamed template no
    *     longer publishes.
    *   - `NOT deletedAt: *` excludes soft-deleted templates.
-   * `fields: ['fieldNames']` keeps the payload limited to the only
+   * `fields: ['fieldDefinitions']` keeps the payload limited to the only
    * attribute this method reads. The SO API skips migrations for
    * partial-field reads, which is safe here because both filter fields
-   * and `fieldNames` have been on the template SO since its first model
+   * and `fieldDefinitions` have been on the template SO since its first model
    * version.
    */
   private async collectSnakeKeysForSpace(spaceId: string): Promise<string[]> {
@@ -458,12 +458,12 @@ export class CasesAnalyticsV2DataViewService {
         // only from templates in this space.
         namespaces: [spaceId],
         filter: `${CASE_TEMPLATE_SAVED_OBJECT}.attributes.isLatest: true AND NOT ${CASE_TEMPLATE_SAVED_OBJECT}.attributes.deletedAt: *`,
-        fields: ['fieldNames'],
+        fields: ['fieldDefinitions'],
       });
 
       for (const tpl of response.saved_objects) {
-        const fieldNames = tpl.attributes?.fieldNames ?? [];
-        for (const f of fieldNames) {
+        const fieldDefinitions = tpl.attributes?.fieldDefinitions ?? [];
+        for (const f of fieldDefinitions) {
           const name = typeof f?.name === 'string' ? f.name : undefined;
           const type = typeof f?.type === 'string' ? f.type : undefined;
           if (name && type) {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/search.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/search.ts
@@ -146,7 +146,7 @@ export const search = async (
     const templateMetadata = templateSOs.map((so) => ({
       templateId: so.attributes.templateId,
       templateVersion: so.attributes.templateVersion,
-      fieldNames: so.attributes.fieldNames,
+      fieldDefinitions: so.attributes.fieldDefinitions,
     }));
 
     const rawFilters = paramArgs.extendedFieldFilters;

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
@@ -2243,14 +2243,14 @@ describe('enrichCasesWithFieldLabels', () => {
       definition: '',
       templateVersion: 1,
       deletedAt: null,
-      fieldNames: [
+      fieldDefinitions: [
         { name: 'priority', label: 'Priority Level', type: 'keyword', control: 'INPUT_TEXT' },
         { name: 'effort', label: 'Effort Points', type: 'integer', control: 'INPUT_NUMBER' },
       ],
     },
   };
 
-  it('populates extended_fields_labels from the matched template fieldNames', () => {
+  it('populates extended_fields_labels from the matched template fieldDefinitions', () => {
     const result = enrichCasesWithFieldLabels([caseWithTemplate], [templateSO]);
 
     expect(result[0].extended_fields_labels).toEqual({
@@ -2304,7 +2304,7 @@ describe('enrichCasesWithFieldLabels', () => {
       attributes: {
         ...templateSO.attributes,
         templateVersion: 2,
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'priority', label: 'Priority Level v2', type: 'keyword', control: 'INPUT_TEXT' },
         ],
       },
@@ -2338,7 +2338,7 @@ describe('enrichCasesWithFieldLabels', () => {
         ...templateSO.attributes,
         templateId: 'template-id-2',
         templateVersion: 1,
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'severity', label: 'Severity Label', type: 'keyword', control: 'SELECT_BASIC' },
         ],
       },

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -724,7 +724,7 @@ export const enrichCasesWithFieldLabels = (
   const labelsByTemplateKey = new Map<string, Record<string, string>>();
   for (const so of templateSOs) {
     const fieldKeyToLabel = Object.fromEntries(
-      (so.attributes.fieldNames ?? []).map((field) => [
+      (so.attributes.fieldDefinitions ?? []).map((field) => [
         `${field.name}_as_${field.type}`,
         field.label,
       ])

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/parse_template.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/parse_template.test.ts
@@ -57,7 +57,9 @@ describe('parseTemplate', () => {
       description: 'A description',
       tags: ['tag-1', 'tag-2'],
       fieldCount: 1,
-      fieldNames: [{ name: 'test_field', label: 'Test Field', type: 'keyword', control: 'TEXT' }],
+      fieldDefinitions: [
+        { name: 'test_field', label: 'Test Field', type: 'keyword', control: 'TEXT' },
+      ],
       usageCount: 5,
       lastUsedAt: '2024-01-15T10:00:00.000Z',
       isDefault: true,
@@ -74,7 +76,7 @@ describe('parseTemplate', () => {
     expect(result.tags).toEqual(['tag-1', 'tag-2']);
     expect(result.author).toBe('test-user');
     expect(result.fieldCount).toBe(1);
-    expect(result.fieldNames).toEqual([
+    expect(result.fieldDefinitions).toEqual([
       { name: 'test_field', label: 'Test Field', type: 'keyword', control: 'TEXT' },
     ]);
     expect(result.usageCount).toBe(5);

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/parse_template.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/parse_template.ts
@@ -29,7 +29,7 @@ export const parseTemplate = (template: Template): ParsedTemplate => {
     author: template.author,
     usageCount: template.usageCount,
     fieldCount: template.fieldCount,
-    fieldNames: template.fieldNames,
+    fieldDefinitions: template.fieldDefinitions,
     lastUsedAt: template.lastUsedAt,
     isDefault: template.isDefault,
     isLatest: template.isLatest ?? false,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.test.ts
@@ -36,7 +36,7 @@ describe('caseTemplateSavedObjectType', () => {
           "fieldCount": Object {
             "type": "integer",
           },
-          "fieldNames": Object {
+          "fieldDefinitions": Object {
             "properties": Object {
               "control": Object {
                 "ignore_above": 1024,
@@ -55,6 +55,9 @@ describe('caseTemplateSavedObjectType', () => {
               },
             },
             "type": "nested",
+          },
+          "fieldNames": Object {
+            "type": "keyword",
           },
           "isDefault": Object {
             "type": "boolean",

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.ts
@@ -10,6 +10,7 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 import { type Template } from '../../../common/types/domain/template/latest';
 import { CASE_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
 import { modelVersion1 } from './model_versions/model_version_1';
+import { modelVersion2 } from './model_versions/model_version_2';
 
 const mappings = {
   dynamic: false,
@@ -55,7 +56,12 @@ const mappings = {
     fieldCount: {
       type: 'integer',
     },
+    // NOTE: deprecated in favor of `fieldDefinitions`, kept for forward-compatibility with
+    // documents written before the fieldDefinitions migration (see model_version_2).
     fieldNames: {
+      type: 'keyword',
+    },
+    fieldDefinitions: {
       type: 'nested',
       properties: {
         name: { type: 'keyword', ignore_above: 1024 },
@@ -93,6 +99,7 @@ export const caseTemplateSavedObjectType: SavedObjectsType = {
   mappings,
   modelVersions: {
     1: modelVersion1,
+    2: modelVersion2,
   },
 };
 

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_1.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_1.ts
@@ -15,6 +15,7 @@ import {
   MAX_TEMPLATE_TAG_LENGTH,
   MAX_DESCRIPTION_LENGTH,
   MAX_TITLE_LENGTH,
+  MAX_FIELD_DEFINITIONS_PER_OWNER,
 } from '../../../../common/constants';
 
 export const templateSchema = schema.object({
@@ -36,7 +37,9 @@ export const templateSchema = schema.object({
   // NOTE: 9.4 production stored this field as plain keyword strings (not nested objects), so the
   // schema here must tolerate string arrays for forward-compatibility with documents written by
   // older nodes. This was incorrectly typed as an object array in PR #269962.
-  fieldNames: schema.maybe(schema.arrayOf(schema.string())),
+  fieldNames: schema.maybe(
+    schema.arrayOf(schema.string(), { maxSize: MAX_FIELD_DEFINITIONS_PER_OWNER })
+  ),
   lastUsedAt: schema.maybe(schema.string({ maxLength: 30 })),
   isDefault: schema.maybe(schema.boolean()),
   isLatest: schema.maybe(schema.boolean()),

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_1.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_1.ts
@@ -15,7 +15,6 @@ import {
   MAX_TEMPLATE_TAG_LENGTH,
   MAX_DESCRIPTION_LENGTH,
   MAX_TITLE_LENGTH,
-  MAX_FIELD_DEFINITIONS_PER_OWNER,
 } from '../../../../common/constants';
 
 export const templateSchema = schema.object({
@@ -34,17 +33,10 @@ export const templateSchema = schema.object({
   author: schema.maybe(schema.string({ maxLength: MAX_TITLE_LENGTH })),
   usageCount: schema.maybe(schema.number()),
   fieldCount: schema.maybe(schema.number()),
-  fieldNames: schema.maybe(
-    schema.arrayOf(
-      schema.object({
-        name: schema.string({ maxLength: MAX_TITLE_LENGTH }),
-        label: schema.string({ maxLength: MAX_TITLE_LENGTH }),
-        type: schema.string({ maxLength: 50 }),
-        control: schema.string({ maxLength: 50 }),
-      }),
-      { maxSize: MAX_FIELD_DEFINITIONS_PER_OWNER }
-    )
-  ),
+  // NOTE: 9.4 production stored this field as plain keyword strings (not nested objects), so the
+  // schema here must tolerate string arrays for forward-compatibility with documents written by
+  // older nodes. This was incorrectly typed as an object array in PR #269962.
+  fieldNames: schema.maybe(schema.arrayOf(schema.string())),
   lastUsedAt: schema.maybe(schema.string({ maxLength: 30 })),
   isDefault: schema.maybe(schema.boolean()),
   isLatest: schema.maybe(schema.boolean()),

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  SavedObjectModelDataBackfillFn,
+  SavedObjectsModelDataBackfillChange,
+} from '@kbn/core-saved-objects-server';
+import { modelVersion2, templateSchemaV2 } from './model_version_2';
+
+interface TemplateAttributes {
+  fieldNames?: unknown;
+  fieldDefinitions?: unknown;
+}
+
+// Exercise the real backfill from the model version rather than a re-implementation.
+const dataBackfillChange = modelVersion2.changes.find(
+  (change): change is SavedObjectsModelDataBackfillChange => change.type === 'data_backfill'
+);
+const backfillFn = dataBackfillChange?.backfillFn as SavedObjectModelDataBackfillFn<
+  TemplateAttributes,
+  TemplateAttributes
+>;
+
+const runBackfill = (attributes: TemplateAttributes) => {
+  const doc = { id: 'template-1', type: 'cases-templates', attributes } as Parameters<
+    typeof backfillFn
+  >[0];
+  const context = {} as Parameters<typeof backfillFn>[1];
+
+  return backfillFn(doc, context) as { attributes: TemplateAttributes };
+};
+
+describe('templates model version 2', () => {
+  it('registers mappings_addition, mappings_deprecation and data_backfill changes', () => {
+    expect(modelVersion2.changes.map((change) => change.type)).toEqual([
+      'mappings_addition',
+      'mappings_deprecation',
+      'data_backfill',
+    ]);
+  });
+
+  describe('data_backfill', () => {
+    it('normalizes legacy 9.4 keyword string arrays into field definition objects', () => {
+      const { attributes } = runBackfill({ fieldNames: ['Severity', 'Priority'] });
+
+      expect(attributes.fieldDefinitions).toEqual([
+        { name: 'Severity', label: 'Severity', type: '', control: '' },
+        { name: 'Priority', label: 'Priority', type: '', control: '' },
+      ]);
+      expect(attributes.fieldNames).toBeUndefined();
+    });
+
+    it('passes through 9.5 BC2 object arrays unchanged', () => {
+      const objects = [
+        { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
+      ];
+
+      const { attributes } = runBackfill({ fieldNames: objects });
+
+      expect(attributes.fieldDefinitions).toEqual(objects);
+      expect(attributes.fieldNames).toBeUndefined();
+    });
+
+    it('produces field definitions that satisfy the v2 schema', () => {
+      const { attributes } = runBackfill({ fieldNames: ['Severity'] });
+
+      expect(() =>
+        templateSchemaV2.validate({
+          templateId: 'template-1',
+          name: 'Template',
+          owner: 'securitySolution',
+          definition: '',
+          templateVersion: 1,
+          deletedAt: null,
+          fieldDefinitions: attributes.fieldDefinitions,
+        })
+      ).not.toThrow();
+    });
+
+    it('is a no-op when fieldDefinitions is already populated', () => {
+      const { attributes } = runBackfill({
+        fieldNames: ['Severity'],
+        fieldDefinitions: [{ name: 'severity', label: 'Severity', type: 'keyword', control: 'X' }],
+      });
+
+      expect(attributes).toEqual({});
+    });
+
+    it('is a no-op when there is no legacy fieldNames value', () => {
+      const { attributes } = runBackfill({});
+
+      expect(attributes).toEqual({});
+    });
+
+    it('clears a non-array legacy value without propagating it', () => {
+      const { attributes } = runBackfill({ fieldNames: 'unexpected' });
+
+      expect(attributes.fieldDefinitions).toEqual([]);
+      expect(attributes.fieldNames).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.test.ts
@@ -51,7 +51,6 @@ describe('templates model version 2', () => {
         { name: 'Severity', label: 'Severity', type: '', control: '' },
         { name: 'Priority', label: 'Priority', type: '', control: '' },
       ]);
-      expect(attributes.fieldNames).toBeUndefined();
     });
 
     it('passes through 9.5 BC2 object arrays unchanged', () => {
@@ -62,7 +61,17 @@ describe('templates model version 2', () => {
       const { attributes } = runBackfill({ fieldNames: objects });
 
       expect(attributes.fieldDefinitions).toEqual(objects);
-      expect(attributes.fieldNames).toBeUndefined();
+    });
+
+    it('coerces malformed objects missing name/label so downstream readers stay safe', () => {
+      const { attributes } = runBackfill({
+        fieldNames: [{ label: 'Priority', type: 'keyword' }, { name: 'severity' }],
+      });
+
+      expect(attributes.fieldDefinitions).toEqual([
+        { name: '', label: 'Priority', type: 'keyword', control: '' },
+        { name: 'severity', label: '', type: '', control: '' },
+      ]);
     });
 
     it('produces field definitions that satisfy the v2 schema', () => {
@@ -96,11 +105,10 @@ describe('templates model version 2', () => {
       expect(attributes).toEqual({});
     });
 
-    it('clears a non-array legacy value without propagating it', () => {
+    it('produces empty field definitions for a non-array legacy value', () => {
       const { attributes } = runBackfill({ fieldNames: 'unexpected' });
 
       expect(attributes.fieldDefinitions).toEqual([]);
-      expect(attributes.fieldNames).toBeUndefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
+import { schema } from '@kbn/config-schema';
+import {
+  MAX_TEMPLATE_KEY_LENGTH,
+  MAX_TEMPLATE_NAME_LENGTH,
+  MAX_TEMPLATE_DESCRIPTION_LENGTH,
+  MAX_TAGS_PER_TEMPLATE,
+  MAX_TEMPLATE_TAG_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_TITLE_LENGTH,
+  MAX_FIELD_DEFINITIONS_PER_OWNER,
+} from '../../../../common/constants';
+
+export const templateSchemaV2 = schema.object({
+  templateId: schema.string({ maxLength: MAX_TEMPLATE_KEY_LENGTH }),
+  name: schema.string({ maxLength: MAX_TEMPLATE_NAME_LENGTH }),
+  owner: schema.string({ maxLength: 30 }),
+  definition: schema.string({ maxLength: MAX_DESCRIPTION_LENGTH }),
+  templateVersion: schema.number(),
+  deletedAt: schema.nullable(schema.string({ maxLength: 30 })),
+  description: schema.maybe(schema.string({ maxLength: MAX_TEMPLATE_DESCRIPTION_LENGTH })),
+  tags: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_TEMPLATE_TAG_LENGTH }), {
+      maxSize: MAX_TAGS_PER_TEMPLATE,
+    })
+  ),
+  author: schema.maybe(schema.string({ maxLength: MAX_TITLE_LENGTH })),
+  usageCount: schema.maybe(schema.number()),
+  fieldCount: schema.maybe(schema.number()),
+  fieldDefinitions: schema.maybe(
+    schema.arrayOf(
+      schema.object({
+        name: schema.string({ maxLength: MAX_TITLE_LENGTH }),
+        label: schema.string({ maxLength: MAX_TITLE_LENGTH }),
+        type: schema.string({ maxLength: 50 }),
+        control: schema.string({ maxLength: 50 }),
+      }),
+      { maxSize: MAX_FIELD_DEFINITIONS_PER_OWNER }
+    )
+  ),
+  lastUsedAt: schema.maybe(schema.string({ maxLength: 30 })),
+  isDefault: schema.maybe(schema.boolean()),
+  isLatest: schema.maybe(schema.boolean()),
+  isEnabled: schema.maybe(schema.boolean()),
+});
+
+export const modelVersion2: SavedObjectsModelVersion = {
+  changes: [
+    {
+      type: 'mappings_addition',
+      addedMappings: {
+        fieldDefinitions: {
+          type: 'nested',
+          properties: {
+            name: { type: 'keyword', ignore_above: 1024 },
+            label: { type: 'text' },
+            type: { type: 'keyword', ignore_above: 1024 },
+            control: { type: 'keyword', ignore_above: 1024 },
+          },
+        },
+      },
+    },
+    {
+      type: 'mappings_deprecation',
+      deprecatedMappings: ['fieldNames'],
+    },
+    {
+      type: 'data_backfill',
+      backfillFn: (doc) => {
+        const attrs = doc.attributes as Record<string, unknown>;
+        // fieldNames may hold string arrays (9.4 keyword storage) or object arrays
+        // (written by 9.5 BC2 before this fix) — copy whatever is present
+        if (attrs.fieldNames != null && attrs.fieldDefinitions == null) {
+          return {
+            attributes: {
+              fieldDefinitions: attrs.fieldNames,
+              fieldNames: undefined,
+            },
+          };
+        }
+        return { attributes: {} };
+      },
+    },
+  ],
+  schemas: {
+    create: templateSchemaV2,
+    forwardCompatibility: templateSchemaV2.extends({}, { unknowns: 'ignore' }),
+  },
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.ts
@@ -64,14 +64,29 @@ export const modelVersion2: SavedObjectsModelVersion = {
           ? (attrs.fieldNames as Array<string | Record<string, unknown>>)
           : [];
 
-        const fieldDefinitions = legacy.map((field) =>
-          typeof field === 'string' ? { name: field, label: field, type: '', control: '' } : field
-        );
+        const fieldDefinitions = legacy.map((field) => {
+          if (typeof field === 'string') {
+            return { name: field, label: field, type: '', control: '' };
+          }
+          // Coerce malformed objects (missing name/label) so a one-shot migration can't leave
+          // values that crash downstream readers (e.g. `field.label.toLowerCase()`).
+          if (typeof field.name !== 'string' || typeof field.label !== 'string') {
+            return {
+              name: String(field.name ?? ''),
+              label: String(field.label ?? ''),
+              type: typeof field.type === 'string' ? field.type : '',
+              control: typeof field.control === 'string' ? field.control : '',
+            };
+          }
+          return field;
+        });
 
+        // `fieldNames` is intentionally left untouched: `data_backfill` merges via lodash and drops
+        // `undefined`, so it cannot remove the attribute. The mapping is deprecated instead; the
+        // stale value is harmless and would be purged by a future `data_removal`.
         return {
           attributes: {
             fieldDefinitions,
-            fieldNames: undefined,
           },
         };
       },

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/model_versions/model_version_2.ts
@@ -7,33 +7,13 @@
 
 import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
 import { schema } from '@kbn/config-schema';
-import {
-  MAX_TEMPLATE_KEY_LENGTH,
-  MAX_TEMPLATE_NAME_LENGTH,
-  MAX_TEMPLATE_DESCRIPTION_LENGTH,
-  MAX_TAGS_PER_TEMPLATE,
-  MAX_TEMPLATE_TAG_LENGTH,
-  MAX_DESCRIPTION_LENGTH,
-  MAX_TITLE_LENGTH,
-  MAX_FIELD_DEFINITIONS_PER_OWNER,
-} from '../../../../common/constants';
+import { MAX_TITLE_LENGTH, MAX_FIELD_DEFINITIONS_PER_OWNER } from '../../../../common/constants';
+import { templateSchema } from './model_version_1';
 
-export const templateSchemaV2 = schema.object({
-  templateId: schema.string({ maxLength: MAX_TEMPLATE_KEY_LENGTH }),
-  name: schema.string({ maxLength: MAX_TEMPLATE_NAME_LENGTH }),
-  owner: schema.string({ maxLength: 30 }),
-  definition: schema.string({ maxLength: MAX_DESCRIPTION_LENGTH }),
-  templateVersion: schema.number(),
-  deletedAt: schema.nullable(schema.string({ maxLength: 30 })),
-  description: schema.maybe(schema.string({ maxLength: MAX_TEMPLATE_DESCRIPTION_LENGTH })),
-  tags: schema.maybe(
-    schema.arrayOf(schema.string({ maxLength: MAX_TEMPLATE_TAG_LENGTH }), {
-      maxSize: MAX_TAGS_PER_TEMPLATE,
-    })
-  ),
-  author: schema.maybe(schema.string({ maxLength: MAX_TITLE_LENGTH })),
-  usageCount: schema.maybe(schema.number()),
-  fieldCount: schema.maybe(schema.number()),
+// Derived from the v1 schema: drops the deprecated `fieldNames` and adds `fieldDefinitions`
+// (backfilled from `fieldNames` below).
+export const templateSchemaV2 = templateSchema.extends({
+  fieldNames: undefined,
   fieldDefinitions: schema.maybe(
     schema.arrayOf(
       schema.object({
@@ -45,10 +25,6 @@ export const templateSchemaV2 = schema.object({
       { maxSize: MAX_FIELD_DEFINITIONS_PER_OWNER }
     )
   ),
-  lastUsedAt: schema.maybe(schema.string({ maxLength: 30 })),
-  isDefault: schema.maybe(schema.boolean()),
-  isLatest: schema.maybe(schema.boolean()),
-  isEnabled: schema.maybe(schema.boolean()),
 });
 
 export const modelVersion2: SavedObjectsModelVersion = {
@@ -75,17 +51,29 @@ export const modelVersion2: SavedObjectsModelVersion = {
       type: 'data_backfill',
       backfillFn: (doc) => {
         const attrs = doc.attributes as Record<string, unknown>;
-        // fieldNames may hold string arrays (9.4 keyword storage) or object arrays
-        // (written by 9.5 BC2 before this fix) — copy whatever is present
-        if (attrs.fieldNames != null && attrs.fieldDefinitions == null) {
-          return {
-            attributes: {
-              fieldDefinitions: attrs.fieldNames,
-              fieldNames: undefined,
-            },
-          };
+
+        // Nothing to migrate when the legacy field is absent or the new field is already populated.
+        if (attrs.fieldNames == null || attrs.fieldDefinitions != null) {
+          return { attributes: {} };
         }
-        return { attributes: {} };
+
+        // Normalize the two legacy shapes into objects: 9.4 stored plain keyword strings, 9.5 BC2
+        // stored full objects. Strings only carried the name; `type`/`control` are repopulated on
+        // the next template write.
+        const legacy = Array.isArray(attrs.fieldNames)
+          ? (attrs.fieldNames as Array<string | Record<string, unknown>>)
+          : [];
+
+        const fieldDefinitions = legacy.map((field) =>
+          typeof field === 'string' ? { name: field, label: field, type: '', control: '' } : field
+        );
+
+        return {
+          attributes: {
+            fieldDefinitions,
+            fieldNames: undefined,
+          },
+        };
       },
     },
   ],

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -24,7 +24,7 @@ describe('resolveExtendedFieldFilters', () => {
     {
       templateId: 'tmpl-a',
       templateVersion: 1,
-      fieldNames: [
+      fieldDefinitions: [
         { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
         { name: 'region', label: 'Region', type: 'keyword', control: 'SELECT_BASIC' },
         { name: 'effort', label: 'Effort Level', type: 'integer', control: 'INPUT_NUMBER' },
@@ -39,7 +39,7 @@ describe('resolveExtendedFieldFilters', () => {
     {
       templateId: 'tmpl-b',
       templateVersion: 1,
-      fieldNames: [
+      fieldDefinitions: [
         { name: 'due_date', label: 'Due Date', type: 'date', control: 'DATE_PICKER' },
         { name: 'score', label: 'Score', type: 'double', control: 'INPUT_NUMBER' },
       ],
@@ -166,7 +166,7 @@ describe('resolveExtendedFieldFilters', () => {
         {
           templateId: 'tmpl-c',
           templateVersion: 1,
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'reviewers', label: 'Reviewers', type: 'keyword', control: 'USER_PICKER' },
           ],
         },
@@ -186,10 +186,10 @@ describe('resolveExtendedFieldFilters', () => {
     ]);
   });
 
-  it('handles templates with no fieldNames', () => {
+  it('handles templates with no fieldDefinitions', () => {
     const result = resolveExtendedFieldFilters(
       [{ label: 'Priority', value: 'high' }],
-      [{ templateId: 'tmpl-x', templateVersion: 1, fieldNames: undefined }]
+      [{ templateId: 'tmpl-x', templateVersion: 1, fieldDefinitions: undefined }]
     );
 
     expect(result).toEqual([]);
@@ -204,21 +204,21 @@ describe('resolveExtendedFieldFilters', () => {
         {
           templateId: 'tmpl-x',
           templateVersion: 1,
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'effort', label: 'Estimate', type: 'integer', control: 'INPUT_NUMBER' },
           ],
         },
         {
           templateId: 'tmpl-y',
           templateVersion: 1,
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'story_points', label: 'Estimate', type: 'integer', control: 'INPUT_NUMBER' },
           ],
         },
         {
           templateId: 'tmpl-z',
           templateVersion: 1,
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'effort', label: 'Estimate', type: 'integer', control: 'INPUT_NUMBER' },
           ],
         },
@@ -254,14 +254,14 @@ describe('resolveExtendedFieldFilters', () => {
         {
           templateId: 'tmpl-1',
           templateVersion: 1,
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'prio', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
           ],
         },
         {
           templateId: 'tmpl-2',
           templateVersion: 1,
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'prio', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
           ],
         },
@@ -286,7 +286,7 @@ describe('resolveExtendedFieldFilters', () => {
       {
         templateId: 'incident-template',
         templateVersion: 1,
-        fieldNames: [
+        fieldDefinitions: [
           {
             name: 'effort_estimate',
             label: 'Effort Estimate',
@@ -298,7 +298,7 @@ describe('resolveExtendedFieldFilters', () => {
       {
         templateId: 'incident-template',
         templateVersion: 2,
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'some_estimate', label: 'Some Estimate', type: 'long', control: 'INPUT_NUMBER' },
         ],
       },
@@ -327,17 +327,23 @@ describe('resolveExtendedFieldFilters', () => {
       {
         templateId: 'incident-template',
         templateVersion: 1,
-        fieldNames: [{ name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT' }],
+        fieldDefinitions: [
+          { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT' },
+        ],
       },
       {
         templateId: 'incident-template',
         templateVersion: 2,
-        fieldNames: [{ name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT' }],
+        fieldDefinitions: [
+          { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT' },
+        ],
       },
       {
         templateId: 'incident-template',
         templateVersion: 3,
-        fieldNames: [{ name: 'severity', label: 'Severity', type: 'keyword', control: 'SELECT' }],
+        fieldDefinitions: [
+          { name: 'severity', label: 'Severity', type: 'keyword', control: 'SELECT' },
+        ],
       },
     ];
 
@@ -1450,7 +1456,7 @@ describe('resolveFieldLabelSearch', () => {
     {
       templateId: 'tmpl-a',
       templateVersion: 1,
-      fieldNames: [
+      fieldDefinitions: [
         { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
         { name: 'region', label: 'Region', type: 'keyword', control: 'SELECT_BASIC' },
         {
@@ -1470,7 +1476,7 @@ describe('resolveFieldLabelSearch', () => {
     {
       templateId: 'tmpl-b',
       templateVersion: 1,
-      fieldNames: [
+      fieldDefinitions: [
         {
           name: 'start_security',
           label: 'Start date security',

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -137,7 +137,7 @@ const buildPainlessScript = (
 
 export const resolveExtendedFieldFilters = (
   extendedFieldFilters: ExtendedFieldFilter[],
-  templates: Array<Pick<Template, 'fieldNames' | 'templateId' | 'templateVersion'>>
+  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>
 ): ResolvedExtendedFieldFilter[][] => {
   const labelToMetas = buildLabelToMetasIndex(templates);
 
@@ -346,12 +346,12 @@ type LabelToMetasMap = Map<
 >;
 
 const buildLabelToMetasIndex = (
-  templates: Array<Pick<Template, 'fieldNames' | 'templateId' | 'templateVersion'>>
+  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>
 ): LabelToMetasMap => {
   const labelToMetas: LabelToMetasMap = new Map();
 
   for (const template of templates) {
-    for (const field of template.fieldNames ?? []) {
+    for (const field of template.fieldDefinitions ?? []) {
       const labelKey = field.label.toLowerCase();
       const storageKey = `${field.name}_as_${field.type}`;
 
@@ -389,7 +389,7 @@ const buildLabelToMetasIndex = (
  */
 export const resolveFieldLabelSearch = (
   tokens: LabelSearchToken[],
-  templates: Array<Pick<Template, 'fieldNames' | 'templateId' | 'templateVersion'>>
+  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>
 ): ResolvedFieldLabelFilter[] => {
   if (tokens.length === 0 || templates.length === 0) return [];
 

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
@@ -377,13 +377,13 @@ describe('TemplatesService', () => {
                   }),
                   expect.objectContaining({
                     nested: expect.objectContaining({
-                      path: `${CASE_TEMPLATE_SAVED_OBJECT}.fieldNames`,
+                      path: `${CASE_TEMPLATE_SAVED_OBJECT}.fieldDefinitions`,
                       query: expect.objectContaining({
                         bool: expect.objectContaining({
                           should: expect.arrayContaining([
                             expect.objectContaining({
                               wildcard: expect.objectContaining({
-                                [`${CASE_TEMPLATE_SAVED_OBJECT}.fieldNames.name`]:
+                                [`${CASE_TEMPLATE_SAVED_OBJECT}.fieldDefinitions.name`]:
                                   expect.objectContaining({
                                     value: '*my-search*',
                                     case_insensitive: true,
@@ -392,7 +392,8 @@ describe('TemplatesService', () => {
                             }),
                             expect.objectContaining({
                               match: expect.objectContaining({
-                                [`${CASE_TEMPLATE_SAVED_OBJECT}.fieldNames.label`]: 'my-search',
+                                [`${CASE_TEMPLATE_SAVED_OBJECT}.fieldDefinitions.label`]:
+                                  'my-search',
                               }),
                             }),
                           ]),
@@ -573,7 +574,7 @@ describe('TemplatesService', () => {
         const soMatch = createTemplateSO('so-match', {
           templateId: 't-match',
           name: 'Matching Template',
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'severity', label: 'Severity', type: 'keyword', control: 'TEXT' },
             { name: 'hostname', label: 'Hostname', type: 'keyword', control: 'TEXT' },
           ],
@@ -581,7 +582,7 @@ describe('TemplatesService', () => {
         const soNoMatch = createTemplateSO('so-nomatch', {
           templateId: 't-nomatch',
           name: 'No Match Template',
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'effort', label: 'Effort', type: 'keyword', control: 'TEXT' },
             { name: 'details', label: 'Details', type: 'keyword', control: 'TEXT' },
           ],
@@ -604,12 +605,12 @@ describe('TemplatesService', () => {
         expect(result.templates[1].fieldSearchMatches).toBe(false);
       });
 
-      it('is case-insensitive when matching fieldNames', async () => {
+      it('is case-insensitive when matching fieldDefinitions', async () => {
         const service = createService();
         const so = createTemplateSO('so-1', {
           templateId: 't-1',
           name: 'Template',
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'HostName', label: 'HostName', type: 'keyword', control: 'TEXT' },
             { name: 'Severity', label: 'Severity', type: 'keyword', control: 'TEXT' },
           ],
@@ -631,7 +632,7 @@ describe('TemplatesService', () => {
         const so = createTemplateSO('so-1', {
           templateId: 't-1',
           name: 'Template',
-          fieldNames: [
+          fieldDefinitions: [
             { name: 'severity', label: 'Severity', type: 'keyword', control: 'TEXT' },
             { name: 'hostname', label: 'Hostname', type: 'keyword', control: 'TEXT' },
           ],
@@ -645,12 +646,12 @@ describe('TemplatesService', () => {
         expect(result.templates[0].fieldSearchMatches).toBe(false);
       });
 
-      it('sets fieldSearchMatches to false when fieldNames is undefined', async () => {
+      it('sets fieldSearchMatches to false when fieldDefinitions is undefined', async () => {
         const service = createService();
         const so = createTemplateSO('so-1', {
           templateId: 't-1',
           name: 'Template',
-          // no fieldNames set
+          // no fieldDefinitions set
         });
 
         unsecuredSavedObjectsClient.search.mockResolvedValue(createMockSearchResponse([so]));
@@ -740,7 +741,7 @@ describe('TemplatesService', () => {
         templateVersion: 1,
         isLatest: false,
         owner: 'securitySolution',
-        fieldNames: [
+        fieldDefinitions: [
           {
             name: 'effort_estimate',
             label: 'Effort Estimate',
@@ -755,7 +756,7 @@ describe('TemplatesService', () => {
         templateVersion: 2,
         isLatest: true,
         owner: 'securitySolution',
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'some_estimate', label: 'Some Estimate', type: 'long', control: 'INPUT_NUMBER' },
         ],
       });
@@ -788,7 +789,7 @@ describe('TemplatesService', () => {
         templateVersion: 1,
         isLatest: false,
         owner: 'securitySolution',
-        fieldNames: [],
+        fieldDefinitions: [],
       });
       const template1V2 = createTemplateSO('t1-v2', {
         templateId: 'template-1',
@@ -796,7 +797,7 @@ describe('TemplatesService', () => {
         templateVersion: 2,
         isLatest: true,
         owner: 'securitySolution',
-        fieldNames: [],
+        fieldDefinitions: [],
       });
       const template2V1 = createTemplateSO('t2-v1', {
         templateId: 'template-2',
@@ -804,7 +805,7 @@ describe('TemplatesService', () => {
         templateVersion: 1,
         isLatest: true,
         owner: 'securitySolution',
-        fieldNames: [],
+        fieldDefinitions: [],
       });
 
       const searchResponse = createMockSearchResponse([template1V1, template1V2, template2V1]);
@@ -867,7 +868,7 @@ describe('TemplatesService', () => {
         tags: ['security', 'network'],
         author: 'alice',
         fieldCount: 1,
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'field_one', label: 'field_one', type: 'keyword', control: 'INPUT_TEXT' },
         ],
         isLatest: true,
@@ -1054,7 +1055,7 @@ describe('TemplatesService', () => {
         tags: ['updated', 'tag'],
         author: 'bob',
         fieldCount: 1,
-        fieldNames: [
+        fieldDefinitions: [
           { name: 'field_one', label: 'field_one', type: 'keyword', control: 'INPUT_TEXT' },
         ],
         isLatest: true,

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
@@ -22,7 +22,7 @@ import type {
   Template,
   UpdateTemplateInput,
 } from '../../../common/types/domain/template/v1';
-import { toFieldNames, trimFieldDefaults } from './utils';
+import { toFieldDefinitions, trimFieldDefaults } from './utils';
 import { CASE_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
 import type {
   TemplatesFindRequest,
@@ -85,7 +85,7 @@ export class TemplatesService {
         ...so.attributes,
         fieldSearchMatches:
           searchLower !== '' &&
-          (so.attributes.fieldNames ?? []).some(
+          (so.attributes.fieldDefinitions ?? []).some(
             (field) =>
               field.label.toLowerCase().includes(searchLower) ||
               field.name.toLowerCase().includes(searchLower)
@@ -261,13 +261,13 @@ export class TemplatesService {
                 },
                 {
                   nested: {
-                    path: `${SO}.fieldNames`,
+                    path: `${SO}.fieldDefinitions`,
                     query: {
                       bool: {
                         should: [
                           {
                             wildcard: {
-                              [`${SO}.fieldNames.name`]: {
+                              [`${SO}.fieldDefinitions.name`]: {
                                 value: `*${search}*`,
                                 case_insensitive: true,
                               },
@@ -275,7 +275,7 @@ export class TemplatesService {
                           },
                           {
                             match: {
-                              [`${SO}.fieldNames.label`]: search,
+                              [`${SO}.fieldDefinitions.label`]: search,
                             },
                           },
                         ],
@@ -357,7 +357,7 @@ export class TemplatesService {
         tags: input.tags,
         author,
         fieldCount: parsedDefinition.fields.length,
-        fieldNames: toFieldNames(parsedDefinition.fields),
+        fieldDefinitions: toFieldDefinitions(parsedDefinition.fields),
         isEnabled: input.isEnabled ?? true,
       } as Template,
       { refresh: true, id }
@@ -399,7 +399,7 @@ export class TemplatesService {
         tags: input.tags,
         author: currentTemplate.attributes.author,
         fieldCount: parsedDefinition.fields.length,
-        fieldNames: toFieldNames(parsedDefinition.fields),
+        fieldDefinitions: toFieldDefinitions(parsedDefinition.fields),
         usageCount: currentTemplate.attributes.usageCount,
         lastUsedAt: currentTemplate.attributes.lastUsedAt,
         isEnabled: input.isEnabled ?? currentTemplate.attributes.isEnabled ?? true,
@@ -422,7 +422,7 @@ export class TemplatesService {
       { refresh: true }
     );
 
-    // Update may shift `fieldNames` (different field set, renamed fields,
+    // Update may shift `fieldDefinitions` (different field set, renamed fields,
     // changed types). Tell v2 to refresh.
     this.dependencies.refreshAnalyticsV2DataView();
 

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/utils.test.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { toFieldNames, trimFieldDefaults } from './utils';
+import { toFieldDefinitions, trimFieldDefaults } from './utils';
 
-describe('toFieldNames', () => {
-  it('maps fields to field names with label falling back to name', () => {
+describe('toFieldDefinitions', () => {
+  it('maps fields to field definitions with label falling back to name', () => {
     const fields = [
       {
         name: 'field_one',
@@ -19,14 +19,14 @@ describe('toFieldNames', () => {
       { name: 'field_two', type: 'keyword' as const, control: 'TEXTAREA' as const },
     ];
 
-    expect(toFieldNames(fields)).toEqual([
+    expect(toFieldDefinitions(fields)).toEqual([
       { name: 'field_one', label: 'Field One', type: 'keyword', control: 'INPUT_TEXT' },
       { name: 'field_two', label: 'field_two', type: 'keyword', control: 'TEXTAREA' },
     ]);
   });
 
   it('returns an empty array when given no fields', () => {
-    expect(toFieldNames([])).toEqual([]);
+    expect(toFieldDefinitions([])).toEqual([]);
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/utils.ts
@@ -11,7 +11,7 @@ import { isInlineField } from '../../../common/types/domain/template/fields';
 
 type ParsedField = ParsedTemplate['definition']['fields'][number];
 
-export const toFieldNames = (fields: ParsedField[]) =>
+export const toFieldDefinitions = (fields: ParsedField[]) =>
   fields.filter(isInlineField).map((f) => ({
     name: f.name,
     label: f.label ?? f.name,

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/migrate_configuration.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/migrate_configuration.ts
@@ -17,7 +17,7 @@ import type { ConfigurationPersistedAttributes } from '../../common/types/config
 import type { FieldDefinition } from '../../../common/types/domain/field_definition/v1';
 import { ParsedTemplateDefinitionSchema } from '../../../common/types/domain/template/v1';
 import type { Template } from '../../../common/types/domain/template/v1';
-import { toFieldNames, trimFieldDefaults } from '../../services/templates/utils';
+import { toFieldDefinitions, trimFieldDefaults } from '../../services/templates/utils';
 import { buildFieldDefinitionYaml } from './build_field_definition_yaml';
 import { buildTemplateYaml } from './build_template_yaml';
 import type { LegacyCustomField, LegacyTemplate, MigrationCounts } from './types';
@@ -223,7 +223,7 @@ const migrateTemplates = async (
             tags: legacyTemplate.tags,
             author: 'system',
             fieldCount: parsedDefinition.fields.length,
-            fieldNames: toFieldNames(parsedDefinition.fields),
+            fieldDefinitions: toFieldDefinitions(parsedDefinition.fields),
             isEnabled: true,
           } as Template,
           { id, ...(nsOption ? { namespace: nsOption } : {}), refresh: false }


### PR DESCRIPTION
## What & Why
Renames the `cases-templates` saved object attribute `fieldNames` to `fieldDefinitions` across the domain schema, ES mapping, services, analytics-v2, and UI, since the old name no longer reflects what it stores (structured field metadata, not just names). Along the way, fixes a bug from #269962 where model version 1's config-schema incorrectly typed the field as an object array when 9.4 production actually stored plain keyword strings — model version 2 now backfills `fieldDefinitions` from the deprecated `fieldNames` and tolerates both shapes. The field keeps its existing `nested` mapping (name/label/type/control) so search behavior is unchanged — this is a near-pure rename.

## How to Test
1. Create or update a case template with several fields defined in its YAML.
2. Confirm the template list, field-count tooltip, and "change template" confirmation modal show the field names/labels correctly.
3. Search templates by a field name or label in the templates list and confirm matches still surface (`getAllTemplates` search).
4. On an upgrade from a 9.4-era index (or a doc with `fieldNames` populated), confirm the template reads back correctly with `fieldDefinitions` populated and `fieldNames` deprecated.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->