### PR TITLE
[Entity Analytics] Two stage ESQL identity field evaluations for recent anomalies panel

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
@@ -11,6 +11,7 @@ import {
   getEuidEsqlFilterBasedOnDocument,
   getFieldEvaluationsEsql,
   getFieldEvaluationsEsqlFromDefinition,
+  getIdentityFieldEvaluationsEsql,
   collectRankingFields,
   buildRankingCaseEsql,
   buildSourcePickerEsql,
@@ -317,6 +318,52 @@ describe('getEuidEsqlEvaluation', () => {
 
     expect(result).toContain('my_custom_euid =');
     expect(result).not.toContain('entity.id =');
+  });
+
+  describe('skipIdentityFieldEvaluations option', () => {
+    it('omits identity field evaluations (e.g. entity.namespace) when true', () => {
+      const result = getEuidEsqlEvaluation('user', 'user_euid', {
+        skipIdentityFieldEvaluations: true,
+      });
+
+      // entity.namespace derivation must be absent
+      expect(result).not.toContain('entity.namespace =');
+      // but _present columns and the EUID formula must still be present
+      expect(result).toContain('entity_namespace_present =');
+      expect(result).toContain('user_euid =');
+    });
+
+    it('includes identity field evaluations by default', () => {
+      const result = getEuidEsqlEvaluation('user', 'user_euid');
+
+      expect(result).toContain('entity.namespace =');
+    });
+
+    it('matches the output of getIdentityFieldEvaluationsEsql for the skipped block', () => {
+      const withSkip = getEuidEsqlEvaluation('user', 'user_euid', {
+        skipIdentityFieldEvaluations: true,
+      });
+      const withoutSkip = getEuidEsqlEvaluation('user', 'user_euid');
+      const identityEvals = getIdentityFieldEvaluationsEsql('user');
+
+      // The default evaluation is the skipped evaluation prepended with the identity evals
+      expect(withoutSkip).toContain(identityEvals!);
+      expect(withSkip).not.toContain(identityEvals!);
+    });
+
+    it('is a no-op for entity types without identity field evaluations (host)', () => {
+      const withSkip = getEuidEsqlEvaluation('host', 'host_euid', {
+        skipIdentityFieldEvaluations: true,
+      });
+      const withoutSkip = getEuidEsqlEvaluation('host', 'host_euid');
+
+      expect(withSkip).toBe(withoutSkip);
+    });
+
+    it('getIdentityFieldEvaluationsEsql returns undefined for entity types with no identity field evaluations', () => {
+      expect(getIdentityFieldEvaluationsEsql('host')).toBeUndefined();
+      expect(getIdentityFieldEvaluationsEsql('service')).toBeUndefined();
+    });
   });
 });
 

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
@@ -394,6 +394,29 @@ export function getEuidEsqlDocumentsContainsIdFilter(entityType: EntityType) {
 }
 
 /**
+ * Returns the EVAL fragment for the identity-specific field evaluations of the given entity type
+ * (e.g. the `entity.namespace` derivation for the user entity).
+ *
+ * **Use this together with `getEuidEsqlEvaluation({ skipIdentityFieldEvaluations: true })`**
+ * to emit the field evaluations in a **separate** `| EVAL` stage that precedes the EUID
+ * computation. This is required when `SET unmapped_fields="nullify"` is in effect (e.g. when
+ * querying `.ml-anomalies-*`): within a single `| EVAL`, newly-assigned columns whose names
+ * match unmapped source fields (like `entity.namespace`) may resolve back to NULL instead of
+ * the just-computed value, silently nullifying all `_present` columns that reference them.
+ * A separate `| EVAL` stage commits the computed value before the next stage references it.
+ *
+ * Returns `undefined` when the entity type has no identity-specific field evaluations.
+ */
+export function getIdentityFieldEvaluationsEsql(entityType: EntityType): string | undefined {
+  const entityDefinition = getEntityDefinitionWithoutId(entityType);
+  const { identityField } = entityDefinition;
+  if (isSingleFieldIdentity(identityField)) return undefined;
+  const evaluations = identityField.fieldEvaluations ?? [];
+  if (evaluations.length === 0) return undefined;
+  return evaluations.map((e) => buildOneFieldEvaluationEsql(e)).join(',\n ');
+}
+
+/**
  * Returns a comma-separated ES|QL EVAL assignments fragment that computes the entity id
  * for the given entity type and assigns it to `outputColumn`.
  *
@@ -405,11 +428,18 @@ export function getEuidEsqlDocumentsContainsIdFilter(entityType: EntityType) {
  * ```ts
  * parts.push(`| EVAL ${getEuidEsqlEvaluation(type, 'entity.id')}`);
  * ```
+ *
+ * When querying indices with `SET unmapped_fields="nullify"`, pass
+ * `skipIdentityFieldEvaluations: true` and emit a dedicated `| EVAL` for
+ * `getIdentityFieldEvaluationsEsql` first — see that function's docs for details.
  */
 export function getEuidEsqlEvaluation(
   entityType: EntityType,
   outputColumn: string,
-  { withTypeId = true }: { withTypeId?: boolean } = {}
+  {
+    withTypeId = true,
+    skipIdentityFieldEvaluations = false,
+  }: { withTypeId?: boolean; skipIdentityFieldEvaluations?: boolean } = {}
 ): string {
   const entityDefinition = getEntityDefinitionWithoutId(entityType);
   const { identityField } = entityDefinition;
@@ -433,9 +463,12 @@ export function getEuidEsqlEvaluation(
   const assignments: string[] = [];
 
   // Identity-specific field evaluations (e.g. entity.namespace for user) must precede
-  // the _present columns that may reference their output.
-  for (const evaluation of identityField.fieldEvaluations ?? []) {
-    assignments.push(buildOneFieldEvaluationEsql(evaluation));
+  // the _present columns that may reference their output.  When skipIdentityFieldEvaluations
+  // is true the caller emits them in a prior | EVAL stage via getIdentityFieldEvaluationsEsql.
+  if (!skipIdentityFieldEvaluations) {
+    for (const evaluation of identityField.fieldEvaluations ?? []) {
+      assignments.push(buildOneFieldEvaluationEsql(evaluation));
+    }
   }
   for (const f of presentFields) {
     assignments.push(`${esqlPresentColumnName(f)} = ${esqlIsNotNullOrEmpty(f)}`);

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
@@ -20,6 +20,7 @@ export {
   getEuidEsqlEvaluation,
   getEuidEsqlFilterBasedOnDocument,
   getFieldEvaluationsEsql,
+  getIdentityFieldEvaluationsEsql,
 } from './esql';
 export {
   applyFieldEvaluations,

--- a/x-pack/solutions/security/plugins/entity_store/common/euid_helpers.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/euid_helpers.ts
@@ -85,6 +85,19 @@ export const euid = {
      * Input: entity type. Output: ESQL expression string for `EVAL`, or `undefined` if none defined.
      */
     getFieldEvaluations: euidModule.getFieldEvaluationsEsql,
+
+    /**
+     * Returns the ESQL `EVAL` expressions for identity-specific field evaluations only
+     * (e.g. entity.namespace derivation for the user entity).
+     *
+     * Emit this in a **separate** `| EVAL` stage before `getEuidEvaluation` when querying
+     * indices with `SET unmapped_fields="nullify"` (e.g. `.ml-anomalies-*`). Pass
+     * `skipIdentityFieldEvaluations: true` to `getEuidEvaluation` in that case to avoid
+     * re-emitting these assignments in the same `| EVAL` where they would be read.
+     *
+     * Input: entity type. Output: ESQL expression string for `EVAL`, or `undefined` if none defined.
+     */
+    getIdentityFieldEvaluations: euidModule.getIdentityFieldEvaluationsEsql,
   },
 
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.test.ts
@@ -29,11 +29,38 @@ describe('recent anomalies ES|QL sources', () => {
         esql: {
           getFieldEvaluations: (entityType: string) =>
             `${entityType}_field = TO_STRING(${entityType}.name)`,
+          getIdentityFieldEvaluations: (entityType: string) =>
+            `${entityType}_namespace = "test_ns"`,
           getEuidEvaluation: (entityType: string, target: string) =>
             `${target} = CONCAT("${entityType}:", ${entityType}.name)`,
         },
       },
     });
+  });
+
+  it('emits identity field evals in a separate | EVAL stage before the EUID formula', () => {
+    const { result } = renderHook(() =>
+      useRecentAnomaliesTopRowsEsqlSource({
+        anomalyBands: [],
+        viewBy: 'entity',
+        spaceId: 'default',
+        rowsLimit: 5,
+      })
+    );
+    const source = result.current!;
+
+    // All three | EVAL stages must be present
+    const topLevelPos = source.indexOf('| EVAL user_field =');
+    const identityPos = source.indexOf('| EVAL user_namespace =');
+    const euidPos = source.indexOf('| EVAL user_euid =');
+
+    expect(topLevelPos).toBeGreaterThan(-1);
+    expect(identityPos).toBeGreaterThan(-1);
+    expect(euidPos).toBeGreaterThan(-1);
+
+    // Identity field evals must come after top-level field evals and before the EUID formula
+    expect(topLevelPos).toBeLessThan(identityPos);
+    expect(identityPos).toBeLessThan(euidPos);
   });
 
   const expectTimeRangeBeforeLookupJoin = (source: string | undefined) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
@@ -57,11 +57,25 @@ const getEuidEvaluationBlock = (euidApi: EntityStoreEuid) => {
   const parts: string[] = [];
 
   for (const entityType of ANOMALY_ENTITY_TYPES) {
+    // Stage 1: top-level field evals (e.g. entity.source)
     const fieldEvals = euidApi.esql.getFieldEvaluations(entityType);
     if (fieldEvals) {
       parts.push(`| EVAL ${fieldEvals}`);
     }
-    parts.push(`| EVAL ${euidApi.esql.getEuidEvaluation(entityType, `${entityType}_euid`)}`);
+    // Stage 2: identity-specific field evals (e.g. entity.namespace) in a separate | EVAL.
+    // Required because SET unmapped_fields="nullify" causes entity.namespace — an unmapped
+    // field in .ml-anomalies-* — to resolve back to NULL when referenced in the same | EVAL
+    // that assigns it.  A separate stage commits the computed value before stage 3 reads it.
+    const identityFieldEvals = euidApi.esql.getIdentityFieldEvaluations(entityType);
+    if (identityFieldEvals) {
+      parts.push(`| EVAL ${identityFieldEvals}`);
+    }
+    // Stage 3: EUID formula (identity field evals already committed above)
+    parts.push(
+      `| EVAL ${euidApi.esql.getEuidEvaluation(entityType, `${entityType}_euid`, {
+        skipIdentityFieldEvaluations: true,
+      })}`
+    );
   }
 
   parts.push(


### PR DESCRIPTION
## Summary

The recent anomalies panel was producing `user_euid = NULL` for certain anomaly records, so not all user entities were showing up, even if there were recent anomalies

### Root cause

ML anomaly records are stored in `.ml-anomalies-*` index, which does not map ECS fields like `entity.namespace`. The recent anomalies panel query uses `SET unmapped_fields="nullify"` to avoid errors on missing fields. This setting has a subtle interaction with ES|QL `| EVAL`: when a column name matches an *unmapped* source field, ES|QL resolves subsequent references to that name within the **same** `| EVAL` block back to the original nullified value rather than the just-computed value.

The previous query emitted `entity.namespace = COALESCE(...)` and then immediately `entity_namespace_present = TO_STRING(entity.namespace) IS NOT NULL AND ...` in the **same** `| EVAL` block. Because `entity.namespace` is unmapped in `.ml-anomalies-*`, the `_present` column read back NULL — making `entity_namespace_present_or_null = NULL`, which nullified every `CONCAT` arm in `_euid_branch_1_formula`, and ultimately `user_euid = CONCAT("user:", NULL) = NULL`.

### Fix

Split the identity-specific field evaluations (`entity.namespace` derivation) into a **separate `| EVAL` stage** that precedes the `_present` columns and EUID formula. A committed `| EVAL` stage cannot be un-done by `unmapped_fields="nullify"` in a subsequent stage, so `entity.namespace` is stable by the time the EUID formula reads it.

The resulting query now has three stages for user:

```esql
| EVAL entity.source = ...              -- top-level shared field evals
| EVAL entity.namespace = ...           -- identity field evals (new separate stage)
| EVAL entity_namespace_present = ...,  -- _present booleans + EUID formula
       user_euid = CONCAT("user:", ...)
```

### Previous query

<details>
<summary> Previous Recent Anomalies Query </summary>

```
SET unmapped_fields = "nullify";
FROM .ml-anomalies-shared*
  | WHERE result_type == "record" AND is_interim == FALSE AND record_score >= 1
  | EVAL
      _src_entity_source0 = MV_FIRST(TO_STRING(event.module)),
      _src_entity_source1 = MV_FIRST(TO_STRING(event.dataset)),
      _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
      _src_entity_source =
        COALESCE(CASE(_src_entity_source0 IS NOT NULL AND _src_entity_source0 != "", _src_entity_source0), CASE(_src_entity_source1 IS NOT NULL AND _src_entity_source1 != "", _src_entity_source1), CASE(_src_entity_source2 IS NOT NULL AND _src_entity_source2 != "", _src_entity_source2)),
      entity.source = CASE(_src_entity_source IS NULL OR _src_entity_source == "", NULL, _src_entity_source)
  | EVAL
      _src_entity_namespace0 = MV_FIRST(TO_STRING(event.module)),
      _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), ".")),
      _src_entity_namespace = COALESCE(CASE(_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != "", _src_entity_namespace0), CASE(_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != "", _src_entity_namespace1)),
      _eval_entity_namespace_arm0 =
        (TO_STRING(user.name) IS NOT NULL AND
          TO_STRING(user.name) != "" AND
          TO_STRING(host.id) IS NOT NULL AND
          TO_STRING(host.id) != "" AND
          NOT (TO_STRING(user.name) IN ("root", "bin", "daemon", "sys", "nobody", "jenkins", "ansible", "deploy", "terraform", "gitlab-runner", "postgres", "mysql", "redis", "elasticsearch", "kafka", "admin", "operator", "service")) AND
          (MV_CONTAINS(TO_STRING(event.kind), "asset") OR
            NOT (MV_CONTAINS(TO_STRING(event.kind), "asset") OR
              (TO_STRING(event.kind) != "enrichment" OR TO_STRING(event.kind) IS NULL AND) AND
                MV_CONTAINS(TO_STRING(event.category), "iam") AND
                (MV_CONTAINS(TO_STRING(event.type), "user") OR MV_CONTAINS(TO_STRING(event.type), "creation") OR MV_CONTAINS(TO_STRING(event.type), "deletion") OR MV_CONTAINS(TO_STRING(event.type), "group"),),),),),
      _eval_entity_namespace_arm1 = (MV_CONTAINS(TO_STRING(event.kind), "asset") AND MV_CONTAINS(TO_STRING(event.module), "asset_discovery")),
      entity.namespace =
        COALESCE(
          CASE(COALESCE(_eval_entity_namespace_arm0, FALSE), "local"),
          CASE(COALESCE(_eval_entity_namespace_arm1, FALSE), CASE(MV_FIRST(TO_STRING(cloud.provider)) == "aws", "aws", MV_FIRST(TO_STRING(cloud.provider)) == "gcp", "gcp", MV_FIRST(TO_STRING(cloud.provider)) == "azure", "entra_id")),
          CASE(COALESCE(_src_entity_namespace IN ("okta", "entityanalytics_okta"), FALSE), "okta"),
          CASE(COALESCE(_src_entity_namespace IN ("azure", "entityanalytics_entra_id"), FALSE), "entra_id"),
          CASE(COALESCE(_src_entity_namespace IN ("o365", "o365_metrics"), FALSE), "microsoft_365"),
          CASE(COALESCE(_src_entity_namespace IN ("entityanalytics_ad"), FALSE), "active_directory"),
          CASE(_src_entity_namespace IS NULL OR _src_entity_namespace == "", "unknown"),
          _src_entity_namespace0), 
      user_name_present = (TO_STRING(MV_FIRST(user.name)) IS NOT NULL AND TO_STRING(MV_FIRST(user.name)) != ""),
      host_id_present = (TO_STRING(MV_FIRST(host.id)) IS NOT NULL AND TO_STRING(MV_FIRST(host.id)) != ""),
      entity_namespace_present = (TO_STRING(MV_FIRST(entity.namespace)) IS NOT NULL AND TO_STRING(MV_FIRST(entity.namespace)) != ""),
      user_email_present = (TO_STRING(MV_FIRST(user.email)) IS NOT NULL AND TO_STRING(MV_FIRST(user.email)) != ""),
      user_id_present = (TO_STRING(MV_FIRST(user.id)) IS NOT NULL AND TO_STRING(MV_FIRST(user.id)) != ""),
      user_domain_present = (TO_STRING(MV_FIRST(user.domain)) IS NOT NULL AND TO_STRING(MV_FIRST(user.domain)) != ""),
      user_name_present_or_null = CASE(user_name_present, MV_FIRST(TO_STRING(user.name))),
      host_id_present_or_null = CASE(host_id_present, MV_FIRST(TO_STRING(host.id))),
      entity_namespace_present_or_null = CASE(entity_namespace_present, MV_FIRST(TO_STRING(entity.namespace))),
      user_email_present_or_null = CASE(user_email_present, MV_FIRST(TO_STRING(user.email))),
      user_id_present_or_null = CASE(user_id_present, MV_FIRST(TO_STRING(user.id))),
      user_domain_present_or_null = CASE(user_domain_present, MV_FIRST(TO_STRING(user.domain))),
      _euid_branch_0_formula = CONCAT(user_name_present_or_null, "@", host_id_present_or_null, "@", entity_namespace_present_or_null),
      _euid_branch_0_cond = (TO_STRING(entity.namespace) == "local"),
      _euid_branch_1_formula =
        COALESCE(CONCAT(user_email_present_or_null, "@", entity_namespace_present_or_null), CONCAT(user_id_present_or_null, "@", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, "@", user_domain_present_or_null, "@", entity_namespace_present_or_null),
          CONCAT(user_name_present_or_null, "@", entity_namespace_present_or_null)),
      user_euid = CONCAT("user:", CASE(_euid_branch_0_cond, _euid_branch_0_formula, TRUE, _euid_branch_1_formula, NULL))
  | WHERE user_euid IS NOT NULL
```
</details>


### Updated query

<details>
<summary> Updated Recent Anomalies Query </summary>

```
SET unmapped_fields = "nullify";
FROM .ml-anomalies-shared*
  | WHERE result_type == "record" AND is_interim == FALSE AND record_score >= 1
  | EVAL
      _src_entity_source0 = MV_FIRST(TO_STRING(event.module)),
      _src_entity_source1 = MV_FIRST(TO_STRING(event.dataset)),
      _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
      _src_entity_source =
        COALESCE(CASE(_src_entity_source0 IS NOT NULL AND _src_entity_source0 != "", _src_entity_source0), CASE(_src_entity_source1 IS NOT NULL AND _src_entity_source1 != "", _src_entity_source1), CASE(_src_entity_source2 IS NOT NULL AND _src_entity_source2 != "", _src_entity_source2)),
      entity.source = CASE(_src_entity_source IS NULL OR _src_entity_source == "", NULL, _src_entity_source)
  | EVAL
      _src_entity_namespace0 = MV_FIRST(TO_STRING(event.module)),
      _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), ".")),
      _src_entity_namespace = COALESCE(CASE(_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != "", _src_entity_namespace0), CASE(_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != "", _src_entity_namespace1)),
      _eval_entity_namespace_arm0 =
        (TO_STRING(user.name) IS NOT NULL AND
          TO_STRING(user.name) != "" AND
          TO_STRING(host.id) IS NOT NULL AND
          TO_STRING(host.id) != "" AND
          NOT (TO_STRING(user.name) IN ("root", "bin", "daemon", "sys", "nobody", "jenkins", "ansible", "deploy", "terraform", "gitlab-runner", "postgres", "mysql", "redis", "elasticsearch", "kafka", "admin", "operator", "service")) AND
          (MV_CONTAINS(TO_STRING(event.kind), "asset") OR
            NOT (MV_CONTAINS(TO_STRING(event.kind), "asset") OR
              (TO_STRING(event.kind) != "enrichment" OR TO_STRING(event.kind) IS NULL AND) AND
                MV_CONTAINS(TO_STRING(event.category), "iam") AND
                (MV_CONTAINS(TO_STRING(event.type), "user") OR MV_CONTAINS(TO_STRING(event.type), "creation") OR MV_CONTAINS(TO_STRING(event.type), "deletion") OR MV_CONTAINS(TO_STRING(event.type), "group"),),),),),
      _eval_entity_namespace_arm1 = (MV_CONTAINS(TO_STRING(event.kind), "asset") AND MV_CONTAINS(TO_STRING(event.module), "asset_discovery")),
      entity.namespace =
        COALESCE(
          CASE(COALESCE(_eval_entity_namespace_arm0, FALSE), "local"),
          CASE(COALESCE(_eval_entity_namespace_arm1, FALSE), CASE(MV_FIRST(TO_STRING(cloud.provider)) == "aws", "aws", MV_FIRST(TO_STRING(cloud.provider)) == "gcp", "gcp", MV_FIRST(TO_STRING(cloud.provider)) == "azure", "entra_id")),
          CASE(COALESCE(_src_entity_namespace IN ("okta", "entityanalytics_okta"), FALSE), "okta"),
          CASE(COALESCE(_src_entity_namespace IN ("azure", "entityanalytics_entra_id"), FALSE), "entra_id"),
          CASE(COALESCE(_src_entity_namespace IN ("o365", "o365_metrics"), FALSE), "microsoft_365"),
          CASE(COALESCE(_src_entity_namespace IN ("entityanalytics_ad"), FALSE), "active_directory"),
          CASE(_src_entity_namespace IS NULL OR _src_entity_namespace == "", "unknown"),
          _src_entity_namespace)
  | EVAL
      user_name_present = (TO_STRING(MV_FIRST(user.name)) IS NOT NULL AND TO_STRING(MV_FIRST(user.name)) != ""),
      host_id_present = (TO_STRING(MV_FIRST(host.id)) IS NOT NULL AND TO_STRING(MV_FIRST(host.id)) != ""),
      entity_namespace_present = (TO_STRING(MV_FIRST(entity.namespace)) IS NOT NULL AND TO_STRING(MV_FIRST(entity.namespace)) != ""),
      user_email_present = (TO_STRING(MV_FIRST(user.email)) IS NOT NULL AND TO_STRING(MV_FIRST(user.email)) != ""),
      user_id_present = (TO_STRING(MV_FIRST(user.id)) IS NOT NULL AND TO_STRING(MV_FIRST(user.id)) != ""),
      user_domain_present = (TO_STRING(MV_FIRST(user.domain)) IS NOT NULL AND TO_STRING(MV_FIRST(user.domain)) != ""),
      user_name_present_or_null = CASE(user_name_present, MV_FIRST(TO_STRING(user.name))),
      host_id_present_or_null = CASE(host_id_present, MV_FIRST(TO_STRING(host.id))),
      entity_namespace_present_or_null = CASE(entity_namespace_present, MV_FIRST(TO_STRING(entity.namespace))),
      user_email_present_or_null = CASE(user_email_present, MV_FIRST(TO_STRING(user.email))),
      user_id_present_or_null = CASE(user_id_present, MV_FIRST(TO_STRING(user.id))),
      user_domain_present_or_null = CASE(user_domain_present, MV_FIRST(TO_STRING(user.domain))),
      _euid_branch_0_formula = CONCAT(user_name_present_or_null, "@", host_id_present_or_null, "@", entity_namespace_present_or_null),
      _euid_branch_0_cond = (TO_STRING(entity.namespace) == "local"),
      _euid_branch_1_formula =
        COALESCE(CONCAT(user_email_present_or_null, "@", entity_namespace_present_or_null), CONCAT(user_id_present_or_null, "@", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, "@", user_domain_present_or_null, "@", entity_namespace_present_or_null),
          CONCAT(user_name_present_or_null, "@", entity_namespace_present_or_null)),
      user_euid = CONCAT("user:", CASE(_euid_branch_0_cond, _euid_branch_0_formula, TRUE, _euid_branch_1_formula, NULL))
  | WHERE user_euid IS NOT NULL
```
</details>