### PR TITLE
[8.19] OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -58030,8 +58030,6 @@ components:
             - id
             - text
     Observability_AI_Assistant_API_Message:
-      name: Message
-      type: object
       properties:
         '@timestamp':
           description: The timestamp when the message was created.
@@ -58061,6 +58059,8 @@ components:
       required:
         - '@timestamp'
         - message
+      title: Message
+      type: object
     Observability_AI_Assistant_API_MessageRoleEnum:
       description: The role of the message sender.
       enum:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -42916,6 +42916,95 @@ components:
           $ref: '#/components/schemas/Machine_learning_APIs_mlSyncResponseSuccess'
       title: Sync API response for trained models
       type: object
+    Observability_AI_Assistant_API_Function:
+      type: object
+      properties:
+        description:
+          description: The description of the function.
+          type: string
+        name:
+          description: The name of the function.
+          type: string
+        parameters:
+          description: The parameters of the function.
+          type: object
+    Observability_AI_Assistant_API_FunctionCall:
+      description: Details of the function call within the message.
+      type: object
+      properties:
+        arguments:
+          description: The arguments for the function call.
+          type: string
+        name:
+          description: The name of the function.
+          type: string
+        trigger:
+          description: The trigger of the function call.
+          enum:
+            - assistant
+            - user
+            - elastic
+          type: string
+      required:
+        - name
+        - trigger
+    Observability_AI_Assistant_API_Instruction:
+      oneOf:
+        - description: A simple instruction represented as a string.
+          type: string
+        - description: A detailed instruction with an ID and text.
+          type: object
+          properties:
+            id:
+              description: A unique identifier for the instruction.
+              type: string
+            text:
+              description: The text of the instruction.
+              type: string
+          required:
+            - id
+            - text
+    Observability_AI_Assistant_API_Message:
+      properties:
+        '@timestamp':
+          description: The timestamp when the message was created.
+          type: string
+        message:
+          description: The main content of the message.
+          type: object
+          properties:
+            content:
+              description: The content of the message.
+              type: string
+            data:
+              description: Additional data associated with the message.
+              type: string
+            event:
+              description: The event related to the message.
+              type: string
+            function_call:
+              $ref: '#/components/schemas/Observability_AI_Assistant_API_FunctionCall'
+            name:
+              description: The name associated with the message.
+              type: string
+            role:
+              $ref: '#/components/schemas/Observability_AI_Assistant_API_MessageRoleEnum'
+          required:
+            - role
+      required:
+        - '@timestamp'
+        - message
+      title: Message
+      type: object
+    Observability_AI_Assistant_API_MessageRoleEnum:
+      description: The role of the message sender.
+      enum:
+        - system
+        - assistant
+        - function
+        - user
+        - elastic
+      type: string
     Saved_objects_400_response:
       title: Bad request
       type: object

