### PR TITLE
[Synthetics] Include remote clusters (CCS) in Monitors page Test runs stat

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
@@ -13,6 +13,7 @@ import type { ClientPluginsStart } from '../../../../../../plugin';
 import { useRefreshedRange } from '../../../../hooks';
 import { useMonitorFilters } from '../../hooks/use_monitor_filters';
 import { useMonitorQueryFilters } from '../../hooks/use_monitor_query_filters';
+import { useOverviewDataViewIndexPatterns } from '../../hooks/use_overview_data_view_index_patterns';
 import * as labels from '../labels';
 
 export const MonitorTestRunsCount = () => {
@@ -24,10 +25,18 @@ export const MonitorTestRunsCount = () => {
   const { from, to } = useRefreshedRange(30, 'days');
   const filters = useMonitorFilters({});
   const queryFilter = useMonitorQueryFilters();
+  const { dataTypesIndexPatterns, loading } = useOverviewDataViewIndexPatterns();
+
+  // Wait for the CCS index pattern to resolve before mounting the embeddable;
+  // it latches its first data view title (see useOverviewDataViewIndexPatterns).
+  if (loading) {
+    return null;
+  }
 
   return (
     <ExploratoryViewEmbeddable
       dslFilters={queryFilter}
+      dataTypesIndexPatterns={dataTypesIndexPatterns}
       align="left"
       reportType={ReportTypes.SINGLE_METRIC}
       attributes={[

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
@@ -12,6 +12,7 @@ import type { ClientPluginsStart } from '../../../../../../plugin';
 import { useRefreshedRange } from '../../../../hooks';
 import { useMonitorFilters } from '../../hooks/use_monitor_filters';
 import { useMonitorQueryFilters } from '../../hooks/use_monitor_query_filters';
+import { useOverviewDataViewIndexPatterns } from '../../hooks/use_overview_data_view_index_patterns';
 import * as labels from '../labels';
 
 export const MonitorTestRunsSparkline = () => {
@@ -23,6 +24,7 @@ export const MonitorTestRunsSparkline = () => {
   const { from, to } = useRefreshedRange(30, 'days');
   const filters = useMonitorFilters({});
   const queryFilter = useMonitorQueryFilters();
+  const { dataTypesIndexPatterns, loading } = useOverviewDataViewIndexPatterns();
 
   const attributes = useMemo(() => {
     return [
@@ -43,6 +45,12 @@ export const MonitorTestRunsSparkline = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [from, euiTheme.colors.vis.euiColorVis0, to]);
 
+  // Wait for the CCS index pattern to resolve before mounting the embeddable;
+  // it latches its first data view title (see useOverviewDataViewIndexPatterns).
+  if (loading) {
+    return null;
+  }
+
   return (
     <ExploratoryViewEmbeddable
       id="monitor-test-runs-sparkline"
@@ -53,6 +61,7 @@ export const MonitorTestRunsSparkline = () => {
       attributes={attributes}
       customHeight={'68px'}
       dslFilters={queryFilter}
+      dataTypesIndexPatterns={dataTypesIndexPatterns}
     />
   );
 };


### PR DESCRIPTION
## Summary

The Monitors page **Test runs** count and sparkline (the *Last 30 days* summary stats) only queried the local `synthetics-*` indices, so they ignored the Synthetics **remote clusters (CCS)** setting. This is inconsistent with the Overview **Errors** panel and every **Monitor details** stat panel, which already span `synthetics-*,*:synthetics-*` when CCS is enabled.

Both `monitor_test_runs.tsx` and `monitor_test_runs_sparkline.tsx` rendered `ExploratoryViewEmbeddable` without a `dataTypesIndexPatterns` prop, so the embeddable fell back to the default local synthetics data view.

### Change
- Wire both components to `useOverviewDataViewIndexPatterns()` (the same hook the Overview Errors panel uses).
- Gate mounting on its `loading` flag — the embeddable latches the first data view title it sees, so mounting with the interim local pattern would pin it to local-only data.
- Pass the resolved `dataTypesIndexPatterns` to the embeddable.

Closes #278209

## Test plan
- [ ] With CCS configured and **Use all remote clusters** enabled, open the Monitors page: the *Last 30 days* → **Test runs** count and sparkline include remote-cluster data (matching the Overview Errors panel and Monitor details pages).
- [ ] With a specific remote cluster selected, the count reflects local + that cluster.
- [ ] With CCS disabled / no remote selection, behavior is unchanged (local only).
