### PR TITLE
[Entity Analytics] Using `now-30d` for alerts query when opening entity flyouts from EA homepage scope

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/alerts_findings_details_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/alerts_findings_details_table.test.tsx
@@ -10,6 +10,12 @@ import { render, fireEvent } from '@testing-library/react';
 import { AlertsDetailsTable } from './alerts_findings_details_table';
 import { TestProviders } from '../../../common/mock/test_providers';
 import { EntityIdentifierFields } from '../../../../common/entity_analytics/types';
+import { useNonClosedAlerts } from '../../hooks/use_non_closed_alerts';
+import {
+  ENTITY_ANALYTICS_TABLE_ID,
+  ENTITY_ANALYTICS_ALERTS_FROM,
+  ENTITY_ANALYTICS_ALERTS_TO,
+} from '../../../entity_analytics/components/home/constants';
 
 jest.mock('@kbn/cloud-security-posture-common/utils/ui_metrics', () => ({
   uiMetricService: { trackUiMetric: jest.fn() },
@@ -104,5 +110,46 @@ describe('AlertsDetailsTable', () => {
     clickRowAction();
 
     expect(onShowAlert).toHaveBeenCalledWith('alert-1', 'index-1');
+  });
+
+  describe('time range', () => {
+    const renderWithScopeId = (scopeId?: string) =>
+      render(
+        <TestProviders>
+          <AlertsDetailsTable
+            field={EntityIdentifierFields.hostName}
+            value="my-host"
+            onShowAlert={jest.fn()}
+            scopeId={scopeId}
+          />
+        </TestProviders>
+      );
+
+    it('uses the global time range when no scopeId is provided', () => {
+      renderWithScopeId();
+
+      expect(useNonClosedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({ from: '2022-01-01', to: '2023-01-01' })
+      );
+    });
+
+    it('uses the scope time-range override for the EA homepage scope', () => {
+      renderWithScopeId(ENTITY_ANALYTICS_TABLE_ID);
+
+      expect(useNonClosedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: ENTITY_ANALYTICS_ALERTS_FROM,
+          to: ENTITY_ANALYTICS_ALERTS_TO,
+        })
+      );
+    });
+
+    it('falls back to the global time range for an unregistered scopeId', () => {
+      renderWithScopeId('some-other-scope');
+
+      expect(useNonClosedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({ from: '2022-01-01', to: '2023-01-01' })
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/alerts_findings_details_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/alerts_findings_details_table.tsx
@@ -38,8 +38,7 @@ import {
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { useNavigateToAlertsPageWithFilters } from '../../../common/hooks/use_navigate_to_alerts_page_with_filters';
 import type { ESBoolQuery } from '../../../../common/typed_json';
-import { useGlobalTime } from '../../../common/containers/use_global_time';
-import { SCOPE_ALERT_TIME_RANGE_OVERRIDES } from '../../../entity_analytics/components/home/constants';
+import { useAlertTimeRange } from '../../../entity_analytics/hooks/use_alert_time_range';
 import { useUiSetting } from '../../../common/lib/kibana';
 import { useQueryAlerts } from '../../../detections/containers/detection_engine/alerts/use_query';
 import { ALERTS_QUERY_NAMES } from '../../../detections/containers/detection_engine/alerts/constants';
@@ -149,10 +148,7 @@ export const AlertsDetailsTable = memo(
       };
     };
 
-    const { to: globalTo, from: globalFrom } = useGlobalTime();
-    const scopeOverride = scopeId ? SCOPE_ALERT_TIME_RANGE_OVERRIDES[scopeId] : undefined;
-    const from = scopeOverride?.from ?? globalFrom;
-    const to = scopeOverride?.to ?? globalTo;
+    const { from, to } = useAlertTimeRange(scopeId);
     const timerange = encode({
       global: {
         [URL_PARAM_KEY.timerange]: {

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/alerts_findings_details_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/alerts_findings_details_table.tsx
@@ -39,6 +39,7 @@ import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { useNavigateToAlertsPageWithFilters } from '../../../common/hooks/use_navigate_to_alerts_page_with_filters';
 import type { ESBoolQuery } from '../../../../common/typed_json';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
+import { SCOPE_ALERT_TIME_RANGE_OVERRIDES } from '../../../entity_analytics/components/home/constants';
 import { useUiSetting } from '../../../common/lib/kibana';
 import { useQueryAlerts } from '../../../detections/containers/detection_engine/alerts/use_query';
 import { ALERTS_QUERY_NAMES } from '../../../detections/containers/detection_engine/alerts/constants';
@@ -92,6 +93,7 @@ export const AlertsDetailsTable = memo(
     entityId,
     entityType,
     onShowAlert,
+    scopeId,
   }: {
     field: CloudPostureEntityIdentifier;
     value: string;
@@ -100,6 +102,12 @@ export const AlertsDetailsTable = memo(
     entityType?: 'host' | 'user';
     /** Callback executed after opening the alert details for a row. */
     onShowAlert: (eventId: string, indexName: string) => void;
+    /**
+     * Scope ID of the table or panel that opened this flyout. When the scope has
+     * a registered time-range override in {@link SCOPE_ALERT_TIME_RANGE_OVERRIDES}
+     * that window is used for the alerts query instead of the global time range.
+     */
+    scopeId?: string;
   }) => {
     const { euiTheme } = useEuiTheme();
 
@@ -141,7 +149,10 @@ export const AlertsDetailsTable = memo(
       };
     };
 
-    const { to, from } = useGlobalTime();
+    const { to: globalTo, from: globalFrom } = useGlobalTime();
+    const scopeOverride = scopeId ? SCOPE_ALERT_TIME_RANGE_OVERRIDES[scopeId] : undefined;
+    const from = scopeOverride?.from ?? globalFrom;
+    const to = scopeOverride?.to ?? globalTo;
     const timerange = encode({
       global: {
         [URL_PARAM_KEY.timerange]: {

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/insights_tab_csp.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/insights_tab_csp.tsx
@@ -278,6 +278,7 @@ export const InsightsTabCsp = memo(
             value={value}
             entityId={entityId}
             onShowAlert={onShowAlert}
+            scopeId={scopeId}
           />
         )}
       </>

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EntityInsight } from './entity_insight';
+import { TestProviders } from '../../common/mock/test_providers';
+import { EntityIdentifierFields } from '../../../common/entity_analytics/types';
+import { useNonClosedAlerts } from '../hooks/use_non_closed_alerts';
+import {
+  ENTITY_ANALYTICS_TABLE_ID,
+  ENTITY_ANALYTICS_ALERTS_FROM,
+  ENTITY_ANALYTICS_ALERTS_TO,
+} from '../../entity_analytics/components/home/constants';
+
+jest.mock('@kbn/entity-store/public', () => ({
+  ...jest.requireActual('@kbn/entity-store/public'),
+  useEntityStoreEuidApi: jest.fn().mockReturnValue({ euid: null }),
+}));
+
+jest.mock('@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations', () => ({
+  useHasMisconfigurations: jest.fn().mockReturnValue({
+    hasMisconfigurationFindings: false,
+    passedFindings: 0,
+    failedFindings: 0,
+  }),
+}));
+
+jest.mock('@kbn/cloud-security-posture/src/hooks/use_has_vulnerabilities', () => ({
+  useHasVulnerabilities: jest.fn().mockReturnValue({ hasVulnerabilitiesFindings: false }),
+}));
+
+jest.mock('../../common/containers/use_global_time', () => ({
+  useGlobalTime: jest.fn().mockReturnValue({ to: '2023-01-01', from: '2022-01-01' }),
+}));
+
+jest.mock('../hooks/use_non_closed_alerts', () => ({
+  useNonClosedAlerts: jest
+    .fn()
+    .mockReturnValue({ hasNonClosedAlerts: false, filteredAlertsData: null }),
+}));
+
+describe('EntityInsight', () => {
+  const defaultProps = {
+    identityFields: { [EntityIdentifierFields.hostName]: 'my-host' },
+    isPreviewMode: false,
+    openDetailsPanel: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('time range', () => {
+    const renderWithScopeId = (scopeId?: string) =>
+      render(
+        <TestProviders>
+          <EntityInsight {...defaultProps} scopeId={scopeId} />
+        </TestProviders>
+      );
+
+    it('uses the global time range when no scopeId is provided', () => {
+      renderWithScopeId();
+
+      expect(useNonClosedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({ from: '2022-01-01', to: '2023-01-01' })
+      );
+    });
+
+    it('uses the scope time-range override for the EA homepage scope', () => {
+      renderWithScopeId(ENTITY_ANALYTICS_TABLE_ID);
+
+      expect(useNonClosedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: ENTITY_ANALYTICS_ALERTS_FROM,
+          to: ENTITY_ANALYTICS_ALERTS_TO,
+        })
+      );
+    });
+
+    it('falls back to the global time range for an unregistered scopeId', () => {
+      renderWithScopeId('some-other-scope');
+
+      expect(useNonClosedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({ from: '2022-01-01', to: '2023-01-01' })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
@@ -22,6 +22,7 @@ import { MisconfigurationsPreview } from './misconfiguration/misconfiguration_pr
 import { VulnerabilitiesPreview } from './vulnerabilities/vulnerabilities_preview';
 import { AlertsPreview } from './alerts/alerts_preview';
 import { useGlobalTime } from '../../common/containers/use_global_time';
+import { SCOPE_ALERT_TIME_RANGE_OVERRIDES } from '../../entity_analytics/components/home/constants';
 import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../overview/components/detection_response/alerts_by_status/types';
 import { useNonClosedAlerts } from '../hooks/use_non_closed_alerts';
 import type { EntityDetailsPath } from '../../flyout/entity_details/shared/components/left_panel/left_panel_header';
@@ -43,6 +44,7 @@ export const EntityInsight = <T,>({
   entityType,
   entityRecord,
   hideHeaderIcons,
+  scopeId,
 }: {
   identityFields: IdentityFields;
   isPreviewMode: boolean;
@@ -52,6 +54,12 @@ export const EntityInsight = <T,>({
   entityRecord?: EntityStoreRecord | null;
   /** When true, hides the chevron icons in the section headers. Used by the v2 flyout. */
   hideHeaderIcons?: boolean;
+  /**
+   * Scope ID of the table or panel that opened this flyout. When the scope has
+   * a registered time-range override in {@link SCOPE_ALERT_TIME_RANGE_OVERRIDES}
+   * that window is used for the alerts query instead of the global time range.
+   */
+  scopeId?: string;
 }) => {
   const { euiTheme } = useEuiTheme();
   const euidApi = useEntityStoreEuidApi();
@@ -77,7 +85,10 @@ export const EntityInsight = <T,>({
   const showVulnerabilitiesPreview =
     hasVulnerabilitiesFindings && Object.keys(identityFields).length > 0;
 
-  const { to, from } = useGlobalTime();
+  const { to: globalTo, from: globalFrom } = useGlobalTime();
+  const scopeOverride = scopeId ? SCOPE_ALERT_TIME_RANGE_OVERRIDES[scopeId] : undefined;
+  const from = scopeOverride?.from ?? globalFrom;
+  const to = scopeOverride?.to ?? globalTo;
 
   const { hasNonClosedAlerts: showAlertsPreview, filteredAlertsData } = useNonClosedAlerts({
     identityFields,

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
@@ -21,8 +21,7 @@ import type { IdentityFields } from '../../flyout/document_details/shared/utils'
 import { MisconfigurationsPreview } from './misconfiguration/misconfiguration_preview';
 import { VulnerabilitiesPreview } from './vulnerabilities/vulnerabilities_preview';
 import { AlertsPreview } from './alerts/alerts_preview';
-import { useGlobalTime } from '../../common/containers/use_global_time';
-import { SCOPE_ALERT_TIME_RANGE_OVERRIDES } from '../../entity_analytics/components/home/constants';
+import { useAlertTimeRange } from '../../entity_analytics/hooks/use_alert_time_range';
 import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../overview/components/detection_response/alerts_by_status/types';
 import { useNonClosedAlerts } from '../hooks/use_non_closed_alerts';
 import type { EntityDetailsPath } from '../../flyout/entity_details/shared/components/left_panel/left_panel_header';
@@ -85,10 +84,7 @@ export const EntityInsight = <T,>({
   const showVulnerabilitiesPreview =
     hasVulnerabilitiesFindings && Object.keys(identityFields).length > 0;
 
-  const { to: globalTo, from: globalFrom } = useGlobalTime();
-  const scopeOverride = scopeId ? SCOPE_ALERT_TIME_RANGE_OVERRIDES[scopeId] : undefined;
-  const from = scopeOverride?.from ?? globalFrom;
-  const to = scopeOverride?.to ?? globalTo;
+  const { from, to } = useAlertTimeRange(scopeId);
 
   const { hasNonClosedAlerts: showAlertsPreview, filteredAlertsData } = useNonClosedAlerts({
     identityFields,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/alert_time_range_overrides.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/alert_time_range_overrides.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ENTITY_ANALYTICS_TABLE_ID,
+  ENTITY_ANALYTICS_ALERTS_FROM,
+  ENTITY_ANALYTICS_ALERTS_TO,
+} from '../components/home/constants';
+
+/**
+ * Maps a scope ID to the alert query time range that should be used when an
+ * entity flyout or insights tab is opened from that scope. Components look up
+ * their `scopeId` here and, when a match is found, use the returned `{ from, to }`
+ * instead of the global Kibana time range.
+ *
+ * Add an entry here whenever a new surface pins alerts to a fixed window.
+ */
+export const SCOPE_ALERT_TIME_RANGE_OVERRIDES: Readonly<
+  Record<string, { from: string; to: string }>
+> = {
+  [ENTITY_ANALYTICS_TABLE_ID]: {
+    from: ENTITY_ANALYTICS_ALERTS_FROM,
+    to: ENTITY_ANALYTICS_ALERTS_TO,
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/constants.ts
@@ -9,6 +9,28 @@ export { getEntitiesAlias, ENTITY_LATEST } from '@kbn/entity-store/common';
 
 export const ENTITY_ANALYTICS_TABLE_ID = 'entity-analytics-home-table';
 
+// The EA homepage hides the global date picker, so alert queries on this page
+// use a fixed "last 30 days" window instead of the global time range.
+export const ENTITY_ANALYTICS_ALERTS_FROM = 'now-30d';
+export const ENTITY_ANALYTICS_ALERTS_TO = 'now';
+
+/**
+ * Maps a scope ID to the alert query time range that should be used when the
+ * entity flyout (right panel) or left-panel insights tab is opened from that
+ * scope. Components look up their `scopeId` here and, when a match is found,
+ * use the returned `{ from, to }` instead of the global Kibana time range.
+ *
+ * Add an entry here whenever a new surface pins alerts to a fixed window.
+ */
+export const SCOPE_ALERT_TIME_RANGE_OVERRIDES: Readonly<
+  Record<string, { from: string; to: string }>
+> = {
+  [ENTITY_ANALYTICS_TABLE_ID]: {
+    from: ENTITY_ANALYTICS_ALERTS_FROM,
+    to: ENTITY_ANALYTICS_ALERTS_TO,
+  },
+};
+
 const LOCAL_STORAGE_PREFIX = 'entityAnalytics';
 export const ENTITY_ANALYTICS_LOCAL_STORAGE_COLUMNS_KEY = `${LOCAL_STORAGE_PREFIX}:columns`;
 export const ENTITY_ANALYTICS_LOCAL_STORAGE_PAGE_SIZE_KEY = `${LOCAL_STORAGE_PREFIX}:dataTable:pageSize`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/constants.ts
@@ -14,23 +14,6 @@ export const ENTITY_ANALYTICS_TABLE_ID = 'entity-analytics-home-table';
 export const ENTITY_ANALYTICS_ALERTS_FROM = 'now-30d';
 export const ENTITY_ANALYTICS_ALERTS_TO = 'now';
 
-/**
- * Maps a scope ID to the alert query time range that should be used when the
- * entity flyout (right panel) or left-panel insights tab is opened from that
- * scope. Components look up their `scopeId` here and, when a match is found,
- * use the returned `{ from, to }` instead of the global Kibana time range.
- *
- * Add an entry here whenever a new surface pins alerts to a fixed window.
- */
-export const SCOPE_ALERT_TIME_RANGE_OVERRIDES: Readonly<
-  Record<string, { from: string; to: string }>
-> = {
-  [ENTITY_ANALYTICS_TABLE_ID]: {
-    from: ENTITY_ANALYTICS_ALERTS_FROM,
-    to: ENTITY_ANALYTICS_ALERTS_TO,
-  },
-};
-
 const LOCAL_STORAGE_PREFIX = 'entityAnalytics';
 export const ENTITY_ANALYTICS_LOCAL_STORAGE_COLUMNS_KEY = `${LOCAL_STORAGE_PREFIX}:columns`;
 export const ENTITY_ANALYTICS_LOCAL_STORAGE_PAGE_SIZE_KEY = `${LOCAL_STORAGE_PREFIX}:dataTable:pageSize`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
@@ -22,6 +22,7 @@ import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 import { SecurityPageName, useNavigation } from '@kbn/security-solution-navigation';
 import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import type { EntityStoreRecord } from '../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+import { ENTITY_ANALYTICS_ALERTS_FROM, ENTITY_ANALYTICS_ALERTS_TO } from './constants';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
 import { FILTER_OPEN, FILTER_ACKNOWLEDGED } from '../../../../common/types';
@@ -47,13 +48,10 @@ import { getFormattedAlertStats } from '../../../flyout_v2/document/main/compone
 
 const QUERY_KEY_ENTITY_ALERTS_BY_STATUS = 'entity-analytics-alerts-by-status';
 
-// The Entity Analytics home page hides the global date picker (see `hideDatePicker`
-// in entity_analytics_home_page.tsx), so we can't rely on the global time range — it
-// carries whatever the user last set on another page. Pin the alerts column to a
-// fixed "last 30 days" window instead. ES resolves the date-math expressions at
-// query time, so clicking the global refresh button always returns up-to-date counts.
-const ALERTS_CELL_FROM_STR = 'now-30d';
-const ALERTS_CELL_TO_STR = 'now';
+// Local aliases — the source of truth lives in ./constants and is shared with the
+// entity flyout insights section to keep both time windows in sync.
+const ALERTS_CELL_FROM_STR = ENTITY_ANALYTICS_ALERTS_FROM;
+const ALERTS_CELL_TO_STR = ENTITY_ANALYTICS_ALERTS_TO;
 
 const ENTITY_FILTER_TITLE = i18n.translate(
   'xpack.securitySolution.entityAnalytics.homePage.alertsColumn.entityFilterTitle',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_alert_time_range.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/hooks/use_alert_time_range.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useGlobalTime } from '../../common/containers/use_global_time';
+import { SCOPE_ALERT_TIME_RANGE_OVERRIDES } from '../common/alert_time_range_overrides';
+
+/**
+ * Returns `{ from, to }` for alert queries. When `scopeId` has a registered
+ * entry in {@link SCOPE_ALERT_TIME_RANGE_OVERRIDES} that window wins; otherwise
+ * falls back to the Kibana global time range.
+ */
+export const useAlertTimeRange = (scopeId?: string): { from: string; to: string } => {
+  const { to: globalTo, from: globalFrom } = useGlobalTime();
+  const scopeOverride = scopeId ? SCOPE_ALERT_TIME_RANGE_OVERRIDES[scopeId] : undefined;
+  return {
+    from: scopeOverride?.from ?? globalFrom,
+    to: scopeOverride?.to ?? globalTo,
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/content.tsx
@@ -205,6 +205,7 @@ export const Content = ({
         openDetailsPanel={openDetailsPanel}
         entityType={EntityType.host}
         hideHeaderIcons={hideHeaderIcons}
+        scopeId={scopeId}
       />
       <ObservedDataSection
         entityType={EntityType.host}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/content.tsx
@@ -207,6 +207,7 @@ export const Content = ({
         openDetailsPanel={openDetailsPanel}
         entityType={EntityType.user}
         hideHeaderIcons={hideHeaderIcons}
+        scopeId={scopeId}
       />
       <ObservedDataSection
         entityType={EntityType.user}


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/278334

## Summary

The alerts column on the entities table on the EA homepage always queries alerts for the last 30 days https://github.com/elastic/kibana/blob/d16fe602ee86c92e6035819c9fe4eab4b04e2437/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx#L55
whereas the entity flyout insights sections loads alerts using the `useGlobalTime` hook, which defaults to `Today`. This causes a mismatch between what's shown on the entity table and what is shown when the flyout opens.

This PR uses the `scopeId` to look up what time range to use when querying for alerts on the entity flyout insights section and the insights tab on the left flyout. When scoped to the EA homepage, the alerts query will use the same 30 day time range. When not scoped to the EA homepage (opened from the alerts table for example), it falls back to the existing `useGlobalTime` parameters.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->