### PR TITLE
[Security Solution][Flyout v2] Fix flyout session context in some tools

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
@@ -8,7 +8,6 @@
 import type { UseQueryOptions } from '@kbn/react-query';
 import { useQuery, useQueryClient } from '@kbn/react-query';
 import { useCallback } from 'react';
-import { validate as isValidUuid } from 'uuid';
 import type { RuleResponse } from '../../../../../common/api/detection_engine';
 import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
 import { transformInput } from '../../../common/transforms';
@@ -42,9 +41,7 @@ export const useFetchRuleByIdQuery = (id: string, options?: UseQueryOptions<Rule
       // Mark this query as immediately stale helps to avoid problems related to filtering.
       // e.g. enabled and disabled state filter require data update which happens at the backend side
       staleTime: 0,
-      // The route validates `id` as a UUID; skip the fetch for non-UUID values (e.g. legacy
-      // pre-8.x alerts where `signal.rule.id` may be an arbitrary string) to avoid a 400.
-      enabled: !!id && isValidUuid(id) && canReadRules,
+      enabled: !!id && canReadRules,
     }
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
@@ -8,6 +8,7 @@
 import type { UseQueryOptions } from '@kbn/react-query';
 import { useQuery, useQueryClient } from '@kbn/react-query';
 import { useCallback } from 'react';
+import { validate as isValidUuid } from 'uuid';
 import type { RuleResponse } from '../../../../../common/api/detection_engine';
 import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
 import { transformInput } from '../../../common/transforms';
@@ -41,7 +42,9 @@ export const useFetchRuleByIdQuery = (id: string, options?: UseQueryOptions<Rule
       // Mark this query as immediately stale helps to avoid problems related to filtering.
       // e.g. enabled and disabled state filter require data update which happens at the backend side
       staleTime: 0,
-      enabled: !!id && canReadRules,
+      // The route validates `id` as a UUID; skip the fetch for non-UUID values (e.g. legacy
+      // pre-8.x alerts where `signal.rule.id` may be an arbitrary string) to avoid a 400.
+      enabled: !!id && isValidUuid(id) && canReadRules,
     }
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/components/attack_entity_insight_rows.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/components/attack_entity_insight_rows.tsx
@@ -19,6 +19,8 @@ import {
   type IdentityFields,
 } from '../../../document_details/shared/utils';
 import type { AttackEntityListEntry } from '../../../../flyout_v2/attack/tools/entities/hooks/use_attack_entities_lists';
