### PR TITLE
[core] Attribute solution nav-tree links to their owning plugin

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -126,7 +126,7 @@ pageLoadAssetSize:
   ml: 99842
   mockIdpPlugin: 7421
   monitoring: 28983
-  navigation: 18600
+  navigation: 20531
   newsfeed: 11110
   noDataPage: 1749
   notificationCenter: 1791

--- a/src/core/packages/application/browser-internal/index.ts
+++ b/src/core/packages/application/browser-internal/index.ts
@@ -14,6 +14,7 @@ export type {
   InternalApplicationStart,
   Mounter,
   ParsedAppUrl,
+  RegisteredAppInfo,
 } from './src/types';
 export {
   appendAppPath,

--- a/src/core/packages/application/browser-internal/src/application_service.test.ts
+++ b/src/core/packages/application/browser-internal/src/application_service.test.ts
@@ -1279,3 +1279,55 @@ describe('#stop()', () => {
     expect(removeListenerSpy).toHaveBeenCalledWith('beforeunload', handler);
   });
 });
+
+describe('#start() getRegisteredAppsInfo()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const http = httpServiceMock.createSetupContract({ basePath: '/base-path' });
+    const analytics = analyticsServiceMock.createAnalyticsServiceSetup();
+    setupDeps = { http, analytics, redirectTo: jest.fn() };
+    startDeps = {
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      theme: themeServiceMock.createStartContract(),
+      customBranding: customBrandingServiceMock.createStartContract(),
+      analytics: analyticsServiceMock.createAnalyticsServiceStart(),
+    };
+    service = new ApplicationService();
+  });
+
+  it('attributes each registered app to the plugin that registered it', async () => {
+    const discoverPlugin = Symbol('discover');
+    const dashboardPlugin = Symbol('dashboard');
+    const { register } = service.setup(setupDeps);
+    register(discoverPlugin, createApp({ id: 'discover' }));
+    register(dashboardPlugin, createApp({ id: 'dashboards' }));
+
+    const { getRegisteredAppsInfo } = await service.start(startDeps);
+
+    expect(getRegisteredAppsInfo()).toEqual([
+      { appId: 'discover', owner: discoverPlugin, deepLinkIds: [] },
+      { appId: 'dashboards', owner: dashboardPlugin, deepLinkIds: [] },
+    ]);
+  });
+
+  it('flattens nested deep-link ids that resolve to a path', async () => {
+    const owner = Symbol('management');
+    const deepLinks: AppDeepLink[] = [
+      {
+        id: 'transform',
+        title: 'Transform',
+        path: '/transform',
+        deepLinks: [{ id: 'transform_create', title: 'Create', path: '/transform/create' }],
+      },
+      { id: 'no_path_group', title: 'Group', deepLinks: [] },
+    ];
+    const { register } = service.setup(setupDeps);
+    register(owner, createApp({ id: 'management', deepLinks }));
+
+    const { getRegisteredAppsInfo } = await service.start(startDeps);
+
+    const info = getRegisteredAppsInfo().find(({ appId }) => appId === 'management');
+    expect(info?.deepLinkIds).toEqual(['transform', 'transform_create']);
+  });
+});

--- a/src/core/packages/application/browser-internal/src/application_service.tsx
+++ b/src/core/packages/application/browser-internal/src/application_service.tsx
@@ -106,6 +106,7 @@ interface AppInternalState {
  */
 export class ApplicationService {
   private readonly apps = new Map<string, App<any>>();
+  private readonly appOwners = new Map<string, PluginOpaqueId>();
   private readonly mounters = new Map<string, Mounter>();
   private readonly capabilities = new CapabilitiesService();
   private readonly appInternalStates = new Map<string, AppInternalState>();
@@ -219,6 +220,7 @@ export class ApplicationService {
           status: app.status ?? AppStatus.accessible,
           deepLinks: populateDeepLinkDefaults(appProps.deepLinks),
         });
+        this.appOwners.set(app.id, plugin);
         if (updater$) {
           registerStatusUpdater(app.id, updater$);
         }
@@ -335,6 +337,12 @@ export class ApplicationService {
         takeUntil(this.stop$)
       ),
       history: this.history!,
+      getRegisteredAppsInfo: () =>
+        [...this.apps.entries()].map(([appId, app]) => ({
+          appId,
+          owner: this.appOwners.get(appId)!,
+          deepLinkIds: Object.keys(flattenDeepLinks(app.deepLinks)),
+        })),
       isAppRegistered: (appId: string): boolean => {
         return applications$.value.get(appId) !== undefined;
       },

--- a/src/core/packages/application/browser-internal/src/types.ts
+++ b/src/core/packages/application/browser-internal/src/types.ts
@@ -46,10 +46,35 @@ export interface InternalApplicationSetup extends Pick<ApplicationSetup, 'regist
   ): void;
 }
 
