### PR TITLE
[ML] SMV in Dashboard: Ensure Single Metric Viewer dashboard pdf/png export shows up correctly

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/context_chart_zoom_pipeline.test.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/context_chart_zoom_pipeline.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Subject, forkJoin, of } from 'rxjs';
+import { EMPTY, Subject, forkJoin, of, throwError } from 'rxjs';
 
 import { createContextChartZoomSubscription } from './context_chart_zoom_pipeline';
 
@@ -79,22 +79,108 @@ describe('createContextChartZoomSubscription', () => {
     sub.unsubscribe();
   });
 
-  it('does not call onFocusPipelineResult when getFocusPipeline returns null', () => {
+  it('calls onFocusPipelineEmpty when getFocusPipeline returns null after focus load starts', () => {
     jest.useFakeTimers();
     const contextChart$ = new Subject<typeof selection>();
     const onFocusPipelineResult = jest.fn();
+    const onFocusPipelineEmpty = jest.fn();
+    const onFocusPipelineError = jest.fn();
 
     const sub = createContextChartZoomSubscription(contextChart$, {
       ...baseHandlers,
       includeAnomaliesTable: true,
       getFocusPipeline$: () => null,
       onFocusPipelineResult,
+      onFocusPipelineEmpty,
+      onFocusPipelineError,
     });
 
     contextChart$.next(selection);
     jest.advanceTimersByTime(500);
 
     expect(onFocusPipelineResult).not.toHaveBeenCalled();
+    expect(onFocusPipelineEmpty).toHaveBeenCalledWith(selection);
+    expect(onFocusPipelineError).not.toHaveBeenCalled();
+
+    sub.unsubscribe();
+  });
+
+  it('does not call terminal handlers when pipeline is null and focus load did not start', () => {
+    jest.useFakeTimers();
+    const contextChart$ = new Subject<typeof selection>();
+    const onFocusPipelineResult = jest.fn();
+    const onFocusPipelineEmpty = jest.fn();
+    const onFocusPipelineError = jest.fn();
+
+    const sub = createContextChartZoomSubscription(contextChart$, {
+      ...baseHandlers,
+      shouldTriggerFocusLoad: () => false,
+      includeAnomaliesTable: true,
+      getFocusPipeline$: () => null,
+      onFocusPipelineResult,
+      onFocusPipelineEmpty,
+      onFocusPipelineError,
+    });
+
+    contextChart$.next(selection);
+    jest.advanceTimersByTime(500);
+
+    expect(onFocusPipelineResult).not.toHaveBeenCalled();
+    expect(onFocusPipelineEmpty).not.toHaveBeenCalled();
+    expect(onFocusPipelineError).not.toHaveBeenCalled();
+
+    sub.unsubscribe();
+  });
+
+  it('calls onFocusPipelineError when focus pipeline errors', () => {
+    jest.useFakeTimers();
+    const contextChart$ = new Subject<typeof selection>();
+    const onFocusPipelineResult = jest.fn();
+    const onFocusPipelineEmpty = jest.fn();
+    const onFocusPipelineError = jest.fn();
+    const boom = new Error('focus failed');
+
+    const sub = createContextChartZoomSubscription(contextChart$, {
+      ...baseHandlers,
+      includeAnomaliesTable: false,
+      getFocusPipeline$: () => throwError(() => boom),
+      onFocusPipelineResult,
+      onFocusPipelineEmpty,
+      onFocusPipelineError,
+    });
+
+    contextChart$.next(selection);
+    jest.advanceTimersByTime(500);
+
+    expect(onFocusPipelineResult).not.toHaveBeenCalled();
+    expect(onFocusPipelineEmpty).not.toHaveBeenCalled();
+    expect(onFocusPipelineError).toHaveBeenCalledWith(boom);
+
+    sub.unsubscribe();
+  });
+
+  it('calls onFocusPipelineEmpty when focus pipeline completes without a result', () => {
+    jest.useFakeTimers();
+    const contextChart$ = new Subject<typeof selection>();
+    const onFocusPipelineResult = jest.fn();
+    const onFocusPipelineEmpty = jest.fn();
+    const onFocusPipelineError = jest.fn();
+
+    const sub = createContextChartZoomSubscription(contextChart$, {
+      ...baseHandlers,
+      includeAnomaliesTable: false,
+      getFocusPipeline$: () => EMPTY,
+      onFocusPipelineResult,
+      onFocusPipelineEmpty,
+      onFocusPipelineError,
+    });
+
+    contextChart$.next(selection);
+    jest.advanceTimersByTime(500);
+
+    expect(onFocusPipelineResult).not.toHaveBeenCalled();
+    expect(onFocusPipelineEmpty).toHaveBeenCalledWith(selection);
+    expect(onFocusPipelineError).not.toHaveBeenCalled();
 
     sub.unsubscribe();
   });

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/context_chart_zoom_pipeline.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/context_chart_zoom_pipeline.ts
@@ -10,12 +10,17 @@ import {
   type Observable,
   type Subscription,
   EMPTY,
+  catchError,
   debounceTime,
+  defaultIfEmpty,
+  filter,
   map,
   switchMap,
   tap,
   withLatestFrom,
 } from 'rxjs';
+
+const FOCUS_PIPELINE_EMPTY = Symbol('focusPipelineEmpty');
 
 export interface ContextChartSelection {
   from: Date;
@@ -56,6 +61,16 @@ export interface ContextChartZoomHandlers<TFocus = unknown, TTable = unknown> {
   ) => Observable<[TFocus, TTable] | TFocus> | null;
   /** Merge focus + optional table payload into component state. */
   onFocusPipelineResult: (data: [TFocus, TTable], selection: ContextChartSelection) => void;
+  /**
+   * Focus load started but produced no result (null pipeline / empty completion).
+   * Opt-in for hosts that defer reporting until focus settles.
+   */
+  onFocusPipelineEmpty?: (selection: ContextChartSelection) => void;
+  /**
+   * Focus load started and then failed.
+   * Opt-in for hosts that defer reporting until focus settles.
+   */
+  onFocusPipelineError?: (error: unknown) => void;
 }
 
 function hasContextChartData(state: ContextChartZoomChartState): boolean {
@@ -64,6 +79,12 @@ function hasContextChartData(state: ContextChartZoomChartState): boolean {
   const hasCtx = Array.isArray(ctx) && ctx.length > 0;
   const hasFc = Array.isArray(fc) && fc.length > 0;
   return hasCtx || hasFc;
+}
+
+function hasFocusTerminalHandlers<TFocus, TTable>(
+  handlers: ContextChartZoomHandlers<TFocus, TTable>
+): boolean {
+  return handlers.onFocusPipelineEmpty !== undefined || handlers.onFocusPipelineError !== undefined;
 }
 
 /**
@@ -82,30 +103,58 @@ export function createContextChartZoomSubscription<TFocus = unknown, TTable = un
         handlers.onZoomPreview(selection);
       }),
       debounceTime(500),
-      tap((selection) => {
+      map((selection) => {
         const state = handlers.getChartState();
-        if (!hasContextChartData(state)) {
-          return;
-        }
-        if (handlers.shouldTriggerFocusLoad(selection, state)) {
+        // Track whether we entered the focus-load path so empty/error can settle that wait later.
+        let focusLoadStarted = false;
+        if (hasContextChartData(state) && handlers.shouldTriggerFocusLoad(selection, state)) {
           handlers.onFocusLoadInit();
           handlers.onFocusLoadStart();
+          focusLoadStarted = true;
         }
+        return { selection, focusLoadStarted };
       }),
-      switchMap((selection) => {
+      switchMap(({ selection, focusLoadStarted }) => {
         const pipeline$ = handlers.getFocusPipeline$(selection);
         if (pipeline$ === null) {
+          // Load was promised but there is no observable — treat as empty, not failure.
+          if (focusLoadStarted) {
+            handlers.onFocusPipelineEmpty?.(selection);
+          }
           return EMPTY;
         }
-        if (handlers.includeAnomaliesTable) {
-          return pipeline$ as Observable<[TFocus, TTable]>;
+
+        const normalized$: Observable<[TFocus, TTable]> = handlers.includeAnomaliesTable
+          ? (pipeline$ as Observable<[TFocus, TTable]>)
+          : pipeline$.pipe(
+              map((emission) => {
+                if (Array.isArray(emission)) {
+                  return emission as [TFocus, TTable];
+                }
+                return [emission as TFocus, { tableData: undefined } as TTable];
+              })
+            );
+
+        // Without terminal handlers (full-page SMV), keep the original success-only path.
+        if (!focusLoadStarted || !hasFocusTerminalHandlers(handlers)) {
+          return normalized$;
         }
-        return pipeline$.pipe(
-          map((emission) => {
-            if (Array.isArray(emission)) {
-              return emission as [TFocus, TTable];
+
+        // Ensure every started focus load reaches a terminal: success, empty, or error.
+        return normalized$.pipe(
+          // Completing with no emission is a valid empty result for reporting.
+          defaultIfEmpty(FOCUS_PIPELINE_EMPTY),
+          tap((result) => {
+            if (result === FOCUS_PIPELINE_EMPTY) {
+              handlers.onFocusPipelineEmpty?.(selection);
             }
-            return [emission as TFocus, { tableData: undefined } as TTable];
+          }),
+          // Drop the sentinel so subscribers only see real focus payloads.
+          filter((result): result is [TFocus, TTable] => result !== FOCUS_PIPELINE_EMPTY),
+          catchError((error) => {
+            // Swallow after notifying the host so the subscription stays alive for later brushes.
+            handlers.onFocusPipelineError?.(error);
+            return EMPTY;
           })
         );
       }),

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/index.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/index.ts
@@ -64,8 +64,10 @@ export { PartitionFieldsRequiredCallout } from './partition_fields_required_call
 export { SingleMetricViewerChartSurface } from './single_metric_viewer_chart_surface';
 export { useSingleMetricViewerChartModel } from './use_single_metric_viewer_chart_model';
 export {
+  buildSmvEmptyFocusStatePatch,
   consumeSmvContextLoadResult,
   getSmvContextLoadErrorMessages,
+  getSmvFocusLoadErrorMessage,
   subscribeSmvBrushToFocusZoom,
   type ConsumeSmvContextLoadResultOptions,
   type SmvBrushToFocusZoomHost,

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.test.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.test.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { consumeSmvContextLoadResult, getSmvContextLoadErrorMessages } from './smv_host_wiring';
+import {
+  buildSmvEmptyFocusStatePatch,
+  consumeSmvContextLoadResult,
+  getSmvContextLoadErrorMessages,
+  getSmvFocusLoadErrorMessage,
+} from './smv_host_wiring';
 
 describe('smv_host_wiring', () => {
   describe('getSmvContextLoadErrorMessages', () => {
@@ -19,6 +24,36 @@ describe('smv_host_wiring', () => {
           forecast: expect.any(String),
         })
       );
+    });
+  });
+
+  describe('getSmvFocusLoadErrorMessage', () => {
+    it('returns the focus chart error message', () => {
+      expect(getSmvFocusLoadErrorMessage()).toBe('Error getting focus chart data');
+    });
+  });
+
+  describe('buildSmvEmptyFocusStatePatch', () => {
+    it('clears focus-only fields and records the empty selection without touching context data', () => {
+      const selection = {
+        from: new Date('2020-01-01T00:00:00.000Z'),
+        to: new Date('2020-01-02T00:00:00.000Z'),
+      };
+
+      const patch = buildSmvEmptyFocusStatePatch(selection);
+
+      expect(patch).toEqual({
+        loading: false,
+        focusChartData: undefined,
+        focusForecastData: undefined,
+        focusAnnotationData: [],
+        showModelBoundsCheckbox: false,
+        showForecastCheckbox: false,
+        zoomFromFocusLoaded: selection.from,
+        zoomToFocusLoaded: selection.to,
+      });
+      expect(patch).not.toHaveProperty('contextChartData');
+      expect(patch).not.toHaveProperty('contextForecastData');
     });
   });
 

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.test.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.test.ts
@@ -49,7 +49,7 @@ describe('smv_host_wiring', () => {
       expect(applyStatePatch).not.toHaveBeenCalled();
     });
 
-    it('applies state, zoom, forecast sync, and after hook', () => {
+    it('applies state, zoom, forecast sync, and after hook with pending focus', () => {
       const applyStatePatch = jest.fn();
       const applyZoomSelection = jest.fn();
       const syncPrevious = jest.fn();
@@ -74,7 +74,85 @@ describe('smv_host_wiring', () => {
       expect(syncPrevious).toHaveBeenCalledTimes(1);
       expect(applyZoomSelection).toHaveBeenCalledWith(zoomSelection);
       expect(applyStatePatch).toHaveBeenCalledWith({ loading: false, hasResults: true });
-      expect(afterStatePatch).toHaveBeenCalledWith({ loading: false, hasResults: true });
+      // Embeddable defers onRenderComplete when focus will load next.
+      expect(afterStatePatch).toHaveBeenCalledWith(
+        { loading: false, hasResults: true },
+        { hasPendingFocus: true }
+      );
+    });
+
+    it('invokes afterStatePatch without pending focus for dataNotChartable', () => {
+      const afterStatePatch = jest.fn();
+      const applyStatePatch = jest.fn();
+
+      consumeSmvContextLoadResult({
+        result: {
+          statePatch: { loading: false, hasResults: false, dataNotChartable: true },
+          shouldUpdatePreviousSelectedForecastId: false,
+        },
+        isUnmounted: () => false,
+        loadCounterWhenStarted: 1,
+        readLoadCounter: () => 1,
+        syncPreviousSelectedForecastIdFromProps: jest.fn(),
+        applyStatePatch,
+        afterStatePatch,
+      });
+
+      expect(applyStatePatch).toHaveBeenCalledWith({
+        loading: false,
+        hasResults: false,
+        dataNotChartable: true,
+      });
+      // Terminal empty state: complete immediately so reporting cannot hang.
+      expect(afterStatePatch).toHaveBeenCalledWith(
+        {
+          loading: false,
+          hasResults: false,
+          dataNotChartable: true,
+        },
+        { hasPendingFocus: false }
+      );
+    });
+
+    it('reports hasPendingFocus false when context finishes without zoomSelection', () => {
+      const afterStatePatch = jest.fn();
+
+      consumeSmvContextLoadResult({
+        result: {
+          statePatch: { loading: false, hasResults: false },
+          shouldUpdatePreviousSelectedForecastId: false,
+        },
+        isUnmounted: () => false,
+        loadCounterWhenStarted: 1,
+        readLoadCounter: () => 1,
+        syncPreviousSelectedForecastIdFromProps: jest.fn(),
+        applyStatePatch: jest.fn(),
+        afterStatePatch,
+      });
+
+      expect(afterStatePatch).toHaveBeenCalledWith(
+        { loading: false, hasResults: false },
+        { hasPendingFocus: false }
+      );
+    });
+
+    it('does not invoke afterStatePatch for stale loads', () => {
+      const afterStatePatch = jest.fn();
+
+      consumeSmvContextLoadResult({
+        result: {
+          statePatch: { loading: false, hasResults: true },
+          shouldUpdatePreviousSelectedForecastId: false,
+        },
+        isUnmounted: () => false,
+        loadCounterWhenStarted: 1,
+        readLoadCounter: () => 2,
+        syncPreviousSelectedForecastIdFromProps: jest.fn(),
+        applyStatePatch: jest.fn(),
+        afterStatePatch,
+      });
+
+      expect(afterStatePatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.ts
@@ -40,6 +40,12 @@ export function getSmvContextLoadErrorMessages(selectedForecastId: string | unde
   };
 }
 
+export function getSmvFocusLoadErrorMessage(): string {
+  return i18n.translate('xpack.ml.timeSeriesExplorer.focusChartDataErrorMessage', {
+    defaultMessage: 'Error getting focus chart data',
+  });
+}
+
 export interface ConsumeSmvContextLoadResultOptions {
   result: LoadSingleMetricContextDataSuccess | null;
   isUnmounted: () => boolean;
@@ -111,6 +117,29 @@ export interface SmvBrushToFocusZoomHost {
   readModelPlotEnabled: () => boolean;
   readSelectedForecastId: () => string | undefined;
   applyFocusPipelinePatch: (patch: Record<string, unknown>) => void;
+  /** Focus produced no result; hosts should clear loading / complete reporting without error UI. */
+  onFocusPipelineEmpty?: (selection: ContextChartSelection) => void;
+  /** Focus load failed; hosts should surface error and complete reporting. */
+  onFocusPipelineError?: (error: unknown) => void;
+}
+
+/**
+ * Clears stale focus-only state and records the empty selection so retries are not re-triggered.
+ * Context-chart fields are intentionally left untouched.
+ */
+export function buildSmvEmptyFocusStatePatch(
+  selection: ContextChartSelection
+): Record<string, unknown> {
+  return {
+    loading: false,
+    focusChartData: undefined,
+    focusForecastData: undefined,
+    focusAnnotationData: [],
+    showModelBoundsCheckbox: false,
+    showForecastCheckbox: false,
+    zoomFromFocusLoaded: selection.from,
+    zoomToFocusLoaded: selection.to,
+  };
 }
 
 function buildSmvFocusPipelineStatePatch(args: {
@@ -192,5 +221,7 @@ export function subscribeSmvBrushToFocusZoom(
         })
       );
     },
+    onFocusPipelineEmpty: host.onFocusPipelineEmpty,
+    onFocusPipelineError: host.onFocusPipelineError,
   });
 }

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_chart_controller/smv_host_wiring.ts
@@ -50,8 +50,11 @@ export interface ConsumeSmvContextLoadResultOptions {
   /** Invoked when `zoomSelection` is returned (hosts typically forward to `contextChartSelected`). */
   applyZoomSelection?: (range: { from: Date; to: Date }) => void;
   applyStatePatch: (patch: Record<string, unknown>) => void;
-  /** e.g. embeddable `onRenderComplete` when chartable */
-  afterStatePatch?: (patch: Record<string, unknown>) => void;
+  /**
+   * Called after state is applied. `hasPendingFocus` is true when a zoom/focus load will follow
+   * (hosts should defer reporting `onRenderComplete` until that focus pipeline settles).
+   */
+  afterStatePatch?: (patch: Record<string, unknown>, meta: { hasPendingFocus: boolean }) => void;
 }
 
 /**
@@ -87,7 +90,7 @@ export function consumeSmvContextLoadResult(options: ConsumeSmvContextLoadResult
     applyZoomSelection?.(zoomSelection);
   }
   applyStatePatch(statePatch);
-  afterStatePatch?.(statePatch);
+  afterStatePatch?.(statePatch, { hasPendingFocus: zoomSelection !== undefined });
 }
 
 export interface SmvBrushToFocusZoomHost {

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_embeddable_chart/timeseriesexplorer_embeddable_chart.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_embeddable_chart/timeseriesexplorer_embeddable_chart.js
@@ -65,6 +65,7 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
     chartWidth: PropTypes.number.isRequired,
     chartHeight: PropTypes.number,
     lastRefresh: PropTypes.number.isRequired,
+    onLoading: PropTypes.func,
     onRenderComplete: PropTypes.func,
     previousRefresh: PropTypes.number.isRequired,
     selectedJob: PropTypes.object.isRequired,
@@ -260,7 +261,9 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
     if (this.props.toastNotificationService) {
       this.props.toastNotificationService.displayErrorToast(error, errorMsg, 2000);
     }
-    this.setState({ loading: false, chartDataError: errorMsg });
+    this.setState({ loading: false, chartDataError: errorMsg }, () => {
+      this.props.onRenderComplete?.();
+    });
   };
 
   loadSingleMetricData = (fullRefresh = true) => {
@@ -288,6 +291,8 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
     const contextLoadSignal = this.contextLoadAbortController.signal;
 
     this.contextChartSelectedInitCallDone = false;
+
+    this.props.onLoading?.(true);
 
     // Only when `fullRefresh` is true we'll reset all data
     // and show the loading spinner within the page.
@@ -355,12 +360,11 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
             },
             applyZoomSelection: (range) => this.contextChartSelected(range),
             applyStatePatch: (patch) => this.setState(patch),
-            afterStatePatch: (statePatch) => {
-              if (
-                statePatch.dataNotChartable !== true &&
-                this.props.onRenderComplete !== undefined
-              ) {
-                this.props.onRenderComplete();
+            // If focus will load next, wait for applyFocusPipelinePatch before completing.
+            // Otherwise complete now (empty / dataNotChartable / no zoom) so reporting cannot hang.
+            afterStatePatch: (_statePatch, { hasPendingFocus }) => {
+              if (!hasPendingFocus) {
+                this.props.onRenderComplete?.();
               }
             },
           });
@@ -421,6 +425,7 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
           zoomToFocusLoaded: this.state.zoomToFocusLoaded,
         }),
         onFocusPipelineStarting: () => {
+          this.props.onLoading?.(true);
           this.setState({
             loading: true,
             fullRefresh: false,
@@ -433,7 +438,11 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
           this.loadAnomaliesTableData(earliestMs, latestMs),
         readModelPlotEnabled: () => this.state.modelPlotEnabled,
         readSelectedForecastId: () => this.props.selectedForecastId,
-        applyFocusPipelinePatch: (patch) => this.setState(patch),
+        applyFocusPipelinePatch: (patch) => {
+          this.setState(patch, () => {
+            this.props.onRenderComplete?.();
+          });
+        },
       })
     );
 

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_embeddable_chart/timeseriesexplorer_embeddable_chart.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer_embeddable_chart/timeseriesexplorer_embeddable_chart.js
@@ -48,9 +48,11 @@ import {
   buildCriteriaFields,
   consumeSmvContextLoadResult,
   fetchAnomaliesTableData$,
+  buildSmvEmptyFocusStatePatch,
   getModelPlotEnabledForDetector,
   getSmvContextLoadErrorMessages,
   getSmvDataReloadPlan,
+  getSmvFocusLoadErrorMessage,
   loadSingleMetricContextData,
   smvReloadSnapshotFromSmvHostProps,
   subscribeSmvBrushToFocusZoom,
@@ -429,6 +431,7 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
           this.setState({
             loading: true,
             fullRefresh: false,
+            chartDataError: undefined,
           });
         },
         getFocusAggregationInterval: (selection) => this.getFocusAggregationInterval(selection),
@@ -442,6 +445,16 @@ export class TimeSeriesExplorerEmbeddableChart extends React.Component {
           this.setState(patch, () => {
             this.props.onRenderComplete?.();
           });
+        },
+        onFocusPipelineEmpty: (selection) => {
+          // Empty focus is terminal for reporting, not an error.
+          this.setState(buildSmvEmptyFocusStatePatch(selection), () => {
+            this.props.onRenderComplete?.();
+          });
+        },
+        onFocusPipelineError: (error) => {
+          // Completes reporting via onRenderComplete so deferred focus waits cannot hang.
+          this.displayErrorToastMessages(error, getSmvFocusLoadErrorMessage());
         },
       })
     );

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.test.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { act, render, waitFor, screen } from '@testing-library/react';
+import React from 'react';
+import type { SingleMetricViewerEmbeddableState } from '@kbn/ml-server-schemas/embeddables/single_metric_viewer';
+import { ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE } from '@kbn/ml-common-types/embeddables/single_metric_viewer';
+import { dispatchRenderComplete, dispatchRenderStart } from '@kbn/kibana-utils-plugin/public';
+import { getSingleMetricViewerEmbeddableFactory } from './single_metric_viewer_embeddable_factory';
+import type { SingleMetricViewerEmbeddableApi } from '../types';
+import type { SingleMetricViewerProps } from '../../shared_components/single_metric_viewer/single_metric_viewer';
+
+const mockPluginStartDeps = {
+  data: dataPluginMock.createStartContract(),
+};
+
+const getStartServices = coreMock.createSetup({
+  pluginStartDeps: mockPluginStartDeps,
+}).getStartServices;
+
+jest.mock('@kbn/kibana-utils-plugin/public', () => {
+  const actual = jest.requireActual('@kbn/kibana-utils-plugin/public');
+  return {
+    ...actual,
+    dispatchRenderComplete: jest.fn(),
+    dispatchRenderStart: jest.fn(),
+  };
+});
+
+jest.mock('../../application/capabilities/check_capabilities', () => {
+  return {
+    checkPermissionAsync: jest.fn().mockResolvedValue(true),
+  };
+});
+
+jest.mock('../common/use_embeddable_execution_context', () => ({
+  useReactEmbeddableExecutionContext: jest.fn(),
+}));
+
+jest.mock('./get_services', () => {
+  return {
+    getServices: jest.fn().mockImplementation(async () => [
+      {
+        executionContext: {
+          set: jest.fn(),
+          clear: jest.fn(),
+        },
+        notifications: { toasts: {} },
+      },
+      mockPluginStartDeps,
+      {},
+    ]),
+  };
+});
+
+let mockLatestSmvProps: SingleMetricViewerProps | undefined;
+
+jest.mock('../../shared_components/single_metric_viewer', () => {
+  return {
+    getSingleMetricViewerComponent: () => {
+      return function MockSingleMetricViewer(props: SingleMetricViewerProps) {
+        mockLatestSmvProps = props;
+        return (
+          <div
+            data-test-subj={`mlSingleMetricViewer_${props.uuid}`}
+            data-shared-item=""
+            data-render-complete={props.isRenderComplete ?? false}
+            ref={props.wrapperRef}
+          />
+        );
+      };
+    },
+  };
+});
+
+describe('getSingleMetricViewerEmbeddableFactory reporting readiness', () => {
+  const factory = getSingleMetricViewerEmbeddableFactory(getStartServices);
+
+  beforeEach(() => {
+    mockLatestSmvProps = undefined;
+    jest.clearAllMocks();
+  });
+
+  async function buildAndRender() {
+    const uuid = 'smv-uuid';
+    const parentApi = {
+      executionContext: {
+        type: 'dashboard',
+        id: 'dashboard-id',
+      },
+    };
+    const { api, Component } = await factory.buildEmbeddable({
+      initializeDrilldownsManager: jest.fn(),
+      initialState: {
+        job_ids: ['my-job'],
+        selected_detector_index: 0,
+      } satisfies SingleMetricViewerEmbeddableState,
+      finalizeApi: (preFinalizeApi) => {
+        return {
+          ...preFinalizeApi,
+          uuid,
+          parentApi,
+          type: ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE,
+        } as SingleMetricViewerEmbeddableApi;
+      },
+      parentApi,
+      uuid,
+    });
+
+    const result = render(<Component />);
+    await waitFor(() => {
+      expect(screen.getByTestId('mlSingleMetricViewer_smv-uuid')).toBeInTheDocument();
+    });
+    return { api, ...result };
+  }
+
+  it('starts with data-render-complete false so screenshotting waits', async () => {
+    await buildAndRender();
+
+    const wrapper = screen.getByTestId('mlSingleMetricViewer_smv-uuid');
+    expect(wrapper).toHaveAttribute('data-render-complete', 'false');
+    expect(dispatchRenderStart).toHaveBeenCalled();
+  });
+
+  it('marks render complete after onRenderComplete and dispatches renderComplete', async () => {
+    const { api } = await buildAndRender();
+
+    await act(async () => {
+      mockLatestSmvProps?.onRenderComplete?.();
+    });
+
+    await waitFor(() => {
+      const wrapper = screen.getByTestId('mlSingleMetricViewer_smv-uuid');
+      expect(wrapper).toHaveAttribute('data-render-complete', 'true');
+      expect(api.dataLoading$?.value).toEqual(false);
+      expect(dispatchRenderComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('resets readiness when loading starts again', async () => {
+    await buildAndRender();
+
+    await act(async () => {
+      mockLatestSmvProps?.onRenderComplete?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mlSingleMetricViewer_smv-uuid')).toHaveAttribute(
+        'data-render-complete',
+        'true'
+      );
+    });
+
+    await act(async () => {
+      mockLatestSmvProps?.onLoading?.(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mlSingleMetricViewer_smv-uuid')).toHaveAttribute(
+        'data-render-complete',
+        'false'
+      );
+      expect(dispatchRenderStart).toHaveBeenCalled();
+    });
+  });
+
+  it('marks render complete on error so reporting cannot hang', async () => {
+    await buildAndRender();
+
+    await act(async () => {
+      mockLatestSmvProps?.onError?.(new Error('job missing'));
+    });
+
+    await waitFor(() => {
+      const wrapper = screen.getByTestId('mlSingleMetricViewer_smv-uuid');
+      expect(wrapper).toHaveAttribute('data-render-complete', 'true');
+      expect(dispatchRenderComplete).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { openLazyFlyout } from '@kbn/presentation-util';
 
 import type { EmbeddablePublicDefinition } from '@kbn/embeddable-plugin/public';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import useUnmount from 'react-use/lib/useUnmount';
 import type { SingleMetricViewerEmbeddableState } from '@kbn/ml-server-schemas/embeddables/single_metric_viewer';
 import {
@@ -20,10 +20,12 @@ import {
   initializeTitleManager,
   timeRangeComparators,
   titleComparators,
+  useBatchedPublishingSubjects,
   useStateFromPublishingSubject,
 } from '@kbn/presentation-publishing';
 import { BehaviorSubject, Subscription, merge } from 'rxjs';
 import { initializeStateApi } from '@kbn/presentation-publishing';
+import { dispatchRenderComplete, dispatchRenderStart } from '@kbn/kibana-utils-plugin/public';
 import { ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE } from '@kbn/ml-common-types/embeddables/single_metric_viewer';
 import type { MlPluginStart, MlStartDependencies } from '../../plugin';
 import type { SingleMetricViewerEmbeddableApi } from '../types';
@@ -145,6 +147,35 @@ export const getSingleMetricViewerEmbeddableFactory = (
 
           const { singleMetricViewerData, bounds, lastRefresh } =
             useStateFromPublishingSubject(singleMetricViewerData$);
+          const [isLoading, error] = useBatchedPublishingSubjects(dataLoading$, blockingError$);
+
+          const [hasRendered, setHasRendered] = useState(false);
+          const wrapperRef = useRef<HTMLDivElement>(null);
+
+          useEffect(() => {
+            if (isLoading) {
+              setHasRendered(false);
+            }
+          }, [isLoading]);
+
+          useEffect(
+            function dispatchRenderMessages() {
+              const el = wrapperRef.current;
+              if (!el) return;
+              if (error) {
+                dispatchRenderComplete(el);
+                return;
+              }
+              if (isLoading) {
+                dispatchRenderStart(el);
+                return;
+              }
+              if (hasRendered) {
+                dispatchRenderComplete(el);
+              }
+            },
+            [isLoading, hasRendered, error]
+          );
 
           useReactEmbeddableExecutionContext(
             services[0].executionContext,
@@ -172,15 +203,26 @@ export const getSingleMetricViewerEmbeddableFactory = (
               bounds={bounds}
               functionDescription={functionDescription}
               lastRefresh={lastRefresh}
-              onError={(error) => blockingError$.next(error)}
+              onError={(err) => {
+                blockingError$.next(err);
+                if (err) {
+                  dataLoading$.next(false);
+                }
+              }}
               selectedDetectorIndex={singleMetricViewerData?.selectedDetectorIndex}
               selectedEntities={singleMetricViewerData?.selectedEntities}
               selectedJobId={singleMetricViewerData?.jobIds[0]}
               forecastId={singleMetricViewerData?.forecastId}
               uuid={api.uuid}
               onForecastIdChange={api.updateForecastId}
+              wrapperRef={wrapperRef}
+              isRenderComplete={error ? true : hasRendered}
+              onLoading={(loading) => {
+                dataLoading$.next(loading);
+              }}
               onRenderComplete={() => {
                 dataLoading$.next(false);
+                setHasRendered(true);
               }}
             />
           );

--- a/x-pack/platform/plugins/shared/ml/public/shared_components/single_metric_viewer/single_metric_viewer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/shared_components/single_metric_viewer/single_metric_viewer.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import moment from 'moment';
 import useMountedState from 'react-use/lib/useMountedState';
-import type { FC } from 'react';
+import type { FC, Ref } from 'react';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiResizeObserver } from '@elastic/eui';
@@ -81,9 +81,15 @@ export interface SingleMetricViewerProps {
    */
   lastRefresh?: number;
   onRenderComplete?: () => void;
