### PR TITLE
[9.5] OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -109698,8 +109698,6 @@ components:
             - id
             - text
     Observability_AI_Assistant_API_Message:
-      name: Message
-      type: object
       properties:
         '@timestamp':
           description: The timestamp when the message was created.
@@ -109729,6 +109727,8 @@ components:
       required:
         - '@timestamp'
         - message
+      title: Message
+      type: object
     Observability_AI_Assistant_API_MessageRoleEnum:
       description: The role of the message sender.
       enum:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -122505,8 +122505,6 @@ components:
             - id
             - text
     Observability_AI_Assistant_API_Message:
-      name: Message
-      type: object
       properties:
         '@timestamp':
           description: The timestamp when the message was created.
@@ -122536,6 +122534,8 @@ components:
       required:
         - '@timestamp'
         - message
+      title: Message
+      type: object
     Observability_AI_Assistant_API_MessageRoleEnum:
       description: The role of the message sender.
       enum:

--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 17,
-  "./oas_docs/output/kibana.serverless.yaml": 14
+  "./oas_docs/output/kibana.yaml": 16,
+  "./oas_docs/output/kibana.serverless.yaml": 13
 }

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/docs/openapi/observability_ai_assistant_app_apis.yaml
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/docs/openapi/observability_ai_assistant_app_apis.yaml
@@ -124,7 +124,7 @@ components:
   schemas:
     Message:
       type: object
-      name: Message
+      title: Message
       properties:
         '@timestamp':
           type: string


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)](https://github.com/elastic/kibana/pull/277441)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Calanog","email":"jan.calanog@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T19:43:13Z","message":"OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)\n\n## What\nRenames an invalid `name` key to `title` in the `Message` component\nschema in the Observability AI Assistant OpenAPI spec, and regenerates\nthe two bundled outputs (`kibana.yaml`, `kibana.serverless.yaml`) that\ninclude it.\n\n## Why\n`elastic/docs-actions/openapi/lint` now enforces `oas3-schema` at error\nseverity. OpenAPI 3.x Schema Objects have no `name` field (it's only\nvalid on Parameter/Tag objects), so this pre-existing key fails the\ncheck on any PR that touches the bundled spec — e.g.\nhttps://github.com/elastic/kibana/actions/runs/29087706085/job/86345287857.\n\n`title` is the correct Schema Object keyword for a human-readable\ndisplay name, so this renames the key rather than dropping it,\npreserving the original intent.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e472eb2d016c7b04cdeb450cc59440a4ccc51461","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","backport:version","v9.5.0","v9.6.0","v8.19.19"],"title":"OpenAPI: Rename invalid name key to title in AI Assistant schema","number":277441,"url":"https://github.com/elastic/kibana/pull/277441","mergeCommit":{"message":"OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)\n\n## What\nRenames an invalid `name` key to `title` in the `Message` component\nschema in the Observability AI Assistant OpenAPI spec, and regenerates\nthe two bundled outputs (`kibana.yaml`, `kibana.serverless.yaml`) that\ninclude it.\n\n## Why\n`elastic/docs-actions/openapi/lint` now enforces `oas3-schema` at error\nseverity. OpenAPI 3.x Schema Objects have no `name` field (it's only\nvalid on Parameter/Tag objects), so this pre-existing key fails the\ncheck on any PR that touches the bundled spec — e.g.\nhttps://github.com/elastic/kibana/actions/runs/29087706085/job/86345287857.\n\n`title` is the correct Schema Object keyword for a human-readable\ndisplay name, so this renames the key rather than dropping it,\npreserving the original intent.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e472eb2d016c7b04cdeb450cc59440a4ccc51461"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","8.19"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277441","number":277441,"mergeCommit":{"message":"OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)\n\n## What\nRenames an invalid `name` key to `title` in the `Message` component\nschema in the Observability AI Assistant OpenAPI spec, and regenerates\nthe two bundled outputs (`kibana.yaml`, `kibana.serverless.yaml`) that\ninclude it.\n\n## Why\n`elastic/docs-actions/openapi/lint` now enforces `oas3-schema` at error\nseverity. OpenAPI 3.x Schema Objects have no `name` field (it's only\nvalid on Parameter/Tag objects), so this pre-existing key fails the\ncheck on any PR that touches the bundled spec — e.g.\nhttps://github.com/elastic/kibana/actions/runs/29087706085/job/86345287857.\n\n`title` is the correct Schema Object keyword for a human-readable\ndisplay name, so this renames the key rather than dropping it,\npreserving the original intent.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e472eb2d016c7b04cdeb450cc59440a4ccc51461"}},{"branch":"8.19","label":"v8.19.19","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->