### PR TITLE
[Security Solution][Flyout] fix new flyout interaction with Timeline

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
@@ -79,7 +79,10 @@ describe('useAttackFlyoutApi', () => {
       expect.objectContaining({ size: 'm', session: 'start', historyKey: documentFlyoutHistoryKey })
     );
     const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
-    expect(children.props.value).toBe('inherit');
+    expect(children.props.value).toEqual({
+      session: 'inherit',
+      historyKey: documentFlyoutHistoryKey,
+    });
   });
 
   it('openAttackEntities opens the entities tool flyout with the tools properties and propagates inherit context to its content', () => {
@@ -91,7 +94,10 @@ describe('useAttackFlyoutApi', () => {
       expect.objectContaining({ size: 'm', session: 'start', historyKey: documentFlyoutHistoryKey })
     );
     const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
-    expect(children.props.value).toBe('inherit');
+    expect(children.props.value).toEqual({
+      session: 'inherit',
+      historyKey: documentFlyoutHistoryKey,
+    });
   });
 
   it('uses the doc-viewer history key when outside the security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -10,11 +10,9 @@ import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { noop } from 'lodash/fp';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { cellActionRenderer } from '../shared/components/cell_actions';
 import { flyoutProviders } from '../shared/components/flyout_provider';
@@ -23,7 +21,6 @@ import {
   defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the attack flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the attack flyout graph into their
@@ -99,10 +96,8 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // The main/child flyout and the tools differ only in their properties (base size + session). Both
   // are kept private here so callers never reason about them: they pick the method they want and
@@ -111,7 +106,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
     (
       children: ReactNode,
       properties: OverlaySystemFlyoutOpenOptions,
-      propagatedMainFlyoutSessionMode = mainFlyoutSessionMode
+      propagatedSessionMode = sessionMode
     ) => {
       overlays.openSystemFlyout(
         flyoutProviders({
@@ -119,7 +114,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           store,
           history,
           children: (
-            <FlyoutSessionContextProvider value={propagatedMainFlyoutSessionMode}>
+            <FlyoutSessionContextProvider value={{ session: propagatedSessionMode, historyKey }}>
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
           ),
@@ -127,7 +122,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         properties
       );
     },
-    [overlays, services, store, history, mainFlyoutSessionMode]
+    [overlays, services, store, history, historyKey, sessionMode]
   );
 
   const openAttackFlyout = useCallback(
@@ -144,10 +139,10 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           onAttackUpdated={onAttackUpdated}
           renderCellActions={renderCellActions}
         />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: mainFlyoutSessionMode }
+        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode }
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey, mainFlyoutSessionMode]
+    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const openAttackFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
@@ -9,15 +9,12 @@ import type { ReactNode } from 'react';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { OpenFindingInSystemFlyoutHandle } from '@kbn/cloud-security-posture-plugin/public';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context';
 import type { MisconfigurationProps } from './misconfiguration/main';
 import type { VulnerabilityProps } from './vulnerability/main'; // Lazy-loaded so consumers of this hook don't statically pull the CSP finding flyout graph into
@@ -85,10 +82,8 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` (and, for child flyouts, an optional history `title`) are the only things that differ
   // between a main and a child open. Kept private here so callers never reason about them: they pick
@@ -108,7 +103,10 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
           history,
           children: (
             <FlyoutSessionContextProvider
-              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+              value={{
+                session: session === 'inherit' ? 'inherit' : sessionMode,
+                historyKey,
+              }}
             >
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
@@ -118,21 +116,12 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => flyoutRef.close(), onClose: flyoutRef.onClose };
     },
-    [
-      overlays,
-      services,
-      store,
-      history,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      mainFlyoutSessionMode,
-    ]
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const openMisconfigurationFinding = useCallback(
-    (params: MisconfigurationProps) =>
-      open(<Misconfiguration {...params} />, mainFlyoutSessionMode),
-    [open, mainFlyoutSessionMode]
+    (params: MisconfigurationProps) => open(<Misconfiguration {...params} />, sessionMode),
+    [open, sessionMode]
   );
 
   const openMisconfigurationFindingAsChild = useCallback(
@@ -142,8 +131,8 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
   );
 
   const openVulnerabilityFinding = useCallback(
-    (params: VulnerabilityProps) => open(<Vulnerability {...params} />, mainFlyoutSessionMode),
-    [open, mainFlyoutSessionMode]
+    (params: VulnerabilityProps) => open(<Vulnerability {...params} />, sessionMode),
+    [open, sessionMode]
   );
 
   const openVulnerabilityFindingAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/graph/index.tsx
@@ -18,7 +18,6 @@ import {
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { DocumentToolsFlyoutHeader } from '../../../shared/components/document_tools_flyout_header';
 import type { CellActionRenderer } from '../../../shared/components/cell_actions';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
@@ -26,13 +25,11 @@ import { EventKind } from '../../main/constants/event_kinds';
 import { GraphVisualization } from './components/graph_visualization';
 import { useGraphPreview } from '../../main/hooks/use_graph_preview';
 import { useKibana } from '../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../../../shared/constants/flyout_history';
 import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { useFlyoutApi } from '../../../use_flyout_api';
 import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
-import { FlyoutSessionContextProvider } from '../../../session_context';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../../session_context';
 
 export const GRAPH_TOOLS_TEST_ID = `${PREFIX}GraphTools` as const;
 
@@ -57,8 +54,7 @@ export const GraphDetails = memo(
     const { overlays } = services;
     const store = useStore();
     const history = useHistory();
-    const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+    const { historyKey } = useFlyoutSessionContext();
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
     const {
       openDocumentFlyoutFromIndexAsChild,
@@ -108,7 +104,7 @@ export const GraphDetails = memo(
             store,
             history,
             children: (
-              <FlyoutSessionContextProvider value="inherit">
+              <FlyoutSessionContextProvider value={{ session: 'inherit', historyKey }}>
                 <GraphGroupedNodePreviewPanel
                   {...params}
                   scopeId={GRAPH_SCOPE_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/session_view/index.tsx
@@ -25,7 +25,7 @@ import { useSessionViewConfig } from './hooks/use_session_view_config';
 import { flyoutProviders } from '../../../shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../shared/hooks/use_default_flyout_properties';
 import { SessionViewDetails } from './components/session_view_details';
-import { FlyoutSessionContextProvider } from '../../../session_context';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../../session_context';
 
 export const SESSION_VIEW_TEST_ID = `${PREFIX}SessionView` as const;
 
@@ -74,6 +74,7 @@ export const SessionView: FC<SessionViewProps> = memo(
     const store = useStore();
     const history = useHistory();
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+    const { historyKey } = useFlyoutSessionContext();
     const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
     const { canReadPolicyManagement } = useUserPrivileges().endpointPrivileges;
@@ -139,7 +140,7 @@ export const SessionView: FC<SessionViewProps> = memo(
             store,
             history,
             children: (
-              <FlyoutSessionContextProvider value="inherit">
+              <FlyoutSessionContextProvider value={{ session: 'inherit', historyKey }}>
                 <SessionViewDetails
                   selectedProcess={selectedProcess}
                   index={sessionViewConfig.index}
@@ -155,11 +156,13 @@ export const SessionView: FC<SessionViewProps> = memo(
           }),
           {
             ...defaultFlyoutProperties,
+            historyKey,
             session: 'inherit',
           }
         );
       },
       [
+        historyKey,
         defaultFlyoutProperties,
         handleJumpToEvent,
         history,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -112,7 +112,10 @@ describe('useDocumentFlyoutApi', () => {
       expect.objectContaining({ size: 'm', session: 'start' })
     );
     const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
-    expect(children.props.value).toBe('inherit');
+    expect(children.props.value).toEqual({
+      session: 'inherit',
+      historyKey: documentFlyoutHistoryKey,
+    });
   });
 
   it('openDocumentCorrelations opens a tools flyout as a new session and propagates inherit context to its content', () => {
@@ -129,7 +132,10 @@ describe('useDocumentFlyoutApi', () => {
       expect.objectContaining({ size: 'm', session: 'start' })
     );
     const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
-    expect(children.props.value).toBe('inherit');
+    expect(children.props.value).toEqual({
+      session: 'inherit',
+      historyKey: documentFlyoutHistoryKey,
+    });
   });
 
   it('openDocumentPrevalence opens a tools flyout as a new session and propagates inherit context to its content', () => {
@@ -146,7 +152,10 @@ describe('useDocumentFlyoutApi', () => {
       expect.objectContaining({ size: 'm', session: 'start' })
     );
     const { children } = (flyoutProviders as jest.Mock).mock.calls[0][0];
-    expect(children.props.value).toBe('inherit');
+    expect(children.props.value).toEqual({
+      session: 'inherit',
+      historyKey: documentFlyoutHistoryKey,
+    });
   });
 
   it.each([

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -10,12 +10,10 @@ import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { noop } from 'lodash/fp';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { PrevalenceDetailsProps } from './tools/prevalence';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { cellActionRenderer } from '../shared/components/cell_actions';
 import { flyoutProviders } from '../shared/components/flyout_provider';
@@ -24,7 +22,6 @@ import {
   defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
 
 // Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
@@ -192,16 +189,14 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   const open = useCallback(
     (
       children: ReactNode,
       properties: OverlaySystemFlyoutOpenOptions,
-      propagatedMainFlyoutSessionMode = mainFlyoutSessionMode
+      propagatedSessionMode = sessionMode
     ) => {
       overlays.openSystemFlyout(
         flyoutProviders({
@@ -209,7 +204,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           store,
           history,
           children: (
-            <FlyoutSessionContextProvider value={propagatedMainFlyoutSessionMode}>
+            <FlyoutSessionContextProvider value={{ session: propagatedSessionMode, historyKey }}>
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
           ),
@@ -217,7 +212,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         properties
       );
     },
-    [overlays, services, store, history, mainFlyoutSessionMode]
+    [overlays, services, store, history, sessionMode, historyKey]
   );
 
   // Builds the document flyout content (resolved from a concrete `_index`), shared by both the main
@@ -245,16 +240,10 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       open(buildFromIndexContent(params), {
         ...defaultDocumentFlyoutProperties,
         historyKey,
-        session: mainFlyoutSessionMode,
+        session: sessionMode,
       });
     },
-    [
-      open,
-      buildFromIndexContent,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      mainFlyoutSessionMode,
-    ]
+    [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const openDocumentFlyoutFromIndexAsChild = useCallback(
@@ -286,10 +275,10 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           renderCellActions={renderCellActions}
           onAlertUpdated={onAlertUpdated}
         />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: mainFlyoutSessionMode }
+        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode }
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey, mainFlyoutSessionMode]
+    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const openAnalyzer = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/shared/tools/graph_view/index.tsx
@@ -11,22 +11,19 @@ import { i18n } from '@kbn/i18n';
 import { noop } from 'lodash/fp';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import {
   GraphGroupedNodePreviewPanel,
   type GraphGroupedNodePreviewPanelProps,
 } from '@kbn/cloud-security-posture-graph';
 import { FlowTargetSourceDest } from '../../../../../../common/search_strategy';
 import { useKibana } from '../../../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../../../../shared/components/flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../../../../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../../../../shared/constants/flyout_history';
 import { useFlyoutApi } from '../../../../use_flyout_api';
 import { cellActionRenderer } from '../../../../shared/components/cell_actions';
 import { ToolsFlyoutHeader } from '../../../../shared/components/tools_flyout_header';
 import { GraphVisualization } from '../../../../document/tools/graph/components/graph_visualization';
-import { FlyoutSessionContextProvider } from '../../../../session_context';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../../../session_context';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.entityDetails.graphView.title', {
   defaultMessage: 'Graph',
@@ -60,8 +57,7 @@ export const GraphView = memo(
     const { overlays } = services;
     const store = useStore();
     const history = useHistory();
-    const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+    const { historyKey } = useFlyoutSessionContext();
     const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
     const { openDocumentFlyoutFromIndexAsChild, openNetworkFlyoutAsChild } = useFlyoutApi();
 
@@ -94,7 +90,7 @@ export const GraphView = memo(
             store,
             history,
             children: (
-              <FlyoutSessionContextProvider value="inherit">
+              <FlyoutSessionContextProvider value={{ session: 'inherit', historyKey }}>
                 <GraphGroupedNodePreviewPanel
                   {...params}
                   scopeId={scopeId}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -9,17 +9,14 @@ import type { ReactNode } from 'react';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import {
   defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
 } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context';
 import type { HostProps } from './host/main';
 import type { UserProps } from './user/main';
@@ -172,16 +169,14 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   const open = useCallback(
     (
       children: ReactNode,
       properties: OverlaySystemFlyoutOpenOptions,
-      propagatedMainFlyoutSessionMode = mainFlyoutSessionMode
+      propagatedSessionMode = sessionMode
     ) => {
       overlays.openSystemFlyout(
         flyoutProviders({
@@ -189,7 +184,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
           store,
           history,
           children: (
-            <FlyoutSessionContextProvider value={propagatedMainFlyoutSessionMode}>
+            <FlyoutSessionContextProvider value={{ session: propagatedSessionMode, historyKey }}>
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
           ),
@@ -197,19 +192,19 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         properties
       );
     },
-    [overlays, services, store, history, mainFlyoutSessionMode]
+    [overlays, services, store, history, sessionMode, historyKey]
   );
 
   // The entity flyouts differ only in their base properties (document vs tools size) and session;
   // both are kept private here so callers never reason about them — they pick the method they want.
   const mainProperties = useCallback(
-    (session = mainFlyoutSessionMode, title?: string): OverlaySystemFlyoutOpenOptions => ({
+    (session = sessionMode, title?: string): OverlaySystemFlyoutOpenOptions => ({
       ...defaultDocumentFlyoutProperties,
       historyKey,
       session,
       ...(title !== undefined ? { title } : {}),
     }),
-    [defaultDocumentFlyoutProperties, historyKey, mainFlyoutSessionMode]
+    [defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const toolProperties = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
@@ -9,18 +9,15 @@ import type { ReactNode } from 'react';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { Indicator } from '../../../common/threat_intelligence/types/indicator';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { cellActionRenderer } from '../shared/components/cell_actions';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the IOC flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the IOC flyout graph into their
@@ -64,10 +61,8 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` is the only thing that differs between a main and a child flyout. It is kept private
   // here so callers never have to reason about it: they pick `openIocFlyout` (main) or
@@ -86,7 +81,10 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
           history,
           children: (
             <FlyoutSessionContextProvider
-              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+              value={{
+                session: session === 'inherit' ? 'inherit' : sessionMode,
+                historyKey,
+              }}
             >
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
@@ -95,15 +93,7 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
         properties
       );
     },
-    [
-      overlays,
-      services,
-      store,
-      history,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      mainFlyoutSessionMode,
-    ]
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   // Builds the flyout content (an `IOCDetails` element with a record derived from the indicator),
@@ -121,8 +111,8 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
   );
 
   const openIocFlyout = useCallback(
-    (params: OpenIocFlyoutParams) => open(buildContent(params), mainFlyoutSessionMode),
-    [open, buildContent, mainFlyoutSessionMode]
+    (params: OpenIocFlyoutParams) => open(buildContent(params), sessionMode),
+    [open, buildContent, sessionMode]
   );
 
   const openIocFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
