### PR TITLE
[Security Solution][Flyout] fix rule flyout failing when missing severity_mapping or risk_score_mapping

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/helpers.test.tsx
@@ -205,6 +205,50 @@ describe('rule helpers', () => {
 
       expect(result.investigationFields).toEqual([]);
     });
+
+    test('does not throw when severity_mapping is absent (fallback rule from alert data)', () => {
+      const mockedRule = mockRuleWithEverything('test-id');
+      // @ts-expect-error — intentionally simulating a rule reconstructed from alert data that
+      // omits severity_mapping, which is what useRuleWithFallback returns for deleted rules
+      delete mockedRule.severity_mapping;
+      expect(() => getAboutStepsData(mockedRule, false)).not.toThrow();
+    });
+
+    test('does not throw when risk_score_mapping is absent (fallback rule from alert data)', () => {
+      const mockedRule = mockRuleWithEverything('test-id');
+      // @ts-expect-error — same scenario: risk_score_mapping missing from alert-reconstructed rule
+      delete mockedRule.risk_score_mapping;
+      expect(() => getAboutStepsData(mockedRule, false)).not.toThrow();
+    });
+  });
+
+  describe('fillEmptySeverityMappings', () => {
+    test('returns all four severity levels when passed an empty array', () => {
+      const result = fillEmptySeverityMappings([]);
+      expect(result.map((m) => m.severity).sort()).toEqual(['critical', 'high', 'low', 'medium']);
+    });
+
+    test('does not throw and returns all four levels when passed undefined', () => {
+      expect(() => fillEmptySeverityMappings(undefined)).not.toThrow();
+      const result = fillEmptySeverityMappings(undefined);
+      expect(result.map((m) => m.severity).sort()).toEqual(['critical', 'high', 'low', 'medium']);
+    });
+
+    test('preserves existing mappings and fills only missing severity levels', () => {
+      const existing = [
+        {
+          field: 'host.risk',
+          value: '90',
+          operator: 'equals' as const,
+          severity: 'critical' as const,
+        },
+      ];
+      const result = fillEmptySeverityMappings(existing);
+      expect(result.find((m) => m.severity === 'critical')).toEqual(existing[0]);
+      expect(result.filter((m) => m.severity !== 'critical').every((m) => m.field === '')).toBe(
+        true
+      );
+    });
   });
 
   describe('determineDetailsValue', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/helpers.tsx
@@ -248,14 +248,14 @@ export const getAboutStepsData = (rule: RuleResponse, detailsView: boolean): Abo
     references,
     severity: {
       value: severity as Severity,
-      mapping: fillEmptySeverityMappings(severityMapping),
-      isMappingChecked: severityMapping.length > 0,
+      mapping: fillEmptySeverityMappings(severityMapping ?? []),
+      isMappingChecked: (severityMapping?.length ?? 0) > 0,
     },
     tags,
     riskScore: {
       value: riskScore,
       mapping: requiredOptional(riskScoreMapping),
-      isMappingChecked: riskScoreMapping.length > 0,
+      isMappingChecked: (riskScoreMapping?.length ?? 0) > 0,
     },
     falsePositives,
     investigationFields: investigationFields?.field_names ?? [],
@@ -273,16 +273,19 @@ const severitySortMapping = {
   critical: 3,
 };
 
-export const fillEmptySeverityMappings = (mappings: SeverityMapping): SeverityMapping => {
+export const fillEmptySeverityMappings = (
+  mappings: SeverityMapping | undefined
+): SeverityMapping => {
+  const safeMappings = mappings ?? [];
   const missingMappings: SeverityMapping = Object.values(SeverityLevel).flatMap((severityLevel) => {
-    const isSeverityLevelInMappings = mappings.some(
+    const isSeverityLevelInMappings = safeMappings.some(
       (mapping) => mapping.severity === severityLevel
     );
     return isSeverityLevelInMappings
       ? []
       : [{ field: '', value: '', operator: 'equals', severity: severityLevel }];
   });
-  return [...mappings, ...missingMappings].sort(
+  return [...safeMappings, ...missingMappings].sort(
     (a, b) => severitySortMapping[a.severity] - severitySortMapping[b.severity]
   );
 };


### PR DESCRIPTION
## Summary

## Summary

Opening an alert's rule panel flyout for a **deleted rule** crashes the entire Security app with `TypeError: Cannot read properties of undefined (reading 'some')`.

The crash happens because `useRuleWithFallback` — which recovers rule data from the most recent alert when the rule API returns 404 — reconstructs a partial `RuleResponse` from the alert document. Alert documents don't store `severity_mapping` or `risk_score_mapping`, so those fields come back as `undefined`. Two call sites in `getAboutStepsData` then crash unconditionally on `.length` / `.some()` against those `undefined` values.

Three guard fixes in `helpers.tsx`:

- `fillEmptySeverityMappings` now accepts `SeverityMapping | undefined` and normalises `undefined` to `[]` before any array operations — so any future caller passing `undefined` is safe.
- `getAboutStepsData`: `severityMapping ?? []` at the call site, and `severityMapping?.length ?? 0` for the `isMappingChecked` flag.
- `getAboutStepsData`: same `?.length ?? 0` guard for `riskScoreMapping.length`.

### Steps to reproduce:
1. Create a custom-query detection rule (no severity mapping needed — the default is fine).
2. Index or generate at least one alert for that rule (so `useRuleWithFallback` has data to fall back to).
3. Delete the rule via the API or Kibana UI.
4. Navigate to the Alerts page with the rule panel flyout open for the deleted rule's ID, e.g.:
   ```
   /app/security/alerts?flyout=(preview:!(),right:(id:rule-panel,params:(ruleId:'<deleted-rule-id>')))
   ```
5. The page crashes with a React error boundary. Without the fix, the browser console shows:
   ```
   TypeError: Cannot read properties of undefined (reading 'some')
       at fillEmptySeverityMappings (helpers.tsx)
   ```

## How to test

Run the repro script below against a local ES + Kibana instance (default `elastic:changeme` credentials), then open the printed URL in your browser — with the fix applied, the rule panel should show the `FlyoutError` "Rule not found" state instead of crashing:

```bash
node - <<'EOF'
const ES = 'http://localhost:9200', KB = 'http://localhost:5601';
const H = { 'Content-Type': 'application/json', Authorization: 'Basic ' + Buffer.from('elastic:changeme').toString('base64'), 'kbn-xsrf': 'true' };
const kb = (m, p, b) => fetch(`${KB}${p}`, { method: m, headers: H, body: b && JSON.stringify(b) }).then(r => r.json());
const es = (m, p, b) => fetch(`${ES}${p}`, { method: m, headers: H, body: b && JSON.stringify(b) }).then(r => r.json());

const rule = await kb('POST', '/api/detection_engine/rules', { type: 'query', name: '[repro] crash test', description: 'safe to delete', enabled: false, query: 'event.kind:"event"', language: 'kuery', index: ['logs-*'], risk_score: 47, severity: 'medium', from: 'now-6m', interval: '5m' });
const id = rule.id;
const alias = await es('GET', '/.alerts-security.alerts-default/_alias');
const idx = Object.entries(alias).find(([,v]) => v.aliases?.['.alerts-security.alerts-default']?.is_write_index)?.[0] ?? '.alerts-security.alerts-default';
await es('PUT', `/${idx}/_doc/repro-${Date.now()}?refresh=true`, { '@timestamp': new Date().toISOString(), 'event.kind': 'signal', 'kibana.alert.rule.uuid': id, 'kibana.alert.rule.name': '[repro] crash test', 'kibana.alert.status': 'active', 'kibana.alert.workflow_status': 'open', 'kibana.alert.severity': 'medium', 'kibana.alert.rule.parameters': { type: 'query', severity: 'medium', risk_score: 47 }, 'kibana.space_ids': ['default'] });
await kb('DELETE', `/api/detection_engine/rules?id=${id}`);
console.log(`\nOpen: ${KB}/app/security/alerts?flyout=(preview:!(),right:(id:rule-panel,params:(ruleId:'${id}')))\n`);
EOF
```

**Expected (with fix):** rule panel opens, shows "This rule has been deleted" / `FlyoutError` state — no crash, no error boundary.

https://github.com/user-attachments/assets/ffc2df09-1465-4c17-8f53-8554a438ed58

**Expected (without fix):** React error boundary fires, full page crashes, browser console shows `TypeError: Cannot read properties of undefined (reading 'some')`.

https://github.com/user-attachments/assets/34554141-ab40-4ea8-a16a-294a1017f14b

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->