### PR TITLE
[Entity Analytics] Update resolution group accordion headers when risk score is recalculated

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_risk_score_recalculation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_risk_score_recalculation.ts
@@ -14,6 +14,11 @@ import { useCalculateEntityRiskScore } from './use_calculate_entity_risk_score';
 import { useRefetchQueryById } from './use_refetch_query_by_id';
 import { RISK_INPUTS_TAB_QUERY_ID } from '../../components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab';
 import { RESOLUTION_GROUP_QUERY_KEY } from '../../components/entity_resolution/hooks/use_resolution_group';
+import {
+  QUERY_KEY_ENTITY_ANALYTICS,
+  QUERY_KEY_GRID_DATA,
+  QUERY_KEY_TARGET_METADATA,
+} from '../../components/home/entities_table/constants';
 import { useOnAssetCriticalityToolEvent } from '../../hooks/use_on_asset_criticality_tool_event';
 
 interface UseEntityRiskScoreRecalculationParams<T extends EntityType> {
@@ -57,14 +62,27 @@ export const useEntityRiskScoreRecalculation = <T extends EntityType>({
   const queryClient = useQueryClient();
 
   const onRiskScoreUpdated = useCallback(() => {
+    // Flyout header risk badge: V2 reads from the entity store record, V1 from the risk score API.
     if (entityStoreV2Enabled) {
       entityFromStoreResult.refetch();
     } else {
       riskScoreState.refetch();
     }
+    // Flyout Risk Summary panel (base + resolution scores).
     entityRiskScores.refetch();
+    // Flyout Risk Inputs tab (the alerts/inputs contributing to the score).
     (refetchRiskInputsTab as Refetch | null)?.();
+    // Entity resolution group tab/table shown in the flyout.
     queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });
+    // Entity analytics home table rows (flat grid + the leaf tables inside expanded groups).
+    queryClient.invalidateQueries({ queryKey: [QUERY_KEY_ENTITY_ANALYTICS, QUERY_KEY_GRID_DATA] });
+    // Risk score on the resolution group accordion headers. We refresh only this
+    // metadata (not the grouping aggregation) so the header badge updates without
+    // re-ordering the buckets, which would collapse any expanded groups.
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEY_ENTITY_ANALYTICS, QUERY_KEY_TARGET_METADATA],
+    });
+    // Context-specific extras (e.g. agent-builder attachment cache).
     onRecalculation?.();
   }, [
     entityStoreV2Enabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_VISIBLE_ROWS_PER_PAGE = 25;
 
 export const QUERY_KEY_GRID_DATA = 'entity_analytics_grid_data';
 export const QUERY_KEY_GROUPING_DATA = 'entity-analytics-grouping-data';
+export const QUERY_KEY_TARGET_METADATA = 'entity-analytics-resolution-target-metadata';
 export const QUERY_KEY_ENTITY_ANALYTICS = 'entity-analytics-query-key';
 
 const LOCAL_STORAGE_PREFIX = 'entityAnalytics';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -14,7 +14,12 @@ import { showErrorToast } from '@kbn/cloud-security-posture';
 import { useContext, useMemo } from 'react';
 import type { EntityType } from '../../../../../../common/entity_analytics/types';
 import { useKibana } from '../../../../../common/lib/kibana';
-import { ENTITY_FIELDS, QUERY_KEY_GROUPING_DATA, QUERY_KEY_ENTITY_ANALYTICS } from '../constants';
+import {
+  ENTITY_FIELDS,
+  QUERY_KEY_GROUPING_DATA,
+  QUERY_KEY_TARGET_METADATA,
+  QUERY_KEY_ENTITY_ANALYTICS,
+} from '../constants';
 import { DataViewContext } from '..';
 
 export type EntitiesGroupingQuery = GroupingQuery | SearchRequest;
@@ -136,8 +141,6 @@ export const useFetchGroupedData = ({
     }
   );
 };
