### PR TITLE
[Console] Fix put_mapping nested-field autocomplete scope links

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/index.test.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/index.test.ts
@@ -78,4 +78,29 @@ describe('console query DSL autocomplete globals', () => {
       });
     });
   });
+
+  // The `put_mapping` rules predate the Elasticsearch 7.x removal of mapping
+  // types, but its nested-object and multi-field scope links still pointed at
+  // the removed `type` level (`put_mapping.type.properties`). That path no
+  // longer exists in the rule tree, so sub-field autocomplete inside
+  // `properties.<field>.properties` and `properties.<field>.fields` resolved
+  // to nothing. The links must target the real top-level `properties` key.
+  describe('put_mapping nested field scope links', () => {
+    it('points nested object properties at the put_mapping properties rules', () => {
+      expect(endpoints.put_mapping.data_autocomplete_rules).toMatchObject({
+        properties: {
+          '*': {
+            properties: { __scope_link: 'put_mapping.properties' },
+            fields: { '*': { __scope_link: 'put_mapping.properties.field' } },
+          },
+        },
+      });
+    });
+
+    it('does not reference the removed mapping `type` level anywhere', () => {
+      expect(JSON.stringify(endpoints.put_mapping.data_autocomplete_rules)).not.toContain(
+        'put_mapping.type'
+      );
+    });
+  });
 });

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -262,13 +262,13 @@ export const mappings = (specService: SpecDefinitionsService) => {
 
           // objects
           properties: {
-            __scope_link: 'put_mapping.type.properties',
+            __scope_link: 'put_mapping.properties',
           },
 
           // multi_field
           fields: {
             '*': {
-              __scope_link: 'put_mapping.type.properties.field',
+              __scope_link: 'put_mapping.properties.field',
             },
           },
           copy_to: { __one_of: ['{field}', ['{field}']] },


### PR DESCRIPTION
Closes #278506.

## Summary

- Console autocomplete for nested mapping fields (`properties.<field>.properties`) and multi-fields (`properties.<field>.fields`) resolves to nothing in every context that scope-links to the `put_mapping` rules (index creation mappings, index/component templates, rollover).

## Root Cause

- The `put_mapping` autocomplete rules predate the Elasticsearch 7.x removal of mapping types: the nested-object and multi-field slots still scope-link to `put_mapping.type.properties` / `put_mapping.type.properties.field`. The `type` level no longer exists in the rule tree, so both links are dead references and sub-field suggestions silently resolve to nothing.

## Fix

- Repoint the two scope links at the real top-level key: `put_mapping.properties` and `put_mapping.properties.field`.
- Add regression tests asserting the links resolve and that no `put_mapping.type` reference remains.

## Test Plan

- `node scripts/jest src/platform/plugins/shared/console/server/lib/spec_definitions` — all tests pass, including the new `put_mapping nested field scope links` tests
- Manual repro (reviewer-runnable):
  1. Open **Dev Tools → Console**.
  2. Paste:
     ```
     PUT test-index
     {
       "mappings": {
         "properties": {
           "name": {
             "properties": {
               "sub": {}
             }
           }
         }
       }
     }
     ```
  3. Place the cursor inside the nested `"sub"` object and trigger autocomplete (`Ctrl+Space`).
  4. **Before:** Monaco shows "No suggestions." **After:** the full field-mapping option set appears (`type`, `analyzer`, `copy_to`, …) — same as top-level `properties`.
  5. Repeat with `"fields"` instead of the inner `"properties"` to verify multi-fields.
- Live-verified on this branch (local Kibana): nested `properties.<field>.properties.<sub>` object suggests the full field-mapping option set (`analyzer, boost, copy_to, fields, format, …`); same for multi-field `fields.<name>`.

## Before/After Screenshots (or Video)

### Before

- "No suggestions." at the nested `properties` position
<img width="620" height="420" alt="image" src="https://github.com/user-attachments/assets/285668b5-d1ce-4a37-90db-6a51a08dc71a" />


### After

- nested `properties` suggestions
<img width="620" height="420" alt="278508_nested_properties_after" src="https://github.com/user-attachments/assets/7ebc3e38-79fe-4c63-a8ec-7bdadc94e8de" />

## Release Note

- Fixes Console autocomplete not suggesting mapping options for nested object fields and multi-fields in index mapping bodies.

Assisted with Copilot using Claude Fable 5



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->