### PR TITLE
[8.19] [ResponseOps][MW] Keep internal API limits off public alerting schemas

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -1360,7 +1360,6 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -1399,12 +1398,10 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },
@@ -2296,7 +2293,6 @@
                               "properties": {
                                 "dsl": {
                                   "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
-                                  "maxLength": 10000,
                                   "type": "string"
                                 },
                                 "filters": {
@@ -2335,12 +2331,10 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "kql": {
                                   "description": "A filter written in Kibana Query Language (KQL).",
-                                  "maxLength": 10000,
                                   "type": "string"
                                 }
                               },
@@ -2628,7 +2622,6 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -2667,12 +2660,10 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },
@@ -3563,7 +3554,6 @@
                               "properties": {
                                 "dsl": {
                                   "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
-                                  "maxLength": 10000,
                                   "type": "string"
                                 },
                                 "filters": {
@@ -3602,12 +3592,10 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "kql": {
                                   "description": "A filter written in Kibana Query Language (KQL).",
-                                  "maxLength": 10000,
                                   "type": "string"
                                 }
                               },
@@ -3879,7 +3867,6 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -3918,12 +3905,10 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },
@@ -5588,7 +5573,6 @@
                                 "properties": {
                                   "dsl": {
                                     "description": "A filter written in Elasticsearch Query Domain Specific Language (DSL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   },
                                   "filters": {
@@ -5627,12 +5611,10 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "kql": {
                                     "description": "A filter written in Kibana Query Language (KQL).",
-                                    "maxLength": 10000,
                                     "type": "string"
                                   }
                                 },

--- a/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/index.ts
@@ -5,5 +5,9 @@
  * 2.0.
  */
 
-export { alertsFilterQuerySchema } from './schemas/latest';
-export { alertsFilterQuerySchema as alertsFilterQuerySchemaV1 } from './schemas/v1';
+export { alertsFilterQuerySchema, getAlertsFilterQuerySchema } from './schemas/latest';
+export type { AlertsFilterQuerySchemaLimits } from './schemas/latest';
+export {
+  alertsFilterQuerySchema as alertsFilterQuerySchemaV1,
+  getAlertsFilterQuerySchema as getAlertsFilterQuerySchemaV1,
+} from './schemas/v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/schemas/latest.ts
@@ -5,4 +5,5 @@
  * 2.0.
  */
 
-export { alertsFilterQuerySchema } from './v1';
+export { alertsFilterQuerySchema, getAlertsFilterQuerySchema } from './v1';
+export type { AlertsFilterQuerySchemaLimits } from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/alerts_filter_query/schemas/v1.ts
@@ -8,63 +8,81 @@
 import { schema } from '@kbn/config-schema';
 import { FilterStateStore } from '@kbn/es-query';
 
-export const alertsFilterQuerySchema = schema.object({
-  kql: schema.string({
-    maxLength: 10000,
-    meta: { description: 'A filter written in Kibana Query Language (KQL).' },
-  }),
-  filters: schema.arrayOf(
-    schema.object({
-      query: schema.maybe(
-        schema.recordOf(
+export interface AlertsFilterQuerySchemaLimits {
+  /** Max length of the `kql` string. Omit for no limit. */
+  maxKqlLength?: number;
+  /** Max number of `filters`. Omit for no limit. */
+  maxFilters?: number;
+  /** Max length of the `dsl` string. Omit for no limit. */
+  maxDslLength?: number;
+}
+
+/**
+ * Builds the alerts filter query schema. Limits default to unbounded so the
+ * shared/public consumers (e.g. the alerting rule APIs) keep their existing
+ * contract. Internal consumers that need request bounds (e.g. the Maintenance
+ * Windows internal APIs) pass explicit limits.
+ */
+export const getAlertsFilterQuerySchema = (limits: AlertsFilterQuerySchemaLimits = {}) =>
+  schema.object({
+    kql: schema.string({
+      maxLength: limits.maxKqlLength,
+      meta: { description: 'A filter written in Kibana Query Language (KQL).' },
+    }),
+    filters: schema.arrayOf(
+      schema.object({
+        query: schema.maybe(
+          schema.recordOf(
+            schema.string(),
+            schema.any({
+              meta: {
+                description: 'A query for the filter.',
+              },
+            })
+          )
+        ),
+        meta: schema.recordOf(
           schema.string(),
           schema.any({
             meta: {
-              description: 'A query for the filter.',
+              description:
+                'An object with fields such as "controlledBy", "disabled", "field", "group", "index", "isMultiIndex", "key", "negate", "params",  "type", "value"',
             },
           })
-        )
-      ),
-      meta: schema.recordOf(
-        schema.string(),
-        schema.any({
-          meta: {
-            description:
-              'An object with fields such as "controlledBy", "disabled", "field", "group", "index", "isMultiIndex", "key", "negate", "params",  "type", "value"',
-          },
-        })
-      ),
-      $state: schema.maybe(
-        schema.object({
-          store: schema.oneOf(
-            [
-              schema.literal(FilterStateStore.APP_STATE),
-              schema.literal(FilterStateStore.GLOBAL_STATE),
-            ],
-            {
-              meta: {
-                description:
-                  'A filter can be either specific to an application context or applied globally.',
-              },
-            }
-          ),
-        })
-      ),
-    }),
-    {
-      maxSize: 100,
-      meta: {
-        description:
-          'A filter written in Elasticsearch Query Domain Specific Language (DSL) as defined in the `kbn-es-query` package.',
-      },
-    }
-  ),
-  dsl: schema.maybe(
-    schema.string({
-      maxLength: 10000,
-      meta: {
-        description: 'A filter written in Elasticsearch Query Domain Specific Language (DSL).',
-      },
-    })
-  ),
-});
+        ),
+        $state: schema.maybe(
+          schema.object({
+            store: schema.oneOf(
+              [
+                schema.literal(FilterStateStore.APP_STATE),
+                schema.literal(FilterStateStore.GLOBAL_STATE),
+              ],
+              {
+                meta: {
+                  description:
+                    'A filter can be either specific to an application context or applied globally.',
+                },
+              }
+            ),
+          })
+        ),
+      }),
+      {
+        maxSize: limits.maxFilters,
+        meta: {
+          description:
+            'A filter written in Elasticsearch Query Domain Specific Language (DSL) as defined in the `kbn-es-query` package.',
+        },
+      }
+    ),
+    dsl: schema.maybe(
+      schema.string({
+        maxLength: limits.maxDslLength,
+        meta: {
+          description: 'A filter written in Elasticsearch Query Domain Specific Language (DSL).',
+        },
+      })
+    ),
+  });
+
+export const alertsFilterQuerySchema = getAlertsFilterQuerySchema();

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/create/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/create/schemas/v1.ts
@@ -6,15 +6,17 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { maintenanceWindowCategoryIdsSchemaV1 } from '../../../../shared';
+import {
+  maintenanceWindowCategoryIdsSchemaV1,
+  maintenanceWindowRRuleRequestSchemaV1,
+  maintenanceWindowScopedQuerySchemaV1,
+} from '../../../../shared';
 import { TITLE_MAX_LENGTH } from '../../../../shared/constants/latest';
-import { rRuleRequestSchemaV1 } from '../../../../../r_rule';
-import { alertsFilterQuerySchemaV1 } from '../../../../../alerts_filter_query';
 
 export const createBodySchema = schema.object({
   title: schema.string({ maxLength: TITLE_MAX_LENGTH }),
   duration: schema.number(),
-  r_rule: rRuleRequestSchemaV1,
+  r_rule: maintenanceWindowRRuleRequestSchemaV1,
   category_ids: maintenanceWindowCategoryIdsSchemaV1,
-  scoped_query: schema.maybe(schema.nullable(alertsFilterQuerySchemaV1)),
+  scoped_query: schema.maybe(schema.nullable(maintenanceWindowScopedQuerySchemaV1)),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/update/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/internal/apis/update/schemas/v1.ts
@@ -6,10 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { maintenanceWindowCategoryIdsSchemaV1 } from '../../../../shared';
+import {
+  maintenanceWindowCategoryIdsSchemaV1,
+  maintenanceWindowRRuleRequestSchemaV1,
+  maintenanceWindowScopedQuerySchemaV1,
+} from '../../../../shared';
 import { ID_MAX_LENGTH, TITLE_MAX_LENGTH } from '../../../../shared/constants/latest';
-import { rRuleRequestSchemaV1 } from '../../../../../r_rule';
-import { alertsFilterQuerySchemaV1 } from '../../../../../alerts_filter_query';
 
 export const updateParamsSchema = schema.object({
   id: schema.string({ maxLength: ID_MAX_LENGTH }),
@@ -19,7 +21,7 @@ export const updateBodySchema = schema.object({
   title: schema.maybe(schema.string({ maxLength: TITLE_MAX_LENGTH })),
   enabled: schema.maybe(schema.boolean()),
   duration: schema.maybe(schema.number()),
-  r_rule: schema.maybe(rRuleRequestSchemaV1),
+  r_rule: schema.maybe(maintenanceWindowRRuleRequestSchemaV1),
   category_ids: maintenanceWindowCategoryIdsSchemaV1,
-  scoped_query: schema.maybe(schema.nullable(alertsFilterQuerySchemaV1)),
+  scoped_query: schema.maybe(schema.nullable(maintenanceWindowScopedQuerySchemaV1)),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/index.ts
@@ -7,10 +7,18 @@
 
 export { maintenanceWindowCategoryIdTypes } from './constants/latest';
 export type { MaintenanceWindowCategoryIdTypes } from './constants/latest';
-export { maintenanceWindowCategoryIdsSchema } from './schemas/latest';
+export {
+  maintenanceWindowCategoryIdsSchema,
+  maintenanceWindowScopedQuerySchema,
+  maintenanceWindowRRuleRequestSchema,
+} from './schemas/latest';
 export type { MaintenanceWindowCategoryIds } from './types/latest';
 
 export { maintenanceWindowCategoryIdTypes as maintenanceWindowCategoryIdTypesV1 } from './constants/v1';
 export type { MaintenanceWindowCategoryIdTypes as MaintenanceWindowCategoryIdTypesV1 } from './constants/v1';
-export { maintenanceWindowCategoryIdsSchema as maintenanceWindowCategoryIdsSchemaV1 } from './schemas/v1';
+export {
+  maintenanceWindowCategoryIdsSchema as maintenanceWindowCategoryIdsSchemaV1,
+  maintenanceWindowScopedQuerySchema as maintenanceWindowScopedQuerySchemaV1,
+  maintenanceWindowRRuleRequestSchema as maintenanceWindowRRuleRequestSchemaV1,
+} from './schemas/v1';
 export type { MaintenanceWindowCategoryIds as MaintenanceWindowCategoryIdsV1 } from './types/v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/schemas/latest.ts
@@ -5,4 +5,8 @@
  * 2.0.
  */
 
-export { maintenanceWindowCategoryIdsSchema } from './v1';
+export {
+  maintenanceWindowCategoryIdsSchema,
+  maintenanceWindowScopedQuerySchema,
+  maintenanceWindowRRuleRequestSchema,
+} from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/shared/schemas/v1.ts
@@ -10,6 +10,30 @@ import {
   CATEGORY_IDS_MAX_SIZE,
   maintenanceWindowCategoryIdTypes as maintenanceWindowCategoryIdTypesV1,
 } from '../constants/v1';
+import { getAlertsFilterQuerySchemaV1 } from '../../../alerts_filter_query';
+import { getRRuleRequestSchemaV1 } from '../../../r_rule';
+
+/**
+ * Request bounds applied only to the Maintenance Windows internal APIs. These
+ * live here (not on the shared `alertsFilterQuerySchema` / `rRuleRequestSchema`)
+ * so the public alerting rule APIs, which reuse those shared schemas, keep their
+ * previous unbounded contract.
+ */
+export const maintenanceWindowScopedQuerySchema = getAlertsFilterQuerySchemaV1({
+  maxKqlLength: 10000,
+  maxFilters: 100,
+  maxDslLength: 10000,
+});
+
+export const maintenanceWindowRRuleRequestSchema = getRRuleRequestSchemaV1({
+  maxDtstartLength: 100,
+  maxTzidLength: 64,
+  maxUntilLength: 100,
+  maxByweekdayLength: 10,
+  maxByweekday: 50,
+  maxBymonthday: 31,
+  maxBymonth: 12,
+});
 
 export const maintenanceWindowCategoryIdsSchema = schema.maybe(
   schema.nullable(

--- a/x-pack/platform/plugins/shared/alerting/common/routes/r_rule/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/r_rule/index.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-export { rRuleRequestSchema } from './request/schemas/latest';
+export { rRuleRequestSchema, getRRuleRequestSchema } from './request/schemas/latest';
+export type { RRuleRequestSchemaLimits } from './request/schemas/latest';
 export { rRuleResponseSchema } from './response/schemas/latest';
 export type { RRuleRequest } from './request/types/latest';
 export type { RRuleResponse } from './response/types/latest';
 
-export { rRuleRequestSchema as rRuleRequestSchemaV1 } from './request/schemas/v1';
+export {
+  rRuleRequestSchema as rRuleRequestSchemaV1,
+  getRRuleRequestSchema as getRRuleRequestSchemaV1,
+} from './request/schemas/v1';
 export { rRuleResponseSchema as rRuleResponseSchemaV1 } from './response/schemas/v1';
 export type { RRuleRequest as RRuleRequestV1 } from './request/types/v1';
 export type { RRuleResponse as RRuleResponseV1 } from './response/types/v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/r_rule/request/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/r_rule/request/schemas/v1.ts
@@ -13,44 +13,75 @@ import {
   validateRecurrenceByWeekdayV1,
 } from '../../validation';
 
-export const rRuleRequestSchema = schema.object({
-  dtstart: schema.string({ validate: validateStartDateV1, maxLength: 100 }),
-  tzid: schema.string({ validate: validateTimezone, maxLength: 64 }),
-  freq: schema.maybe(
-    schema.oneOf([schema.literal(0), schema.literal(1), schema.literal(2), schema.literal(3)])
-  ),
-  interval: schema.maybe(
-    schema.number({
-      validate: (interval: number) => {
-        if (!Number.isInteger(interval)) {
-          return 'rRule interval must be an integer greater than 0';
-        }
-      },
-      min: 1,
-    })
-  ),
-  until: schema.maybe(schema.string({ validate: validateEndDateV1, maxLength: 100 })),
-  count: schema.maybe(
-    schema.number({
-      validate: (count: number) => {
-        if (!Number.isInteger(count)) {
-          return 'rRule count must be an integer greater than 0';
-        }
-      },
-      min: 1,
-    })
-  ),
-  byweekday: schema.maybe(
-    schema.arrayOf(schema.string({ maxLength: 10 }), {
-      minSize: 1,
-      maxSize: 50,
-      validate: validateRecurrenceByWeekdayV1,
-    })
-  ),
-  bymonthday: schema.maybe(
-    schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1, maxSize: 31 })
-  ),
-  bymonth: schema.maybe(
-    schema.arrayOf(schema.number({ min: 1, max: 12 }), { minSize: 1, maxSize: 12 })
-  ),
-});
+export interface RRuleRequestSchemaLimits {
+  /** Max length of the `dtstart` string. Omit for no limit. */
+  maxDtstartLength?: number;
+  /** Max length of the `tzid` string. Omit for no limit. */
+  maxTzidLength?: number;
+  /** Max length of the `until` string. Omit for no limit. */
+  maxUntilLength?: number;
+  /** Max length of each `byweekday` element. Omit for no limit. */
+  maxByweekdayLength?: number;
+  /** Max number of `byweekday` entries. Omit for no limit. */
+  maxByweekday?: number;
+  /** Max number of `bymonthday` entries. Omit for no limit. */
+  maxBymonthday?: number;
+  /** Max number of `bymonth` entries. Omit for no limit. */
+  maxBymonth?: number;
+}
+
+/**
+ * Builds the r_rule request schema. Limits default to unbounded so the
+ * shared/public consumers (e.g. the alerting rule APIs and snooze schedules)
+ * keep their existing contract. Internal consumers that need request bounds
+ * (e.g. the Maintenance Windows internal APIs) pass explicit limits.
+ */
+export const getRRuleRequestSchema = (limits: RRuleRequestSchemaLimits = {}) =>
+  schema.object({
+    dtstart: schema.string({ validate: validateStartDateV1, maxLength: limits.maxDtstartLength }),
+    tzid: schema.string({ validate: validateTimezone, maxLength: limits.maxTzidLength }),
+    freq: schema.maybe(
+      schema.oneOf([schema.literal(0), schema.literal(1), schema.literal(2), schema.literal(3)])
+    ),
+    interval: schema.maybe(
+      schema.number({
+        validate: (interval: number) => {
+          if (!Number.isInteger(interval)) {
+            return 'rRule interval must be an integer greater than 0';
+          }
+        },
+        min: 1,
+      })
+    ),
+    until: schema.maybe(
+      schema.string({ validate: validateEndDateV1, maxLength: limits.maxUntilLength })
+    ),
+    count: schema.maybe(
+      schema.number({
+        validate: (count: number) => {
+          if (!Number.isInteger(count)) {
+            return 'rRule count must be an integer greater than 0';
+          }
+        },
+        min: 1,
+      })
+    ),
+    byweekday: schema.maybe(
+      schema.arrayOf(schema.string({ maxLength: limits.maxByweekdayLength }), {
+        minSize: 1,
+        maxSize: limits.maxByweekday,
+        validate: validateRecurrenceByWeekdayV1,
+      })
+    ),
+    bymonthday: schema.maybe(
+      schema.arrayOf(schema.number({ min: 1, max: 31 }), {
+        minSize: 1,
+        maxSize: limits.maxBymonthday,
+      })
+    ),
+    bymonth: schema.maybe(
+      schema.arrayOf(schema.number({ min: 1, max: 12 }), { minSize: 1, maxSize: limits.maxBymonth })
+    ),
+  });
+
+export const rRuleRequestSchema = getRRuleRequestSchema();


### PR DESCRIPTION
## Summary

Follow-up fix for the 8.19 backport #278355 (of #272671, "Add limits to all of the MWs internal APIs").

That backport added request limits **directly to the shared** `alertsFilterQuerySchema` and `rRuleRequestSchema`. On 8.19 those schemas are also consumed by the **public** alerting rule APIs (`/api/alerting/rule/{id}`, `/api/alerting/rules/_find`, snooze schedules), so the new `maxLength`/`maxItems` bounds leaked into the public API contract. This surfaced as a failing **Check OAS Snapshot** step on the merge build ([failed build](https://buildkite.com/elastic/kibana-pull-request/builds/469190)).

On `main` this never happened: Maintenance Windows was extracted into its own plugin (`x-pack/platform/plugins/shared/maintenance_windows`, in #242145) with its own schema copies, and #272671 added the bounds to those **plugin-owned copies** — never to the shared `alerting` schemas. 8.19 predates that split and still reuses the shared schemas from the `alerting` plugin, so the backport had to be adapted and inadvertently widened the scope to public.

## What this does

Requirements: **no public API contract change**, but **all MW internal APIs keep their limits**.

- `alertsFilterQuerySchema` and `rRuleRequestSchema` become factories (`getAlertsFilterQuerySchema` / `getRRuleRequestSchema`) whose limits default to **unbounded**. The plain exports call them with no args, so the public contract is byte-identical to before (config-schema drops both the validation and the OAS `x-oas-*` meta when a limit is `undefined`).
- MW `create`/`update` consume new MW-owned `maintenanceWindowScopedQuerySchema` and `maintenanceWindowRRuleRequestSchema`, which pass the same limit values `main` uses in its MW-plugin copies.
- Regenerated `oas_docs/bundle.json`: **18 limit lines removed, 0 added**; the `maxLength`/`maxItems` are gone from the public alerting rule paths. MW internal (`/internal/...`) routes are not in the public OAS, so their limits are unchanged.

## Exact values (parity with #272671)

The MW-owned bounded schemas use the **exact values #272671 shipped** in main's plugin copies. No values were changed.

**`alerts_filter_query` → `maintenanceWindowScopedQuerySchema`**

| Field | #272671 (main) | This PR (8.19) |
|---|---|---|
| `kql` maxLength | 10000 | 10000 |
| `filters` maxSize | 100 | 100 |
| `dsl` maxLength | 10000 | 10000 |

**`r_rule` → `maintenanceWindowRRuleRequestSchema`**

| Field | #272671 (main) | This PR (8.19) |
|---|---|---|
| `dtstart` maxLength | 100 | 100 |
| `tzid` maxLength | 64 | 64 |
| `until` maxLength | 100 | 100 |
| `byweekday` element maxLength | 10 | 10 |
| `byweekday` array maxSize | 50 | 50 |
| `bymonthday` array maxSize | 31 | 31 |
| `bymonth` array maxSize | 12 | 12 |

**No other field has been touched.** Only the fields #272671 bounded are parameterized. Pre-existing bounds that were already on these schemas before #272671 — `interval`/`count` `min: 1`, the `bymonthday` number `min:1/max:31`, the `bymonth` number `min:1/max:12`, and `minSize: 1` on the arrays — are kept unconditional and continue to apply to both public and internal consumers exactly as before.

> Note: `interval`/`count` intentionally have **no** `max` (only `min: 1`), matching main — despite the #272671 description table mentioning `max: 1000`, which was never actually shipped.

## Verification

- All 8 MW internal APIs retain their limits (create, update, find, bulk_get, get, delete, finish, archive).
- Public alerting rule paths confirmed unbounded in the regenerated bundle.
- Type check clean for the changed files; eslint clean.

## Release note

`release_note:skip`
