### PR TITLE
[core] Enforce declared cross-plugin navigation dependencies

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -436,6 +436,7 @@ module.exports = {
     '@kbn/eslint/no_conditional_saved_object_type_registration': 'error',
     '@kbn/eslint/no_unsafe_console': 'error',
     '@kbn/eslint/no_unsafe_hash': 'error',
+    '@kbn/eslint/valid_nav_tree_owner_plugin_id': 'error',
     '@kbn/imports/no_unresolvable_imports': 'error',
     '@kbn/imports/uniform_imports': 'error',
     '@kbn/imports/no_unused_imports': 'error',

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -44,5 +44,6 @@ module.exports = {
     no_sync_import_from_plugin: require('./rules/no_sync_import_from_plugin'),
     no_npx_playwright: require('./rules/no_npx_playwright'),
     no_viz_naming: require('./rules/no_viz_naming'),
+    valid_nav_tree_owner_plugin_id: require('./rules/valid_nav_tree_owner_plugin_id'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/valid_nav_tree_owner_plugin_id.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/valid_nav_tree_owner_plugin_id.js
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const Fs = require('fs');
+const Path = require('path');
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+/**
+ * The `ownerPluginId` passed to `addSolutionNavigation` / `initNavigation` is later trusted, at
+ * runtime, to attribute a solution nav tree's cross-plugin references to a plugin (see
+ * https://github.com/elastic/kibana/issues/66682). This rule statically guarantees that the value
+ * matches the `plugin.id` of the plugin the call actually lives in, so the attribution cannot lie.
+ */
+
+const NAV_REGISTRATION_METHODS = new Set(['addSolutionNavigation', 'initNavigation']);
+
+/** Cache of directory -> resolved `plugin.id` (or null) to avoid re-reading manifests. */
+const pluginIdByDir = new Map();
+
+/**
+ * Walk up from a file to the nearest `kibana.jsonc` and extract its `plugin.id`.
+ * @param {string} fromPath absolute path of the linted file
+ * @returns {string | null}
+ */
+function resolvePluginId(fromPath) {
+  let dir = Path.dirname(fromPath);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (pluginIdByDir.has(dir)) {
+      return pluginIdByDir.get(dir);
+    }
+
+    const manifestPath = Path.join(dir, 'kibana.jsonc');
+    if (Fs.existsSync(manifestPath)) {
+      const pluginId = readPluginId(manifestPath);
+      pluginIdByDir.set(dir, pluginId);
+      return pluginId;
+    }
+
+    const parent = Path.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Extract `plugin.id` from a `kibana.jsonc` manifest. Uses a tolerant regex rather than a JSONC
+ * parser to keep the rule dependency-free.
+ * @param {string} manifestPath
+ * @returns {string | null}
+ */
+function readPluginId(manifestPath) {
+  try {
+    const contents = Fs.readFileSync(manifestPath, 'utf8');
+    const match = contents.match(/"plugin"\s*:\s*\{[\s\S]*?"id"\s*:\s*"([^"]+)"/);
+    return match ? match[1] : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Find the `ownerPluginId` string literal node for a nav-registration call, if present.
+ * @param {any} node CallExpression
+ * @param {string} methodName
+ * @returns {any | null} the Literal node, or null when absent / not a static string
+ */
+function findOwnerPluginIdLiteral(node, methodName) {
+  if (methodName === 'initNavigation') {
+    const arg = node.arguments[2];
+    return arg && arg.type === 'Literal' && typeof arg.value === 'string' ? arg : null;
+  }
+
+  // addSolutionNavigation({ ..., ownerPluginId: '...' })
+  const [arg] = node.arguments;
+  if (!arg || arg.type !== 'ObjectExpression') {
+    return null;
+  }
+  const property = arg.properties.find(
+    (prop) =>
+      prop.type === 'Property' &&
+      !prop.computed &&
+      ((prop.key.type === 'Identifier' && prop.key.name === 'ownerPluginId') ||
+        (prop.key.type === 'Literal' && prop.key.value === 'ownerPluginId'))
+  );
+  if (!property || property.value.type !== 'Literal' || typeof property.value.value !== 'string') {
+    return null;
+  }
+  return property.value;
+}
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Ensure the ownerPluginId passed to solution navigation registration matches the calling plugin's id.",
+    },
+    schema: [],
+    messages: {
+      mismatch:
+        'ownerPluginId "{{ owner }}" does not match the plugin that registers this navigation ("{{ actual }}"). Pass the id of the plugin this file belongs to so cross-plugin navigation dependencies are attributed correctly.',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.property.type !== 'Identifier' ||
+          !NAV_REGISTRATION_METHODS.has(callee.property.name)
+        ) {
+          return;
+        }
+
+        const ownerLiteral = findOwnerPluginIdLiteral(node, callee.property.name);
+        if (!ownerLiteral) {
+          return;
+        }
+
+        const actualPluginId = resolvePluginId(context.getFilename());
+        if (!actualPluginId || actualPluginId === ownerLiteral.value) {
+          return;
+        }
+
+        context.report({
+          node: ownerLiteral,
+          messageId: 'mismatch',
+          data: { owner: ownerLiteral.value, actual: actualPluginId },
+        });
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/valid_nav_tree_owner_plugin_id.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/valid_nav_tree_owner_plugin_id.test.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const Path = require('path');
+const { RuleTester } = require('eslint');
+const rule = require('./valid_nav_tree_owner_plugin_id');
+
+const REPO_ROOT = Path.resolve(__dirname, '../../..');
+
+// Real plugin entry files whose `kibana.jsonc` resolves to a known `plugin.id`.
+const ENTERPRISE_SEARCH_FILE = Path.join(
+  REPO_ROOT,
+  'x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts'
+);
+const SERVERLESS_SEARCH_FILE = Path.join(
+  REPO_ROOT,
+  'x-pack/solutions/search/plugins/serverless_search/public/plugin.ts'
+);
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2020,
+  },
+});
+
+const MISMATCH = { messageId: 'mismatch' };
+
+ruleTester.run('@kbn/eslint/valid_nav_tree_owner_plugin_id', rule, {
+  valid: [
+    {
+      name: 'addSolutionNavigation with the correct ownerPluginId',
+      filename: ENTERPRISE_SEARCH_FILE,
+      code: `navigation.addSolutionNavigation({ id: 'es', navigationTree$, ownerPluginId: 'enterpriseSearch' });`,
+    },
+    {
+      name: 'initNavigation with the correct ownerPluginId',
+      filename: SERVERLESS_SEARCH_FILE,
+      code: `serverless.initNavigation('es', navigationTree$, 'serverlessSearch');`,
+    },
+    {
+      name: 'no ownerPluginId provided',
+      filename: SERVERLESS_SEARCH_FILE,
+      code: `serverless.initNavigation('es', navigationTree$);`,
+    },
+    {
+      name: 'ownerPluginId is not a static string literal',
+      filename: SERVERLESS_SEARCH_FILE,
+      code: `serverless.initNavigation('es', navigationTree$, ownerPluginId);`,
+    },
+    {
+      name: 'unrelated method call',
+      filename: SERVERLESS_SEARCH_FILE,
+      code: `something.initNavigationOther('es', tree, 'whatever'); foo.register({ ownerPluginId: 'x' });`,
+    },
+    {
+      name: 'file is not inside a plugin (no manifest to compare against)',
+      filename: Path.join(REPO_ROOT, 'not-a-plugin/some_file.ts'),
+      code: `serverless.initNavigation('es', navigationTree$, 'anything');`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'addSolutionNavigation with a mismatched ownerPluginId',
+      filename: ENTERPRISE_SEARCH_FILE,
+      code: `navigation.addSolutionNavigation({ id: 'es', navigationTree$, ownerPluginId: 'serverlessSearch' });`,
+      errors: [MISMATCH],
+    },
+    {
+      name: 'initNavigation with a mismatched ownerPluginId',
+      filename: SERVERLESS_SEARCH_FILE,
+      code: `serverless.initNavigation('es', navigationTree$, 'enterpriseSearch');`,
+      errors: [MISMATCH],
+    },
+  ],
+});

--- a/src/core/moon.yml
+++ b/src/core/moon.yml
@@ -182,6 +182,7 @@ dependsOn:
   - '@kbn/scout'
   - '@kbn/core-user-storage-server-internal'
   - '@kbn/core-user-storage-common'
+  - '@kbn/repo-packages'
 tags:
   - core
   - package
@@ -195,6 +196,7 @@ fileGroups:
     - types/**/*
     - test_helpers/**/*
     - test/scout/**/*
+    - test/scout_nav_deps/**/*
     - utils/**/*
     - index.ts
     - '!target/**/*'

--- a/src/core/test/scout_nav_deps/ui/nav_dependencies/compute_nav_dependency_violations.test.ts
+++ b/src/core/test/scout_nav_deps/ui/nav_dependencies/compute_nav_dependency_violations.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  collectNavDependencyEdges,
+  computeNavDependencyViolations,
+  resolveAppId,
+  type NavDependenciesSnapshot,
+} from './compute_nav_dependency_violations';
+
+const noDeclaredDependencies = () => [] as string[];
+
+describe('resolveAppId', () => {
+  it('returns the app id unchanged for a bare app link', () => {
+    expect(resolveAppId('discover')).toBe('discover');
+  });
+
+  it('returns the leading app id segment for a deep-link target', () => {
+    expect(resolveAppId('management:dataViews')).toBe('management');
+    expect(resolveAppId('observability-overview:alerts:detail')).toBe('observability-overview');
+  });
+});
+
+describe('computeNavDependencyViolations', () => {
+  it('flags a cross-plugin link that is not declared in the source manifest', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [{ appId: 'discover', ownerPluginId: 'discover', deepLinkIds: [] }],
+      navTrees: [{ ownerPluginId: 'serverlessSearch', linkTargets: ['discover'] }],
+    };
+
+    expect(computeNavDependencyViolations(snapshot, noDeclaredDependencies)).toEqual([
+      { sourcePluginId: 'serverlessSearch', targetPluginId: 'discover', linkTarget: 'discover' },
+    ]);
+  });
+
+  it('does not flag a cross-plugin link that is already declared', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [{ appId: 'discover', ownerPluginId: 'discover', deepLinkIds: [] }],
+      navTrees: [{ ownerPluginId: 'serverlessSearch', linkTargets: ['discover'] }],
+    };
+
+    const declaredBy = (pluginId: string) => (pluginId === 'serverlessSearch' ? ['discover'] : []);
+
+    expect(computeNavDependencyViolations(snapshot, declaredBy)).toEqual([]);
+  });
+
+  it('ignores links internal to the source plugin', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [{ appId: 'enterpriseSearchApp', ownerPluginId: 'enterpriseSearch', deepLinkIds: [] }],
+      navTrees: [{ ownerPluginId: 'enterpriseSearch', linkTargets: ['enterpriseSearchApp'] }],
+    };
+
+    expect(computeNavDependencyViolations(snapshot, noDeclaredDependencies)).toEqual([]);
+  });
+
+  it('ignores link targets that cannot be attributed to an owner', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [{ appId: 'discover', ownerPluginId: null, deepLinkIds: [] }],
+      navTrees: [
+        { ownerPluginId: 'serverlessSearch', linkTargets: ['discover', 'someUnknownApp'] },
+      ],
+    };
+
+    expect(computeNavDependencyViolations(snapshot, noDeclaredDependencies)).toEqual([]);
+  });
+
+  it('resolves deep-link targets to the owning app', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [{ appId: 'management', ownerPluginId: 'management', deepLinkIds: ['dataViews'] }],
+      navTrees: [{ ownerPluginId: 'serverlessSearch', linkTargets: ['management:dataViews'] }],
+    };
+
+    expect(computeNavDependencyViolations(snapshot, noDeclaredDependencies)).toEqual([
+      {
+        sourcePluginId: 'serverlessSearch',
+        targetPluginId: 'management',
+        linkTarget: 'management:dataViews',
+      },
+    ]);
+  });
+
+  it('deduplicates multiple links between the same plugin pair', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [
+        { appId: 'management', ownerPluginId: 'management', deepLinkIds: ['dataViews', 'roles'] },
+      ],
+      navTrees: [
+        {
+          ownerPluginId: 'serverlessSearch',
+          linkTargets: ['management:dataViews', 'management:roles'],
+        },
+      ],
+    };
+
+    expect(computeNavDependencyViolations(snapshot, noDeclaredDependencies)).toEqual([
+      {
+        sourcePluginId: 'serverlessSearch',
+        targetPluginId: 'management',
+        linkTarget: 'management:dataViews',
+      },
+    ]);
+  });
+
+  it('reports one violation per distinct target plugin', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [
+        { appId: 'discover', ownerPluginId: 'discover', deepLinkIds: [] },
+        { appId: 'dashboards', ownerPluginId: 'dashboard', deepLinkIds: [] },
+      ],
+      navTrees: [{ ownerPluginId: 'serverlessSearch', linkTargets: ['discover', 'dashboards'] }],
+    };
+
+    expect(computeNavDependencyViolations(snapshot, noDeclaredDependencies)).toEqual([
+      { sourcePluginId: 'serverlessSearch', targetPluginId: 'discover', linkTarget: 'discover' },
+      { sourcePluginId: 'serverlessSearch', targetPluginId: 'dashboard', linkTarget: 'dashboards' },
+    ]);
+  });
+});
+
+describe('collectNavDependencyEdges', () => {
+  it('returns every cross-plugin edge and flags whether it is declared', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [
+        { appId: 'discover', ownerPluginId: 'discover', deepLinkIds: [] },
+        { appId: 'dashboards', ownerPluginId: 'dashboard', deepLinkIds: [] },
+      ],
+      navTrees: [{ ownerPluginId: 'serverlessSearch', linkTargets: ['discover', 'dashboards'] }],
+    };
+
+    const declaredBy = (pluginId: string) => (pluginId === 'serverlessSearch' ? ['discover'] : []);
+
+    expect(collectNavDependencyEdges(snapshot, declaredBy)).toEqual([
+      {
+        sourcePluginId: 'serverlessSearch',
+        targetPluginId: 'discover',
+        linkTarget: 'discover',
+        declared: true,
+      },
+      {
+        sourcePluginId: 'serverlessSearch',
+        targetPluginId: 'dashboard',
+        linkTarget: 'dashboards',
+        declared: false,
+      },
+    ]);
+  });
+
+  it('excludes internal and unattributable links, matching the enforcement scope', () => {
+    const snapshot: NavDependenciesSnapshot = {
+      apps: [{ appId: 'ownApp', ownerPluginId: 'serverlessSearch', deepLinkIds: [] }],
+      navTrees: [{ ownerPluginId: 'serverlessSearch', linkTargets: ['ownApp', 'someUnknownApp'] }],
+    };
+
+    expect(collectNavDependencyEdges(snapshot, noDeclaredDependencies)).toEqual([]);
+  });
+});

