### PR TITLE
[Agent Builder] Bootstrap context engine pages

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -30,6 +30,7 @@ pageLoadAssetSize:
   console: 31191
   contentConnectors: 33014
   contentManagement: 8350
+  contextEngine: 5837
   controls: 10300
   core: 606422
   cps: 9209

--- a/packages/kbn-rspack-optimizer/limits.yml
+++ b/packages/kbn-rspack-optimizer/limits.yml
@@ -6,12 +6,12 @@ pageLoadAssetSize:
   agentBuilderPlatform: 22339
   agentBuilderSml: 328
   agentBuilderVisualizations: 1284
-  agentBuilderWorkflows: 854
+  agentBuilderWorkflows: 761
   aiAssistantManagementSelection: 355
   aiops: 317
   alerting: 8789
-  alertingVTwo: 15636
-  apm: 31420
+  alertingVTwo: 15502
+  apm: 31419
   apmShared: 1896
   apmSourcesAccess: 779
   automaticImport: 13257
@@ -23,13 +23,14 @@ pageLoadAssetSize:
   cloudConnect: 4998
   cloudDataMigration: 1755
   cloudDefend: 3152
-  cloudExperiments: 75153
+  cloudExperiments: 67357
   cloudFullStory: 1373
   cloudLinks: 18103
   cloudSecurityPosture: 12224
   console: 24516
   contentConnectors: 2789
   contentManagement: 6738
+  contextEngine: 1415
   controls: 4166
   core: 320
   cps: 5002
@@ -37,7 +38,7 @@ pageLoadAssetSize:
   customIntegrations: 636
   dashboard: 452
   dashboardMarkdown: 4012
-  data: 11799
+  data: 11798
   dataFederation: 3324
   dataQuality: 5836
   datasetQuality: 41081
@@ -82,7 +83,7 @@ pageLoadAssetSize:
   files: 3957
   filesManagement: 952
   fileUpload: 217
-  fleet: 4772
+  fleet: 6095
   genAiSettings: 1542
   globalSearch: 5183
   globalSearchBar: 21462
@@ -176,22 +177,22 @@ pageLoadAssetSize:
   serverless: 1272
   serverlessObservability: 14136
   serverlessSearch: 18103
-  serverlessVectordb: 7168
+  serverlessVectordb: 7165
   serverlessWorkplaceAI: 3338
   sessionView: 379
   share: 440
   shared-core: 348361
-  shared-misc: 103676
+  shared-misc: 103637
   shared-packages: 4103474
   shared-plugins: 12276963
-  shared-solution-packages: 353542
-  significant_events: 2588
+  shared-solution-packages: 353531
+  significant_events: 2455
   slo: 19531
   snapshotRestore: 16909
   spaces: 22966
   stackAlerts: 1717
   stackConnectors: 63574
-  streams: 6521
+  streams: 4709
   streamsApp: 83679
   synthetics: 18443
   telemetry: 20586
@@ -211,13 +212,13 @@ pageLoadAssetSize:
   vendors: 4591364
   vendors-heavy: 2182280
   visDefaultEditor: 738
-  visTypeGauge: 7639
-  visTypeHeatmap: 6961
-  visTypeMetric: 6932
-  visTypePie: 22756
+  visTypeGauge: 7638
+  visTypeHeatmap: 6960
+  visTypeMetric: 6931
+  visTypePie: 22755
   visTypeTable: 13200
-  visTypeTagcloud: 3119
-  visTypeTimelion: 6661
+  visTypeTagcloud: 3118
+  visTypeTimelion: 6660
   visTypeTimeseries: 12718
   visTypeVega: 4860
   visTypeVislib: 21971

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/application_usage/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/application_usage/schema.ts
@@ -138,6 +138,7 @@ export const applicationUsageSchema = {
   automaticImport: commonSchema,
   canvas: commonSchema,
   cloud_connect: commonSchema,
+  context_engine: commonSchema,
   enterpriseSearch: commonSchema,
   enterpriseSearchContent: commonSchema,
   searchPlayground: commonSchema,

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -2360,6 +2360,137 @@
             }
           }
         },
+        "context_engine": {
+          "properties": {
+            "appId": {
+              "type": "keyword",
+              "_meta": {
+                "description": "The application being tracked"
+              }
+            },
+            "viewId": {
+              "type": "keyword",
+              "_meta": {
+                "description": "Always `main`"
+              }
+            },
+            "clicks_total": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application since we started counting them"
+              }
+            },
+            "clicks_7_days": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application over the last 7 days"
+              }
+            },
+            "clicks_30_days": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application over the last 30 days"
+              }
+            },
+            "clicks_90_days": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application over the last 90 days"
+              }
+            },
+            "minutes_on_screen_total": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen since we started counting them."
+              }
+            },
+            "minutes_on_screen_7_days": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen over the last 7 days"
+              }
+            },
+            "minutes_on_screen_30_days": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen over the last 30 days"
+              }
+            },
+            "minutes_on_screen_90_days": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen over the last 90 days"
+              }
+            },
+            "views": {
+              "type": "array",
+              "items": {
+                "properties": {
+                  "appId": {
+                    "type": "keyword",
+                    "_meta": {
+                      "description": "The application being tracked"
+                    }
+                  },
+                  "viewId": {
+                    "type": "keyword",
+                    "_meta": {
+                      "description": "The application view being tracked"
+                    }
+                  },
+                  "clicks_total": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the application sub view since we started counting them"
+                    }
+                  },
+                  "clicks_7_days": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the active application sub view over the last 7 days"
+                    }
+                  },
+                  "clicks_30_days": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the active application sub view over the last 30 days"
+                    }
+                  },
+                  "clicks_90_days": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the active application sub view over the last 90 days"
+                    }
+                  },
+                  "minutes_on_screen_total": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application sub view is active and on-screen since we started counting them."
+                    }
+                  },
+                  "minutes_on_screen_7_days": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application is active and on-screen active application sub view over the last 7 days"
+                    }
+                  },
+                  "minutes_on_screen_30_days": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application is active and on-screen active application sub view over the last 30 days"
+                    }
+                  },
+                  "minutes_on_screen_90_days": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application is active and on-screen active application sub view over the last 90 days"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "enterpriseSearch": {
           "properties": {
             "appId": {

--- a/x-pack/platform/plugins/shared/context_engine/common/constants.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/constants.ts
@@ -11,6 +11,12 @@ export const aiIndexPath = `${publicApiPath}/ai_index`;
 export const aiIndexByIdPath = `${aiIndexPath}/{aiIndexId}`;
 
 /**
+ * Version of the public AI index API, shared between the server route
+ * registration and browser clients.
+ */
+export const AI_INDEX_API_VERSION = '2023-10-31';
+
+/**
  * Hard limit on the number of AI indices returned by the list API.
  * TODO: Remove this limit (or make it configurable) and add pagination support to List API.
  */

--- a/x-pack/platform/plugins/shared/context_engine/common/features.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/features.ts
@@ -7,7 +7,14 @@
 
 export const CONTEXT_ENGINE_FEATURE_ID = 'contextEngine';
 
+export const CONTEXT_ENGINE_APP_ID = 'context_engine';
+export const CONTEXT_ENGINE_APP_PATH = '/app/context_engine';
+
 export const apiPrivileges = {
   readContextEngine: `${CONTEXT_ENGINE_FEATURE_ID}:read`,
   writeContextEngine: `${CONTEXT_ENGINE_FEATURE_ID}:write`,
+};
+
+export const uiPrivileges = {
+  show: 'show',
 };

--- a/x-pack/platform/plugins/shared/context_engine/common/features.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/features.ts
@@ -10,6 +10,12 @@ export const CONTEXT_ENGINE_FEATURE_ID = 'contextEngine';
 export const CONTEXT_ENGINE_APP_ID = 'context_engine';
 export const CONTEXT_ENGINE_APP_PATH = '/app/context_engine';
 
+/**
+ * Feature flag gating the Context Engine browser app. When disabled, the app is
+ * hidden from navigation and global search.
+ */
+export const CONTEXT_ENGINE_ENABLED_FLAG = 'contextEngine.enabled';
+
 export const apiPrivileges = {
   readContextEngine: `${CONTEXT_ENGINE_FEATURE_ID}:read`,
   writeContextEngine: `${CONTEXT_ENGINE_FEATURE_ID}:write`,

--- a/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
@@ -7,7 +7,7 @@
   "plugin": {
     "id": "contextEngine",
     "server": true,
-    "browser": false,
+    "browser": true,
     "requiredPlugins": ["features"]
   }
 }

--- a/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
@@ -8,6 +8,7 @@
     "id": "contextEngine",
     "server": true,
     "browser": true,
-    "requiredPlugins": ["features"]
+    "requiredPlugins": ["features"],
+    "requiredBundles": ["kibanaReact"]
   }
 }