--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,0 +1,4 @@
+{
+  "./oas_docs/output/kibana.yaml": 16,
+  "./oas_docs/output/kibana.serverless.yaml": 13
+}

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/docs/openapi/observability_ai_assistant_app_apis.yaml
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/docs/openapi/observability_ai_assistant_app_apis.yaml
@@ -1,0 +1,253 @@
+openapi: 3.0.3
+info:
+  title: Observability AI Assistant API
+  description: Kibana API for the Observability AI Assistant
+  version: '1.0.1'
+  license:
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+tags:
+  - name: observability_ai_assistant
+    x-displayName: Observability AI Assistant
+    externalDocs:
+      url: https://www.elastic.co/docs/solutions/observability/observability-ai-assistant
+      description: Observability AI Assistant
+    description: Interact with the Observability AI Assistant resources.
+servers:
+  - url: /
+paths:
+  /api/observability_ai_assistant/chat/complete:
+    post:
+      summary: Generate a chat completion
+      operationId: observability-ai-assistant-chat-complete
+      description: |
+        Create a new chat completion by using the Observability AI Assistant.
+
+        The API returns the model's response based on the current conversation context.
+
+        It also handles any tool requests within the conversation, which may trigger multiple calls to the underlying large language model (LLM).
+
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      x-state: Technical Preview
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl --request POST 'localhost:5601/api/observability_ai_assistant/chat/complete' -u <username>:<password> -H 'kbn-xsrf: true' -H "Content-Type: application/json" --data '
+            {
+            "connectorId": "<connectorId>",
+            "disableFunctions": false,
+              "messages": [
+                {
+                  "@timestamp": "2025-06-25T23:45:00.000Z",
+                  "message": {
+                    "role": "user",
+                    "content": "Is my Elasticsearch cluster healthy right now?"
+                  }
+                }
+              ],
+            "persist": false,
+            "actions": [
+              {
+                "name": "get_cluster_health",
+                "description": "Fetch the current Elasticsearch cluster-health status and key metrics.",
+                "parameters": {
+                  "type": "object",
+                  "properties": {
+                    "includeShardStats": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
+                }
+              }
+            ],
+            "instructions": ["When the user asks about Elasticsearch cluster health, use the get_cluster_health tool to retrieve cluster health, then summarize the response in plain English."]
+            }'
+      tags:
+        - observability_ai_assistant
+      security:
+        - authz: ['ai_assistant']
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                messages:
+                  type: array
+                  description: An array of message objects containing the conversation history.
+                  items:
+                    $ref: '#/components/schemas/Message'
+                connectorId:
+                  type: string
+                  description: A unique identifier for the connector.
+                conversationId:
+                  type: string
+                  description: A unique identifier for the conversation if you are continuing an existing conversation.
+                title:
+                  type: string
+                  description: A title for the conversation.
+                persist:
+                  type: boolean
+                  description: Indicates whether the conversation should be saved to storage. If true, the conversation will be saved and will be available in Kibana.
+                actions:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Function'
+                disableFunctions:
+                  type: boolean
+                  description: Flag indicating whether all function calls should be disabled for the conversation. If true, no calls to functions will be made.
+                instructions:
+                  type: array
+                  description: An array of instruction objects, which can be either simple strings or detailed objects.
+                  items:
+                    $ref: '#/components/schemas/Instruction'
+              required:
+                - messages
+                - connectorId
+                - persist
+            examples:
+              chatCompleteRequestExample:
+                $ref: '#/components/examples/ChatCompleteRequestExample'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                chatCompleteResponseExample:
+                  $ref: '#/components/examples/ChatCompleteResponseExample'
+
+components:
+  schemas:
+    Message:
+      type: object
+      title: Message
+      properties:
+        '@timestamp':
+          type: string
+          description: The timestamp when the message was created.
+        message:
+          type: object
+          description: The main content of the message.
+          properties:
+            role:
+              $ref: '#/components/schemas/MessageRoleEnum'
+            content:
+              type: string
+              description: The content of the message.
+            name:
+              type: string
+              description: The name associated with the message.
+            event:
+              type: string
+              description: The event related to the message.
+            data:
+              type: string
+              description: Additional data associated with the message.
+            function_call:
+              $ref: '#/components/schemas/FunctionCall'
+          required:
+            - role
+      required:
+        - '@timestamp'
+        - message
+    MessageRoleEnum:
+      description: The role of the message sender.
+      type: string
+      enum:
+        - system
+        - assistant
+        - function
+        - user
+        - elastic
+    FunctionCall:
+      type: object
+      description: Details of the function call within the message.
+      properties:
+        name:
+          type: string
+          description: The name of the function.
+        trigger:
+          type: string
+          enum:
+            - assistant
+            - user
+            - elastic
+          description: The trigger of the function call.
+        arguments:
+          type: string
+          description: The arguments for the function call.
+      required:
+        - name
+        - trigger
+    Function:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the function.
+        description:
+          type: string
+          description: The description of the function.
+        parameters:
+          type: object
+          description: The parameters of the function.
+    Instruction:
+      oneOf:
+        - type: string
+          description: A simple instruction represented as a string.
+        - type: object
+          description: A detailed instruction with an ID and text.
+          properties:
+            id:
+              type: string
+              description: A unique identifier for the instruction.
+            text:
+              type: string
+              description: The text of the instruction.
+          required:
+            - id
+            - text
+  examples:
+    ChatCompleteResponseExample:
+      summary: Get a chat completion from the Observability AI Assistant
+      value: |
+        data: {"model":"unknown","choices":[{"delta":{"content":"","function_call":{"name":"get_cluster_health","arguments":"{\"includeShardStats\":true}"}},"finish_reason":null,"index":0}],"created":1750936626911,"id":"9c8eff9b-4fd4-4203-a4ab-2e364688deff","object":"chat.completion.chunk"}
+
+        data: [DONE]
+    ChatCompleteRequestExample:
+      summary: Example of completing a chat interaction
+      value: |
+        {
+          "connectorId": "<connectorId>",
+          "disableFunctions": false,
+          "messages": [
+            {
+              "@timestamp": "2025-06-25T23:45:00.000Z",
+              "message": {
+                "role": "user",
+                "content": "Is my Elasticsearch cluster healthy right now?"
+              }
+            }
+          ],
+          "persist": false,
+          "actions": [
+            {
+              "name": "get_cluster_health",
+              "description": "Fetch the current Elasticsearch cluster-health status and key metrics.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "includeShardStats": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          ],
+          "instructions": ["When the user asks about Elasticsearch cluster health, use the get_cluster_health tool to retrieve cluster health, then summarize the response in plain English."]
+        }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)](https://github.com/elastic/kibana/pull/277441)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Calanog","email":"jan.calanog@elastic.co"},"sourceCommit":{"committedDate":"2026-07-13T19:43:13Z","message":"OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)\n\n## What\nRenames an invalid `name` key to `title` in the `Message` component\nschema in the Observability AI Assistant OpenAPI spec, and regenerates\nthe two bundled outputs (`kibana.yaml`, `kibana.serverless.yaml`) that\ninclude it.\n\n## Why\n`elastic/docs-actions/openapi/lint` now enforces `oas3-schema` at error\nseverity. OpenAPI 3.x Schema Objects have no `name` field (it's only\nvalid on Parameter/Tag objects), so this pre-existing key fails the\ncheck on any PR that touches the bundled spec — e.g.\nhttps://github.com/elastic/kibana/actions/runs/29087706085/job/86345287857.\n\n`title` is the correct Schema Object keyword for a human-readable\ndisplay name, so this renames the key rather than dropping it,\npreserving the original intent.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e472eb2d016c7b04cdeb450cc59440a4ccc51461","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","backport:version","v9.5.0","v9.6.0","v8.19.19"],"title":"OpenAPI: Rename invalid name key to title in AI Assistant schema","number":277441,"url":"https://github.com/elastic/kibana/pull/277441","mergeCommit":{"message":"OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)\n\n## What\nRenames an invalid `name` key to `title` in the `Message` component\nschema in the Observability AI Assistant OpenAPI spec, and regenerates\nthe two bundled outputs (`kibana.yaml`, `kibana.serverless.yaml`) that\ninclude it.\n\n## Why\n`elastic/docs-actions/openapi/lint` now enforces `oas3-schema` at error\nseverity. OpenAPI 3.x Schema Objects have no `name` field (it's only\nvalid on Parameter/Tag objects), so this pre-existing key fails the\ncheck on any PR that touches the bundled spec — e.g.\nhttps://github.com/elastic/kibana/actions/runs/29087706085/job/86345287857.\n\n`title` is the correct Schema Object keyword for a human-readable\ndisplay name, so this renames the key rather than dropping it,\npreserving the original intent.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e472eb2d016c7b04cdeb450cc59440a4ccc51461"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","8.19"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277441","number":277441,"mergeCommit":{"message":"OpenAPI: Rename invalid name key to title in AI Assistant schema (#277441)\n\n## What\nRenames an invalid `name` key to `title` in the `Message` component\nschema in the Observability AI Assistant OpenAPI spec, and regenerates\nthe two bundled outputs (`kibana.yaml`, `kibana.serverless.yaml`) that\ninclude it.\n\n## Why\n`elastic/docs-actions/openapi/lint` now enforces `oas3-schema` at error\nseverity. OpenAPI 3.x Schema Objects have no `name` field (it's only\nvalid on Parameter/Tag objects), so this pre-existing key fails the\ncheck on any PR that touches the bundled spec — e.g.\nhttps://github.com/elastic/kibana/actions/runs/29087706085/job/86345287857.\n\n`title` is the correct Schema Object keyword for a human-readable\ndisplay name, so this renames the key rather than dropping it,\npreserving the original intent.\n\n---------\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e472eb2d016c7b04cdeb450cc59440a4ccc51461"}},{"branch":"8.19","label":"v8.19.19","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->