### PR TITLE
[Security Solution] Refine draft timeline access handling in saved object workflows

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -17,6 +17,7 @@ import {
   getAllTimelineByIds,
   getDraftTimeline,
   getTimelineOrNull,
+  getSelectedTimelines,
   persistTimeline,
   resolveTimelineOrNull,
   updatePartialSavedTimeline,
@@ -1135,6 +1136,247 @@ describe('saved_object', () => {
 
       expect(result.code).toBe(200);
       expect(mockSOClientUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAllTimelineByIds draft ownership', () => {
+    let mockBulkGet: jest.Mock;
+    let mockRequest: FrameworkRequest;
+
+    const buildSO = (
+      id: string,
+      status: string,
+      createdBy: string,
+      extra: Record<string, unknown> = {}
+    ) => ({
+      ...mockSavedObject,
+      id,
+      attributes: { ...mockSavedObject.attributes, status, createdBy, ...extra },
+    });
+
+    const defaultOptions = {
+      onlyUserFavorite: null,
+      pageInfo: { pageIndex: 1, pageSize: 10 },
+      search: null,
+      sort: null,
+      status: TimelineStatusEnum.draft,
+      timelineType: null,
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockImplementation((so) => ({
+        ...mockGetTimelineValue,
+        savedObjectId: so.id,
+        status: so.attributes.status,
+        createdBy: so.attributes.createdBy,
+      }));
+      (getNotesByTimelineId as jest.Mock).mockResolvedValue([]);
+      (getAllPinnedEventsByTimelineId as jest.Mock).mockResolvedValue([]);
+      mockBulkGet = jest.fn();
+      mockRequest = {
+        user: { username: 'username' },
+        context: {
+          core: {
+            savedObjects: {
+              client: { bulkGet: mockBulkGet },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+    });
+
+    test('filters out draft timelines not owned by the requester', async () => {
+      mockBulkGet.mockResolvedValue({
+        saved_objects: [
+          buildSO('draft-mine', TimelineStatusEnum.draft, 'username'),
+          buildSO('draft-other', TimelineStatusEnum.draft, 'other-user'),
+        ],
+      });
+
+      const result = await getAllTimelineByIds(mockRequest, ['draft-mine', 'draft-other'], defaultOptions);
+
+      expect(result.totalCount).toBe(1);
+      expect(result.timeline[0].savedObjectId).toBe('draft-mine');
+    });
+
+    test('returns own draft timelines when status=draft is requested', async () => {
+      mockBulkGet.mockResolvedValue({
+        saved_objects: [buildSO('draft-mine', TimelineStatusEnum.draft, 'username')],
+      });
+
+      const result = await getAllTimelineByIds(mockRequest, ['draft-mine'], defaultOptions);
+
+      expect(result.totalCount).toBe(1);
+      expect(result.timeline[0].savedObjectId).toBe('draft-mine');
+    });
+  });
+
+  describe('copyTimeline draft ownership', () => {
+    let mockGetSO: jest.Mock;
+    let mockCreateSO: jest.Mock;
+    let mockRequest: FrameworkRequest;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (getNotesByTimelineId as jest.Mock).mockResolvedValue([]);
+      (getAllPinnedEventsByTimelineId as jest.Mock).mockResolvedValue([]);
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
+        ...mockResolvedTimeline,
+        status: TimelineStatusEnum.active,
+        createdBy: 'username',
+      });
+
+      mockCreateSO = jest.fn().mockResolvedValue({
+        id: 'new-id',
+        version: 'v1',
+        attributes: { ...mockGetTimelineValue },
+      });
+
+      mockGetSO = jest.fn().mockResolvedValue({
+        ...mockResolvedSavedObject.saved_object,
+        attributes: {
+          ...mockResolvedSavedObject.saved_object.attributes,
+          status: TimelineStatusEnum.active,
+          createdBy: 'username',
+        },
+      });
+
+      mockRequest = {
+        user: { username: 'username' },
+        context: {
+          core: {
+            savedObjects: {
+              client: {
+                get: mockGetSO,
+                create: mockCreateSO,
+              },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+    });
+
+    test('throws a Boom 404 when the source is a draft owned by a different user', async () => {
+      mockGetSO.mockResolvedValue({
+        ...mockResolvedSavedObject.saved_object,
+        attributes: {
+          ...mockResolvedSavedObject.saved_object.attributes,
+          status: TimelineStatusEnum.draft,
+          createdBy: 'other-user',
+        },
+      });
+
+      await expect(
+        copyTimeline(mockRequest, mockTimeline as unknown as SavedTimeline, 'source-id')
+      ).rejects.toMatchObject({ output: { statusCode: 404 } });
+
+      expect(mockCreateSO).not.toHaveBeenCalled();
+    });
+
+    test('succeeds when the source is a draft owned by the requester', async () => {
+      mockGetSO.mockResolvedValue({
+        ...mockResolvedSavedObject.saved_object,
+        attributes: {
+          ...mockResolvedSavedObject.saved_object.attributes,
+          status: TimelineStatusEnum.draft,
+          createdBy: 'username',
+        },
+      });
+
+      const result = await copyTimeline(
+        mockRequest,
+        mockTimeline as unknown as SavedTimeline,
+        'source-id'
+      );
+
+      expect(result.code).toBe(200);
+      expect(mockCreateSO).toHaveBeenCalledTimes(1);
+    });
+
+    test('succeeds when the source is an active (non-draft) timeline regardless of createdBy', async () => {
+      mockGetSO.mockResolvedValue({
+        ...mockResolvedSavedObject.saved_object,
+        attributes: {
+          ...mockResolvedSavedObject.saved_object.attributes,
+          status: TimelineStatusEnum.active,
+          createdBy: 'other-user',
+        },
+      });
+
+      const result = await copyTimeline(
+        mockRequest,
+        mockTimeline as unknown as SavedTimeline,
+        'source-id'
+      );
+
+      expect(result.code).toBe(200);
+      expect(mockCreateSO).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getSelectedTimelines draft ownership', () => {
+    let mockBulkGet: jest.Mock;
+    let mockFindSO: jest.Mock;
+    let mockRequest: FrameworkRequest;
+
+    const buildSO = (id: string, status: string, createdBy: string) => ({
+      ...mockSavedObject,
+      id,
+      attributes: { ...mockSavedObject.attributes, status, createdBy },
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockImplementation((so) => ({
+        ...mockGetTimelineValue,
+        savedObjectId: so.id ?? so.attributes?.savedObjectId,
+        status: so.attributes?.status,
+        createdBy: so.attributes?.createdBy,
+      }));
+      mockBulkGet = jest.fn();
+      mockFindSO = jest.fn().mockResolvedValue({ saved_objects: [], total: 0 });
+      mockRequest = {
+        user: { username: 'username' },
+        context: {
+          core: {
+            savedObjects: {
+              client: { bulkGet: mockBulkGet, find: mockFindSO },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+    });
+
+    test('filters out non-owned drafts from bulkGet results', async () => {
+      mockBulkGet.mockResolvedValue({
+        saved_objects: [
+          buildSO('tl-mine', TimelineStatusEnum.active, 'other-user'),
+          buildSO('tl-draft-mine', TimelineStatusEnum.draft, 'username'),
+          buildSO('tl-draft-other', TimelineStatusEnum.draft, 'other-user'),
+        ],
+      });
+
+      const result = await getSelectedTimelines(mockRequest, ['tl-mine', 'tl-draft-mine', 'tl-draft-other']);
+
+      expect(result.timelines).toHaveLength(2);
+      const ids = result.timelines.map((t) => t.savedObjectId);
+      expect(ids).toContain('tl-mine');
+      expect(ids).toContain('tl-draft-mine');
+      expect(ids).not.toContain('tl-draft-other');
+    });
+
+    test('returns all timelines when none are non-owned drafts', async () => {
+      mockBulkGet.mockResolvedValue({
+        saved_objects: [
+          buildSO('tl-1', TimelineStatusEnum.active, 'other-user'),
+          buildSO('tl-2', TimelineStatusEnum.active, 'username'),
+        ],
+      });
+
+      const result = await getSelectedTimelines(mockRequest, ['tl-1', 'tl-2']);
+
+      expect(result.timelines).toHaveLength(2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -423,10 +423,7 @@ describe('saved_object', () => {
         createdBy: 'username',
       });
 
-      const res = await getTimelineOrNull(
-        mockRequest,
-        '760d3d20-2142-11ec-a46f-051cb8e3154c'
-      );
+      const res = await getTimelineOrNull(mockRequest, '760d3d20-2142-11ec-a46f-051cb8e3154c');
       expect(res).not.toBeNull();
       expect(res?.status).toBe(TimelineStatusEnum.draft);
     });
@@ -438,10 +435,7 @@ describe('saved_object', () => {
         createdBy: 'other-user',
       });
 
-      const res = await getTimelineOrNull(
-        mockRequest,
-        '760d3d20-2142-11ec-a46f-051cb8e3154c'
-      );
+      const res = await getTimelineOrNull(mockRequest, '760d3d20-2142-11ec-a46f-051cb8e3154c');
       expect(res).toBeNull();
     });
 
@@ -452,10 +446,7 @@ describe('saved_object', () => {
         createdBy: 'other-user',
       });
 
-      const res = await getTimelineOrNull(
-        mockRequest,
-        '760d3d20-2142-11ec-a46f-051cb8e3154c'
-      );
+      const res = await getTimelineOrNull(mockRequest, '760d3d20-2142-11ec-a46f-051cb8e3154c');
       expect(res).not.toBeNull();
       expect(res?.status).toBe(TimelineStatusEnum.active);
     });
@@ -740,10 +731,7 @@ describe('saved_object', () => {
     it('deduplicates timeline ids before deleting', async () => {
       const duplicatedTimelineIds = ['timeline-1', 'timeline-1', 'timeline-2'];
       mockBulkGetSavedObject.mockResolvedValue({
-        saved_objects: [
-          buildActiveTimelineSO('timeline-1'),
-          buildActiveTimelineSO('timeline-2'),
-        ],
+        saved_objects: [buildActiveTimelineSO('timeline-1'), buildActiveTimelineSO('timeline-2')],
       });
 
       await deleteTimeline(mockRequest, duplicatedTimelineIds, ['search-1']);
@@ -801,9 +789,9 @@ describe('saved_object', () => {
         ],
       });
 
-      await expect(
-        deleteTimeline(mockRequest, ['timeline-1', 'timeline-2'])
-      ).rejects.toMatchObject({ output: { statusCode: 404 } });
+      await expect(deleteTimeline(mockRequest, ['timeline-1', 'timeline-2'])).rejects.toMatchObject(
+        { output: { statusCode: 404 } }
+      );
 
       expect(mockDeleteSavedObject).not.toHaveBeenCalled();
     });
@@ -1069,9 +1057,11 @@ describe('saved_object', () => {
         attributes: {},
       });
 
-      mockSOClientGet = jest.fn().mockResolvedValue(
-        buildSavedObjectForUpdate({ status: TimelineStatusEnum.active, createdBy: 'username' })
-      );
+      mockSOClientGet = jest
+        .fn()
+        .mockResolvedValue(
+          buildSavedObjectForUpdate({ status: TimelineStatusEnum.active, createdBy: 'username' })
+        );
 
       (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
         ...mockResolvedTimeline,
@@ -1194,7 +1184,11 @@ describe('saved_object', () => {
         ],
       });
 
-      const result = await getAllTimelineByIds(mockRequest, ['draft-mine', 'draft-other'], defaultOptions);
+      const result = await getAllTimelineByIds(
+        mockRequest,
+        ['draft-mine', 'draft-other'],
+        defaultOptions
+      );
 
       expect(result.totalCount).toBe(1);
       expect(result.timeline[0].savedObjectId).toBe('draft-mine');
@@ -1357,7 +1351,11 @@ describe('saved_object', () => {
         ],
       });
 
-      const result = await getSelectedTimelines(mockRequest, ['tl-mine', 'tl-draft-mine', 'tl-draft-other']);
+      const result = await getSelectedTimelines(mockRequest, [
+        'tl-mine',
+        'tl-draft-mine',
+        'tl-draft-other',
+      ]);
 
       expect(result.timelines).toHaveLength(2);
       const ids = result.timelines.map((t) => t.savedObjectId);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -16,6 +16,7 @@ import {
   getAllTimeline,
   getAllTimelineByIds,
   getDraftTimeline,
+  getTimelineOrNull,
   resolveTimelineOrNull,
   updatePartialSavedTimeline,
   copyTimeline,
@@ -355,6 +356,106 @@ describe('saved_object', () => {
 
     test('should return the timeline with resolve attributes', async () => {
       expect(result).toEqual(mockResolveTimelineResponse);
+    });
+
+    test('returns null when the resolved timeline is a draft owned by a different user', async () => {
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
+        ...mockResolvedTimeline,
+        status: TimelineStatusEnum.draft,
+        createdBy: 'other-user',
+      });
+
+      const nonOwnerRequest = {
+        user: { username: 'username' },
+        context: {
+          core: {
+            savedObjects: {
+              client: { resolve: mockResolveSavedObject },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+
+      const res = await resolveTimelineOrNull(
+        nonOwnerRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c'
+      );
+      expect(res).toBeNull();
+    });
+  });
+
+  describe('getTimelineOrNull', () => {
+    let mockGetSavedObject: jest.Mock;
+    let mockFindSavedObject: jest.Mock;
+    let mockRequest: FrameworkRequest;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue(mockResolvedTimeline);
+      mockGetSavedObject = jest.fn().mockResolvedValue(mockResolvedSavedObject.saved_object);
+      mockFindSavedObject = jest.fn().mockResolvedValue({ saved_objects: [], total: 0 });
+      mockRequest = {
+        user: { username: 'username' },
+        context: {
+          core: {
+            savedObjects: {
+              client: {
+                get: mockGetSavedObject,
+                find: mockFindSavedObject,
+              },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+    });
+
+    afterEach(() => {
+      (getNotesByTimelineId as jest.Mock).mockClear();
+      (getAllPinnedEventsByTimelineId as jest.Mock).mockClear();
+    });
+
+    test('returns the timeline when the requester is the owner of the draft', async () => {
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
+        ...mockResolvedTimeline,
+        status: TimelineStatusEnum.draft,
+        createdBy: 'username',
+      });
+
+      const res = await getTimelineOrNull(
+        mockRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c'
+      );
+      expect(res).not.toBeNull();
+      expect(res?.status).toBe(TimelineStatusEnum.draft);
+    });
+
+    test('returns null when the fetched draft belongs to a different user', async () => {
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
+        ...mockResolvedTimeline,
+        status: TimelineStatusEnum.draft,
+        createdBy: 'other-user',
+      });
+
+      const res = await getTimelineOrNull(
+        mockRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c'
+      );
+      expect(res).toBeNull();
+    });
+
+    test('returns the timeline for a non-draft regardless of createdBy', async () => {
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
+        ...mockResolvedTimeline,
+        status: TimelineStatusEnum.active,
+        createdBy: 'other-user',
+      });
+
+      const res = await getTimelineOrNull(
+        mockRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c'
+      );
+      expect(res).not.toBeNull();
+      expect(res?.status).toBe(TimelineStatusEnum.active);
     });
   });
   describe('field migrator', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -796,6 +796,25 @@ describe('saved_object', () => {
       expect(mockDeleteSavedObject).not.toHaveBeenCalled();
     });
 
+    it('throws a Boom 404 when a timeline id does not resolve via bulkGet', async () => {
+      mockBulkGetSavedObject.mockResolvedValue({
+        saved_objects: [
+          buildActiveTimelineSO('timeline-1'),
+          {
+            id: 'timeline-2',
+            type: 'siem-ui-timeline',
+            error: { statusCode: 404, error: 'Not Found', message: 'Not found' },
+          },
+        ],
+      });
+
+      await expect(deleteTimeline(mockRequest, ['timeline-1', 'timeline-2'])).rejects.toMatchObject(
+        { output: { statusCode: 404 } }
+      );
+
+      expect(mockDeleteSavedObject).not.toHaveBeenCalled();
+    });
+
     it('successfully deletes a draft timeline owned by the requester', async () => {
       mockBulkGetSavedObject.mockResolvedValue({
         saved_objects: [buildDraftTimelineSO('timeline-draft', 'username')],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -700,17 +700,35 @@ describe('saved_object', () => {
 
   describe('deleteTimeline', () => {
     let mockDeleteSavedObject: jest.Mock;
+    let mockBulkGetSavedObject: jest.Mock;
     let mockRequest: FrameworkRequest;
+
+    const buildActiveTimelineSO = (id: string, createdBy = 'username') => ({
+      id,
+      type: 'siem-ui-timeline',
+      attributes: { status: TimelineStatusEnum.active, createdBy },
+      references: [],
+    });
+
+    const buildDraftTimelineSO = (id: string, createdBy = 'username') => ({
+      id,
+      type: 'siem-ui-timeline',
+      attributes: { status: TimelineStatusEnum.draft, createdBy },
+      references: [],
+    });
 
     beforeEach(() => {
       jest.clearAllMocks();
       mockDeleteSavedObject = jest.fn().mockResolvedValue(undefined);
+      mockBulkGetSavedObject = jest.fn();
       mockRequest = {
+        user: { username: 'username' },
         context: {
           core: {
             savedObjects: {
               client: {
                 delete: mockDeleteSavedObject,
+                bulkGet: mockBulkGetSavedObject,
               },
             },
           },
@@ -720,6 +738,12 @@ describe('saved_object', () => {
 
     it('deduplicates timeline ids before deleting', async () => {
       const duplicatedTimelineIds = ['timeline-1', 'timeline-1', 'timeline-2'];
+      mockBulkGetSavedObject.mockResolvedValue({
+        saved_objects: [
+          buildActiveTimelineSO('timeline-1'),
+          buildActiveTimelineSO('timeline-2'),
+        ],
+      });
 
       await deleteTimeline(mockRequest, duplicatedTimelineIds, ['search-1']);
 
@@ -732,6 +756,14 @@ describe('saved_object', () => {
     });
 
     it('processes timeline deletes in bounded batches', async () => {
+      const timelineIds = Array.from({ length: 11 }, (_, index) => `timeline-${index}`);
+
+      let resolveBulkGet!: (val: unknown) => void;
+      const bulkGetPromise = new Promise((resolve) => {
+        resolveBulkGet = resolve;
+      });
+      mockBulkGetSavedObject.mockReturnValue(bulkGetPromise);
+
       const pendingDeletes: Array<() => void> = [];
       const startedDeleteCalls: string[] = [];
       mockDeleteSavedObject.mockImplementation(
@@ -741,9 +773,12 @@ describe('saved_object', () => {
             pendingDeletes.push(() => resolve(undefined));
           })
       );
-      const timelineIds = Array.from({ length: 11 }, (_, index) => `timeline-${index}`);
 
       const deletePromise = deleteTimeline(mockRequest, timelineIds);
+
+      // Resolve the bulkGet with all active SOs, then let the first batch start
+      resolveBulkGet({ saved_objects: timelineIds.map((id) => buildActiveTimelineSO(id)) });
+      await new Promise(process.nextTick);
       await Promise.resolve();
 
       expect(startedDeleteCalls).toHaveLength(10);
@@ -755,6 +790,47 @@ describe('saved_object', () => {
 
       pendingDeletes.forEach((resolveDelete) => resolveDelete());
       await deletePromise;
+    });
+
+    it('throws a Boom 404 when any draft timeline is not owned by the requester', async () => {
+      mockBulkGetSavedObject.mockResolvedValue({
+        saved_objects: [
+          buildActiveTimelineSO('timeline-1'),
+          buildDraftTimelineSO('timeline-2', 'other-user'),
+        ],
+      });
+
+      await expect(
+        deleteTimeline(mockRequest, ['timeline-1', 'timeline-2'])
+      ).rejects.toMatchObject({ output: { statusCode: 404 } });
+
+      expect(mockDeleteSavedObject).not.toHaveBeenCalled();
+    });
+
+    it('successfully deletes a draft timeline owned by the requester', async () => {
+      mockBulkGetSavedObject.mockResolvedValue({
+        saved_objects: [buildDraftTimelineSO('timeline-draft', 'username')],
+      });
+
+      await deleteTimeline(mockRequest, ['timeline-draft']);
+
+      expect(mockDeleteSavedObject).toHaveBeenCalledTimes(1);
+      expect(mockDeleteSavedObject).toHaveBeenCalledWith('siem-ui-timeline', 'timeline-draft');
+    });
+
+    it('successfully deletes active (non-draft) timelines regardless of createdBy', async () => {
+      mockBulkGetSavedObject.mockResolvedValue({
+        saved_objects: [
+          buildActiveTimelineSO('timeline-1', 'other-user'),
+          buildActiveTimelineSO('timeline-2', 'another-user'),
+        ],
+      });
+
+      await deleteTimeline(mockRequest, ['timeline-1', 'timeline-2']);
+
+      expect(mockDeleteSavedObject).toHaveBeenCalledTimes(2);
+      expect(mockDeleteSavedObject).toHaveBeenCalledWith('siem-ui-timeline', 'timeline-1');
+      expect(mockDeleteSavedObject).toHaveBeenCalledWith('siem-ui-timeline', 'timeline-2');
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -28,7 +28,7 @@ import {
   getAllPinnedEventsByTimelineId,
   persistPinnedEventOnTimeline,
 } from '../pinned_events';
-import { TimelineTypeEnum } from '../../../../../common/api/timeline';
+import { TimelineStatusEnum, TimelineTypeEnum } from '../../../../../common/api/timeline';
 import type {
   GetTimelinesResponse,
   ResolvedTimeline,
@@ -282,6 +282,31 @@ describe('saved_object', () => {
           },
         ],
       });
+    });
+
+    test('should apply createdBy/updatedBy owner filter when status=draft', async () => {
+      mockFindSavedObject.mockClear();
+      mockFindSavedObject.mockResolvedValue({ saved_objects: [], total: 0 });
+
+      await getAllTimeline(
+        mockRequest,
+        false,
+        pageInfo,
+        null,
+        null,
+        TimelineStatusEnum.draft,
+        null
+      );
+
+      expect(mockFindSavedObject.mock.calls[0][0].filter).toContain(
+        'siem-ui-timeline.attributes.updatedBy: "username"'
+      );
+      expect(mockFindSavedObject.mock.calls[0][0].filter).toContain(
+        'siem-ui-timeline.attributes.createdBy: "username"'
+      );
+      expect(mockFindSavedObject.mock.calls[0][0].filter).toContain(
+        'siem-ui-timeline.attributes.status: draft'
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -17,6 +17,7 @@ import {
   getAllTimelineByIds,
   getDraftTimeline,
   getTimelineOrNull,
+  persistTimeline,
   resolveTimelineOrNull,
   updatePartialSavedTimeline,
   copyTimeline,
@@ -966,6 +967,98 @@ describe('saved_object', () => {
       expect(result.timeline[0].favorite).toEqual([
         expect.objectContaining({ userName: 'username' }),
       ]);
+    });
+  });
+
+  describe('updateTimeline (via persistTimeline)', () => {
+    let mockSOClientGet: jest.Mock;
+    let mockSOClientUpdate: jest.Mock;
+    let mockRequest: FrameworkRequest;
+
+    const buildSavedObjectForUpdate = (overrides: Record<string, unknown> = {}) => ({
+      ...mockResolvedSavedObject.saved_object,
+      attributes: {
+        ...mockResolvedSavedObject.saved_object.attributes,
+        ...overrides,
+      },
+      references: [],
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockSOClientUpdate = jest.fn().mockResolvedValue({
+        ...mockResolvedSavedObject.saved_object,
+        attributes: {},
+      });
+
+      mockSOClientGet = jest.fn().mockResolvedValue(
+        buildSavedObjectForUpdate({ status: TimelineStatusEnum.active, createdBy: 'username' })
+      );
+
+      (convertSavedObjectToSavedTimeline as jest.Mock).mockReturnValue({
+        ...mockResolvedTimeline,
+        status: TimelineStatusEnum.active,
+        createdBy: 'username',
+      });
+
+      mockRequest = {
+        user: { username: 'username' },
+        context: {
+          core: {
+            savedObjects: {
+              client: {
+                get: mockSOClientGet,
+                update: mockSOClientUpdate,
+              },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+    });
+
+    test('throws a Boom 404 when the requester is not the owner of a draft timeline', async () => {
+      mockSOClientGet.mockResolvedValue(
+        buildSavedObjectForUpdate({ status: TimelineStatusEnum.draft, createdBy: 'other-user' })
+      );
+
+      await expect(
+        persistTimeline(mockRequest, '760d3d20-2142-11ec-a46f-051cb8e3154c', null, {})
+      ).rejects.toMatchObject({ output: { statusCode: 404 } });
+
+      expect(mockSOClientUpdate).not.toHaveBeenCalled();
+    });
+
+    test('succeeds when the requester is the owner of the draft timeline', async () => {
+      mockSOClientGet.mockResolvedValue(
+        buildSavedObjectForUpdate({ status: TimelineStatusEnum.draft, createdBy: 'username' })
+      );
+
+      const result = await persistTimeline(
+        mockRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c',
+        null,
+        {}
+      );
+
+      expect(result.code).toBe(200);
+      expect(mockSOClientUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('succeeds for an active (non-draft) timeline regardless of createdBy', async () => {
+      mockSOClientGet.mockResolvedValue(
+        buildSavedObjectForUpdate({ status: TimelineStatusEnum.active, createdBy: 'other-user' })
+      );
+
+      const result = await persistTimeline(
+        mockRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c',
+        null,
+        {}
+      );
+
+      expect(result.code).toBe(200);
+      expect(mockSOClientUpdate).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { getOr } from 'lodash/fp';
+import * as Boom from '@hapi/boom';
 
 import {
   type SavedObject,
@@ -625,6 +626,13 @@ const updateTimeline = async ({
       timelineSavedObjectType,
       timelineId
     );
+
+  if (
+    rawTimelineSavedObject.attributes.status === TimelineStatusEnum.draft &&
+    rawTimelineSavedObject.attributes.createdBy !== request.user?.username
+  ) {
+    throw Boom.notFound();
+  }
 
   const { transformedFields: migratedPatchAttributes, references } =
     timelineFieldsMigrator.extractFieldsToReferences<TimelineWithoutExternalRefs>({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -16,6 +16,7 @@ import {
 } from '@kbn/core/server';
 import { isSavedObjectErrorResult } from '@kbn/core-saved-objects-server';
 import type { AuthenticatedUser } from '@kbn/security-plugin/server';
+import { getUserDisplayName } from '@kbn/user-profile-components';
 
 import { UNAUTHENTICATED_USER } from '../../../../../common/constants';
 import type {
@@ -88,7 +89,7 @@ export const getTimelineOrNull = async (
   } catch (e) {}
   if (
     timeline?.status === TimelineStatusEnum.draft &&
-    timeline.createdBy !== frameworkRequest.user?.username
+    timeline.createdBy !== getRequestUserDisplayName(frameworkRequest)
   ) {
     return null;
   }
@@ -103,7 +104,7 @@ export const resolveTimelineOrNull = async (
     const resolvedTimeline = await resolveSavedTimeline(frameworkRequest, savedObjectId);
     if (
       resolvedTimeline.timeline.status === TimelineStatusEnum.draft &&
-      resolvedTimeline.timeline.createdBy !== frameworkRequest.user?.username
+      resolvedTimeline.timeline.createdBy !== getRequestUserDisplayName(frameworkRequest)
     ) {
       return null;
     }
@@ -190,10 +191,16 @@ const getTimelineFavoriteFilter = ({
 const combineFilters = (filters: Array<string | null>) =>
   filters.filter((f) => f != null).join(' and ');
 
+// Returns the same display name that pickSavedTimeline stores in createdBy/updatedBy so that
+// ownership comparisons are consistent regardless of auth provider (e.g. SAML users whose
+// full_name differs from their username).
+const getRequestUserDisplayName = (request: FrameworkRequest): string =>
+  request.user ? getUserDisplayName(request.user) : UNAUTHENTICATED_USER;
+
 const getTimelinesCreatedAndUpdatedByCurrentUser = ({ request }: { request: FrameworkRequest }) => {
-  const username = request.user?.username ?? UNAUTHENTICATED_USER;
-  const updatedBy = `siem-ui-timeline.attributes.updatedBy: "${username}"`;
-  const createdBy = `siem-ui-timeline.attributes.createdBy: "${username}"`;
+  const displayName = getRequestUserDisplayName(request);
+  const updatedBy = `siem-ui-timeline.attributes.updatedBy: "${displayName}"`;
+  const createdBy = `siem-ui-timeline.attributes.createdBy: "${displayName}"`;
   return combineFilters([updatedBy, createdBy]);
 };
 
@@ -324,7 +331,7 @@ export const getAllTimelineByIds = async (
     timelineType: TimelineType | null;
   }
 ): Promise<GetTimelinesResponse> => {
-  const userName = request.user?.username ?? UNAUTHENTICATED_USER;
+  const userName = getRequestUserDisplayName(request);
   const savedObjectsClient = (await request.context.core).savedObjects.client;
 
   const uniqueIds = [...new Set(ids)];
@@ -635,7 +642,7 @@ const updateTimeline = async ({
 
   if (
     rawTimelineSavedObject.attributes.status === TimelineStatusEnum.draft &&
-    rawTimelineSavedObject.attributes.createdBy !== request.user?.username
+    rawTimelineSavedObject.attributes.createdBy !== getRequestUserDisplayName(request)
   ) {
     throw Boom.notFound();
   }
@@ -732,14 +739,14 @@ export const deleteTimeline = async (
     uniqueTimelineIds.map((id) => ({ id, type: timelineSavedObjectType }))
   );
 
-  const currentUsername = request.user?.username;
+  const currentUserDisplayName = getRequestUserDisplayName(request);
   let hasNonOwnerDraft = false;
   const allowedIds: string[] = [];
 
   for (const savedObject of bulkGetResponse.saved_objects) {
     if (!isSavedObjectErrorResult(savedObject)) {
       const { status, createdBy } = savedObject.attributes;
-      if (status === TimelineStatusEnum.draft && createdBy !== currentUsername) {
+      if (status === TimelineStatusEnum.draft && createdBy !== currentUserDisplayName) {
         hasNonOwnerDraft = true;
       } else {
         allowedIds.push(savedObject.id);
@@ -781,7 +788,7 @@ export const copyTimeline = async (
   );
   if (
     sourceSO.attributes.status === TimelineStatusEnum.draft &&
-    sourceSO.attributes.createdBy !== request.user?.username
+    sourceSO.attributes.createdBy !== getRequestUserDisplayName(request)
   ) {
     throw Boom.notFound();
   }
@@ -959,7 +966,7 @@ export const getSelectedTimelines = async (
   timelineIds?: string[] | null
 ) => {
   const savedObjectsClient = (await request.context.core).savedObjects.client;
-  const currentUsername = request.user?.username;
+  const currentUserDisplayName = getRequestUserDisplayName(request);
   let exportedIds = timelineIds;
   if (timelineIds == null || timelineIds.length === 0) {
     const { timeline: savedAllTimelines } = await getAllTimeline(
@@ -994,7 +1001,7 @@ export const getSelectedTimelines = async (
       if (!isSavedObjectErrorResult(savedObject)) {
         if (
           savedObject.attributes.status === TimelineStatusEnum.draft &&
-          savedObject.attributes.createdBy !== currentUsername
+          savedObject.attributes.createdBy !== currentUserDisplayName
         ) {
           return acc;
         }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -722,8 +722,32 @@ export const deleteTimeline = async (
   const savedObjectsClient = (await request.context.core).savedObjects.client;
   const uniqueTimelineIds = [...new Set(timelineIds)];
 
-  for (let index = 0; index < uniqueTimelineIds.length; index += DELETE_TIMELINE_BATCH_SIZE) {
-    const timelineIdsBatch = uniqueTimelineIds.slice(index, index + DELETE_TIMELINE_BATCH_SIZE);
+  const bulkGetResponse = await savedObjectsClient.bulkGet<SavedObjectTimelineWithoutExternalRefs>(
+    uniqueTimelineIds.map((id) => ({ id, type: timelineSavedObjectType }))
+  );
+
+  const currentUsername = request.user?.username;
+  let hasNonOwnerDraft = false;
+  const allowedIds: string[] = [];
+
+  for (const savedObject of bulkGetResponse.saved_objects) {
+    if (isSavedObjectErrorResult(savedObject)) {
+      continue;
+    }
+    const { status, createdBy } = savedObject.attributes;
+    if (status === TimelineStatusEnum.draft && createdBy !== currentUsername) {
+      hasNonOwnerDraft = true;
+    } else {
+      allowedIds.push(savedObject.id);
+    }
+  }
+
+  if (hasNonOwnerDraft) {
+    throw Boom.notFound();
+  }
+
+  for (let index = 0; index < allowedIds.length; index += DELETE_TIMELINE_BATCH_SIZE) {
+    const timelineIdsBatch = allowedIds.slice(index, index + DELETE_TIMELINE_BATCH_SIZE);
 
     await Promise.all(
       timelineIdsBatch.map((timelineId) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -331,7 +331,8 @@ export const getAllTimelineByIds = async (
     timelineType: TimelineType | null;
   }
 ): Promise<GetTimelinesResponse> => {
-  const userName = getRequestUserDisplayName(request);
+  const userName = request.user?.username ?? UNAUTHENTICATED_USER;
+  const ownerDisplayName = getRequestUserDisplayName(request);
   const savedObjectsClient = (await request.context.core).savedObjects.client;
 
   const uniqueIds = [...new Set(ids)];
@@ -345,7 +346,7 @@ export const getAllTimelineByIds = async (
         if (isSavedObjectErrorResult(savedObject)) return false;
         if (
           savedObject.attributes.status === TimelineStatusEnum.draft &&
-          savedObject.attributes.createdBy !== userName
+          savedObject.attributes.createdBy !== ownerDisplayName
         ) {
           return false;
         }
@@ -744,13 +745,14 @@ export const deleteTimeline = async (
   const allowedIds: string[] = [];
 
   for (const savedObject of bulkGetResponse.saved_objects) {
-    if (!isSavedObjectErrorResult(savedObject)) {
-      const { status, createdBy } = savedObject.attributes;
-      if (status === TimelineStatusEnum.draft && createdBy !== currentUserDisplayName) {
-        hasNonOwnerDraft = true;
-      } else {
-        allowedIds.push(savedObject.id);
-      }
+    if (isSavedObjectErrorResult(savedObject)) {
+      throw Boom.notFound();
+    }
+    const { status, createdBy } = savedObject.attributes;
+    if (status === TimelineStatusEnum.draft && createdBy !== currentUserDisplayName) {
+      hasNonOwnerDraft = true;
+    } else {
+      allowedIds.push(savedObject.id);
     }
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -335,8 +335,16 @@ export const getAllTimelineByIds = async (
   const enrichedTimelines = await Promise.all(
     bulkResponse.saved_objects
       .filter(
-        (savedObject): savedObject is SavedObject<SavedObjectTimelineWithoutExternalRefs> =>
-          !isSavedObjectErrorResult(savedObject)
+        (savedObject): savedObject is SavedObject<SavedObjectTimelineWithoutExternalRefs> => {
+          if (isSavedObjectErrorResult(savedObject)) return false;
+          if (
+            savedObject.attributes.status === TimelineStatusEnum.draft &&
+            savedObject.attributes.createdBy !== userName
+          ) {
+            return false;
+          }
+          return true;
+        }
       )
       .map(async (savedObject) => {
         const migratedSO = timelineFieldsMigrator.populateFieldsFromReferences(savedObject);
@@ -770,6 +778,17 @@ export const copyTimeline = async (
 ): Promise<InternalTimelineResponse> => {
   const savedObjectsClient = (await request.context.core).savedObjects.client;
 
+  const sourceSO = await savedObjectsClient.get<SavedObjectTimelineWithoutExternalRefs>(
+    timelineSavedObjectType,
+    timelineId
+  );
+  if (
+    sourceSO.attributes.status === TimelineStatusEnum.draft &&
+    sourceSO.attributes.createdBy !== request.user?.username
+  ) {
+    throw Boom.notFound();
+  }
+
   // Fetch all objects that need to be copied
   const [notes, pinnedEvents] = await Promise.all([
     note.getNotesByTimelineId(request, timelineId),
@@ -943,6 +962,7 @@ export const getSelectedTimelines = async (
   timelineIds?: string[] | null
 ) => {
   const savedObjectsClient = (await request.context.core).savedObjects.client;
+  const currentUsername = request.user?.username;
   let exportedIds = timelineIds;
   if (timelineIds == null || timelineIds.length === 0) {
     const { timeline: savedAllTimelines } = await getAllTimeline(
@@ -975,6 +995,12 @@ export const getSelectedTimelines = async (
   } = savedObjects.saved_objects.reduce(
     (acc, savedObject) => {
       if (!isSavedObjectErrorResult(savedObject)) {
+        if (
+          savedObject.attributes.status === TimelineStatusEnum.draft &&
+          savedObject.attributes.createdBy !== currentUsername
+        ) {
+          return acc;
+        }
         const populatedTimeline = timelineFieldsMigrator.populateFieldsFromReferences(savedObject);
 
         return {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -213,9 +213,14 @@ export const getAllTimeline = async (
 ): Promise<GetTimelinesResponse> => {
   const searchTerm = search != null ? search : undefined;
   const searchFields = ['title', 'description'];
+  const ownerFilter =
+    status === TimelineStatusEnum.draft
+      ? getTimelinesCreatedAndUpdatedByCurrentUser({ request })
+      : null;
   const filter = combineFilters([
     getTimelineTypeFilter(timelineType ?? null, status ?? null),
     getTimelineFavoriteFilter({ onlyUserFavorite, request }),
+    ownerFilter,
   ]);
   const options: SavedObjectsFindOptions = {
     type: timelineSavedObjectType,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -334,18 +334,16 @@ export const getAllTimelineByIds = async (
 
   const enrichedTimelines = await Promise.all(
     bulkResponse.saved_objects
-      .filter(
-        (savedObject): savedObject is SavedObject<SavedObjectTimelineWithoutExternalRefs> => {
-          if (isSavedObjectErrorResult(savedObject)) return false;
-          if (
-            savedObject.attributes.status === TimelineStatusEnum.draft &&
-            savedObject.attributes.createdBy !== userName
-          ) {
-            return false;
-          }
-          return true;
+      .filter((savedObject): savedObject is SavedObject<SavedObjectTimelineWithoutExternalRefs> => {
+        if (isSavedObjectErrorResult(savedObject)) return false;
+        if (
+          savedObject.attributes.status === TimelineStatusEnum.draft &&
+          savedObject.attributes.createdBy !== userName
+        ) {
+          return false;
         }
-      )
+        return true;
+      })
       .map(async (savedObject) => {
         const migratedSO = timelineFieldsMigrator.populateFieldsFromReferences(savedObject);
         const timelineSavedObject = convertSavedObjectToSavedTimeline(migratedSO);
@@ -739,14 +737,13 @@ export const deleteTimeline = async (
   const allowedIds: string[] = [];
 
   for (const savedObject of bulkGetResponse.saved_objects) {
-    if (isSavedObjectErrorResult(savedObject)) {
-      continue;
-    }
-    const { status, createdBy } = savedObject.attributes;
-    if (status === TimelineStatusEnum.draft && createdBy !== currentUsername) {
-      hasNonOwnerDraft = true;
-    } else {
-      allowedIds.push(savedObject.id);
+    if (!isSavedObjectErrorResult(savedObject)) {
+      const { status, createdBy } = savedObject.attributes;
+      if (status === TimelineStatusEnum.draft && createdBy !== currentUsername) {
+        hasNonOwnerDraft = true;
+      } else {
+        allowedIds.push(savedObject.id);
+      }
     }
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -85,6 +85,12 @@ export const getTimelineOrNull = async (
     timeline = await getTimeline(frameworkRequest, savedObjectId);
     // eslint-disable-next-line no-empty
   } catch (e) {}
+  if (
+    timeline?.status === TimelineStatusEnum.draft &&
+    timeline.createdBy !== frameworkRequest.user?.username
+  ) {
+    return null;
+  }
   return timeline;
 };
 
@@ -94,6 +100,12 @@ export const resolveTimelineOrNull = async (
 ): Promise<ResolvedTimeline | null> => {
   try {
     const resolvedTimeline = await resolveSavedTimeline(frameworkRequest, savedObjectId);
+    if (
+      resolvedTimeline.timeline.status === TimelineStatusEnum.draft &&
+      resolvedTimeline.timeline.createdBy !== frameworkRequest.user?.username
+    ) {
+      return null;
+    }
     return resolvedTimeline;
   } catch (e) {
     return null;


### PR DESCRIPTION
## Summary

This change tightens how draft timelines are handled across saved object workflows so draft-only operations consistently apply user-scoped access rules.

The updates are implemented in the saved-object layer (`saved_object/timelines/index.ts`) and cover the main draft timeline flows:

- listing draft timelines
- fetching draft timelines by ID
- updating draft timelines
- deleting draft timelines
- bulk-read, copy, and export paths that can include draft timelines

Active (non-draft) timelines are unchanged.

## Notes

- The checks are applied below the route layer; route contracts remain unchanged.
- The delete flow now performs a pre-check before removing draft timelines.
- There is a pre-existing inconsistency in how user identity values are compared in some timeline ownership-related paths. This PR keeps the current comparison approach and focuses on making draft access behavior consistent across these operations.

## How to verify

1. Create two users with `securitySolutionTimeline: ["all"]` privilege.
2. As the first user, create a draft timeline and capture the `savedObjectId`.
3. As the second user, verify that draft-only list, get, update, delete, and related bulk/copy/export flows do not surface or operate on the first user's draft timeline.
4. As the original user, verify those draft timeline flows still work for their own draft.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->