--- a/x-pack/platform/plugins/shared/context_engine/moon.yml
+++ b/x-pack/platform/plugins/shared/context_engine/moon.yml
@@ -18,6 +18,8 @@ project:
   sourceRoot: x-pack/platform/plugins/shared/context_engine
 dependsOn:
   - '@kbn/core'
+  - '@kbn/core-http-browser'
+  - '@kbn/react-query'
   - '@kbn/scout'
   - '@kbn/logging'
   - '@kbn/config-schema'

--- a/x-pack/platform/plugins/shared/context_engine/moon.yml
+++ b/x-pack/platform/plugins/shared/context_engine/moon.yml
@@ -27,6 +27,10 @@ dependsOn:
   - '@kbn/storage-adapter'
   - '@kbn/es-errors'
   - '@kbn/management-settings-ids'
+  - '@kbn/shared-ux-router'
+  - '@kbn/shared-ux-page-kibana-template'
+  - '@kbn/i18n-react'
+  - '@kbn/kibana-react-plugin'
 tags:
   - plugin
   - prod
@@ -36,6 +40,7 @@ tags:
 fileGroups:
   src:
     - common/**/*
+    - public/**/*
     - server/**/*
     - test/scout/**/*
     - '!target/**/*'

--- a/x-pack/platform/plugins/shared/context_engine/public/application/api/ai_indices.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/api/ai_indices.test.ts
@@ -43,6 +43,6 @@ describe('listAiIndices', () => {
 
     await listAiIndices(http);
 
-    expect(http.get.mock.calls[0][1]).not.toHaveProperty('signal');
+    expect(http.get).toHaveBeenCalledWith(aiIndexPath, { version: AI_INDEX_API_VERSION });
   });
 });