-
-const QUERY_KEY_TARGET_METADATA = 'entity-analytics-resolution-target-metadata';
 
 export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap => {
   const { searchService, toasts, indexPattern } = useEntitySearchParams();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -17,8 +17,6 @@ import { useUpdateAssetCriticality } from '../../../entity_analytics/api/hooks/u
 import { buildEuidCspPreviewOptions } from '../../../cloud_security_posture/utils/build_euid_csp_preview_options';
 import { useNonClosedAlerts } from '../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../../overview/components/detection_response/alerts_by_status/types';
-import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../common/types';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
@@ -55,7 +53,6 @@ import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_pan
 import { EntityPanelHeaderTabs } from '../shared/components/entity_panel_tabs';
 import { EntityStoreTableTab } from '../shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../shared/components/entity_summary_grid';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../entity_analytics/components/home/constants';
 
 export { HOST_PANEL_RISK_SCORE_QUERY_ID, HOST_PANEL_OBSERVED_HOST_QUERY_ID };
 
@@ -138,12 +135,6 @@ export const HostPanel = memo(function HostPanel({
   const { data: hostRisk } = riskScoreState;
   const hostRiskData = hostRisk && hostRisk.length > 0 ? hostRisk[0] : undefined;
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.host,
@@ -152,13 +143,11 @@ export const HostPanel = memo(function HostPanel({
       entityStoreV2Enabled: true,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('host', {
     onSuccess: calculateEntityRiskScore,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -13,8 +13,6 @@ import { EuiSpacer } from '@elastic/eui';
 import type { CriticalityLevelWithUnassigned } from '../../../../common/entity_analytics/asset_criticality/types';
 import type { ESQuery } from '../../../../common/typed_json';
 import { buildEntityNameFilter, type RiskSeverity } from '../../../../common/search_strategy';
-import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../common/types';
 import { useUpdateAssetCriticality } from '../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
@@ -37,7 +35,6 @@ import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_pan
 import { EntityPanelHeaderTabs } from '../shared/components/entity_panel_tabs';
 import { EntityStoreTableTab } from '../shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../shared/components/entity_summary_grid';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../entity_analytics/components/home/constants';
 
 export interface ServicePanelProps extends Record<string, unknown> {
   contextID: string;
@@ -105,12 +102,6 @@ export const ServicePanel = memo(function ServicePanel({
   const serviceRiskData = serviceRisk && serviceRisk.length > 0 ? serviceRisk[0] : undefined;
   const isRiskScoreExist = !!serviceRiskData?.service.risk;
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const entityStoreV2Enabled = true;
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
@@ -120,13 +111,11 @@ export const ServicePanel = memo(function ServicePanel({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('service', {
     onSuccess: calculateEntityRiskScore,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -19,8 +19,6 @@ import { buildEuidCspPreviewOptions } from '../../../cloud_security_posture/util
 import { buildUserNamesFilter, type RiskSeverity } from '../../../../common/search_strategy';
 import { useKibana } from '../../../common/lib/kibana';
 import { useNonClosedAlerts } from '../../../cloud_security_posture/hooks/use_non_closed_alerts';
-import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../common/types';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
 import { ManagedUserDatasetKey } from '../../../../common/search_strategy/security_solution/users/managed_details';
@@ -57,7 +55,6 @@ import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_pan
 import { EntityPanelHeaderTabs } from '../shared/components/entity_panel_tabs';
 import { EntityStoreTableTab } from '../shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../shared/components/entity_summary_grid';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../entity_analytics/components/home/constants';
 import { ENABLE_ASSET_INVENTORY_SETTING } from '../../../../common/constants';
 
 export { USER_PANEL_RISK_SCORE_QUERY_ID, USER_PANEL_OBSERVED_USER_QUERY_ID };
@@ -148,12 +145,6 @@ export const UserPanel = memo(function UserPanel({
   const { data: userRisk } = riskScoreState;
   const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const entityStoreV2Enabled = true;
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
@@ -163,13 +154,11 @@ export const UserPanel = memo(function UserPanel({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('user', {
     onSuccess: calculateEntityRiskScore,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/index.tsx
@@ -13,10 +13,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { useUpdateAssetCriticality } from '../../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useAssetCriticalityPrivileges } from '../../../../entity_analytics/components/asset_criticality/use_asset_criticality';
-import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../../common/types';
 import { useEntityRiskScoreRecalculation } from '../../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../../entity_analytics/components/home/constants';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -174,11 +171,6 @@ export const Host: FC<HostProps> = memo(function Host({
     entityStoreV2Enabled ? entityFromStoreResult : undefined
   );
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.host,
@@ -187,13 +179,11 @@ export const Host: FC<HostProps> = memo(function Host({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('host', {
     onSuccess: onAssetCriticalityChanged,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/service/main/index.tsx
@@ -14,14 +14,11 @@ import type { CriticalityLevelWithUnassigned } from '../../../../../common/entit
 import type { ESQuery } from '../../../../../common/typed_json';
 import { buildEntityNameFilter, type RiskSeverity } from '../../../../../common/search_strategy';
 import { EntityType } from '../../../../../common/entity_analytics/types';
-import type { Refetch } from '../../../../common/types';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
-import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
 import { useUpdateAssetCriticality } from '../../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../../entity_analytics/components/home/constants';
 import type { IdentityFields } from '../../../../flyout/document_details/shared/utils';
 import {
   EntityDetailsLeftPanelTab,
@@ -121,11 +118,6 @@ export const Service: FC<ServiceProps> = memo(function Service({
   const { setQuery, deleteQuery } = useGlobalTime();
   const observedService = useObservedService(documentEntityIdentifiers, scopeId);
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.service,
@@ -134,13 +126,11 @@ export const Service: FC<ServiceProps> = memo(function Service({
       entityStoreV2Enabled: true,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('service', {
     onSuccess: onAssetCriticalityChanged,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/index.tsx
@@ -13,10 +13,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { useUpdateAssetCriticality } from '../../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useAssetCriticalityPrivileges } from '../../../../entity_analytics/components/asset_criticality/use_asset_criticality';
-import { useRefetchQueryById } from '../../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../../common/types';
 import { useEntityRiskScoreRecalculation } from '../../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../../entity_analytics/components/home/constants';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -176,11 +173,6 @@ export const User: FC<UserProps> = memo(function User({
     entityStoreV2Enabled ? entityFromStoreResult : undefined
   );
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.user,
@@ -189,13 +181,11 @@ export const User: FC<UserProps> = memo(function User({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('user', {
     onSuccess: onAssetCriticalityChanged,


### PR DESCRIPTION
## Summary

Follow-up to [#271539](https://github.com/elastic/kibana/pull/271539). After that PR, changing an entity's asset criticality correctly updated the entities table rows, but when the table is grouped by resolution the risk score shown on the group accordion header was not refreshed. This PR fixes that, and centralizes the table-refresh logic inside the `useEntityRiskScoreRecalculation` hook.

## How to test
1. Load some risk score data. I used the `risk-score-v2` command from [security-documents-generator](https://github.com/elastic/security-documents-generator):
  ```
  yarn start risk-score-v2
  ```
2. Navigate to the Entity Analytics page and groups entities on the entities table by resolution
3. Open any entity flyout from the entities table
4. Change the Asset Criticality
5. Close the flyout and verify the entities table reflects the updated score on the entities row and the resolution group accordion header

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->