### PR TITLE
[9.4] [Security Solution][Endpoint] Fix endpoint metadata query and response actions for agents using agent-specific policy ids (#277100)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/endpoint_metadata_filter.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/endpoint_metadata_filter.test.ts
@@ -92,8 +92,15 @@ describe('buildBaseEndpointMetadataFilter', () => {
               },
             },
             {
-              terms: {
-                'united.agent.policy_id': [],
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    terms: {
+                      'united.agent.policy_id': [],
+                    },
+                  },
+                ],
               },
             },
           ],
@@ -126,8 +133,22 @@ describe('buildBaseEndpointMetadataFilter', () => {
               },
             },
             {
-              terms: {
-                'united.agent.policy_id': ['policy-1'],
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    terms: {
+                      'united.agent.policy_id': ['policy-1'],
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-1#*',
+                      },
+                    },
+                  },
+                ],
               },
             },
           ],
@@ -160,8 +181,36 @@ describe('buildBaseEndpointMetadataFilter', () => {
               },
             },
             {
-              terms: {
-                'united.agent.policy_id': ['policy-1', 'policy-2', 'policy-3'],
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    terms: {
+                      'united.agent.policy_id': ['policy-1', 'policy-2', 'policy-3'],
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-1#*',
+                      },
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-2#*',
+                      },
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-3#*',
+                      },
+                    },
+                  },
+                ],
               },
             },
           ],
@@ -194,8 +243,36 @@ describe('buildBaseEndpointMetadataFilter', () => {
               },
             },
             {
-              terms: {
-                'united.agent.policy_id': ['policy-1', 'policy-2', 'policy-3'],
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    terms: {
+                      'united.agent.policy_id': ['policy-1', 'policy-2', 'policy-3'],
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-1#*',
+                      },
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-2#*',
+                      },
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'policy-3#*',
+                      },
+                    },
+                  },
+                ],
               },
             },
           ],

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/endpoint_metadata_filter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/endpoint_metadata_filter.ts
@@ -27,19 +27,23 @@ export function buildBaseEndpointMetadataFilter(policyIds?: string[]): QueryDslQ
     { exists: { field: 'united.endpoint.agent.id' } },
     { exists: { field: 'united.agent.agent.id' } },
     // agent is enrolled