--- a/x-pack/platform/plugins/shared/context_engine/public/application/api/ai_indices.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/api/ai_indices.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { AI_INDEX_API_VERSION, aiIndexPath } from '../../../common/constants';
+import type { ListAiIndexResponse } from '../../../common/http_api/ai_indices';
+import { listAiIndices } from './ai_indices';
+
+describe('listAiIndices', () => {
+  const createHttp = () => coreMock.createStart().http;
+
+  it('requests the versioned list endpoint and returns the response', async () => {
+    const http = createHttp();
+    const response: ListAiIndexResponse = { ai_indices: [] };
+    http.get.mockResolvedValue(response);
+
+    const result = await listAiIndices(http);
+
+    expect(http.get).toHaveBeenCalledWith(aiIndexPath, { version: AI_INDEX_API_VERSION });
+    expect(result).toBe(response);
+  });
+
+  it('forwards the abort signal when provided', async () => {
+    const http = createHttp();
+    http.get.mockResolvedValue({ ai_indices: [] });
+    const signal = new AbortController().signal;
+
+    await listAiIndices(http, { signal });
+
+    expect(http.get).toHaveBeenCalledWith(aiIndexPath, {
+      version: AI_INDEX_API_VERSION,
+      signal,
+    });
+  });
+
+  it('does not include a signal key when none is provided', async () => {
+    const http = createHttp();
+    http.get.mockResolvedValue({ ai_indices: [] });
+
+    await listAiIndices(http);
+
+    expect(http.get.mock.calls[0][1]).not.toHaveProperty('signal');
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/public/application/api/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/api/ai_indices.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import { AI_INDEX_API_VERSION, aiIndexPath } from '../../../common/constants';
+import type { ListAiIndexResponse } from '../../../common/http_api/ai_indices';
+
+interface ListAiIndicesArgs {
+  signal?: AbortSignal;
+}
+
+export const listAiIndices = (
+  http: HttpStart,
+  { signal }: ListAiIndicesArgs = {}
+): Promise<ListAiIndexResponse> =>
+  http.get<ListAiIndexResponse>(aiIndexPath, {
+    version: AI_INDEX_API_VERSION,
+    ...(signal ? { signal } : {}),
+  });

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
@@ -5,22 +5,159 @@
  * 2.0.
  */
 
-import { EuiFlexGrid, EuiSkeletonRectangle } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiCard,
+  EuiEmptyPrompt,
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiSkeletonRectangle,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import moment from 'moment';
 import React from 'react';
+import type { AiIndexHttpItem } from '../../../common/http_api/ai_indices';
+import { useListAiIndices } from '../hooks/use_list_ai_indices';
+import { useNavigation } from '../hooks/use_navigation';
+import { getAiIndexDetailPath } from '../paths';
 
-const AI_INDEX_CARD_COUNT = 3;
+const SKELETON_CARD_COUNT = 3;
+
+const AiIndexCard = ({ aiIndex, href }: { aiIndex: AiIndexHttpItem; href: string }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const sourcesLabel = i18n.translate('xpack.contextEngine.landing.card.sourcesCount', {
+    defaultMessage: '{count, plural, one {# source} other {# sources}}',
+    values: { count: aiIndex.sources.length },
+  });
+
+  const automationsLabel = i18n.translate('xpack.contextEngine.landing.card.automationsCount', {
+    defaultMessage: '{count, plural, one {# automation} other {# automations}}',
+    values: { count: aiIndex.automations.length },
+  });
+
+  const updatedLabel = i18n.translate('xpack.contextEngine.landing.card.updated', {
+    defaultMessage: 'Updated {time}',
+    values: { time: moment(aiIndex.date_modified).fromNow() },
+  });
+
+  return (
+    <EuiCard
+      data-test-subj="contextAiIndexCard"
+      textAlign="left"
+      titleSize="xs"
+      paddingSize="l"
+      title={aiIndex.name}
+      href={href}
+      description={false}
+      footer={
+        <>
+          <EuiHorizontalRule margin="m" />
+          <EuiText size="xs" color="subdued" data-test-subj="contextAiIndexCardUpdated">
+            {updatedLabel}
+          </EuiText>
+        </>
+      }
+    >
+      <EuiFlexGroup
+        gutterSize="s"
+        wrap
+        responsive={false}
+        css={css`
+          margin-block-start: ${euiTheme.size.s};
+        `}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="hollow" iconType="documents" data-test-subj="contextAiIndexCardSources">
+            {sourcesLabel}
+          </EuiBadge>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="hollow" iconType="gear" data-test-subj="contextAiIndexCardAutomations">
+            {automationsLabel}
+          </EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiCard>
+  );
+};
 
 export const AiIndexCards = () => {
+  const { createContextEngineUrl } = useNavigation();
+  const { aiIndices, isLoading, error } = useListAiIndices();
+
+  if (isLoading) {
+    return (
+      <EuiFlexGrid columns={3} gutterSize="l">
+        {Array.from({ length: SKELETON_CARD_COUNT }).map((_, index) => (
+          <EuiSkeletonRectangle
+            key={index}
+            width="100%"
+            height={160}
+            borderRadius="m"
+            data-test-subj="contextAiIndexCardSkeleton"
+          />
+        ))}
+      </EuiFlexGrid>
+    );
+  }
+
+  if (error) {
+    return (
+      <EuiEmptyPrompt
+        color="danger"
+        iconType="error"
+        data-test-subj="contextAiIndexCardsError"
+        title={
+          <h2>
+            {i18n.translate('xpack.contextEngine.landing.errorTitle', {
+              defaultMessage: 'Unable to load AI Indexes',
+            })}
+          </h2>
+        }
+        body={<p>{error.message}</p>}
+      />
+    );
+  }
+
+  if (aiIndices.length === 0) {
+    return (
+      <EuiEmptyPrompt
+        iconType="index"
+        data-test-subj="contextAiIndexCardsEmpty"
+        title={
+          <h2>
+            {i18n.translate('xpack.contextEngine.landing.emptyTitle', {
+              defaultMessage: 'No AI Indexes yet',
+            })}
+          </h2>
+        }
+        body={
+          <p>
+            {i18n.translate('xpack.contextEngine.landing.emptyBody', {
+              defaultMessage:
+                'Create an AI Index to organize and retrieve contextual knowledge for your agents.',
+            })}
+          </p>
+        }
+      />
+    );
+  }
+
   return (
-    <EuiFlexGrid columns={3} gutterSize="m">
-      {Array.from({ length: AI_INDEX_CARD_COUNT }).map((_, index) => (
-        <EuiSkeletonRectangle
-          key={index}
-          width="100%"
-          height={120}
-          borderRadius="m"
-          data-test-subj="contextAiIndexCard"
-        />
+    <EuiFlexGrid columns={3} gutterSize="l">
+      {aiIndices.map((aiIndex) => (
+        <EuiFlexItem key={aiIndex.id}>
+          <AiIndexCard
+            aiIndex={aiIndex}
+            href={createContextEngineUrl(getAiIndexDetailPath(aiIndex.id))}
+          />
+        </EuiFlexItem>
       ))}
     </EuiFlexGrid>
   );

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
@@ -25,6 +25,7 @@ import type { AiIndexHttpItem } from '../../../common/http_api/ai_indices';
 import { useListAiIndices } from '../hooks/use_list_ai_indices';
 import { useNavigation } from '../hooks/use_navigation';
 import { getAiIndexDetailPath } from '../paths';
+import { CreateAiIndexButton } from './create_ai_index_button';
 
 const SKELETON_CARD_COUNT = 3;
 
@@ -143,6 +144,7 @@ export const AiIndexCards = () => {
             })}
           </p>
         }
+        actions={<CreateAiIndexButton />}
       />
     );
   }
@@ -150,12 +152,11 @@ export const AiIndexCards = () => {
   return (
     <EuiFlexGrid columns={3} gutterSize="l">
       {aiIndices.map((aiIndex) => (
-        <EuiFlexItem key={aiIndex.id}>
-          <AiIndexCard
-            aiIndex={aiIndex}
-            href={createContextEngineUrl(getAiIndexDetailPath(aiIndex.id))}
-          />
-        </EuiFlexItem>
+        <AiIndexCard
+          key={aiIndex.id}
+          aiIndex={aiIndex}
+          href={createContextEngineUrl(getAiIndexDetailPath(aiIndex.id))}
+        />
       ))}
     </EuiFlexGrid>
   );

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGrid, EuiSkeletonRectangle } from '@elastic/eui';
+import React from 'react';
+
+const AI_INDEX_CARD_COUNT = 3;
+
+export const AiIndexCards = () => {
+  return (
+    <EuiFlexGrid columns={3} gutterSize="m">
+      {Array.from({ length: AI_INDEX_CARD_COUNT }).map((_, index) => (
+        <EuiSkeletonRectangle
+          key={index}
+          width="100%"
+          height={120}
+          borderRadius="m"
+          data-test-subj="contextAiIndexCard"
+        />
+      ))}
+    </EuiFlexGrid>
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/ai_index_cards.tsx
@@ -19,7 +19,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import moment from 'moment';
+import { FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
 import React from 'react';
 import type { AiIndexHttpItem } from '../../../common/http_api/ai_indices';
 import { useListAiIndices } from '../hooks/use_list_ai_indices';
@@ -41,11 +41,6 @@ const AiIndexCard = ({ aiIndex, href }: { aiIndex: AiIndexHttpItem; href: string
     values: { count: aiIndex.automations.length },
   });
 
-  const updatedLabel = i18n.translate('xpack.contextEngine.landing.card.updated', {
-    defaultMessage: 'Updated {time}',
-    values: { time: moment(aiIndex.date_modified).fromNow() },
-  });
-
   return (
     <EuiCard
       data-test-subj="contextAiIndexCard"
@@ -54,12 +49,15 @@ const AiIndexCard = ({ aiIndex, href }: { aiIndex: AiIndexHttpItem; href: string
       paddingSize="l"
       title={aiIndex.name}
       href={href}
-      description={false}
       footer={
         <>
           <EuiHorizontalRule margin="m" />
           <EuiText size="xs" color="subdued" data-test-subj="contextAiIndexCardUpdated">
-            {updatedLabel}
+            <FormattedMessage
+              id="xpack.contextEngine.landing.card.updated"
+              defaultMessage="Updated {time}"
+              values={{ time: <FormattedRelative value={aiIndex.date_modified} /> }}
+            />
           </EuiText>
         </>
       }

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/create_ai_index_button.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/create_ai_index_button.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+export const CreateAiIndexButton = () => {
+  return (
+    <EuiButton
+      fill
+      data-test-subj="contextCreateAiIndexButton"
+      onClick={() => {
+        // TODO: open AI Index creation flow
+      }}
+    >
+      {i18n.translate('xpack.contextEngine.createAiIndexButton', {
+        defaultMessage: 'Create AI Index',
+      })}
+    </EuiButton>
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/create_ai_index_button.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/create_ai_index_button.tsx
@@ -8,15 +8,17 @@
 import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { CONTEXT_ENGINE_PATHS } from '../paths';
 
 export const CreateAiIndexButton = () => {
+  const history = useHistory();
+
   return (
     <EuiButton
       fill
       data-test-subj="contextCreateAiIndexButton"
-      onClick={() => {
-        // TODO: open AI Index creation flow
-      }}
+      onClick={() => history.push(CONTEXT_ENGINE_PATHS.create)}
     >
       {i18n.translate('xpack.contextEngine.createAiIndexButton', {
         defaultMessage: 'Create AI Index',

--- a/x-pack/platform/plugins/shared/context_engine/public/application/components/create_ai_index_button.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/components/create_ai_index_button.tsx
@@ -8,17 +8,17 @@
 import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigation } from '../hooks/use_navigation';
 import { CONTEXT_ENGINE_PATHS } from '../paths';
 
 export const CreateAiIndexButton = () => {
-  const history = useHistory();
+  const { createContextEngineUrl } = useNavigation();
 
   return (
     <EuiButton
       fill
       data-test-subj="contextCreateAiIndexButton"
-      onClick={() => history.push(CONTEXT_ENGINE_PATHS.create)}
+      href={createContextEngineUrl(CONTEXT_ENGINE_PATHS.create)}
     >
       {i18n.translate('xpack.contextEngine.createAiIndexButton', {
         defaultMessage: 'Create AI Index',

--- a/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import { EuiProvider } from '@elastic/eui';
+import { coreMock } from '@kbn/core/public/mocks';
 import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { MemoryRouter } from '@kbn/shared-ux-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
@@ -16,7 +18,9 @@ const renderWithProviders = (ui: React.ReactElement) =>
   render(
     <I18nProvider>
       <EuiProvider>
-        <MemoryRouter>{ui}</MemoryRouter>
+        <KibanaContextProvider services={coreMock.createStart()}>
+          <MemoryRouter>{ui}</MemoryRouter>
+        </KibanaContextProvider>
       </EuiProvider>
     </I18nProvider>
   );

--- a/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
@@ -70,6 +70,16 @@ describe('ContextLandingPage', () => {
     await waitFor(() => expect(core.http.get).toHaveBeenCalled());
   });
 
+  it('renders skeleton cards while the list API is loading', () => {
+    const core = createCore();
+    core.http.get.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(core);
+
+    expect(screen.getAllByTestId('contextAiIndexCardSkeleton')).toHaveLength(3);
+    expect(screen.queryByTestId('contextAiIndexCard')).not.toBeInTheDocument();
+  });
+
   it('renders a card per AI index returned by the list API and links to its detail page', async () => {
     const core = createCore();
     core.http.get.mockResolvedValue({

--- a/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
@@ -7,6 +7,7 @@
 
 import { EuiProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
+import { MemoryRouter } from '@kbn/shared-ux-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ContextLandingPage } from './context_landing_page';
@@ -14,7 +15,9 @@ import { ContextLandingPage } from './context_landing_page';
 const renderWithProviders = (ui: React.ReactElement) =>
   render(
     <I18nProvider>
-      <EuiProvider>{ui}</EuiProvider>
+      <EuiProvider>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </EuiProvider>
     </I18nProvider>
   );
 

--- a/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
@@ -6,28 +6,60 @@
  */
 
 import { EuiProvider } from '@elastic/eui';
+import type { CoreStart } from '@kbn/core/public';
 import { coreMock } from '@kbn/core/public/mocks';
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { MemoryRouter } from '@kbn/shared-ux-router';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import type { AiIndexHttpItem } from '../../common/http_api/ai_indices';
 import { ContextLandingPage } from './context_landing_page';
 
-const renderWithProviders = (ui: React.ReactElement) =>
+const buildAiIndex = (overrides: Partial<AiIndexHttpItem> = {}): AiIndexHttpItem => ({
+  id: 'my-ai-index',
+  name: 'My AI index',
+  dest: { type: 'data_stream', value: '.ai-index-ds-my-ai-index' },
+  automations: [],
+  sources: [],
+  date_created: '2026-07-17T00:00:00.000Z',
+  date_modified: '2026-07-17T00:00:00.000Z',
+  ...overrides,
+});
+
+const createTestQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (core: CoreStart) =>
   render(
     <I18nProvider>
       <EuiProvider>
-        <KibanaContextProvider services={coreMock.createStart()}>
-          <MemoryRouter>{ui}</MemoryRouter>
+        <KibanaContextProvider services={core}>
+          <QueryClientProvider client={createTestQueryClient()}>
+            <MemoryRouter>
+              <ContextLandingPage />
+            </MemoryRouter>
+          </QueryClientProvider>
         </KibanaContextProvider>
       </EuiProvider>
     </I18nProvider>
   );
 
 describe('ContextLandingPage', () => {
-  it('renders the landing page with create button and skeleton cards', () => {
-    renderWithProviders(<ContextLandingPage />);
+  const createCore = () => {
+    const core = coreMock.createStart();
+    core.application.getUrlForApp.mockImplementation(
+      (appId, options) => `/app/${appId}${options?.path ?? ''}`
+    );
+    return core;
+  };
+
+  it('renders the header and create button', async () => {
+    const core = createCore();
+    core.http.get.mockResolvedValue({ ai_indices: [] });
+
+    renderWithProviders(core);
 
     expect(screen.getByTestId('contextLandingPage')).toBeInTheDocument();
 
@@ -35,6 +67,64 @@ describe('ContextLandingPage', () => {
     expect(createButton).toBeInTheDocument();
     expect(createButton).toHaveTextContent('Create AI Index');
 
-    expect(screen.getAllByTestId('contextAiIndexCard')).toHaveLength(3);
+    await waitFor(() => expect(core.http.get).toHaveBeenCalled());
+  });
+
+  it('renders a card per AI index returned by the list API and links to its detail page', async () => {
+    const core = createCore();
+    core.http.get.mockResolvedValue({
+      ai_indices: [
+        buildAiIndex({
+          id: 'first',
+          name: 'First index',
+          sources: [
+            { type: 'esql', value: 'FROM a' },
+            { type: 'esql', value: 'FROM b' },
+          ],
+          automations: [{ type: 'workflow', value: 'nightly' }],
+        }),
+        buildAiIndex({ id: 'second', name: 'Second index' }),
+      ],
+    });
+
+    renderWithProviders(core);
+
+    const cards = await screen.findAllByTestId('contextAiIndexCard');
+    expect(cards).toHaveLength(2);
+
+    const firstLink = screen.getByRole('link', { name: /First index/ });
+    expect(firstLink).toHaveAttribute('href', '/app/context_engine/indexes/first');
+
+    const [firstSources, secondSources] = screen.getAllByTestId('contextAiIndexCardSources');
+    expect(firstSources).toHaveTextContent('2 sources');
+    expect(secondSources).toHaveTextContent('0 sources');
+
+    const [firstAutomations, secondAutomations] = screen.getAllByTestId(
+      'contextAiIndexCardAutomations'
+    );
+    expect(firstAutomations).toHaveTextContent('1 automation');
+    expect(secondAutomations).toHaveTextContent('0 automations');
+
+    expect(screen.getAllByTestId('contextAiIndexCardUpdated')[0]).toHaveTextContent(/^Updated /);
+  });
+
+  it('renders an empty prompt when there are no AI indexes', async () => {
+    const core = createCore();
+    core.http.get.mockResolvedValue({ ai_indices: [] });
+
+    renderWithProviders(core);
+
+    expect(await screen.findByTestId('contextAiIndexCardsEmpty')).toBeInTheDocument();
+    expect(screen.queryByTestId('contextAiIndexCard')).not.toBeInTheDocument();
+  });
+
+  it('renders an error prompt when the list API fails', async () => {
+    const core = createCore();
+    core.http.get.mockRejectedValue(new Error('Boom'));
+
+    renderWithProviders(core);
+
+    expect(await screen.findByTestId('contextAiIndexCardsError')).toBeInTheDocument();
+    expect(screen.getByText('Boom')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ContextLandingPage } from './context_landing_page';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+describe('ContextLandingPage', () => {
+  it('renders the landing page with create button and skeleton cards', () => {
+    renderWithProviders(<ContextLandingPage />);
+
+    expect(screen.getByTestId('contextLandingPage')).toBeInTheDocument();
+
+    const createButton = screen.getByTestId('contextCreateAiIndexButton');
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toHaveTextContent('Create AI Index');
+
+    expect(screen.getAllByTestId('contextAiIndexCard')).toHaveLength(3);
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/context_landing_page.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import React from 'react';
+import { CreateAiIndexButton } from './components/create_ai_index_button';
+import { AiIndexCards } from './components/ai_index_cards';
+
+export const ContextLandingPage = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <KibanaPageTemplate data-test-subj="contextLandingPage">
+      <KibanaPageTemplate.Header
+        pageTitle={i18n.translate('xpack.contextEngine.landing.title', {
+          defaultMessage: 'Context',
+        })}
+        description={i18n.translate('xpack.contextEngine.landing.description', {
+          defaultMessage:
+            'Manage AI Indexes to organize and retrieve contextual knowledge for your agents.',
+        })}
+        css={css`
+          background-color: ${euiTheme.colors.backgroundBasePlain};
+          border-block-end: none;
+        `}
+        rightSideItems={[<CreateAiIndexButton key="create-ai-index-button" />]}
+      />
+      <KibanaPageTemplate.Section>
+        <AiIndexCards />
+      </KibanaPageTemplate.Section>
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/query_keys.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/query_keys.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const contextEngineQueryKeys = {
+  aiIndex: {
+    list: () => ['context_engine', 'ai_index', 'list'] as const,
+  },
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_kibana.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_kibana.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+
+const useTypedKibana = () => useKibana<CoreStart>();
+
+export { useTypedKibana as useKibana };

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_list_ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_list_ai_indices.ts
@@ -15,7 +15,6 @@ interface UseListAiIndicesResult {
   aiIndices: AiIndexHttpItem[];
   isLoading: boolean;
   error: Error | undefined;
-  refetch: () => void;
 }
 
 export const useListAiIndices = (): UseListAiIndicesResult => {
@@ -23,10 +22,10 @@ export const useListAiIndices = (): UseListAiIndicesResult => {
     services: { http },
   } = useKibana();
 
-  const { data, isLoading, error, refetch } = useQuery<ListAiIndexResponse, Error>({
+  const { data, isLoading, error } = useQuery<ListAiIndexResponse, Error>({
     queryKey: contextEngineQueryKeys.aiIndex.list(),
     queryFn: ({ signal }) => listAiIndices(http, { signal }),
   });
 
-  return { aiIndices: data?.ai_indices ?? [], isLoading, error: error ?? undefined, refetch };
+  return { aiIndices: data?.ai_indices ?? [], isLoading, error: error ?? undefined };
 };

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_list_ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_list_ai_indices.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { AiIndexHttpItem, ListAiIndexResponse } from '../../../common/http_api/ai_indices';
+import { listAiIndices } from '../api/ai_indices';
+import { contextEngineQueryKeys } from './query_keys';
+import { useKibana } from './use_kibana';
+
+interface UseListAiIndicesResult {
+  aiIndices: AiIndexHttpItem[];
+  isLoading: boolean;
+  error: Error | undefined;
+  refetch: () => void;
+}
+
+export const useListAiIndices = (): UseListAiIndicesResult => {
+  const {
+    services: { http },
+  } = useKibana();
+
+  const { data, isLoading, error, refetch } = useQuery<ListAiIndexResponse, Error>({
+    queryKey: contextEngineQueryKeys.aiIndex.list(),
+    queryFn: ({ signal }) => listAiIndices(http, { signal }),
+  });
+
+  return { aiIndices: data?.ai_indices ?? [], isLoading, error: error ?? undefined, refetch };
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_navigation.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_navigation.ts
@@ -14,12 +14,6 @@ const buildPath = (path: string, params?: Record<string, string>): string => {
   return queryParams.size ? `${path}?${queryParams}` : path;
 };
 
-/**
- * Centralized navigation for the Context Engine app. URLs are resolved through
- * Kibana's `application` service so they include the app base path, and clicks
- * on the resulting `href`s are turned into in-app (SPA) navigation by the
- * `RedirectAppLinks` wrapper mounted in `mount.tsx`.
- */
 export const useNavigation = () => {
   const {
     services: { application },

--- a/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_navigation.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/hooks/use_navigation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { CONTEXT_ENGINE_APP_ID } from '../../../common/features';
+import { useKibana } from './use_kibana';
+
+const buildPath = (path: string, params?: Record<string, string>): string => {
+  const queryParams = new URLSearchParams(params);
+  return queryParams.size ? `${path}?${queryParams}` : path;
+};
+
+/**
+ * Centralized navigation for the Context Engine app. URLs are resolved through
+ * Kibana's `application` service so they include the app base path, and clicks
+ * on the resulting `href`s are turned into in-app (SPA) navigation by the
+ * `RedirectAppLinks` wrapper mounted in `mount.tsx`.
+ */
+export const useNavigation = () => {
+  const {
+    services: { application },
+  } = useKibana();
+
+  const createContextEngineUrl = useCallback(
+    (path: string, params?: Record<string, string>): string =>
+      application.getUrlForApp(CONTEXT_ENGINE_APP_ID, { path: buildPath(path, params) }),
+    [application]
+  );
+
+  const navigateToContextEngine = useCallback(
+    (path: string, params?: Record<string, string>): void => {
+      application.navigateToApp(CONTEXT_ENGINE_APP_ID, { path: buildPath(path, params) });
+    },
+    [application]
+  );
+
+  return { createContextEngineUrl, navigateToContextEngine };
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { mountApp } from './mount';

--- a/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
@@ -7,10 +7,13 @@
 
 import type { CoreStart, ScopedHistory } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { Router } from '@kbn/shared-ux-router';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ContextEngineRoutes } from './routes';
+
+const queryClient = new QueryClient();
 
 export const mountApp = ({
   core,
@@ -24,9 +27,11 @@ export const mountApp = ({
   ReactDOM.render(
     core.rendering.addContext(
       <KibanaContextProvider services={core}>
-        <Router history={history}>
-          <ContextEngineRoutes />
-        </Router>
+        <QueryClientProvider client={queryClient}>
+          <Router history={history}>
+            <ContextEngineRoutes />
+          </Router>
+        </QueryClientProvider>
       </KibanaContextProvider>
     ),
     element

--- a/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { CoreStart, ScopedHistory } from '@kbn/core/public';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { Router } from '@kbn/shared-ux-router';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -22,9 +23,11 @@ export const mountApp = ({
 }) => {
   ReactDOM.render(
     core.rendering.addContext(
-      <Router history={history}>
-        <ContextEngineRoutes />
-      </Router>
+      <KibanaContextProvider services={core}>
+        <Router history={history}>
+          <ContextEngineRoutes />
+        </Router>
+      </KibanaContextProvider>
     ),
     element
   );

--- a/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
@@ -9,7 +9,7 @@ import type { CoreStart, ScopedHistory } from '@kbn/core/public';
 import { Router } from '@kbn/shared-ux-router';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ContextLandingPage } from './context_landing_page';
+import { ContextEngineRoutes } from './routes';
 
 export const mountApp = ({
   core,
@@ -23,7 +23,7 @@ export const mountApp = ({
   ReactDOM.render(
     core.rendering.addContext(
       <Router history={history}>
-        <ContextLandingPage />
+        <ContextEngineRoutes />
       </Router>
     ),
     element

--- a/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/mount.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, ScopedHistory } from '@kbn/core/public';
+import { Router } from '@kbn/shared-ux-router';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { ContextLandingPage } from './context_landing_page';
+
+export const mountApp = ({
+  core,
+  element,
+  history,
+}: {
+  core: CoreStart;
+  element: HTMLElement;
+  history: ScopedHistory;
+}) => {
+  ReactDOM.render(
+    core.rendering.addContext(
+      <Router history={history}>
+        <ContextLandingPage />
+      </Router>
+    ),
+    element
+  );
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(element);
+  };
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
@@ -42,7 +42,10 @@ export const AiIndexDetailPage = () => {
     <KibanaPageTemplate data-test-subj="contextAiIndexDetailPage">
       <KibanaPageTemplate.Header
         pageTitle={
-          <FormattedMessage id="xpack.contextEngine.aiIndexDetail.title" defaultMessage="My AI index" />
+          <FormattedMessage
+            id="xpack.contextEngine.aiIndexDetail.title"
+            defaultMessage="My AI index"
+          />
         }
       />
       <KibanaPageTemplate.Section>

--- a/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
@@ -13,11 +13,17 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React from 'react';
 
-const Panel = ({ title, description }: { title: string; description: string }) => (
+const Panel = ({
+  title,
+  description,
+}: {
+  title: React.ReactNode;
+  description: React.ReactNode;
+}) => (
   <EuiPanel hasBorder paddingSize="l">
     <EuiTitle size="s">
       <h2>{title}</h2>
@@ -36,49 +42,56 @@ export const AiIndexDetailPage = () => {
     <KibanaPageTemplate data-test-subj="contextAiIndexDetailPage">
       <KibanaPageTemplate.Header
         pageTitle={
-          <>
-            {i18n.translate('xpack.contextEngine.aiIndexDetail.title', {
-              defaultMessage: 'My AI index',
-            })}
-          </>
+          <FormattedMessage id="xpack.contextEngine.aiIndexDetail.title" defaultMessage="My AI index" />
         }
       />
       <KibanaPageTemplate.Section>
         <Panel
-          title={i18n.translate('xpack.contextEngine.aiIndexDetail.description.title', {
-            defaultMessage: 'Description',
-          })}
-          description={i18n.translate('xpack.contextEngine.aiIndexDetail.description.description', {
-            defaultMessage:
-              'No sources yet — add a source and a summary will be generated automatically.',
-          })}
+          title={
+            <FormattedMessage
+              id="xpack.contextEngine.aiIndexDetail.description.title"
+              defaultMessage="Description"
+            />
+          }
+          description={
+            <FormattedMessage
+              id="xpack.contextEngine.aiIndexDetail.description.description"
+              defaultMessage="No sources yet — add a source and a summary will be generated automatically."
+            />
+          }
         />
         <EuiSpacer size="l" />
         <Panel
-          title={i18n.translate('xpack.contextEngine.aiIndexDetail.sources.title', {
-            defaultMessage: 'Sources',
-          })}
-          description={i18n.translate('xpack.contextEngine.aiIndexDetail.sources.description', {
-            defaultMessage:
-              'ES|QL views, indices, Connectors and stream signals feeding this AI index.',
-          })}
+          title={
+            <FormattedMessage
+              id="xpack.contextEngine.aiIndexDetail.sources.title"
+              defaultMessage="Sources"
+            />
+          }
+          description={
+            <FormattedMessage
+              id="xpack.contextEngine.aiIndexDetail.sources.description"
+              defaultMessage="ES|QL views, indices, Connectors and stream signals feeding this AI index."
+            />
+          }
         />
         <EuiSpacer size="l" />
         <EuiPanel hasBorder paddingSize="l">
           <EuiTitle size="s">
             <h2>
-              {i18n.translate('xpack.contextEngine.aiIndexDetail.automations.title', {
-                defaultMessage: 'Automations',
-              })}
+              <FormattedMessage
+                id="xpack.contextEngine.aiIndexDetail.automations.title"
+                defaultMessage="Automations"
+              />
             </h2>
           </EuiTitle>
           <EuiSpacer size="s" />
           <EuiText size="s" color="subdued">
             <p>
-              {i18n.translate('xpack.contextEngine.aiIndexDetail.automations.description', {
-                defaultMessage:
-                  "Automations extract and refresh this AI index's Knowledge Indicators from its sources.",
-              })}
+              <FormattedMessage
+                id="xpack.contextEngine.aiIndexDetail.automations.description"
+                defaultMessage="Automations extract and refresh this AI index's Knowledge Indicators from its sources."
+              />
             </p>
           </EuiText>
           <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiPanel,
+  EuiSkeletonRectangle,
+  EuiSkeletonText,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import React from 'react';
+
+const Panel = ({ title, description }: { title: string; description: string }) => (
+  <EuiPanel hasBorder paddingSize="l">
+    <EuiTitle size="s">
+      <h2>{title}</h2>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiText size="s" color="subdued">
+      <p>{description}</p>
+    </EuiText>
+    <EuiSpacer size="m" />
+    <EuiSkeletonText lines={2} />
+  </EuiPanel>
+);
+
+export const AiIndexDetailPage = () => {
+  return (
+    <KibanaPageTemplate data-test-subj="contextAiIndexDetailPage">
+      <KibanaPageTemplate.Header
+        pageTitle={
+          <>
+            {i18n.translate('xpack.contextEngine.aiIndexDetail.title', {
+              defaultMessage: 'My AI index',
+            })}{' '}
+            <EuiBadge color="success">
+              {i18n.translate('xpack.contextEngine.aiIndexDetail.statusBadge', {
+                defaultMessage: 'Active',
+              })}
+            </EuiBadge>
+          </>
+        }
+      />
+      <KibanaPageTemplate.Section>
+        <Panel
+          title={i18n.translate('xpack.contextEngine.aiIndexDetail.description.title', {
+            defaultMessage: 'Description',
+          })}
+          description={i18n.translate('xpack.contextEngine.aiIndexDetail.description.description', {
+            defaultMessage:
+              'No sources yet — add a source and a summary will be generated automatically.',
+          })}
+        />
+        <EuiSpacer size="l" />
+        <Panel
+          title={i18n.translate('xpack.contextEngine.aiIndexDetail.sources.title', {
+            defaultMessage: 'Sources',
+          })}
+          description={i18n.translate('xpack.contextEngine.aiIndexDetail.sources.description', {
+            defaultMessage:
+              'ES|QL views, indices, Connectors and stream signals feeding this AI index.',
+          })}
+        />
+        <EuiSpacer size="l" />
+        <EuiPanel hasBorder paddingSize="l">
+          <EuiTitle size="s">
+            <h2>
+              {i18n.translate('xpack.contextEngine.aiIndexDetail.automations.title', {
+                defaultMessage: 'Automations',
+              })}
+            </h2>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s" color="subdued">
+            <p>
+              {i18n.translate('xpack.contextEngine.aiIndexDetail.automations.description', {
+                defaultMessage:
+                  "Automations extract and refresh this AI index's Knowledge Indicators from its sources.",
+              })}
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+          <EuiSkeletonRectangle width="100%" height={88} borderRadius="m" />
+        </EuiPanel>
+      </KibanaPageTemplate.Section>
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/pages/ai_index_detail_page.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  EuiBadge,
   EuiPanel,
   EuiSkeletonRectangle,
   EuiSkeletonText,
@@ -40,12 +39,7 @@ export const AiIndexDetailPage = () => {
           <>
             {i18n.translate('xpack.contextEngine.aiIndexDetail.title', {
               defaultMessage: 'My AI index',
-            })}{' '}
-            <EuiBadge color="success">
-              {i18n.translate('xpack.contextEngine.aiIndexDetail.statusBadge', {
-                defaultMessage: 'Active',
-              })}
-            </EuiBadge>
+            })}
           </>
         }
       />

--- a/x-pack/platform/plugins/shared/context_engine/public/application/pages/create_ai_index_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/pages/create_ai_index_page.tsx
@@ -16,13 +16,13 @@ import {
 import { i18n } from '@kbn/i18n';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigation } from '../hooks/use_navigation';
 import { getAiIndexDetailPath } from '../paths';
 
 const SOURCE_PLACEHOLDER_COUNT = 2;
 
 export const CreateAiIndexPage = () => {
-  const history = useHistory();
+  const { createContextEngineUrl } = useNavigation();
 
   return (
     <KibanaPageTemplate data-test-subj="contextCreateAiIndexPage">
@@ -32,7 +32,7 @@ export const CreateAiIndexPage = () => {
         })}
         description={i18n.translate('xpack.contextEngine.createAiIndex.description', {
           defaultMessage:
-            'Start by picking a source to build context from — or skip and add sources later.',
+            'Start by picking a source to build context from or skip and add sources later.',
         })}
       />
       <KibanaPageTemplate.Section>
@@ -68,7 +68,7 @@ export const CreateAiIndexPage = () => {
           <EuiSpacer size="s" />
           <EuiLink
             data-test-subj="contextCreateAiIndexContinueLink"
-            onClick={() => history.push(getAiIndexDetailPath('new'))}
+            href={createContextEngineUrl(getAiIndexDetailPath('new'))}
           >
             {i18n.translate('xpack.contextEngine.createAiIndex.continueLink', {
               defaultMessage: 'Continue to AI index',

--- a/x-pack/platform/plugins/shared/context_engine/public/application/pages/create_ai_index_page.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/pages/create_ai_index_page.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiLink,
+  EuiPanel,
+  EuiSkeletonRectangle,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { getAiIndexDetailPath } from '../paths';
+
+const SOURCE_PLACEHOLDER_COUNT = 2;
+
+export const CreateAiIndexPage = () => {
+  const history = useHistory();
+
+  return (
+    <KibanaPageTemplate data-test-subj="contextCreateAiIndexPage">
+      <KibanaPageTemplate.Header
+        pageTitle={i18n.translate('xpack.contextEngine.createAiIndex.title', {
+          defaultMessage: 'Create AI index',
+        })}
+        description={i18n.translate('xpack.contextEngine.createAiIndex.description', {
+          defaultMessage:
+            'Start by picking a source to build context from — or skip and add sources later.',
+        })}
+      />
+      <KibanaPageTemplate.Section>
+        <EuiPanel hasBorder paddingSize="l">
+          <EuiTitle size="s">
+            <h2>
+              {i18n.translate('xpack.contextEngine.createAiIndex.addSource.title', {
+                defaultMessage: 'Add a source',
+              })}
+            </h2>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s" color="subdued">
+            <p>
+              {i18n.translate('xpack.contextEngine.createAiIndex.addSource.description', {
+                defaultMessage:
+                  'Pick what this AI index should build context from. You can add more than one.',
+              })}
+            </p>
+          </EuiText>
+          <EuiSpacer size="l" />
+          {Array.from({ length: SOURCE_PLACEHOLDER_COUNT }).map((_, index) => (
+            <React.Fragment key={index}>
+              <EuiSkeletonRectangle
+                width="100%"
+                height={56}
+                borderRadius="m"
+                data-test-subj="contextCreateAiIndexSourcePlaceholder"
+              />
+              <EuiSpacer size="s" />
+            </React.Fragment>
+          ))}
+          <EuiSpacer size="s" />
+          <EuiLink
+            data-test-subj="contextCreateAiIndexContinueLink"
+            onClick={() => history.push(getAiIndexDetailPath('new'))}
+          >
+            {i18n.translate('xpack.contextEngine.createAiIndex.continueLink', {
+              defaultMessage: 'Continue to AI index',
+            })}
+          </EuiLink>
+        </EuiPanel>
+      </KibanaPageTemplate.Section>
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/application/paths.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/paths.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CONTEXT_ENGINE_PATHS = {
+  landing: '/',
+  create: '/create',
+  detail: '/indexes/:id',
+} as const;
+
+export const getAiIndexDetailPath = (id: string): string => `/indexes/${id}`;

--- a/x-pack/platform/plugins/shared/context_engine/public/application/routes.tsx
+++ b/x-pack/platform/plugins/shared/context_engine/public/application/routes.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Route, Routes } from '@kbn/shared-ux-router';
+import React from 'react';
+import { ContextLandingPage } from './context_landing_page';
+import { AiIndexDetailPage } from './pages/ai_index_detail_page';
+import { CreateAiIndexPage } from './pages/create_ai_index_page';
+import { CONTEXT_ENGINE_PATHS } from './paths';
+
+export const ContextEngineRoutes = () => (
+  <Routes>
+    <Route path={CONTEXT_ENGINE_PATHS.create} exact component={CreateAiIndexPage} />
+    <Route path={CONTEXT_ENGINE_PATHS.detail} exact component={AiIndexDetailPage} />
+    <Route path={CONTEXT_ENGINE_PATHS.landing} exact component={ContextLandingPage} />
+  </Routes>
+);

--- a/x-pack/platform/plugins/shared/context_engine/public/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginInitializerContext } from '@kbn/core/public';
+import { ContextEnginePlugin } from './plugin';
+
+export type { ContextEnginePluginSetup, ContextEnginePluginStart } from './types';
+
+export const plugin = (context: PluginInitializerContext) => new ContextEnginePlugin(context);

--- a/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
@@ -16,9 +16,12 @@ import {
   type PluginInitializerContext,
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
-import { BehaviorSubject, distinctUntilChanged, type Subscription } from 'rxjs';
-import { CONTEXT_ENGINE_APP_ID, CONTEXT_ENGINE_APP_PATH } from '../common/features';
+import { from, map, switchMap } from 'rxjs';
+import {
+  CONTEXT_ENGINE_APP_ID,
+  CONTEXT_ENGINE_APP_PATH,
+  CONTEXT_ENGINE_ENABLED_FLAG,
+} from '../common/features';
 import type {
   ContextEnginePluginSetup,
   ContextEnginePluginStart,
@@ -45,22 +48,30 @@ export class ContextEnginePlugin
       ContextEngineStartDependencies
     >
 {
-  private readonly appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
-  private experimentalSubscription?: Subscription;
-
   constructor(_context: PluginInitializerContext) {}
 
   setup(core: CoreSetup<ContextEngineStartDependencies>): ContextEnginePluginSetup {
+    const startServices = core.getStartServices();
+
     core.application.register({
       id: CONTEXT_ENGINE_APP_ID,
       appRoute: CONTEXT_ENGINE_APP_PATH,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       title: APP_TITLE,
       euiIconType: 'logoElasticsearch',
-      // Hidden by default; visibility is toggled at runtime by the experimental flag.
+      // Hidden by default; visibility is toggled by the feature flag via updater$.
       visibleIn: [],
       keywords: ['context', 'ai index', 'context engine'],
-      updater$: this.appUpdater$,
+      updater$: from(startServices).pipe(
+        switchMap(([coreStart]) =>
+          coreStart.featureFlags.getBooleanValue$(CONTEXT_ENGINE_ENABLED_FLAG, false).pipe(
+            map(
+              (enabled): AppUpdater =>
+                () => ({ visibleIn: enabled ? [...VISIBLE_LOCATIONS] : [] })
+            )
+          )
+        )
+      ),
       defaultPath: '/',
       async mount(params: AppMountParameters) {
         const { mountApp } = await import('./application');
@@ -73,20 +84,9 @@ export class ContextEnginePlugin
     return {};
   }
 
-  start(core: CoreStart): ContextEnginePluginStart {
-    this.experimentalSubscription = core.uiSettings
-      .get$<boolean>(AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID, false)
-      .pipe(distinctUntilChanged())
-      .subscribe((experimentalFeaturesEnabled) => {
-        this.appUpdater$.next(() => ({
-          visibleIn: experimentalFeaturesEnabled ? [...VISIBLE_LOCATIONS] : [],
-        }));
-      });
-
+  start(_core: CoreStart): ContextEnginePluginStart {
     return {};
   }
 
-  stop() {
-    this.experimentalSubscription?.unsubscribe();
-  }
+  stop() {}
 }

--- a/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  DEFAULT_APP_CATEGORIES,
+  type AppDeepLinkLocations,
+  type AppMountParameters,
+  type AppUpdater,
+  type CoreSetup,
+  type CoreStart,
+  type Plugin,
+  type PluginInitializerContext,
+} from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import { BehaviorSubject, distinctUntilChanged, type Subscription } from 'rxjs';
+import { CONTEXT_ENGINE_APP_ID, CONTEXT_ENGINE_APP_PATH } from '../common/features';
+import type {
+  ContextEnginePluginSetup,
+  ContextEnginePluginStart,
+  ContextEngineSetupDependencies,
+  ContextEngineStartDependencies,
+} from './types';
+
+const APP_TITLE = i18n.translate('xpack.contextEngine.app.title', {
+  defaultMessage: 'Context',
+});
+
+const VISIBLE_LOCATIONS: readonly AppDeepLinkLocations[] = [
+  'classicSideNav',
+  'projectSideNav',
+  'globalSearch',
+];
+
+export class ContextEnginePlugin
+  implements
+    Plugin<
+      ContextEnginePluginSetup,
+      ContextEnginePluginStart,
+      ContextEngineSetupDependencies,
+      ContextEngineStartDependencies
+    >
+{
+  private readonly appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
+  private experimentalSubscription?: Subscription;
+
+  constructor(_context: PluginInitializerContext) {}
+
+  setup(core: CoreSetup<ContextEngineStartDependencies>): ContextEnginePluginSetup {
+    core.application.register({
+      id: CONTEXT_ENGINE_APP_ID,
+      appRoute: CONTEXT_ENGINE_APP_PATH,
+      category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
+      title: APP_TITLE,
+      euiIconType: 'logoElasticsearch',
+      // Hidden by default; visibility is toggled at runtime by the experimental flag.
+      visibleIn: [],
+      keywords: ['context', 'ai index', 'context engine'],
+      updater$: this.appUpdater$,
+      defaultPath: '/',
+      async mount(params: AppMountParameters) {
+        const { mountApp } = await import('./application');
+        const [coreStart] = await core.getStartServices();
+        coreStart.chrome.docTitle.change(APP_TITLE);
+        return mountApp({ core: coreStart, element: params.element, history: params.history });
+      },
+    });
+
+    return {};
+  }
+
+  start(core: CoreStart): ContextEnginePluginStart {
+    this.experimentalSubscription = core.uiSettings
+      .get$<boolean>(AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID, false)
+      .pipe(distinctUntilChanged())
+      .subscribe((experimentalFeaturesEnabled) => {
+        this.appUpdater$.next(() => ({
+          visibleIn: experimentalFeaturesEnabled ? [...VISIBLE_LOCATIONS] : [],
+        }));
+      });
+
+    return {};
+  }
+
+  stop() {
+    this.experimentalSubscription?.unsubscribe();
+  }
+}

--- a/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
@@ -16,7 +16,8 @@ import {
   type PluginInitializerContext,
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-import { from, map, switchMap } from 'rxjs';
+import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
+import { combineLatest, from, map, switchMap } from 'rxjs';
 import {
   CONTEXT_ENGINE_APP_ID,
   CONTEXT_ENGINE_APP_PATH,
@@ -59,15 +60,18 @@ export class ContextEnginePlugin
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       title: APP_TITLE,
       euiIconType: 'logoElasticsearch',
-      // Hidden by default; visibility is toggled by the feature flag via updater$.
+      // Hidden by default; visible only when both the feature flag and the advanced setting are on.
       visibleIn: [],
       keywords: ['context', 'ai index', 'context engine'],
       updater$: from(startServices).pipe(
         switchMap(([coreStart]) =>
-          coreStart.featureFlags.getBooleanValue$(CONTEXT_ENGINE_ENABLED_FLAG, false).pipe(
+          combineLatest([
+            coreStart.featureFlags.getBooleanValue$(CONTEXT_ENGINE_ENABLED_FLAG, false),
+            coreStart.uiSettings.get$<boolean>(CONTEXT_ENGINE_ENABLED_SETTING_ID, false),
+          ]).pipe(
             map(
-              (enabled): AppUpdater =>
-                () => ({ visibleIn: enabled ? [...VISIBLE_LOCATIONS] : [] })
+              ([flagEnabled, settingEnabled]): AppUpdater =>
+                () => ({ visibleIn: flagEnabled && settingEnabled ? [...VISIBLE_LOCATIONS] : [] })
             )
           )
         )

--- a/x-pack/platform/plugins/shared/context_engine/public/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextEnginePluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextEnginePluginStart {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextEngineSetupDependencies {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextEngineStartDependencies {}

--- a/x-pack/platform/plugins/shared/context_engine/server/features.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/features.ts
@@ -8,7 +8,12 @@
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { CONTEXT_ENGINE_FEATURE_ID, apiPrivileges } from '../common/features';
+import {
+  CONTEXT_ENGINE_APP_ID,
+  CONTEXT_ENGINE_FEATURE_ID,
+  apiPrivileges,
+  uiPrivileges,
+} from '../common/features';
 
 export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }) => {
   features.registerKibanaFeature({
@@ -19,28 +24,28 @@ export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }
     minimumLicense: 'enterprise',
     order: 1002,
     category: DEFAULT_APP_CATEGORIES.kibana,
-    app: [],
+    app: [CONTEXT_ENGINE_APP_ID],
     catalogue: [],
     privileges: {
       all: {
-        app: [],
+        app: [CONTEXT_ENGINE_APP_ID],
         api: [apiPrivileges.readContextEngine, apiPrivileges.writeContextEngine],
         catalogue: [],
         savedObject: {
           all: [],
           read: [],
         },
-        ui: [],
+        ui: [uiPrivileges.show],
       },
       read: {
-        app: [],
+        app: [CONTEXT_ENGINE_APP_ID],
         api: [apiPrivileges.readContextEngine],
         catalogue: [],
         savedObject: {
           all: [],
           read: [],
         },
-        ui: [],
+        ui: [uiPrivileges.show],
       },
     },
   });

--- a/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/routes/ai_indices.ts
@@ -10,6 +10,7 @@ import type { IRouter, KibanaResponseFactory, RequestHandler } from '@kbn/core/s
 import type { RouteSecurity } from '@kbn/core-http-server';
 import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import {
+  AI_INDEX_API_VERSION,
   MAX_AI_INDEX_AUTOMATION_LENGTH,
   MAX_AI_INDEX_AUTOMATIONS,
   MAX_AI_INDEX_DESCRIPTION_LENGTH,
@@ -35,8 +36,6 @@ import {
   AiIndexNotFoundError,
 } from '../ai_indices/errors';
 import type { AiIndexService } from '../ai_indices/service';
-
-const API_VERSION = '2023-10-31';
 
 const READ_SECURITY: RouteSecurity = {
   authz: { requiredPrivileges: [apiPrivileges.readContextEngine] },
@@ -159,7 +158,7 @@ export const registerAiIndexRoutes = ({
     })
     .addVersion(
       {
-        version: API_VERSION,
+        version: AI_INDEX_API_VERSION,
         validate: {
           request: {
             params: aiIndexIdParamsSchema,
@@ -193,7 +192,7 @@ export const registerAiIndexRoutes = ({
     })
     .addVersion(
       {
-        version: API_VERSION,
+        version: AI_INDEX_API_VERSION,
         validate: {
           request: {
             params: aiIndexIdParamsSchema,
@@ -225,7 +224,7 @@ export const registerAiIndexRoutes = ({
     })
     .addVersion(
       {
-        version: API_VERSION,
+        version: AI_INDEX_API_VERSION,
         validate: false,
       },
       withContextEngineFeatureFlag(async (ctx, request, response) => {
@@ -252,7 +251,7 @@ export const registerAiIndexRoutes = ({
     })
     .addVersion(
       {
-        version: API_VERSION,
+        version: AI_INDEX_API_VERSION,
         validate: {
           request: {
             params: aiIndexIdParamsSchema,

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": ["../../../../../typings/**/*", "common/**/*", "server/**/*", "test/scout/**/*"],
+  "include": [
+    "../../../../../typings/**/*",
+    "common/**/*",
+    "public/**/*",
+    "server/**/*",
+    "test/scout/**/*"
+  ],
   "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/core",
@@ -15,6 +21,9 @@
     "@kbn/features-plugin",
     "@kbn/storage-adapter",
     "@kbn/es-errors",
-    "@kbn/management-settings-ids"
+    "@kbn/management-settings-ids",
+    "@kbn/shared-ux-router",
+    "@kbn/shared-ux-page-kibana-template",
+    "@kbn/i18n-react"
   ]
 }

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -13,6 +13,8 @@
   "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/core",
+    "@kbn/core-http-browser",
+    "@kbn/react-query",
     "@kbn/scout",
     "@kbn/logging",
     "@kbn/config-schema",

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -24,6 +24,7 @@
     "@kbn/management-settings-ids",
     "@kbn/shared-ux-router",
     "@kbn/shared-ux-page-kibana-template",
-    "@kbn/i18n-react"
+    "@kbn/i18n-react",
+    "@kbn/kibana-react-plugin"
   ]
 }


### PR DESCRIPTION
## Summary

Adds the browser (public) side of the `context_engine` plugin, which was server-only after #277316. This scaffolds the Context app UI so follow-up PRs can build features on top of it.

- Registers a top-level Kibana app (`context_engine` at `/app/context_engine`) and adds a new **Context** navigation menu item (side nav + global search), **hidden by default** and shown only when **both** the `contextEngine.enabled` feature flag **and** the `contextEngine:enabled` advanced setting are enabled.
- Adds the **Context landing page** listing AI Indexes as cards (backed by the existing `GET /api/context_engine/ai_index` route), with loading / empty / error states and a `Create AI Index` action.
- Bootstraps **Create AI Index** and **AI Index detail** pages as placeholders (skeleton UI, navigation wired, no real behavior yet).


### Visuals
<img width="1169" height="623" alt="Screenshot 2026-07-20 at 15 56 46" src="https://github.com/user-attachments/assets/f20c2782-68d1-4f44-b020-f1114b88fe6e"/>


**Landing (populated)**


**Loading**
<img width="1165" height="359" alt="Screenshot 2026-07-20 at 16 00 04" src="https://github.com/user-attachments/assets/fa03dd24-3df2-4b90-95c5-09b4e7734c68"/>


**Landing (empty)**
<img width="1168" height="410" alt="Screenshot 2026-07-20 at 16 04 25" src="https://github.com/user-attachments/assets/476865c2-3b1f-452a-b642-93730b8fcdb4"/>



### How to test

1. Enable **both** gates that control the app, and ensure an Enterprise license (the feature requires `minimumLicense: &#39;enterprise&#39;`):
   - the `contextEngine.enabled` **feature flag**, and
   - the `contextEngine:enabled` **advanced setting** (Stack Management → Advanced Settings → "Context Engine", `experimental`, default off). This same setting also gates the `GET /api/context_engine/ai_index` route on the server.
2. Confirm the **Context** menu item appears in the side nav and global search only when **both** are on; turning off either the feature flag or the advanced setting hides it.
3. Open the Context landing page:
   - With AI Indexes present: a card renders per index with correct source/automation counts and a relative &#34;Updated&#34; time; clicking a card navigates to `/indexes/:id`.
   - With none: the empty prompt is shown.
   - Force the list API to fail (e.g. turn the `contextEngine:enabled` advanced setting off so the route returns `notFound`): the error prompt shows the error message.
4. Click **Create AI Index** → lands on the create placeholder; the &#34;Continue to AI index&#34; link navigates to the detail placeholder.

### Checklist

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