+/**
+ * Ownership and deep-link metadata for a single registered application.
+ * Used by Core's dev/test-only navigation-dependency snapshot to attribute cross-plugin
+ * navigation references to the plugin that owns the target application.
+ *
+ * @internal
+ */
+export interface RegisteredAppInfo {
+  /** The registered application id. */
+  appId: string;
+  /** Opaque id of the plugin (or Core) that registered the application. */
+  owner: PluginOpaqueId;
+  /** Ids of the application's (nested) deep links that resolve to a path. */
+  deepLinkIds: string[];
+}
+
 /** @internal */
 export interface InternalApplicationStart extends ApplicationStart {
   // Internal APIs
   getComponent(): JSX.Element | null;
+
+  /**
+   * Returns ownership and deep-link metadata for every registered application, unfiltered by
+   * capabilities. Used by Core's dev/test-only navigation-dependency snapshot (see
+   * https://github.com/elastic/kibana/issues/66682).
+   *
+   * @internal
+   */
+  getRegisteredAppsInfo(): RegisteredAppInfo[];
 
   /**
    * The potential action menu set by the currently mounted app.

--- a/src/core/packages/application/browser-mocks/src/application_service.mock.ts
+++ b/src/core/packages/application/browser-mocks/src/application_service.mock.ts
@@ -95,6 +95,7 @@ const createInternalStartContractMock = (
     currentLocation$: currentLocation$.asObservable(),
     currentActionMenu$: new BehaviorSubject<MountPoint | undefined>(undefined),
     getComponent: jest.fn(),
+    getRegisteredAppsInfo: jest.fn().mockReturnValue([]),
     getUrlForApp: jest.fn(),
     isAppRegistered: jest.fn(),
     navigateToApp: jest.fn().mockImplementation((appId) => currentAppId$.next(appId)),

--- a/src/core/packages/base/browser-internal/src/core_context.ts
+++ b/src/core/packages/base/browser-internal/src/core_context.ts
@@ -24,4 +24,10 @@ export interface CoreEnv {
   packageInfo: Readonly<PackageInfo>;
   airgapped: boolean;
   isCoreRenderingInReactConcurrentMode: boolean;
+  /**
+   * When `true`, browser core exposes an inert `window.__kbnNavDependencies__()`
+   * bridge reporting cross-plugin navigation dependencies. Enabled only via the
+   * internal `plugins.exposeNavDependencies` config (off by default).
+   */
+  exposeNavDependencies?: boolean;
 }

--- a/src/core/packages/base/browser-mocks/src/core_context.mock.ts
+++ b/src/core/packages/base/browser-mocks/src/core_context.mock.ts
@@ -36,6 +36,7 @@ function createCoreContext({ production = false }: { production?: boolean } = {}
       },
       airgapped: false,
       isCoreRenderingInReactConcurrentMode: true,
+      exposeNavDependencies: false,
     },
   });
 }

--- a/src/core/packages/chrome/browser-internal-types/index.ts
+++ b/src/core/packages/chrome/browser-internal-types/index.ts
@@ -33,6 +33,17 @@ import type {
   SolutionId,
 } from '@kbn/core-chrome-browser';
 
+/**
+ * Cross-plugin navigation references collected from a solution nav tree.
+ * @internal
+ */
+export interface NavTreeDependencies {
+  /** Id of the plugin that registered the solution nav tree. */
+  ownerPluginId: string;
+  /** `link` targets referenced by the tree (app ids or deep-link ids). */
+  linkTargets: string[];
+}
+
 /** @internal */
 export type InternalChromeSetup = ChromeSetup;
 