+  onLoading?: (loading: boolean) => void;
   onError?: (error?: Error) => void;
   onForecastIdChange?: (forecastId: string | undefined) => void;
   uuid: string;
+  /**
+   * Reporting readiness for screenshotting. Defaults to false so PDF/PNG waits.
+   */
+  isRenderComplete?: boolean;
+  wrapperRef?: Ref<HTMLDivElement>;
 }
 
 type Zoom = AppStateZoom | undefined;
@@ -101,6 +107,7 @@ const SingleMetricViewerWrapper: FC<SingleMetricViewerPropsWithDeps> = ({
   lastRefresh,
   onError,
   onForecastIdChange,
+  onLoading,
   onRenderComplete,
   forecastId,
   selectedDetectorIndex,
@@ -108,6 +115,8 @@ const SingleMetricViewerWrapper: FC<SingleMetricViewerPropsWithDeps> = ({
   selectedJobId,
   shouldShowForecastButton,
   uuid,
+  isRenderComplete,
+  wrapperRef,
 }) => {
   const timeseriesExplorerStyles = useTimeseriesExplorerStyles();
   const annotationStyles = useAnnotationStyles();
@@ -255,10 +264,18 @@ const SingleMetricViewerWrapper: FC<SingleMetricViewerPropsWithDeps> = ({
             padding: '8px',
           }}
           data-test-subj={`mlSingleMetricViewer_${uuid}`}
-          ref={resizeRef}
+          ref={(el) => {
+            resizeRef(el);
+            if (typeof wrapperRef === 'function') {
+              wrapperRef(el);
+            } else if (wrapperRef) {
+              (wrapperRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+            }
+          }}
           css={[timeseriesExplorerStyles, annotationStyles]}
           data-shared-item="" // TODO: Remove data-shared-item as part of https://github.com/elastic/kibana/issues/179376
           data-rendering-count={1}
+          data-render-complete={isRenderComplete ?? false}
         >
           <KibanaRenderContextProvider {...startServices}>
             <KibanaContextProvider
@@ -296,6 +313,7 @@ const SingleMetricViewerWrapper: FC<SingleMetricViewerPropsWithDeps> = ({
                       functionDescription={functionDescription}
                       selectedJob={selectedJobWrapper.job}
                       selectedJobStats={selectedJobWrapper.stats}
+                      onLoading={onLoading}
                       onRenderComplete={onRenderComplete}
                       onForecastComplete={onForecastComplete}
                       shouldShowForecastButton={shouldShowForecastButton}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/183448

This PR:
- Fixes Single Metric Viewer (SMV) dashboard PDF/PNG exports capturing too early (resulting often in “No results found”, or missing the focus chart).
- Aligns SMV with the anomaly swimlane reporting contract: data-render-complete + renderStart/renderComplete on the existing data-shared-item wrapper.
- Keeps Reporting incomplete through both load phases (context chart and focus chart) and completes on empty/error states so jobs don’t hang.
- gives the focus phase a safety net so a failed focus load can't leave a screenshot job waiting indefinitely.

<img width="2522" height="968" alt="testing the fix -dashboard" src="https://github.com/user-attachments/assets/5dc7e13e-c6de-4282-8775-b6c2b35a7db4" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->