### PR TITLE
[Spike] Use SET instead of KQL to solve Discover data stream mix issue

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace_context_log_events/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace_context_log_events/index.tsx
@@ -59,6 +59,7 @@ export function TraceContextLogEvents({
   const { discoverUrl, esqlQueryString } = useDiscoverLinkAndEsqlQuery({
     indexPattern: indexes.logs,
     whereClause: createTraceContextWhereClause({ traceId, spanId, transactionId }),
+    unmappedFieldsPolicy: 'NULLIFY',
   });
 
   const openInDiscoverSectionAction = useOpenInDiscoverSectionAction({

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/index.ts
@@ -28,7 +28,7 @@ export function useDiscoverLinkAndEsqlQuery({
   }
 
   const settingsPrefix = unmappedFieldsPolicy
-    ? `SET unmapped_fields = "${unmappedFieldsPolicy}"\n`
+    ? `SET unmapped_fields = "${unmappedFieldsPolicy}";\n`
     : '';
   const esqlQueryString = `${settingsPrefix}${from(indexPattern).pipe(whereClause).toString()}`;
   const discoverUrl = generateDiscoverLink(whereClause);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/index.ts
@@ -13,19 +13,24 @@ import { useGetGenerateDiscoverLink } from '../use_generate_discover_link';
 export interface UseDiscoverLinkAndEsqlQueryParams {
   indexPattern?: string;
   whereClause?: QueryOperator;
+  unmappedFieldsPolicy?: 'NULLIFY' | 'SKIP';
 }
 
 export function useDiscoverLinkAndEsqlQuery({
   indexPattern,
   whereClause,
+  unmappedFieldsPolicy,
 }: UseDiscoverLinkAndEsqlQueryParams) {
-  const { generateDiscoverLink } = useGetGenerateDiscoverLink({ indexPattern });
+  const { generateDiscoverLink } = useGetGenerateDiscoverLink({ indexPattern, unmappedFieldsPolicy });
 
   if (!indexPattern || !whereClause) {
     return { discoverUrl: undefined, esqlQueryString: undefined };
   }
 
-  const esqlQueryString = from(indexPattern).pipe(whereClause).toString();
+  const settingsPrefix = unmappedFieldsPolicy
+    ? `SET unmapped_fields = "${unmappedFieldsPolicy}"\n`
+    : '';
+  const esqlQueryString = `${settingsPrefix}${from(indexPattern).pipe(whereClause).toString()}`;
   const discoverUrl = generateDiscoverLink(whereClause);
 
   return { discoverUrl, esqlQueryString };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/use_discover_link_and_esql_query.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/use_discover_link_and_esql_query.test.ts
@@ -63,7 +63,7 @@ describe('useDiscoverLinkAndEsqlQuery', () => {
     );
 
     expect(result.current.esqlQueryString).toBe(
-      `SET unmapped_fields = "NULLIFY"\n${from(indexPattern).pipe(whereClause).toString()}`
+      `SET unmapped_fields = "NULLIFY";\n${from(indexPattern).pipe(whereClause).toString()}`
     );
   });
 });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/use_discover_link_and_esql_query.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_discover_link_and_esql_query/use_discover_link_and_esql_query.test.ts
@@ -49,4 +49,21 @@ describe('useDiscoverLinkAndEsqlQuery', () => {
     expect(result.current.discoverUrl).toBe(DISCOVER_URL);
     expect(result.current.esqlQueryString).toBe(from(indexPattern).pipe(whereClause).toString());
   });
+
+  it('prepends SET directive when unmappedFieldsPolicy is provided', () => {
+    const DISCOVER_URL = 'http://discover/url';
+    const generateDiscoverLink = jest.fn(() => DISCOVER_URL);
+    mockUseGetGenerateDiscoverLink.mockReturnValue({ generateDiscoverLink });
+
+    const indexPattern = 'logs-*';
+    const whereClause = where('trace.id == ?traceId', { traceId: 'abc123' });
+
+    const { result } = renderHook(() =>
+      useDiscoverLinkAndEsqlQuery({ indexPattern, whereClause, unmappedFieldsPolicy: 'NULLIFY' })
+    );
+
+    expect(result.current.esqlQueryString).toBe(
+      `SET unmapped_fields = "NULLIFY"\n${from(indexPattern).pipe(whereClause).toString()}`
+    );
+  });
 });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_generate_discover_link/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_generate_discover_link/index.ts
@@ -35,7 +35,7 @@ export function useGetGenerateDiscoverLink({
   const indices = castArray(indexPattern).filter(Boolean);
 
   const settingsPrefix = unmappedFieldsPolicy
-    ? `SET unmapped_fields = "${unmappedFieldsPolicy}"\n`
+    ? `SET unmapped_fields = "${unmappedFieldsPolicy}";\n`
     : '';
 
   const generateDiscoverLink: GenerateDiscoverLink = (

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_generate_discover_link/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_generate_discover_link/index.ts
@@ -19,8 +19,10 @@ export interface GenerateDiscoverLink {
 
 export function useGetGenerateDiscoverLink({
   indexPattern,
+  unmappedFieldsPolicy,
 }: {
   indexPattern?: string | (string | undefined)[];
+  unmappedFieldsPolicy?: 'NULLIFY' | 'SKIP';
 }) {
   const {
     data,
@@ -31,6 +33,10 @@ export function useGetGenerateDiscoverLink({
   const timeRange = data.query.timefilter.timefilter.getAbsoluteTime();
   const discoverLocator = locators.get('DISCOVER_APP_LOCATOR');
   const indices = castArray(indexPattern).filter(Boolean);
+
+  const settingsPrefix = unmappedFieldsPolicy
+    ? `SET unmapped_fields = "${unmappedFieldsPolicy}"\n`
+    : '';
 
   const generateDiscoverLink: GenerateDiscoverLink = (
     first?: Record<string, any> | WhereClause,
@@ -44,7 +50,7 @@ export function useGetGenerateDiscoverLink({
     const _from = from(indices.join());
 
     if (typeof first === 'function') {
-      esql = _from.pipe(first as WhereClause, ...rest).toString();
+      esql = `${settingsPrefix}${_from.pipe(first as WhereClause, ...rest).toString()}`;
     } else if (first && typeof first === 'object') {
       const whereClause = first as Record<string, any>;
       const paramKeysMap = new Map<string, string>();
@@ -58,7 +64,7 @@ export function useGetGenerateDiscoverLink({
           params.push({ [paramKey]: whereClause[key] });
         });
 
-      esql = _from
+      esql = `${settingsPrefix}${_from
         .pipe(
           where(
             Array.from(paramKeysMap.keys())
@@ -67,9 +73,9 @@ export function useGetGenerateDiscoverLink({
             params
           )
         )
-        .toString();
+        .toString()}`;
     } else {
-      esql = _from.toString();
+      esql = `${settingsPrefix}${_from.toString()}`;
     }
 
     const url = discoverLocator.getRedirectUrl({


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/278294.

Exploring an alternative solution mentioned in PR review.

### Pros

- This solution does give us the benefit of not modifying the query building piece of the feature in the way the KQL solution in the linked PR does.
- Named params are preserved.
- Avoids mixing ES|QL and KQL in a single query, so cleaner in this regard.

### Cons

- The SET call will result in behavior modification for _any_ unmapped field in the query, whereas the KQL method is more targeted. For this particular query it may not be a big deal.
- Slightly higher footprint compared to the more self-contained KQL solution.

### Comparison

`SET` method: 
<img width="1171" height="112" alt="image" src="https://github.com/user-attachments/assets/3b2aca74-4f03-4fd4-a0d6-092b99d0ec71" />

`KQL` method:
<img width="1205" height="253" alt="image" src="https://github.com/user-attachments/assets/192f4d21-a84b-4409-800c-1860601a4b45" />
