### PR TITLE
[Cases] Strip hidden conditional extended_fields at write time

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
@@ -2490,6 +2490,140 @@ describe('update', () => {
     });
   });
 
+  describe('Conditional extended_fields stripping', () => {
+    const clientArgs = createCasesClientMockArgs();
+
+    const makeTemplateSO = (fields: object[]) => ({
+      id: 'so-tpl',
+      type: 'cases-templates',
+      references: [],
+      attributes: {
+        templateId: 'tmpl-cond',
+        name: 'Conditional Template',
+        owner: SECURITY_SOLUTION_OWNER,
+        definition: yamlStringify({ name: 'Conditional Template', fields }),
+        templateVersion: 1,
+        deletedAt: null,
+        isLatest: true,
+      },
+    });
+
+    const templateFields = [
+      {
+        control: 'CHECKBOX_GROUP',
+        name: 'affected_components',
+        label: 'Affected components',
+        type: 'keyword',
+        metadata: { options: ['api', 'ui'] },
+      },
+      {
+        control: 'INPUT_TEXT',
+        name: 'environment',
+        label: 'Environment',
+        type: 'keyword',
+        display: {
+          show_when: {
+            field: 'affected_components',
+            operator: 'contains',
+            value: 'ui',
+          },
+        },
+      },
+    ];
+
+    const caseWithTemplate = {
+      ...mockCases[0],
+      attributes: {
+        ...mockCases[0].attributes,
+        template: { id: 'tmpl-cond', version: 1 },
+        extended_fields: {
+          affected_components_as_keyword: '["ui","api"]',
+          environment_as_keyword: 'staging',
+        },
+      },
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientArgs.services.caseService.getCases.mockResolvedValue({
+        saved_objects: [caseWithTemplate],
+      });
+      clientArgs.services.caseService.getAllCaseComments.mockResolvedValue({
+        saved_objects: [],
+        total: 0,
+        per_page: 10,
+        page: 1,
+      });
+      clientArgs.services.caseService.patchCases.mockResolvedValue({
+        saved_objects: [caseWithTemplate],
+      });
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
+      clientArgs.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
+        [caseWithTemplate.id]: 0,
+      });
+      clientArgs.services.fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [],
+        total: 0,
+      });
+      clientArgs.services.templatesService.getTemplate.mockResolvedValue(
+        makeTemplateSO(templateFields)
+      );
+    });
+
+    it('strips a dependent field when a controlling field update hides it', async () => {
+      await bulkUpdate(
+        {
+          cases: [
+            {
+              id: caseWithTemplate.id,
+              version: caseWithTemplate.version ?? '',
+              extended_fields: {
+                affected_components_as_keyword: '["api"]',
+              },
+            },
+          ],
+        },
+        clientArgs,
+        casesClientMock
+      );
+
+      const updatedAttributes =
+        clientArgs.services.caseService.patchCases.mock.calls[0][0].cases[0].updatedAttributes;
+
+      expect(updatedAttributes.extended_fields).toEqual({
+        affected_components_as_keyword: '["api"]',
+      });
+    });
+
+    it('keeps a visible dependent field when the controlling value still satisfies show_when', async () => {
+      await bulkUpdate(
+        {
+          cases: [
+            {
+              id: caseWithTemplate.id,
+              version: caseWithTemplate.version ?? '',
+              extended_fields: {
+                environment_as_keyword: 'production',
+              },
+            },
+          ],
+        },
+        clientArgs,
+        casesClientMock
+      );
+
+      const updatedAttributes =
+        clientArgs.services.caseService.patchCases.mock.calls[0][0].cases[0].updatedAttributes;
+
+      expect(updatedAttributes.extended_fields).toEqual({
+        affected_components_as_keyword: '["ui","api"]',
+        environment_as_keyword: 'production',
+      });
+    });
+  });
+
   describe('Metrics', () => {
     const clientArgs = createCasesClientMockArgs();
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
@@ -78,7 +78,7 @@ import {
   validateCustomFields,
   validateExtendedFieldsInRequest,
   validateExtendedFieldsOnClose,
-  resolveTemplateFieldsForClose,
+  resolveTemplateFieldsForCase,
   resolveGlobalFields,
   stripHiddenExtendedFields,
 } from './validators';
@@ -649,10 +649,11 @@ export const bulkUpdate = async (
     const templateFieldsByKey = new Map<string, InlineField[]>(
       await Promise.all(
         casesNeedingTemplateFields.map(async ({ id, version }) => {
-          const fields = await resolveTemplateFieldsForClose({
+          const fields = await resolveTemplateFieldsForCase({
             templateId: id,
             templateVersion: version,
             templatesService,
+            fieldDefinitionsService,
             logger,
           });
           return [`${id}@${version}`, fields] as [string, InlineField[]];

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
@@ -80,6 +80,7 @@ import {
   validateExtendedFieldsOnClose,
   resolveTemplateFieldsForClose,
   resolveGlobalFields,
+  stripHiddenExtendedFields,
 } from './validators';
 import type { InlineField } from '../../../common/types/domain/template/fields';
 import { emptyCasesAssigneesSanitizer } from './sanitizers';
@@ -616,7 +617,7 @@ export const bulkUpdate = async (
       )
     );
 
-    // Pre-resolve template fields for cases transitioning to closed.
+    // Pre-resolve template fields for cases updating extended_fields or transitioning to closed.
     // Deduplicates SO fetches: N cases sharing the same (template id, version) pair issue only one getTemplate call.
     const getEffectiveTemplate = (
       updateReq: CasePatchRequest,
@@ -631,14 +632,15 @@ export const bulkUpdate = async (
     };
 
     // Deduplicate by "id@version" so different versions of the same template are fetched separately.
-    const closingCasesTemplates = [
+    const casesNeedingTemplateFields = [
       ...new Map(
         casesToUpdate
-          .filter(
-            ({ updateReq, originalCase }) =>
+          .filter(({ updateReq, originalCase }) => {
+            const isClosing =
               updateReq.status === CaseStatuses.closed &&
-              originalCase.attributes.status !== CaseStatuses.closed
-          )
+              originalCase.attributes.status !== CaseStatuses.closed;
+            return updateReq.extended_fields != null || isClosing;
+          })
           .map(({ updateReq, originalCase }) => getEffectiveTemplate(updateReq, originalCase))
           .filter((t): t is { id: string; version: number } => t != null)
           .map((t) => [`${t.id}@${t.version}`, t] as const)
@@ -646,7 +648,7 @@ export const bulkUpdate = async (
     ];
     const templateFieldsByKey = new Map<string, InlineField[]>(
       await Promise.all(
-        closingCasesTemplates.map(async ({ id, version }) => {
+        casesNeedingTemplateFields.map(async ({ id, version }) => {
           const fields = await resolveTemplateFieldsForClose({
             templateId: id,
             templateVersion: version,
@@ -670,10 +672,27 @@ export const bulkUpdate = async (
       });
     }
 
+    const resolvedFieldsByCaseId = new Map<string, InlineField[]>(
+      casesToUpdate.map(({ updateReq, originalCase }) => {
+        const effectiveTemplate = getEffectiveTemplate(updateReq, originalCase);
+        const templateKey =
+          effectiveTemplate != null ? `${effectiveTemplate.id}@${effectiveTemplate.version}` : null;
+
+        return [
+          originalCase.id,
+          [
+            ...(globalFieldsByOwner.get(originalCase.attributes.owner) ?? []),
+            ...(templateKey != null ? templateFieldsByKey.get(templateKey) ?? [] : []),
+          ],
+        ];
+      })
+    );
+
     const patchCasesPayload = createPatchCasesPayload({
       user,
       casesToUpdate,
       customFieldsConfigurationMap,
+      resolvedFieldsByCaseId,
     });
     let userActionsDict = userActionService.creator.buildUserActions({
       updatedCases: patchCasesPayload,
@@ -876,10 +895,12 @@ const createPatchCasesPayload = ({
   casesToUpdate,
   user,
   customFieldsConfigurationMap,
+  resolvedFieldsByCaseId,
 }: {
   casesToUpdate: UpdateRequestWithOriginalCase[];
   user: User;
   customFieldsConfigurationMap: Map<string, CustomFieldsConfiguration>;
+  resolvedFieldsByCaseId: Map<string, InlineField[]>;
 }): PatchCasesArgs => {
   const updatedDt = new Date().toISOString();
 
@@ -904,21 +925,20 @@ const createPatchCasesPayload = ({
 
       // Merge incoming extended_fields on top of existing so that concurrent saves
       // from GlobalCaseFields and TemplateFields (two independent form instances)
-      // don't clobber each other's values.
-      //
-      // Intentional: ALL existing keys are preserved — including any template-specific
-      // keys that remain on the SO after a template is cleared. Orphaned keys are
-      // harmless: the UI only renders fields that have a matching definition, and
-      // validation rejects future writes of non-global keys without a template.
-      // Preserving them also allows values to survive a template re-application.
+      // don't clobber each other's values. Then strip keys for fields whose show_when
+      // condition currently evaluates to false so search does not match hidden fields.
       if (
         trimmedCaseAttributes.extended_fields &&
         typeof trimmedCaseAttributes.extended_fields === 'object'
       ) {
-        trimmedCaseAttributes.extended_fields = {
+        const mergedExtendedFields = {
           ...(originalCase.attributes.extended_fields ?? {}),
           ...trimmedCaseAttributes.extended_fields,
         };
+        trimmedCaseAttributes.extended_fields = stripHiddenExtendedFields(
+          mergedExtendedFields,
+          resolvedFieldsByCaseId.get(originalCase.id) ?? []
+        );
       }
 
       return {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
@@ -1009,5 +1009,50 @@ describe('create', () => {
         )
       ).rejects.toThrow('Template tmpl-ext has an invalid definition');
     });
+
+    it('strips hidden conditional extended_fields before persisting a new case', async () => {
+      clientArgs.services.templatesService.getTemplate.mockResolvedValue(
+        makeTemplateSO([
+          {
+            control: 'TOGGLE',
+            name: 'requires_escalation',
+            label: 'Requires escalation',
+            type: 'keyword',
+          },
+          {
+            control: 'INPUT_TEXT',
+            name: 'environment',
+            label: 'Environment',
+            type: 'keyword',
+            display: {
+              show_when: { field: 'requires_escalation', operator: 'eq', value: true },
+            },
+          },
+        ])
+      );
+
+      await create(
+        {
+          ...theCase,
+          template: { id: 'tmpl-ext', version: 1 },
+          extended_fields: {
+            requires_escalation_as_keyword: 'false',
+            environment_as_keyword: 'staging',
+          },
+        },
+        clientArgs,
+        casesClientMock
+      );
+
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            extended_fields: {
+              requires_escalation_as_keyword: 'false',
+            },
+          }),
+        })
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
@@ -24,6 +24,8 @@ import {
   validateCustomFields,
   resolveGlobalFields,
   validateCaseExtendedFields,
+  resolveTemplateFieldsForClose,
+  stripHiddenExtendedFields,
 } from './validators';
 import { emptyCaseAssigneesSanitizer } from './sanitizers';
 import { normalizeCreateCaseRequest } from './utils';
@@ -85,6 +87,20 @@ export const create = async (
         globalFields,
         templatesService,
       });
+
+      const templateFields = query.template
+        ? await resolveTemplateFieldsForClose({
+            templateId: query.template.id,
+            templateVersion: query.template.version,
+            templatesService,
+            logger,
+          })
+        : [];
+
+      query.extended_fields = stripHiddenExtendedFields(query.extended_fields, [
+        ...globalFields,
+        ...templateFields,
+      ]);
     }
 
     /**

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
@@ -24,7 +24,7 @@ import {
   validateCustomFields,
   resolveGlobalFields,
   validateCaseExtendedFields,
-  resolveTemplateFieldsForClose,
+  resolveTemplateFieldsForCase,
   stripHiddenExtendedFields,
 } from './validators';
 import { emptyCaseAssigneesSanitizer } from './sanitizers';
@@ -89,10 +89,11 @@ export const create = async (
       });
 
       const templateFields = query.template
-        ? await resolveTemplateFieldsForClose({
+        ? await resolveTemplateFieldsForCase({
             templateId: query.template.id,
             templateVersion: query.template.version,
             templatesService,
+            fieldDefinitionsService,
             logger,
           })
         : [];

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts
@@ -20,6 +20,7 @@ import {
   validateExtendedFieldsInRequest,
   validateExtendedFieldsOnClose,
   resolveTemplateFieldsForClose,
+  stripHiddenExtendedFields,
 } from './validators';
 import type { CaseSavedObjectTransformed } from '../../common/types/case';
 import type { TemplatesService } from '../../services/templates';
@@ -1281,6 +1282,134 @@ describe('validators', () => {
           globalFields: makeGlobalFields(),
         })
       ).not.toThrow();
+    });
+  });
+
+  describe('stripHiddenExtendedFields', () => {
+    const makeField = (
+      def: Partial<InlineField> & { name: string; control?: string }
+    ): InlineField =>
+      ({
+        control: def.control ?? 'INPUT_TEXT',
+        type: 'keyword',
+        label: def.name,
+        ...def,
+      } as unknown as InlineField);
+
+    it('removes keys for fields hidden by show_when', () => {
+      const allFields: InlineField[] = [
+        makeField({ name: 'requires_escalation', control: 'TOGGLE' }),
+        makeField({
+          name: 'environment',
+          display: {
+            show_when: { field: 'requires_escalation', operator: 'eq', value: true },
+          },
+        }),
+      ];
+
+      const result = stripHiddenExtendedFields(
+        {
+          requires_escalation_as_keyword: 'false',
+          environment_as_keyword: 'staging',
+          other_as_keyword: 'keep',
+        },
+        allFields
+      );
+
+      expect(result).toEqual({
+        requires_escalation_as_keyword: 'false',
+        other_as_keyword: 'keep',
+      });
+    });
+
+    it('keeps keys for fields visible by show_when', () => {
+      const allFields: InlineField[] = [
+        makeField({ name: 'requires_escalation', control: 'TOGGLE' }),
+        makeField({
+          name: 'environment',
+          display: {
+            show_when: { field: 'requires_escalation', operator: 'eq', value: true },
+          },
+        }),
+      ];
+
+      const result = stripHiddenExtendedFields(
+        {
+          requires_escalation_as_keyword: 'true',
+          environment_as_keyword: 'staging',
+        },
+        allFields
+      );
+
+      expect(result).toEqual({
+        requires_escalation_as_keyword: 'true',
+        environment_as_keyword: 'staging',
+      });
+    });
+
+    it('respects compound show_when conditions', () => {
+      const allFields: InlineField[] = [
+        makeField({ name: 'affected_components', control: 'CHECKBOX_GROUP' }),
+        makeField({
+          name: 'environment',
+          display: {
+            show_when: {
+              combine: 'all',
+              rules: [
+                { field: 'affected_components', operator: 'contains', value: 'api' },
+                { field: 'affected_components', operator: 'contains', value: 'ui' },
+              ],
+            },
+          },
+        }),
+      ];
+
+      const hidden = stripHiddenExtendedFields(
+        {
+          affected_components_as_keyword: '["api"]',
+          environment_as_keyword: 'staging',
+        },
+        allFields
+      );
+      expect(hidden).toEqual({ affected_components_as_keyword: '["api"]' });
+
+      const visible = stripHiddenExtendedFields(
+        {
+          affected_components_as_keyword: '["api","ui"]',
+          environment_as_keyword: 'staging',
+        },
+        allFields
+      );
+      expect(visible).toEqual({
+        affected_components_as_keyword: '["api","ui"]',
+        environment_as_keyword: 'staging',
+      });
+    });
+
+    it('evaluates CHECKBOX_GROUP contains in show_when', () => {
+      const allFields: InlineField[] = [
+        makeField({ name: 'affected_components', control: 'CHECKBOX_GROUP' }),
+        makeField({
+          name: 'environment',
+          display: {
+            show_when: {
+              field: 'affected_components',
+              operator: 'contains',
+              value: 'ui',
+            },
+          },
+        }),
+      ];
+
+      const result = stripHiddenExtendedFields(
+        {
+          affected_components_as_keyword: '["api"]',
+          environment_as_keyword: 'staging',
+        },
+        allFields
+      );
+
+      expect(result).toEqual({ affected_components_as_keyword: '["api"]' });
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts
@@ -19,11 +19,12 @@ import {
   validateSearchCasesCustomFields,
   validateExtendedFieldsInRequest,
   validateExtendedFieldsOnClose,
-  resolveTemplateFieldsForClose,
+  resolveTemplateFieldsForCase,
   stripHiddenExtendedFields,
 } from './validators';
 import type { CaseSavedObjectTransformed } from '../../common/types/case';
 import type { TemplatesService } from '../../services/templates';
+import type { FieldDefinitionsService } from '../../services/field_definitions';
 import type { InlineField } from '../../../common/types/domain/template/fields';
 
 describe('validators', () => {
@@ -1413,7 +1414,7 @@ describe('validators', () => {
     });
   });
 
-  describe('resolveTemplateFieldsForClose', () => {
+  describe('resolveTemplateFieldsForCase', () => {
     const makeTemplatesSO = (definition: object) => ({
       id: 'so-id',
       type: 'cases-templates',
@@ -1443,19 +1444,24 @@ describe('validators', () => {
       });
 
     let templatesService: jest.Mocked<Pick<TemplatesService, 'getTemplate'>>;
+    let fieldDefinitionsService: jest.Mocked<Pick<FieldDefinitionsService, 'getFieldDefinitions'>>;
     let logger: jest.Mocked<Logger>;
 
     beforeEach(() => {
       templatesService = {
         getTemplate: jest.fn().mockResolvedValue(templateWithRequiredOnClose()),
       };
+      fieldDefinitionsService = {
+        getFieldDefinitions: jest.fn().mockResolvedValue({ fieldDefinitions: [], total: 0 }),
+      };
       logger = loggingSystemMock.create().get() as jest.Mocked<Logger>;
     });
 
     it('returns parsed inline fields from a valid template SO', async () => {
-      const fields = await resolveTemplateFieldsForClose({
+      const fields = await resolveTemplateFieldsForCase({
         templateId: 'tpl-1',
         templatesService: templatesService as unknown as TemplatesService,
+        fieldDefinitionsService: fieldDefinitionsService as unknown as FieldDefinitionsService,
         logger,
       });
       expect(fields.length).toBeGreaterThan(0);
@@ -1464,10 +1470,11 @@ describe('validators', () => {
     });
 
     it('passes templateVersion as string to getTemplate when provided', async () => {
-      await resolveTemplateFieldsForClose({
+      await resolveTemplateFieldsForCase({
         templateId: 'tpl-1',
         templateVersion: 3,
         templatesService: templatesService as unknown as TemplatesService,
+        fieldDefinitionsService: fieldDefinitionsService as unknown as FieldDefinitionsService,
         logger,
       });
       expect(templatesService.getTemplate).toHaveBeenCalledWith('tpl-1', '3');
@@ -1475,9 +1482,10 @@ describe('validators', () => {
 
     it('returns [] when template is not found', async () => {
       templatesService.getTemplate.mockResolvedValue(undefined);
-      const fields = await resolveTemplateFieldsForClose({
+      const fields = await resolveTemplateFieldsForCase({
         templateId: 'tpl-missing',
         templatesService: templatesService as unknown as TemplatesService,
+        fieldDefinitionsService: fieldDefinitionsService as unknown as FieldDefinitionsService,
         logger,
       });
       expect(fields).toEqual([]);
@@ -1491,15 +1499,60 @@ describe('validators', () => {
         attributes: { ...invalidSO.attributes, definition: '{invalid yaml: [unclosed' },
       } as unknown as Awaited<ReturnType<TemplatesService['getTemplate']>>);
 
-      const fields = await resolveTemplateFieldsForClose({
+      const fields = await resolveTemplateFieldsForCase({
         templateId: 'tpl-1',
         templatesService: templatesService as unknown as TemplatesService,
+        fieldDefinitionsService: fieldDefinitionsService as unknown as FieldDefinitionsService,
         logger,
       });
       expect(fields).toEqual([]);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Failed to parse template "tpl-1"')
       );
+    });
+
+    it('resolves $ref fields from the field-definition library', async () => {
+      templatesService.getTemplate.mockResolvedValue(
+        makeTemplatesSO({
+          fields: [{ $ref: 'lib_environment' }],
+        })
+      );
+      fieldDefinitionsService.getFieldDefinitions.mockResolvedValue({
+        fieldDefinitions: [
+          {
+            fieldDefinitionId: 'fd-1',
+            name: 'lib_environment',
+            owner: 'securitySolution',
+            isGlobal: false,
+            definition: yamlStringify({
+              control: 'INPUT_TEXT',
+              name: 'environment',
+              label: 'Environment',
+              type: 'keyword',
+              display: {
+                show_when: { field: 'requires_escalation', operator: 'eq', value: true },
+              },
+            }),
+          },
+        ],
+        total: 1,
+      });
+
+      const fields = await resolveTemplateFieldsForCase({
+        templateId: 'tpl-1',
+        templatesService: templatesService as unknown as TemplatesService,
+        fieldDefinitionsService: fieldDefinitionsService as unknown as FieldDefinitionsService,
+        logger,
+      });
+
+      expect(fields).toHaveLength(1);
+      expect(fields[0].name).toBe('environment');
+      expect(fields[0].display?.show_when).toEqual({
+        field: 'requires_escalation',
+        operator: 'eq',
+        value: true,
+      });
+      expect(fieldDefinitionsService.getFieldDefinitions).toHaveBeenCalledWith('securitySolution');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/validators.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/validators.ts
@@ -24,9 +24,13 @@ import type { TemplatesService } from '../../services/templates';
 import type { FieldDefinitionsService } from '../../services/field_definitions';
 import { parseTemplate } from '../../routes/api/templates/parse_template';
 import { validateExtendedFields } from '../../../common/types/domain/template/validate_extended_fields';
-import { parseFieldDefinitionsToInlineFields, getFieldSnakeKey } from '../../../common/utils';
+import {
+  parseFieldDefinitionsToInlineFields,
+  getFieldSnakeKey,
+  resolveTemplateFields,
+} from '../../../common/utils';
 import type { InlineField } from '../../../common/types/domain/template/fields';
-import { isInlineField, FieldType } from '../../../common/types/domain/template/fields';
+import { FieldType } from '../../../common/types/domain/template/fields';
 import { evaluateCondition } from '../../../common/types/domain/template/evaluate_conditions';
 
 interface CustomFieldValidationParams {
@@ -302,23 +306,26 @@ export const validateExtendedFieldsInRequest = async ({
 };
 
 /**
- * Fetches and parses a template's inline fields for use in close-time validation.
+ * Fetches and resolves a template's fields (inline and `$ref` library entries) for server-side
+ * case operations: close validation, extended_fields stripping, etc.
  * Returns [] if the template is not found or its definition is unparseable.
  * Callers in bulk operations should pre-resolve templates by ID+version to avoid N SO fetches.
  *
- * Pass `templateVersion` to pin validation to the version the case was created with, preventing
- * a later template edit (adding a required_on_close field) from blocking closure of older cases.
+ * Pass `templateVersion` to pin resolution to the version the case was created with, preventing
+ * a later template edit (e.g. adding a required_on_close field) from affecting older cases.
  * When omitted, falls back to the latest version.
  */
-export const resolveTemplateFieldsForClose = async ({
+export const resolveTemplateFieldsForCase = async ({
   templateId,
   templateVersion,
   templatesService,
+  fieldDefinitionsService,
   logger,
 }: {
   templateId: string;
   templateVersion?: number;
   templatesService: TemplatesService;
+  fieldDefinitionsService: FieldDefinitionsService;
   logger: Logger;
 }): Promise<InlineField[]> => {
   const templateSO = await templatesService.getTemplate(
@@ -330,10 +337,13 @@ export const resolveTemplateFieldsForClose = async ({
   }
   try {
     const parsedTemplate = parseTemplate(templateSO.attributes);
-    return parsedTemplate.definition.fields.filter(isInlineField);
+    const { fieldDefinitions } = await fieldDefinitionsService.getFieldDefinitions(
+      templateSO.attributes.owner
+    );
+    return resolveTemplateFields(parsedTemplate.definition.fields ?? [], fieldDefinitions);
   } catch (err) {
     logger.warn(
-      `Failed to parse template "${templateId}" definition during close validation — skipping template field enforcement: ${err}`
+      `Failed to parse template "${templateId}" definition during template field resolution — skipping template field enforcement: ${err}`
     );
     return [];
   }
@@ -345,7 +355,7 @@ export const resolveTemplateFieldsForClose = async ({
  * Only checks fields with `required_on_close: true` — regular required fields are a write-time
  * concern and are not re-validated here. Orphaned keys from old templates are silently ignored.
  *
- * Template fields must be pre-resolved by the caller (via resolveTemplateFieldsForClose) so that
+ * Template fields must be pre-resolved by the caller (via resolveTemplateFieldsForCase) so that
  * bulk operations can deduplicate SO fetches across cases sharing the same template.
  *
  * NOTE: We intentionally do not delegate to the common validateExtendedFields({ onClose: true })

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/validators.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/validators.ts
@@ -419,6 +419,41 @@ export const validateExtendedFieldsOnClose = ({
   }
 };
 
+/**
+ * Removes extended_fields keys for fields whose show_when condition currently evaluates to false.
+ * Operates on the full merged extended_fields map so stale values for newly-hidden fields are
+ * stripped even when the update request only touched a controlling field.
+ */
+export const stripHiddenExtendedFields = (
+  extendedFields: Record<string, string>,
+  allFields: InlineField[]
+): Record<string, string> => {
+  const fieldValues: Record<string, string | undefined> = {};
+  const fieldTypeMap: Record<string, string> = {};
+  const fieldControlMap: Record<string, string> = {};
+  for (const field of allFields) {
+    fieldValues[field.name] = extendedFields[getFieldSnakeKey(field.name, field.type)];
+    fieldTypeMap[field.name] = field.type;
+    fieldControlMap[field.name] = field.control;
+  }
+
+  const hiddenKeys = new Set(
+    allFields
+      .filter(
+        (field) =>
+          field.display?.show_when != null &&
+          !evaluateCondition(field.display.show_when, fieldValues, fieldTypeMap, fieldControlMap)
+      )
+      .map((field) => getFieldSnakeKey(field.name, field.type))
+  );
+
+  if (hiddenKeys.size === 0) {
+    return extendedFields;
+  }
+
+  return Object.fromEntries(Object.entries(extendedFields).filter(([key]) => !hiddenKeys.has(key)));
+};
+
 export const validateSearchCasesCustomFields = ({
   customFieldsConfiguration,
   customFields,

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.test.ts
@@ -413,6 +413,43 @@ describe('UserActionPersister', () => {
         ).toEqual(getExtendedFieldsUserActions({ isMock: false, payload: { risk_score: 'high' } }));
       });
 
+      it('creates a user action when extended_fields keys are removed', () => {
+        const baseCase = patchUpdateExtendedFieldsCasesRequest.cases[0];
+        const removalRequest = {
+          cases: [
+            {
+              ...baseCase,
+              updatedAttributes: {
+                extended_fields: { risk_score: 'low', severity: 'medium' },
+              },
+              originalCase: {
+                ...baseCase.originalCase,
+                attributes: {
+                  ...baseCase.originalCase.attributes,
+                  extended_fields: {
+                    risk_score: 'low',
+                    severity: 'medium',
+                    environment: 'staging',
+                  },
+                },
+              },
+            },
+          ],
+        };
+
+        expect(
+          persister.buildUserActions({
+            updatedCases: removalRequest,
+            user: testUser,
+          })
+        ).toEqual(
+          getExtendedFieldsUserActions({
+            isMock: false,
+            payload: { environment: '' },
+          })
+        );
+      });
+
       it('creates no user action when extended_fields have not changed', () => {
         const noDiffRequest = {
           cases: [

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.ts
@@ -228,10 +228,18 @@ export class UserActionPersister {
     const { originalValue, newValue, caseId, owner, user } = params;
     // Only record the fields that actually changed, not the full merged object.
     const oldFields = isExtendedFields(originalValue) ? originalValue : {};
-    const changedFields = pickBy(
-      isExtendedFields(newValue) ? newValue : {},
+    const newFields = isExtendedFields(newValue) ? newValue : {};
+    const changedFields: Record<string, string> = pickBy(
+      newFields,
       (value, key) => oldFields[key] !== value
     );
+
+    // Keys removed from extended_fields (e.g. hidden conditional fields stripped on save).
+    for (const key of Object.keys(oldFields)) {
+      if (!(key in newFields)) {
+        changedFields[key] = '';
+      }
+    }
 
     if (Object.keys(changedFields).length === 0) {
       return [];


### PR DESCRIPTION
## What & Why
When a template field's `show_when` condition evaluates to false, its `extended_fields` value was previously left on the case saved object. This caused field-label search to incorrectly match cases where the field is actually hidden from the UI. This PR strips those hidden-field keys at write time, on both case create and bulk update, so search results reflect what's actually displayed.

## How to Test
1. Create a template with a conditional field (`show_when`) and a controlling field.
2. Create a case with the controlling field set so the conditional field is hidden, but still populate the conditional field's value in `extended_fields`.
3. Verify the conditional field's key is absent from the saved case's `extended_fields`.
4. Repeat via bulk update: update a case's controlling field so a previously-visible conditional field becomes hidden, and confirm its stale value is stripped from `extended_fields` on save.
5. Search cases by the conditional field's now-hidden value and confirm the case no longer matches.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)