### PR TITLE
[Security Solution][OneDiscover] Fix "Explore in Alerts" ignoring the new flyout setting

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
@@ -65,7 +65,9 @@ export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
   const {
     application: { getUrlForApp },
     fieldsMetadata,
+    uiSettings,
   } = useDiscoverServices();
+  const enableNewFlyout = uiSettings.get<boolean>('securitySolution:enableNewFlyout', false);
 
   const timelinesURL = getUrlForApp('securitySolutionUI', {
     path: 'alerts',
@@ -97,6 +99,21 @@ export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
     const index = getFieldValue(hit, '_index') as string | undefined;
     if (isNonLocalIndexName(index ?? '')) return undefined;
 
+    // When the new flyout is enabled, keep the timeline open (for context) but use dedicated URL
+    // params for the flyout so the alerts page opens the new (EUI-based) flyout imperatively
+    // instead of the old expandable flyout driven by the `timelineFlyout` URL param.
+    if (enableNewFlyout) {
+      const timestamp = getFieldValue(hit, '@timestamp') as string;
+      return getSecurityTimelineRedirectUrl({
+        from: timestamp,
+        to: timestamp,
+        eventId: documentId,
+        index: index as string,
+        baseURL: timelinesURL,
+        useNewFlyout: true,
+      });
+    }
+
     // This will only be reached for local alerts that don't have the `kibana.alert.url` or all local events.
     return getSecurityTimelineRedirectUrl({
       from: getFieldValue(hit, '@timestamp') as string,
@@ -105,7 +122,7 @@ export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
       index: index as string,
       baseURL: timelinesURL,
     });
-  }, [hit, timelinesURL]);
+  }, [hit, timelinesURL, enableNewFlyout]);
 
   const eventCategory = useMemo(() => getFieldValue(hit, 'event.category') as string, [hit]);
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/index.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/index.tsx
@@ -20,6 +20,12 @@ export interface TimelineRedirectArgs {
   eventId?: string;
   index: string;
   baseURL: string;
+  /**
+   * When true, omits the `timelineFlyout` URL param (which drives the old expandable flyout) and
+   * instead adds `flyoutDocumentId`/`flyoutDocumentIndex` params so the alerts page opens the new
+   * (EUI-based) flyout imperatively while still opening the timeline for context.
+   */
+  useNewFlyout?: boolean;
 }
 
 export const getSecurityTimelineRedirectUrl = ({
@@ -28,6 +34,7 @@ export const getSecurityTimelineRedirectUrl = ({
   index,
   eventId,
   baseURL,
+  useNewFlyout = false,
 }: TimelineRedirectArgs) => {
   let timelineTimerangeSearchParam = {};
   if (from && to) {
@@ -54,6 +61,19 @@ export const getSecurityTimelineRedirectUrl = ({
     isOpen: true,
   };
 
+  const encodedTimelineParam = encode(timelineSearchParam);
+  const encodedTimelineTimerangeParam = encode(timelineTimerangeSearchParam);
+
+  if (useNewFlyout) {
+    const urlParams = new URLSearchParams({
+      timeline: encodedTimelineParam,
+      timerange: encodedTimelineTimerangeParam,
+      flyoutDocumentId: eventId ?? '',
+      flyoutDocumentIndex: index,
+    });
+    return `${baseURL}?${urlParams.toString()}`;
+  }
+
   const timelineFlyoutSearchParam = {
     right: {
       id: 'document-details-right',
@@ -65,14 +85,10 @@ export const getSecurityTimelineRedirectUrl = ({
     },
   };
 
-  const encodedTimelineParam = encode(timelineSearchParam);
-  const encodedTimelineTimerangeParam = encode(timelineTimerangeSearchParam);
-  const encodedTimelineFlyoutParam = encode(timelineFlyoutSearchParam);
-
   const urlParams = new URLSearchParams({
     timeline: encodedTimelineParam,
     timerange: encodedTimelineTimerangeParam,
-    timelineFlyout: encodedTimelineFlyoutParam,
+    timelineFlyout: encode(timelineFlyoutSearchParam),
   });
 
   return `${baseURL}?${urlParams.toString()}`;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/constants.ts
@@ -22,4 +22,7 @@ export const URL_PARAM_KEY = {
   entityId: 'entityId',
   /** Identity field map for entity resolution on explore detail URLs (Rison-encoded object). */
   identityFields: 'identityFields',
+  /** Used when navigating to the alerts page to open the new (EUI-based) flyout for a specific document. */
+  flyoutDocumentId: 'flyoutDocumentId',
+  flyoutDocumentIndex: 'flyoutDocumentIndex',
 } as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.tsx
@@ -9,6 +9,7 @@ import { EuiHorizontalRule, EuiSpacer, EuiWindowEvent } from '@elastic/eui';
 import styled from '@emotion/styled';
 import { noop } from 'lodash/fp';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import { isTab } from '@kbn/timelines-plugin/public';
 import type { Filter } from '@kbn/es-query';
 import { dataTableSelectors, tableDefaults, TableId } from '@kbn/securitysolution-data-table';
@@ -17,6 +18,9 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import { PAGE_TITLE } from '../../pages/alerts/translations';
 import { useShallowEqualSelector } from '../../../common/hooks/use_selector';
 import { HeaderPage } from '../../../common/components/header_page';
+import { URL_PARAM_KEY } from '../../../common/hooks/constants';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../flyout_v2/use_flyout_api';
 import { KPIsSection } from './kpis/kpis_section';
 import { FiltersSection } from './filters/filters_section';
 import { HeaderSection } from './header/header_section';
@@ -57,6 +61,22 @@ export interface AlertsPageContentProps {
  */
 export const AlertsPageContent = memo(({ dataView }: AlertsPageContentProps) => {
   const containerElement = useRef<HTMLDivElement | null>(null);
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { search } = useLocation();
+  const history = useHistory();
+  const { openDocumentFlyoutFromIndex } = useFlyoutApi();
+
+  useEffect(() => {
+    if (!enableNewFlyout) return;
+    const searchParams = new URLSearchParams(search);
+    const documentId = searchParams.get(URL_PARAM_KEY.flyoutDocumentId);
+    const indexName = searchParams.get(URL_PARAM_KEY.flyoutDocumentIndex);
+    if (!documentId) return;
+    openDocumentFlyoutFromIndex({ documentId, indexName: indexName ?? undefined });
+    searchParams.delete(URL_PARAM_KEY.flyoutDocumentId);
+    searchParams.delete(URL_PARAM_KEY.flyoutDocumentIndex);
+    history.replace({ search: searchParams.toString() });
+  }, [enableNewFlyout, search, history, openDocumentFlyoutFromIndex]);
 
   const { globalFullScreen } = useGlobalFullScreen();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
@@ -17,9 +17,11 @@ import { ALERTS_PATH, DEFAULT_ALERTS_INDEX } from '../../../../common/constants'
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { inputsSelectors } from '../../../common/store';
 import { formatPageFilterSearchParam } from '../../../../common/utils/format_page_filter_search_param';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
 import { resolveFlyoutParams } from './utils';
 
 export const AlertDetailsRedirect = () => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
   const { alertId } = useParams<{ alertId: string }>();
   const { search } = useLocation();
   const searchParams = new URLSearchParams(search);
@@ -72,7 +74,12 @@ export const AlertDetailsRedirect = () => {
     [URL_PARAM_KEY.appQuery]: kqlAppQuery,
     [URL_PARAM_KEY.timerange]: timerange,
     [URL_PARAM_KEY.pageFilter]: pageFiltersQuery,
-    [URL_PARAM_KEY.flyout]: resolveFlyoutParams({ index, alertId }, currentFlyoutParams),
+    ...(enableNewFlyout
+      ? {
+          [URL_PARAM_KEY.flyoutDocumentId]: alertId,
+          [URL_PARAM_KEY.flyoutDocumentIndex]: index,
+        }
+      : { [URL_PARAM_KEY.flyout]: resolveFlyoutParams({ index, alertId }, currentFlyoutParams) }),
   });
 
   const url = `${ALERTS_PATH}?${urlParams.toString()}`;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/hooks/use_explore_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/hooks/use_explore_actions.test.tsx
@@ -21,6 +21,10 @@ jest.mock('../../../../common/lib/kibana', () => ({
   }),
 }));
 
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled', () => ({
+  useIsNewFlyoutEnabled: jest.fn().mockReturnValue(false),
+}));
+
 const createHit = (
   flattened: Record<string, unknown> = {},
   id: string = 'test-id',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/hooks/use_explore_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/hooks/use_explore_actions.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useKibana } from '../../../../common/lib/kibana';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
 import { getExploreButtonInfo } from '../utils/get_explore_url';
 
 export interface UseExploreActionsParams {
@@ -39,13 +40,14 @@ export const useExploreActions = ({
   closePopover,
 }: UseExploreActionsParams): UseExploreActionsResult => {
   const { services } = useKibana();
+  const enableNewFlyout = useIsNewFlyoutEnabled();
 
   const { url, label } = useMemo(() => {
     const timelinesURL = services.application.getUrlForApp('securitySolutionUI', {
       path: 'alerts',
     });
-    return getExploreButtonInfo(hit, timelinesURL);
-  }, [hit, services.application]);
+    return getExploreButtonInfo(hit, timelinesURL, enableNewFlyout);
+  }, [hit, services.application, enableNewFlyout]);
 
   const onClick = useCallback(() => {
     closePopover();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_explore_url.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_explore_url.ts
@@ -96,7 +96,8 @@ const getSecurityTimelineRedirectUrl = ({
  */
 export const getExploreButtonInfo = (
   hit: DataTableRecord,
-  timelinesURL: string
+  timelinesURL: string,
+  enableNewFlyout: boolean = false
 ): { url: string; label: string } => {
   const isAlert = (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal;
 
@@ -106,6 +107,33 @@ export const getExploreButtonInfo = (
 
   const documentId = getFieldValue(hit, '_id') as string;
   const index = (getFieldValue(hit, '_index') as string) ?? '';
+
+  // When the new flyout is enabled, keep the timeline open (for context) but use dedicated URL params
+  // for the flyout so the alerts page opens the new (EUI-based) flyout imperatively instead of the
+  // old expandable flyout driven by the `timelineFlyout` URL param.
+  if (enableNewFlyout) {
+    const from = getFieldValue(hit, '@timestamp') as string;
+    const to = from;
+    let timelineTimerangeSearchParam = {};
+    if (from && to) {
+      timelineTimerangeSearchParam = {
+        timeline: { timerange: { from, to, kind: 'absolute', linkTo: false } },
+      };
+    }
+    const timelineSearchParam = {
+      activeTab: 'query',
+      query: { kind: 'kuery', expression: `_id: ${documentId}` },
+      isOpen: true,
+    };
+    const urlParams = new URLSearchParams({
+      timeline: encode(timelineSearchParam),
+      timerange: encode(timelineTimerangeSearchParam),
+      flyoutDocumentId: documentId,
+      flyoutDocumentIndex: index,
+    });
+    return { url: `${timelinesURL}?${urlParams.toString()}`, label: EXPLORE_IN_ALERTS };
+  }
+
   const url = getSecurityTimelineRedirectUrl({
     from: getFieldValue(hit, '@timestamp') as string,
     to: getFieldValue(hit, '@timestamp') as string,


### PR DESCRIPTION
## Summary

Both redirect paths from Discover's "Explore in Alerts" always hardcoded `document-details-right` (old expandable flyout panel key) in URL params, so `securitySolution:enableNewFlyout` was never consulted.

When the new flyout is enabled:
- AlertDetailsRedirect (path via kibana.alert.url) now uses `flyoutDocumentId`/`flyoutDocumentIndex` URL params instead of the old `flyout` rison param; AlertsPageContent reads them and opens the new flyout imperatively via `openDocumentFlyoutFromIndex`.
- The "Take action" explore hook in flyout_v2 and the AlertEventOverview button in Discover (path when kibana.alert.url is absent) now keep the `timeline`/`timerange` params so the timeline modal still opens, but replace `timelineFlyout` (which drove the old flyout) with the new `flyoutDocumentId`/`flyoutDocumentIndex` params.

Still functions the same as before with the advanced setting off:

https://github.com/user-attachments/assets/3f23d8ff-f344-4654-b949-2935d4c80dc0

Should use the new flyout with advanced setting on:

https://github.com/user-attachments/assets/8d181ab8-c111-4881-b7f0-0efeeebb5500

## Testing

### Prerequisites
- Enable the new flyout: **Stack Management → Advanced Settings → `securitySolution:enableNewFlyout`** → on.

### Path A — `kibana.alert.url` present (most alerts)

1. Open Discover and search an alerts index (e.g. `.alerts-security.alerts-*`).
2. Open any alert document that has a `kibana.alert.url` field.
3. Click **"Explore in Alerts"** (either from the Overview tab or the Take action dropdown in the flyout).
4. ✅ The Security Solution alerts page opens in a new tab, filtered to that alert, with the **new flyout** open (not the old expandable flyout).

### Path B — `kibana.alert.url` absent (events / older alerts)

1. Open Discover and search a document without `kibana.alert.url`.
2. Click **"Explore in Alerts"** from the Take action dropdown.
3. ✅ The Security Solution alerts page opens in a new tab with the **timeline modal open** (filtered to the document's `_id`) and the **new flyout** open alongside it.

### Regression — new flyout setting off

1. Disable the new flyout: **Stack Management → Advanced Settings → `securitySolution:enableNewFlyout`** → off.
2. Repeat both paths above.
3. ✅ Behaviour is unchanged from before — the old expandable flyout opens as expected.