@@ -145,6 +156,22 @@ export interface InternalChromeStart extends ChromeStart {
 
     /** Register the handler that opens the navigation customization modal. Called once by the navigation plugin. */
     registerCustomizeNavigationHandler(handler: () => void): void;
+
+    /**
+     * Register a solution nav tree so Core can (in development builds) track the cross-plugin
+     * `link` references it declares. No-op in production builds. Called by the navigation and
+     * serverless plugins for every tree that provides an `ownerPluginId`.
+     */
+    registerNavTreeDependencies(
+      ownerPluginId: string,
+      navigationTree$: Observable<NavigationTreeDefinition>
+    ): void;
+
+    /**
+     * Return the latest cross-plugin navigation references collected from all registered solution
+     * nav trees. Empty in production builds. Consumed by the navigation-dependency snapshot.
+     */
+    getNavTreeDependencies(): NavTreeDependencies[];
   };
 
   /** @internal Extends public `next` with `get$` for Chrome layout components. */

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -84,6 +84,9 @@ export function createChromeApi({
     getCustomizeNavigationHandler$: () => projectNavigation.getCustomizeNavigationHandler$(),
     registerCustomizeNavigationHandler: (handler) =>
       projectNavigation.registerCustomizeNavigationHandler(handler),
+    registerNavTreeDependencies: (ownerPluginId, navigationTree$) =>
+      projectNavigation.registerNavTreeDependencies(ownerPluginId, navigationTree$),
+    getNavTreeDependencies: () => projectNavigation.getNavTreeDependencies(),
   };
 
   let appHeaderRegistrationId = 0;

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -83,7 +83,12 @@ export class ChromeService {
   constructor(private readonly params: ConstructorParams) {
     this.logger = params.coreContext.logger.get('chrome-browser');
     this.isServerless = params.coreContext.env.packageInfo.buildFlavor === 'serverless';
-    this.projectNavigation = new ProjectNavigationService(this.isServerless);
+    // Collect cross-plugin navigation dependencies only in development builds, for the
+    // navigation-dependency enforcement test (see https://github.com/elastic/kibana/issues/66682).
+    this.projectNavigation = new ProjectNavigationService(
+      this.isServerless,
+      params.coreContext.env.mode.dev
+    );
     this.sidebar = new SidebarService({ basePath: params.basePath });
   }
 

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -83,11 +83,12 @@ export class ChromeService {
   constructor(private readonly params: ConstructorParams) {
     this.logger = params.coreContext.logger.get('chrome-browser');
     this.isServerless = params.coreContext.env.packageInfo.buildFlavor === 'serverless';
-    // Collect cross-plugin navigation dependencies only in development builds, for the
-    // navigation-dependency enforcement test (see https://github.com/elastic/kibana/issues/66682).
+    // Collect cross-plugin navigation dependencies only when explicitly enabled via the internal
+    // `plugins.exposeNavDependencies` config, for the navigation-dependency enforcement test
+    // (see https://github.com/elastic/kibana/issues/66682).
     this.projectNavigation = new ProjectNavigationService(
       this.isServerless,
-      params.coreContext.env.mode.dev
+      params.coreContext.env.exposeNavDependencies ?? false
     );
     this.sidebar = new SidebarService({ basePath: params.basePath });
   }

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
@@ -65,18 +65,23 @@ const setup = ({
   navLinkIds,
   isServerless = true,
   isNextChrome = false,
+  collectNavDependencies = false,
 }: {
   locationPathName?: string;
   navLinkIds?: Readonly<string[]>;
   isServerless?: boolean;
   isNextChrome?: boolean;
+  collectNavDependencies?: boolean;
 } = {}) => {
   const history = createMemoryHistory({
     initialEntries: [locationPathName],
   });
   history.replace(locationPathName);
 
-  const projectNavigationService = new ProjectNavigationService(isServerless);
+  const projectNavigationService = new ProjectNavigationService(
+    isServerless,
+    collectNavDependencies
+  );
   const chromeBreadcrumbs$ = new BehaviorSubject<ChromeBreadcrumb[]>([]);
   const navLinksService = getNavLinksService(navLinkIds);
 
@@ -92,6 +97,54 @@ const setup = ({
 
   return { projectNavigation, history, chromeBreadcrumbs$, navLinksService };
 };
+
+describe('nav-tree dependency tracking', () => {
+  const buildNavTree = (linkTargets: string[]) =>
+    ({
+      body: linkTargets.map((link, idx) => ({ id: `node-${idx}`, link })),
+    } as unknown as NavigationTreeDefinition);
+
+  test('collects link targets per owner plugin when collection is enabled', () => {
+    const { projectNavigation } = setup({ collectNavDependencies: true });
+
+    projectNavigation.registerNavTreeDependencies(
+      'enterpriseSearch',
+      of(buildNavTree(['discover', 'management:transform']))
+    );
+    projectNavigation.registerNavTreeDependencies(
+      'securitySolutionEss',
+      of(buildNavTree(['alerts']))
+    );
+
+    expect(projectNavigation.getNavTreeDependencies()).toEqual([
+      { ownerPluginId: 'enterpriseSearch', linkTargets: ['discover', 'management:transform'] },
+      { ownerPluginId: 'securitySolutionEss', linkTargets: ['alerts'] },
+    ]);
+  });
+
+  test('keeps only the latest emission for a given owner plugin', () => {
+    const { projectNavigation } = setup({ collectNavDependencies: true });
+    const navTree$ = new BehaviorSubject(buildNavTree(['discover']));
+
+    projectNavigation.registerNavTreeDependencies('enterpriseSearch', navTree$);
+    navTree$.next(buildNavTree(['dashboards']));
+
+    expect(projectNavigation.getNavTreeDependencies()).toEqual([
+      { ownerPluginId: 'enterpriseSearch', linkTargets: ['dashboards'] },
+    ]);
+  });
+
+  test('is a no-op when collection is disabled (production builds)', () => {
+    const { projectNavigation } = setup({ collectNavDependencies: false });
+
+    projectNavigation.registerNavTreeDependencies(
+      'enterpriseSearch',
+      of(buildNavTree(['discover']))
+    );
+
+    expect(projectNavigation.getNavTreeDependencies()).toEqual([]);
+  });
+});
 
 describe('initNavigation()', () => {
   const setupInitNavigation = () => {

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.ts
@@ -39,7 +39,7 @@ import type { Location, History } from 'history';
 import deepEqual from 'react-fast-compare';
 import type { Logger } from '@kbn/logging';
 
-import { findActiveNodes, stripQueryParams } from './utils';
+import { collectNavTreeLinks, findActiveNodes, stripQueryParams } from './utils';
 import { buildBreadcrumbs } from './breadcrumbs';
 import { getCloudLinks } from './cloud_links';
 import { applyCustomization, type ParsedNavigation } from './apply_customization';
@@ -61,7 +61,13 @@ export class ProjectNavigationService {
   );
   private readonly customizeNavigationHandler$ = new BehaviorSubject<(() => void) | null>(null);
 
-  constructor(private isServerless: boolean) {}
+  /**
+   * Latest `link` targets referenced by each registered solution nav tree, keyed by the id of the
+   * plugin that owns the tree. Only populated in development builds (see `collectNavDependencies`).
+   */
+  private readonly navTreeDependencies = new Map<string, string[]>();
+
+  constructor(private isServerless: boolean, private collectNavDependencies: boolean = false) {}
 
   public start(startDeps: StartDeps) {
     const {
@@ -227,6 +233,21 @@ export class ProjectNavigationService {
           })
         );
       },
+      registerNavTreeDependencies: (
+        ownerPluginId: string,
+        navTreeDefinition$: Observable<NavigationTreeDefinition>
+      ) => {
+        // Dev/test-only bookkeeping for the navigation-dependency enforcement test. No-op otherwise.
+        if (!this.collectNavDependencies) return;
+        navTreeDefinition$.pipe(takeUntil(this.stop$)).subscribe((def) => {
+          this.navTreeDependencies.set(ownerPluginId, collectNavTreeLinks(def));
+        });
+      },
+      getNavTreeDependencies: () =>
+        [...this.navTreeDependencies.entries()].map(([ownerPluginId, linkTargets]) => ({
+          ownerPluginId,
+          linkTargets,
+        })),
       getActiveSolutionNavId$: () => activeSolutionNavId$,
       getActiveSolutionNavId: () => currentNavSource$.getValue()?.id ?? null,
       setNavigationCustomization: (customization: NavigationCustomization | undefined) =>

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.test.ts
@@ -13,7 +13,7 @@ import type {
   ChromeProjectNavigationNode,
   NavigationTreeDefinition,
 } from '@kbn/core-chrome-browser/src';
-import { flattenNav, findActiveNodes, parseNavigationTree } from './utils';
+import { collectNavTreeLinks, flattenNav, findActiveNodes, parseNavigationTree } from './utils';
 
 const getDeepLink = (id: string, path: string, title = ''): ChromeNavLink => ({
   id,
@@ -22,6 +22,52 @@ const getDeepLink = (id: string, path: string, title = ''): ChromeNavLink => ({
   title,
   baseUrl: '',
   visibleIn: ['globalSearch', 'classicSideNav', 'projectSideNav'],
+});
+
+describe('collectNavTreeLinks', () => {
+  test('collects link targets from body and footer, recursing into children', () => {
+    const navTree = {
+      body: [
+        { type: 'recentlyAccessed' },
+        {
+          id: 'root',
+          title: 'Root',
+          children: [
+            { id: 'discover', link: 'discover' },
+            {
+              id: 'group',
+              title: 'Group',
+              children: [{ id: 'transform', link: 'management:transform' }],
+            },
+          ],
+        },
+      ],
+      footer: [{ id: 'dashboards', link: 'dashboards' }],
+    } as unknown as NavigationTreeDefinition;
+
+    expect(collectNavTreeLinks(navTree)).toEqual([
+      'discover',
+      'management:transform',
+      'dashboards',
+    ]);
+  });
+
+  test('de-duplicates repeated link targets', () => {
+    const navTree = {
+      body: [
+        { id: 'a', link: 'discover' },
+        { id: 'b', link: 'discover' },
+      ],
+    } as unknown as NavigationTreeDefinition;
+
+    expect(collectNavTreeLinks(navTree)).toEqual(['discover']);
+  });
+
+  test('returns an empty array when there are no links', () => {
+    const navTree = { body: [{ type: 'recentlyAccessed' }] } as unknown as NavigationTreeDefinition;
+
+    expect(collectNavTreeLinks(navTree)).toEqual([]);
+  });
 });
 
 describe('flattenNav', () => {

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/utils.ts
@@ -24,6 +24,36 @@ import type { SideNavigationSection } from '@kbn/core-chrome-browser/src/project
 
 const wrapIdx = (index: number): string => `[${index}]`;
 
+/** Minimal structural shape of a navigation node needed to walk `link`/`children`. */
+interface NavTreeNodeLike {
+  link?: string;
+  children?: NavTreeNodeLike[];
+}
+
+/**
+ * Recursively collect every `link` target referenced by a navigation tree definition. A target is
+ * either an application id (e.g. `"discover"`) or a deep-link id (e.g. `"management:transform"`).
+ *
+ * Used, in development builds only, to attribute a solution nav tree's cross-plugin navigation
+ * references (see https://github.com/elastic/kibana/issues/66682).
+ */
+export const collectNavTreeLinks = (navTree: NavigationTreeDefinition): string[] => {
+  const links = new Set<string>();
+
+  const visit = (node: NavTreeNodeLike): void => {
+    if (typeof node.link === 'string') {
+      links.add(node.link);
+    }
+    node.children?.forEach(visit);
+  };
+
+  [...(navTree.body ?? []), ...(navTree.footer ?? [])].forEach((node) =>
+    visit(node as unknown as NavTreeNodeLike)
+  );
+
+  return [...links];
+};
+
 /**
  * Flatten the navigation tree into a record of path => node
  * for quicker access when detecting the active path

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.tsx
@@ -139,6 +139,8 @@ const createStartContractMock = () => {
       setNavigationCustomization: jest.fn(),
       getCustomizeNavigationHandler$: jest.fn().mockReturnValue(new BehaviorSubject(null)),
       registerCustomizeNavigationHandler: jest.fn(),
+      registerNavTreeDependencies: jest.fn(),
+      getNavTreeDependencies: jest.fn().mockReturnValue([]),
     }),
     next: lazyObject({
       isEnabled: false,

--- a/src/core/packages/chrome/browser/src/project_navigation.ts
+++ b/src/core/packages/chrome/browser/src/project_navigation.ts
@@ -274,6 +274,12 @@ export interface SolutionNavigationDefinition<LinkId extends AppDeepLinkId = App
   navigationTree$: Observable<NavigationTreeDefinition<LinkId>>;
   /** Optional icon for the solution navigation to render in the select dropdown. */
   icon?: IconType;
+  /**
+   * Id of the plugin that owns this navigation tree. When provided, Core (in development builds)
+   * attributes the tree's `link` references to this plugin so implicit navigation dependencies can
+   * be cross-checked against the plugin's manifest (see https://github.com/elastic/kibana/issues/66682).
+   */
+  ownerPluginId?: string;
 }
 
 export type SolutionNavigationDefinitions = {

--- a/src/core/packages/injected-metadata/common-internal/src/types.ts
+++ b/src/core/packages/injected-metadata/common-internal/src/types.ts
@@ -66,6 +66,7 @@ export interface InjectedMetadata {
     packageInfo: PackageInfo;
     airgapped: boolean;
     isCoreRenderingInReactConcurrentMode: boolean;
+    exposeNavDependencies?: boolean;
   };
   featureFlags?: {
     overrides: Record<string, unknown>;

--- a/src/core/packages/plugins/browser-internal/moon.yml
+++ b/src/core/packages/plugins/browser-internal/moon.yml
@@ -40,6 +40,7 @@ dependsOn:
   - '@kbn/core-http-browser-mocks'
   - '@kbn/core-deprecations-browser-mocks'
   - '@kbn/utility-types'
+  - '@kbn/core-application-browser-internal'
   - '@kbn/core-plugins-contracts-browser'
   - '@kbn/core-security-browser-mocks'
   - '@kbn/core-user-profile-browser-mocks'

--- a/src/core/packages/plugins/browser-internal/moon.yml
+++ b/src/core/packages/plugins/browser-internal/moon.yml
@@ -41,6 +41,7 @@ dependsOn:
   - '@kbn/core-deprecations-browser-mocks'
   - '@kbn/utility-types'
   - '@kbn/core-application-browser-internal'
+  - '@kbn/core-chrome-browser-internal-types'
   - '@kbn/core-plugins-contracts-browser'
   - '@kbn/core-security-browser-mocks'
   - '@kbn/core-user-profile-browser-mocks'

--- a/src/core/packages/plugins/browser-internal/src/nav_dependencies_snapshot.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/nav_dependencies_snapshot.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PluginName, PluginOpaqueId } from '@kbn/core-base-common';
+import type { RegisteredAppInfo } from '@kbn/core-application-browser-internal';
+import {
+  NAV_DEPENDENCIES_GLOBAL,
+  buildNavDependenciesSnapshot,
+  exposeNavDependenciesSnapshot,
+  type NavDependencyTreeInfo,
+} from './nav_dependencies_snapshot';
+
+const discoverId = Symbol('discover');
+const dashboardId = Symbol('dashboard');
+const coreId = Symbol('core');
+
+const createApplication = (apps: RegisteredAppInfo[]) => ({
+  getRegisteredAppsInfo: jest.fn(() => apps),
+});
+
+const opaqueIdToPluginId = new Map<PluginOpaqueId, PluginName>([
+  [discoverId, 'discover'],
+  [dashboardId, 'dashboard'],
+]);
+
+describe('buildNavDependenciesSnapshot', () => {
+  it('resolves each app owner opaque id to its plugin id', () => {
+    const application = createApplication([
+      { appId: 'discover', owner: discoverId, deepLinkIds: [] },
+      { appId: 'dashboards', owner: dashboardId, deepLinkIds: ['dashboards:list'] },
+    ]);
+
+    const snapshot = buildNavDependenciesSnapshot({ application, opaqueIdToPluginId });
+
+    expect(snapshot.apps).toEqual([
+      { appId: 'discover', ownerPluginId: 'discover', deepLinkIds: [] },
+      { appId: 'dashboards', ownerPluginId: 'dashboard', deepLinkIds: ['dashboards:list'] },
+    ]);
+  });
+
+  it('reports a null owner for Core-owned apps (opaque id not mapped to a plugin)', () => {
+    const application = createApplication([{ appId: 'home', owner: coreId, deepLinkIds: [] }]);
+
+    const snapshot = buildNavDependenciesSnapshot({ application, opaqueIdToPluginId });
+
+    expect(snapshot.apps).toEqual([{ appId: 'home', ownerPluginId: null, deepLinkIds: [] }]);
+  });
+
+  it('includes nav trees provided by getNavTrees', () => {
+    const application = createApplication([]);
+    const navTrees: NavDependencyTreeInfo[] = [
+      { ownerPluginId: 'enterpriseSearch', linkTargets: ['discover', 'management:transform'] },
+    ];
+
+    const snapshot = buildNavDependenciesSnapshot({
+      application,
+      opaqueIdToPluginId,
+      getNavTrees: () => navTrees,
+    });
+
+    expect(snapshot.navTrees).toEqual(navTrees);
+  });
+
+  it('defaults nav trees to an empty array when no provider is given', () => {
+    const application = createApplication([]);
+
+    const snapshot = buildNavDependenciesSnapshot({ application, opaqueIdToPluginId });
+
+    expect(snapshot.navTrees).toEqual([]);
+  });
+});
+
+describe('exposeNavDependenciesSnapshot', () => {
+  afterEach(() => {
+    delete window[NAV_DEPENDENCIES_GLOBAL];
+  });
+
+  it('attaches a lazy accessor on window that returns the snapshot on demand', () => {
+    const application = createApplication([
+      { appId: 'discover', owner: discoverId, deepLinkIds: [] },
+    ]);
+
+    exposeNavDependenciesSnapshot({ application, opaqueIdToPluginId });
+
+    // Not called until the accessor is invoked (inert until read).
+    expect(application.getRegisteredAppsInfo).not.toHaveBeenCalled();
+
+    const snapshot = window[NAV_DEPENDENCIES_GLOBAL]!();
+
+    expect(application.getRegisteredAppsInfo).toHaveBeenCalledTimes(1);
+    expect(snapshot.apps).toEqual([
+      { appId: 'discover', ownerPluginId: 'discover', deepLinkIds: [] },
+    ]);
+  });
+});

--- a/src/core/packages/plugins/browser-internal/src/nav_dependencies_snapshot.ts
+++ b/src/core/packages/plugins/browser-internal/src/nav_dependencies_snapshot.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PluginName, PluginOpaqueId } from '@kbn/core-base-common';
+import type { InternalApplicationStart } from '@kbn/core-application-browser-internal';
+
+/**
+ * Ownership metadata for a single registered application.
+ * @internal
+ */
+export interface NavDependencyAppInfo {
+  appId: string;
+  /** Id of the plugin that registered the app, or `null` for Core-owned apps. */
+  ownerPluginId: string | null;
+  /** Ids of the app's deep links that resolve to a path. */
+  deepLinkIds: string[];
+}
+
+/**
+ * A solution navigation tree together with the plugin that registered it and the app/deep-link
+ * targets it references. Populated once solution nav-tree attribution is in place.
+ * @internal
+ */
+export interface NavDependencyTreeInfo {
+  ownerPluginId: string;
+  /** `link` targets, each an appId (`"discover"`) or deep-link id (`"management:transform"`). */
+  linkTargets: string[];
+}
+
+/**
+ * Inert snapshot of the browser-side data needed to reconstruct cross-plugin navigation edges.
+ * Exposed on `window` in development builds only and consumed by the navigation-dependency
+ * enforcement test. It never enforces anything by itself.
+ *
+ * @internal
+ */
+export interface NavDependenciesSnapshot {
+  apps: NavDependencyAppInfo[];
+  navTrees: NavDependencyTreeInfo[];
+}
+
+/** Name of the `window` global exposing {@link NavDependenciesSnapshot} in dev builds. */
+export const NAV_DEPENDENCIES_GLOBAL = '__kbnNavDependencies__' as const;
+
+declare global {
+  interface Window {
+    /**
+     * Dev/test-only accessor returning the cross-plugin navigation dependency snapshot.
+     * Present only in development builds; consumed by the navigation-dependency enforcement
+     * test (see https://github.com/elastic/kibana/issues/66682).
+     * @internal
+     */
+    __kbnNavDependencies__?: () => NavDependenciesSnapshot;
+  }
+}
+
+/** @internal */
+export interface NavDependenciesSnapshotDeps {
+  application: Pick<InternalApplicationStart, 'getRegisteredAppsInfo'>;
+  opaqueIdToPluginId: ReadonlyMap<PluginOpaqueId, PluginName>;
+  /** Provider for the registered solution nav trees. Absent until nav-tree attribution lands. */
+  getNavTrees?: () => NavDependencyTreeInfo[];
+}
+
+/**
+ * Builds the (inert) navigation-dependency snapshot from the current application registry and the
+ * opaque-id -> plugin-id reverse map. Kept pure so it can be unit tested without touching `window`.
+ *
+ * @internal
+ */
+export const buildNavDependenciesSnapshot = ({
+  application,
+  opaqueIdToPluginId,
+  getNavTrees,
+}: NavDependenciesSnapshotDeps): NavDependenciesSnapshot => ({
+  apps: application.getRegisteredAppsInfo().map(({ appId, owner, deepLinkIds }) => ({
+    appId,
+    ownerPluginId: opaqueIdToPluginId.get(owner) ?? null,
+    deepLinkIds,
+  })),
+  navTrees: getNavTrees?.() ?? [],
+});
+
+/**
+ * Attaches the dev/test-only navigation-dependency accessor to `window`. No-op outside a browser
+ * environment. Callers are responsible for gating this to development builds.
+ *
+ * @internal
+ */
+export const exposeNavDependenciesSnapshot = (deps: NavDependenciesSnapshotDeps): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window[NAV_DEPENDENCIES_GLOBAL] = () => buildNavDependenciesSnapshot(deps);
+};

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -155,9 +155,10 @@ export class PluginsService
 
     this.runtimeResolver.resolveStartRequests(contracts);
 
-    // Dev/test-only: expose an inert snapshot of cross-plugin navigation dependencies on `window`
-    // for the navigation-dependency enforcement test. Never enforces anything at runtime.
-    if (this.coreContext.env.mode.dev) {
+    // Test-only: expose an inert snapshot of cross-plugin navigation dependencies on `window`
+    // for the navigation-dependency enforcement test. Gated behind the internal
+    // `plugins.exposeNavDependencies` config (off by default); never enforces anything at runtime.
+    if (this.coreContext.env.exposeNavDependencies) {
       exposeNavDependenciesSnapshot({
         application: deps.application,
         opaqueIdToPluginId: new Map<PluginOpaqueId, PluginName>(

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -18,6 +18,7 @@ import {
   createPluginStartContext,
 } from './plugin_context';
 import { RuntimePluginContractResolver } from './plugin_contract_resolver';
+import { exposeNavDependenciesSnapshot } from './nav_dependencies_snapshot';
 
 /** @internal */
 export type PluginsServiceSetupDeps = InternalCoreSetup;
@@ -153,6 +154,17 @@ export class PluginsService
     }
 
     this.runtimeResolver.resolveStartRequests(contracts);
+
+    // Dev/test-only: expose an inert snapshot of cross-plugin navigation dependencies on `window`
+    // for the navigation-dependency enforcement test. Never enforces anything at runtime.
+    if (this.coreContext.env.mode.dev) {
+      exposeNavDependenciesSnapshot({
+        application: deps.application,
+        opaqueIdToPluginId: new Map<PluginOpaqueId, PluginName>(
+          [...this.plugins].map(([pluginName, plugin]) => [plugin.opaqueId, pluginName])
+        ),
+      });
+    }
 
     // Expose start contracts
     return { contracts };

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -11,6 +11,7 @@ import type { CoreService, CoreContext } from '@kbn/core-base-browser-internal';
 import type { PluginName, PluginOpaqueId } from '@kbn/core-base-common';
 import type { InjectedMetadataPlugin } from '@kbn/core-injected-metadata-common-internal';
 import type { InternalCoreSetup, InternalCoreStart } from '@kbn/core-lifecycle-browser-internal';
+import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-types';
 import { PluginWrapper } from './plugin';
 import {
   createPluginInitializerContext,
@@ -164,6 +165,7 @@ export class PluginsService
         opaqueIdToPluginId: new Map<PluginOpaqueId, PluginName>(
           [...this.plugins].map(([pluginName, plugin]) => [plugin.opaqueId, pluginName])
         ),
+        getNavTrees: () => (deps.chrome as InternalChromeStart).project.getNavTreeDependencies(),
       });
     }
 

--- a/src/core/packages/plugins/browser-internal/tsconfig.json
+++ b/src/core/packages/plugins/browser-internal/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/core-http-browser-mocks",
     "@kbn/core-deprecations-browser-mocks",
     "@kbn/utility-types",
+    "@kbn/core-application-browser-internal",
     "@kbn/core-plugins-contracts-browser",
     "@kbn/core-security-browser-mocks",
     "@kbn/core-user-profile-browser-mocks",

--- a/src/core/packages/plugins/browser-internal/tsconfig.json
+++ b/src/core/packages/plugins/browser-internal/tsconfig.json
@@ -36,6 +36,7 @@
     "@kbn/core-deprecations-browser-mocks",
     "@kbn/utility-types",
     "@kbn/core-application-browser-internal",
+    "@kbn/core-chrome-browser-internal-types",
     "@kbn/core-plugins-contracts-browser",
     "@kbn/core-security-browser-mocks",
     "@kbn/core-user-profile-browser-mocks",

--- a/src/core/packages/plugins/server-internal/src/plugins_config.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_config.ts
@@ -42,6 +42,14 @@ const configSchema = schema.object({
    * internal purposes.
    */
   forceEnableAllPlugins: schema.maybe(schema.boolean({ defaultValue: false })),
+
+  /**
+   * Internal config, not intended to be used by end users. When enabled, the
+   * browser exposes an inert `window.__kbnNavDependencies__()` bridge that
+   * reports cross-plugin navigation dependencies. Only consumed by the
+   * navigation dependency enforcement test.
+   */
+  exposeNavDependencies: schema.maybe(schema.boolean({ defaultValue: false })),
 });
 
 type InternalPluginsConfigType = TypeOf<typeof configSchema>;

--- a/src/core/packages/rendering/server-internal/src/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/packages/rendering/server-internal/src/__snapshots__/rendering_service.test.ts.snap
@@ -17,6 +17,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -116,6 +117,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -211,6 +213,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -310,6 +313,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -407,6 +411,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -502,6 +507,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -603,6 +609,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -698,6 +705,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -793,6 +801,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -888,6 +897,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": true,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -988,6 +998,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1087,6 +1098,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1189,6 +1201,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1293,6 +1306,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1388,6 +1402,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1488,6 +1503,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1592,6 +1608,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1692,6 +1709,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1792,6 +1810,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,
@@ -1894,6 +1913,7 @@ Object {
   "customBranding": Object {},
   "env": Object {
     "airgapped": Any<Boolean>,
+    "exposeNavDependencies": false,
     "isCoreRenderingInReactConcurrentMode": false,
     "mode": Object {
       "dev": Any<Boolean>,

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -75,6 +75,7 @@ export class RenderingService {
   private readonly logger: Logger;
   private airgapped: boolean = false;
   private isCoreRenderingInReactConcurrentMode: boolean = true;
+  private exposeNavDependencies: boolean = false;
   private userStorageStart?: UserStorageServiceStart;
   constructor(private readonly coreContext: CoreContext) {
     this.logger = coreContext.logger.get('rendering');
@@ -120,6 +121,12 @@ export class RenderingService {
     this.isCoreRenderingInReactConcurrentMode = await firstValueFrom(
       this.coreContext.configService.atPath<boolean>('isCoreRenderingInReactConcurrentMode')
     ).catch(() => true);
+
+    this.exposeNavDependencies = await firstValueFrom(
+      this.coreContext.configService.atPath<{ exposeNavDependencies?: boolean }>('plugins')
+    )
+      .then((pluginsConfig) => pluginsConfig?.exposeNavDependencies ?? false)
+      .catch(() => false);
 
     registerBootstrapRoute({
       router: http.createRouter<InternalRenderingRequestHandlerContext>(''),
@@ -190,6 +197,7 @@ export class RenderingService {
       packageInfo: this.coreContext.env.packageInfo,
       airgapped: this.airgapped,
       isCoreRenderingInReactConcurrentMode: this.isCoreRenderingInReactConcurrentMode,
+      exposeNavDependencies: this.exposeNavDependencies,
     };
     const staticAssetsHrefBase = http.staticAssets.getHrefBase();
     const usingCdn = http.staticAssets.isUsingCdn();

--- a/src/platform/plugins/shared/navigation/public/plugin.tsx
+++ b/src/platform/plugins/shared/navigation/public/plugin.tsx
@@ -186,6 +186,11 @@ export class NavigationPublicPlugin
 
   private addSolutionNavigation(def: AddSolutionNavigationArg) {
     this.solutionNavDefinitions.set(def.id, def);
+    if (def.ownerPluginId) {
+      // Dev-only bookkeeping (chrome no-ops in production): lets Core attribute this tree's
+      // cross-plugin links to the owning plugin for the nav-dependency enforcement test.
+      this.chrome?.project.registerNavTreeDependencies(def.ownerPluginId, def.navigationTree$);
+    }
     this.tryInitNavigation();
   }
 

--- a/x-pack/platform/plugins/shared/serverless/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/serverless/public/plugin.tsx
@@ -64,8 +64,12 @@ export class ServerlessPlugin
     });
 
     return {
-      initNavigation: (id, navigationTree$) => {
+      initNavigation: (id, navigationTree$, ownerPluginId) => {
         project.initNavigation(id, navigationTree$);
+        if (ownerPluginId) {
+          // Dev-only bookkeeping (chrome no-ops in production) for the nav-dependency test.
+          project.registerNavTreeDependencies(ownerPluginId, navigationTree$);
+        }
       },
       setBreadcrumbs: (breadcrumbs, params) => project.setBreadcrumbs(breadcrumbs, params),
       getNavigationCards$: (roleManagementEnabled, extendCardNavDefinitions) => {

--- a/x-pack/platform/plugins/shared/serverless/public/types.ts
+++ b/x-pack/platform/plugins/shared/serverless/public/types.ts
@@ -23,7 +23,16 @@ export interface ServerlessPluginStart {
     breadcrumbs: ChromeBreadcrumb | ChromeBreadcrumb[],
     params?: Partial<ChromeSetProjectBreadcrumbsParams>
   ) => void;
-  initNavigation(id: SolutionId, navigationTree$: Observable<NavigationTreeDefinition>): void;
+  initNavigation(
+    id: SolutionId,
+    navigationTree$: Observable<NavigationTreeDefinition>,
+    /**
+     * Id of the plugin that owns this navigation tree. When provided, Core (in development builds)
+     * attributes the tree's `link` references to this plugin for the navigation-dependency
+     * enforcement test (see https://github.com/elastic/kibana/issues/66682).
+     */
+    ownerPluginId?: string
+  ): void;
   getNavigationCards$(
     roleManagementEnabled?: boolean,
     extendCardNavDefinitions?: Record<string, CardNavExtensionDefinition>

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/plugin.ts
@@ -64,7 +64,7 @@ export class ServerlessObservabilityPlugin
         });
       })
     );
-    serverless.initNavigation('oblt', navigationTree$);
+    serverless.initNavigation('oblt', navigationTree$, 'serverlessObservability');
 
     if (workflowsManagement && !core.pricing.isFeatureAvailable('observability:workflows')) {
       workflowsManagement.setUnavailableInServerlessTier({

--- a/x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts
@@ -300,13 +300,14 @@ export class EnterpriseSearchPlugin implements Plugin {
     docLinks.setDocLinks(core.docLinks);
 
     import('./navigation_tree').then(({ getNavigationTreeDefinition }) => {
-      return plugins.navigation.addSolutionNavigation(
-        getNavigationTreeDefinition({
+      return plugins.navigation.addSolutionNavigation({
+        ...getNavigationTreeDefinition({
           core,
           dynamicItems$: this.sideNavDynamicItems$,
           isCloudEnabled: plugins.cloud?.isCloudEnabled,
-        })
-      );
+        }),
+        ownerPluginId: 'enterpriseSearch',
+      });
     });
 
     this.licenseSubscription = plugins.licensing?.license$.subscribe((license) => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -147,7 +147,7 @@ export class ServerlessSearchPlugin
         });
       })
     );
-    serverless.initNavigation('es', navigationTree$);
+    serverless.initNavigation('es', navigationTree$, 'serverlessSearch');
 
     this.managementCardsSubscription = serverless
       .getNavigationCards$(

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/solution_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/solution_navigation.ts
@@ -37,5 +37,6 @@ export const registerSolutionNavigation = async (services: Services) => {
     title: SOLUTION_NAME,
     icon: 'logoSecurity',
     navigationTree$,
+    ownerPluginId: 'securitySolutionEss',
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
@@ -53,5 +53,9 @@ export const registerSolutionNavigation = async (
 
   services.securitySolution.setSolutionNavigationTree(navigationTree);
 
-  services.serverless.initNavigation('security', Rx.of(navigationTree));
+  services.serverless.initNavigation(
+    'security',
+    Rx.of(navigationTree),
+    'securitySolutionServerless'
+  );
 };

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/plugin.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/plugin.ts
@@ -84,7 +84,7 @@ export class ServerlessVectordbPlugin
         });
       })
     );
-    serverless.initNavigation('vectordb', navigationTree$);
+    serverless.initNavigation('vectordb', navigationTree$, 'serverlessVectordb');
     return {};
   }
 

--- a/x-pack/solutions/workplaceai/plugins/serverless_workplace_ai/public/plugin.ts
+++ b/x-pack/solutions/workplaceai/plugins/serverless_workplace_ai/public/plugin.ts
@@ -40,7 +40,7 @@ export class WorkplaceAIServerlessPlugin
   ): WorkplaceAIServerlessPluginStart {
     const navigationTree$ = of(createNavigationTree(core));
 
-    serverless.initNavigation('workplaceai', navigationTree$);
+    serverless.initNavigation('workplaceai', navigationTree$, 'serverlessWorkplaceAI');
 
     return {};
   }


### PR DESCRIPTION
## Summary

Adds an optional `ownerPluginId` to `SolutionNavigationDefinition` and harvests the link targets of each registered solution navigation tree (dev-mode only), attributing them to the owning plugin. The aggregated data extends the `window.__kbnNavDependencies__()` snapshot.

Wires `ownerPluginId` through the `navigation` and `serverless` plugins and sets it at the 7 solution nav-tree registration call sites.

Part of elastic/kibana#66682.