@@ -9,15 +9,12 @@ import type { ReactNode } from 'react';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { FlowTargetSourceDest } from '../../../common/search_strategy/security_solution/network';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the network flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the network flyout graph into their
@@ -62,10 +59,8 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` is the only thing that differs between a main and a child flyout. It is kept private
   // here so callers never have to reason about it: they pick `openNetworkFlyout` (main) or
@@ -84,7 +79,10 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
           history,
           children: (
             <FlyoutSessionContextProvider
-              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+              value={{
+                session: session === 'inherit' ? 'inherit' : sessionMode,
+                historyKey,
+              }}
             >
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
@@ -93,22 +91,14 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
         properties
       );
     },
-    [
-      overlays,
-      services,
-      store,
-      history,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      mainFlyoutSessionMode,
-    ]
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const openNetworkFlyout = useCallback(
     ({ ip, flowTarget }: OpenNetworkFlyoutParams) => {
-      open(<Network ip={ip} flowTarget={flowTarget} />, mainFlyoutSessionMode);
+      open(<Network ip={ip} flowTarget={flowTarget} />, sessionMode);
     },
-    [open, mainFlyoutSessionMode]
+    [open, sessionMode]
   );
 
   const openNetworkFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
@@ -9,14 +9,11 @@ import type { ReactNode } from 'react';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import { useKibana } from '../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { FlyoutLoading } from '../shared/components/flyout_loading';
 import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the rule flyout graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the rule flyout graph into their
@@ -59,10 +56,8 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
 
   // `session` is the only thing that differs between a main and a child flyout. It is kept private
   // here so callers never have to reason about it: they pick `openRuleFlyout` (main) or
@@ -81,7 +76,10 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
           history,
           children: (
             <FlyoutSessionContextProvider
-              value={session === 'inherit' ? 'inherit' : mainFlyoutSessionMode}
+              value={{
+                session: session === 'inherit' ? 'inherit' : sessionMode,
+                historyKey,
+              }}
             >
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
@@ -90,22 +88,14 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
         properties
       );
     },
-    [
-      overlays,
-      services,
-      store,
-      history,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      mainFlyoutSessionMode,
-    ]
+    [overlays, services, store, history, defaultDocumentFlyoutProperties, historyKey, sessionMode]
   );
 
   const openRuleFlyout = useCallback(
     ({ ruleId }: OpenRuleFlyoutParams) => {
-      open(<RuleDetails ruleId={ruleId} />, mainFlyoutSessionMode);
+      open(<RuleDetails ruleId={ruleId} />, sessionMode);
     },
-    [open, mainFlyoutSessionMode]
+    [open, sessionMode]
   );
 
   const openRuleFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_context.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_context.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { useIsInSecurityApp } from '../common/hooks/is_in_security_app';
+import { documentFlyoutHistoryKey } from './shared/constants/flyout_history';
+import {
+  FlyoutSessionContextProvider,
+  type FlyoutSessionContextValue,
+  useFlyoutSessionContext,
+} from './session_context';
+
+jest.mock('../common/hooks/is_in_security_app');
+
+const renderWithProvider = (value?: FlyoutSessionContextValue) =>
+  renderHook(() => useFlyoutSessionContext(), {
+    wrapper: ({ children }: PropsWithChildren<{}>) =>
+      value ? (
+        <FlyoutSessionContextProvider value={value}>{children}</FlyoutSessionContextProvider>
+      ) : (
+        <>{children}</>
+      ),
+  });
+
+describe('session_context', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useIsInSecurityApp as jest.Mock).mockReturnValue(true);
+  });
+
+  describe('useFlyoutSessionContext', () => {
+    it('defaults to a "start" session with no provider above it', () => {
+      const { result } = renderWithProvider();
+
+      expect(result.current.session).toBe('start');
+    });
+
+    it('resolves historyKey to documentFlyoutHistoryKey when inside the Security app and no provider is set', () => {
+      const { result } = renderWithProvider();
+
+      expect(result.current.historyKey).toBe(documentFlyoutHistoryKey);
+    });
+
+    it('resolves historyKey to DOC_VIEWER_FLYOUT_HISTORY_KEY when outside the Security app and no provider is set', () => {
+      (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+
+      const { result } = renderWithProvider();
+
+      expect(result.current.historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+    });
+
+    it('reads the session propagated by a provider', () => {
+      const { result } = renderWithProvider({
+        session: 'inherit',
+        historyKey: documentFlyoutHistoryKey,
+      });
+
+      expect(result.current.session).toBe('inherit');
+    });
+
+    it('uses the ambient historyKey from a provider instead of the app-wide default', () => {
+      const timelineHistoryKey = Symbol('timeline');
+
+      const { result } = renderWithProvider({ session: 'start', historyKey: timelineHistoryKey });
+
+      expect(result.current.historyKey).toBe(timelineHistoryKey);
+    });
+
+    it('falls back to the app-wide default when a provider does not set an ambient historyKey', () => {
+      (useIsInSecurityApp as jest.Mock).mockReturnValue(false);
+
+      const { result } = renderWithProvider({ session: 'start' } as FlyoutSessionContextValue);
+
+      expect(result.current.historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_context.tsx
@@ -7,16 +7,50 @@
 
 import type { FC, PropsWithChildren } from 'react';
 import React, { createContext, useContext } from 'react';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { useIsInSecurityApp } from '../common/hooks/is_in_security_app';
+import { documentFlyoutHistoryKey } from './shared/constants/flyout_history';
 
 export type MainFlyoutSession = 'start' | 'inherit';
 
-const DEFAULT_FLYOUT_SESSION: MainFlyoutSession = 'start';
+/**
+ * Ambient state threaded from a flyout into whatever it opens next, so nested opens can inherit it
+ * without every call site having to pass it down explicitly through props.
+ */
+export interface FlyoutSessionContextValue {
+  /** Whether the next flyout should start a fresh session or inherit the current one. */
+  session: MainFlyoutSession;
+  /**
+   * Ambient override for the `historyKey` passed to `openSystemFlyout`. `undefined` means "no
+   * ambient override in scope" - `useFlyoutSessionContext` resolves that down to the app-wide
+   * default before returning, so consumers never have to do that fallback themselves.
+   *
+   * This is what lets Timeline provide its own `timelineFlyoutHistoryKey` around the flyouts it
+   * opens: it keeps that whole chain's back/history navigation and close-all-in-group behavior
+   * scoped to itself, isolated from whatever flyout was already open before Timeline was shown.
+   */
+  historyKey?: symbol;
+}
 
-const FlyoutSessionContext = createContext<MainFlyoutSession>(DEFAULT_FLYOUT_SESSION);
+const FlyoutSessionContext = createContext<FlyoutSessionContextValue>({ session: 'start' });
 
-export const FlyoutSessionContextProvider: FC<PropsWithChildren<{ value: MainFlyoutSession }>> = ({
-  value,
-  children,
-}) => <FlyoutSessionContext.Provider value={value}>{children}</FlyoutSessionContext.Provider>;
+export const FlyoutSessionContextProvider: FC<
+  PropsWithChildren<{ value: FlyoutSessionContextValue }>
+> = ({ value, children }) => (
+  <FlyoutSessionContext.Provider value={value}>{children}</FlyoutSessionContext.Provider>
+);
 
-export const useFlyoutSessionContext = (): MainFlyoutSession => useContext(FlyoutSessionContext);
+/**
+ * Reads the ambient `{ session, historyKey }` state. `historyKey` is always resolved to a concrete
+ * symbol here: if no `FlyoutSessionContextProvider` above set one, it falls back to the app-wide
+ * default - shared by alert/event/IOC flyouts when inside Security, or Discover's document viewer
+ * key when outside it.
+ */
+export const useFlyoutSessionContext = (): Required<FlyoutSessionContextValue> => {
+  const { session, historyKey: ambientHistoryKey } = useContext(FlyoutSessionContext);
+  const isInSecurityApp = useIsInSecurityApp();
+  const historyKey =
+    ambientHistoryKey ??
+    (isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  return { session, historyKey };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.tsx
@@ -11,12 +11,9 @@ import { EuiLink } from '@elastic/eui';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { flyoutProviders } from './flyout_provider';
 import { useDefaultDocumentFlyoutProperties } from '../hooks/use_default_flyout_properties';
 import { useKibana } from '../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../constants/flyout_history';
 import { OPEN_FLYOUT_LINK_TEST_ID } from './test_ids';
 import { buildFlyoutContent } from '../utils/build_flyout_content';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../session_context';
@@ -75,22 +72,20 @@ export const OpenFlyoutLink: FC<OpenFlyoutLinkProps> = ({
   const store = useStore();
   const history = useHistory();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
 
   const flyoutContent = useMemo(() => buildFlyoutContent(field, value, hit), [field, value, hit]);
 
   const onClick = useCallback(() => {
     if (flyoutContent) {
-      const resolvedSession = asParent ? 'start' : mainFlyoutSessionMode;
+      const resolvedSession = asParent ? 'start' : sessionMode;
       overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
           history,
           children: (
-            <FlyoutSessionContextProvider value={resolvedSession}>
+            <FlyoutSessionContextProvider value={{ session: resolvedSession, historyKey }}>
               {flyoutContent}
             </FlyoutSessionContextProvider>
           ),
@@ -108,9 +103,9 @@ export const OpenFlyoutLink: FC<OpenFlyoutLinkProps> = ({
     history,
     flyoutContent,
     historyKey,
-    mainFlyoutSessionMode,
     overlays,
     services,
+    sessionMode,
     store,
     asParent,
   ]);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/constants/flyout_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/constants/flyout_history.ts
@@ -11,3 +11,14 @@
  * allowing back-navigation across flyout types if/when cross-navigation is added.
  */
 export const documentFlyoutHistoryKey = Symbol('document');
+
+/**
+ * Dedicated history key for flyouts opened from within Timeline. Kept separate from
+ * `documentFlyoutHistoryKey` so that a flyout opened from Timeline (eg after "Investigate in
+ * timeline" from a flyout opened elsewhere) doesn't share back/history navigation with - or get
+ * closed alongside - whatever flyout was already open before Timeline was shown.
+ *
+ * See `session_context.tsx` for how this gets threaded into flyouts opened from Timeline (and
+ * propagated into anything opened from within those).
+ */
+export const timelineFlyoutHistoryKey = Symbol('timeline');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -12,20 +12,17 @@ import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { noop } from 'lodash/fp';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { EventKind } from '../../document/main/constants/event_kinds';
 import { getDocumentTitle } from '../../document/main/utils/get_header_title';
 import { useKibana } from '../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import type { CellActionRenderer } from '../components/cell_actions';
 import { noopCellActionRenderer } from '../components/cell_actions';
 import { flyoutProviders } from '../components/flyout_provider';
 import { DocumentFlyout } from '../../document/main';
 import { useDefaultDocumentFlyoutProperties } from './use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../constants/flyout_history';
 import { DocumentSeverity } from '../../document/main/components/severity';
 import { Timestamp } from '../components/timestamp';
-import { FlyoutSessionContextProvider } from '../../session_context';
+import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../session_context';
 
 export interface UseDocumentFlyoutTitleOptions {
   /** The source document to derive display values from. */
@@ -61,8 +58,7 @@ export const useDocumentFlyoutTitle = ({
   const store = useStore();
   const history = useHistory();
   const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
+  const { historyKey } = useFlyoutSessionContext();
 
   const isAlert = useMemo(
     () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -79,7 +75,7 @@ export const useDocumentFlyoutTitle = ({
         store,
         history,
         children: (
-          <FlyoutSessionContextProvider value="inherit">
+          <FlyoutSessionContextProvider value={{ session: 'inherit', historyKey }}>
             <DocumentFlyout
               hit={hit}
               renderCellActions={renderCellActions}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
@@ -9,15 +9,12 @@ import type { ReactNode } from 'react';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useKibana } from '../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../components/flyout_provider';
 import { FlyoutLoading } from '../components/flyout_loading';
 import { defaultToolsFlyoutProperties } from '../hooks/use_default_flyout_properties';
-import { documentFlyoutHistoryKey } from '../constants/flyout_history';
 import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../session_context'; // Lazy-loaded so consumers of this hook don't statically pull the shared tool graph into their
 
 // Lazy-loaded so consumers of this hook don't statically pull the shared tool graph into their
@@ -52,9 +49,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
-  const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? documentFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-  const mainFlyoutSessionMode = useFlyoutSessionContext();
+  const { session: sessionMode, historyKey } = useFlyoutSessionContext();
 
   const open = useCallback(
     (children: ReactNode, properties: OverlaySystemFlyoutOpenOptions) => {
@@ -64,7 +59,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
           store,
           history,
           children: (
-            <FlyoutSessionContextProvider value={mainFlyoutSessionMode}>
+            <FlyoutSessionContextProvider value={{ session: sessionMode, historyKey }}>
               <Suspense fallback={<FlyoutLoading />}>{children}</Suspense>
             </FlyoutSessionContextProvider>
           ),
@@ -72,7 +67,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
         properties
       );
     },
-    [overlays, services, store, history, mainFlyoutSessionMode]
+    [overlays, services, store, history, historyKey, sessionMode]
   );
 
   const openNotes = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
@@ -16,7 +16,14 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 
-export const usePaneStyles = () => {
+/**
+ * @param zIndexOverride When the new flyout system is enabled, this is dynamically computed by
+ * `useTimelinePortalZIndex` so that Timeline stays correctly stacked relative to the new
+ * EUI-managed flyouts. Falls back to the static `maskBelowHeader` theme value otherwise (ie the
+ * legacy expandable flyout system, where `TimelineFlyout`/`SecuritySolutionFlyout` handle their own
+ * fixed offsets relative to that same static value).
+ */
+export const usePaneStyles = (zIndexOverride?: number) => {
   const EuiTheme = useEuiTheme();
   const { euiTheme } = EuiTheme;
 
@@ -29,7 +36,7 @@ export const usePaneStyles = () => {
     bottom: var(--kbn-layout--application-bottom, 0px);
     // TODO EUI: add color with transparency
     background: ${transparentize(euiTheme.colors.plainDark, 0.5)};
-    z-index: ${euiTheme.levels.maskBelowHeader};
+    z-index: ${zIndexOverride ?? euiTheme.levels.maskBelowHeader};
 
     ${euiCanAnimate} {
       animation: ${euiAnimFadeIn} ${euiTheme.animation.fast} ease-in;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.test.tsx
@@ -11,10 +11,23 @@ import React from 'react';
 import { TestProviders } from '../../../common/mock';
 import { TimelineId } from '../../../../common/types/timeline';
 import { TimelineModal } from '.';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useTimelinePortalZIndex } from './use_timeline_portal_z_index';
+import { timelineFlyoutHistoryKey } from '../../../flyout_v2/shared/constants/flyout_history';
 
-jest.mock('../timeline', () => ({
-  StatefulTimeline: () => <div data-test-subj="StatefulTimelineMock" />,
-}));
+const mockCapturedFlyoutSessionContext = jest.fn();
+jest.mock('../timeline', () => {
+  const { useFlyoutSessionContext } = jest.requireActual('../../../flyout_v2/session_context');
+  return {
+    StatefulTimeline: () => {
+      mockCapturedFlyoutSessionContext(useFlyoutSessionContext());
+      return <div data-test-subj="StatefulTimelineMock" />;
+    },
+  };
+});
+
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('./use_timeline_portal_z_index');
 
 const mockIsFullScreen = jest.fn(() => false);
 jest.mock('../../../common/store/selectors', () => ({
@@ -35,6 +48,8 @@ const renderTimelineModal = () =>
 describe('TimelineModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    jest.mocked(useTimelinePortalZIndex).mockReturnValue(undefined);
   });
 
   it('should render the timeline', async () => {
@@ -61,5 +76,40 @@ describe('TimelineModal', () => {
     expect(getByTestId('timeline-portal-overlay-mask')).toHaveClass(
       'timeline-portal-overlay-mask--full-screen'
     );
+  });
+
+  it('passes its visibility down to useTimelinePortalZIndex', () => {
+    renderTimelineModal();
+
+    expect(useTimelinePortalZIndex).toHaveBeenCalledWith(true);
+  });
+
+  describe('when the new flyout system is enabled', () => {
+    beforeEach(() => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+    });
+
+    it('scopes flyouts opened from within Timeline to their own, dedicated history key', () => {
+      renderTimelineModal();
+
+      expect(mockCapturedFlyoutSessionContext).toHaveBeenCalledWith({
+        session: 'start',
+        historyKey: timelineFlyoutHistoryKey,
+      });
+    });
+  });
+
+  describe('when the new flyout system is disabled', () => {
+    beforeEach(() => {
+      jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+    });
+
+    it('does not scope flyouts opened from within Timeline to a dedicated history key', () => {
+      renderTimelineModal();
+
+      expect(mockCapturedFlyoutSessionContext).toHaveBeenCalledTimes(1);
+      const [context] = mockCapturedFlyoutSessionContext.mock.calls[0];
+      expect(context.historyKey).not.toBe(timelineFlyoutHistoryKey);
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.tsx
@@ -16,6 +16,10 @@ import { CustomEuiPortal } from './custom_portal';
 import { useShallowEqualSelector } from '../../../common/hooks/use_selector';
 import { inputsSelectors } from '../../../common/store/selectors';
 import { usePaneStyles, OverflowHiddenGlobalStyles } from './index.styles';
+import { useTimelinePortalZIndex } from './use_timeline_portal_z_index';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { FlyoutSessionContextProvider } from '../../../flyout_v2/session_context';
+import { timelineFlyoutHistoryKey } from '../../../flyout_v2/shared/constants/flyout_history';
 
 const TIMELINE_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.timeline.modal.timelinePropertiesAriaLabel',
@@ -48,7 +52,14 @@ export const TimelineModal = React.memo<TimelineModalProps>(
     const isFullScreen =
       useShallowEqualSelector(inputsSelectors.timelineFullScreenSelector) ?? false;
 
-    const styles = usePaneStyles();
+    // Only returns a value when the new flyout system is enabled, undefined otherwise (in which
+    // case usePaneStyles falls back to its static default)
+    const dynamicZIndex = useTimelinePortalZIndex(visible);
+    const styles = usePaneStyles(dynamicZIndex);
+    // Gates on the same flag as `useTimelinePortalZIndex` above. Gives flyouts opened from within
+    // Timeline (host/user/rule/network/document/notes/...) their own history group, isolated from
+    // whatever flyout was already open before Timeline, see `session_context.tsx`.
+    const isNewFlyoutEnabled = useIsNewFlyoutEnabled();
     const wrapperClassName = classNames('timeline-portal-overlay-mask', styles, {
       'timeline-portal-overlay-mask--full-screen': isFullScreen,
       'timeline-portal-overlay-mask--hidden': !visible,
@@ -68,12 +79,25 @@ export const TimelineModal = React.memo<TimelineModalProps>(
               data-test-subj="timeline-container"
               className="timeline-container"
             >
-              <StatefulTimeline
-                renderCellValue={DefaultCellRenderer}
-                rowRenderers={defaultRowRenderers}
-                timelineId={timelineId}
-                openToggleRef={openToggleRef}
-              />
+              {isNewFlyoutEnabled ? (
+                <FlyoutSessionContextProvider
+                  value={{ session: 'start', historyKey: timelineFlyoutHistoryKey }}
+                >
+                  <StatefulTimeline
+                    renderCellValue={DefaultCellRenderer}
+                    rowRenderers={defaultRowRenderers}
+                    timelineId={timelineId}
+                    openToggleRef={openToggleRef}
+                  />
+                </FlyoutSessionContextProvider>
+              ) : (
+                <StatefulTimeline
+                  renderCellValue={DefaultCellRenderer}
+                  rowRenderers={defaultRowRenderers}
+                  timelineId={timelineId}
+                  openToggleRef={openToggleRef}
+                />
+              )}
             </div>
           </div>
         </CustomEuiPortal>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/use_timeline_portal_z_index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/use_timeline_portal_z_index.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { getFlyoutManagerStore } from '@elastic/eui';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useTimelinePortalZIndex } from './use_timeline_portal_z_index';
+
+const TIMELINE_UNMANAGED_FLYOUT_ID = 'security-solution-timeline';
+
+const mockAddUnmanagedFlyout = jest.fn();
+const mockCloseUnmanagedFlyout = jest.fn();
+const mockGetState = jest.fn(() => ({ currentZIndex: 0 }));
+
+jest.mock('@elastic/eui', () => ({
+  ...jest.requireActual('@elastic/eui'),
+  getFlyoutManagerStore: jest.fn(() => ({
+    getState: mockGetState,
+    addUnmanagedFlyout: mockAddUnmanagedFlyout,
+    closeUnmanagedFlyout: mockCloseUnmanagedFlyout,
+  })),
+  useEuiTheme: () => ({ euiTheme: { levels: { flyout: 1000 } } }),
+}));
+
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+
+describe('useTimelinePortalZIndex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetState.mockReturnValue({ currentZIndex: 0 });
+  });
+
+  it('returns undefined and does not register when the new flyout system is disabled', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(false);
+
+    const { result } = renderHook(() => useTimelinePortalZIndex(true));
+
+    expect(result.current).toBeUndefined();
+    expect(getFlyoutManagerStore).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined and does not register when Timeline is not visible, even if enabled', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+
+    const { result } = renderHook(() => useTimelinePortalZIndex(false));
+
+    expect(result.current).toBeUndefined();
+    expect(getFlyoutManagerStore).not.toHaveBeenCalled();
+  });
+
+  it('registers as an unmanaged flyout and returns flyoutLevel + currentZIndex when enabled and visible', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+    mockGetState.mockReturnValue({ currentZIndex: 6 });
+
+    const { result } = renderHook(() => useTimelinePortalZIndex(true));
+
+    expect(result.current).toBe(1006);
+    expect(mockAddUnmanagedFlyout).toHaveBeenCalledWith(TIMELINE_UNMANAGED_FLYOUT_ID);
+  });
+
+  it('unregisters the unmanaged flyout on unmount', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+
+    const { unmount } = renderHook(() => useTimelinePortalZIndex(true));
+    unmount();
+
+    expect(mockCloseUnmanagedFlyout).toHaveBeenCalledWith(TIMELINE_UNMANAGED_FLYOUT_ID);
+  });
+
+  it('unregisters and resets the z-index when Timeline transitions from visible to hidden', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+
+    const { result, rerender } = renderHook(({ visible }) => useTimelinePortalZIndex(visible), {
+      initialProps: { visible: true },
+    });
+    expect(result.current).toBeDefined();
+
+    rerender({ visible: false });
+
+    expect(mockCloseUnmanagedFlyout).toHaveBeenCalledWith(TIMELINE_UNMANAGED_FLYOUT_ID);
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/use_timeline_portal_z_index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/use_timeline_portal_z_index.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { getFlyoutManagerStore, useEuiTheme } from '@elastic/eui';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+
+/**
+ * Id used to register the Timeline portal with EUI's flyout manager. This does not need to be
+ * unique across the app (Timeline is a singleton), it only needs to be stable.
+ */
+const TIMELINE_UNMANAGED_FLYOUT_ID = 'security-solution-timeline';
+
+/**
+ * Only relevant when the new (EUI-managed) flyout system is enabled (see `useIsNewFlyoutEnabled`).
+ *
+ * The new flyout system bumps a shared `currentZIndex` counter by 3 every time a new main flyout
+ * is opened (1000, 1003, 1006, ...), regardless of whether that flyout was opened from Timeline or
+ * not. Timeline's z-index used to be a static value (`euiTheme.levels.maskBelowHeader`), which meant
+ * that as soon as 2 flyouts were stacked, the second one would render above Timeline - even though
+ * Timeline itself was opened "on top" of the first flyout via "Investigate in timeline".
+ *
+ * To fix this, we register Timeline as an "unmanaged flyout" with EUI's flyout manager
+ * (`getFlyoutManagerStore`). This is the same mechanism EUI itself uses for plain, unmanaged
+ * `EuiFlyout`s (ie `session={false}`), so that any content that isn't a managed flyout can still
+ * slot into the same shared z-index sequence.
+ *
+ * The key trick is *when* we capture our z-index: we read `currentZIndex` right before we register,
+ * so we claim whatever slot was "next in line" at the moment Timeline opened.
+ *  - Flyouts opened *before* Timeline already claimed a lower slot -> they stay behind Timeline.
+ *  - Flyouts opened *after* Timeline is shown (eg from within Timeline's own table) will read
+ *    `currentZIndex` *after* Timeline bumped it -> they render above Timeline.
+ *
+ * This means we don't need to know/care whether a flyout was opened "from Timeline" or not -  the
+ * ordering falls out naturally from *when* each surface registered itself.
+ *
+ * Returns `undefined` when the new flyout system is disabled or Timeline isn't visible, in which
+ * case the caller should fall back to the existing static z-index behavior.
+ */
+export const useTimelinePortalZIndex = (visible: boolean): number | undefined => {
+  const isNewFlyoutEnabled = useIsNewFlyoutEnabled();
+  const { euiTheme } = useEuiTheme();
+  const [zIndex, setZIndex] = useState<number | undefined>(undefined);
+  const flyoutLevel = euiTheme.levels.flyout as number;
+
+  // avoid re-registering on every render because of an unstable `flyoutLevel` reference
+  const flyoutLevelRef = useRef(flyoutLevel);
+  flyoutLevelRef.current = flyoutLevel;
+
+  useEffect(() => {
+    if (!isNewFlyoutEnabled || !visible) {
+      setZIndex(undefined);
+      return;
+    }
+
+    const store = getFlyoutManagerStore();
+
+    // capture the offset BEFORE registering ourselves, see explanation above
+    const offset = store.getState().currentZIndex;
+    setZIndex(flyoutLevelRef.current + offset);
+
+    store.addUnmanagedFlyout(TIMELINE_UNMANAGED_FLYOUT_ID);
+
+    return () => {
+      store.closeUnmanagedFlyout(TIMELINE_UNMANAGED_FLYOUT_ID);
+    };
+  }, [isNewFlyoutEnabled, visible]);
+
+  return isNewFlyoutEnabled ? zIndex : undefined;
+};


### PR DESCRIPTION
## Summary

This PR fixes two related issues in how the new system flyout interacts with Timeline, both gated behind `useIsNewFlyoutEnabled`:

1. `z-index` stacking

The new flyout system bumps a shared `currentZIndex` counter by 3 for every new main flyout opened (1000, 1003, 1006, ...). Timeline's `z-index` was static (we did this as part of the expandable flyout work), so as soon as a second flyout was opened, it would render above Timeline — even if Timeline itself had been opened on top of the first flyout via "Investigate in timeline".

https://github.com/user-attachments/assets/8d879c24-11c2-4719-a01e-a14d96380b07

This was fixed by registering Timeline as an unmanaged flyout with EUI's flyout manager (`getFlyoutManagerStore().addUnmanagedFlyout/closeUnmanagedFlyout`) — the same mechanism EUI uses for its own unmanaged EuiFlyouts. Timeline captures `currentZIndex` right before registering, so it claims whatever slot was "next in line" at the moment it opened:
- Flyouts opened before Timeline keep their lower `z-index` → stay behind it.
- Flyouts opened after Timeline is shown (e.g. from within Timeline's own table) read a bumped `currentZIndex` → render above it.

2. Shared flyout history across Timeline

All Security Solution flyouts shared a single `documentFlyoutHistoryKey`, so a flyout opened from within Timeline (e.g. via "Investigate in timeline" from an already-open flyout, then opening another flyout inside Timeline) shared back/history navigation with whatever flyout was open before Timeline. This meant:
- An out-of-place "back" button on Timeline-originated flyouts.
- Closing a Timeline-originated flyout would close the whole shared history group, losing the previous investigation's flyout.

https://github.com/user-attachments/assets/1382c1a6-50dc-4f46-a78f-366b184d6fed

This was fixed by giving Timeline its own dedicated `timelineFlyoutHistoryKey`, threaded into everything opened from within Timeline via FlyoutSessionContextProvider. This mimics a bit what we had done in the expandable flyout where we had 2 distinct instances of the flyout.

### New behavior handles z-index and multiple sessions

https://github.com/user-attachments/assets/0c6998ec-1c55-4193-a3d6-7c9a7441c637

### How to test

- generate some documents and alerts
- open the flyout on the main pages (like alert page, host, user...) and navigate throughout multiple tools (to purposefully bump the `z-index`
- then land on a flyout where you can `Investigate in Timeline`
- verify that Timeline opens on top (the flyout should still be behind)
- open a new flyout from the Timeline table
- verify that the flyout is rendered above Timeline and it's a new session (no `Back` button at the top) and navigate within this new flyout session
- close the flyout, then close Timeline and verify that the previous flyout is still opened

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->