--- a/src/core/test/scout_nav_deps/ui/nav_dependencies/compute_nav_dependency_violations.ts
+++ b/src/core/test/scout_nav_deps/ui/nav_dependencies/compute_nav_dependency_violations.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Shape of a single registered application, as exposed at runtime by the
+ * `window.__kbnNavDependencies__()` bridge (dev/test only).
+ */
+export interface NavDependencyApp {
+  appId: string;
+  /** Plugin that registered the app, or `null` when it could not be resolved. */
+  ownerPluginId: string | null;
+  deepLinkIds: string[];
+}
+
+/**
+ * Shape of a single solution navigation tree, as exposed at runtime by the
+ * `window.__kbnNavDependencies__()` bridge (dev/test only).
+ */
+export interface NavDependencyTree {
+  /** Plugin that registered the navigation tree. */
+  ownerPluginId: string;
+  /** Flattened list of `AppDeepLinkId` link targets referenced by the tree. */
+  linkTargets: string[];
+}
+
+export interface NavDependenciesSnapshot {
+  apps: NavDependencyApp[];
+  navTrees: NavDependencyTree[];
+}
+
+/**
+ * A cross-plugin navigation edge: a link from a plugin's navigation tree to an
+ * application owned by another plugin.
+ */
+export interface NavDependencyEdge {
+  /** Plugin that owns the navigation tree containing the link. */
+  sourcePluginId: string;
+  /** Plugin that owns the application the link points to. */
+  targetPluginId: string;
+  /** An example link target that produced this edge. */
+  linkTarget: string;
+  /** Whether the target plugin is declared in the source plugin's manifest. */
+  declared: boolean;
+}
+
+/**
+ * A cross-plugin navigation edge that is not declared in the source plugin's
+ * `kibana.jsonc` manifest.
+ */
+export interface NavDependencyViolation {
+  /** Plugin that owns the navigation tree containing the link. */
+  sourcePluginId: string;
+  /** Plugin that owns the application the link points to. */
+  targetPluginId: string;
+  /** An example link target that triggered the violation. */
+  linkTarget: string;
+}
+
+/**
+ * Resolves the owning `appId` of an `AppDeepLinkId`. Link targets are either a
+ * bare `appId` or an `appId:deepLinkId` (possibly nested) form; the owner is
+ * always determined by the leading `appId` segment.
+ */
+export const resolveAppId = (linkTarget: string): string => linkTarget.split(':')[0];
+
+/**
+ * Given a runtime navigation snapshot and a resolver for each plugin's declared
+ * dependencies (the union of `requiredPlugins`, `optionalPlugins` and
+ * `runtimePluginDependencies`), returns every cross-plugin navigation edge,
+ * flagging whether each one is already declared in the source manifest.
+ *
+ * This is the full inventory of tracked links; it powers both the enforcement
+ * check (undeclared edges) and the test's materialized artifact.
+ *
+ * The function is pure: manifest reading and browser interaction happen in the
+ * caller, keeping this logic trivially unit-testable.
+ */
+export const collectNavDependencyEdges = (
+  { apps, navTrees }: NavDependenciesSnapshot,
+  getDeclaredDependencies: (pluginId: string) => readonly string[]
+): NavDependencyEdge[] => {
+  const ownerByAppId = new Map<string, string>();
+  apps.forEach(({ appId, ownerPluginId }) => {
+    if (ownerPluginId) {
+      ownerByAppId.set(appId, ownerPluginId);
+    }
+  });
+
+  const edges = new Map<string, NavDependencyEdge>();
+
+  navTrees.forEach(({ ownerPluginId: sourcePluginId, linkTargets }) => {
+    const declared = new Set(getDeclaredDependencies(sourcePluginId));
+
+    linkTargets.forEach((linkTarget) => {
+      const targetPluginId = ownerByAppId.get(resolveAppId(linkTarget));
+
+      // Skip links we cannot attribute (e.g. app disabled in this deployment)
+      // and links internal to the source plugin.
+      if (!targetPluginId || targetPluginId === sourcePluginId) {
+        return;
+      }
+
+      const key = `${sourcePluginId} -> ${targetPluginId}`;
+      if (!edges.has(key)) {
+        edges.set(key, {
+          sourcePluginId,
+          targetPluginId,
+          linkTarget,
+          declared: declared.has(targetPluginId),
+        });
+      }
+    });
+  });
+
+  return [...edges.values()];
+};
+
+/**
+ * Returns the cross-plugin navigation edges that are missing from the source
+ * plugin's `kibana.jsonc` manifest, i.e. the enforcement violations.
+ */
+export const computeNavDependencyViolations = (
+  snapshot: NavDependenciesSnapshot,
+  getDeclaredDependencies: (pluginId: string) => readonly string[]
+): NavDependencyViolation[] =>
+  collectNavDependencyEdges(snapshot, getDeclaredDependencies)
+    .filter(({ declared }) => !declared)
+    .map(({ sourcePluginId, targetPluginId, linkTarget }) => ({
+      sourcePluginId,
+      targetPluginId,
+      linkTarget,
+    }));

