### PR TITLE
[ES|QL] Resolve @timestamp for datasets in the timefield route

### DIFF
--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.test.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
+import { TIMEFIELD_ROUTE } from '@kbn/esql-types';
+import { registerGetTimeFieldRoute } from './get_timefield';
+
+jest.mock('@kbn/esql-server-utils', () => ({
+  EsqlService: jest.fn(),
+}));
+
+jest.mock('@kbn/esql-utils', () => ({
+  getTimeFieldFromESQLQuery: jest.fn(),
+  getIndexPatternFromESQLQuery: jest.fn(),
+}));
+
+jest.mock('@elastic/esql', () => ({
+  Parser: { parse: jest.fn() },
+  isSubQuery: jest.fn(),
+}));
+
+jest.mock('../metrics', () => ({
+  esqlRouteRequestCounter: { add: jest.fn() },
+  getErrorStatusCode: jest.fn(() => 500),
+}));
+
+const { EsqlService } = jest.requireMock('@kbn/esql-server-utils');
+const { getTimeFieldFromESQLQuery, getIndexPatternFromESQLQuery } =
+  jest.requireMock('@kbn/esql-utils');
+const { Parser, isSubQuery } = jest.requireMock('@elastic/esql');
+
+const getViews = jest.fn();
+const getDatasets = jest.fn();
+const fieldCaps = jest.fn();
+const transportRequest = jest.fn();
+
+function buildMocks() {
+  const handler = jest.fn();
+  const router = {
+    post: jest.fn((_, h) => {
+      handler.mockImplementation(h);
+    }),
+  };
+  const asCurrentUser = { fieldCaps, transport: { request: transportRequest } };
+  const core = { elasticsearch: { client: { asCurrentUser } } };
+  const requestHandlerContext = { core: Promise.resolve(core) };
+  const request = { body: { query: 'FROM my_source' } };
+  const response = { ok: jest.fn((r) => ({ status: 200, ...r })) };
+  const context = { logger: { get: () => ({ error: jest.fn() }) } };
+
+  return {
+    router: router as unknown as IRouter,
+    handler,
+    requestHandlerContext,
+    request,
+    response,
+    context: context as unknown as PluginInitializerContext,
+  };
+}
+
+describe('registerGetTimeFieldRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    EsqlService.mockImplementation(() => ({ getViews, getDatasets }));
+    getViews.mockResolvedValue({ views: [] });
+    getDatasets.mockResolvedValue({ datasets: [] });
+    getTimeFieldFromESQLQuery.mockReturnValue(undefined);
+    getIndexPatternFromESQLQuery.mockReturnValue('my_source');
+    Parser.parse.mockReturnValue({ root: { commands: [{ name: 'from', args: [] }] } });
+    isSubQuery.mockReturnValue(false);
+    fieldCaps.mockResolvedValue({ fields: {} });
+    transportRequest.mockResolvedValue({ columns: [] });
+  });
+
+  it('registers a POST handler at the timefield path', () => {
+    const { router, context } = buildMocks();
+    registerGetTimeFieldRoute(router, context);
+    expect(router.post).toHaveBeenCalledWith(
+      expect.objectContaining({ path: TIMEFIELD_ROUTE }),
+      expect.any(Function)
+    );
+  });
+
+  it('resolves @timestamp for a dataset via the FROM | LIMIT 0 probe when fieldCaps cannot describe it', async () => {
+    const { router, handler, requestHandlerContext, request, response, context } = buildMocks();
+    registerGetTimeFieldRoute(router, context);
+
+    // The source is a dataset (not an index): fieldCaps has no @timestamp, but the dataset exposes one
+    // (e.g. via a `path` rename), which the probe surfaces.
+    getDatasets.mockResolvedValue({ datasets: [{ name: 'my_source' }] });
+    transportRequest.mockResolvedValue({ columns: [{ name: '@timestamp', type: 'date' }] });
+
+    await handler(requestHandlerContext, request, response);
+
+    expect(transportRequest).toHaveBeenCalled(); // the probe ran for the dataset
+    expect(response.ok).toHaveBeenCalledWith({ body: { timeField: '@timestamp' } });
+  });
+
+  it('returns undefined when a dataset does not expose an @timestamp column', async () => {
+    const { router, handler, requestHandlerContext, request, response, context } = buildMocks();
+    registerGetTimeFieldRoute(router, context);
+
+    getDatasets.mockResolvedValue({ datasets: [{ name: 'my_source' }] });
+    transportRequest.mockResolvedValue({ columns: [{ name: 'event_time', type: 'date' }] });
+
+    await handler(requestHandlerContext, request, response);
+
+    expect(response.ok).toHaveBeenCalledWith({ body: { timeField: undefined } });
+  });
+
+  it('still resolves @timestamp for an index via fieldCaps (no probe needed)', async () => {
+    const { router, handler, requestHandlerContext, request, response, context } = buildMocks();
+    registerGetTimeFieldRoute(router, context);
+
+    fieldCaps.mockResolvedValue({ fields: { '@timestamp': {} } });
+
+    await handler(requestHandlerContext, request, response);
+
+    expect(transportRequest).not.toHaveBeenCalled(); // fieldCaps resolved it; no dataset/view probe
+    expect(response.ok).toHaveBeenCalledWith({ body: { timeField: '@timestamp' } });
+  });
+});

