### PR TITLE
[ci] Bump pick_test_group_run_order disk to 130gb

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/const.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/const.ts
@@ -95,9 +95,9 @@ export const TEST_STEP_TIMEOUT_MINUTES = 50;
 
 /** Agent disk sizes (GiB) per step type. */
 export const AGENT_DISK_GIB = {
-  JEST_UNIT: 110,
-  JEST_INTEGRATION: 105,
-  FTR: 105,
+  JEST_UNIT: 130,
+  JEST_INTEGRATION: 130,
+  FTR: 130,
 } as const;
 
 /** Well-known Buildkite pipeline slugs referenced in source prioritization. */


### PR DESCRIPTION
null

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->