### PR TITLE
[8.19] [ResponseOps][MW] Add limits to all of the MWs internal APIs (#272671)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -1359,6 +1359,7 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -1397,10 +1398,12 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },
@@ -2292,6 +2295,7 @@
                               "properties": {
                                 "dsl": {
                                   "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
+                                  "maxLength": 10000,
                                   "type": "string"
                                 },
                                 "filters": {
@@ -2330,10 +2334,12 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "kql": {
                                   "description": "A filter written in Kibana Query Language (KQL).",
+                                  "maxLength": 10000,
                                   "type": "string"
                                 }
                               },
@@ -2621,6 +2627,7 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -2659,10 +2666,12 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },
@@ -3553,6 +3562,7 @@
                               "properties": {
                                 "dsl": {
                                   "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
+                                  "maxLength": 10000,
                                   "type": "string"
                                 },
                                 "filters": {
@@ -3591,10 +3601,12 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "kql": {
                                   "description": "A filter written in Kibana Query Language (KQL).",
+                                  "maxLength": 10000,
                                   "type": "string"
                                 }
                               },
@@ -3866,6 +3878,7 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -3904,10 +3917,12 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },
@@ -5572,6 +5587,7 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -5610,10 +5626,12 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
+                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },

--- a/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/schemas/v1.ts
@@ -9,7 +9,10 @@ import { schema } from '@kbn/config-schema';
 import { FilterStateStore } from '@kbn/es-query';
 
 export const alertsFilterQuerySchema = schema.object({
-  kql: schema.string({ meta: { description: 'A filter written in Kibana Query Language (KQL).' } }),
+  kql: schema.string({
+    maxLength: 10000,
+    meta: { description: 'A filter written in Kibana Query Language (KQL).' },
+  }),
   filters: schema.arrayOf(
     schema.object({
       query: schema.maybe(
@@ -49,6 +52,7 @@ export const alertsFilterQuerySchema = schema.object({
       ),
     }),
     {
+      maxSize: 100,
       meta: {
         description:
           'A filter written in Elasticsearch Query Domain Specific Language (DSL) as defined in the `kbn-es-query` package.',
@@ -57,6 +61,7 @@ export const alertsFilterQuerySchema = schema.object({
   ),
   dsl: schema.maybe(
     schema.string({
+      maxLength: 10000,
       meta: {
         description: 'A filter written in Elasticsearch Query Domain Specific Language (DSL).',
       },

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/archive/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/archive/schemas/v1.ts
@@ -6,9 +6,10 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { ID_MAX_LENGTH } from '../../../../shared/constants/latest';
 
 export const archiveParamsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: ID_MAX_LENGTH }),
 });
 
 export const archiveBodySchema = schema.object({

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/bulk_get/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/bulk_get/schemas/v1.ts
@@ -6,7 +6,10 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { BULK_GET_IDS_MAX_SIZE, ID_MAX_LENGTH } from '../../../../shared/constants/latest';
 
 export const bulkGetBodySchema = schema.object({
-  ids: schema.arrayOf(schema.string()),
+  ids: schema.arrayOf(schema.string({ maxLength: ID_MAX_LENGTH }), {
+    maxSize: BULK_GET_IDS_MAX_SIZE,
+  }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/create/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/create/schemas/v1.ts
@@ -7,11 +7,12 @@
 
 import { schema } from '@kbn/config-schema';
 import { maintenanceWindowCategoryIdsSchemaV1 } from '../../../../shared';
+import { TITLE_MAX_LENGTH } from '../../../../shared/constants/latest';
 import { rRuleRequestSchemaV1 } from '../../../../../r_rule';
 import { alertsFilterQuerySchemaV1 } from '../../../../../alerts_filter_query';
 
 export const createBodySchema = schema.object({
-  title: schema.string(),
+  title: schema.string({ maxLength: TITLE_MAX_LENGTH }),
   duration: schema.number(),
   r_rule: rRuleRequestSchemaV1,
   category_ids: maintenanceWindowCategoryIdsSchemaV1,

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/delete/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/delete/schemas/v1.ts
@@ -6,7 +6,8 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { ID_MAX_LENGTH } from '../../../../shared/constants/latest';
 
 export const deleteParamsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: ID_MAX_LENGTH }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/find/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/find/schemas/v1.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { maintenanceWindowResponseSchemaV1 } from '../../../response';
+import { SEARCH_MAX_LENGTH, STATUS_FILTER_MAX_SIZE } from '../../../../shared/constants/latest';
 
 const MAX_DOCS = 10000;
 
@@ -43,9 +44,15 @@ export const findMaintenanceWindowsRequestQuerySchema = schema.object(
           description:
             'An Elasticsearch simple_query_string query that filters the objects in the response.',
         },
+        maxLength: SEARCH_MAX_LENGTH,
       })
     ),
-    status: schema.maybe(schema.oneOf([statusSchema, schema.arrayOf(statusSchema)])),
+    status: schema.maybe(
+      schema.oneOf([
+        statusSchema,
+        schema.arrayOf(statusSchema, { maxSize: STATUS_FILTER_MAX_SIZE }),
+      ])
+    ),
   },
   {
     validate: (params) => {

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/finish/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/finish/schemas/v1.ts
@@ -6,7 +6,8 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { ID_MAX_LENGTH } from '../../../../shared/constants/latest';
 
 export const finishParamsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: ID_MAX_LENGTH }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/get/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/get/schemas/v1.ts
@@ -6,7 +6,8 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { ID_MAX_LENGTH } from '../../../../shared/constants/latest';
 
 export const getParamsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: ID_MAX_LENGTH }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/update/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/update/schemas/v1.ts
@@ -7,15 +7,16 @@
 
 import { schema } from '@kbn/config-schema';
 import { maintenanceWindowCategoryIdsSchemaV1 } from '../../../../shared';
+import { ID_MAX_LENGTH, TITLE_MAX_LENGTH } from '../../../../shared/constants/latest';
 import { rRuleRequestSchemaV1 } from '../../../../../r_rule';
 import { alertsFilterQuerySchemaV1 } from '../../../../../alerts_filter_query';
 
 export const updateParamsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: ID_MAX_LENGTH }),
 });
 
 export const updateBodySchema = schema.object({
-  title: schema.maybe(schema.string()),
+  title: schema.maybe(schema.string({ maxLength: TITLE_MAX_LENGTH })),
   enabled: schema.maybe(schema.boolean()),
   duration: schema.maybe(schema.number()),
   r_rule: schema.maybe(rRuleRequestSchemaV1),

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/constants/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/constants/latest.ts
@@ -7,4 +7,12 @@
 
 export type { MaintenanceWindowCategoryIdTypes } from './v1';
 
-export { maintenanceWindowCategoryIdTypes } from './v1';
+export {
+  maintenanceWindowCategoryIdTypes,
+  ID_MAX_LENGTH,
+  TITLE_MAX_LENGTH,
+  SEARCH_MAX_LENGTH,
+  BULK_GET_IDS_MAX_SIZE,
+  STATUS_FILTER_MAX_SIZE,
+  CATEGORY_IDS_MAX_SIZE,
+} from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/constants/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/constants/v1.ts
@@ -14,3 +14,10 @@ export const maintenanceWindowCategoryIdTypes = {
 
 export type MaintenanceWindowCategoryIdTypes =
   (typeof maintenanceWindowCategoryIdTypes)[keyof typeof maintenanceWindowCategoryIdTypes];
+
+export const ID_MAX_LENGTH = 100;
+export const TITLE_MAX_LENGTH = 256;
+export const SEARCH_MAX_LENGTH = 1024;
+export const BULK_GET_IDS_MAX_SIZE = 100;
+export const STATUS_FILTER_MAX_SIZE = 4;
+export const CATEGORY_IDS_MAX_SIZE = 3;

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/schemas/v1.ts
@@ -6,7 +6,10 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { maintenanceWindowCategoryIdTypes as maintenanceWindowCategoryIdTypesV1 } from '../constants/v1';
+import {
+  CATEGORY_IDS_MAX_SIZE,
+  maintenanceWindowCategoryIdTypes as maintenanceWindowCategoryIdTypesV1,
+} from '../constants/v1';
 
 export const maintenanceWindowCategoryIdsSchema = schema.maybe(
   schema.nullable(
@@ -15,7 +18,14 @@ export const maintenanceWindowCategoryIdsSchema = schema.maybe(
         schema.literal(maintenanceWindowCategoryIdTypesV1.OBSERVABILITY),
         schema.literal(maintenanceWindowCategoryIdTypesV1.SECURITY_SOLUTION),
         schema.literal(maintenanceWindowCategoryIdTypesV1.MANAGEMENT),
-      ])
+      ]),
+      {
+        maxSize: CATEGORY_IDS_MAX_SIZE,
+        meta: {
+          description:
+            'The category IDs for the maintenance window. It can be "observability", "securitySolution", or "management".',
+        },
+      }
     )
   )
 );

--- a/x-pack/platform/plugins/shared/alerting/common/routes/r_rule/request/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/r_rule/request/schemas/v1.ts
@@ -14,8 +14,8 @@ import {
 } from '../../validation';
 
 export const rRuleRequestSchema = schema.object({
-  dtstart: schema.string({ validate: validateStartDateV1 }),
-  tzid: schema.string({ validate: validateTimezone }),
+  dtstart: schema.string({ validate: validateStartDateV1, maxLength: 100 }),
+  tzid: schema.string({ validate: validateTimezone, maxLength: 64 }),
   freq: schema.maybe(
     schema.oneOf([schema.literal(0), schema.literal(1), schema.literal(2), schema.literal(3)])
   ),
@@ -29,7 +29,7 @@ export const rRuleRequestSchema = schema.object({
       min: 1,
     })
   ),
-  until: schema.maybe(schema.string({ validate: validateEndDateV1 })),
+  until: schema.maybe(schema.string({ validate: validateEndDateV1, maxLength: 100 })),
   count: schema.maybe(
     schema.number({
       validate: (count: number) => {
@@ -41,11 +41,16 @@ export const rRuleRequestSchema = schema.object({
     })
   ),
   byweekday: schema.maybe(
-    schema.arrayOf(schema.string(), {
+    schema.arrayOf(schema.string({ maxLength: 10 }), {
       minSize: 1,
+      maxSize: 50,
       validate: validateRecurrenceByWeekdayV1,
     })
   ),
-  bymonthday: schema.maybe(schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1 })),
-  bymonth: schema.maybe(schema.arrayOf(schema.number({ min: 1, max: 12 }), { minSize: 1 })),
+  bymonthday: schema.maybe(
+    schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1, maxSize: 31 })
+  ),
+  bymonth: schema.maybe(
+    schema.arrayOf(schema.number({ min: 1, max: 12 }), { minSize: 1, maxSize: 12 })
+  ),
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][MW] Add limits to all of the MWs internal APIs (#272671)](https://github.com/elastic/kibana/pull/272671)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2026-07-14T13:15:20Z","message":"[ResponseOps][MW] Add limits to all of the MWs internal APIs (#272671)\n\nCloses https://github.com/elastic/kibana/issues/271191\n\n## Summary\n\n- Adds request validation limits to all internal Maintenance Windows API\nschemas (closes\n[#271191](https://github.com/elastic/kibana/issues/271191)). Bounds\nevery previously unbounded string, number, and array on create, update,\nfind, bulk_get, get, delete, finish, archive, and the shared r_rule\nrequest schema.\n\n\nEndpoint / schema | Field | Limit | Notes\n-- | -- | -- | --\ncreate, update | title | maxLength: 256 (TITLE_MAX_LENGTH) |\nHuman-entered name; same cap as other MW UIs\ncreate, update | duration | max: 365 * 24 * 60 * 60 * 1000 ms\n(DURATION_MAX_MS) | 1 year hard cap\ncreate, update (scoped_query) | kql, dsl | maxLength: 8192 | KQL / DSL\nquery body\ncreate, update (scoped_query) | filters array | maxSize: 100 |  \nupdate, get, delete, finish, archive | params.id | maxLength:\n36 (ID_MAX_LENGTH) | Server-generated UUID v4 is exactly 36 chars\nbulk_get | ids array size | maxSize: 100 (BULK_GET_IDS_MAX_SIZE) |\nMatches the find per_page cap\nbulk_get | ids[] element | maxLength: 36 (ID_MAX_LENGTH) | Same UUID\nreason\nfind | search | maxLength: 1024 (SEARCH_MAX_LENGTH) |\nsimple_query_string body\nfind | status array | maxSize: 5 (STATUS_FILTER_MAX_SIZE) | Derived\nfrom Object.keys(maintenanceWindowStatus).length — exactly the number of\nvalid status values\nshared | category_ids array | maxSize: 3 (CATEGORY_IDS_MAX_SIZE) |\nSchema accepts only observability, securitySolution, management —\nnatural domain\nr_rule | dtstart, tzid, until | maxLength: 64 | ISO-8601 and IANA\ntimezone names stay well under\nr_rule | interval, count | max: 1000 | Caps pathological recurrence\nconfigs\nr_rule | byweekday[] element | maxLength: 4 | Longest valid entry is\ne.g. \"+2TU\"\nr_rule | byweekday array | maxSize: 35 | 7 weekdays ×\npossible ±n prefixes\nr_rule | bymonthday array | maxSize: 31 | Days in a month\nr_rule | bymonth array | maxSize: 12 | Months in a year\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>","sha":"4b0b6cf9af0858bb5163b263a08110e7607aa243","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:all-open","v9.6.0"],"title":"[ResponseOps][MW] Add limits to all of the MWs internal APIs","number":272671,"url":"https://github.com/elastic/kibana/pull/272671","mergeCommit":{"message":"[ResponseOps][MW] Add limits to all of the MWs internal APIs (#272671)\n\nCloses https://github.com/elastic/kibana/issues/271191\n\n## Summary\n\n- Adds request validation limits to all internal Maintenance Windows API\nschemas (closes\n[#271191](https://github.com/elastic/kibana/issues/271191)). Bounds\nevery previously unbounded string, number, and array on create, update,\nfind, bulk_get, get, delete, finish, archive, and the shared r_rule\nrequest schema.\n\n\nEndpoint / schema | Field | Limit | Notes\n-- | -- | -- | --\ncreate, update | title | maxLength: 256 (TITLE_MAX_LENGTH) |\nHuman-entered name; same cap as other MW UIs\ncreate, update | duration | max: 365 * 24 * 60 * 60 * 1000 ms\n(DURATION_MAX_MS) | 1 year hard cap\ncreate, update (scoped_query) | kql, dsl | maxLength: 8192 | KQL / DSL\nquery body\ncreate, update (scoped_query) | filters array | maxSize: 100 |  \nupdate, get, delete, finish, archive | params.id | maxLength:\n36 (ID_MAX_LENGTH) | Server-generated UUID v4 is exactly 36 chars\nbulk_get | ids array size | maxSize: 100 (BULK_GET_IDS_MAX_SIZE) |\nMatches the find per_page cap\nbulk_get | ids[] element | maxLength: 36 (ID_MAX_LENGTH) | Same UUID\nreason\nfind | search | maxLength: 1024 (SEARCH_MAX_LENGTH) |\nsimple_query_string body\nfind | status array | maxSize: 5 (STATUS_FILTER_MAX_SIZE) | Derived\nfrom Object.keys(maintenanceWindowStatus).length — exactly the number of\nvalid status values\nshared | category_ids array | maxSize: 3 (CATEGORY_IDS_MAX_SIZE) |\nSchema accepts only observability, securitySolution, management —\nnatural domain\nr_rule | dtstart, tzid, until | maxLength: 64 | ISO-8601 and IANA\ntimezone names stay well under\nr_rule | interval, count | max: 1000 | Caps pathological recurrence\nconfigs\nr_rule | byweekday[] element | maxLength: 4 | Longest valid entry is\ne.g. \"+2TU\"\nr_rule | byweekday array | maxSize: 35 | 7 weekdays ×\npossible ±n prefixes\nr_rule | bymonthday array | maxSize: 31 | Days in a month\nr_rule | bymonth array | maxSize: 12 | Months in a year\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>","sha":"4b0b6cf9af0858bb5163b263a08110e7607aa243"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272671","number":272671,"mergeCommit":{"message":"[ResponseOps][MW] Add limits to all of the MWs internal APIs (#272671)\n\nCloses https://github.com/elastic/kibana/issues/271191\n\n## Summary\n\n- Adds request validation limits to all internal Maintenance Windows API\nschemas (closes\n[#271191](https://github.com/elastic/kibana/issues/271191)). Bounds\nevery previously unbounded string, number, and array on create, update,\nfind, bulk_get, get, delete, finish, archive, and the shared r_rule\nrequest schema.\n\n\nEndpoint / schema | Field | Limit | Notes\n-- | -- | -- | --\ncreate, update | title | maxLength: 256 (TITLE_MAX_LENGTH) |\nHuman-entered name; same cap as other MW UIs\ncreate, update | duration | max: 365 * 24 * 60 * 60 * 1000 ms\n(DURATION_MAX_MS) | 1 year hard cap\ncreate, update (scoped_query) | kql, dsl | maxLength: 8192 | KQL / DSL\nquery body\ncreate, update (scoped_query) | filters array | maxSize: 100 |  \nupdate, get, delete, finish, archive | params.id | maxLength:\n36 (ID_MAX_LENGTH) | Server-generated UUID v4 is exactly 36 chars\nbulk_get | ids array size | maxSize: 100 (BULK_GET_IDS_MAX_SIZE) |\nMatches the find per_page cap\nbulk_get | ids[] element | maxLength: 36 (ID_MAX_LENGTH) | Same UUID\nreason\nfind | search | maxLength: 1024 (SEARCH_MAX_LENGTH) |\nsimple_query_string body\nfind | status array | maxSize: 5 (STATUS_FILTER_MAX_SIZE) | Derived\nfrom Object.keys(maintenanceWindowStatus).length — exactly the number of\nvalid status values\nshared | category_ids array | maxSize: 3 (CATEGORY_IDS_MAX_SIZE) |\nSchema accepts only observability, securitySolution, management —\nnatural domain\nr_rule | dtstart, tzid, until | maxLength: 64 | ISO-8601 and IANA\ntimezone names stay well under\nr_rule | interval, count | max: 1000 | Caps pathological recurrence\nconfigs\nr_rule | byweekday[] element | maxLength: 4 | Longest valid entry is\ne.g. \"+2TU\"\nr_rule | byweekday array | maxSize: 35 | 7 weekdays ×\npossible ±n prefixes\nr_rule | bymonthday array | maxSize: 31 | Days in a month\nr_rule | bymonth array | maxSize: 12 | Months in a year\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>","sha":"4b0b6cf9af0858bb5163b263a08110e7607aa243"}},{"url":"https://github.com/elastic/kibana/pull/278147","number":278147,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->