### PR TITLE
[9.4] [Entity Analytics] Update resolution group accordion headers when risk score is recalculated (#278289)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_risk_score_recalculation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_entity_risk_score_recalculation.ts
@@ -14,6 +14,11 @@ import { useCalculateEntityRiskScore } from './use_calculate_entity_risk_score';
 import { useRefetchQueryById } from './use_refetch_query_by_id';
 import { RISK_INPUTS_TAB_QUERY_ID } from '../../components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab';
 import { RESOLUTION_GROUP_QUERY_KEY } from '../../components/entity_resolution/hooks/use_resolution_group';
+import {
+  QUERY_KEY_ENTITY_ANALYTICS,
+  QUERY_KEY_GRID_DATA,
+  QUERY_KEY_TARGET_METADATA,
+} from '../../components/home/entities_table/constants';
 
 interface UseEntityRiskScoreRecalculationParams<T extends EntityType> {
   entityType: T;
@@ -56,14 +61,27 @@ export const useEntityRiskScoreRecalculation = <T extends EntityType>({
   const queryClient = useQueryClient();
 
   const onRiskScoreUpdated = useCallback(() => {
+    // Flyout header risk badge: V2 reads from the entity store record, V1 from the risk score API.
     if (entityStoreV2Enabled) {
       entityFromStoreResult.refetch();
     } else {
       riskScoreState.refetch();
     }
+    // Flyout Risk Summary panel (base + resolution scores).
     entityRiskScores.refetch();
+    // Flyout Risk Inputs tab (the alerts/inputs contributing to the score).
     (refetchRiskInputsTab as Refetch | null)?.();
+    // Entity resolution group tab/table shown in the flyout.
     queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });
+    // Entity analytics home table rows (flat grid + the leaf tables inside expanded groups).
+    queryClient.invalidateQueries({ queryKey: [QUERY_KEY_ENTITY_ANALYTICS, QUERY_KEY_GRID_DATA] });
+    // Risk score on the resolution group accordion headers. We refresh only this
+    // metadata (not the grouping aggregation) so the header badge updates without
+    // re-ordering the buckets, which would collapse any expanded groups.
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEY_ENTITY_ANALYTICS, QUERY_KEY_TARGET_METADATA],
+    });
+    // Context-specific extras (e.g. agent-builder attachment cache).
     onRecalculation?.();
   }, [
     entityStoreV2Enabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_VISIBLE_ROWS_PER_PAGE = 25;
 
 export const QUERY_KEY_GRID_DATA = 'entity_analytics_grid_data';
 export const QUERY_KEY_GROUPING_DATA = 'entity-analytics-grouping-data';
+export const QUERY_KEY_TARGET_METADATA = 'entity-analytics-resolution-target-metadata';
 export const QUERY_KEY_ENTITY_ANALYTICS = 'entity-analytics-query-key';
 
 const LOCAL_STORAGE_PREFIX = 'entityAnalytics';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -14,7 +14,12 @@ import { showErrorToast } from '@kbn/cloud-security-posture';
 import { useContext, useMemo } from 'react';
 import type { EntityType } from '../../../../../../common/entity_analytics/types';
 import { useKibana } from '../../../../../common/lib/kibana';
-import { ENTITY_FIELDS, QUERY_KEY_GROUPING_DATA, QUERY_KEY_ENTITY_ANALYTICS } from '../constants';
+import {
+  ENTITY_FIELDS,
+  QUERY_KEY_GROUPING_DATA,
+  QUERY_KEY_TARGET_METADATA,
+  QUERY_KEY_ENTITY_ANALYTICS,
+} from '../constants';
 import { DataViewContext } from '..';
 
 export type EntitiesGroupingQuery = GroupingQuery | SearchRequest;
@@ -132,8 +137,6 @@ export const useFetchGroupedData = ({
     }
   );
 };
