### PR TITLE
[Agent Builder] Fix flaky test due to flag_streams

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/converse_tracing_snapshot_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/converse_tracing_snapshot_api.spec.ts
@@ -70,6 +70,11 @@ interface SpanEvent {
 const sanitizeAttributes = (attrs: Record<string, unknown>): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(attrs)) {
+    // `kibana.*` attributes (e.g. feature-flag `kibana.flag_*` labels) are stamped onto
+    // whatever OTel span is active at that moment, so they leak non-deterministically onto
+    // these spans. Drop them.
+    if (key.startsWith('kibana.')) continue;
+
     if (key in PLACEHOLDER_ATTRIBUTES) {
       if (value != null) {
         result[key] = PLACEHOLDER_ATTRIBUTES[key];

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/fixtures/expected_trace_spans.json
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/fixtures/expected_trace_spans.json
@@ -6,8 +6,7 @@
       "gen_ai.agent.name": "test_agent",
       "gen_ai.conversation.id": "[CONVERSATION_ID]",
       "gen_ai.operation.name": "invoke_agent",
-      "gen_ai.provider.name": "OpenAI",
-      "kibana.inference.root": false
+      "gen_ai.provider.name": "OpenAI"
     },
     "kind": "Internal",
     "name": "invoke_agent test_agent"
@@ -19,8 +18,7 @@
       "gen_ai.agent.name": "test_agent",
       "gen_ai.conversation.id": "[CONVERSATION_ID]",
       "gen_ai.operation.name": "invoke_agent",
-      "gen_ai.provider.name": "OpenAI",
-      "kibana.inference.root": true
+      "gen_ai.provider.name": "OpenAI"
     },
     "kind": "Internal",
     "name": "invoke_agent test_agent"
@@ -28,8 +26,7 @@
   {
     "attributes": {
       "elastic.inference.span.kind": "CHAIN",
-      "gen_ai.conversation.id": "[CONVERSATION_ID]",
-      "kibana.inference.root": false
+      "gen_ai.conversation.id": "[CONVERSATION_ID]"
     },
     "kind": "Internal",
     "name": "generate_title"
@@ -49,7 +46,6 @@
       "gen_ai.tool.definitions": "[TOOL_DEFINITIONS]",
       "gen_ai.usage.input_tokens": "[TOKENS]",
       "gen_ai.usage.output_tokens": "[TOKENS]",
-      "kibana.inference.root": false,
       "openai.raw_request": "[RAW_REQUEST]"
     },
     "kind": "Client",
@@ -70,7 +66,6 @@
       "gen_ai.tool.definitions": "[TOOL_DEFINITIONS]",
       "gen_ai.usage.input_tokens": "[TOKENS]",
       "gen_ai.usage.output_tokens": "[TOKENS]",
-      "kibana.inference.root": false,
       "openai.raw_request": "[RAW_REQUEST]"
     },
     "kind": "Client",
@@ -91,7 +86,6 @@
       "gen_ai.tool.definitions": "[TOOL_DEFINITIONS]",
       "gen_ai.usage.input_tokens": "[TOKENS]",
       "gen_ai.usage.output_tokens": "[TOKENS]",
-      "kibana.inference.root": false,
       "openai.raw_request": "[RAW_REQUEST]"
     },
     "kind": "Client",
@@ -107,8 +101,7 @@
       "gen_ai.tool.call.result": "[TOOL_RESULT]",
       "gen_ai.tool.description": "[TOOL_DESCRIPTION]",
       "gen_ai.tool.name": "platform.core.list_indices",
-      "gen_ai.tool.type": "extension",
-      "kibana.inference.root": false
+      "gen_ai.tool.type": "extension"
     },
     "kind": "Internal",
     "name": "execute_tool platform.core.list_indices"


### PR DESCRIPTION
## Summary

The feature-flags service stamps `kibana.flag_*` labels onto whatever OTel span is active when a flag is evaluated. Flag evaluations from other plugins (e.g. streams.significantEventsAvailable) run asynchronously and independently of the converse request, so they leak non-deterministically onto the agent spans. 

Fix: the snapshot sanitizer now drops any `kibana.*` attribute, and the expected fixture is regenerated accordingly. This makes the snapshot robust against any flag that happens to be evaluated during the run, not just this one and the test focus only on gen AI attributes.

Closes https://github.com/elastic/kibana/issues/278335


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



