### PR TITLE
[9.4] [SecuritySolution] Preserve threat_match concurrent_searches/items_per_search on GUI save (#276823)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.artifacts
+docs/**/.artifacts
+/.superset
 .aws-config.json
 .signing-config.json
 .ackrc

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.test.ts
@@ -34,7 +34,12 @@ import {
   formatDefineStepData,
   formatRule,
   formatScheduleStepData,
+  getApiOnlyThreatMatchFields,
 } from './helpers';
+import {
+  getRulesSchemaMock,
+  getThreatMatchingSchemaMock,
+} from '../../../../../common/api/detection_engine/model/rule_schema/rule_response_schema.mock';
 import {
   mockAboutStepRule,
   mockActionsStepRule,
@@ -1167,6 +1172,37 @@ describe('helpers', () => {
       );
 
       expect(result).not.toHaveProperty<RuleCreateProps>('id');
+    });
+  });
+
+  describe('getApiOnlyThreatMatchFields', () => {
+    // https://github.com/elastic/kibana/issues/276203
+    it('returns concurrent_searches/items_per_search from a threat_match rule', () => {
+      const rule = {
+        ...getThreatMatchingSchemaMock(),
+        concurrent_searches: 4,
+        items_per_search: 2500,
+      };
+
+      const result = getApiOnlyThreatMatchFields(rule);
+
+      expect(result).toEqual({ concurrent_searches: 4, items_per_search: 2500 });
+    });
+
+    it('returns undefined values when a threat_match rule has none set', () => {
+      const rule = getThreatMatchingSchemaMock();
+
+      const result = getApiOnlyThreatMatchFields(rule);
+
+      expect(result).toEqual({ concurrent_searches: undefined, items_per_search: undefined });
+    });
+
+    it('returns an empty object for non-threat_match rules', () => {
+      const rule = getRulesSchemaMock();
+
+      const result = getApiOnlyThreatMatchFields(rule);
+
+      expect(result).toEqual({});
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.ts
@@ -53,6 +53,8 @@ import type {
 import { DataSourceType, AlertSuppressionDurationType } from '../../../common/types';
 import type {
   RuleCreateProps,
+  RuleResponse,
+  ThreatMatchRuleUpdateProps,
   AlertSuppression,
   RequiredFieldInput,
   SeverityMapping,
@@ -693,6 +695,20 @@ export const formatRule = <T>(
     formatScheduleStepData(scheduleData),
     formatActionsStepData(actionsData, actionTypeRegistry),
   ]) as unknown as T;
+
+/**
+ * concurrent_searches/items_per_search are API-only fields with no UI controls
+ * (see #276203), so they never round-trip through the define step form. On
+ * rule edit, merge them back in directly from the previously loaded rule
+ * rather than routing them through form state, since the edit form saves via
+ * a full-replace PUT.
+ */
+export const getApiOnlyThreatMatchFields = (
+  rule: RuleResponse
+): Pick<ThreatMatchRuleUpdateProps, 'concurrent_searches' | 'items_per_search'> =>
+  rule.type === 'threat_match'
+    ? { concurrent_searches: rule.concurrent_searches, items_per_search: rule.items_per_search }
+    : {};
 
 export const formatPreviewRule = ({
   defineRuleData,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -51,7 +51,7 @@ import { StepDefineRule } from '../../components/step_define_rule';
 import { useExperimentalFeatureFieldsTransform } from '../../components/step_define_rule/use_experimental_feature_fields_transform';
 import { StepScheduleRule } from '../../components/step_schedule_rule';
 import { StepRuleActions } from '../../../rule_creation/components/step_rule_actions';
-import { formatRule } from '../rule_creation/helpers';
+import { formatRule, getApiOnlyThreatMatchFields } from '../rule_creation/helpers';
 import {
   getActionMessageParams,
   getStepsData,
@@ -423,8 +423,9 @@ const EditRulePageComponent: FC<{ rule: RuleResponse }> = ({ rule }) => {
 
     const updatedRule = await updateRule({
       ...formattedRule,
+      ...getApiOnlyThreatMatchFields(rule),
       ...(ruleId ? { id: ruleId } : {}),
-    });
+    } as RuleUpdateProps);
 
     const aiSession = aiRuleCreation.getSession();
     const isAiEdited = isAiRuleUpdateRef.current;

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules.ts
@@ -28,6 +28,7 @@ import type TestAgent from 'supertest/lib/agent';
 import type {
   RuleResponse,
   RuleUpdateProps,
+  ThreatMatchRuleUpdateProps,
 } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import { v4 as uuidV4 } from 'uuid';
 import { createSupertestErrorLogger } from '../../../../edr_workflows/utils';
@@ -51,6 +52,7 @@ import {
   getActionsWithoutFrequencies,
   getSomeActionsWithFrequencies,
   getCustomQueryRuleParams,
+  getSimpleThreatMatch,
 } from '../../../utils';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
@@ -552,6 +554,57 @@ export default ({ getService }: FtrProviderContext) => {
 
           expect(outputRule.type).to.be('query');
           expect(outputRule.saved_id).to.be(undefined);
+        });
+      });
+
+      describe('threat_match rule type', () => {
+        // https://github.com/elastic/kibana/issues/276203
+        it('should preserve concurrent_searches and items_per_search when they are included in the update payload', async () => {
+          const ruleId = 'rule-1';
+          await createRule(supertest, log, {
+            ...getSimpleThreatMatch(ruleId),
+            concurrent_searches: 4,
+            items_per_search: 2500,
+          });
+
+          const updatedRule: ThreatMatchRuleUpdateProps = {
+            ...getSimpleThreatMatch(ruleId),
+            rule_id: ruleId,
+            name: 'updated name',
+            concurrent_searches: 4,
+            items_per_search: 2500,
+          };
+
+          const { body: outputRule } = await detectionsApi
+            .updateRule({ body: updatedRule })
+            .expect(200);
+
+          expect(outputRule.name).to.be('updated name');
+          expect(outputRule.concurrent_searches).to.be(4);
+          expect(outputRule.items_per_search).to.be(2500);
+        });
+
+        it('should reset concurrent_searches and items_per_search to their defaults when they are omitted from the update payload', async () => {
+          const ruleId = 'rule-1';
+          await createRule(supertest, log, {
+            ...getSimpleThreatMatch(ruleId),
+            concurrent_searches: 4,
+            items_per_search: 2500,
+          });
+
+          const updatedRule: ThreatMatchRuleUpdateProps = {
+            ...getSimpleThreatMatch(ruleId),
+            rule_id: ruleId,
+            name: 'updated name',
+          };
+
+          const { body: outputRule } = await detectionsApi
+            .updateRule({ body: updatedRule })
+            .expect(200);
+
+          expect(outputRule.name).to.be('updated name');
+          expect(outputRule.concurrent_searches).to.be(undefined);
+          expect(outputRule.items_per_search).to.be(undefined);
         });
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[SecuritySolution] Preserve threat_match concurrent_searches/items_per_search on GUI save (#276823)](https://github.com/elastic/kibana/pull/276823)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Devin W. Hurley","email":"devin.hurley@elastic.co"},"sourceCommit":{"committedDate":"2026-07-09T15:39:52Z","message":"[SecuritySolution] Preserve threat_match concurrent_searches/items_per_search on GUI save (#276823)\n\n## Summary\n\nFixes #276203.\n\nFor `threat_match` (Indicator Match) rules, the API-only fields\n`concurrent_searches` and `items_per_search` were silently reset to\ntheir defaults whenever the rule was edited and saved through the GUI,\nbecause the rule edit form saves via a full-replace `PUT`, and these\nfields were never round-tripped through the form state.\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>","sha":"913107633ea4223cc81dbac3f03fcb80447f94ce","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["review","release_note:fix","backport missing","backport:all-open","v9.5.0","v9.6.0"],"title":"[SecuritySolution] Preserve threat_match concurrent_searches/items_per_search on GUI save","number":276823,"url":"https://github.com/elastic/kibana/pull/276823","mergeCommit":{"message":"[SecuritySolution] Preserve threat_match concurrent_searches/items_per_search on GUI save (#276823)\n\n## Summary\n\nFixes #276203.\n\nFor `threat_match` (Indicator Match) rules, the API-only fields\n`concurrent_searches` and `items_per_search` were silently reset to\ntheir defaults whenever the rule was edited and saved through the GUI,\nbecause the rule edit form saves via a full-replace `PUT`, and these\nfields were never round-tripped through the form state.\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>","sha":"913107633ea4223cc81dbac3f03fcb80447f94ce"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277248","number":277248,"state":"OPEN"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276823","number":276823,"mergeCommit":{"message":"[SecuritySolution] Preserve threat_match concurrent_searches/items_per_search on GUI save (#276823)\n\n## Summary\n\nFixes #276203.\n\nFor `threat_match` (Indicator Match) rules, the API-only fields\n`concurrent_searches` and `items_per_search` were silently reset to\ntheir defaults whenever the rule was edited and saved through the GUI,\nbecause the rule edit form saves via a full-replace `PUT`, and these\nfields were never round-tripped through the form state.\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>","sha":"913107633ea4223cc81dbac3f03fcb80447f94ce"}}]}] BACKPORT-->