-
-const QUERY_KEY_TARGET_METADATA = 'entity-analytics-resolution-target-metadata';
 
 export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap => {
   const { searchService, toasts, indexPattern } = useEntitySearchParams();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -17,8 +17,6 @@ import { useUpdateAssetCriticality } from '../../../entity_analytics/api/hooks/u
 import { buildEuidCspPreviewOptions } from '../../../cloud_security_posture/utils/build_euid_csp_preview_options';
 import { useNonClosedAlerts } from '../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../../overview/components/detection_response/alerts_by_status/types';
-import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../common/types';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
@@ -51,7 +49,6 @@ import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_pan
 import { EntityPanelHeaderTabs } from '../shared/components/entity_panel_tabs';
 import { EntityStoreTableTab } from '../shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../shared/components/entity_summary_grid';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../entity_analytics/components/home/constants';
 
 export { HOST_PANEL_RISK_SCORE_QUERY_ID, HOST_PANEL_OBSERVED_HOST_QUERY_ID };
 
@@ -149,12 +146,6 @@ export const HostPanel = memo(function HostPanel({
     [entityId, entityStoreV2Enabled, observedHost.entityRecord?.entity?.id]
   );
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.host,
@@ -163,13 +154,11 @@ export const HostPanel = memo(function HostPanel({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('host', {
     onSuccess: onAssetCriticalityChanged,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -14,8 +14,6 @@ import type { CriticalityLevelWithUnassigned } from '../../../../common/entity_a
 import type { ESQuery } from '../../../../common/typed_json';
 import { buildEntityNameFilter, type RiskSeverity } from '../../../../common/search_strategy';
 import { useUiSetting } from '../../../common/lib/kibana';
-import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../common/types';
 import { useUpdateAssetCriticality } from '../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -37,7 +37,6 @@ import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_pan
 import { EntityPanelHeaderTabs } from '../shared/components/entity_panel_tabs';
 import { EntityStoreTableTab } from '../shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../shared/components/entity_summary_grid';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../entity_analytics/components/home/constants';
 
 export interface ServicePanelProps extends Record<string, unknown> {
   contextID: string;
@@ -106,12 +105,6 @@ export const ServicePanel = memo(function ServicePanel({
   const serviceRiskData = serviceRisk && serviceRisk.length > 0 ? serviceRisk[0] : undefined;
   const isRiskScoreExist = !!serviceRiskData?.service.risk;
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.service,
@@ -120,13 +113,11 @@ export const ServicePanel = memo(function ServicePanel({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('service', {
     onSuccess: onAssetCriticalityChanged,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -17,8 +17,6 @@ import { buildEuidCspPreviewOptions } from '../../../cloud_security_posture/util
 import { buildUserNamesFilter, type RiskSeverity } from '../../../../common/search_strategy';
 import { useUiSetting, useKibana } from '../../../common/lib/kibana';
 import { useNonClosedAlerts } from '../../../cloud_security_posture/hooks/use_non_closed_alerts';
-import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
-import type { Refetch } from '../../../common/types';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useEntityRiskScoreRecalculation } from '../../../entity_analytics/api/hooks/use_entity_risk_score_recalculation';
 import { ManagedUserDatasetKey } from '../../../../common/search_strategy/security_solution/users/managed_details';
@@ -52,7 +50,6 @@ import { useEntityPanelTabs, TABLE_TAB_ID } from '../shared/hooks/use_entity_pan
 import { EntityPanelHeaderTabs } from '../shared/components/entity_panel_tabs';
 import { EntityStoreTableTab } from '../shared/components/entity_store_table_tab';
 import { EntitySummaryGrid } from '../shared/components/entity_summary_grid';
-import { ENTITY_ANALYTICS_TABLE_ID } from '../../../entity_analytics/components/home/constants';
 
 export { USER_PANEL_RISK_SCORE_QUERY_ID, USER_PANEL_OBSERVED_USER_QUERY_ID };
 
@@ -155,12 +152,6 @@ export const UserPanel = memo(function UserPanel({
   const { data: userRisk } = riskScoreState;
   const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
 
-  const refetchEntitiesTable = useRefetchQueryById(ENTITY_ANALYTICS_TABLE_ID);
-
-  const onRecalculation = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
-  }, [refetchEntitiesTable]);
-
   const { entityRiskScores, recalculatingScore, calculateEntityRiskScore } =
     useEntityRiskScoreRecalculation({
       entityType: EntityType.user,
@@ -169,13 +160,11 @@ export const UserPanel = memo(function UserPanel({
       entityStoreV2Enabled,
       entityFromStoreResult,
       riskScoreState,
-      onRecalculation,
     });
 
   const onAssetCriticalityChanged = useCallback(() => {
-    (refetchEntitiesTable as Refetch | null)?.();
     calculateEntityRiskScore();
-  }, [calculateEntityRiskScore, refetchEntitiesTable]);
+  }, [calculateEntityRiskScore]);
 
   const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('user', {
     onSuccess: onAssetCriticalityChanged,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] Update resolution group accordion headers when risk score is recalculated (#278289)](https://github.com/elastic/kibana/pull/278289)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"tcalopes","email":"tatiana.lopes@elastic.co"},"sourceCommit":{"committedDate":"2026-07-15T20:33:23Z","message":"[Entity Analytics] Update resolution group accordion headers when risk score is recalculated (#278289)\n\n## Summary\n\nFollow-up to [#271539](https://github.com/elastic/kibana/pull/271539).\nAfter that PR, changing an entity's asset criticality correctly updated\nthe entities table rows, but when the table is grouped by resolution the\nrisk score shown on the group accordion header was not refreshed. This\nPR fixes that, and centralizes the table-refresh logic inside the\n`useEntityRiskScoreRecalculation` hook.\n\n## How to test\n1. Load some risk score data. I used the `risk-score-v2` command from\n[security-documents-generator](https://github.com/elastic/security-documents-generator):\n  ```\n  yarn start risk-score-v2\n  ```\n2. Navigate to the Entity Analytics page and groups entities on the\nentities table by resolution\n3. Open any entity flyout from the entities table\n4. Change the Asset Criticality\n5. Close the flyout and verify the entities table reflects the updated\nscore on the entities row and the resolution group accordion header","sha":"9cbd4f132001bee4c943491b18ea8ea78e53a9e4","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Entity Analytics","backport:version","v9.4.0","v9.5.0","v9.6.0"],"title":"[Entity Analytics] Update resolution group accordion headers when risk score is recalculated","number":278289,"url":"https://github.com/elastic/kibana/pull/278289","mergeCommit":{"message":"[Entity Analytics] Update resolution group accordion headers when risk score is recalculated (#278289)\n\n## Summary\n\nFollow-up to [#271539](https://github.com/elastic/kibana/pull/271539).\nAfter that PR, changing an entity's asset criticality correctly updated\nthe entities table rows, but when the table is grouped by resolution the\nrisk score shown on the group accordion header was not refreshed. This\nPR fixes that, and centralizes the table-refresh logic inside the\n`useEntityRiskScoreRecalculation` hook.\n\n## How to test\n1. Load some risk score data. I used the `risk-score-v2` command from\n[security-documents-generator](https://github.com/elastic/security-documents-generator):\n  ```\n  yarn start risk-score-v2\n  ```\n2. Navigate to the Entity Analytics page and groups entities on the\nentities table by resolution\n3. Open any entity flyout from the entities table\n4. Change the Asset Criticality\n5. Close the flyout and verify the entities table reflects the updated\nscore on the entities row and the resolution group accordion header","sha":"9cbd4f132001bee4c943491b18ea8ea78e53a9e4"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/278592","number":278592,"state":"OPEN"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278289","number":278289,"mergeCommit":{"message":"[Entity Analytics] Update resolution group accordion headers when risk score is recalculated (#278289)\n\n## Summary\n\nFollow-up to [#271539](https://github.com/elastic/kibana/pull/271539).\nAfter that PR, changing an entity's asset criticality correctly updated\nthe entities table rows, but when the table is grouped by resolution the\nrisk score shown on the group accordion header was not refreshed. This\nPR fixes that, and centralizes the table-refresh logic inside the\n`useEntityRiskScoreRecalculation` hook.\n\n## How to test\n1. Load some risk score data. I used the `risk-score-v2` command from\n[security-documents-generator](https://github.com/elastic/security-documents-generator):\n  ```\n  yarn start risk-score-v2\n  ```\n2. Navigate to the Entity Analytics page and groups entities on the\nentities table by resolution\n3. Open any entity flyout from the entities table\n4. Change the Asset Criticality\n5. Close the flyout and verify the entities table reflects the updated\nscore on the entities row and the resolution group accordion header","sha":"9cbd4f132001bee4c943491b18ea8ea78e53a9e4"}}]}] BACKPORT-->