### PR TITLE
[CI] Limit oas linting workflow to main

### DIFF
--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -2,6 +2,8 @@ name: OpenAPI lint
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - 'oas_docs/**'
 

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'oas_docs/**'
+      - '.github/workflows/openapi-pr.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

This action is failing on non-main branches, so scoping it to only run on PRs which target `main`. It also is linting serverless specs on non-main branches which is not necessary.




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->