### PR TITLE
[Discover][Flyout] show Table and JSON tabs to the document and attack flyouts when opened as child flyouts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/attack_flyout_wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/attack_flyout_wrapper.test.tsx
@@ -9,9 +9,11 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
 import { useAttackDetails } from '../../../flyout/attack_details/hooks/use_attack_details';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { AttackFlyoutWrapper } from './attack_flyout_wrapper';
 
 jest.mock('../../../flyout/attack_details/hooks/use_attack_details');
+jest.mock('../../../data_view_manager/hooks/use_data_view');
 
 const mockAttackFlyout = jest.fn((props: { onAttackUpdated?: () => void }) => (
   <button
@@ -44,8 +46,14 @@ const renderWrapper = (props: Partial<React.ComponentProps<typeof AttackFlyoutWr
   );
 
 describe('<AttackFlyoutWrapper />', () => {
+  const mockDataView = { hasMatchedIndices: () => true };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: mockDataView,
+    });
   });
 
   it('renders FlyoutLoading on the initial fetch when there is no hit yet', () => {
@@ -124,7 +132,9 @@ describe('<AttackFlyoutWrapper />', () => {
 
     renderWrapper();
 
-    expect(mockAttackFlyout).toHaveBeenCalledWith(expect.objectContaining({ attack: mockAttack }));
+    expect(mockAttackFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ attack: mockAttack, dataView: mockDataView })
+    );
   });
 
   it('invokes the consumer onAttackUpdated AND refetches when AttackFlyout reports an update', () => {
@@ -156,5 +166,41 @@ describe('<AttackFlyoutWrapper />', () => {
     renderWrapper({ attackId: 'my-attack', indexName: 'my-index' });
 
     expect(useAttackDetails).toHaveBeenCalledWith({ attackId: 'my-attack', indexName: 'my-index' });
+  });
+
+  it('renders loading while data view is loading and hit is not available', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'loading',
+      dataView: mockDataView,
+    });
+    (useAttackDetails as jest.Mock).mockReturnValue({
+      loading: false,
+      searchHit: undefined,
+      attack: null,
+      refetch: jest.fn(),
+    });
+
+    const { getByTestId } = renderWrapper();
+
+    expect(getByTestId('attack-flyout-wrapper-loading')).toBeInTheDocument();
+  });
+
+  it('renders error when data view has no matched indices', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        hasMatchedIndices: () => false,
+      },
+    });
+    (useAttackDetails as jest.Mock).mockReturnValue({
+      loading: false,
+      searchHit: mockSearchHit,
+      attack: mockAttack,
+      refetch: jest.fn(),
+    });
+
+    const { getByTestId } = renderWrapper();
+
+    expect(getByTestId('attack-flyout-wrapper-error')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/attack_flyout_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/attack_flyout_wrapper.tsx
@@ -8,11 +8,13 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils';
+import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import { useAttackDetails } from '../../../flyout/attack_details/hooks/use_attack_details';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
 import { AttackFlyout } from '.';
 
 const FETCH_ERROR = i18n.translate('xpack.securitySolution.flyoutV2.attack.wrapper.fetchError', {
@@ -50,7 +52,12 @@ export interface AttackFlyoutWrapperProps {
  */
 export const AttackFlyoutWrapper = memo(
   ({ attackId, indexName, onAttackUpdated, renderCellActions }: AttackFlyoutWrapperProps) => {
+    const { dataView, status } = useDataView(PageScope.default);
     const { loading, searchHit, attack, refetch } = useAttackDetails({ attackId, indexName });
+
+    const isDataViewLoading = status === 'loading' || status === 'pristine';
+    const isDataViewInvalid =
+      status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
 
     const hit = useMemo(
       () => (searchHit ? buildDataTableRecord(searchHit as EsHitRecord) : null),
@@ -62,15 +69,11 @@ export const AttackFlyoutWrapper = memo(
       refetch();
     }, [onAttackUpdated, refetch]);
 
-    // Only render the full-flyout loading state on the initial fetch (no hit yet).
-    // Subsequent refetches (e.g. after a mutation) keep the flyout visible so the
-    // header does not flicker; child components can render their own loading state
-    // if needed.
-    if (loading && !hit) {
+    if ((isDataViewLoading || loading) && !hit) {
       return <FlyoutLoading data-test-subj="attack-flyout-wrapper-loading" />;
     }
 
-    if (!hit || !attack) {
+    if (isDataViewInvalid || !hit || !attack) {
       return (
         <EuiCallOut
           announceOnMount
@@ -86,6 +89,7 @@ export const AttackFlyoutWrapper = memo(
       <AttackFlyout
         hit={hit}
         attack={attack}
+        dataView={dataView}
         onAttackUpdated={handleAttackUpdated}
         renderCellActions={renderCellActions}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/index.test.tsx
@@ -12,8 +12,13 @@ import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
 import { AttackFlyout, JSON_TAB_TEST_ID, OVERVIEW_TAB_TEST_ID, TABLE_TAB_TEST_ID } from '.';
 import { TestProviders } from '../../../common/mock';
 import { useSharedToolsFlyoutApi } from '../../shared/tools/use_shared_tools_flyout_api';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 
 jest.mock('../../shared/tools/use_shared_tools_flyout_api');
+jest.mock('../../../common/hooks/is_in_security_app');
+jest.mock('@kbn/unified-doc-viewer-plugin/public', () => ({
+  UnifiedDocViewer: () => <div data-test-subj="mock-unified-doc-viewer" />,
+}));
 
 jest.mock('./footer', () => ({
   Footer: ({ onAttackUpdated }: { onAttackUpdated: () => void }) => (
@@ -73,6 +78,7 @@ const createAttackHit = (extra: DataTableRecord['flattened'] = {}): DataTableRec
   } as DataTableRecord);
 
 const mockAttack = {} as AttackDiscoveryAlert;
+const mockDataView = { hasMatchedIndices: () => true } as never;
 
 describe('<AttackFlyout />', () => {
   const mockOpenNotes = jest.fn();
@@ -80,12 +86,18 @@ describe('<AttackFlyout />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(useSharedToolsFlyoutApi).mockReturnValue({ openNotes: mockOpenNotes });
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
   });
 
   it('renders the header, body, and footer', () => {
     const { getByTestId } = render(
       <TestProviders>
-        <AttackFlyout hit={createAttackHit()} attack={mockAttack} onAttackUpdated={jest.fn()} />
+        <AttackFlyout
+          hit={createAttackHit()}
+          attack={mockAttack}
+          dataView={mockDataView}
+          onAttackUpdated={jest.fn()}
+        />
       </TestProviders>
     );
 
@@ -97,7 +109,12 @@ describe('<AttackFlyout />', () => {
   it('renders Overview and JSON tabs and switches between them', () => {
     const { getByTestId, queryByTestId } = render(
       <TestProviders>
-        <AttackFlyout hit={createAttackHit()} attack={mockAttack} onAttackUpdated={jest.fn()} />
+        <AttackFlyout
+          hit={createAttackHit()}
+          attack={mockAttack}
+          dataView={mockDataView}
+          onAttackUpdated={jest.fn()}
+        />
       </TestProviders>
     );
 
@@ -134,7 +151,12 @@ describe('<AttackFlyout />', () => {
 
     const { getByTestId } = render(
       <TestProviders>
-        <AttackFlyout hit={minimalHit} attack={mockAttack} onAttackUpdated={jest.fn()} />
+        <AttackFlyout
+          hit={minimalHit}
+          attack={mockAttack}
+          dataView={mockDataView}
+          onAttackUpdated={jest.fn()}
+        />
       </TestProviders>
     );
 
@@ -147,7 +169,12 @@ describe('<AttackFlyout />', () => {
     const hit = createAttackHit();
     const { getByTestId } = render(
       <TestProviders>
-        <AttackFlyout hit={hit} attack={mockAttack} onAttackUpdated={jest.fn()} />
+        <AttackFlyout
+          hit={hit}
+          attack={mockAttack}
+          dataView={mockDataView}
+          onAttackUpdated={jest.fn()}
+        />
       </TestProviders>
     );
 
@@ -164,6 +191,7 @@ describe('<AttackFlyout />', () => {
         <AttackFlyout
           hit={createAttackHit()}
           attack={mockAttack}
+          dataView={mockDataView}
           onAttackUpdated={onAttackUpdated}
         />
       </TestProviders>
@@ -180,6 +208,7 @@ describe('<AttackFlyout />', () => {
         <AttackFlyout
           hit={createAttackHit()}
           attack={mockAttack}
+          dataView={mockDataView}
           onAttackUpdated={onAttackUpdated}
         />
       </TestProviders>
@@ -187,5 +216,25 @@ describe('<AttackFlyout />', () => {
 
     fireEvent.click(getByTestId('mock-footer'));
     expect(onAttackUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders UnifiedDocViewer outside Security Solution (e.g. Discover)', () => {
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+
+    const { getByTestId, queryByTestId } = render(
+      <TestProviders>
+        <AttackFlyout
+          hit={createAttackHit()}
+          attack={mockAttack}
+          dataView={mockDataView}
+          onAttackUpdated={jest.fn()}
+        />
+      </TestProviders>
+    );
+
+    expect(queryByTestId(OVERVIEW_TAB_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(TABLE_TAB_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(JSON_TAB_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId('mock-unified-doc-viewer')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/index.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -17,11 +18,13 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+import { UnifiedDocViewer } from '@kbn/unified-doc-viewer-plugin/public';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
-import { JsonTab as SharedJsonTab } from '../../shared/components/json_tab';
 import { cellActionRenderer } from '../../shared/components/cell_actions';
+import { JsonTab as SharedJsonTab } from '../../shared/components/json_tab';
 import { useSharedToolsFlyoutApi } from '../../shared/tools/use_shared_tools_flyout_api';
 import { useTabs } from '../../shared/hooks/use_tabs';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { Header } from './header';
 import { OverviewTab } from './tabs/overview_tab';
 import { TableTab } from './tabs/table_tab';
@@ -68,6 +71,10 @@ export interface AttackFlyoutProps {
    * Renderer for cell actions in this flyout and nested alert flyouts.
    */
   renderCellActions?: CellActionRenderer;
+  /**
+   * Data view used by the underlying document viewer.
+   */
+  dataView: DataView;
 }
 
 /**
@@ -76,8 +83,15 @@ export interface AttackFlyoutProps {
  * header, overview tab, and footer.
  */
 export const AttackFlyout = memo(
-  ({ hit, attack, onAttackUpdated, renderCellActions = cellActionRenderer }: AttackFlyoutProps) => {
+  ({
+    hit,
+    attack,
+    onAttackUpdated,
+    renderCellActions = cellActionRenderer,
+    dataView,
+  }: AttackFlyoutProps) => {
     const { openNotes } = useSharedToolsFlyoutApi();
+    const isSecurityApp = useIsInSecurityApp();
 
     // The selected tab is persisted to localStorage, sharing the key with the legacy
     // attack flyout so the user's preference carries across both implementations.
@@ -90,12 +104,10 @@ export const AttackFlyout = memo(
       openNotes({ hit });
     }, [openNotes, hit]);
 
-    return (
-      <>
-        <EuiFlyoutHeader data-test-subj="attack-flyout-header">
-          <Header hit={hit} onAttackUpdated={onAttackUpdated} onShowNotes={onShowNotes} />
-        </EuiFlyoutHeader>
-        <EuiFlyoutBody data-test-subj="attack-flyout-body">
+    // Overview, Table and JSON tabs rendered when the flyout is displayed in Security Solution
+    const securityTabs = useMemo(
+      () => (
+        <>
           <EuiTabs>
             <EuiTab
               isSelected={selectedTabId === 'overview'}
@@ -120,6 +132,16 @@ export const AttackFlyout = memo(
             </EuiTab>
           </EuiTabs>
           <EuiSpacer size="m" />
+        </>
+      ),
+      [selectedTabId, setSelectedTabId]
+    );
+
+    // Overview, Table and JSON tab contents rendered when the flyout is displayed in Security Solution
+    // We're using our custom Security Solution document Table and JSON tabs
+    const securityTabContents = useMemo(
+      () => (
+        <>
           {selectedTabId === 'table' ? (
             <TableTab hit={hit} renderCellActions={renderCellActions} />
           ) : selectedTabId === 'json' ? (
@@ -134,6 +156,59 @@ export const AttackFlyout = memo(
               onAttackUpdated={onAttackUpdated}
               renderCellActions={renderCellActions}
             />
+          )}
+        </>
+      ),
+      [hit, onAttackUpdated, renderCellActions, selectedTabId]
+    );
+
+    // Overview, Table and JSON tabs rendered when the flyout is displayed in Discover
+    // We're then using the Discover Table and JSON tabs
+    const discoverContent = useMemo(
+      () => (
+        <UnifiedDocViewer
+          key={hit.id}
+          hit={hit}
+          dataView={dataView}
+          columns={Object.keys(hit.flattened)}
+          onAddColumn={() => {}}
+          onRemoveColumn={() => {}}
+          docViewsRegistry={(registry) => {
+            registry.add({
+              id: 'doc_view_attack_overview',
+              title: OVERVIEW_TAB_LABEL,
+              order: 0,
+              render: () => (
+                <>
+                  <EuiSpacer size="m" />
+                  <OverviewTab
+                    hit={hit}
+                    onAttackUpdated={onAttackUpdated}
+                    renderCellActions={renderCellActions}
+                  />
+                </>
+              ),
+            });
+            return registry;
+          }}
+        />
+      ),
+      [dataView, hit, onAttackUpdated, renderCellActions]
+    );
+
+    return (
+      <>
+        <EuiFlyoutHeader data-test-subj="attack-flyout-header">
+          <Header hit={hit} onAttackUpdated={onAttackUpdated} onShowNotes={onShowNotes} />
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody data-test-subj="attack-flyout-body">
+          {isSecurityApp ? (
+            <>
+              {securityTabs}
+              {securityTabContents}
+            </>
+          ) : (
+            <>{discoverContent}</>
           )}
         </EuiFlyoutBody>
         <EuiFlyoutFooter data-test-subj="attack-flyout-footer">

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.test.tsx
@@ -137,6 +137,7 @@ describe('DocumentFlyoutWrapper', () => {
     expect(mockDocumentFlyout).toHaveBeenCalledWith(
       expect.objectContaining({
         hit,
+        dataView: mockDataView,
         onAlertUpdated: expect.any(Function),
       })
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.tsx
@@ -127,6 +127,7 @@ export const DocumentFlyoutWrapper = memo(
       return (
         <DocumentFlyout
           hit={hit}
+          dataView={dataView}
           renderCellActions={renderCellActions}
           onAlertUpdated={handleAlertUpdated}
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
@@ -20,8 +20,9 @@ jest.mock('@kbn/discover-utils', () => ({
   getFieldValue: jest.fn(() => 'event'),
 }));
 // Stub the presentational flyout so we don't need its full provider tree.
+const mockDocumentFlyout = jest.fn((props) => <div data-test-subj="document-flyout" />);
 jest.mock('.', () => ({
-  DocumentFlyout: () => <div data-test-subj="document-flyout" />,
+  DocumentFlyout: (props: unknown) => mockDocumentFlyout(props),
 }));
 
 const props = {
@@ -35,10 +36,15 @@ const setEventsDetails = (tuple: unknown[]) =>
   (useTimelineEventsDetails as jest.Mock).mockReturnValue(tuple);
 
 describe('DocumentFlyoutWrapperFromPattern', () => {
+  const mockDataView = {
+    getRuntimeMappings: jest.fn(() => ({})),
+    hasMatchedIndices: jest.fn(() => true),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useDataView as jest.Mock).mockReturnValue({
-      dataView: { getRuntimeMappings: jest.fn(() => ({})), hasMatchedIndices: jest.fn(() => true) },
+      dataView: mockDataView,
       status: 'ready',
     });
     (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
@@ -55,6 +61,11 @@ describe('DocumentFlyoutWrapperFromPattern', () => {
   it('renders the document flyout once the document is resolved', () => {
     const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
     expect(getByTestId('document-flyout')).toBeInTheDocument();
+    expect(mockDocumentFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataView: mockDataView,
+      })
+    );
   });
 
   it('shows a not-found callout when no document matches the id across the pattern', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
@@ -109,6 +109,7 @@ export const DocumentFlyoutWrapperFromPattern = memo(
     if (hit) {
       return (
         <DocumentFlyout
+          dataView={dataView}
           hit={hit}
           renderCellActions={renderCellActions}
           onAlertUpdated={handleAlertUpdated}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.test.tsx
@@ -16,6 +16,9 @@ import { createStartServicesMock } from '../../../common/lib/kibana/kibana_react
 
 jest.mock('../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../../../common/hooks/is_in_security_app');
+jest.mock('@kbn/unified-doc-viewer-plugin/public', () => ({
+  UnifiedDocViewer: () => <div data-test-subj="mock-unified-doc-viewer" />,
+}));
 jest.mock('./tabs/table_tab', () => ({
   TableTab: () => <div data-test-subj="mock-table-tab" />,
 }));
@@ -53,6 +56,7 @@ const createAlertHit = (extra: DataTableRecord['flattened'] = {}): DataTableReco
     flattened: { 'event.kind': 'signal', ...extra },
     isAnchor: false,
   } as DataTableRecord);
+const mockDataView = { hasMatchedIndices: () => true } as never;
 
 describe('<DocumentFlyout />', () => {
   const startServices = createStartServicesMock();
@@ -69,6 +73,7 @@ describe('<DocumentFlyout />', () => {
       <TestProviders>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           onAlertUpdated={jest.fn()}
           renderCellActions={jest.fn()}
         />
@@ -85,6 +90,7 @@ describe('<DocumentFlyout />', () => {
       <TestProviders>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           onAlertUpdated={jest.fn()}
           renderCellActions={jest.fn()}
         />
@@ -102,6 +108,7 @@ describe('<DocumentFlyout />', () => {
       <TestProviders>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           renderCellActions={jest.fn()}
           onAlertUpdated={jest.fn()}
         />
@@ -120,6 +127,7 @@ describe('<DocumentFlyout />', () => {
       <TestProviders>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           renderCellActions={jest.fn()}
           onAlertUpdated={jest.fn()}
         />
@@ -146,7 +154,7 @@ describe('<DocumentFlyout />', () => {
     expect(queryByTestId('mock-table-tab')).not.toBeInTheDocument();
   });
 
-  it('does not render the Table and JSON tabs outside Security Solution (e.g. Discover)', () => {
+  it('renders UnifiedDocViewer without Security tabs outside Security Solution (e.g. Discover)', () => {
     (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
     (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
 
@@ -154,15 +162,17 @@ describe('<DocumentFlyout />', () => {
       <TestProviders>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           renderCellActions={jest.fn()}
           onAlertUpdated={jest.fn()}
         />
       </TestProviders>
     );
 
+    expect(queryByTestId(OVERVIEW_TAB_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(TABLE_TAB_TEST_ID)).not.toBeInTheDocument();
     expect(queryByTestId(JSON_TAB_TEST_ID)).not.toBeInTheDocument();
-    // the overview content still renders directly
-    expect(getByTestId('mock-overview-tab')).toBeInTheDocument();
+    expect(getByTestId('mock-unified-doc-viewer')).toBeInTheDocument();
   });
 
   it('opens notes in a system flyout when notes action is clicked', () => {
@@ -177,6 +187,7 @@ describe('<DocumentFlyout />', () => {
       <TestProviders startServices={startServices}>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           renderCellActions={jest.fn()}
           onAlertUpdated={jest.fn()}
         />
@@ -203,6 +214,7 @@ describe('<DocumentFlyout />', () => {
       <TestProviders startServices={startServices}>
         <DocumentFlyout
           hit={createAlertHit()}
+          dataView={mockDataView}
           renderCellActions={jest.fn()}
           onAlertUpdated={jest.fn()}
         />
@@ -220,6 +232,7 @@ describe('<DocumentFlyout />', () => {
         <TestProviders>
           <DocumentFlyout
             hit={createAlertHit({ _index: 'remote-cluster:.alerts-security.alerts-default' })}
+            dataView={mockDataView}
             renderCellActions={jest.fn()}
             onAlertUpdated={jest.fn()}
           />
@@ -247,6 +260,7 @@ describe('<DocumentFlyout />', () => {
         <TestProviders>
           <DocumentFlyout
             hit={remoteEventHit}
+            dataView={mockDataView}
             renderCellActions={jest.fn()}
             onAlertUpdated={jest.fn()}
           />
@@ -267,6 +281,7 @@ describe('<DocumentFlyout />', () => {
         <TestProviders>
           <DocumentFlyout
             hit={createAlertHit({ _index: '.alerts-security.alerts-default' })}
+            dataView={mockDataView}
             renderCellActions={jest.fn()}
             onAlertUpdated={jest.fn()}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { memo, useCallback, useMemo } from 'react';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -19,6 +20,7 @@ import { css } from '@emotion/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
+import { UnifiedDocViewer } from '@kbn/unified-doc-viewer-plugin/public';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { FlyoutLoading } from '../../shared/components/flyout_loading';
@@ -87,13 +89,17 @@ export interface DocumentFlyoutProps {
    * Callback invoked after alert mutations to refresh related flyouts.
    */
   onAlertUpdated: () => void;
+  /**
+   * Data view used by the underlying document viewer.
+   */
+  dataView: DataView;
 }
 
 /**
  * Content for the document flyout, combining the header and overview tab.
  */
 export const DocumentFlyout = memo(
-  ({ hit, onAlertUpdated, renderCellActions }: DocumentFlyoutProps) => {
+  ({ hit, onAlertUpdated, renderCellActions, dataView }: DocumentFlyoutProps) => {
     const { openNotes } = useFlyoutApi();
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -146,6 +152,98 @@ export const DocumentFlyout = memo(
       openNotes({ hit });
     }, [openNotes, hit]);
 
+    // Overview, Table and JSON tabs rendered when the flyout is displayed in Security Solution
+    const securityTabs = useMemo(
+      () => (
+        <>
+          <EuiTabs>
+            <EuiTab
+              isSelected={selectedTabId === 'overview'}
+              onClick={() => setSelectedTabId('overview')}
+              data-test-subj={OVERVIEW_TAB_TEST_ID}
+            >
+              {OVERVIEW_TAB_LABEL}
+            </EuiTab>
+            <EuiTab
+              isSelected={selectedTabId === 'table'}
+              onClick={() => setSelectedTabId('table')}
+              data-test-subj={TABLE_TAB_TEST_ID}
+            >
+              {TABLE_TAB_LABEL}
+            </EuiTab>
+            <EuiTab
+              isSelected={selectedTabId === 'json'}
+              onClick={() => setSelectedTabId('json')}
+              data-test-subj={JSON_TAB_TEST_ID}
+            >
+              {JSON_TAB_LABEL}
+            </EuiTab>
+          </EuiTabs>
+          <EuiSpacer size="m" />
+        </>
+      ),
+      [selectedTabId, setSelectedTabId]
+    );
+
+    // Overview, Table and JSON tab contents rendered when the flyout is displayed in Security Solution
+    // We're using our custom Security Solution document Table and JSON tabs
+    const securityTabContents = useMemo(
+      () => (
+        <>
+          {selectedTabId === 'table' ? (
+            <TableTab
+              hit={hit}
+              renderCellActions={renderCellActions}
+              renderFlyoutLink={renderFlyoutLink}
+            />
+          ) : selectedTabId === 'json' ? (
+            <JsonTab hit={hit} />
+          ) : (
+            <OverviewTab
+              hit={hit}
+              renderCellActions={renderCellActions}
+              onAlertUpdated={onAlertUpdated}
+            />
+          )}
+        </>
+      ),
+      [hit, onAlertUpdated, renderCellActions, renderFlyoutLink, selectedTabId]
+    );
+
+    // Overview, Table and JSON tabs rendered when the flyout is displayed in Discover
+    // We're then using the Discover Table and JSON tabs
+    const discoverContent = useMemo(
+      () => (
+        <UnifiedDocViewer
+          key={hit.id}
+          hit={hit}
+          dataView={dataView}
+          columns={Object.keys(hit.flattened)}
+          onAddColumn={() => {}}
+          onRemoveColumn={() => {}}
+          docViewsRegistry={(registry) => {
+            registry.add({
+              id: 'doc_view_alerts_overview',
+              title: OVERVIEW_TAB_LABEL,
+              order: 0,
+              render: () => (
+                <>
+                  <EuiSpacer size="m" />
+                  <OverviewTab
+                    hit={hit}
+                    renderCellActions={renderCellActions}
+                    onAlertUpdated={onAlertUpdated}
+                  />
+                </>
+              ),
+            });
+            return registry;
+          }}
+        />
+      ),
+      [dataView, hit, onAlertUpdated, renderCellActions]
+    );
+
     if (isAlert && loading) {
       return <FlyoutLoading data-test-subj="document-overview-loading" />;
     }
@@ -166,48 +264,13 @@ export const DocumentFlyout = memo(
           />
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
-          {isSecurityApp && (
+          {isSecurityApp ? (
             <>
-              <EuiTabs>
-                <EuiTab
-                  isSelected={selectedTabId === 'overview'}
-                  onClick={() => setSelectedTabId('overview')}
-                  data-test-subj={OVERVIEW_TAB_TEST_ID}
-                >
-                  {OVERVIEW_TAB_LABEL}
-                </EuiTab>
-                <EuiTab
-                  isSelected={selectedTabId === 'table'}
-                  onClick={() => setSelectedTabId('table')}
-                  data-test-subj={TABLE_TAB_TEST_ID}
-                >
-                  {TABLE_TAB_LABEL}
-                </EuiTab>
-                <EuiTab
-                  isSelected={selectedTabId === 'json'}
-                  onClick={() => setSelectedTabId('json')}
-                  data-test-subj={JSON_TAB_TEST_ID}
-                >
-                  {JSON_TAB_LABEL}
-                </EuiTab>
-              </EuiTabs>
-              <EuiSpacer size="m" />
+              {securityTabs}
+              {securityTabContents}
             </>
-          )}
-          {isSecurityApp && selectedTabId === 'table' ? (
-            <TableTab
-              hit={hit}
-              renderCellActions={renderCellActions}
-              renderFlyoutLink={renderFlyoutLink}
-            />
-          ) : isSecurityApp && selectedTabId === 'json' ? (
-            <JsonTab hit={hit} />
           ) : (
-            <OverviewTab
-              hit={hit}
-              renderCellActions={renderCellActions}
-              onAlertUpdated={onAlertUpdated}
-            />
+            <>{discoverContent}</>
           )}
         </EuiFlyoutBody>
         <EuiFlyoutFooter css={footerStyles}>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
@@ -13,6 +13,7 @@ import { useDocumentFlyoutTitle } from './use_document_flyout_title';
 import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { documentFlyoutHistoryKey } from '../constants/flyout_history';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -24,6 +25,7 @@ jest.mock('react-router-dom', () => ({
 }));
 jest.mock('../../../common/lib/kibana');
 jest.mock('../../../common/hooks/is_in_security_app');
+jest.mock('../../../data_view_manager/hooks/use_data_view');
 jest.mock('../components/flyout_provider', () => ({
   flyoutProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -59,11 +61,17 @@ const eventHit = createHit({
 describe('useDocumentFlyoutTitle', () => {
   const mockUseKibana = jest.mocked(useKibana);
   const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
+  const mockUseDataView = jest.mocked(useDataView);
   const openSystemFlyout = jest.fn();
+  const mockDataView = { hasMatchedIndices: () => true } as never;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseIsInSecurityApp.mockReturnValue(true);
+    mockUseDataView.mockReturnValue({
+      dataView: mockDataView,
+      status: 'ready',
+    });
     mockUseKibana.mockReturnValue({
       services: {
         overlays: { openSystemFlyout },
@@ -125,5 +133,19 @@ describe('useDocumentFlyoutTitle', () => {
 
     expect(result.current.badge).toBeTruthy();
     expect(result.current.timestamp).toBeTruthy();
+  });
+
+  it('passes dataView when opening the child document flyout', () => {
+    const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: alertHit }));
+
+    act(() => {
+      result.current.onTitleClick();
+    });
+
+    const flyoutTree = openSystemFlyout.mock.calls[0][0] as React.ReactElement;
+    const flyoutSessionProvider = flyoutTree.props.children as React.ReactElement;
+    const documentFlyoutElement = flyoutSessionProvider.props.children as React.ReactElement;
+
+    expect(documentFlyoutElement.props.dataView).toBe(mockDataView);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -26,6 +26,8 @@ import { documentFlyoutHistoryKey } from '../constants/flyout_history';
 import { DocumentSeverity } from '../../document/main/components/severity';
 import { Timestamp } from '../components/timestamp';
 import { FlyoutSessionContextProvider } from '../../session_context';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
 
 export interface UseDocumentFlyoutTitleOptions {
   /** The source document to derive display values from. */
@@ -63,6 +65,7 @@ export const useDocumentFlyoutTitle = ({
   const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const isInSecurityApp = useIsInSecurityApp();
   const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { dataView } = useDataView(PageScope.default);
 
   const isAlert = useMemo(
     () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -81,6 +84,7 @@ export const useDocumentFlyoutTitle = ({
         children: (
           <FlyoutSessionContextProvider value="inherit">
             <DocumentFlyout
+              dataView={dataView}
               hit={hit}
               renderCellActions={renderCellActions}
               onAlertUpdated={onAlertUpdated}
@@ -96,6 +100,7 @@ export const useDocumentFlyoutTitle = ({
     historyKey,
     hit,
     onAlertUpdated,
+    dataView,
     renderCellActions,
     services,
     store,


### PR DESCRIPTION
## Summary

This PR makes a small change to the document and attack flyout when opened as childs (meaning when opened from tools flyout like analyzer, prevalence, correlations...).

> [!IMPORTANT]
> The changes are only applied to Discover usage of the flyout. No changes in Security Solution.

#### Before

We were only displaying the Overview tab content.

https://github.com/user-attachments/assets/b9b46756-a745-435b-a969-df7a50f7fde0

#### After

We're now displaying the Overview, Table and JSON tabs

https://github.com/user-attachments/assets/b95bfe97-0bd2-4af0-9da2-6410d7516662

The Table and JSON tabs displayed are actually the ones from Discover, NOT the custom ones we have in Security Solution. The reason is we want consistency between the flyouts opened from the Discover table and the ones opened as children.

#### Security Solution is untouched

Security Solution already had its own Table and JSON tabs rendered (see [PR](https://github.com/elastic/kibana/pull/276406), [PR](https://github.com/elastic/kibana/pull/276386) and [PR](https://github.com/elastic/kibana/pull/276364))

https://github.com/user-attachments/assets/fb3e25ea-a70e-449f-af4a-6cf0b495aa1a

> [!NOTE]
> I purposefully did not apply the changes to the ioc flyout because as of right now we do not show that flyout as a child. Also, the implementation was different from the other 2, and I didn't like it. We'll implement the tabs if one day we need them.

### How to test

- generate documents and alerts
- navigate to Discover and use the different tools (correlations, analyzer...) that can open alerts/document as child flyouts

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