--- a/src/core/test/scout_nav_deps/ui/nav_dependencies/jest.config.js
+++ b/src/core/test/scout_nav_deps/ui/nav_dependencies/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../../..',
+  roots: ['<rootDir>/src/core/test/scout_nav_deps/ui/nav_dependencies'],
+};

--- a/src/core/test/scout_nav_deps/ui/playwright.config.ts
+++ b/src/core/test/scout_nav_deps/ui/playwright.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/src/core/test/scout_nav_deps/ui/tests/nav_dependencies.spec.ts
+++ b/src/core/test/scout_nav_deps/ui/tests/nav_dependencies.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { test, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { REPO_ROOT } from '@kbn/repo-info';
+import { getPackages, getPluginPackagesFilter } from '@kbn/repo-packages';
+import {
+  collectNavDependencyEdges,
+  computeNavDependencyViolations,
+  type NavDependenciesSnapshot,
+} from '../nav_dependencies/compute_nav_dependency_violations';
+
+declare global {
+  interface Window {
+    /**
+     * Test-only bridge exposed by `@kbn/core-plugins-browser-internal`, gated
+     * behind the internal `plugins.exposeNavDependencies` config that the
+     * `nav_deps` Scout config set enables.
+     */
+    __kbnNavDependencies__?: () => NavDependenciesSnapshot;
+  }
+}
+
+/**
+ * Every deployment that has a `nav_deps` server config, so that each solution's
+ * navigation tree is harvested at least once. Stateful only has a real server
+ * config for `classic`; the serverless project types cover the solution trees
+ * registered via `serverless.initNavigation`.
+ */
+const NAV_DEPS_DEPLOYMENTS = [
+  ...tags.stateful.classic,
+  ...tags.serverless.search,
+  ...tags.serverless.observability.complete,
+  ...tags.serverless.security.complete,
+  ...tags.serverless.workplaceai,
+  ...tags.serverless.vectordb,
+];
+
+/**
+ * Builds a resolver returning the plugins each plugin declares as dependencies
+ * (`requiredPlugins` ∪ `optionalPlugins` ∪ `runtimePluginDependencies`), read
+ * straight from the `kibana.jsonc` manifests in the repo.
+ */
+const buildDeclaredDependencyResolver = (): ((pluginId: string) => readonly string[]) => {
+  const declaredByPlugin = new Map<string, Set<string>>();
+
+  getPackages(REPO_ROOT)
+    .filter(getPluginPackagesFilter())
+    .forEach(({ manifest }) => {
+      if (manifest.type !== 'plugin') {
+        return;
+      }
+      const {
+        id,
+        requiredPlugins = [],
+        optionalPlugins = [],
+        runtimePluginDependencies = [],
+      } = manifest.plugin;
+
+      declaredByPlugin.set(
+        id,
+        new Set([...requiredPlugins, ...optionalPlugins, ...runtimePluginDependencies])
+      );
+    });
+
+  return (pluginId) => [...(declaredByPlugin.get(pluginId) ?? [])];
+};
+
+test.describe('cross-plugin navigation dependencies', { tag: NAV_DEPS_DEPLOYMENTS }, () => {
+  test.beforeEach(async ({ browserAuth, page, kbnUrl }) => {
+    await browserAuth.loginAsAdmin();
+    // Navigating to the root boots the Kibana SPA (and therefore every browser
+    // plugin), which is what populates the nav-dependency snapshot. `kbnUrl.get`
+    // resolves the deployment's absolute Kibana URL (Scout does not configure a
+    // Playwright `baseURL`, so a bare relative path is not navigable).
+    await page.goto(kbnUrl.get('/'));
+    await page.waitForFunction(() => typeof window.__kbnNavDependencies__ === 'function');
+  });
+
+  test('are declared in the owning plugin kibana.jsonc manifest', async ({ page }, testInfo) => {
+    const snapshot = await page.evaluate(() => window.__kbnNavDependencies__!());
+
+    const getDeclaredDependencies = buildDeclaredDependencyResolver();
+    const edges = collectNavDependencyEdges(snapshot, getDeclaredDependencies);
+
+    // Materialize the full inventory of tracked cross-plugin navigation links so
+    // the harvested graph is visible in the Playwright report / CI artifacts,
+    // regardless of whether the test passes or fails.
+    await testInfo.attach('nav-dependencies.json', {
+      contentType: 'application/json',
+      body: JSON.stringify({ snapshot, edges }, null, 2),
+    });
+
+    const violations = computeNavDependencyViolations(snapshot, getDeclaredDependencies);
+
+    const summary = violations
+      .map(
+        ({ sourcePluginId, targetPluginId, linkTarget }) =>
+          `  - "${sourcePluginId}" links to "${targetPluginId}" (via "${linkTarget}") ` +
+          `but does not declare it in requiredPlugins/optionalPlugins/runtimePluginDependencies`
+      )
+      .join('\n');
+
+    expect(
+      violations,
+      `Found ${violations.length} undeclared cross-plugin navigation dependency(ies).\n` +
+        `Add the missing plugin id to the source plugin's runtimePluginDependencies:\n${summary}`
+    ).toEqual([]);
+  });
+});

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -10,6 +10,7 @@
     "types/**/*",
     "test_helpers/**/*",
     "test/scout/**/*",
+    "test/scout_nav_deps/**/*",
     "utils/**/*",
     "index.ts"
   ],
