### PR TITLE
[Change History] Shared user-profile name resolution in `@kbn/change-history`

### DIFF
--- a/x-pack/platform/packages/shared/kbn-change-history/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-change-history/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: x-pack/platform/packages/shared/kbn-change-history
 dependsOn:
   - '@kbn/core'
+  - '@kbn/core-user-profile-server'
   - '@kbn/data-streams'
   - '@kbn/es-mappings'
   - '@kbn/logging'

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock, userProfileServiceMock } from '@kbn/core/server/mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { DataStreamClient } from '@kbn/data-streams';
 import { FLAGS } from './constants';
@@ -60,5 +60,68 @@ describe('ChangeHistoryClient.initialize', () => {
       DataStreamClientMock.initialize.mock.calls[0]?.[0].dataStream.template.settings
     ).toBeUndefined();
     expect(client.isInitialized()).toBe(true);
+  });
+});
+
+describe('ChangeHistoryClient.getHistory', () => {
+  const logger = loggingSystemMock.createLogger();
+  const defaultConstructorOpts = {
+    module: 'workflows',
+    dataset: 'definitions',
+    logger,
+    kibanaVersion: '9.4.0',
+  };
+
+  const searchResult = {
+    hits: {
+      total: { value: 1 },
+      hits: [
+        {
+          _source: {
+            '@timestamp': '2026-01-01T00:00:00.000Z',
+            user: { id: 'uid-1', name: 'alice' },
+            event: { id: 'e1', module: 'workflows', dataset: 'definitions', action: 'update' },
+            object: { id: 'obj-1', type: 'workflow' },
+          },
+        },
+      ],
+    },
+  };
+
+  let dataStreamMock: { search: jest.Mock };
+
+  beforeEach(() => {
+    FLAGS.FEATURE_ENABLED = true;
+    dataStreamMock = { search: jest.fn().mockResolvedValue(searchResult) };
+    DataStreamClientMock.initialize.mockResolvedValue(dataStreamMock as never);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('does not call userProfileService.bulkGet when no service was provided at initialize()', async () => {
+    const service = userProfileServiceMock.createStart();
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+    await client.initialize(elasticsearchServiceMock.createElasticsearchClient());
+
+    const result = await client.getHistory('default', 'workflow', 'obj-1');
+
+    expect(service.bulkGet).not.toHaveBeenCalled();
+    expect(result.items[0].user.full_name).toBeUndefined();
+  });
+
+  it('calls userProfileService.bulkGet and enriches full_name when service was provided', async () => {
+    const service = userProfileServiceMock.createStart();
+    service.bulkGet.mockResolvedValue([
+      { uid: 'uid-1', user: { username: 'alice', full_name: 'Alice A.' } } as never,
+    ]);
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+    await client.initialize(elasticsearchServiceMock.createElasticsearchClient(), {
+      userProfileService: service,
+    });
+
+    const result = await client.getHistory('default', 'workflow', 'obj-1');
+
+    expect(service.bulkGet).toHaveBeenCalledWith({ uids: new Set(['uid-1']) });
+    expect(result.items[0].user.full_name).toBe('Alice A.');
   });
 });

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -12,6 +12,7 @@ import type {
   SortCombinations,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
 import { type DataStreamDefinition, DataStreamClient } from '@kbn/data-streams';
 import type { ClientCreateRequest } from '@kbn/data-streams/src/types/es_api';
 import type { Logger } from '@kbn/logging';
@@ -30,7 +31,7 @@ import type {
   GetChangeHistoryOptions,
   ObjectChange,
 } from './types';
-import { sha256, sanitizeFields } from './utils';
+import { sha256, sanitizeFields, enrichWithProfiles } from './utils';
 
 export { DATA_STREAM_NAME } from './constants';
 
@@ -39,9 +40,17 @@ type ChangeHistoryDataStreamClient = DataStreamClient<
   ChangeHistoryDocument
 >;
 
+export interface ChangeHistoryClientInitializeOptions {
+  /** When supplied, `getHistory` resolves `user.full_name` at read time; lookup failures are swallowed. */
+  userProfileService?: UserProfileServiceStart;
+}
+
 export interface IChangeHistoryClient {
   isInitialized(): boolean;
-  initialize(elasticsearchClient: ElasticsearchClient): Promise<void>;
+  initialize(
+    elasticsearchClient: ElasticsearchClient,
+    opts?: ChangeHistoryClientInitializeOptions
+  ): Promise<void>;
   log(change: ObjectChange, opts: LogChangeHistoryOptions): Promise<void>;
   logBulk(changes: ObjectChange[], opts: LogChangeHistoryOptions): Promise<void>;
   getHistory(
@@ -58,6 +67,7 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
   private kibanaVersion: string;
   private logger: Logger;
   private client?: ChangeHistoryDataStreamClient;
+  private userProfileService?: UserProfileServiceStart;
 
   constructor({
     module,
@@ -97,15 +107,20 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
   /**
    * Initialize the change tracking service.
    * @param elasticsearchClient The privileged elasticsearch client `core.elasticsearch.client.asInternalUser`.
+   * @param opts Optional integration hooks; see {@link ChangeHistoryClientInitializeOptions}.
    * @returns A promise that resolves when the change tracking service is initialized.
    * @throws An error if the data stream is not initialized properly.
    */
-  async initialize(elasticsearchClient: ElasticsearchClient) {
+  async initialize(
+    elasticsearchClient: ElasticsearchClient,
+    opts?: ChangeHistoryClientInitializeOptions
+  ) {
     if (!FLAGS.FEATURE_ENABLED) {
       const error = new Error(`Change history is disabled. Skipping initialization.`);
       this.logger.error(error);
       throw error;
     }
+    this.userProfileService = opts?.userProfileService;
     const definition: DataStreamDefinition<typeof changeHistoryMappings.v1, ChangeHistoryDocument> =
       {
         name: DATA_STREAM_NAME,
@@ -287,9 +302,13 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
       size: opts?.size ?? DEFAULT_RESULT_SIZE,
       from: opts?.from,
     });
+    const items = history.hits.hits.map((h) => h._source).filter((i) => !!i);
+    if (this.userProfileService) {
+      await enrichWithProfiles(items, this.userProfileService, this.logger);
+    }
     return {
       total: Number((history.hits.total as SearchTotalHits)?.value) || 0,
-      items: history.hits.hits.map((h) => h._source).filter((i) => !!i),
+      items,
     };
   }
 }

--- a/x-pack/platform/packages/shared/kbn-change-history/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/types.ts
@@ -27,6 +27,8 @@ export interface ChangeHistoryDocument {
     id?: string;
     /** Current login name for user that generated the change. */
     name: string;
+    /** Resolved at read time from the user profile; not persisted. */
+    full_name?: string;
   };
 
   event: {

--- a/x-pack/platform/packages/shared/kbn-change-history/src/utils.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/utils.test.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { sha256, sanitizeFields, REDACTED } from './utils';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { userProfileServiceMock } from '@kbn/core/server/mocks';
+import { sha256, sanitizeFields, REDACTED, enrichWithProfiles } from './utils';
+import type { ChangeHistoryDocument } from './types';
 
 describe('#sanitizeFields', () => {
   describe('when fieldsToHash is not provided', () => {
@@ -260,5 +263,72 @@ describe('#sanitizeFields', () => {
 
       expect(snapshot.api).toBe(api);
     });
+  });
+});
+
+describe('#enrichWithProfiles', () => {
+  const logger = loggingSystemMock.createLogger();
+
+  const doc = (id: string | undefined, name: string): ChangeHistoryDocument =>
+    ({ user: { id, name } } as ChangeHistoryDocument);
+
+  const profile = (uid: string, full_name?: string) =>
+    ({ uid, user: { username: uid, full_name } } as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('populates full_name from resolved profiles', async () => {
+    const service = userProfileServiceMock.createStart();
+    service.bulkGet.mockResolvedValue([profile('u1', 'Alice A.'), profile('u2', 'Bob B.')]);
+    const items = [doc('u1', 'alice'), doc('u2', 'bob')];
+
+    await enrichWithProfiles(items, service, logger);
+
+    expect(service.bulkGet).toHaveBeenCalledWith({ uids: new Set(['u1', 'u2']) });
+    expect(items[0].user.full_name).toBe('Alice A.');
+    expect(items[1].user.full_name).toBe('Bob B.');
+  });
+
+  it('short-circuits and skips bulkGet when no user.id present', async () => {
+    const service = userProfileServiceMock.createStart();
+    const items = [doc(undefined, 'alice'), doc(undefined, 'bob')];
+
+    await enrichWithProfiles(items, service, logger);
+
+    expect(service.bulkGet).not.toHaveBeenCalled();
+    expect(items[0].user.full_name).toBeUndefined();
+  });
+
+  it('leaves full_name unset when no matching profile is returned', async () => {
+    const service = userProfileServiceMock.createStart();
+    service.bulkGet.mockResolvedValue([]);
+    const items = [doc('u1', 'alice')];
+
+    await enrichWithProfiles(items, service, logger);
+
+    expect(items[0].user.full_name).toBeUndefined();
+  });
+
+  it('leaves full_name unset when the profile has no full_name', async () => {
+    const service = userProfileServiceMock.createStart();
+    service.bulkGet.mockResolvedValue([profile('u1', undefined)]);
+    const items = [doc('u1', 'alice')];
+
+    await enrichWithProfiles(items, service, logger);
+
+    expect(items[0].user.full_name).toBeUndefined();
+  });
+
+  it('swallows bulkGet failures and warns', async () => {
+    const service = userProfileServiceMock.createStart();
+    service.bulkGet.mockRejectedValue(new Error('es down'));
+    const items = [doc('u1', 'alice')];
+
+    await expect(enrichWithProfiles(items, service, logger)).resolves.toBeUndefined();
+
+    expect(items[0].user.full_name).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to resolve user profiles for change history: Error: es down/)
+    );
   });
 });

--- a/x-pack/platform/packages/shared/kbn-change-history/src/utils.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/utils.ts
@@ -7,7 +7,9 @@
 
 import crypto from 'node:crypto';
 import { flattenObject as flatten, unflattenObject as unflatten } from '@kbn/object-utils';
-import type { ChangeHistoryFieldsToMask } from './types';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
+import type { Logger } from '@kbn/logging';
+import type { ChangeHistoryDocument, ChangeHistoryFieldsToMask } from './types';
 
 export const sha256 = (text: string) => crypto.createHash('sha256').update(text).digest('hex');
 
@@ -87,3 +89,35 @@ export function sanitizeFields(
     snapshot: unflatten(flatSnapshot),
   };
 }
+
+/**
+ * Best-effort read-time enrichment: mutates each item's `user.full_name` in place from the
+ * matching user profile. Short-circuits when no `user.id`s are present. `bulkGet` failures
+ * are logged via `logger.warn` and swallowed so history reads never fail on profile lookup.
+ * @param items - Change history documents to enrich in place.
+ * @param service - User profile service used to resolve display names.
+ * @param logger - Logger used to record lookup failures.
+ */
+export const enrichWithProfiles = async (
+  items: ChangeHistoryDocument[],
+  service: UserProfileServiceStart,
+  logger: Logger
+): Promise<void> => {
+  const uids = new Set<string>();
+  for (const item of items) {
+    if (item.user.id) uids.add(item.user.id);
+  }
+  if (uids.size === 0) return;
+  try {
+    const profiles = await service.bulkGet({ uids });
+    const map = new Map(profiles.map((p) => [p.uid, p]));
+    for (const item of items) {
+      const profile = item.user.id ? map.get(item.user.id) : undefined;
+      if (profile?.user.full_name) {
+        item.user.full_name = profile.user.full_name;
+      }
+    }
+  } catch (err) {
+    logger.warn(`Failed to resolve user profiles for change history: ${err}`);
+  }
+};

--- a/x-pack/platform/packages/shared/kbn-change-history/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-change-history/tsconfig.json
@@ -8,6 +8,7 @@
   "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/core",
+    "@kbn/core-user-profile-server",
     "@kbn/data-streams",
     "@kbn/es-mappings",
     "@kbn/logging",

--- a/x-pack/platform/plugins/shared/alerting/moon.yml
+++ b/x-pack/platform/plugins/shared/alerting/moon.yml
@@ -66,6 +66,7 @@ dependsOn:
   - '@kbn/search-types'
   - '@kbn/alerting-state-types'
   - '@kbn/core-security-server'
+  - '@kbn/core-user-profile-server'
   - '@kbn/security-plugin-types-server'
   - '@kbn/core-http-server'
   - '@kbn/core-spaces-common'

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -679,6 +679,7 @@ export class AlertingPlugin {
     changeTrackingService?.initialize({
       elasticsearchClient: core.elasticsearch.client.asInternalUser,
       authService: core.security.authc,
+      userProfileService: core.userProfile,
     });
 
     rulesClientFactory.initialize({

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking/service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking/service.test.ts
@@ -10,6 +10,7 @@ import {
   elasticsearchServiceMock,
   httpServerMock,
   loggingSystemMock,
+  userProfileServiceMock,
 } from '@kbn/core/server/mocks';
 import { ChangeHistoryClient } from '@kbn/change-history';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../saved_objects';
@@ -24,7 +25,7 @@ const ChangeHistoryClientMock = ChangeHistoryClient as jest.MockedClass<typeof C
 
 interface MockChangeHistoryClient {
   isInitialized: jest.Mock<boolean, []>;
-  initialize: jest.Mock<Promise<void>, [unknown]>;
+  initialize: jest.Mock<Promise<void>, [unknown, unknown?]>;
   logBulk: jest.Mock<Promise<void>, [unknown, unknown]>;
   getHistory: jest.Mock<
     Promise<{ items: unknown[]; total: number }>,
@@ -53,6 +54,7 @@ describe('ChangeTrackingService', () => {
     service.initialize({
       elasticsearchClient: elasticsearchServiceMock.createClusterClient().asInternalUser,
       authService,
+      userProfileService: userProfileServiceMock.createStart(),
     });
     return { authService };
   };
@@ -114,10 +116,12 @@ describe('ChangeTrackingService', () => {
 
       const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       const authService = coreMock.createStart().security.authc;
-      service.initialize({ elasticsearchClient, authService });
+      const userProfileService = userProfileServiceMock.createStart();
+      service.initialize({ elasticsearchClient, authService, userProfileService });
 
       await new Promise(process.nextTick);
 
+      // TODO: assert `{ userProfileService }` once passed through to the client.
       expect(stackClient.initialize).toHaveBeenCalledWith(elasticsearchClient);
       expect(securityClient.initialize).toHaveBeenCalledWith(elasticsearchClient);
 

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking/service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking/service.ts
@@ -11,6 +11,7 @@ import type {
   ElasticsearchClient,
   KibanaRequest,
 } from '@kbn/core/server';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
 import type { RuleTypeSolution } from '@kbn/alerting-types';
 import type { Logger } from '@kbn/logging';
 import type {
@@ -40,6 +41,7 @@ export class ChangeTrackingService implements IChangeTrackingService {
   private modules: RuleTypeSolution[];
   private dataset = ALERTING_RULE_DATASET;
   private authService?: CoreAuthenticationService;
+  private userProfileService?: UserProfileServiceStart;
 
   constructor(logger: Logger, kibanaVersion: string) {
     this.clients = {} as Record<RuleTypeSolution, ChangeHistoryClient>;
@@ -63,9 +65,14 @@ export class ChangeTrackingService implements IChangeTrackingService {
     return !!this.clients[module]?.isInitialized();
   }
 
-  initialize({ elasticsearchClient, authService }: ChangeTrackingServiceInitializeParams): void {
+  initialize({
+    elasticsearchClient,
+    authService,
+    userProfileService,
+  }: ChangeTrackingServiceInitializeParams): void {
     this.logger.debug(`Initializing change tracking..`);
     this.authService = authService;
+    this.userProfileService = userProfileService;
 
     void this.initializeAll(elasticsearchClient).catch((cause) => {
       const error = new Error(
@@ -108,6 +115,8 @@ export class ChangeTrackingService implements IChangeTrackingService {
     // Initialize each change history client (in sequence - better than in parallel)
     for (const [module, client] of Object.entries(this.clients)) {
       try {
+        // TODO: Pass the userProfileService when `user.full_name` is implemented downstream
+        // @see https://github.com/elastic/kibana/issues/278422
         await client.initialize(elasticsearchClient);
         this.logger.info(`Change tracking initialized for [${module}, ${this.dataset}]`);
       } catch (cause) {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking/types.ts
@@ -10,6 +10,7 @@ import type {
   ElasticsearchClient,
   KibanaRequest,
 } from '@kbn/core/server';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
 import type { RuleTypeSolution } from '@kbn/alerting-types';
 import type {
   ObjectChange,
@@ -51,6 +52,7 @@ export interface RuleChange extends Omit<ObjectChange, 'snapshot'> {
 export interface ChangeTrackingServiceInitializeParams {
   elasticsearchClient: ElasticsearchClient;
   authService: CoreAuthenticationService;
+  userProfileService: UserProfileServiceStart;
 }
 
 export interface IChangeTrackingService {

--- a/x-pack/platform/plugins/shared/alerting/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting/tsconfig.json
@@ -61,6 +61,7 @@
     "@kbn/search-types",
     "@kbn/alerting-state-types",
     "@kbn/core-security-server",
+    "@kbn/core-user-profile-server",
     "@kbn/security-plugin-types-server",
     "@kbn/core-http-server",
     "@kbn/core-spaces-common",


### PR DESCRIPTION
## Summary

Addresses #278422.

Lifts the display-name resolution used by `getHistory()` consumers into `@kbn/change-history` itself, so any team using  `ChangeHistoryClient.getHistory()`  while passing `userProfileService` during `initialization()` automatically gets `user.full_name` on returned change history docs.

## To be included after rebase

Wait for the following PR to be merged and apply similar logic.

- #276947 — [Alerting V2] Rule versioning using change history datastream
  - Once merged, rebase this PR on top and mirror the legacy wiring on the v2 side so `getHistory` returns `user.full_name` there too.

## Follow-ups

- #278353 — [Security] temporary fix
  - Remove Security's local resolver in `security_solution/detection_rules_client/methods/get_history_for_rule.ts`.
  - Flip the `TODO` in `ChangeTrackingService.initializeAll` (legacy alerting) to pass `userProfileService` through to `ChangeHistoryClient.initialize`.
- #278426 — [Workflows] temporary fix
  - Undo local resolver.
  - Pass `userProfileService` during `ChangeHistoryClient.initialize` from Workflows' own bootstrap.

## Release notes

Not user-facing on its own; enables downstream cleanups that fix `user.name` rendering for LDAP/PKI/API-key-derived sessions.