-    {
-      term: {
-        'united.agent.active': {
-          value: true,
-        },
-      },
-    },
+    { term: { 'united.agent.active': { value: true } } },
   ];
 
   // Only include policy filter if policyIds are explicitly provided
   if (policyIds) {
     baseFilters.push({
-      terms: { 'united.agent.policy_id': uniq(policyIds) },
+      bool: {
+        should: [
+          { terms: { 'united.agent.policy_id': uniq(policyIds) } },
+          // Wildcard match needed due to change made in Fleet in support of Agent specific policies
+          // See https://github.com/elastic/ingest-dev/issues/8624
+          ...uniq(policyIds).map((policyId) => {
+            return { wildcard: { 'united.agent.policy_id': { value: `${policyId}#*` } } };
+          }),
+        ],
+        minimum_should_match: 1,
+      },
     });
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/migrations/space_awareness_migration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/migrations/space_awareness_migration.ts
@@ -620,8 +620,8 @@ class AgentPolicyInfoBuilder {
     if (!agentPolicyIdPromise) {
       const fleetServices = this.endpointService.getInternalFleetServices(undefined, true);
 
-      agentPolicyIdPromise = fleetServices.agent
-        .getAgent(agentId)
+      agentPolicyIdPromise = fleetServices
+        .fetchAgent(agentId)
         .then((agent) => {
           if (!agent.policy_id) {
             throw new EndpointError(

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -195,7 +195,18 @@ describe('test endpoint routes', () => {
                   { exists: { field: 'united.endpoint.agent.id' } },
                   { exists: { field: 'united.agent.agent.id' } },
                   { term: { 'united.agent.active': { value: true } } },
-                  { terms: { 'united.agent.policy_id': [] } },
+                  {
+                    bool: {
+                      minimum_should_match: 1,
+                      should: [
+                        {
+                          terms: {
+                            'united.agent.policy_id': [],
+                          },
+                        },
+                      ],
+                    },
+                  },
                 ],
               },
             },

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
@@ -36,8 +36,22 @@ export const expectedCompleteUnitedIndexQuery = {
               },
             },
             {
-              terms: {
-                'united.agent.policy_id': ['test-endpoint-policy-id'],
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    terms: {
+                      'united.agent.policy_id': ['test-endpoint-policy-id'],
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'united.agent.policy_id': {
+                        value: 'test-endpoint-policy-id#*',
+                      },
+                    },
+                  },
+                ],
               },
             },
           ],

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/query_builders.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/query_builders.test.ts
@@ -95,8 +95,15 @@ describe('query builder', () => {
               },
             },
             {
-              terms: {
-                'united.agent.policy_id': [],
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    terms: {
+                      'united.agent.policy_id': [],
+                    },
+                  },
+                ],
               },
             },
           ],

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/query_builders.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/query_builders.ts
@@ -157,7 +157,7 @@ interface BuildUnitedIndexQueryResponse extends estypes.SearchRequest {
 export async function buildUnitedIndexQuery(
   soClient: SavedObjectsClientContract,
   queryOptions: GetMetadataListRequestQuery,
-  endpointPolicyIds: string[] = []
+  fleetAgentPolicyIds: string[] = []
 ): Promise<BuildUnitedIndexQueryResponse> {
   const {
     page = ENDPOINT_DEFAULT_PAGE,
@@ -169,7 +169,7 @@ export async function buildUnitedIndexQuery(
   } = queryOptions || {};
 
   const statusesKuery = buildStatusesKuery(hostStatuses);
-  const idFilter = buildBaseEndpointMetadataFilter(endpointPolicyIds);
+  const idFilter = buildBaseEndpointMetadataFilter(fleetAgentPolicyIds);
 
   let query: BuildUnitedIndexQueryResponse['query'] = idFilter;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/policy/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/policy/service.ts
@@ -5,13 +5,11 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
-import type { Agent } from '@kbn/fleet-plugin/common/types/models';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import type { ISearchRequestParams } from '@kbn/search-types';
 import type { EndpointFleetServicesInterface } from '../../services/fleet';
 import { policyIndexPattern } from '../../../../common/endpoint/constants';
 import { catchAndWrapError } from '../../utils';
-import type { EndpointAppContext } from '../../types';
 import { INITIAL_POLICY_ID } from '.';
 import type { GetHostPolicyResponse, HostPolicyResponse } from '../../../../common/endpoint/types';
 
@@ -64,40 +62,4 @@ export async function getPolicyResponseByAgentId(
   }
 
   return undefined;
-}
-
-export async function agentVersionsMap(
-  endpointAppContext: EndpointAppContext,
-  request: KibanaRequest,
-  kqlQuery: string,
-  pageSize: number = 1000
-): Promise<Map<string, number>> {
-  const searchOptions = (pageNum: number) => {
-    return {
-      page: pageNum,
-      perPage: pageSize,
-      showInactive: false,
-      kuery: kqlQuery,
-    };
-  };
-
-  let page = 1;
-  const result: Map<string, number> = new Map<string, number>();
-  let hasMore = true;
-  while (hasMore) {
-    const queryResult = await endpointAppContext.service
-      .getInternalFleetServices()
-      .agent.listAgents(searchOptions(page++));
-    queryResult.agents.forEach((agent: Agent) => {
-      const agentVersion = agent.local_metadata?.elastic?.agent?.version;
-      if (result.has(agentVersion)) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        result.set(agentVersion, result.get(agentVersion)! + 1);
-      } else {
-        result.set(agentVersion, 1);
-      }
-    });
-    hasMore = queryResult.agents.length > 0;
-  }
-  return result;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/suggestions/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/suggestions/index.test.ts
@@ -394,8 +394,29 @@ describe('when calling the Suggestions route handler', () => {
                     },
                   },
                   {
-                    terms: {
-                      'united.agent.policy_id': ['policy-1', 'policy-2'],
+                    bool: {
+                      minimum_should_match: 1,
+                      should: [
+                        {
+                          terms: {
+                            'united.agent.policy_id': ['policy-1', 'policy-2'],
+                          },
+                        },
+                        {
+                          wildcard: {
+                            'united.agent.policy_id': {
+                              value: 'policy-1#*',
+                            },
+                          },
+                        },
+                        {
+                          wildcard: {
+                            'united.agent.policy_id': {
+                              value: 'policy-2#*',
+                            },
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
@@ -481,8 +502,15 @@ describe('when calling the Suggestions route handler', () => {
                     },
                   },
                   {
-                    terms: {
-                      'united.agent.policy_id': [],
+                    bool: {
+                      minimum_should_match: 1,
+                      should: [
+                        {
+                          terms: {
+                            'united.agent.policy_id': [],
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
@@ -606,8 +634,22 @@ describe('when calling the Suggestions route handler', () => {
                     },
                   },
                   {
-                    terms: {
-                      'united.agent.policy_id': ['space-policy-1'],
+                    bool: {
+                      minimum_should_match: 1,
+                      should: [
+                        {
+                          terms: {
+                            'united.agent.policy_id': ['space-policy-1'],
+                          },
+                        },
+                        {
+                          wildcard: {
+                            'united.agent.policy_id': {
+                              value: 'space-policy-1#*',
+                            },
+                          },
+                        },
+                      ],
                     },
                   },
                 ],

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
@@ -295,7 +295,7 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
     const policyInfo: LogsEndpointAction['agent']['policy'] = [];
 
     // Get a list of Agent records so we can identify the Agent Policy ID
-    const agents = await fleetServices.agent.getByIds(agentIds).catch(catchAndWrapError);
+    const agents = await fleetServices.fetchAgentsById(agentIds).catch(catchAndWrapError);
 
     this.log.debug(
       () => `Fleet agent records for agent IDs [${agentIds.join(' | ')}]:\n${stringify(agents, 2)}`
@@ -334,6 +334,13 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
 
     for (const agent of agents) {
       if (agent.policy_id) {
+        if (!agentPolicyToIntegrationPolicyMap[agent.policy_id]) {
+          throw new ResponseActionsClientError(
+            `Data inconsistency detected. Agent [${agent.id}][${agent.local_metadata?.host?.hostname}] has agent policy_id [${agent.policy_id}] but no integration policy was found associated with that agent policy id.`,
+            400
+          );
+        }
+
         policyInfo.push({
           agentId: agent.id,
           elasticAgentId: agent.id,
@@ -589,6 +596,7 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
     try {
       await this.fetchAgentPolicyInfo(actionRequest.endpoint_ids);
     } catch (err) {
+      this.log.debug(`Error retrieving agent policy info: ${err.message}`, { error: err });
       return { isValid: false, error: err };
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/mocks.ts
@@ -24,6 +24,7 @@ import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import { createEndpointFleetServicesFactoryMock } from '../../fleet/endpoint_fleet_services_factory.mocks';
 import { ScriptsLibraryMock } from '../../scripts_library/mocks';
 import type { MemoryDumpActionRequestBody } from '../../../../../common/api/endpoint/actions/response_actions/memory_dump';
 import { getPackagePolicyInfoFromFleetKuery } from '../../../mocks/utils.mock';
@@ -221,12 +222,12 @@ const createConstructorOptionsMock = (): Required<ResponseActionsClientOptionsMo
     esClient,
   });
 
-  // Enable the mocking of internal fleet services
-  const fleetServices = endpointService.getInternalFleetServices();
-  jest.spyOn(fleetServices, 'ensureInCurrentSpace');
-
+  // use fleet services mock for `getInternalFleetServices()`
   const getInternalFleetServicesMock = jest.spyOn(endpointService, 'getInternalFleetServices');
-  getInternalFleetServicesMock.mockReturnValue(fleetServices);
+  const fleetServicesFactoryMock = createEndpointFleetServicesFactoryMock({
+    fleetDependencies: endpointServiceStartContract.fleetStartServices,
+  });
+  getInternalFleetServicesMock.mockReturnValue(fleetServicesFactoryMock.service.asInternalUser());
 
   // Mock the Scripts Library client
   jest.spyOn(endpointService, 'getScriptsLibraryClient').mockReturnValue(scriptsLibraryClientMock);

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/utils.ts
@@ -580,8 +580,8 @@ export const getAgentHostNamesWithIds = async ({
   }
 
   const fleetServices = endpointService.getInternalFleetServices(spaceId);
-  const agentFound = await fleetServices.agent
-    .getByIds(agentIds, { ignoreMissing: true })
+  const agentFound = await fleetServices
+    .fetchAgentsById(agentIds, { ignoreMissing: true })
     .catch(catchAndWrapError);
   const agentDocById = keyBy(agentFound, 'id');
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.mocks.ts
@@ -72,6 +72,9 @@ export const createEndpointFleetServicesFactoryMock = (
     jest.spyOn(fleetInternalServicesMocked, 'getIntegrationNamespaces');
     jest.spyOn(fleetInternalServicesMocked, 'getSoClient');
     jest.spyOn(fleetInternalServicesMocked, 'isEndpointPackageInstalled');
+    jest.spyOn(fleetInternalServicesMocked, 'fetchAgentsById');
+    jest.spyOn(fleetInternalServicesMocked, 'fetchAgent');
+    jest.spyOn(fleetInternalServicesMocked, 'fetchAgentList');
 
     return fleetInternalServicesMocked;
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.test.ts
@@ -13,6 +13,7 @@ import { createEndpointFleetServicesFactoryMock } from './endpoint_fleet_service
 import { AgentNotFoundError } from '@kbn/fleet-plugin/server';
 import { NotFoundError } from '../../errors';
 import {
+  type Agent,
   type AgentPolicy,
   type PackagePolicy,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
@@ -46,6 +47,9 @@ describe('EndpointServiceFactory', () => {
       'getIntegrationNamespaces',
       'getSoClient',
       'isEndpointPackageInstalled',
+      'fetchAgent',
+      'fetchAgentsById',
+      'fetchAgentList',
     ]);
   });
 
@@ -438,6 +442,109 @@ describe('EndpointServiceFactory', () => {
         ({ name }) => name !== 'endpoint'
       );
       await expect(fleetServicesMock.isEndpointPackageInstalled()).resolves.toBe(false);
+    });
+  });
+
+  describe('Agent fetch methods', () => {
+    let fleetAgentGenerator: FleetAgentGenerator;
+    let agentServiceMock: EndpointInternalFleetServicesInterfaceMocked['agent'];
+
+    beforeEach(() => {
+      fleetAgentGenerator = new FleetAgentGenerator('test');
+      agentServiceMock =
+        fleetServicesFactoryMock.dependencies.fleetDependencies.agentService.asInternalUser;
+    });
+
+    describe('#fetchAgent()', () => {
+      let agentMock: Agent;
+
+      beforeEach(() => {
+        agentMock = fleetAgentGenerator.generate({ id: '1-2-3', policy_id: 'policy-1#9.2' });
+        agentServiceMock.getAgent.mockResolvedValue(agentMock);
+      });
+
+      it('should call the fleet agent client with the provided arguments', async () => {
+        await fleetServicesMock.fetchAgent('1-2-3');
+
+        expect(agentServiceMock.getAgent).toHaveBeenCalledWith('1-2-3');
+      });
+
+      it('should remove the version suffix from the returned agent `policy_id`', async () => {
+        await expect(fleetServicesMock.fetchAgent('1-2-3')).resolves.toEqual(
+          expect.objectContaining({ policy_id: 'policy-1' })
+        );
+      });
+
+      it('should leave `policy_id` unchanged when no version suffix is present', async () => {
+        agentMock.policy_id = 'policy-1';
+
+        await expect(fleetServicesMock.fetchAgent('1-2-3')).resolves.toEqual(
+          expect.objectContaining({ policy_id: 'policy-1' })
+        );
+      });
+    });
+
+    describe('#fetchAgentsById()', () => {
+      let agentsMock: Agent[];
+
+      beforeEach(() => {
+        agentsMock = [
+          fleetAgentGenerator.generate({ id: '1-2-3', policy_id: 'policy-1#9.2' }),
+          fleetAgentGenerator.generate({ id: '4-5-6', policy_id: 'policy-2#10.1' }),
+        ];
+        agentServiceMock.getByIds.mockResolvedValue(agentsMock);
+      });
+
+      it('should call the fleet agent client with the provided arguments', async () => {
+        await fleetServicesMock.fetchAgentsById(['1-2-3', '4-5-6']);
+
+        expect(agentServiceMock.getByIds).toHaveBeenCalledWith(['1-2-3', '4-5-6']);
+      });
+
+      it('should remove the version suffix from every returned agent `policy_id`', async () => {
+        await expect(fleetServicesMock.fetchAgentsById(['1-2-3', '4-5-6'])).resolves.toEqual([
+          expect.objectContaining({ id: '1-2-3', policy_id: 'policy-1' }),
+          expect.objectContaining({ id: '4-5-6', policy_id: 'policy-2' }),
+        ]);
+      });
+    });
+
+    describe('#fetchAgentList()', () => {
+      let agentsMock: Agent[];
+
+      beforeEach(() => {
+        agentsMock = [
+          fleetAgentGenerator.generate({ id: '1-2-3', policy_id: 'policy-1#9.2' }),
+          fleetAgentGenerator.generate({ id: '4-5-6', policy_id: 'policy-2' }),
+        ];
+        agentServiceMock.listAgents.mockResolvedValue({
+          agents: agentsMock,
+          total: agentsMock.length,
+          page: 1,
+          perPage: 20,
+        });
+      });
+
+      it('should call the fleet agent client with the provided arguments', async () => {
+        const listOptions = { page: 1, perPage: 20, showInactive: false };
+
+        await fleetServicesMock.fetchAgentList(listOptions);
+
+        expect(agentServiceMock.listAgents).toHaveBeenCalledWith(listOptions);
+      });
+
+      it('should remove the version suffix from the returned agents `policy_id`', async () => {
+        await expect(
+          fleetServicesMock.fetchAgentList({ page: 1, perPage: 20, showInactive: false })
+        ).resolves.toEqual(
+          expect.objectContaining({
+            agents: [
+              expect.objectContaining({ id: '1-2-3', policy_id: 'policy-1' }),
+              expect.objectContaining({ id: '4-5-6', policy_id: 'policy-2' }),
+            ],
+          })
+        );
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.ts
@@ -15,6 +15,7 @@ import type {
 import { AgentNotFoundError } from '@kbn/fleet-plugin/server';
 import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  type Agent,
   type PackagePolicy,
   type AgentPolicy,
 } from '@kbn/fleet-plugin/common';
@@ -24,6 +25,10 @@ import {
   PackagePolicyNotFoundError,
 } from '@kbn/fleet-plugin/server/errors';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import {
+  hasVersionSuffix,
+  removeVersionSuffixFromPolicyId,
+} from '@kbn/fleet-plugin/common/services/version_specific_policies_utils';
 import { EndpointError } from '../../../../common/endpoint/errors';
 import { catchAndWrapError } from '../../utils';
 import { stringify } from '../../utils/stringify';
@@ -36,6 +41,11 @@ import type { SavedObjectsClientFactory } from '../saved_objects';
 export interface EndpointFleetServicesInterface {
   /** The space id used to initialize the current `EndpointFleetServicesInterface` instance */
   spaceId: string;
+
+  /**
+   * IMPORTANT: USE AGENT METHODS EXPOSED DIRECTLY ON `EndpointFleetServicesInterface` FOR
+   * RETRIEVING AGENT DATA FROM FLEET INSTEAD OF THESE SERVICES PROVIDED BY FLEET.
+   */
   agent: AgentClient;
   agentPolicy: AgentPolicyServiceInterface;
   packages: PackageClient;
@@ -76,6 +86,33 @@ export interface EndpointFleetServicesInterface {
 
   /** Checks to see if the Endpoint (Elastic Defend) package is installed */
   isEndpointPackageInstalled: () => Promise<boolean>;
+
+  /**
+   *  Fetch single agent from Fleet.
+   *  Method differs from the one provided by Fleet's `AgentClinet` in that it removes the
+   *  suffix from `policy_id` from the returned agent.
+   */
+  fetchAgent: (
+    ...props: Parameters<AgentClient['getAgent']>
+  ) => ReturnType<AgentClient['getAgent']>;
+
+  /**
+   *  Fetch list of agents from Fleet.
+   *  Method differs from the one provided by Fleet's `AgentClinet` in that it removes the
+   *  suffix from `policy_id` from the returned list of agents.
+   */
+  fetchAgentList: (
+    ...props: Parameters<AgentClient['listAgents']>
+  ) => ReturnType<AgentClient['listAgents']>;
+
+  /**
+   *  Fetch list of agents from Fleet usign their UUIDs.
+   *  Method differs from the one provided by Fleet's `AgentClinet` in that it removes the
+   *  suffix from `policy_id` from the returned list of agents.
+   */
+  fetchAgentsById: (
+    ...props: Parameters<AgentClient['getByIds']>
+  ) => ReturnType<AgentClient['getByIds']>;
 }
 
 export interface EndpointInternalFleetServicesInterface extends EndpointFleetServicesInterface {
@@ -157,6 +194,7 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
         agentService: agent,
         agentPolicyService: agentPolicy,
         packagePolicyService: packagePolicy,
+        logger: this.logger,
         options,
         integrationPolicyIds,
         agentPolicyIds,
@@ -217,6 +255,10 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
       getIntegrationNamespaces,
       getSoClient,
       isEndpointPackageInstalled,
+
+      fetchAgent: fetchFleetAgent.bind(null, agent, this.logger),
+      fetchAgentsById: fetchFleetAgentsById.bind(null, agent, this.logger),
+      fetchAgentList: fetchFleetAgentList.bind(null, agent, this.logger),
     };
   }
 }
@@ -226,6 +268,7 @@ interface CheckInCurrentSpaceOptions {
   agentService: AgentClient;
   agentPolicyService: AgentPolicyServiceInterface;
   packagePolicyService: PackagePolicyClient;
+  logger: Logger;
   options?: {
     /**
      * Ensures that all IDs passed on input MUST be accessible in active space. When set to `false`,
@@ -259,6 +302,7 @@ const checkInCurrentSpace = async ({
   agentService,
   agentPolicyService,
   packagePolicyService,
+  logger,
   integrationPolicyIds = [],
   agentPolicyIds = [],
   agentIds = [],
@@ -279,8 +323,7 @@ const checkInCurrentSpace = async ({
 
   await Promise.all([
     agentIds.length
-      ? agentService
-          .getByIds(agentIds, { ignoreMissing: !matchAll })
+      ? fetchFleetAgentsById(agentService, logger, agentIds, { ignoreMissing: !matchAll })
           .catch(handlePromiseErrors)
           .then((response) => {
             // When `matchAll` is false, the results must have at least matched 1 id
@@ -505,4 +548,61 @@ const fetchIntegrationNamespaces = async ({
   logger.debug(() => `Integration namespaces in use:\n${stringify(response)}`);
 
   return response;
+};
+
+// Note that this function will possibly mutate the Agent record
+const adjustAgentData = (data: Agent | Agent[], methodName: string, _logger: Logger): void => {
+  const logger = _logger.get('adjustAgentData');
+  const agentsData = Array.isArray(data) ? data : [data];
+  const updatesDone: string[] = [];
+
+  for (const agentRecord of agentsData) {
+    // Remove version suffix from `policy_id` field
+    // Issue caused by: https://github.com/elastic/package-spec/issues/165
+    if (hasVersionSuffix(agentRecord.policy_id ?? '')) {
+      const updatedPolicyId = removeVersionSuffixFromPolicyId(agentRecord.policy_id ?? '');
+
+      updatesDone.push(
+        `Agent [${agentRecord.id}][${agentRecord.local_metadata?.host?.hostname}]: adjusted 'policy_id' property value from [${agentRecord.policy_id}] to [${updatedPolicyId}]`
+      );
+
+      agentRecord.policy_id = updatedPolicyId;
+    }
+  }
+
+  if (updatesDone.length) {
+    logger
+      .get(methodName)
+      .debug(`Adjusted ${updatesDone.length} agent records:\n${updatesDone.join('\n')}`);
+  }
+};
+
+const fetchFleetAgent = async (
+  agentClient: AgentClient,
+  logger: Logger,
+  ...props: Parameters<AgentClient['getAgent']>
+): ReturnType<AgentClient['getAgent']> => {
+  const agent = await agentClient.getAgent(...props);
+  adjustAgentData(agent, 'getAgent', logger);
+  return agent;
+};
+
+const fetchFleetAgentList = async (
+  agentClient: AgentClient,
+  logger: Logger,
+  ...props: Parameters<AgentClient['listAgents']>
+): ReturnType<AgentClient['listAgents']> => {
+  const agents = await agentClient.listAgents(...props);
+  adjustAgentData(agents.agents, 'listAgents', logger);
+  return agents;
+};
+
+const fetchFleetAgentsById = async (
+  agentClient: AgentClient,
+  logger: Logger,
+  ...props: Parameters<AgentClient['getByIds']>
+): ReturnType<AgentClient['getByIds']> => {
+  const agents = await agentClient.getByIds(...props);
+  adjustAgentData(agents, 'getByIds', logger);
+  return agents;
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.test.ts
@@ -26,6 +26,7 @@ import { createAppContextStartContractMock as fleetCreateAppContextStartContract
 import { appContextService as fleetAppContextService } from '@kbn/fleet-plugin/server/services';
 import { EndpointError } from '../../../../common/endpoint/errors';
 import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { removeVersionSuffixFromPolicyId } from '@kbn/fleet-plugin/common/services/version_specific_policies_utils';
 
 describe('EndpointMetadataService', () => {
   let testMockedContext: EndpointMetadataServiceTestContextMock;
@@ -210,6 +211,96 @@ describe('EndpointMetadataService', () => {
         ],
         total: 1,
       });
+    });
+  });
+
+  describe('#getHostMetadataList - policy_id suffix stripping', () => {
+    let agentPolicyServiceMock: jest.Mocked<AgentPolicyServiceInterface>;
+    let queryOptions: Parameters<typeof metadataService.getHostMetadataList>[0];
+
+    beforeEach(() => {
+      agentPolicyServiceMock = testMockedContext.agentPolicyService;
+      queryOptions = { page: 0, pageSize: 10, kuery: '', hostStatuses: [] };
+    });
+
+    /**
+     * Sets up the ES search + fleet mocks for a single united metadata hit whose
+     * `united.agent.policy_id` is set to `agentPolicyId`. Returns the base (expected/stripped)
+     * policy id along with the generated fleet data.
+     */
+    const setupSingleHit = (agentPolicyId: string) => {
+      const basePolicyId = removeVersionSuffixFromPolicyId(agentPolicyId);
+      const packagePolicies = [
+        Object.assign(endpointDocGenerator.generatePolicyPackagePolicy(), {
+          id: 'test-package-policy-id',
+          policy_ids: [basePolicyId],
+          revision: 1,
+        }),
+      ];
+      const agentPolicies = [
+        Object.assign(endpointDocGenerator.generateAgentPolicy(), {
+          id: basePolicyId,
+          revision: 2,
+          package_policies: packagePolicies,
+        }),
+      ];
+
+      const newDate = new Date();
+      const endpointMetadataDoc = endpointDocGenerator.generateHostMetadata(newDate.getTime());
+      const mockAgent = {
+        agent: { id: 'test-agent-id' },
+        policy_id: agentPolicyId,
+        policy_revision: agentPolicies[0].revision,
+        last_checkin: newDate.toISOString(),
+      } as unknown as Agent;
+
+      esClient.search.mockResponse(
+        unitedMetadataSearchResponseMock(endpointMetadataDoc, mockAgent)
+      );
+      agentPolicyServiceMock.getByIds.mockResolvedValue(agentPolicies);
+      testMockedContext.packagePolicyService.list.mockImplementation(async (_, { page }) => ({
+        items: (page ?? 1) > 1 ? [] : packagePolicies,
+        page: page ?? 1,
+        total: packagePolicies.length,
+        perPage: packagePolicies.length,
+      }));
+
+      return { basePolicyId, agentPolicies, packagePolicies };
+    };
+
+    it('should strip the "#..." suffix from `policy_id` before looking up agent policies', async () => {
+      const { basePolicyId } = setupSingleHit('test-agent-policy-id#9.2');
+
+      await metadataService.getHostMetadataList(queryOptions);
+
+      expect(agentPolicyServiceMock.getByIds).toBeCalledWith(expect.anything(), [basePolicyId]);
+    });
+
+    it('should return the stripped `policy_id` in the applied agent policy info.', async () => {
+      const { basePolicyId } = setupSingleHit('test-agent-policy-id#9.5');
+
+      const response = await metadataService.getHostMetadataList(queryOptions);
+
+      expect(response.data[0].policy_info?.agent.applied.id).toEqual(basePolicyId);
+    });
+
+    it('should not alter a `policy_id` that has no "#..." suffix', async () => {
+      const policyId = 'test-agent-policy-id';
+      setupSingleHit(policyId);
+
+      const response = await metadataService.getHostMetadataList(queryOptions);
+
+      expect(agentPolicyServiceMock.getByIds).toBeCalledWith(expect.anything(), [policyId]);
+      expect(response.data[0].policy_info?.agent.applied.id).toEqual(policyId);
+    });
+
+    it('should strip only the suffix and keep the base policy id intact', async () => {
+      const { basePolicyId } = setupSingleHit('test-agent-policy-id#blah#9.5');
+
+      await metadataService.getHostMetadataList(queryOptions);
+
+      expect(basePolicyId).toEqual('test-agent-policy-id#blah');
+      expect(agentPolicyServiceMock.getByIds).toBeCalledWith(expect.anything(), [basePolicyId]);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
@@ -10,7 +10,6 @@ import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@k
 import type { SearchResponse, SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
 import type { Agent, AgentPolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { AgentNotFoundError } from '@kbn/fleet-plugin/server';
-import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 import {
   hasVersionSuffix,
   removeVersionSuffixFromPolicyId,
@@ -124,7 +123,7 @@ export class EndpointMetadataService {
 
     if (recordsAltered.length > 0) {
       this.logger
-        .get('adjustUnitedIndexSearchResultHits')
+        ?.get('adjustUnitedIndexSearchResultHits')
         .debug(
           () => `Made ${recordsAltered.length} data adjustments:\n${recordsAltered.join('\n')}`
         );
@@ -403,7 +402,7 @@ export class EndpointMetadataService {
 
     let unitedMetadataQueryResponse: SearchResponse<UnitedAgentMetadataPersistedData>;
 
-    logger.debug(() => `Executing query: ${stringify(unitedIndexQuery, 15)}`);
+    this.logger?.debug(() => `Executing query: ${stringify(unitedIndexQuery, 15)}`);
 
     try {
       unitedMetadataQueryResponse = await this.esClient
@@ -491,10 +490,9 @@ export class EndpointMetadataService {
   }
 
   async getMetadataForEndpoints(endpointIDs: string[]): Promise<HostMetadata[]> {
-    const ccsEnabled = await this.endpointContext.isCcsEnabled();
-    const query = getESQueryHostMetadataByIDs(endpointIDs, ccsEnabled);
+    const query = getESQueryHostMetadataByIDs(endpointIDs);
 
-    this.logger.get('getMetadataForEndpoints').debug(() => `with query: ${stringify(query, 15)}`);
+    this.logger?.get('getMetadataForEndpoints').debug(() => `with query: ${stringify(query, 15)}`);
 
     const searchResult = await this.esClient.search<HostMetadata>(query).catch(catchAndWrapError);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
@@ -10,6 +10,12 @@ import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@k
 import type { SearchResponse, SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
 import type { Agent, AgentPolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { AgentNotFoundError } from '@kbn/fleet-plugin/server';
+import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
+import {
+  hasVersionSuffix,
+  removeVersionSuffixFromPolicyId,
+} from '@kbn/fleet-plugin/common/services/version_specific_policies_utils';
+import { stringify } from '../../utils/stringify';
 import type {
   HostInfo,
   HostMetadata,
@@ -85,6 +91,46 @@ export class EndpointMetadataService {
       );
       await this.fleetServices.ensureInCurrentSpace({ agentIds });
     }
+  }
+
+  /**
+   * Mutate the `hits` included in a search response against the United metadata index to address
+   * known issue with data populated in the records
+   * @param data
+   * @private
+   */
+  private adjustUnitedIndexSearchResultHits(
+    data: SearchResponse<UnitedAgentMetadataPersistedData>
+  ): SearchResponse<UnitedAgentMetadataPersistedData> {
+    const hits = data.hits?.hits ?? [];
+    const recordsAltered: string[] = [];
+
+    for (const hit of hits) {
+      // If `united.agent.policy_id` includes a suffix, remove it
+      if (
+        hit._source?.united?.agent?.policy_id &&
+        hasVersionSuffix(hit._source?.united?.agent?.policy_id)
+      ) {
+        const existingPolicyId = hit._source.united.agent.policy_id;
+        const adjustedPolicyId = removeVersionSuffixFromPolicyId(existingPolicyId);
+
+        recordsAltered.push(
+          `Agent [${hit._source?.united?.agent?.agent?.id}]: adjusted 'policy_id' property value from [${existingPolicyId}] to [${adjustedPolicyId}]`
+        );
+
+        (hit._source.united.agent.policy_id as string) = adjustedPolicyId;
+      }
+    }
+
+    if (recordsAltered.length > 0) {
+      this.logger
+        .get('adjustUnitedIndexSearchResultHits')
+        .debug(
+          () => `Made ${recordsAltered.length} data adjustments:\n${recordsAltered.join('\n')}`
+        );
+    }
+
+    return data;
   }
 
   /**
@@ -287,7 +333,7 @@ export class EndpointMetadataService {
    */
   async getFleetAgent(agentId: string): Promise<Agent> {
     try {
-      return await this.fleetServices.agent.getAgent(agentId);
+      return await this.fleetServices.fetchAgent(agentId);
     } catch (error) {
       if (error instanceof AgentNotFoundError) {
         throw new FleetAgentNotFoundError(`agent with id ${agentId} not found`, error);
@@ -357,10 +403,13 @@ export class EndpointMetadataService {
 
     let unitedMetadataQueryResponse: SearchResponse<UnitedAgentMetadataPersistedData>;
 
+    logger.debug(() => `Executing query: ${stringify(unitedIndexQuery, 15)}`);
+
     try {
-      unitedMetadataQueryResponse = await this.esClient.search<UnitedAgentMetadataPersistedData>(
-        unitedIndexQuery
-      );
+      unitedMetadataQueryResponse = await this.esClient
+        .search<UnitedAgentMetadataPersistedData>(unitedIndexQuery)
+        .then(this.adjustUnitedIndexSearchResultHits.bind(this));
+
       // FYI: we don't need to run the ES search response through `this.ensureDataValidForSpace()` because
       // the query (`unitedIndexQuery`) above already included a filter with all of the valid policy ids
       // for the current space - thus data is already coped to the space
@@ -442,7 +491,11 @@ export class EndpointMetadataService {
   }
 
   async getMetadataForEndpoints(endpointIDs: string[]): Promise<HostMetadata[]> {
-    const query = getESQueryHostMetadataByIDs(endpointIDs);
+    const ccsEnabled = await this.endpointContext.isCcsEnabled();
+    const query = getESQueryHostMetadataByIDs(endpointIDs, ccsEnabled);
+
+    this.logger.get('getMetadataForEndpoints').debug(() => `with query: ${stringify(query, 15)}`);
+
     const searchResult = await this.esClient.search<HostMetadata>(query).catch(catchAndWrapError);
 
     await this.ensureDataValidForSpace(searchResult);

--- a/x-pack/solutions/security/plugins/security_solution/server/integration_tests/telemetry.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/integration_tests/telemetry.test.ts
@@ -377,15 +377,15 @@ describe('telemetry tasks', () => {
 
     it('should manage runtime errors searching fleet agents', async () => {
       const receiver: TelemetryReceiver = telemetryReceiver as TelemetryReceiver;
-      const agentClient = receiver['agentClient']!;
-      const listAgents = agentClient.listAgents;
+      const fleetServices = receiver['fleetServices']!;
+      const listAgents = fleetServices.fetchAgentList;
       deferred.push(() => {
-        agentClient.listAgents = listAgents;
+        fleetServices.fetchAgentList = listAgents;
       });
 
       const errorMessage = 'Error searching for fleet agents';
 
-      agentClient.listAgents = jest.fn((_) => Promise.reject(Error(errorMessage)));
+      fleetServices.fetchAgentList = jest.fn((_) => Promise.reject(Error(errorMessage)));
 
       const [task, started] = await mockAndScheduleEndpointTask();
 
@@ -411,13 +411,13 @@ describe('telemetry tasks', () => {
 
     it('should work without fleet agents', async () => {
       const receiver: TelemetryReceiver = telemetryReceiver as TelemetryReceiver;
-      const agentClient = receiver['agentClient']!;
-      const listAgents = agentClient.listAgents;
+      const fleetServices = receiver['fleetServices']!;
+      const listAgents = fleetServices.fetchAgentList;
       deferred.push(() => {
-        agentClient.listAgents = listAgents;
+        fleetServices.fetchAgentList = listAgents;
       });
 
-      agentClient.listAgents = jest.fn((_) =>
+      fleetServices.fetchAgentList = jest.fn((_) =>
         Promise.resolve({
           agents: [],
           total: 0,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -46,11 +46,7 @@ import {
 } from '@kbn/securitysolution-rules';
 import type { TransportResult } from '@elastic/elasticsearch';
 import type { AgentPolicy, Installation } from '@kbn/fleet-plugin/common';
-import type {
-  AgentClient,
-  AgentPolicyServiceInterface,
-  PackageService,
-} from '@kbn/fleet-plugin/server';
+import type { PackageService } from '@kbn/fleet-plugin/server';
 import type { ExceptionListClient } from '@kbn/lists-plugin/server';
 import moment from 'moment';
 
@@ -114,6 +110,7 @@ import type {
   Processor,
   Totals,
 } from './ingest_pipelines_stats.types';
+import type { EndpointInternalFleetServicesInterface } from '../../endpoint/services/fleet';
 
 export interface ITelemetryReceiver {
   start(
@@ -291,8 +288,7 @@ export interface ITelemetryReceiver {
 
 export class TelemetryReceiver implements ITelemetryReceiver {
   private readonly logger: TelemetryLogger;
-  private agentClient?: AgentClient;
-  private agentPolicyService?: AgentPolicyServiceInterface;
+  private fleetServices?: EndpointInternalFleetServicesInterface;
   private _esClient?: ElasticsearchClient;
   private exceptionListClient?: ExceptionListClient;
   private soClient?: SavedObjectsClientContract;
@@ -326,8 +322,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
   ) {
     this.getIndexForType = getIndexForType;
     this.alertsIndex = alertsIndex;
-    this.agentClient = endpointContextService?.getInternalFleetServices().agent;
-    this.agentPolicyService = endpointContextService?.getInternalFleetServices().agentPolicy;
+    this.fleetServices = endpointContextService?.getInternalFleetServices();
     this._esClient = core?.elasticsearch.client.asInternalUser;
     this.exceptionListClient = exceptionListClient;
     this.packageService = packageService;
@@ -369,8 +364,8 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     }
 
     return (
-      this.agentClient
-        ?.listAgents({
+      this.fleetServices
+        ?.fetchAgentList({
           perPage: this.maxRecords,
           showInactive: true,
           kuery: 'status:*', // include unenrolled agents
@@ -663,7 +658,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
       );
     }
 
-    return this.agentPolicyService?.get(this.soClient, id);
+    return this.fleetServices?.agentPolicy?.get(this.soClient, id);
   }
 
   public async fetchTrustedApplications() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution][Endpoint] Fix endpoint metadata query and response actions for agents using agent-specific policy ids (#277100)](https://github.com/elastic/kibana/pull/277100)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-14T15:44:20Z","message":"[Security Solution][Endpoint] Fix endpoint metadata query and response actions for agents using agent-specific policy ids (#277100)\n\n## Summary\n\nA recent change in Fleet in support of agent-specific policies (see\nelastic/ingest-dev#8624 and elastic/package-spec#165) can now append a\nversion/suffix to an agent's `policy_id` value in the form\n`<policyId>#<suffix>`.\nThis broke Endpoint queries and workflows that match/compare against the\nbare\nagent policy id, causing endpoints not to be shown in the Endpoint LIst\nand\nresponse actions to fail.\n\nFixes #276295\n\n#### Changes\n\n- **Endpoint metadata filter** (`endpoint_metadata_filter.ts`): the\npolicy id\nfilter against the united index now matches both the exact `policy_id`\nand a\n`<policyId>#*` wildcard, so agents whose `policy_id` carries a suffix\nare\n  included.\n- **EndpointFleetServicesInterface** : added 3 additional methods to\nthis\n- interface - `fetchAgent()`, fetchAgentList() and `fetchAgentsById()` -\nto handle\n- removing the `policy_id` suffix if present on data returned from fleet\n- **Endpoint metadata service** (`endpoint_metadata_service.ts`):\nadjusts the\n`united.agent.policy_id` value on united index search result hits to\nstrip the\n  suffix. Also caps the query debug logging depth.\n- **Base response actions client** (`base_response_actions_client.ts`):\nthrows a\nclearer error when a data inconsistency is detected (agent has a\n`policy_id`\nbut no matching integration policy), and adds debug logging when agent\npolicy\ninfo retrieval fails. The current error being thrown when this condition\nexists is\n`Cannot read properties of undefined (reading 'id')`\n- Removed dead code (`agentVersionsMap`) from the policy route service\nand\n  renamed a query builder param for clarity (`endpointPolicyIds` ->\n  `fleetAgentPolicyIds`).\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"fd90dfecfe455b1fd90a198a833c96f1d4426481","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","backport:version","v9.5.0","v9.4.4","v9.6.0"],"title":"[Security Solution][Endpoint] Fix endpoint metadata query and response actions for agents using agent-specific policy ids","number":277100,"url":"https://github.com/elastic/kibana/pull/277100","mergeCommit":{"message":"[Security Solution][Endpoint] Fix endpoint metadata query and response actions for agents using agent-specific policy ids (#277100)\n\n## Summary\n\nA recent change in Fleet in support of agent-specific policies (see\nelastic/ingest-dev#8624 and elastic/package-spec#165) can now append a\nversion/suffix to an agent's `policy_id` value in the form\n`<policyId>#<suffix>`.\nThis broke Endpoint queries and workflows that match/compare against the\nbare\nagent policy id, causing endpoints not to be shown in the Endpoint LIst\nand\nresponse actions to fail.\n\nFixes #276295\n\n#### Changes\n\n- **Endpoint metadata filter** (`endpoint_metadata_filter.ts`): the\npolicy id\nfilter against the united index now matches both the exact `policy_id`\nand a\n`<policyId>#*` wildcard, so agents whose `policy_id` carries a suffix\nare\n  included.\n- **EndpointFleetServicesInterface** : added 3 additional methods to\nthis\n- interface - `fetchAgent()`, fetchAgentList() and `fetchAgentsById()` -\nto handle\n- removing the `policy_id` suffix if present on data returned from fleet\n- **Endpoint metadata service** (`endpoint_metadata_service.ts`):\nadjusts the\n`united.agent.policy_id` value on united index search result hits to\nstrip the\n  suffix. Also caps the query debug logging depth.\n- **Base response actions client** (`base_response_actions_client.ts`):\nthrows a\nclearer error when a data inconsistency is detected (agent has a\n`policy_id`\nbut no matching integration policy), and adds debug logging when agent\npolicy\ninfo retrieval fails. The current error being thrown when this condition\nexists is\n`Cannot read properties of undefined (reading 'id')`\n- Removed dead code (`agentVersionsMap`) from the policy route service\nand\n  renamed a query builder param for clarity (`endpointPolicyIds` ->\n  `fleetAgentPolicyIds`).\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"fd90dfecfe455b1fd90a198a833c96f1d4426481"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/278200","number":278200,"state":"OPEN"},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277100","number":277100,"mergeCommit":{"message":"[Security Solution][Endpoint] Fix endpoint metadata query and response actions for agents using agent-specific policy ids (#277100)\n\n## Summary\n\nA recent change in Fleet in support of agent-specific policies (see\nelastic/ingest-dev#8624 and elastic/package-spec#165) can now append a\nversion/suffix to an agent's `policy_id` value in the form\n`<policyId>#<suffix>`.\nThis broke Endpoint queries and workflows that match/compare against the\nbare\nagent policy id, causing endpoints not to be shown in the Endpoint LIst\nand\nresponse actions to fail.\n\nFixes #276295\n\n#### Changes\n\n- **Endpoint metadata filter** (`endpoint_metadata_filter.ts`): the\npolicy id\nfilter against the united index now matches both the exact `policy_id`\nand a\n`<policyId>#*` wildcard, so agents whose `policy_id` carries a suffix\nare\n  included.\n- **EndpointFleetServicesInterface** : added 3 additional methods to\nthis\n- interface - `fetchAgent()`, fetchAgentList() and `fetchAgentsById()` -\nto handle\n- removing the `policy_id` suffix if present on data returned from fleet\n- **Endpoint metadata service** (`endpoint_metadata_service.ts`):\nadjusts the\n`united.agent.policy_id` value on united index search result hits to\nstrip the\n  suffix. Also caps the query debug logging depth.\n- **Base response actions client** (`base_response_actions_client.ts`):\nthrows a\nclearer error when a data inconsistency is detected (agent has a\n`policy_id`\nbut no matching integration policy), and adds debug logging when agent\npolicy\ninfo retrieval fails. The current error being thrown when this condition\nexists is\n`Cannot read properties of undefined (reading 'id')`\n- Removed dead code (`agentVersionsMap`) from the policy route service\nand\n  renamed a query builder param for clarity (`endpointPolicyIds` ->\n  `fleetAgentPolicyIds`).\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"fd90dfecfe455b1fd90a198a833c96f1d4426481"}}]}] BACKPORT-->