@@ -179,6 +180,7 @@
     "@kbn/scout",
     "@kbn/core-user-storage-server-internal",
     "@kbn/core-user-storage-common",
+    "@kbn/repo-packages",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/observability_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/observability_complete.serverless.config.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/observability_complete.serverless.config';
+
+// Enables the inert `window.__kbnNavDependencies__()` bridge used by the
+// cross-plugin navigation dependency enforcement test.
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  kbnTestServer: {
+    ...defaultServers.kbnTestServer,
+    serverArgs: [
+      ...defaultServers.kbnTestServer.serverArgs,
+      '--plugins.exposeNavDependencies=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/search.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/search.serverless.config.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/search.serverless.config';
+
+// Enables the inert `window.__kbnNavDependencies__()` bridge used by the
+// cross-plugin navigation dependency enforcement test.
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  kbnTestServer: {
+    ...defaultServers.kbnTestServer,
+    serverArgs: [
+      ...defaultServers.kbnTestServer.serverArgs,
+      '--plugins.exposeNavDependencies=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/security_complete.serverless.config.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/security_complete.serverless.config';
+
+// Enables the inert `window.__kbnNavDependencies__()` bridge used by the
+// cross-plugin navigation dependency enforcement test.
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  kbnTestServer: {
+    ...defaultServers.kbnTestServer,
+    serverArgs: [
+      ...defaultServers.kbnTestServer.serverArgs,
+      '--plugins.exposeNavDependencies=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/vectordb.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/vectordb.serverless.config.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/vectordb.serverless.config';
+
+// Enables the inert `window.__kbnNavDependencies__()` bridge used by the
+// cross-plugin navigation dependency enforcement test.
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  kbnTestServer: {
+    ...defaultServers.kbnTestServer,
+    serverArgs: [
+      ...defaultServers.kbnTestServer.serverArgs,
+      '--plugins.exposeNavDependencies=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/workplaceai.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/serverless/workplaceai.serverless.config.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/workplaceai.serverless.config';
+
+// Enables the inert `window.__kbnNavDependencies__()` bridge used by the
+// cross-plugin navigation dependency enforcement test.
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  kbnTestServer: {
+    ...defaultServers.kbnTestServer,
+    serverArgs: [
+      ...defaultServers.kbnTestServer.serverArgs,
+      '--plugins.exposeNavDependencies=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/nav_deps/stateful/classic.stateful.config.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/stateful/classic.stateful.config';
+
+// Enables the inert `window.__kbnNavDependencies__()` bridge used by the
+// cross-plugin navigation dependency enforcement test.
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  kbnTestServer: {
+    ...defaultServers.kbnTestServer,
+    serverArgs: [
+      ...defaultServers.kbnTestServer.serverArgs,
+      '--plugins.exposeNavDependencies=true',
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Enforces that cross-plugin navigation links are declared as dependencies:

- New ESLint rule `@kbn/eslint/valid_nav_tree_owner_plugin_id` checks that the `ownerPluginId` passed to nav registration matches the `plugin.id` of the file's `kibana.jsonc`, so runtime attribution cannot be spoofed.
- A Scout UI test (stateful + every serverless project type) reads the runtime nav-dependency snapshot and fails when a nav tree links to an app owned by another plugin that is missing from the source plugin's `requiredPlugins` / `optionalPlugins` / `runtimePluginDependencies`.
- The comparison lives in a pure, unit-tested `computeNavDependencyViolations` helper; production code exposes inert data only.

The Scout test reports the missing manifest edges on first run; seeding the `runtimePluginDependencies` for detected edges is a follow-up.

Part of elastic/kibana#66682.