### PR TITLE
[One Workflow] Fix foreach read-undefined when source evicted between `if:` guard and loop entry

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/parallel_step/enter_parallel_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/parallel_step/enter_parallel_node_impl.ts
@@ -527,6 +527,12 @@ export class EnterParallelNodeImpl implements NodeImplementation, CancellableNod
       branchRuntime.abortController
     );
 
+    // Release the read-pins set by ensureContextReady for this branch so its
+    // pinned outputs become eviction-eligible again. Runs on every exit path
+    // (completed / failed / waiting / timed-out). A still-in-flight 'waiting'
+    // branch re-pins on the next tick's ensureContextReady call. Idempotent.
+    branchRuntime.contextManager.releaseReadPins();
+
     if (timedOut) {
       // The deadline aborted the branch's in-flight work mid-run, so the branch
       // node never wrote its own terminal status — its step execution would leak

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/parallel_step/tests/enter_parallel_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/parallel_step/tests/enter_parallel_node_impl.test.ts
@@ -850,9 +850,9 @@ describe('EnterParallelNodeImpl', () => {
     // Only runtimes that went through runBranchNode have both ensureContextReady
     // and releaseReadPins called. We filter on ensureContextReady call count to
     // distinguish the two populations.
-    type CapturedRuntime = {
+    interface CapturedRuntime {
       contextManager: { ensureContextReady: jest.Mock; releaseReadPins: jest.Mock };
-    };
+    }
     let createdRuntimes: CapturedRuntime[];
 
     const makeCapturingFactory = (branchStatus: (index: number) => ExecutionStatus) => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/parallel_step/tests/enter_parallel_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/parallel_step/tests/enter_parallel_node_impl.test.ts
@@ -100,7 +100,7 @@ describe('EnterParallelNodeImpl', () => {
         const index = Number(scopeId ?? 0);
         return {
           abortController: new AbortController(),
-          contextManager: { ensureContextReady: jest.fn() },
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
           get stepExecution() {
             return { status: branchOutcome(index), state: {} };
           },
@@ -255,7 +255,7 @@ describe('EnterParallelNodeImpl', () => {
       const scopeId = lastFrame?.nestedScopes?.[lastFrame.nestedScopes.length - 1]?.scopeId;
       const index = Number(scopeId ?? 0);
       return {
-        contextManager: { ensureContextReady: jest.fn() },
+        contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
         get stepExecution() {
           return { status: ExecutionStatus.COMPLETED, state: {} };
         },
@@ -335,7 +335,7 @@ describe('EnterParallelNodeImpl', () => {
       timeoutStepCalls.push(timeoutStep);
       return {
         abortController,
-        contextManager: { ensureContextReady: jest.fn() },
+        contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
         get stepExecution() {
           // Never settles on its own; only the timeout abort ends it.
           return { status: ExecutionStatus.RUNNING, state: {} };
@@ -578,7 +578,7 @@ describe('EnterParallelNodeImpl', () => {
         timeoutStepCalls.push(timeoutStep);
         return {
           abortController: new AbortController(),
-          contextManager: { ensureContextReady: jest.fn() },
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
           get stepExecution() {
             // Parks in a durable wait and never settles on its own.
             return { status: ExecutionStatus.WAITING, state: {} };
@@ -625,7 +625,7 @@ describe('EnterParallelNodeImpl', () => {
         timeoutStepCalls.push(timeoutStep);
         return {
           abortController: new AbortController(),
-          contextManager: { ensureContextReady: jest.fn() },
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
           get stepExecution() {
             return { status: ExecutionStatus.WAITING, state: {} };
           },
@@ -662,7 +662,7 @@ describe('EnterParallelNodeImpl', () => {
         const index = Number(scopeId ?? 0);
         return {
           abortController: new AbortController(),
-          contextManager: { ensureContextReady: jest.fn() },
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
           get stepExecution() {
             return { status: ExecutionStatus.WAITING, state: {} };
           },
@@ -758,7 +758,7 @@ describe('EnterParallelNodeImpl', () => {
       factory.createStepExecutionRuntime = jest.fn(({ nodeId }) => {
         startedNodes.push(nodeId);
         return {
-          contextManager: { ensureContextReady: jest.fn() },
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
           get stepExecution() {
             return { status: ExecutionStatus.COMPLETED, state: {} };
           },
@@ -806,7 +806,7 @@ describe('EnterParallelNodeImpl', () => {
       factory.createStepExecutionRuntime = jest.fn(({ nodeId }) => {
         const failed = nodeId === 'bad_step';
         return {
-          contextManager: { ensureContextReady: jest.fn() },
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
           get stepExecution() {
             return {
               status: failed ? ExecutionStatus.FAILED : ExecutionStatus.COMPLETED,
@@ -840,6 +840,108 @@ describe('EnterParallelNodeImpl', () => {
       expect(output).toMatchObject({ succeeded: 1, failed: 1, status: 'failed' });
       expect(output.results.map((r) => r.key)).toEqual(['ok', 'bad']);
       expect(output.results.map((r) => r.status)).toEqual(['completed', 'failed']);
+    });
+  });
+
+  describe('releaseReadPins is called on every branch exit path', () => {
+    // Captures every StepExecutionRuntime created by the factory. Note that
+    // finish() and computeResumeAt() also call createStepExecutionRuntime for
+    // read-only lookups — those runtimes never have ensureContextReady called.
+    // Only runtimes that went through runBranchNode have both ensureContextReady
+    // and releaseReadPins called. We filter on ensureContextReady call count to
+    // distinguish the two populations.
+    type CapturedRuntime = {
+      contextManager: { ensureContextReady: jest.Mock; releaseReadPins: jest.Mock };
+    };
+    let createdRuntimes: CapturedRuntime[];
+
+    const makeCapturingFactory = (branchStatus: (index: number) => ExecutionStatus) => {
+      factory.createStepExecutionRuntime = jest.fn(({ stackFrames }) => {
+        const lastFrame = stackFrames[stackFrames.length - 1];
+        const scopeId = lastFrame?.nestedScopes?.[lastFrame.nestedScopes.length - 1]?.scopeId;
+        const index = Number(scopeId ?? 0);
+        const runtime = {
+          abortController: new AbortController(),
+          contextManager: { ensureContextReady: jest.fn(), releaseReadPins: jest.fn() },
+          get stepExecution() {
+            return { status: branchStatus(index), state: {} };
+          },
+          getCurrentStepResult: () => ({ output: { branch: index }, error: undefined }),
+          timeoutStep: jest.fn(),
+        } as unknown as StepExecutionRuntime;
+        createdRuntimes.push(runtime as unknown as CapturedRuntime);
+        return runtime;
+      }) as unknown as typeof factory.createStepExecutionRuntime;
+    };
+
+    beforeEach(() => {
+      createdRuntimes = [];
+    });
+
+    // Returns the subset of captured runtimes that went through runBranchNode —
+    // identified by ensureContextReady having been called on them. Runtimes
+    // created by finish() or computeResumeAt() never call ensureContextReady.
+    const branchNodeRuntimes = (): CapturedRuntime[] =>
+      createdRuntimes.filter((rt) => rt.contextManager.ensureContextReady.mock.calls.length > 0);
+
+    it('calls releaseReadPins on each branch runtime when branches complete', async () => {
+      makeCapturingFactory(() => ExecutionStatus.COMPLETED);
+
+      await build().run();
+
+      const runRuntimes = branchNodeRuntimes();
+      expect(runRuntimes.length).toBe(3); // one per branch
+      for (const rt of runRuntimes) {
+        expect(rt.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('calls releaseReadPins on each branch runtime when branches fail', async () => {
+      makeCapturingFactory(() => ExecutionStatus.FAILED);
+
+      await build().run();
+
+      const runRuntimes = branchNodeRuntimes();
+      expect(runRuntimes.length).toBe(3); // one per branch
+      for (const rt of runRuntimes) {
+        expect(rt.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('calls releaseReadPins on each branch runtime when branches park in a durable wait', async () => {
+      makeCapturingFactory(() => ExecutionStatus.WAITING);
+
+      await build().run();
+
+      const runRuntimes = branchNodeRuntimes();
+      expect(runRuntimes.length).toBe(3); // one per branch
+      for (const rt of runRuntimes) {
+        expect(rt.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('calls releaseReadPins on each branch runtime when the per-branch timeout fires', async () => {
+      node = makeNode({ 'branch-timeout': '20ms', mode: 'settled' });
+      makeCapturingFactory(() => ExecutionStatus.RUNNING);
+      nodesFactory.create = jest.fn(
+        (branchRuntime: StepExecutionRuntime) =>
+          ({
+            run: jest.fn(
+              () =>
+                new Promise<void>((resolve) => {
+                  branchRuntime.abortController.signal.addEventListener('abort', () => resolve());
+                })
+            ),
+          } as unknown as NodeImplementation)
+      ) as unknown as typeof nodesFactory.create;
+
+      await runToCompletion();
+
+      const runRuntimes = branchNodeRuntimes();
+      expect(runRuntimes.length).toBe(3); // one per branch
+      for (const rt of runRuntimes) {
+        expect(rt.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
+      }
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
@@ -46,6 +46,15 @@ export interface StepIoServiceInit {
 export interface PrepareForReadArgs {
   node: GraphNodeUnion;
   predecessorsResolver: PredecessorsResolver;
+  /**
+   * Stable identifier for the node that is about to read context — used to
+   * key the per-consumer read-pin so parallel branches sharing one
+   * {@link StepIoService} instance cannot clobber each other's pins.
+   * Equals {@link StepExecutionRuntime.stepExecutionId} for the invoking node.
+   * Optional only for backwards-compatible callers (e.g. tests) — omitting it
+   * uses a fixed sentinel key that assumes single-consumer access.
+   */
+  consumerId?: string;
 }
 
 /**
@@ -98,6 +107,7 @@ export interface StepIoLifecycle {
   flushStepChanges(): Promise<void>;
   load(): Promise<void>;
   prepareForRead(args: PrepareForReadArgs): Promise<void>;
+  releaseReadPins(consumerId: string): void;
   releaseTransientlyRehydratedOutputs(): void;
   evictStaleLoopOutputs(innerStepIds: Iterable<string>): void;
   evictCompletedLoopsOnResume(graph: {
@@ -217,6 +227,25 @@ export class StepIoService implements StepIoWriter, StepIoLifecycle {
    * outputs they only briefly needed.
    */
   private transientlyRehydratedIds: string[] = [];
+  /**
+   * Per-consumer read-pins: the step execution ids each consuming node has
+   * pinned for the duration of its own execution. Keyed by
+   * {@link PrepareForReadArgs.consumerId} (= the consuming node's step
+   * execution id) → the set of step execution ids that node needs resident.
+   *
+   * Parallel branches share one {@link StepIoService}, so a flat Set cleared
+   * on every {@link prepareForRead} call would let one branch wipe a sibling's
+   * pins mid-flight. Keying by consumer prevents that: each node/branch
+   * releases only its own entry ({@link releaseReadPins}), and an output stays
+   * pinned until every consumer holding it has released. `isPinned` takes the
+   * union across all entries.
+   *
+   * Unlike {@link pinnedOutputIdsByScope} (loop-lifetime pin, survives many
+   * node executions), a read-pin is per-node-execution: it is set at
+   * {@link prepareForRead} and cleared at node completion via
+   * {@link releaseReadPins}.
+   */
+  private readonly readPinnedOutputIdsByConsumer = new Map<string, ReadonlySet<string>>();
 
   /**
    * Per-execution `data.set` output, keyed by step execution id. Populated
@@ -600,13 +629,43 @@ export class StepIoService implements StepIoWriter, StepIoLifecycle {
    * No-op (zero ES calls) when nothing is evicted and nothing is transiently
    * rehydrated from a previous step.
    */
-  public async prepareForRead({ node, predecessorsResolver }: PrepareForReadArgs): Promise<void> {
+  public async prepareForRead({
+    node,
+    predecessorsResolver,
+    consumerId = '__single_consumer__',
+  }: PrepareForReadArgs): Promise<void> {
+    // Fast path: eviction is disabled (default config, evictionMinBytes ===
+    // Infinity). Nothing can ever be evicted → no race possible → zero work.
+    // This must come first so the read-pin logic below only runs when eviction
+    // is actually on — computing rehydration targets unconditionally would
+    // regress the default-config per-node cost.
+    if (this.evictionMinBytes === Infinity) {
+      return;
+    }
+
+    // Compute the set of step execution ids this node will read through
+    // getContext(), then **read-pin** them before any gate or await. Two
+    // ordering rules are load-bearing:
+    //
+    //   1. Set pins before the evicted/transient early-return: if the source
+    //      was resident when a preceding guard checked it (nothing evicted yet),
+    //      both the guard and the foreach hit the old early-return and no pin
+    //      is ever set — the concurrent 500 ms eviction loop can evict the
+    //      source in the await gap between prepareForRead returning and the
+    //      foreach's own pinForeachSource (enter_foreach_node_impl.ts:48).
+    //
+    //   2. Set pins before the `await rehydrateOutputs`: resident co-neededIds
+    //      must be protected during the real ES fetch (a genuine macrotask yield
+    //      where the persistence loop can fire).
+    const neededIds = this.computeRehydrationTargets(node, predecessorsResolver);
+    this.readPinnedOutputIdsByConsumer.set(consumerId, neededIds);
+
+    // Zero-ES-call fast path: nothing is evicted and no stale transients need
+    // releasing. The read-pin above still fires so the source stays protected.
     const noPriorTransients = this.transientlyRehydratedIds.length === 0;
     if (!this.hasEvictedOutputs() && noPriorTransients) {
       return;
     }
-
-    const neededIds = this.computeRehydrationTargets(node, predecessorsResolver);
 
     // Drop the previous step's transient outputs that this step does not
     // need. Anything still in `neededIds` stays resident — `rehydrateOutputs`
@@ -617,6 +676,18 @@ export class StepIoService implements StepIoWriter, StepIoLifecycle {
     // never appear in evictedOutputIds — rehydrateOutputs filters
     // out non-evicted IDs cheaply.
     await this.rehydrateOutputs(Array.from(neededIds));
+  }
+
+  /**
+   * Releases the read-pins recorded for `consumerId` so outputs that were
+   * only needed by that node can be evicted again. Called from `runNode`'s
+   * `finally` block (and `runBranchNode`'s) after the node's synchronous
+   * context reads have completed. Idempotent — safe to call even if
+   * {@link prepareForRead} never ran for this consumer (e.g. eviction-disabled
+   * fast path).
+   */
+  public releaseReadPins(consumerId: string): void {
+    this.readPinnedOutputIdsByConsumer.delete(consumerId);
   }
 
   /**
@@ -652,8 +723,22 @@ export class StepIoService implements StepIoWriter, StepIoLifecycle {
     this.pinLoopSource(foreachStepId, sourceValue);
   }
 
-  /** True if any active loop scope has pinned this output. */
+  /**
+   * True if any active loop scope **or** any currently-executing consumer node
+   * has pinned this output. The union of two independent pin structures:
+   * - {@link pinnedOutputIdsByScope}: loop-lifetime pin, survives many nodes.
+   * - {@link readPinnedOutputIdsByConsumer}: per-node read-pin, released when
+   *   that node finishes.
+   *
+   * This is the single chokepoint consulted by every output-removal path
+   * (`isEvictionCandidate`, `isReleaseCandidate`, `dropStaleStepIo`).
+   */
   private isPinned(stepExecutionId: string): boolean {
+    for (const execIds of this.readPinnedOutputIdsByConsumer.values()) {
+      if (execIds.has(stepExecutionId)) {
+        return true;
+      }
+    }
     for (const execIdsByStepId of this.pinnedOutputIdsByScope.values()) {
       for (const execId of execIdsByStepId.values()) {
         if (execId === stepExecutionId) {
@@ -869,6 +954,10 @@ export class StepIoService implements StepIoWriter, StepIoLifecycle {
    * no-op.
    */
   public releaseTransientlyRehydratedOutputs(): void {
+    // Safety net: at workflow end no further prepareForRead will run, so any
+    // read-pins still held (e.g. from the last node) would permanently block
+    // eviction of the final-flush transients. Clear them before releasing.
+    this.readPinnedOutputIdsByConsumer.clear();
     this.releaseTransientExcept(undefined);
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/event_loop_blocking.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/event_loop_blocking.test.ts
@@ -201,6 +201,7 @@ const createBroaderSurfaceContainer = () => {
   const stepIoService = {
     hasEvictedOutputs: jest.fn().mockReturnValue(false),
     prepareForRead: jest.fn().mockResolvedValue(undefined),
+    releaseReadPins: jest.fn(),
     releaseTransientlyRehydratedOutputs: jest.fn(),
     getStepInput: jest.fn().mockReturnValue(undefined),
     getStepOutput: jest.fn(

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_execution_runtime.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_execution_runtime.test.ts
@@ -61,6 +61,7 @@ function createPassthroughStepIoService(state: WorkflowExecutionState): StepIoSe
     hasEvictedOutputs: jest.fn().mockReturnValue(false),
     rehydrateOutputs: jest.fn().mockResolvedValue(undefined),
     prepareForRead: jest.fn().mockResolvedValue(undefined),
+    releaseReadPins: jest.fn(),
     releaseTransientlyRehydratedOutputs: jest.fn(),
   } as unknown as StepIoService;
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_io_service.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_io_service.test.ts
@@ -2266,7 +2266,11 @@ describe('StepIoService', () => {
           graph.topologicalOrder
             .map((nodeId) => graph.getNode(nodeId))
             .find((n) => n.stepId === stepId)!;
-        return { graph, consumerNode: lookup('step_consumer'), unrelatedNode: lookup('step_unrelated') };
+        return {
+          graph,
+          consumerNode: lookup('step_consumer'),
+          unrelatedNode: lookup('step_unrelated'),
+        };
       }
 
       it('eviction-disabled fast path: prepareForRead is a no-op regardless of evicted state', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_io_service.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_io_service.test.ts
@@ -2237,5 +2237,299 @@ describe('StepIoService', () => {
         expect(stepExecutionRepository.getStepExecutionsByIds).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('read-pinning (prepareForRead pins referenced outputs for the consuming node)', () => {
+      // Shared graph: step_source -> step_consumer -> step_unrelated
+      function buildReadPinWorkflow() {
+        const workflow: WorkflowYaml = {
+          name: 'ReadPin',
+          version: '1',
+          description: 'test',
+          enabled: true,
+          triggers: [],
+          steps: [
+            { name: 'step_source', type: 'console', with: { message: 'src' } } as ConnectorStep,
+            {
+              name: 'step_consumer',
+              type: 'console',
+              with: { message: '{{steps.step_source.output}}' },
+            } as ConnectorStep,
+            {
+              name: 'step_unrelated',
+              type: 'console',
+              with: { message: 'static' },
+            } as ConnectorStep,
+          ],
+        };
+        const graph = WorkflowGraph.fromWorkflowDefinition(workflow);
+        const lookup = (stepId: string) =>
+          graph.topologicalOrder
+            .map((nodeId) => graph.getNode(nodeId))
+            .find((n) => n.stepId === stepId)!;
+        return { graph, consumerNode: lookup('step_consumer'), unrelatedNode: lookup('step_unrelated') };
+      }
+
+      it('eviction-disabled fast path: prepareForRead is a no-op regardless of evicted state', async () => {
+        // With evictionMinBytes === Infinity (default), the race cannot occur —
+        // prepareForRead must do zero work (no ES calls, no pins set).
+        const { state, service, stepExecutionRepository } = buildHarness();
+        const { graph, consumerNode } = buildReadPinWorkflow();
+
+        // Seed a "large" completed step — with Infinity threshold it stays resident.
+        seedCompletedStepWithSize(
+          state,
+          service,
+          'src-exec',
+          'step_source',
+          { items: 'x'.repeat(200) },
+          200,
+          'connector'
+        );
+
+        // Force eviction by directly marking the output evicted (bypasses the
+        // Infinity-gated isEvictionCandidate check; we just need hasEvictedOutputs
+        // to return true to test that the fast path still wins).
+        // We can't trivially do this through the public API when threshold is Infinity,
+        // so instead we use evictionMinBytes: 0 to confirm zero ES calls when nothing
+        // is evicted, and separately confirm the Infinity path here:
+        await service.prepareForRead({
+          node: consumerNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'consumer-exec',
+        });
+        // No ES calls — eviction disabled.
+        expect(stepExecutionRepository.getStepExecutionsByIds).not.toHaveBeenCalled();
+        // releaseReadPins must be idempotent on the fast path.
+        expect(() => service.releaseReadPins('consumer-exec')).not.toThrow();
+      });
+
+      it('read-pins a referenced output during prepareForRead, protecting it across a concurrent eviction cycle', async () => {
+        // Simulates issue #277820: step_source was resident when the preceding if:
+        // guard checked it (no eviction yet), but the 500ms flush evicts it in the
+        // gap between prepareForRead returning and the foreach's getItems().
+        //
+        // With the fix, prepareForRead pins the output BEFORE the has-evicted-outputs
+        // gate, so it is protected even when hasEvictedOutputs() was false at
+        // pin time.
+        const { state, service, stepExecutionRepository } = buildHarness({
+          evictionMinBytes: EVICTION_THRESHOLD,
+        });
+        const { graph, consumerNode, unrelatedNode } = buildReadPinWorkflow();
+
+        // Seed a large (>threshold) output and drive it through two deferred
+        // eviction cycles so it ends up evicted before the consumer runs.
+        seedCompletedStepWithSize(
+          state,
+          service,
+          'src-exec',
+          'step_source',
+          { items: 'x'.repeat(200) },
+          200,
+          'connector'
+        );
+        await service.flushStepChanges();
+        await service.flushStepChanges();
+        expect(service.hasEvictedOutputs()).toBe(true);
+
+        stepExecutionRepository.getStepExecutionsByIds.mockResolvedValue([
+          {
+            id: 'src-exec',
+            output: { items: 'x'.repeat(200) },
+            workflowRunId: 'test-workflow-execution-id',
+          } as unknown as EsWorkflowStepExecution,
+        ]);
+
+        // Consumer's prepareForRead: rehydrates src-exec and read-pins it.
+        await service.prepareForRead({
+          node: consumerNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'consumer-exec',
+        });
+        expect(service.getStepOutput('src-exec')).toEqual({ items: 'x'.repeat(200) });
+
+        // Simulate the concurrent 500ms eviction loop firing in the gap between
+        // prepareForRead returning and the step's synchronous getContext() call.
+        // Re-seed the output at the same size so it re-queues for eviction.
+        service.setStepOutput('src-exec', { items: 'x'.repeat(200) }, 200);
+        await service.flushStepChanges(); // queue it
+        await service.flushStepChanges(); // drain the deferred cycle
+
+        // The read-pin must have protected it — still resident (fails pre-fix).
+        expect(service.getStepOutput('src-exec')).toEqual({ items: 'x'.repeat(200) });
+
+        // Now the consumer finishes and releases its read-pins. Re-queue the
+        // output: the two flushes above already drained pendingOutputEvictionIds
+        // while the pin was active, so we need a fresh setStepOutput to re-enter
+        // the deferred eviction queue.
+        service.releaseReadPins('consumer-exec');
+        service.setStepOutput('src-exec', { items: 'x'.repeat(200) }, 200);
+
+        // Unrelated node runs next: neededIds is empty (references nothing and
+        // src-exec is resident so the conservative fallback does not fire).
+        // Drive the eviction cycle — src-exec is no longer pinned and evicts.
+        await service.prepareForRead({
+          node: unrelatedNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'unrelated-exec',
+        });
+        await service.flushStepChanges();
+        await service.flushStepChanges();
+        service.releaseReadPins('unrelated-exec');
+
+        // The source is no longer pinned and should be evictable again.
+        expect(service.getStepOutput('src-exec')).toBeUndefined();
+      });
+
+      it('"resident-until-the-gap" variant: pins even when hasEvictedOutputs() is false at prepareForRead time', async () => {
+        // The literal reported scenario: step_source has NOT been evicted yet
+        // when the consumer's prepareForRead runs. Both the preceding guard and
+        // the foreach would have hit the old early-return — no pin set, source
+        // evictable in the gap. This test fails if pins are set below the
+        // early-return and passes with the §6 restructure.
+        const { state, service } = buildHarness({ evictionMinBytes: EVICTION_THRESHOLD });
+        const { graph, consumerNode } = buildReadPinWorkflow();
+
+        // Seed a large output but do NOT flush — it stays resident and nothing is evicted.
+        seedCompletedStepWithSize(
+          state,
+          service,
+          'src-exec',
+          'step_source',
+          { items: 'x'.repeat(200) },
+          200,
+          'connector'
+        );
+        expect(service.hasEvictedOutputs()).toBe(false);
+
+        // Consumer's prepareForRead — should pin src-exec even though nothing is evicted.
+        await service.prepareForRead({
+          node: consumerNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'consumer-exec',
+        });
+
+        // Now flush twice to trigger the deferred eviction cycle.
+        await service.flushStepChanges(); // queue
+        await service.flushStepChanges(); // evict
+
+        // The read-pin must have blocked eviction (fails if pin was set after the gate).
+        expect(service.getStepOutput('src-exec')).toEqual({ items: 'x'.repeat(200) });
+
+        // Release and re-queue so the deferred eviction cycle can pick it up.
+        // (The previous two flushes already drained pendingOutputEvictionIds while
+        // the pin was active; calling setStepOutput re-queues for the next cycle.)
+        service.releaseReadPins('consumer-exec');
+        service.setStepOutput('src-exec', { items: 'x'.repeat(200) }, 200);
+        await service.flushStepChanges();
+        await service.flushStepChanges();
+        expect(service.getStepOutput('src-exec')).toBeUndefined();
+      });
+
+      it('releasing one consumer does not unpin outputs still held by another consumer', async () => {
+        // Parallel-branch scenario: two consumers share one StepIoService and
+        // both pin the same predecessor. Releasing one must not expose the other.
+        const { state, service, stepExecutionRepository } = buildHarness({
+          evictionMinBytes: EVICTION_THRESHOLD,
+        });
+        const { graph, consumerNode } = buildReadPinWorkflow();
+
+        seedCompletedStepWithSize(
+          state,
+          service,
+          'src-exec',
+          'step_source',
+          { items: 'x'.repeat(200) },
+          200,
+          'connector'
+        );
+        await service.flushStepChanges();
+        await service.flushStepChanges();
+
+        stepExecutionRepository.getStepExecutionsByIds.mockResolvedValue([
+          {
+            id: 'src-exec',
+            output: { items: 'x'.repeat(200) },
+            workflowRunId: 'test-workflow-execution-id',
+          } as unknown as EsWorkflowStepExecution,
+        ]);
+
+        // Two consumers both pin src-exec.
+        await service.prepareForRead({
+          node: consumerNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'consumer-a',
+        });
+        await service.prepareForRead({
+          node: consumerNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'consumer-b',
+        });
+        expect(service.getStepOutput('src-exec')).toEqual({ items: 'x'.repeat(200) });
+
+        // consumer-a finishes and releases.
+        service.releaseReadPins('consumer-a');
+
+        // Simulate eviction attempt — consumer-b still holds src-exec pinned.
+        service.setStepOutput('src-exec', { items: 'x'.repeat(200) }, 200);
+        await service.flushStepChanges();
+        await service.flushStepChanges();
+
+        // Must still be resident because consumer-b's pin is active.
+        expect(service.getStepOutput('src-exec')).toEqual({ items: 'x'.repeat(200) });
+
+        // Now consumer-b also finishes. Re-queue the output: the two flushes
+        // above already drained pendingOutputEvictionIds while consumer-b's pin
+        // was active, so we need a fresh setStepOutput to re-enter the queue.
+        service.releaseReadPins('consumer-b');
+        service.setStepOutput('src-exec', { items: 'x'.repeat(200) }, 200);
+        await service.flushStepChanges();
+        await service.flushStepChanges();
+
+        // Both released — source is evictable again.
+        expect(service.getStepOutput('src-exec')).toBeUndefined();
+      });
+
+      it('a node referencing nothing leaves its consumer set empty; unrelated outputs evict normally', async () => {
+        // Guards against over-pinning: when neededIds is empty (node templates
+        // reference nothing), no outputs are pinned and eviction proceeds normally.
+        //
+        // Important: prepareForRead is called BEFORE the output is evicted.
+        // computeRehydrationTargets has a conservative fallback: when static
+        // analysis returns an empty set BUT a predecessor is already evicted, it
+        // falls back to pinning all predecessors (guards against missed analysis).
+        // Running prepareForRead while the output is still resident means no
+        // evicted predecessor exists → no fallback → truly empty neededIds.
+        const { state, service } = buildHarness({ evictionMinBytes: EVICTION_THRESHOLD });
+        const { graph, unrelatedNode } = buildReadPinWorkflow();
+
+        // Seed output as resident (not yet flushed).
+        seedCompletedStepWithSize(
+          state,
+          service,
+          'src-exec',
+          'step_source',
+          { items: 'x'.repeat(200) },
+          200,
+          'connector'
+        );
+        expect(service.hasEvictedOutputs()).toBe(false);
+
+        // prepareForRead for unrelated_node: static analysis → empty set;
+        // hasEvictedPredecessor → false (nothing evicted yet) → neededIds = {}.
+        // src-exec must NOT be pinned.
+        await service.prepareForRead({
+          node: unrelatedNode,
+          predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+          consumerId: 'unrelated-exec',
+        });
+
+        // Drive eviction — src-exec is not pinned, so it evicts normally.
+        await service.flushStepChanges(); // queue
+        await service.flushStepChanges(); // evict
+
+        service.releaseReadPins('unrelated-exec');
+        expect(service.getStepOutput('src-exec')).toBeUndefined();
+      });
+    });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
@@ -125,6 +125,7 @@ describe('WorkflowContextManager', () => {
       hasEvictedOutputs: jest.fn().mockReturnValue(false),
       prepareForRead: jest.fn().mockResolvedValue(undefined),
       rehydrateOutputs: jest.fn().mockResolvedValue(undefined),
+      releaseReadPins: jest.fn(),
       releaseTransientlyRehydratedOutputs: jest.fn(),
       setStepInput: jest.fn((id: string, input: unknown) => stepInputs.set(id, input)),
       setStepOutput: jest.fn((id: string, output: unknown) => stepOutputs.set(id, output)),

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -88,6 +88,27 @@ export class WorkflowContextManager {
     return WorkflowScopeStack.fromStackFrames(this.stackFrames);
   }
 
+  /**
+   * Stable identifier for this node's execution — used as the consumer key
+   * in {@link StepIoService.prepareForRead} and {@link StepIoService.releaseReadPins}.
+   * Built from the same `(node.stepId, stackFrames)` the factory uses for
+   * `StepExecutionRuntime.stepExecutionId`, so they are provably identical.
+   * Lazily computed once and cached — the values are immutable after construction.
+   */
+  private get consumerExecutionId(): string {
+    if (!this._consumerExecutionId) {
+      const executionId = this.workflowExecutionState.getWorkflowExecution().id;
+      this._consumerExecutionId = buildStepExecutionId(
+        executionId,
+        this.node.stepId,
+        this.stackFrames
+      );
+    }
+    return this._consumerExecutionId;
+  }
+
+  private _consumerExecutionId: string | undefined;
+
   constructor(init: ContextManagerInit) {
     this.workflowExecutionGraph = init.workflowExecutionGraph;
     this.workflowExecutionState = init.workflowExecutionState;
@@ -109,12 +130,27 @@ export class WorkflowContextManager {
    * (`renderValueAccordingToContext`, `evaluateBooleanExpressionInContext`, etc.)
    * remain synchronous. When nothing has been evicted, this is a no-op with
    * zero overhead.
+   *
+   * Also read-pins the node's referenced outputs for the duration of this
+   * node's execution so the concurrent eviction loop cannot evict them between
+   * the pre-warm and the synchronous `getContext()` call that follows.
    */
   public async ensureContextReady(): Promise<void> {
     await this.stepIoService.prepareForRead({
       node: this.node,
       predecessorsResolver: () => this.predecessors,
+      consumerId: this.consumerExecutionId,
     });
+  }
+
+  /**
+   * Releases the read-pins set by {@link ensureContextReady} for this node.
+   * Must be called when the node finishes (success or error) so its pinned
+   * outputs become eviction candidates again. Idempotent — safe to call even
+   * if `ensureContextReady` was skipped (eviction-disabled fast path).
+   */
+  public releaseReadPins(): void {
+    this.stepIoService.releaseReadPins(this.consumerExecutionId);
   }
 
   // Any change here should be reflected in the 'getContextSchemaForPath' function for frontend validation to work

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.test.ts
@@ -83,6 +83,7 @@ describe('runNode', () => {
       flushEventLogs: jest.fn().mockResolvedValue(undefined),
       contextManager: {
         ensureContextReady: jest.fn().mockResolvedValue(undefined),
+        releaseReadPins: jest.fn(),
       },
     } as unknown as jest.Mocked<StepExecutionRuntime>;
 
@@ -493,6 +494,35 @@ describe('runNode', () => {
         'Failed to execute onCancel hook - continuing execution',
         syncError
       );
+    });
+  });
+
+  describe('releaseReadPins lifecycle hook (pin cleanup on node exit)', () => {
+    it('calls releaseReadPins on every successful run', async () => {
+      await runNode(mockParams);
+
+      expect(mockStepExecutionRuntime.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls releaseReadPins even when run() throws', async () => {
+      mockNodeImplementation.run.mockRejectedValue(new Error('node exploded'));
+
+      await runNode(mockParams);
+
+      // Error is caught → setWorkflowError, but the finally block still fires.
+      expect(mockParams.workflowRuntime.setWorkflowError).toHaveBeenCalled();
+      expect(mockStepExecutionRuntime.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls releaseReadPins on the status !== RUNNING short-circuit even though ensureContextReady never ran', async () => {
+      // Verifies idempotency: the pin release fires in finally regardless of whether
+      // ensureContextReady set any pins (eviction-disabled fast path, or early return).
+      workflowExecution.status = ExecutionStatus.CANCELLED;
+
+      await runNode(mockParams);
+
+      expect(mockNodeImplementation.run).not.toHaveBeenCalled();
+      expect(mockStepExecutionRuntime.contextManager.releaseReadPins).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -206,6 +206,13 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
     // loop's final-flush path is responsible for the workflow-end cleanup
     // — see `releaseTransientlyRehydratedOutputs` in `workflow_execution_loop`.
 
+    // Release the read-pins set by ensureContextReady so outputs that were
+    // only needed by this node become eviction-eligible again. Must run after
+    // the node's synchronous getContext() reads have all completed.
+    // Idempotent — safe even if ensureContextReady took the eviction-disabled
+    // fast path and never set any pins.
+    stepExecutionRuntime?.contextManager.releaseReadPins();
+
     nodeSpan?.end();
   }
 }


### PR DESCRIPTION
Fixes #277820.

A `foreach` step intermittently fails with `Foreach expression must evaluate to an array … resolved to undefined` when the source step output exceeds the eviction threshold. The `prepareForRead` pre-warm makes the output resident before the node runs, but does **not** pin it — the concurrent 500 ms persistence/eviction loop can evict the output in the `await` gap between `prepareForRead` returning and the foreach's own `pinForeachSource` call.

The fix folds pinning into `prepareForRead` itself: for every node, the outputs it is about to read are **read-pinned** for the duration of that node's execution and released when the node finishes. Pins are keyed by the consuming node's stable execution id so parallel branches sharing one `StepIoService` cannot clobber each other. The existing loop-scope pin (`pinForeachSource`/`pinLoopSource`) is unchanged and composes on top for cross-iteration protection.

```mermaid
sequenceDiagram
    participant EL as Eviction timer
    participant RN as runNode
    participant CM as WorkflowContextManager
    participant SIO as StepIoService

    RN->>CM: ensureContextReady
    CM->>SIO: prepareForRead
    Note over SIO: compute neededIds
    Note over SIO: pin neededIds under consumerId (new)
    Note over SIO: rehydrate if evicted
    CM-->>RN: ready

    EL-->>SIO: eviction cycle fires in gap
    Note over SIO: isPinned returns true
    Note over SIO: eviction blocked

    RN->>CM: reads source ok
    RN->>CM: releaseReadPins (new, in finally)
    CM->>SIO: delete consumerId entry
    Note over SIO: source evictable again
```

## Testing

To reproduce the race, eviction must be active (`xpack.workflows_execution_engine.eviction.minPayloadSize: 10kb` in `kibana.yml`) and a workflow must have a step producing a large output followed by a `foreach` guarded by an `if:`.

1. Enable eviction in your local config and start Kibana.
2. Create a workflow that mirrors the failing shape: a connector step returning a large array (>10 KB), an `if:` guard reading that array, then a `foreach` iterating over it.
3. Run the workflow repeatedly (or with a tight trigger loop) and observe that `foreach` never fails with `Foreach expression must evaluate to an array … resolved to undefined`.
4. Confirm no regression on a parallel-branch workflow: a `parallel` step whose branches each read the same large predecessor output should complete without errors or stalled eviction.



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->