--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
@@ -99,7 +99,23 @@ const resolveTimeField = async (
     });
     return { views: [] };
   });
-  const viewNames = new Set(views.map(({ name }) => name));
+  // Datasets (external `FROM` sources) are resolved by ES|QL rather than being indices, so the fieldCaps
+  // check below can't describe them. Collect their names too so a `FROM <source> | LIMIT 0` probe can find
+  // a renamed `@timestamp` column — the same treatment views already get.
+  const { datasets } = await service.getDatasets().catch((datasetsError) => {
+    const message = datasetsError instanceof Error ? datasetsError.message : String(datasetsError);
+    logger.error(`Failed to fetch ES|QL datasets while resolving timefield: ${message}`, {
+      tags: ['esql', 'timefield', 'datasets'],
+      error: {
+        stack_trace: datasetsError instanceof Error ? datasetsError.stack : undefined,
+      },
+    });
+    return { datasets: [] };
+  });
+  const viewLikeNames = new Set([
+    ...views.map(({ name }) => name),
+    ...datasets.map(({ name }) => name),
+  ]);
   const splitSources = sources
     .split(',')
     .map((s) => s.trim())
@@ -147,16 +163,15 @@ const resolveTimeField = async (
       return { timeField: ES_TIMESTAMP_FIELD_NAME };
     }
 
-    // fieldCaps didn't find @timestamp — check if any sources are views
-    const viewSources = splitSources.filter((name) => viewNames.has(name));
+    // fieldCaps didn't find @timestamp — check any view-like sources (ES|QL views or datasets), whose
+    // @timestamp column ES|QL resolves at query time rather than through the index mapping.
+    const viewLikeSources = splitSources.filter((name) => viewLikeNames.has(name));
 
-    if (viewSources.length) {
-      const viewChecks = await Promise.all(
-        viewSources.map((viewName) =>
-          checkViewLikeSourceForTimestamp({ client, sourceName: viewName })
-        )
+    if (viewLikeSources.length) {
+      const viewLikeChecks = await Promise.all(
+        viewLikeSources.map((sourceName) => checkViewLikeSourceForTimestamp({ client, sourceName }))
       );
-      if (viewChecks.every(Boolean)) {
+      if (viewLikeChecks.every(Boolean)) {
         return { timeField: ES_TIMESTAMP_FIELD_NAME };
       }
     }


### PR DESCRIPTION
## Summary

The ES|QL timefield route (`POST /internal/esql/timefield`, used to resolve the time field for an ad-hoc data view / dashboard time picker) resolved `@timestamp` only for:
- **indices** — via `field_caps`, and
- **ES|QL views** — via a `FROM <source> | LIMIT 0` probe that looks for an `@timestamp` column in the output schema.

**Datasets** (external `FROM <name>` sources resolved by ES|QL, which `field_caps` cannot describe) fell through both paths, so a dashboard **time picker produced no time filter for a `FROM <dataset>`** even when the dataset exposes a time field.

This runs the same view-like probe for datasets: it fetches them alongside views (`EsqlService.getDatasets()` already exists) and, when `field_caps` doesn't find `@timestamp`, probes any `FROM` source that is a **view or a dataset** for an `@timestamp` column. A dataset that surfaces an `@timestamp` column — e.g. via a mapping that renames its time field with `path` (`"@timestamp": {"type":"date","path":"event_time"}`) — now drives the time picker exactly like an index or a view.

The change is intentionally minimal — it reuses the existing `getDatasets()` and `checkViewLikeSourceForTimestamp` helpers; no new API call or plumbing.

## What this unblocks

On the Elasticsearch side, the out-of-band request `filter` a dashboard sends (a `range` on the time field + filter pills) is translated and applied to a dataset; a companion ES change proves a dataset behaves like an index for that filter. The one missing link was Kibana resolving the dataset's time field so the picker emits the `range` — which this closes for datasets that expose `@timestamp`.

## Testing

- New unit test `get_timefield.test.ts`: dataset resolves `@timestamp` via the probe when `field_caps` can't; a dataset without an `@timestamp` column returns `undefined`; an index still resolves via `field_caps` with no probe.
- `node scripts/jest` (4/4), `node scripts/type_check --project .../esql/tsconfig.json`, and `node scripts/eslint` all pass locally.

Draft — opening for review + CI.