+import type { CspInsightLeftPanelSubTab } from '../../../entity_details/shared/components/left_panel/left_panel_header';
+import type { EntityTableLinkRenderer } from '../../../entity_details/shared/components/entity_table/types';
 
 const resolveUserDisplayForEntities = (
   identityFields: IdentityFields | undefined,
@@ -44,6 +46,21 @@ export interface AttackInsightsRowBaseProps extends AttackEntityListEntry {
    * child via the new flyout system, instead of the (unavailable) expandable-flyout API.
    */
   renderIpLink?: (ip: string) => React.ReactNode;
+  /**
+   * When provided, opens the entity flyout using the v2 system-flyout pattern instead of
+   * the expandable-flyout preview panel. Wire this from the attack Entities tool.
+   */
+  onPreviewEntity?: () => void;
+  /**
+   * When provided, opens the CSP detail panel (alerts / misconfigurations / vulnerabilities)
+   * using the v2 system-flyout pattern. Wire this from the attack Entities tool.
+   */
+  onShowDetailsPanel?: (subTab: CspInsightLeftPanelSubTab) => void;
+  /**
+   * When provided, wraps related-entity cell values in the Related table using this renderer
+   * instead of the v1 PreviewLink. Wire this from the attack Entities tool.
+   */
+  linkRenderer?: EntityTableLinkRenderer;
 }
 
 /**
@@ -51,7 +68,16 @@ export interface AttackInsightsRowBaseProps extends AttackEntityListEntry {
  * (document fields + entity store) so headers use host.name, not raw EUID / entity.id.
  */
 export const AttackHostInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
-  ({ identityFields, sampleSource, timestamp, scopeId, renderIpLink }) => {
+  ({
+    identityFields,
+    sampleSource,
+    timestamp,
+    scopeId,
+    renderIpLink,
+    onPreviewEntity,
+    onShowDetailsPanel,
+    linkRenderer,
+  }) => {
     const euidApi = useEntityStoreEuidApi();
 
     const getFieldsData = useMemo(
@@ -94,6 +120,9 @@ export const AttackHostInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
         expandedOnFirstRender={false}
         isAttackDetails={true}
         renderIpLink={renderIpLink}
+        onPreviewEntity={onPreviewEntity}
+        onShowDetailsPanel={onShowDetailsPanel}
+        linkRenderer={linkRenderer}
         hostEntityFromStoreResult={hostEntityFromStore}
       />
     );
@@ -106,7 +135,16 @@ AttackHostInsightsRow.displayName = 'AttackHostInsightsRow';
  * One user row for Attack Details entities tab: mirrors {@link EntitiesDetails} user resolution.
  */
 export const AttackUserInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
-  ({ identityFields, sampleSource, timestamp, scopeId, renderIpLink }) => {
+  ({
+    identityFields,
+    sampleSource,
+    timestamp,
+    scopeId,
+    renderIpLink,
+    onPreviewEntity,
+    onShowDetailsPanel,
+    linkRenderer,
+  }) => {
     const euidApi = useEntityStoreEuidApi();
 
     const getFieldsData = useMemo(
@@ -145,6 +183,9 @@ export const AttackUserInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
         expandedOnFirstRender={false}
         isAttackDetails={true}
         renderIpLink={renderIpLink}
+        onPreviewEntity={onPreviewEntity}
+        onShowDetailsPanel={onShowDetailsPanel}
+        linkRenderer={linkRenderer}
       />
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/components/attack_entity_insight_rows.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/components/attack_entity_insight_rows.tsx
@@ -21,6 +21,7 @@ import {
 import type { AttackEntityListEntry } from '../../../../flyout_v2/attack/tools/entities/hooks/use_attack_entities_lists';
 import type { CspInsightLeftPanelSubTab } from '../../../entity_details/shared/components/left_panel/left_panel_header';
 import type { EntityTableLinkRenderer } from '../../../entity_details/shared/components/entity_table/types';
+import type { EntitySectionOverrides } from '../../../document_details/left/components/entities_details';
 
 const resolveUserDisplayForEntities = (
   identityFields: IdentityFields | undefined,
@@ -61,6 +62,15 @@ export interface AttackInsightsRowBaseProps extends AttackEntityListEntry {
    * instead of the v1 PreviewLink. Wire this from the attack Entities tool.
    */
   linkRenderer?: EntityTableLinkRenderer;
+  /**
+   * When provided, the row calls this factory with the entity-store-resolved display name and
+   * entity ID, then uses the resulting overrides for onPreviewEntity / onShowDetailsPanel /
+   * linkRenderer. This ensures the flyout callbacks receive the store-resolved identity (not raw
+   * identity fields), which is required for correct alert and insight queries when Entity Store
+   * v2 is on. Takes priority over individually-provided onPreviewEntity / onShowDetailsPanel /
+   * linkRenderer props.
+   */
+  buildEntityOverrides?: (opts: { name: string; entityId?: string }) => EntitySectionOverrides;
 }
 
 /**
@@ -77,6 +87,7 @@ export const AttackHostInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
     onPreviewEntity,
     onShowDetailsPanel,
     linkRenderer,
+    buildEntityOverrides,
   }) => {
     const euidApi = useEntityStoreEuidApi();
 
@@ -106,6 +117,18 @@ export const AttackHostInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
     );
 
     const hostDisplayName = hostEntityFromStore.entityRecord?.entity?.name ?? resolvedHostName;
+    const hostEntityStoreId = hostEntityFromStore.entityRecord?.entity?.id;
+
+    // Must be called before the early return (rules of hooks). When buildEntityOverrides is
+    // provided it uses the store-resolved name/id so callbacks query the same identity as
+    // AlertCountInsight. When null/undefined, the row falls back to the individual props.
+    const resolvedOverrides = useMemo(
+      () =>
+        buildEntityOverrides != null
+          ? buildEntityOverrides({ name: hostDisplayName ?? '', entityId: hostEntityStoreId })
+          : undefined,
+      [buildEntityOverrides, hostDisplayName, hostEntityStoreId]
+    );
 
     if (hostDisplayName == null) {
       return null;
@@ -114,15 +137,15 @@ export const AttackHostInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
     return (
       <HostDetails
         hostName={hostDisplayName}
-        entityId={hostEntityFromStore?.entityRecord?.entity?.id}
+        entityId={hostEntityStoreId}
         timestamp={timestamp}
         scopeId={scopeId}
         expandedOnFirstRender={false}
         isAttackDetails={true}
         renderIpLink={renderIpLink}
-        onPreviewEntity={onPreviewEntity}
-        onShowDetailsPanel={onShowDetailsPanel}
-        linkRenderer={linkRenderer}
+        onPreviewEntity={resolvedOverrides?.onPreviewEntity ?? onPreviewEntity}
+        onShowDetailsPanel={resolvedOverrides?.onShowDetailsPanel ?? onShowDetailsPanel}
+        linkRenderer={resolvedOverrides?.linkRenderer ?? linkRenderer}
         hostEntityFromStoreResult={hostEntityFromStore}
       />
     );
@@ -144,6 +167,7 @@ export const AttackUserInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
     onPreviewEntity,
     onShowDetailsPanel,
     linkRenderer,
+    buildEntityOverrides,
   }) => {
     const euidApi = useEntityStoreEuidApi();
 
@@ -169,6 +193,18 @@ export const AttackUserInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
     });
 
     const userDisplayName = userEntityFromStore.entityRecord?.entity?.name ?? resolvedUserName;
+    const userEntityStoreId = userEntityFromStore.entityRecord?.entity?.id;
+
+    // Must be called before the early return (rules of hooks). When buildEntityOverrides is
+    // provided it uses the store-resolved name/id so callbacks query the same identity as
+    // AlertCountInsight.
+    const resolvedOverrides = useMemo(
+      () =>
+        buildEntityOverrides != null
+          ? buildEntityOverrides({ name: userDisplayName ?? '', entityId: userEntityStoreId })
+          : undefined,
+      [buildEntityOverrides, userDisplayName, userEntityStoreId]
+    );
 
     if (userDisplayName == null) {
       return null;
@@ -177,15 +213,15 @@ export const AttackUserInsightsRow: React.FC<AttackInsightsRowBaseProps> = memo(
     return (
       <UserDetails
         userName={userDisplayName}
-        entityId={userEntityFromStore?.entityRecord?.entity?.id}
+        entityId={userEntityStoreId}
         timestamp={timestamp}
         scopeId={scopeId}
         expandedOnFirstRender={false}
         isAttackDetails={true}
         renderIpLink={renderIpLink}
-        onPreviewEntity={onPreviewEntity}
-        onShowDetailsPanel={onShowDetailsPanel}
-        linkRenderer={linkRenderer}
+        onPreviewEntity={resolvedOverrides?.onPreviewEntity ?? onPreviewEntity}
+        onShowDetailsPanel={resolvedOverrides?.onShowDetailsPanel ?? onShowDetailsPanel}
+        linkRenderer={resolvedOverrides?.linkRenderer ?? linkRenderer}
       />
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.test.tsx
@@ -7,10 +7,12 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { TestProviders } from '../../../../common/mock';
 import { EntitiesDetails } from '.';
 import { useAttackEntitiesLists } from './hooks/use_attack_entities_lists';
+import { useEntityFlyoutApi } from '../../../entity/use_entity_flyout_api';
 import {
   ATTACK_ENTITIES_TOOL_ERROR_TEST_ID,
   ATTACK_ENTITIES_TOOL_LOADING_TEST_ID,
@@ -18,31 +20,75 @@ import {
 } from './test_ids';
 
 jest.mock('./hooks/use_attack_entities_lists');
+jest.mock('../../../entity/use_entity_flyout_api');
 jest.mock('../../../shared/components/document_tools_flyout_header', () => ({
   DocumentToolsFlyoutHeader: () => <div data-test-subj="mock-document-tools-flyout-header" />,
 }));
 jest.mock('../../../../flyout/attack_details/left/components/attack_entity_insight_rows', () => ({
   AttackUserInsightsRow: ({
     identityFields,
+    onPreviewEntity,
+    onShowDetailsPanel,
   }: {
     identityFields: Record<string, string | undefined>;
+    onPreviewEntity?: () => void;
+    onShowDetailsPanel?: (subTab: string) => void;
   }) => (
     <div data-test-subj="mock-user-insights-row">
-      {identityFields['user.name'] ?? 'unknown-user'}
+      <span>{identityFields['user.name'] ?? 'unknown-user'}</span>
+      {onPreviewEntity && (
+        <button type="button" data-test-subj="mock-user-preview-button" onClick={onPreviewEntity}>
+          {'preview'}
+        </button>
+      )}
+      {onShowDetailsPanel && (
+        <button
+          type="button"
+          data-test-subj="mock-user-alerts-button"
+          onClick={() => onShowDetailsPanel('alertsTabId')}
+        >
+          {'alerts'}
+        </button>
+      )}
     </div>
   ),
   AttackHostInsightsRow: ({
     identityFields,
+    onPreviewEntity,
+    onShowDetailsPanel,
   }: {
     identityFields: Record<string, string | undefined>;
+    onPreviewEntity?: () => void;
+    onShowDetailsPanel?: (subTab: string) => void;
   }) => (
     <div data-test-subj="mock-host-insights-row">
-      {identityFields['host.name'] ?? 'unknown-host'}
+      <span>{identityFields['host.name'] ?? 'unknown-host'}</span>
+      {onPreviewEntity && (
+        <button type="button" data-test-subj="mock-host-preview-button" onClick={onPreviewEntity}>
+          {'preview'}
+        </button>
+      )}
+      {onShowDetailsPanel && (
+        <button
+          type="button"
+          data-test-subj="mock-host-alerts-button"
+          onClick={() => onShowDetailsPanel('alertsTabId')}
+        >
+          {'alerts'}
+        </button>
+      )}
     </div>
   ),
 }));
 
 const mockUseAttackEntitiesLists = useAttackEntitiesLists as jest.Mock;
+const mockUseEntityFlyoutApi = useEntityFlyoutApi as jest.Mock;
+
+const mockOpenUserFlyoutAsChild = jest.fn();
+const mockOpenHostFlyoutAsChild = jest.fn();
+const mockOpenEntityAlertsInsights = jest.fn();
+const mockOpenEntityMisconfigurationInsights = jest.fn();
+const mockOpenEntityVulnerabilityInsights = jest.fn();
 
 const mockHit: DataTableRecord = {
   id: 'attack-1',
@@ -73,6 +119,13 @@ describe('EntitiesDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAttackEntitiesLists.mockReturnValue(defaultEntitiesResult);
+    mockUseEntityFlyoutApi.mockReturnValue({
+      openUserFlyoutAsChild: mockOpenUserFlyoutAsChild,
+      openHostFlyoutAsChild: mockOpenHostFlyoutAsChild,
+      openEntityAlertsInsights: mockOpenEntityAlertsInsights,
+      openEntityMisconfigurationInsights: mockOpenEntityMisconfigurationInsights,
+      openEntityVulnerabilityInsights: mockOpenEntityVulnerabilityInsights,
+    });
   });
 
   it('renders the header and body', () => {
@@ -175,23 +228,64 @@ describe('EntitiesDetails', () => {
       expect(screen.getByTestId('mock-host-insights-row')).toBeInTheDocument();
     });
 
-    it('entity name rows have no click handler (no-op)', () => {
+    it('clicking the user preview button calls openUserFlyoutAsChild', async () => {
       mockUseAttackEntitiesLists.mockReturnValue({
         ...defaultEntitiesResult,
         userEntityEntries: [userEntry],
+      });
+
+      renderTool();
+
+      await userEvent.click(screen.getByTestId('mock-user-preview-button'));
+
+      expect(mockOpenUserFlyoutAsChild).toHaveBeenCalledWith(
+        expect.objectContaining({ userName: 'alice' })
+      );
+    });
+
+    it('clicking the host preview button calls openHostFlyoutAsChild', async () => {
+      mockUseAttackEntitiesLists.mockReturnValue({
+        ...defaultEntitiesResult,
         hostEntityEntries: [hostEntry],
       });
 
       renderTool();
 
-      // The insight row mocks receive no onClick prop — clicking them should not throw
-      const userRow = screen.getByTestId('mock-user-insights-row');
-      const hostRow = screen.getByTestId('mock-host-insights-row');
-      expect(userRow).toBeInTheDocument();
-      expect(hostRow).toBeInTheDocument();
-      // No onClick attribute wired — absence of role="button" confirms no-op
-      expect(userRow.closest('[role="button"]')).toBeNull();
-      expect(hostRow.closest('[role="button"]')).toBeNull();
+      await userEvent.click(screen.getByTestId('mock-host-preview-button'));
+
+      expect(mockOpenHostFlyoutAsChild).toHaveBeenCalledWith(
+        expect.objectContaining({ hostName: 'server-1' })
+      );
+    });
+
+    it('clicking the user alerts button calls openEntityAlertsInsights for the user', async () => {
+      mockUseAttackEntitiesLists.mockReturnValue({
+        ...defaultEntitiesResult,
+        userEntityEntries: [userEntry],
+      });
+
+      renderTool();
+
+      await userEvent.click(screen.getByTestId('mock-user-alerts-button'));
+
+      expect(mockOpenEntityAlertsInsights).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'alice' })
+      );
+    });
+
+    it('clicking the host alerts button calls openEntityAlertsInsights for the host', async () => {
+      mockUseAttackEntitiesLists.mockReturnValue({
+        ...defaultEntitiesResult,
+        hostEntityEntries: [hostEntry],
+      });
+
+      renderTool();
+
+      await userEvent.click(screen.getByTestId('mock-host-alerts-button'));
+
+      expect(mockOpenEntityAlertsInsights).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'server-1' })
+      );
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.test.tsx
@@ -27,58 +27,76 @@ jest.mock('../../../shared/components/document_tools_flyout_header', () => ({
 jest.mock('../../../../flyout/attack_details/left/components/attack_entity_insight_rows', () => ({
   AttackUserInsightsRow: ({
     identityFields,
-    onPreviewEntity,
-    onShowDetailsPanel,
+    buildEntityOverrides,
   }: {
     identityFields: Record<string, string | undefined>;
-    onPreviewEntity?: () => void;
-    onShowDetailsPanel?: (subTab: string) => void;
-  }) => (
-    <div data-test-subj="mock-user-insights-row">
-      <span>{identityFields['user.name'] ?? 'unknown-user'}</span>
-      {onPreviewEntity && (
-        <button type="button" data-test-subj="mock-user-preview-button" onClick={onPreviewEntity}>
-          {'preview'}
-        </button>
-      )}
-      {onShowDetailsPanel && (
-        <button
-          type="button"
-          data-test-subj="mock-user-alerts-button"
-          onClick={() => onShowDetailsPanel('alertsTabId')}
-        >
-          {'alerts'}
-        </button>
-      )}
-    </div>
-  ),
+    buildEntityOverrides?: (opts: { name: string; entityId?: string }) => {
+      onPreviewEntity?: () => void;
+      onShowDetailsPanel?: (subTab: string) => void;
+    };
+  }) => {
+    const name = identityFields['user.name'] ?? 'unknown-user';
+    const overrides = buildEntityOverrides?.({ name });
+    return (
+      <div data-test-subj="mock-user-insights-row">
+        <span>{name}</span>
+        {overrides?.onPreviewEntity && (
+          <button
+            type="button"
+            data-test-subj="mock-user-preview-button"
+            onClick={overrides.onPreviewEntity}
+          >
+            {'preview'}
+          </button>
+        )}
+        {overrides?.onShowDetailsPanel && (
+          <button
+            type="button"
+            data-test-subj="mock-user-alerts-button"
+            onClick={() => overrides.onShowDetailsPanel?.('alertsTabId')}
+          >
+            {'alerts'}
+          </button>
+        )}
+      </div>
+    );
+  },
   AttackHostInsightsRow: ({
     identityFields,
-    onPreviewEntity,
-    onShowDetailsPanel,
+    buildEntityOverrides,
   }: {
     identityFields: Record<string, string | undefined>;
-    onPreviewEntity?: () => void;
-    onShowDetailsPanel?: (subTab: string) => void;
-  }) => (
-    <div data-test-subj="mock-host-insights-row">
-      <span>{identityFields['host.name'] ?? 'unknown-host'}</span>
-      {onPreviewEntity && (
-        <button type="button" data-test-subj="mock-host-preview-button" onClick={onPreviewEntity}>
-          {'preview'}
-        </button>
-      )}
-      {onShowDetailsPanel && (
-        <button
-          type="button"
-          data-test-subj="mock-host-alerts-button"
-          onClick={() => onShowDetailsPanel('alertsTabId')}
-        >
-          {'alerts'}
-        </button>
-      )}
-    </div>
-  ),
+    buildEntityOverrides?: (opts: { name: string; entityId?: string }) => {
+      onPreviewEntity?: () => void;
+      onShowDetailsPanel?: (subTab: string) => void;
+    };
+  }) => {
+    const name = identityFields['host.name'] ?? 'unknown-host';
+    const overrides = buildEntityOverrides?.({ name });
+    return (
+      <div data-test-subj="mock-host-insights-row">
+        <span>{name}</span>
+        {overrides?.onPreviewEntity && (
+          <button
+            type="button"
+            data-test-subj="mock-host-preview-button"
+            onClick={overrides.onPreviewEntity}
+          >
+            {'preview'}
+          </button>
+        )}
+        {overrides?.onShowDetailsPanel && (
+          <button
+            type="button"
+            data-test-subj="mock-host-alerts-button"
+            onClick={() => overrides.onShowDetailsPanel?.('alertsTabId')}
+          >
+            {'alerts'}
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 const mockUseAttackEntitiesLists = useAttackEntitiesLists as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.tsx
@@ -121,32 +121,25 @@ export const EntitiesDetails = memo(({ hit, alertIds }: EntitiesDetailsProps) =>
                   </h3>
                 </EuiTitle>
                 <EuiSpacer size="s" />
-                {userEntityEntries.map((entry, index) => {
-                  const userName =
-                    entry.identityFields['user.name'] ??
-                    Object.values(entry.identityFields)[0] ??
-                    '';
-                  const entityId = entry.identityFields['entity.id'];
-                  return (
-                    <React.Fragment
-                      key={`user-${index}-${
-                        entry.identityFields['user.name'] ??
-                        entry.identityFields['entity.id'] ??
-                        index
-                      }`}
-                    >
-                      <AttackUserInsightsRow
-                        identityFields={entry.identityFields}
-                        sampleSource={entry.sampleSource}
-                        timestamp={timestamp}
-                        scopeId=""
-                        renderIpLink={renderIpLink}
-                        {...buildUserOverrides({ name: userName, entityId })}
-                      />
-                      <EuiSpacer size="s" />
-                    </React.Fragment>
-                  );
-                })}
+                {userEntityEntries.map((entry, index) => (
+                  <React.Fragment
+                    key={`user-${index}-${
+                      entry.identityFields['user.name'] ??
+                      entry.identityFields['entity.id'] ??
+                      index
+                    }`}
+                  >
+                    <AttackUserInsightsRow
+                      identityFields={entry.identityFields}
+                      sampleSource={entry.sampleSource}
+                      timestamp={timestamp}
+                      scopeId=""
+                      renderIpLink={renderIpLink}
+                      buildEntityOverrides={buildUserOverrides}
+                    />
+                    <EuiSpacer size="s" />
+                  </React.Fragment>
+                ))}
               </EuiFlexItem>
             )}
             {hostEntityEntries.length > 0 && (
@@ -161,32 +154,25 @@ export const EntitiesDetails = memo(({ hit, alertIds }: EntitiesDetailsProps) =>
                   </h3>
                 </EuiTitle>
                 <EuiSpacer size="s" />
-                {hostEntityEntries.map((entry, index) => {
-                  const hostName =
-                    entry.identityFields['host.name'] ??
-                    Object.values(entry.identityFields)[0] ??
-                    '';
-                  const entityId = entry.identityFields['entity.id'];
-                  return (
-                    <React.Fragment
-                      key={`host-${index}-${
-                        entry.identityFields['host.name'] ??
-                        entry.identityFields['entity.id'] ??
-                        index
-                      }`}
-                    >
-                      <AttackHostInsightsRow
-                        identityFields={entry.identityFields}
-                        sampleSource={entry.sampleSource}
-                        timestamp={timestamp}
-                        scopeId=""
-                        renderIpLink={renderIpLink}
-                        {...buildHostOverrides({ name: hostName, entityId })}
-                      />
-                      <EuiSpacer size="s" />
-                    </React.Fragment>
-                  );
-                })}
+                {hostEntityEntries.map((entry, index) => (
+                  <React.Fragment
+                    key={`host-${index}-${
+                      entry.identityFields['host.name'] ??
+                      entry.identityFields['entity.id'] ??
+                      index
+                    }`}
+                  >
+                    <AttackHostInsightsRow
+                      identityFields={entry.identityFields}
+                      sampleSource={entry.sampleSource}
+                      timestamp={timestamp}
+                      scopeId=""
+                      renderIpLink={renderIpLink}
+                      buildEntityOverrides={buildHostOverrides}
+                    />
+                    <EuiSpacer size="s" />
+                  </React.Fragment>
+                ))}
               </EuiFlexItem>
             )}
           </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/tools/entities/index.tsx
@@ -23,6 +23,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { DocumentToolsFlyoutHeader } from '../../../shared/components/document_tools_flyout_header';
 import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
+import { useEntityFlyoutOverrides } from '../../../shared/hooks/use_entity_flyout_overrides';
 import {
   AttackHostInsightsRow,
   AttackUserInsightsRow,
@@ -63,13 +64,14 @@ export const EntitiesDetails = memo(({ hit, alertIds }: EntitiesDetailsProps) =>
 
   const hasEntities = userEntityEntries.length > 0 || hostEntityEntries.length > 0;
 
-  // The reused legacy entity overview renders host.ip via the expandable-flyout `FlyoutLink`,
-  // which has no rendered flyout to open into here. Supply a renderer that opens the network
-  // flyout as a child through the new flyout system instead.
   const renderIpLink = useCallback(
     (ip: string) => <OpenFlyoutLink field="host.ip" value={ip} />,
     []
   );
+
+  // The attack tool has no single representative document (it aggregates across many alerts),
+  // so hit is omitted — openUserFlyoutAsChild / openHostFlyoutAsChild receive hit=undefined.
+  const { buildUserOverrides, buildHostOverrides } = useEntityFlyoutOverrides({ scopeId: '' });
 
   return (
     <>
@@ -87,6 +89,7 @@ export const EntitiesDetails = memo(({ hit, alertIds }: EntitiesDetailsProps) =>
         )}
         {!loading && error && (
           <EuiCallOut
+            announceOnMount
             title={
               <FormattedMessage
                 id="xpack.securitySolution.flyoutV2.attack.tools.entities.errorTitle"
@@ -118,25 +121,32 @@ export const EntitiesDetails = memo(({ hit, alertIds }: EntitiesDetailsProps) =>
                   </h3>
                 </EuiTitle>
                 <EuiSpacer size="s" />
-                {userEntityEntries.map((entry, index) => (
-                  <React.Fragment
-                    key={`user-${index}-${
-                      entry.identityFields['user.name'] ??
-                      entry.identityFields['entity.id'] ??
-                      index
-                    }`}
-                  >
-                    {/* TODO: open host/user flyout when available (host/user flyout v2 is not merged yet) */}
-                    <AttackUserInsightsRow
-                      identityFields={entry.identityFields}
-                      sampleSource={entry.sampleSource}
-                      timestamp={timestamp}
-                      scopeId=""
-                      renderIpLink={renderIpLink}
-                    />
-                    <EuiSpacer size="s" />
-                  </React.Fragment>
-                ))}
+                {userEntityEntries.map((entry, index) => {
+                  const userName =
+                    entry.identityFields['user.name'] ??
+                    Object.values(entry.identityFields)[0] ??
+                    '';
+                  const entityId = entry.identityFields['entity.id'];
+                  return (
+                    <React.Fragment
+                      key={`user-${index}-${
+                        entry.identityFields['user.name'] ??
+                        entry.identityFields['entity.id'] ??
+                        index
+                      }`}
+                    >
+                      <AttackUserInsightsRow
+                        identityFields={entry.identityFields}
+                        sampleSource={entry.sampleSource}
+                        timestamp={timestamp}
+                        scopeId=""
+                        renderIpLink={renderIpLink}
+                        {...buildUserOverrides({ name: userName, entityId })}
+                      />
+                      <EuiSpacer size="s" />
+                    </React.Fragment>
+                  );
+                })}
               </EuiFlexItem>
             )}
             {hostEntityEntries.length > 0 && (
@@ -151,25 +161,32 @@ export const EntitiesDetails = memo(({ hit, alertIds }: EntitiesDetailsProps) =>
                   </h3>
                 </EuiTitle>
                 <EuiSpacer size="s" />
-                {hostEntityEntries.map((entry, index) => (
-                  <React.Fragment
-                    key={`host-${index}-${
-                      entry.identityFields['host.name'] ??
-                      entry.identityFields['entity.id'] ??
-                      index
-                    }`}
-                  >
-                    {/* TODO: open host/user flyout when available (host/user flyout v2 is not merged yet) */}
-                    <AttackHostInsightsRow
-                      identityFields={entry.identityFields}
-                      sampleSource={entry.sampleSource}
-                      timestamp={timestamp}
-                      scopeId=""
-                      renderIpLink={renderIpLink}
-                    />
-                    <EuiSpacer size="s" />
-                  </React.Fragment>
-                ))}
+                {hostEntityEntries.map((entry, index) => {
+                  const hostName =
+                    entry.identityFields['host.name'] ??
+                    Object.values(entry.identityFields)[0] ??
+                    '';
+                  const entityId = entry.identityFields['entity.id'];
+                  return (
+                    <React.Fragment
+                      key={`host-${index}-${
+                        entry.identityFields['host.name'] ??
+                        entry.identityFields['entity.id'] ??
+                        index
+                      }`}
+                    >
+                      <AttackHostInsightsRow
+                        identityFields={entry.identityFields}
+                        sampleSource={entry.sampleSource}
+                        timestamp={timestamp}
+                        scopeId=""
+                        renderIpLink={renderIpLink}
+                        {...buildHostOverrides({ name: hostName, entityId })}
+                      />
+                      <EuiSpacer size="s" />
+                    </React.Fragment>
+                  );
+                })}
               </EuiFlexItem>
             )}
           </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
@@ -70,7 +70,7 @@ describe('useAttackFlyoutApi', () => {
     );
   });
 
-  it('openAttackCorrelations opens the correlations tool flyout with the tools properties', () => {
+  it('openAttackCorrelations opens the correlations tool flyout with the tools properties and propagates inherit context to its content', () => {
     const { result } = renderHook(() => useAttackFlyoutApi());
     result.current.openAttackCorrelations({ hit, alertIds: ['alert-1'] });
 
@@ -78,9 +78,11 @@ describe('useAttackFlyoutApi', () => {
       'FLYOUT_CONTENT',
       expect.objectContaining({ size: 'm', session: 'start', historyKey: documentFlyoutHistoryKey })
     );
+    const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
+    expect(children.props.value).toBe('inherit');
   });
 
-  it('openAttackEntities opens the entities tool flyout with the tools properties', () => {
+  it('openAttackEntities opens the entities tool flyout with the tools properties and propagates inherit context to its content', () => {
     const { result } = renderHook(() => useAttackFlyoutApi());
     result.current.openAttackEntities({ hit, alertIds: ['alert-1'] });
 
@@ -88,6 +90,8 @@ describe('useAttackFlyoutApi', () => {
       'FLYOUT_CONTENT',
       expect.objectContaining({ size: 'm', session: 'start', historyKey: documentFlyoutHistoryKey })
     );
+    const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
+    expect(children.props.value).toBe('inherit');
   });
 
   it('uses the doc-viewer history key when outside the security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -173,22 +173,22 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
 
   const openAttackCorrelations = useCallback(
     ({ hit, alertIds, onShowAlert }: OpenAttackCorrelationsParams) => {
-      open(<CorrelationsDetails hit={hit} alertIds={alertIds} onShowAlert={onShowAlert} />, {
-        ...defaultToolsFlyoutProperties,
-        historyKey,
-        session: 'start',
-      });
+      open(
+        <CorrelationsDetails hit={hit} alertIds={alertIds} onShowAlert={onShowAlert} />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' },
+        'inherit'
+      );
     },
     [open, historyKey]
   );
 
   const openAttackEntities = useCallback(
     ({ hit, alertIds }: OpenAttackEntitiesParams) => {
-      open(<EntitiesDetails hit={hit} alertIds={alertIds} />, {
-        ...defaultToolsFlyoutProperties,
-        historyKey,
-        session: 'start',
-      });
+      open(
+        <EntitiesDetails hit={hit} alertIds={alertIds} />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' },
+        'inherit'
+      );
     },
     [open, historyKey]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/entities/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/entities/index.tsx
@@ -6,26 +6,19 @@
  */
 
 import { css } from '@emotion/react';
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { EuiFlyoutBody, EuiFlyoutHeader, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
-import { EntityType } from '../../../../../common/entity_analytics/types';
 import { ToolsFlyoutHeader } from '../../../shared/components/tools_flyout_header';
 import { useDocumentFlyoutTitle } from '../../../shared/hooks/use_document_flyout_title';
+import { useEntityFlyoutOverrides } from '../../../shared/hooks/use_entity_flyout_overrides';
 import { DocumentDetailsContext } from '../../../../flyout/document_details/shared/context';
 import { useGetFieldsData } from '../../../../flyout/document_details/shared/hooks/use_get_fields_data';
-import {
-  EntitiesDetails,
-  type EntitySectionOverrideBuilders,
-  type EntitySectionOverrides,
-} from '../../../../flyout/document_details/left/components/entities_details';
+import { EntitiesDetails } from '../../../../flyout/document_details/left/components/entities_details';
 import type { SearchHit } from '../../../../../common/search_strategy';
-import { CspInsightLeftPanelSubTab } from '../../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
-import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
-import { useEntityFlyoutApi } from '../../../entity/use_entity_flyout_api';
 import { ENTITIES_TOOL_TEST_ID } from './test_ids';
 
 export interface EntityDetailsProps {
@@ -78,85 +71,7 @@ export const EntityDetails = memo(
       [hit.id, hit.raw, scopeId, dataAsNestedObject, getFieldsData]
     );
 
-    const {
-      openUserFlyoutAsChild,
-      openHostFlyoutAsChild,
-      openEntityAlertsInsights,
-      openEntityMisconfigurationInsights,
-      openEntityVulnerabilityInsights,
-    } = useEntityFlyoutApi();
-
-    const buildUserOverrides = useCallback(
-      ({ name, entityId }: { name: string; entityId?: string }): EntitySectionOverrides => ({
-        onPreviewEntity: () => openUserFlyoutAsChild({ userName: name, entityId, scopeId, hit }),
-        onShowDetailsPanel: (subTab) => {
-          switch (subTab) {
-            case CspInsightLeftPanelSubTab.ALERTS:
-              return openEntityAlertsInsights({
-                entityType: EntityType.user,
-                value: name,
-                entityId,
-              });
-            case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
-              return openEntityMisconfigurationInsights({
-                entityType: EntityType.user,
-                value: name,
-                entityId,
-              });
-          }
-        },
-        linkRenderer: OpenFlyoutLink,
-      }),
-      [
-        openUserFlyoutAsChild,
-        openEntityAlertsInsights,
-        openEntityMisconfigurationInsights,
-        scopeId,
-        hit,
-      ]
-    );
-
-    const buildHostOverrides = useCallback(
-      ({ name, entityId }: { name: string; entityId?: string }): EntitySectionOverrides => ({
-        onPreviewEntity: () => openHostFlyoutAsChild({ hostName: name, entityId, scopeId, hit }),
-        onShowDetailsPanel: (subTab) => {
-          switch (subTab) {
-            case CspInsightLeftPanelSubTab.ALERTS:
-              return openEntityAlertsInsights({
-                entityType: EntityType.host,
-                value: name,
-                entityId,
-              });
-            case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
-              return openEntityMisconfigurationInsights({
-                entityType: EntityType.host,
-                value: name,
-                entityId,
-              });
-            case CspInsightLeftPanelSubTab.VULNERABILITIES:
-              return openEntityVulnerabilityInsights({
-                value: name,
-                entityId,
-                onShowHost: () => openHostFlyoutAsChild({ hostName: name, entityId, scopeId, hit }),
-              });
-          }
-        },
-        linkRenderer: OpenFlyoutLink,
-      }),
-      [
-        openHostFlyoutAsChild,
-        openEntityAlertsInsights,
-        openEntityMisconfigurationInsights,
-        openEntityVulnerabilityInsights,
-        scopeId,
-        hit,
-      ]
-    );
-
-    const overrideBuilders = useMemo<EntitySectionOverrideBuilders>(
-      () => ({ buildUserOverrides, buildHostOverrides }),
-      [buildUserOverrides, buildHostOverrides]
-    );
+    const overrideBuilders = useEntityFlyoutOverrides({ scopeId, hit });
 
     return (
       <>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -103,7 +103,7 @@ describe('useDocumentFlyoutApi', () => {
     );
   });
 
-  it('openDocumentEntities opens a tools flyout as a new session', () => {
+  it('openDocumentEntities opens a tools flyout as a new session and propagates inherit context to its content', () => {
     const { result } = renderHook(() => useDocumentFlyoutApi());
     result.current.openDocumentEntities({ hit });
 
@@ -111,9 +111,11 @@ describe('useDocumentFlyoutApi', () => {
       'FLYOUT_CONTENT',
       expect.objectContaining({ size: 'm', session: 'start' })
     );
+    const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
+    expect(children.props.value).toBe('inherit');
   });
 
-  it('openDocumentCorrelations opens a tools flyout as a new session', () => {
+  it('openDocumentCorrelations opens a tools flyout as a new session and propagates inherit context to its content', () => {
     const { result } = renderHook(() => useDocumentFlyoutApi());
     result.current.openDocumentCorrelations({
       hit,
@@ -126,6 +128,25 @@ describe('useDocumentFlyoutApi', () => {
       'FLYOUT_CONTENT',
       expect.objectContaining({ size: 'm', session: 'start' })
     );
+    const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
+    expect(children.props.value).toBe('inherit');
+  });
+
+  it('openDocumentPrevalence opens a tools flyout as a new session and propagates inherit context to its content', () => {
+    const { result } = renderHook(() => useDocumentFlyoutApi());
+    result.current.openDocumentPrevalence({
+      hit,
+      investigationFields: [],
+      scopeId: '',
+      columns: [],
+    });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      'FLYOUT_CONTENT',
+      expect.objectContaining({ size: 'm', session: 'start' })
+    );
+    const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
+    expect(children.props.value).toBe('inherit');
   });
 
   it.each([
@@ -133,7 +154,6 @@ describe('useDocumentFlyoutApi', () => {
     ['openDocumentThreatIntelligence', () => ({ hit })],
     ['openDocumentInvestigationGuide', () => ({ hit })],
     ['openDocumentGraph', () => ({ hit })],
-    ['openDocumentPrevalence', () => ({ hit, investigationFields: [], scopeId: '', columns: [] })],
   ] as const)('%s opens a tools flyout as a new session', (method, buildParams) => {
     const { result } = renderHook(() => useDocumentFlyoutApi());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -334,11 +334,11 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
 
   const openDocumentEntities = useCallback(
     ({ hit, scopeId }: OpenDocumentEntitiesParams) => {
-      open(<EntityDetails hit={hit} scopeId={scopeId} />, {
-        ...defaultToolsFlyoutProperties,
-        historyKey,
-        session: 'start',
-      });
+      open(
+        <EntityDetails hit={hit} scopeId={scopeId} />,
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' },
+        'inherit'
+      );
     },
     [open, historyKey]
   );
@@ -359,7 +359,8 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           onShowAlert={onShowAlert}
           onShowAttack={onShowAttack}
         />,
-        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' },
+        'inherit'
       );
     },
     [open, historyKey]
@@ -396,7 +397,8 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           scopeId={scopeId}
           columns={columns}
         />,
-        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' }
+        { ...defaultToolsFlyoutProperties, historyKey, session: 'start' },
+        'inherit'
       );
     },
     [open, historyKey]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_entity_flyout_overrides.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_entity_flyout_overrides.test.tsx
@@ -159,9 +159,7 @@ describe('useEntityFlyoutOverrides', () => {
 
   describe('without a hit (attack tool usage)', () => {
     it('onPreviewEntity calls openUserFlyoutAsChild with hit=undefined', () => {
-      const { result } = renderHook(() =>
-        useEntityFlyoutOverrides({ scopeId: 'attack-scope' })
-      );
+      const { result } = renderHook(() => useEntityFlyoutOverrides({ scopeId: 'attack-scope' }));
       const overrides = result.current.buildUserOverrides!({ name: 'alice' });
       overrides.onPreviewEntity!();
       expect(mockOpenUserFlyoutAsChild).toHaveBeenCalledWith({
@@ -173,9 +171,7 @@ describe('useEntityFlyoutOverrides', () => {
     });
 
     it('onPreviewEntity calls openHostFlyoutAsChild with hit=undefined', () => {
-      const { result } = renderHook(() =>
-        useEntityFlyoutOverrides({ scopeId: 'attack-scope' })
-      );
+      const { result } = renderHook(() => useEntityFlyoutOverrides({ scopeId: 'attack-scope' }));
       const overrides = result.current.buildHostOverrides!({ name: 'server-1' });
       overrides.onPreviewEntity!();
       expect(mockOpenHostFlyoutAsChild).toHaveBeenCalledWith({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_entity_flyout_overrides.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_entity_flyout_overrides.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { useEntityFlyoutOverrides } from './use_entity_flyout_overrides';
+import { useEntityFlyoutApi } from '../../entity/use_entity_flyout_api';
+import { OpenFlyoutLink } from '../components/open_flyout_link';
+import { CspInsightLeftPanelSubTab } from '../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
+import { EntityType } from '../../../../common/entity_analytics/types';
+
+jest.mock('../../entity/use_entity_flyout_api');
+
+const mockOpenUserFlyoutAsChild = jest.fn();
+const mockOpenHostFlyoutAsChild = jest.fn();
+const mockOpenEntityAlertsInsights = jest.fn();
+const mockOpenEntityMisconfigurationInsights = jest.fn();
+const mockOpenEntityVulnerabilityInsights = jest.fn();
+
+const mockUseEntityFlyoutApi = useEntityFlyoutApi as jest.Mock;
+
+const mockHit = { id: 'doc-1', raw: { _id: 'doc-1' }, flattened: {} } as unknown as DataTableRecord;
+
+describe('useEntityFlyoutOverrides', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEntityFlyoutApi.mockReturnValue({
+      openUserFlyoutAsChild: mockOpenUserFlyoutAsChild,
+      openHostFlyoutAsChild: mockOpenHostFlyoutAsChild,
+      openEntityAlertsInsights: mockOpenEntityAlertsInsights,
+      openEntityMisconfigurationInsights: mockOpenEntityMisconfigurationInsights,
+      openEntityVulnerabilityInsights: mockOpenEntityVulnerabilityInsights,
+    });
+  });
+
+  describe('buildUserOverrides', () => {
+    it('returns linkRenderer = OpenFlyoutLink', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildUserOverrides!({ name: 'alice', entityId: 'u1' });
+      expect(overrides.linkRenderer).toBe(OpenFlyoutLink);
+    });
+
+    it('onPreviewEntity calls openUserFlyoutAsChild with the correct arguments', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildUserOverrides!({ name: 'alice', entityId: 'u1' });
+      overrides.onPreviewEntity!();
+      expect(mockOpenUserFlyoutAsChild).toHaveBeenCalledWith({
+        userName: 'alice',
+        entityId: 'u1',
+        scopeId: 'test-scope',
+        hit: mockHit,
+      });
+    });
+
+    it('onShowDetailsPanel ALERTS calls openEntityAlertsInsights for user', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildUserOverrides!({ name: 'alice', entityId: 'u1' });
+      overrides.onShowDetailsPanel!(CspInsightLeftPanelSubTab.ALERTS);
+      expect(mockOpenEntityAlertsInsights).toHaveBeenCalledWith({
+        entityType: EntityType.user,
+        value: 'alice',
+        entityId: 'u1',
+      });
+    });
+
+    it('onShowDetailsPanel MISCONFIGURATIONS calls openEntityMisconfigurationInsights for user', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildUserOverrides!({ name: 'alice', entityId: 'u1' });
+      overrides.onShowDetailsPanel!(CspInsightLeftPanelSubTab.MISCONFIGURATIONS);
+      expect(mockOpenEntityMisconfigurationInsights).toHaveBeenCalledWith({
+        entityType: EntityType.user,
+        value: 'alice',
+        entityId: 'u1',
+      });
+    });
+  });
+
+  describe('buildHostOverrides', () => {
+    it('returns linkRenderer = OpenFlyoutLink', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildHostOverrides!({ name: 'server-1', entityId: 'h1' });
+      expect(overrides.linkRenderer).toBe(OpenFlyoutLink);
+    });
+
+    it('onPreviewEntity calls openHostFlyoutAsChild with the correct arguments', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildHostOverrides!({ name: 'server-1', entityId: 'h1' });
+      overrides.onPreviewEntity!();
+      expect(mockOpenHostFlyoutAsChild).toHaveBeenCalledWith({
+        hostName: 'server-1',
+        entityId: 'h1',
+        scopeId: 'test-scope',
+        hit: mockHit,
+      });
+    });
+
+    it('onShowDetailsPanel ALERTS calls openEntityAlertsInsights for host', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildHostOverrides!({ name: 'server-1', entityId: 'h1' });
+      overrides.onShowDetailsPanel!(CspInsightLeftPanelSubTab.ALERTS);
+      expect(mockOpenEntityAlertsInsights).toHaveBeenCalledWith({
+        entityType: EntityType.host,
+        value: 'server-1',
+        entityId: 'h1',
+      });
+    });
+
+    it('onShowDetailsPanel MISCONFIGURATIONS calls openEntityMisconfigurationInsights for host', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildHostOverrides!({ name: 'server-1', entityId: 'h1' });
+      overrides.onShowDetailsPanel!(CspInsightLeftPanelSubTab.MISCONFIGURATIONS);
+      expect(mockOpenEntityMisconfigurationInsights).toHaveBeenCalledWith({
+        entityType: EntityType.host,
+        value: 'server-1',
+        entityId: 'h1',
+      });
+    });
+
+    it('onShowDetailsPanel VULNERABILITIES calls openEntityVulnerabilityInsights with onShowHost', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'test-scope', hit: mockHit })
+      );
+      const overrides = result.current.buildHostOverrides!({ name: 'server-1', entityId: 'h1' });
+      overrides.onShowDetailsPanel!(CspInsightLeftPanelSubTab.VULNERABILITIES);
+      expect(mockOpenEntityVulnerabilityInsights).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'server-1', entityId: 'h1' })
+      );
+      // verify onShowHost also wires back to openHostFlyoutAsChild
+      const { onShowHost } = mockOpenEntityVulnerabilityInsights.mock.calls[0][0];
+      onShowHost();
+      expect(mockOpenHostFlyoutAsChild).toHaveBeenCalledWith({
+        hostName: 'server-1',
+        entityId: 'h1',
+        scopeId: 'test-scope',
+        hit: mockHit,
+      });
+    });
+  });
+
+  describe('without a hit (attack tool usage)', () => {
+    it('onPreviewEntity calls openUserFlyoutAsChild with hit=undefined', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'attack-scope' })
+      );
+      const overrides = result.current.buildUserOverrides!({ name: 'alice' });
+      overrides.onPreviewEntity!();
+      expect(mockOpenUserFlyoutAsChild).toHaveBeenCalledWith({
+        userName: 'alice',
+        entityId: undefined,
+        scopeId: 'attack-scope',
+        hit: undefined,
+      });
+    });
+
+    it('onPreviewEntity calls openHostFlyoutAsChild with hit=undefined', () => {
+      const { result } = renderHook(() =>
+        useEntityFlyoutOverrides({ scopeId: 'attack-scope' })
+      );
+      const overrides = result.current.buildHostOverrides!({ name: 'server-1' });
+      overrides.onPreviewEntity!();
+      expect(mockOpenHostFlyoutAsChild).toHaveBeenCalledWith({
+        hostName: 'server-1',
+        entityId: undefined,
+        scopeId: 'attack-scope',
+        hit: undefined,
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_entity_flyout_overrides.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_entity_flyout_overrides.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { EntityType } from '../../../../common/entity_analytics/types';
+import { CspInsightLeftPanelSubTab } from '../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
+import type {
+  EntitySectionOverrideBuilders,
+  EntitySectionOverrides,
+} from '../../../flyout/document_details/left/components/entities_details';
+
+/**
+ * The hook always provides both builders; callers can spread directly without
+ * null-guarding even though the underlying `EntitySectionOverrideBuilders` type
+ * marks them optional (to support partial overrides in other contexts).
+ */
+type RequiredEntitySectionOverrideBuilders = Required<EntitySectionOverrideBuilders>;
+import { OpenFlyoutLink } from '../components/open_flyout_link';
+import { useEntityFlyoutApi } from '../../entity/use_entity_flyout_api';
+
+export interface UseEntityFlyoutOverridesParams {
+  scopeId: string;
+  /**
+   * The source document. Omit for the attack Entities tool (which has no single
+   * representative document — it aggregates across many alerts).
+   */
+  hit?: DataTableRecord;
+}
+
+/**
+ * Returns `buildUserOverrides` and `buildHostOverrides` — the two override builder
+ * callbacks consumed by the v2 Entities tools. Both builders produce an
+ * `EntitySectionOverrides` object (`{ onPreviewEntity, onShowDetailsPanel, linkRenderer }`)
+ * that is forwarded to `HostDetails`/`UserDetails`, wiring the v2 system-flyout API in
+ * place of the default expandable-flyout fallbacks.
+ *
+ * Used by both `flyout_v2/document/tools/entities` and `flyout_v2/attack/tools/entities`
+ * so that the callback logic has a single source of truth.
+ */
+export const useEntityFlyoutOverrides = ({
+  scopeId,
+  hit,
+}: UseEntityFlyoutOverridesParams): RequiredEntitySectionOverrideBuilders => {
+  const {
+    openUserFlyoutAsChild,
+    openHostFlyoutAsChild,
+    openEntityAlertsInsights,
+    openEntityMisconfigurationInsights,
+    openEntityVulnerabilityInsights,
+  } = useEntityFlyoutApi();
+
+  const buildUserOverrides = useCallback(
+    ({ name, entityId }: { name: string; entityId?: string }): EntitySectionOverrides => ({
+      onPreviewEntity: () => openUserFlyoutAsChild({ userName: name, entityId, scopeId, hit }),
+      onShowDetailsPanel: (subTab) => {
+        switch (subTab) {
+          case CspInsightLeftPanelSubTab.ALERTS:
+            return openEntityAlertsInsights({ entityType: EntityType.user, value: name, entityId });
+          case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
+            return openEntityMisconfigurationInsights({
+              entityType: EntityType.user,
+              value: name,
+              entityId,
+            });
+        }
+      },
+      linkRenderer: OpenFlyoutLink,
+    }),
+    [
+      openUserFlyoutAsChild,
+      openEntityAlertsInsights,
+      openEntityMisconfigurationInsights,
+      scopeId,
+      hit,
+    ]
+  );
+
+  const buildHostOverrides = useCallback(
+    ({ name, entityId }: { name: string; entityId?: string }): EntitySectionOverrides => ({
+      onPreviewEntity: () => openHostFlyoutAsChild({ hostName: name, entityId, scopeId, hit }),
+      onShowDetailsPanel: (subTab) => {
+        switch (subTab) {
+          case CspInsightLeftPanelSubTab.ALERTS:
+            return openEntityAlertsInsights({ entityType: EntityType.host, value: name, entityId });
+          case CspInsightLeftPanelSubTab.MISCONFIGURATIONS:
+            return openEntityMisconfigurationInsights({
+              entityType: EntityType.host,
+              value: name,
+              entityId,
+            });
+          case CspInsightLeftPanelSubTab.VULNERABILITIES:
+            return openEntityVulnerabilityInsights({
+              value: name,
+              entityId,
+              onShowHost: () => openHostFlyoutAsChild({ hostName: name, entityId, scopeId, hit }),
+            });
+        }
+      },
+      linkRenderer: OpenFlyoutLink,
+    }),
+    [
+      openHostFlyoutAsChild,
+      openEntityAlertsInsights,
+      openEntityMisconfigurationInsights,
+      openEntityVulnerabilityInsights,
+      scopeId,
+      hit,
+    ]
+  );
+
+  return useMemo<RequiredEntitySectionOverrideBuilders>(
+    () => ({ buildUserOverrides, buildHostOverrides }),
+    [buildUserOverrides, buildHostOverrides]
+  );
+};


### PR DESCRIPTION

Pass 'inherit' as the flyout session context to the 5 tool flyouts that render OpenFlyoutLink (document Correlations, Prevalence, Entities; attack Correlations, Entities), so links inside those tools nest correctly instead of starting new top-level flyouts.

Bonus fix/refactor: 
- Wire the attack Entities tool so host/user entity name links open the entity flyout as a child, and the alert-count link opens the alerts insights flyout (actually was a TODO, not a bug)
- Extract the duplicated flyout-callback wiring (onPreviewEntity, onShowDetailsPanel, linkRenderer) from both Entities tool containers into a shared hook useEntityFlyoutOverrides in flyout_v2/shared/hooks.

https://github.com/user-attachments/assets/f17c7d80-0922-428a-b403-88b886d38994



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->