### PR TITLE
[Security Solution] Remove rule changes history feature flags

### DIFF
--- a/x-pack/platform/packages/shared/kbn-change-history/index.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/index.ts
@@ -7,8 +7,3 @@
 
 export type * from './src/types';
 export * from './src/client';
-/**
- * @internal exported for test use only — do NOT use in production code,
- * this could cause the index to be created before the feature is ready for GA
- */
-export { FLAGS } from './src/constants';

--- a/x-pack/platform/packages/shared/kbn-change-history/integration_tests/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/integration_tests/client.test.ts
@@ -10,7 +10,6 @@ import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { ToolingLog } from '@kbn/tooling-log';
 import type { EsTestCluster } from '@kbn/test';
 import { createTestEsCluster } from '@kbn/test';
-import { FLAGS } from '../src/constants';
 import { ChangeHistoryClient } from '..';
 import { DATA_STREAM_NAME } from '../src/client';
 import type { ObjectChange } from '..';
@@ -46,7 +45,6 @@ describe('ChangeHistoryClient', () => {
   };
 
   beforeAll(async () => {
-    FLAGS.FEATURE_ENABLED = true;
     jest.setTimeout(30_000);
     esServer = createTestEsCluster({
       log: new ToolingLog({ writeTo: process.stdout, level: 'debug' }),
@@ -56,7 +54,6 @@ describe('ChangeHistoryClient', () => {
 
   afterAll(async () => {
     await esServer.stop();
-    FLAGS.FEATURE_ENABLED = false;
   });
 
   afterEach(async () => {

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
@@ -9,7 +9,6 @@ import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { DataStreamClient } from '@kbn/data-streams';
 import { withSpan } from '@kbn/apm-utils';
-import { FLAGS } from './constants';
 import { ChangeHistoryClient } from './client';
 import type { ObjectChange } from './types';
 
@@ -48,7 +47,6 @@ describe('ChangeHistoryClient', () => {
   };
 
   beforeEach(() => {
-    FLAGS.FEATURE_ENABLED = true;
     DataStreamClientMock.initialize.mockResolvedValue(dataStreamClientMock as never);
   });
 
@@ -231,7 +229,7 @@ describe('ChangeHistoryClient.logBulk', () => {
   };
 
   beforeEach(() => {
-    FLAGS.FEATURE_ENABLED = true;
+    DataStreamClientMock.initialize.mockResolvedValue({} as never);
   });
 
   afterEach(() => {

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -17,13 +17,7 @@ import { type DataStreamDefinition, DataStreamClient } from '@kbn/data-streams';
 import type { ClientCreateRequest } from '@kbn/data-streams/src/types/es_api';
 import type { Logger } from '@kbn/logging';
 import { changeHistoryMappings } from './mappings';
-import {
-  FLAGS,
-  DATA_STREAM_NAME,
-  SEPARATOR_CHAR,
-  ECS_VERSION,
-  DEFAULT_RESULT_SIZE,
-} from './constants';
+import { DATA_STREAM_NAME, SEPARATOR_CHAR, ECS_VERSION, DEFAULT_RESULT_SIZE } from './constants';
 import type {
   ChangeHistoryDocument,
   GetHistoryResult,
@@ -102,11 +96,6 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
    * @throws An error if the data stream is not initialized properly.
    */
   async initialize(elasticsearchClient: ElasticsearchClient) {
-    if (!FLAGS.FEATURE_ENABLED) {
-      const error = new Error(`Change history is disabled. Skipping initialization.`);
-      this.logger.error(error);
-      throw error;
-    }
     const definition: DataStreamDefinition<typeof changeHistoryMappings.v1, ChangeHistoryDocument> =
       {
         name: DATA_STREAM_NAME,

--- a/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
@@ -22,11 +22,3 @@ export const ECS_VERSION = '9.3.0';
  * The default size of results when getting history.
  */
 export const DEFAULT_RESULT_SIZE = 100;
-
-/**
- * Acts like a feature flag for this package as it prevents initialization.
- * Remove this after General Availability
- * */
-export const FLAGS = {
-  FEATURE_ENABLED: true,
-};

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/common_utils/log_rule_changes.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/common_utils/log_rule_changes.ts
@@ -105,18 +105,15 @@ export async function logRuleChanges({
 
     const ruleType = getRuleType(ruleTypeRegistry, ruleSO.attributes.alertTypeId, logger);
 
-    // "ruleType.trackChanges" is activated at Alerting plugin's "plugin.ts".
-    //
-    // The activation is gated by the feature flag "xpack.alerting.ruleChangeTracking.enabled".
-    // On top of that "xpack.alerting.ruleChangeTracking.scope" controls what solution rule
-    // types will be activated, e.g. "security" or "observability".
-    //
+    // "ruleType.trackChanges" is activated at Alerting plugin's "plugin.ts", based on
+    // "xpack.alerting.ruleChangeTracking.scope", which controls what solution rule
+    // types are activated, e.g. "security" or "observability".
     if (!ruleType?.trackChanges) {
       continue;
     }
 
     // Security Solution additionally gates rule changes history per-space via its
-    // "Enable rule changes history" advanced setting, on top of the static config flag above.
+    // "Enable rule changes history" advanced setting.
     if (ruleType.solution === 'security') {
       if (securityRuleChangesHistoryEnabled === undefined) {
         try {

--- a/x-pack/platform/plugins/shared/alerting/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/config.test.ts
@@ -25,7 +25,6 @@ describe('config validation', () => {
           "removalDelay": "1h",
         },
         "ruleChangeTracking": Object {
-          "enabled": true,
           "scope": Array [
             "security",
           ],

--- a/x-pack/platform/plugins/shared/alerting/server/config.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/config.ts
@@ -92,7 +92,6 @@ export const configSchema = schema.object({
     totalFieldsLimit: schema.number({ defaultValue: 2800, min: 2500, max: 5000 }),
   }),
   ruleChangeTracking: schema.object({
-    enabled: schema.boolean({ defaultValue: true }),
     scope: schema.arrayOf(ruleChangeTrackingSolutions, { defaultValue: ['security'] }),
   }),
   cancelAlertsOnRuleTimeout: schema.boolean({ defaultValue: true }),

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -277,9 +277,7 @@ export class AlertingPlugin {
     this.disabledRuleTypes = new Set(this.config.disabledRuleTypes || []);
     this.enabledRuleTypes =
       this.config.enabledRuleTypes != null ? new Set(this.config.enabledRuleTypes) : null;
-    if (this.config.ruleChangeTracking.enabled) {
-      this.changeTrackingService = new ChangeTrackingService(this.logger, this.kibanaVersion);
-    }
+    this.changeTrackingService = new ChangeTrackingService(this.logger, this.kibanaVersion);
   }
 
   public setup(

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/create/create_rule_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/create/create_rule_route.test.ts
@@ -51,7 +51,6 @@ describe('createRuleRoute', () => {
     },
     cancelAlertsOnRuleTimeout: true,
     ruleChangeTracking: {
-      enabled: false,
       scope: ['security'] as string[],
     },
     rules: {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_rule_history.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_rule_history.ts
@@ -22,8 +22,7 @@ import type { RuleChangeHistorySnapshot } from '../lib/change_tracking';
 import { getRuleSo } from '../../data/rule';
 
 /**
- * Thrown by {@link RulesClient.getHistory} when rule change tracking is
- * disabled at the framework level (`xpack.alerting.ruleChangeTracking.enabled = false`).
+ * Thrown by {@link RulesClient.getHistory} when the change tracking service is unavailable.
  */
 export class RuleChangeTrackingDisabledError extends Error {
   constructor(message = 'Rule change tracking is disabled.') {

--- a/x-pack/platform/plugins/shared/alerting/server/test_utils/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/test_utils/index.ts
@@ -59,7 +59,6 @@ export function generateAlertingConfig(overwrites: Partial<AlertingConfig> = {})
       totalFieldsLimit: 2800,
     },
     ruleChangeTracking: {
-      enabled: false,
       scope: ['security'],
     },
     invalidateApiKeysTask: {

--- a/x-pack/platform/test/alerting_api_integration/common/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/config.ts
@@ -42,7 +42,7 @@ interface CreateTestConfigOptions {
   maxAlerts?: number;
   emailMaximumBodyLength?: number;
   indexRefreshInterval?: string | false;
-  ruleChangeTrackingEnabled?: boolean;
+  ruleChangeTrackingScope?: string[];
 }
 
 // test.not-enabled is specifically not enabled
@@ -236,7 +236,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
     experimentalFeatures = [],
     maxAlerts = 20,
     indexRefreshInterval,
-    ruleChangeTrackingEnabled = false,
+    ruleChangeTrackingScope,
   } = options;
 
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
@@ -332,11 +332,8 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         ? []
         : [`--xpack.actions.email.maximum_body_length=${options.emailMaximumBodyLength}`];
 
-    const ruleChangeTrackingSettings = ruleChangeTrackingEnabled
-      ? [
-          '--xpack.alerting.ruleChangeTracking.enabled=true',
-          `--xpack.alerting.ruleChangeTracking.scope=${JSON.stringify(['stack'])}`,
-        ]
+    const ruleChangeTrackingSettings = ruleChangeTrackingScope
+      ? [`--xpack.alerting.ruleChangeTracking.scope=${JSON.stringify(ruleChangeTrackingScope)}`]
       : [];
 
     return {

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/moon.yml
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/moon.yml
@@ -35,7 +35,6 @@ dependsOn:
   - '@kbn/alerts-as-data-utils'
   - '@kbn/data-plugin'
   - '@kbn/zod'
-  - '@kbn/change-history'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/plugin.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/plugin.ts
@@ -30,7 +30,6 @@ import type { IEventLogClientService, IEventLogService } from '@kbn/event-log-pl
 import type { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
-import { FLAGS as CHANGE_HISTORY_FLAGS } from '@kbn/change-history';
 import { defineRoutes } from './routes';
 import { defineActionTypes } from './action_types';
 import { defineRuleTypes } from './rule_types';
@@ -111,7 +110,6 @@ export class FixturePlugin implements Plugin<void, void, FixtureSetupDeps, Fixtu
     core: CoreSetup<FixtureStartDeps>,
     { features, actions, alerting, ruleRegistry, eventLog }: FixtureSetupDeps
   ) {
-    CHANGE_HISTORY_FLAGS.FEATURE_ENABLED = true;
     features.registerKibanaFeature({
       id: 'alertsFixture',
       name: 'Alerts',
@@ -225,8 +223,5 @@ export class FixturePlugin implements Plugin<void, void, FixtureSetupDeps, Fixtu
 
     this.notificationsStart$.next(notifications);
     this.notificationsStart$.complete();
-  }
-  public stop() {
-    CHANGE_HISTORY_FLAGS.FEATURE_ENABLED = false;
   }
 }

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/tsconfig.json
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/tsconfig.json
@@ -28,7 +28,6 @@
     "@kbn/alerts-as-data-utils",
     "@kbn/data-plugin",
     "@kbn/zod",
-    "@kbn/change-history",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group6/change_tracking/enabled.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group6/change_tracking/enabled.ts
@@ -13,7 +13,7 @@ export default function changeTrackingEnabledTest({ getService }: FtrProviderCon
   const retry = getService('retry');
 
   describe('change tracking service - enabled', () => {
-    it('should create the change history data stream when ruleChangeTracking is enabled', async () => {
+    it('should create the change history data stream for stack-scoped rule types', async () => {
       await retry.tryForTime(30_000, async () => {
         const response = await es.indices.getDataStream({ name: '.kibana_change_history' });
         expect(response.data_streams.length).to.be.greaterThan(0);

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group6/config_with_change_tracking_enabled.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group6/config_with_change_tracking_enabled.ts
@@ -13,7 +13,7 @@ export default createTestConfig('spaces_only', {
   enableActionsProxy: false,
   verificationMode: 'none',
   useDedicatedTaskRunner: false,
-  ruleChangeTrackingEnabled: true,
+  ruleChangeTrackingScope: ['stack'],
   testFiles: [require.resolve('./change_tracking/enabled.ts')],
   reportName: 'X-Pack Alerting API Integration Tests - Change Tracking Enabled',
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -289,11 +289,6 @@ export const allowedExperimentalValues = Object.freeze({
   prebuiltRulesDeprecationUIEnabled: true,
 
   /**
-   * Enables the Agents, Discover and Workflows external links in the classic Security Solution side navigation
-   */
-  securityClassicNavExternalLinks: true,
-
-  /**
    * Enables public Detection Engine attacks REST APIs
    * (`/api/detection_engine/attacks/*`).
    */

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -289,14 +289,9 @@ export const allowedExperimentalValues = Object.freeze({
   prebuiltRulesDeprecationUIEnabled: true,
 
   /**
-   * Enables the Detection Rule Changes History API endpoint
-   * (`GET /api/detection_engine/rules/_history`).
-   *
-   * Independent of the alerting framework's `xpack.alerting.ruleChangeTracking.enabled`
-   * config flag, which gates the underlying primitive that produces the history
-   * records. Both must be enabled for the API to return non-empty results.
+   * Enables the Agents, Discover and Workflows external links in the classic Security Solution side navigation
    */
-  ruleChangesHistoryEnabled: true,
+  securityClassicNavExternalLinks: true,
 
   /**
    * Enables public Detection Engine attacks REST APIs

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -153,7 +153,6 @@ import { useManualRuleRunConfirmation } from '../../../rule_gaps/components/manu
 // eslint-disable-next-line no-restricted-imports
 import { useLegacyUrlRedirect } from './use_redirect_legacy_url';
 import { RuleDetailTabs, useRuleDetailsTabs } from './use_rule_details_tabs';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useRuleUpdateCallout } from '../../../rule_management/hooks/use_rule_update_callout';
 import { useDeprecatedRuleDetailsCallout } from '../../../rule_management/components/rule_deprecation';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
@@ -237,14 +236,9 @@ export const RuleDetailsPage = connector(
     clearEventsLoading,
     clearSelected,
   }: DetectionEngineComponentProps) {
-    const ruleChangesHistoryFFEnabled = useIsExperimentalFeatureEnabled(
-      'ruleChangesHistoryEnabled'
-    );
-    const [ruleChangesHistoryAdvancedSetting] = useUiSetting$<boolean>(
+    const [isRuleChangesHistoryEnabled] = useUiSetting$<boolean>(
       ENABLE_RULE_CHANGES_HISTORY_SETTING
     );
-    const isRuleChangesHistoryEnabled =
-      ruleChangesHistoryFFEnabled && ruleChangesHistoryAdvancedSetting;
 
     const {
       application,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/rule_actions_overflow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/rule_actions_overflow/index.tsx
@@ -28,7 +28,6 @@ import {
   getRuleChangesHistoryUrl,
 } from '../../../../../common/components/link_to/redirect_to_detection_engine';
 import { useBoolState } from '../../../../../common/hooks/use_bool_state';
-import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { SINGLE_RULE_ACTIONS } from '../../../../../common/lib/apm/user_actions';
 import { useStartTransaction } from '../../../../../common/lib/apm/use_start_transaction';
 import { useKibana, useUiSetting$ } from '../../../../../common/lib/kibana';
@@ -106,12 +105,7 @@ const RuleActionsOverflowComponent = ({
     state: { doesBaseVersionExist },
   } = useRuleCustomizationsContext();
 
-  const ruleChangesHistoryFFEnabled = useIsExperimentalFeatureEnabled('ruleChangesHistoryEnabled');
-  const [ruleChangesHistoryAdvancedSetting] = useUiSetting$<boolean>(
-    ENABLE_RULE_CHANGES_HISTORY_SETTING
-  );
-  const isRuleChangesHistoryEnabled =
-    ruleChangesHistoryFFEnabled && ruleChangesHistoryAdvancedSetting;
+  const [isRuleChangesHistoryEnabled] = useUiSetting$<boolean>(ENABLE_RULE_CHANGES_HISTORY_SETTING);
 
   const actions = useMemo(
     () => [

--- a/x-pack/solutions/security/plugins/security_solution/public/rules/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules/routes.tsx
@@ -202,12 +202,7 @@ const RulesContainerComponent: React.FC = () => {
   const isEndpointExceptionsMovedFFEnabled = useIsExperimentalFeatureEnabled(
     'endpointExceptionsMovedUnderManagement'
   );
-  const ruleChangesHistoryFFEnabled = useIsExperimentalFeatureEnabled('ruleChangesHistoryEnabled');
-  const [ruleChangesHistoryAdvancedSetting] = useUiSetting$<boolean>(
-    ENABLE_RULE_CHANGES_HISTORY_SETTING
-  );
-  const isRuleChangesHistoryEnabled =
-    ruleChangesHistoryFFEnabled && ruleChangesHistoryAdvancedSetting;
+  const [isRuleChangesHistoryEnabled] = useUiSetting$<boolean>(ENABLE_RULE_CHANGES_HISTORY_SETTING);
 
   const subRoutes = useMemo(() => {
     return getRulesSubRoutes(capabilities, {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -59,11 +59,7 @@ export const registerRuleManagementRoutes = (
   // Rules coverage overview
   getCoverageOverviewRoute(router);
 
-  // Rule changes history (gated by experimental flag; the feature also
-  // requires `xpack.alerting.ruleChangeTracking.enabled` to be on for the
-  // alerting framework to actually produce history records).
-  if (config.experimentalFeatures.ruleChangesHistoryEnabled) {
-    ruleHistoryRoute(router);
-    restoreRuleFromHistoryRoute(router);
-  }
+  // Rule changes history
+  ruleHistoryRoute(router);
+  restoreRuleFromHistoryRoute(router);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -25,8 +25,7 @@ describe('initUiSettings', () => {
   const mockExperimentalFeatures = {
     enableAlertsAndAttacksAlignment: false,
     extendedRuleExecutionLoggingEnabled: false,
-    newFlyoutSystemEnabled: false,
-    ruleChangesHistoryEnabled: false,
+    newFlyoutSystemDisabled: false,
   } as ExperimentalFeatures;
 
   beforeEach(() => {

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -25,7 +25,7 @@ describe('initUiSettings', () => {
   const mockExperimentalFeatures = {
     enableAlertsAndAttacksAlignment: false,
     extendedRuleExecutionLoggingEnabled: false,
-    newFlyoutSystemDisabled: false,
+    newFlyoutSystemEnabled: false,
     ruleChangesHistoryEnabled: false,
   } as ExperimentalFeatures;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -362,28 +362,25 @@ export const initUiSettings = (
         solutionViews: ['classic', 'security'],
       },
     }),
-    // TODO(rule-changes-history GA): remove this setting and its call sites (including alerting `log_rule_changes.ts`)
-    ...(experimentalFeatures.ruleChangesHistoryEnabled && {
-      [ENABLE_RULE_CHANGES_HISTORY_SETTING]: {
-        name: i18n.translate('xpack.securitySolution.uiSettings.enableRuleChangesHistoryLabel', {
-          defaultMessage: 'Enable detection rule changes history',
-        }),
-        description: i18n.translate(
-          'xpack.securitySolution.uiSettings.enableRuleChangesHistoryDescription',
-          {
-            defaultMessage:
-              '<p>Enables the detection rule changes history feature within Security Solution.</p>',
-            values: { p: (chunks) => `<p>${chunks}</p>` },
-          }
-        ),
-        type: 'boolean',
-        value: true,
-        category: [APP_ID],
-        requiresPageReload: true,
-        schema: schema.boolean(),
-        solutionViews: ['classic', 'security'],
-      },
-    }),
+    [ENABLE_RULE_CHANGES_HISTORY_SETTING]: {
+      name: i18n.translate('xpack.securitySolution.uiSettings.enableRuleChangesHistoryLabel', {
+        defaultMessage: 'Enable detection rule changes history',
+      }),
+      description: i18n.translate(
+        'xpack.securitySolution.uiSettings.enableRuleChangesHistoryDescription',
+        {
+          defaultMessage:
+            '<p>Enables the detection rule changes history feature within Security Solution.</p>',
+          values: { p: (chunks) => `<p>${chunks}</p>` },
+        }
+      ),
+      type: 'boolean',
+      value: true,
+      category: [APP_ID],
+      requiresPageReload: true,
+      schema: schema.boolean(),
+      solutionViews: ['classic', 'security'],
+    },
     [NEWS_FEED_URL_SETTING]: {
       name: i18n.translate('xpack.securitySolution.uiSettings.newsFeedUrl', {
         defaultMessage: 'News feed URL',

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/queries/get_changes_history_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/queries/get_changes_history_usage.ts
@@ -44,9 +44,8 @@ interface ChangesHistoryUsageAggs {
  * window, aggregated from the `.kibana_change_history` data stream.
  *
  * Degrades to `{ revision_saved: 0, rule_restored: 0 }` (never throws) on
- * any ES error, including `index_not_found_exception` when
- * `xpack.alerting.ruleChangeTracking.enabled` is disabled (the default) and
- * the data stream does not exist. The catch is local so a missing index
+ * any ES error, including `index_not_found_exception` when the
+ * `.kibana_change_history` data stream does not exist yet. The catch is local so a missing index
  * only zeros these two fields, never the whole `detection_rules` metrics
  * group.
  * @param esClient the elastic client which should be a system based client

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -106,11 +106,7 @@ export class SecuritySolutionServerlessPlugin
       projectSettings.push(ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING);
     }
 
-    // TODO(rule-changes-history GA): remove this block when the feature is GA
-    // This setting is only registered when `ruleChangesHistoryEnabled` is enabled
-    if (this.config.experimentalFeatures.ruleChangesHistoryEnabled) {
-      projectSettings.push('securitySolution:enableRuleChangesHistory');
-    }
+    projectSettings.push('securitySolution:enableRuleChangesHistory');
 
     // Workflows is enabled by default since 9.4.0. The setting is retained so admins can opt out.
     // It is only registered in complete and EASE tiers; adding it while in the essentials tier causes an error.

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/ess/config.base.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/ess/config.base.ts
@@ -109,10 +109,7 @@ export function createTestConfig(options: CreateTestConfigOptions, testFiles?: s
           `--xpack.securitySolution.enableExperimental=${JSON.stringify([
             'previewTelemetryUrlEnabled',
             'endpointExceptionsMovedUnderManagement',
-            'ruleChangesHistoryEnabled',
           ])}`,
-          '--xpack.alerting.ruleChangeTracking.enabled=true',
-          '--uiSettings.overrides.securitySolution:enableRuleChangesHistory=true',
           `--plugin-path=${path.resolve(
             __dirname,
             '../../../../../../../src/platform/test/analytics/plugins/analytics_ftr_helpers'

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/serverless/config.base.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/serverless/config.base.ts
@@ -52,9 +52,7 @@ export function createTestConfig(options: CreateTestConfigOptions) {
           `--xpack.actions.preconfigured=${JSON.stringify(PRECONFIGURED_ACTION_CONNECTORS)}`,
           `--xpack.securitySolution.enableExperimental=${JSON.stringify([
             'endpointExceptionsMovedUnderManagement',
-            'ruleChangesHistoryEnabled',
           ])}`,
-          '--xpack.alerting.ruleChangeTracking.enabled=true',
           ...(options.kbnTestServerArgs || []),
           `--plugin-path=${path.resolve(
             __dirname,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
@@ -33,6 +33,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const detectionsApi = getService('detectionsApi');
   const es = getService('es');
   const log = getService('log');
+  const utils = getService('securitySolutionUtils');
 
   const refreshHistory = async () => {
     await es.indices.refresh({ index: CHANGE_HISTORY_DATA_STREAM, ignore_unavailable: true });
@@ -51,10 +52,7 @@ export default ({ getService }: FtrProviderContext): void => {
     }
   };
 
-  // Skip in Serverless until "xpack.alerting.ruleChangeTracking.enabled" and
-  // xpack.securitySolution.enableExperimental: [ruleChangesHistoryEnabled] feature flags
-  // permanently enabled
-  describe('@ess @skipInServerless rule change history', () => {
+  describe('@ess @serverless rule change history', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllPrebuiltRuleAssets(es, log);
@@ -78,9 +76,11 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(body.total).toBe(1);
         expect(body.items).toHaveLength(1);
 
+        const username = await utils.getUsername();
+
         const [item] = body.items;
         expect(item.action).toBe('rule_create');
-        expect(item.user).toEqual({ name: 'elastic' });
+        expect(item.user).toEqual({ name: username });
         expect(item.rule).toMatchObject({ id: rule.id, revision: 0 });
         expect(item.old_values).toBeNull();
       });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
@@ -36,17 +36,23 @@ export default ({ getService }: FtrProviderContext): void => {
   const utils = getService('securitySolutionUtils');
 
   const refreshHistory = async () => {
-    await es.indices.refresh({ index: CHANGE_HISTORY_DATA_STREAM, ignore_unavailable: true });
+    await es.indices.refresh(
+      { index: CHANGE_HISTORY_DATA_STREAM, ignore_unavailable: true },
+      { headers: { 'x-elastic-product-origin': 'kibana' } }
+    );
   };
 
   const clearHistory = async () => {
     try {
-      await es.deleteByQuery({
-        index: CHANGE_HISTORY_DATA_STREAM,
-        query: { match_all: {} },
-        conflicts: 'proceed',
-        refresh: true,
-      });
+      await es.deleteByQuery(
+        {
+          index: CHANGE_HISTORY_DATA_STREAM,
+          query: { match_all: {} },
+          conflicts: 'proceed',
+          refresh: true,
+        },
+        { headers: { 'x-elastic-product-origin': 'kibana' } }
+      );
     } catch {
       // Change history index may not exist yet
     }


### PR DESCRIPTION
**Related to: https://github.com/elastic/security-team/issues/12367**

## Summary

Removes the feature flags gating the Detection Rule Changes History feature, now that it's shipping unconditionally. Both flags defaulted to `true`, so there's no behavior change for the majority of deployments — this only removes the opt-out.

## Details

**Alerting plugin**
- Remove `ruleChangeTracking.enabled` config schema key from `config.ts` (kept `ruleChangeTracking.scope`)
- `plugin.ts` always constructs `ChangeTrackingService`, no longer gated by the removed config flag
- Update `RuleChangeTrackingDisabledError` doc comment in `get_rule_history.ts` to reflect the service can no longer be disabled via config
- Update alerting integration test config (`common/config.ts`, `group6/enabled.ts`, `group6/config_with_change_tracking_enabled.ts`) and unit tests/test utils to drop the removed config key

**Security Solution**
- Remove `ruleChangesHistoryEnabled` experimental feature flag from `experimental_features.ts`
- `ui_settings.ts` always registers `ENABLE_RULE_CHANGES_HISTORY_SETTING`, no longer conditional on the removed flag
- `routes.tsx`, `rule_details/index.tsx`, `rule_actions_overflow/index.tsx`, and `register_routes.ts` drop the `useIsExperimentalFeatureEnabled('ruleChangesHistoryEnabled')` check, relying only on the advanced setting
- `log_rule_changes.ts` updated for the alerting config change

**Security Solution Serverless**
- `plugin.ts` always pushes `securitySolution:enableRuleChangesHistory` to project settings, no longer gated by the removed flag
- Remove now-unneeded flag overrides from `config/ess/config.base.ts` and `config/serverless/config.base.ts`

**Tests**
- Update `trial_license_complete_tier/change_tracking.ts` and `security_solution/server/ui_settings.test.ts` for the flag removal

## How to test

Covered by existing alerting integration tests (`alerting_api_integration/common/config.ts`, `group6/change_tracking`) and `security_solution/server/ui_settings.test.ts`. No new manual testing needed — behavior is unchanged since both flags defaulted to enabled.

## Release note

skip

## Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

Removes the `xpack.alerting.ruleChangeTracking.enabled` config key entirely. Any deployment with this key explicitly set to `false` in `kibana.yml` will hit a config validation error on upgrade, and any deployment relying on it to opt out will lose that opt-out on the backported branches (9.5, 9.6).

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
