### PR TITLE
[Cases][AttachmentsV2] Fix attachments tab persistence and search

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -299,6 +299,7 @@ export const LOCAL_STORAGE_KEYS = {
   templatesYamlEditorEditState: 'templates.yaml.editor.edit',
   userActivitySortOrder: 'cases.userActivity.sortOrder',
   userActivityFilters: 'cases.userActivity.redesign.filters',
+  attachmentFilters: 'cases.attachments.filters',
   casesUtilityBarHideMaxLimitWarning: 'cases.utilityBar.hideMaxLimitWarning',
   caseViewSidebarOpen: 'cases.caseView.sidebarOpen',
   caseViewSidebarAccordions: 'cases.caseView.sidebarAccordions',

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_local_storage.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_local_storage.test.tsx
@@ -56,6 +56,21 @@ describe('useCasesLocalStorage', () => {
       expect(localStorage.getItem(ownerLSKey)).toEqual('{"foo":"test"}');
     });
 
+    it('composes functional updates applied in the same render', async () => {
+      const { result } = renderHook(
+        () => useCasesLocalStorage<{ a: string; b: string }>(lsKey, { a: '', b: '' }),
+        { wrapper: TestProviders }
+      );
+
+      act(() => {
+        result.current[1]((prev) => ({ ...prev, a: 'first' }));
+        result.current[1]((prev) => ({ ...prev, b: 'second' }));
+      });
+
+      expect(result.current[0]).toEqual({ a: 'first', b: 'second' });
+      expect(localStorage.getItem(ownerLSKey)).toEqual('{"a":"first","b":"second"}');
+    });
+
     it('returns the initial value in case of parsing errors', async () => {
       localStorage.setItem(ownerLSKey, 'test');
 

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_local_storage.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_local_storage.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { useCallback, useState, useRef } from 'react';
 import { useCasesContext } from '../components/cases_context/use_cases_context';
 import { useApplication } from './lib/kibana/use_application';
 
@@ -24,24 +24,24 @@ export const useCasesLocalStorage = <T,>(
 
   const [value, setValue] = useState<T>(() => getStorageItem(lsKey, initialValue));
 
-  // Resolve inside the updater so functional updates compose when several
-  // setters run in the same render (e.g. distinct filter fields on one key).
-  const setItem = useCallback<SetLocalStorageItem<T>>((newValue) => {
-    setValue((prev) =>
-      typeof newValue === 'function' ? (newValue as (previous: T) => T)(prev) : newValue
-    );
-  }, []);
+  // Track the latest value in a ref so functional updates compose when several
+  // setters run in the same render (e.g. distinct filter fields on one key)
+  // without moving the localStorage write into the (impure) state updater.
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
-  // Persist after commit, not inside the updater: state updaters must be pure
-  // (StrictMode double-invokes them), so localStorage writes belong in an effect.
-  // Persisting on mount is intentional: it normalizes/repairs the stored value
-  // (e.g. rewrites a corrupt or missing entry to the hydrated default).
-  useEffect(() => {
-    if (!lsKeyPrefix) {
-      return;
-    }
-    saveItemToStorage(lsKey, value);
-  }, [lsKey, lsKeyPrefix, value]);
+  const setItem = useCallback<SetLocalStorageItem<T>>(
+    (newValue) => {
+      const resolved =
+        typeof newValue === 'function'
+          ? (newValue as (previous: T) => T)(valueRef.current)
+          : newValue;
+      valueRef.current = resolved;
+      setValue(resolved);
+      saveItemToStorage(lsKey, resolved);
+    },
+    [lsKey]
+  );
 
   if (!lsKeyPrefix) {
     return [initialValue, setItem];

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_local_storage.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_local_storage.tsx
@@ -5,14 +5,16 @@
  * 2.0.
  */
 
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { useCasesContext } from '../components/cases_context/use_cases_context';
 import { useApplication } from './lib/kibana/use_application';
+
+type SetLocalStorageItem<T> = (newItem: T | ((prev: T) => T)) => void;
 
 export const useCasesLocalStorage = <T,>(
   key: string,
   initialValue: T
-): [T, (newItem: T) => void] => {
+): [T, SetLocalStorageItem<T>] => {
   const isStorageInitialized = useRef(false);
   const { appId } = useApplication();
   const { owner } = useCasesContext();
@@ -22,13 +24,24 @@ export const useCasesLocalStorage = <T,>(
 
   const [value, setValue] = useState<T>(() => getStorageItem(lsKey, initialValue));
 
-  const setItem = useCallback(
-    (newValue: T) => {
-      setValue(newValue);
-      saveItemToStorage(lsKey, newValue);
-    },
-    [lsKey]
-  );
+  // Resolve inside the updater so functional updates compose when several
+  // setters run in the same render (e.g. distinct filter fields on one key).
+  const setItem = useCallback<SetLocalStorageItem<T>>((newValue) => {
+    setValue((prev) =>
+      typeof newValue === 'function' ? (newValue as (previous: T) => T)(prev) : newValue
+    );
+  }, []);
+
+  // Persist after commit, not inside the updater: state updaters must be pure
+  // (StrictMode double-invokes them), so localStorage writes belong in an effect.
+  // Persisting on mount is intentional: it normalizes/repairs the stored value
+  // (e.g. rewrites a corrupt or missing entry to the hydrated default).
+  useEffect(() => {
+    if (!lsKeyPrefix) {
+      return;
+    }
+    saveItemToStorage(lsKey, value);
+  }, [lsKey, lsKeyPrefix, value]);
 
   if (!lsKeyPrefix) {
     return [initialValue, setItem];

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
@@ -122,11 +122,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(({ caseData, refreshRe
         <LensAttachReturnConsumer caseId={caseData.id} />
       )}
       <SavedObjectInAppUrlsProvider caseData={caseData}>
-        <CaseViewTabs
-          caseData={caseWithFilteredAttachments}
-          activeTab={activeTabId as CASE_VIEW_PAGE_TABS}
-          searchTerm={searchTerm}
-        />
+        <CaseViewTabs caseData={caseData} activeTab={activeTabId as CASE_VIEW_PAGE_TABS} />
         <EuiFlexGroup data-test-subj={`case-view-tab-content-${activeTabId}`} alignItems="baseline">
           {activeTabId === CASE_VIEW_PAGE_TABS.ACTIVITY && (
             <CaseViewActivity caseData={caseWithFilteredAttachments} />

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
@@ -26,7 +26,6 @@ import { useAttachmentsTabClickedEBT } from '../../analytics/use_attachments_tab
 export interface CaseViewTabsProps {
   caseData: CaseUI;
   activeTab: CASE_VIEW_PAGE_TABS;
-  searchTerm?: string;
 }
 
 interface Tab {
@@ -35,9 +34,9 @@ interface Tab {
   badge?: ReactNode;
 }
 
-export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab, searchTerm }) => {
+export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab }) => {
   const { navigateToCaseView } = useCaseViewNavigation();
-  const totalAttachments = useCaseAttachmentsTotal({ caseData, searchTerm });
+  const totalAttachments = useCaseAttachmentsTotal({ caseData });
 
   const { euiTheme } = useEuiTheme();
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
@@ -94,6 +94,9 @@ const onUpdateFieldMock = jest.fn();
 
 describe('Case View Attachments tab', () => {
   beforeEach(() => {
+    // Attachment filters now persist to local storage; clear between tests so a
+    // filter selected in one test does not leak into the next.
+    localStorage.clear();
     useGetCaseFileStatsMock.mockReturnValue({ data: fileStatsData });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -13,6 +13,7 @@ import {
   MAP_ATTACHMENT_TYPE,
   SECURITY_ALERT_ATTACHMENT_TYPE,
   SECURITY_EVENT_ATTACHMENT_TYPE,
+  SECURITY_TIMELINE_ATTACHMENT_TYPE,
 } from '../../../../common/constants/attachments';
 import type { AttachmentUIV2 } from '../../../../common/ui/types';
 import { getManualAlertIds } from '../../../../common/utils/attachments/manual_alert_ids';
@@ -231,6 +232,19 @@ describe('Case view helpers', () => {
         });
       });
 
+      it(`matches ${fieldName} case-insensitively`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [{ ...commentTemplate, [fieldName]: `${type}-ABC` }],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, 'abc');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-ABC`],
+        });
+      });
+
       it(`filters ${type} comments with array ${fieldName} that matches search term`, () => {
         const caseData = {
           ...basicCase,
@@ -427,7 +441,47 @@ describe('Case view helpers', () => {
       });
     });
 
-    it('does not apply event-id filtering to non-event unified reference attachments', () => {
+    const buildTimelineComment = (): AttachmentUIV2 =>
+      ({
+        id: 'timeline-1',
+        type: SECURITY_TIMELINE_ATTACHMENT_TYPE,
+        attachmentId: 'timeline-id-1',
+        metadata: { title: 'My investigation' },
+        owner: basicCase.owner,
+        createdAt: basicCase.createdAt,
+        createdBy: basicCase.createdBy,
+        pushedAt: null,
+        pushedBy: null,
+        updatedAt: null,
+        updatedBy: null,
+        version: 'WzQ3LDFc',
+      } as unknown as AttachmentUIV2);
+
+    it('filters timeline attachments whose cached title matches case-insensitively', () => {
+      const timelineComment = buildTimelineComment();
+      const caseData = {
+        ...basicCase,
+        comments: [timelineComment],
+      };
+
+      const result = filterCaseAttachmentsBySearchTerm(caseData, 'INVESTIGATION');
+
+      expect(result.comments).toHaveLength(1);
+      expect(result.comments[0]).toEqual(timelineComment);
+    });
+
+    it('drops timeline attachments that match neither cached title nor attachmentId', () => {
+      const caseData = {
+        ...basicCase,
+        comments: [buildTimelineComment()],
+      };
+
+      const result = filterCaseAttachmentsBySearchTerm(caseData, 'nothing-matches');
+
+      expect(result.comments).toHaveLength(0);
+    });
+
+    it('filters non-event unified reference attachments by attachmentId', () => {
       const nonEventUnifiedReferenceComment = {
         id: 'non-event-unified-ref',
         type: 'lens',
@@ -446,10 +500,13 @@ describe('Case view helpers', () => {
         comments: [nonEventUnifiedReferenceComment],
       };
 
-      const result = filterCaseAttachmentsBySearchTerm(caseData, 'missing-id');
+      const result = filterCaseAttachmentsBySearchTerm(caseData, 'ref-1');
 
       expect(result.comments).toHaveLength(1);
-      expect(result.comments[0]).toEqual(nonEventUnifiedReferenceComment);
+      expect(result.comments[0]).toEqual({
+        ...nonEventUnifiedReferenceComment,
+        attachmentId: ['ref-1'],
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -15,6 +15,7 @@ import {
   SECURITY_EVENT_ATTACHMENT_TYPE,
   SECURITY_TIMELINE_ATTACHMENT_TYPE,
 } from '../../../../common/constants/attachments';
+import { FILE_ATTACHMENT_TYPE } from '../../../../common/constants';
 import type { AttachmentUIV2 } from '../../../../common/ui/types';
 import { getManualAlertIds } from '../../../../common/utils/attachments/manual_alert_ids';
 import { filterCaseAttachmentsBySearchTerm, getAttachmentItemCount } from './helpers';
@@ -479,6 +480,32 @@ describe('Case view helpers', () => {
       const result = filterCaseAttachmentsBySearchTerm(caseData, 'nothing-matches');
 
       expect(result.comments).toHaveLength(0);
+    });
+
+    it('keeps file attachments regardless of the search term (searched server-side)', () => {
+      const fileComment = {
+        id: 'file-1',
+        type: FILE_ATTACHMENT_TYPE,
+        attachmentId: 'file-id-1',
+        metadata: { files: [{ name: 'elastic_logo.png' }] },
+        owner: basicCase.owner,
+        createdAt: basicCase.createdAt,
+        createdBy: basicCase.createdBy,
+        pushedAt: null,
+        pushedBy: null,
+        updatedAt: null,
+        updatedBy: null,
+        version: 'WzQ3LDFc',
+      } as unknown as AttachmentUIV2;
+      const caseData = {
+        ...basicCase,
+        comments: [fileComment],
+      };
+
+      const result = filterCaseAttachmentsBySearchTerm(caseData, 'nothing-matches');
+
+      expect(result.comments).toHaveLength(1);
+      expect(result.comments[0]).toEqual(fileComment);
     });
 
     it('filters non-event unified reference attachments by attachmentId', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -20,6 +20,8 @@ import {
 } from '../../../../common/utils/attachments';
 import { isSavedObjectAttachment } from '../../attachments/common/saved_object/helpers';
 import { LENS_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
+import { FILE_ATTACHMENT_TYPE } from '../../../../common/constants';
+import { resolveUnifiedAttachmentType } from '../../../../common/utils/attachments/migration_utils';
 import { UNKNOWN } from '../../../common/translations';
 
 /**
@@ -126,6 +128,8 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
     return caseData;
   }
 
+  const owner = Array.isArray(caseData.owner) ? caseData.owner[0] : caseData.owner;
+
   return {
     ...caseData,
     comments: caseData.comments
@@ -135,6 +139,12 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
         }
         if (isLegacyEventAttachment(comment)) {
           return filterLegacyEventCommentByIds(comment, searchTerm);
+        }
+        // Files are searched server-side by filename (see `CaseViewFiles` /
+        // `useGetCaseFileStats`); their comment metadata carries no searchable
+        // title, so keep them here and let the files API drive the results.
+        if (resolveUnifiedAttachmentType(comment, owner) === FILE_ATTACHMENT_TYPE) {
+          return comment;
         }
         if (isUnifiedReferenceAttachmentRequest(comment)) {
           return filterUnifiedAttachment(comment, searchTerm);

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -17,15 +17,9 @@ import type {
 import {
   isLegacyEventAttachment,
   isUnifiedReferenceAttachmentRequest,
-  isUnifiedAlertAttachment,
-  isUnifiedEventAttachment,
 } from '../../../../common/utils/attachments';
-import {
-  getSavedObjectAttachmentAttributes,
-  isSavedObjectAttachment,
-} from '../../attachments/common/saved_object/helpers';
+import { isSavedObjectAttachment } from '../../attachments/common/saved_object/helpers';
 import { LENS_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
-import type { SavedObjectAttachmentAttributes } from '../../attachments/common/saved_object/types';
 import { UNKNOWN } from '../../../common/translations';
 
 /**
@@ -69,8 +63,9 @@ const filterAlertCommentByIds = (
   comment: AlertAttachmentUI,
   searchTerm: string
 ): AlertAttachmentUI | null => {
+  const term = searchTerm.toLowerCase();
   const ids = Array.isArray(comment.alertId) ? comment.alertId : [comment.alertId];
-  const filteredIds = ids.filter((id: string) => Boolean(id) && id.includes(searchTerm));
+  const filteredIds = ids.filter((id: string) => Boolean(id) && id.toLowerCase().includes(term));
   if (filteredIds.length === 0) {
     return null;
   }
@@ -84,8 +79,9 @@ const filterLegacyEventCommentByIds = (
   comment: EventAttachmentUI,
   searchTerm: string
 ): EventAttachmentUI | null => {
+  const term = searchTerm.toLowerCase();
   const ids = Array.isArray(comment.eventId) ? comment.eventId : [comment.eventId];
-  const filteredIds = ids.filter((id: string) => Boolean(id) && id.includes(searchTerm));
+  const filteredIds = ids.filter((id: string) => Boolean(id) && id.toLowerCase().includes(term));
   if (filteredIds.length === 0) {
     return null;
   }
@@ -96,34 +92,30 @@ const filterLegacyEventCommentByIds = (
 };
 
 /**
- * SO-typed unified reference attachments (dashboard, map, discoverSession)
- * filter on title (cached in `metadata.title` at attach time) as well as the
- * foreign SO id, case-insensitively — matching the experience the user gets
- * when typing into the modal search.
+ * Unified reference attachments (saved objects, timeline, etc.) filter on the
+ * cached `metadata.title` and `attachmentId`, case-insensitively — matching
+ * the experience the user gets when typing into each tab's search.
  */
-const filterSavedObjectCommentBySearchTerm = (
-  comment: AttachmentUIV2,
-  attributes: SavedObjectAttachmentAttributes,
-  searchTerm: string
-): AttachmentUIV2 | null => {
-  const term = searchTerm.toLowerCase();
-  const title = (attributes.title ?? '').toLowerCase();
-  const id = attributes.attachmentId.toLowerCase();
-  return title.includes(term) || id.includes(term) ? comment : null;
-};
-
-const filterUnifiedCommentById = (
+const filterUnifiedAttachment = (
   comment: UnifiedReferenceAttachmentPayload,
   searchTerm: string
 ): UnifiedReferenceAttachmentPayload | null => {
+  const term = searchTerm.toLowerCase();
+  const title =
+    typeof comment.metadata?.title === 'string' ? comment.metadata.title.toLowerCase() : '';
+  if (title.includes(term)) {
+    return comment;
+  }
+
   if (Array.isArray(comment.attachmentId)) {
-    const matchingIds = comment.attachmentId.filter((id) => id.includes(searchTerm));
+    const matchingIds = comment.attachmentId.filter((id) => id.toLowerCase().includes(term));
     if (matchingIds.length === 0) {
       return null;
     }
     return { ...comment, attachmentId: matchingIds };
   }
-  if (!comment.attachmentId.includes(searchTerm)) {
+
+  if (!comment.attachmentId.toLowerCase().includes(term)) {
     return null;
   }
   return comment;
@@ -144,12 +136,8 @@ export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: 
         if (isLegacyEventAttachment(comment)) {
           return filterLegacyEventCommentByIds(comment, searchTerm);
         }
-        if (isSavedObjectAttachment(comment)) {
-          const savedObjectAttributes = getSavedObjectAttachmentAttributes(comment);
-          return filterSavedObjectCommentBySearchTerm(comment, savedObjectAttributes, searchTerm);
-        }
-        if (isUnifiedEventAttachment(comment) || isUnifiedAlertAttachment(comment)) {
-          return filterUnifiedCommentById(comment, searchTerm);
+        if (isUnifiedReferenceAttachmentRequest(comment)) {
+          return filterUnifiedAttachment(comment, searchTerm);
         }
         return comment;
       })

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/translations.ts
@@ -12,7 +12,7 @@ export const ATTACH_BUTTON_LABEL = i18n.translate('xpack.cases.caseView.attach.b
 });
 
 export const ATTACH_MENU_FILE = i18n.translate('xpack.cases.caseView.attach.menu.file', {
-  defaultMessage: 'Upload file',
+  defaultMessage: 'File',
 });
 
 export const ATTACH_MENU_TIMELINE = i18n.translate('xpack.cases.caseView.attach.menu.timeline', {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/hooks/use_case_view_filters.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/hooks/use_case_view_filters.test.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
+import React from 'react';
 import { act, renderHook } from '@testing-library/react';
 
 import type { CaseUI } from '../../../../common';
+import { LOCAL_STORAGE_KEYS } from '../../../../common/constants';
 import { basicCase, basicComment, elasticUser } from '../../../containers/mock';
+import { TestProviders } from '../../../common/mock';
 import { useCaseViewFilters } from './use_case_view_filters';
 
 const otherUser = {
@@ -25,9 +28,19 @@ const caseWithTwoAuthors: CaseUI = {
   ],
 };
 
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(TestProviders, null, children);
+
+// TestProviders defaults the owner to `securitySolution`, which prefixes the key.
+const localStorageKey = `securitySolution.${LOCAL_STORAGE_KEYS.attachmentFilters}`;
+
 describe('useCaseViewFilters', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('returns inactive flags and the input caseData by default', () => {
-    const { result } = renderHook(() => useCaseViewFilters(basicCase));
+    const { result } = renderHook(() => useCaseViewFilters(basicCase), { wrapper });
 
     expect(result.current.selectedAttachmentTypes).toEqual([]);
     expect(result.current.selectedAuthors).toEqual([]);
@@ -38,7 +51,7 @@ describe('useCaseViewFilters', () => {
   });
 
   it('isTypeVisible returns true for every id when no type is selected', () => {
-    const { result } = renderHook(() => useCaseViewFilters(basicCase));
+    const { result } = renderHook(() => useCaseViewFilters(basicCase), { wrapper });
 
     expect(result.current.isTypeVisible('anything')).toBe(true);
     expect(result.current.isTypeVisible('user')).toBe(true);
@@ -46,7 +59,7 @@ describe('useCaseViewFilters', () => {
 
   describe('attachment type filter', () => {
     it('flips isTypeFilterActive and narrows isTypeVisible when types are selected', () => {
-      const { result } = renderHook(() => useCaseViewFilters(basicCase));
+      const { result } = renderHook(() => useCaseViewFilters(basicCase), { wrapper });
 
       act(() => {
         result.current.setSelectedAttachmentTypes(['user']);
@@ -59,7 +72,7 @@ describe('useCaseViewFilters', () => {
     });
 
     it('clearing the selection restores the inactive state', () => {
-      const { result } = renderHook(() => useCaseViewFilters(basicCase));
+      const { result } = renderHook(() => useCaseViewFilters(basicCase), { wrapper });
 
       act(() => {
         result.current.setSelectedAttachmentTypes(['user']);
@@ -74,7 +87,7 @@ describe('useCaseViewFilters', () => {
     });
 
     it('does not mutate caseData when only the type filter is active', () => {
-      const { result } = renderHook(() => useCaseViewFilters(basicCase));
+      const { result } = renderHook(() => useCaseViewFilters(basicCase), { wrapper });
 
       act(() => {
         result.current.setSelectedAttachmentTypes(['user']);
@@ -86,7 +99,7 @@ describe('useCaseViewFilters', () => {
 
   describe('author filter', () => {
     it('filters comments down to the selected author', () => {
-      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors));
+      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
 
       act(() => {
         result.current.setSelectedAuthors([elasticUser.username]);
@@ -99,7 +112,7 @@ describe('useCaseViewFilters', () => {
     });
 
     it('supports multiple selected authors', () => {
-      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors));
+      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
 
       act(() => {
         result.current.setSelectedAuthors([elasticUser.username, otherUser.username]);
@@ -109,7 +122,7 @@ describe('useCaseViewFilters', () => {
     });
 
     it('clearing the selection restores the original caseData reference', () => {
-      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors));
+      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
 
       act(() => {
         result.current.setSelectedAuthors([elasticUser.username]);
@@ -135,7 +148,7 @@ describe('useCaseViewFilters', () => {
         ],
       };
 
-      const { result } = renderHook(() => useCaseViewFilters(caseWithUnknownAuthor));
+      const { result } = renderHook(() => useCaseViewFilters(caseWithUnknownAuthor), { wrapper });
 
       act(() => {
         result.current.setSelectedAuthors([elasticUser.username]);
@@ -146,7 +159,7 @@ describe('useCaseViewFilters', () => {
   });
 
   it('clearFilters resets every active filter in a single call', () => {
-    const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors));
+    const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
 
     act(() => {
       result.current.setSelectedAttachmentTypes(['user']);
@@ -164,7 +177,7 @@ describe('useCaseViewFilters', () => {
   });
 
   it('type and author filters compose: hasActiveFilter reflects either being active', () => {
-    const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors));
+    const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
 
     act(() => {
       result.current.setSelectedAttachmentTypes(['user']);
@@ -177,5 +190,52 @@ describe('useCaseViewFilters', () => {
     expect(result.current.isTypeVisible('user')).toBe(true);
     expect(result.current.isTypeVisible('alert')).toBe(false);
     expect(result.current.filteredCaseData.comments.map((c) => c.id)).toEqual(['c-1']);
+  });
+
+  describe('local storage persistence', () => {
+    it('persists selections under the attachment filters key', () => {
+      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
+
+      act(() => {
+        result.current.setSelectedAttachmentTypes(['user']);
+      });
+      act(() => {
+        result.current.setSelectedAuthors([elasticUser.username]);
+      });
+
+      expect(JSON.parse(localStorage.getItem(localStorageKey) ?? '{}')).toEqual({
+        selectedAttachmentTypes: ['user'],
+        selectedAuthors: [elasticUser.username],
+      });
+    });
+
+    it('restores persisted selections on mount', () => {
+      localStorage.setItem(
+        localStorageKey,
+        JSON.stringify({ selectedAttachmentTypes: ['file'], selectedAuthors: ['elastic'] })
+      );
+
+      const { result } = renderHook(() => useCaseViewFilters(basicCase), { wrapper });
+
+      expect(result.current.selectedAttachmentTypes).toEqual(['file']);
+      expect(result.current.selectedAuthors).toEqual(['elastic']);
+      expect(result.current.hasActiveFilter).toBe(true);
+    });
+
+    it('clearFilters wipes the persisted selections', () => {
+      const { result } = renderHook(() => useCaseViewFilters(caseWithTwoAuthors), { wrapper });
+
+      act(() => {
+        result.current.setSelectedAttachmentTypes(['user']);
+      });
+      act(() => {
+        result.current.clearFilters();
+      });
+
+      expect(JSON.parse(localStorage.getItem(localStorageKey) ?? '{}')).toEqual({
+        selectedAttachmentTypes: [],
+        selectedAuthors: [],
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/hooks/use_case_view_filters.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/hooks/use_case_view_filters.ts
@@ -5,10 +5,27 @@
  * 2.0.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { CaseUI } from '../../../../common';
+import { LOCAL_STORAGE_KEYS } from '../../../../common/constants';
+import { useCasesLocalStorage } from '../../../common/use_cases_local_storage';
 import { getAttachmentAuthorKey } from '../components/helpers';
+
+/**
+ * Attachment-tab filter selections persisted to local storage so they survive
+ * reloads. Kept separate from the activity-tab filters (different key + shape).
+ * The free-text search term is intentionally excluded.
+ */
+export interface AttachmentTabFilters {
+  selectedAttachmentTypes: string[];
+  selectedAuthors: string[];
+}
+
+const DEFAULT_ATTACHMENT_TAB_FILTERS: AttachmentTabFilters = {
+  selectedAttachmentTypes: [],
+  selectedAuthors: [],
+};
 
 export interface CaseViewFiltersParams {
   selectedAttachmentTypes: string[];
@@ -32,8 +49,21 @@ export interface CaseViewFiltersResult extends CaseViewFiltersParams {
  * per-accordion / per-list views.
  */
 export const useCaseViewFilters = (caseData: CaseUI): CaseViewFiltersResult => {
-  const [selectedAttachmentTypes, setSelectedAttachmentTypes] = useState<string[]>([]);
-  const [selectedAuthors, setSelectedAuthors] = useState<string[]>([]);
+  const [persistedFilters, setPersistedFilters] = useCasesLocalStorage<AttachmentTabFilters>(
+    LOCAL_STORAGE_KEYS.attachmentFilters,
+    DEFAULT_ATTACHMENT_TAB_FILTERS
+  );
+  const { selectedAttachmentTypes, selectedAuthors } = persistedFilters;
+
+  const setSelectedAttachmentTypes = useCallback(
+    (next: string[]) => setPersistedFilters((prev) => ({ ...prev, selectedAttachmentTypes: next })),
+    [setPersistedFilters]
+  );
+
+  const setSelectedAuthors = useCallback(
+    (next: string[]) => setPersistedFilters((prev) => ({ ...prev, selectedAuthors: next })),
+    [setPersistedFilters]
+  );
 
   const isTypeFilterActive = selectedAttachmentTypes.length > 0;
   const isAuthorFilterActive = selectedAuthors.length > 0;
@@ -55,10 +85,10 @@ export const useCaseViewFilters = (caseData: CaseUI): CaseViewFiltersResult => {
     [selectedAttachmentTypes, isTypeFilterActive]
   );
 
-  const clearFilters = useCallback(() => {
-    setSelectedAttachmentTypes([]);
-    setSelectedAuthors([]);
-  }, []);
+  const clearFilters = useCallback(
+    () => setPersistedFilters(DEFAULT_ATTACHMENT_TAB_FILTERS),
+    [setPersistedFilters]
+  );
 
   return {
     selectedAttachmentTypes,

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.tsx
@@ -79,20 +79,14 @@ AttachmentsBadge.displayName = 'AttachmentsBadge';
 
 /**
  * Computes the total count shown on the top-level "Attachments" tab badge.
- * Reflects the active search filter so the badge tracks what the user actually
- * sees: comments matching a registered type with a tab view, plus files (from
- * `fileStatsData`) and — if licensed — observables.
+ * Always the case-wide total (comments matching a registered type with a tab
+ * view, plus files and — if licensed — observables). Deliberately ignores the
+ * search term and filters so the badge stays a stable total.
  */
-export const useCaseAttachmentsTotal = ({
-  caseData,
-  searchTerm,
-}: {
-  caseData: CaseUI;
-  searchTerm?: string;
-}): number => {
+export const useCaseAttachmentsTotal = ({ caseData }: { caseData: CaseUI }): number => {
   const { unifiedAttachmentTypeRegistry } = useCasesContext();
-  const { data: fileStatsData } = useGetCaseFileStats({ caseId: caseData.id, searchTerm });
-  const { observables } = useCaseObservables(caseData, searchTerm);
+  const { data: fileStatsData } = useGetCaseFileStats({ caseId: caseData.id });
+  const { observables } = useCaseObservables(caseData);
   const { observablesAuthorized: canShowObservableTabs, isObservablesFeatureEnabled } =
     useCasesFeatures();
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/case_view_page.tsx
@@ -6,13 +6,12 @@
  */
 
 import { EuiSpacer } from '@elastic/eui';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useCasesTitleBreadcrumbs } from '../../use_breadcrumbs';
 import { CaseViewMetrics } from '../../case_view/metrics';
 import type { CaseViewPageProps } from '../../case_view/types';
 
 import { useOnUpdateField } from '../../case_view/use_on_update_field';
-import { filterCaseAttachmentsBySearchTerm } from '../../case_view/components/helpers';
 import { LensAttachReturnConsumer } from '../../attachments/lens/lens_return/lens_attach_return_consumer';
 import { KibanaServices } from '../../../common/lib/kibana';
 import { CaseDetailsAppHeader } from './components/case_details_header';
@@ -31,11 +30,6 @@ export const CaseViewPageRedesign = React.memo<CaseViewPageRedesignProps>(
         setSearchTerm(newSearch.trim());
       },
       [setSearchTerm]
-    );
-
-    const caseWithFilteredAttachments = useMemo(
-      () => filterCaseAttachmentsBySearchTerm(caseData, searchTerm),
-      [caseData, searchTerm]
     );
 
     useCasesTitleBreadcrumbs(caseData.title);
@@ -57,7 +51,7 @@ export const CaseViewPageRedesign = React.memo<CaseViewPageRedesignProps>(
           <LensAttachReturnConsumer caseId={caseData.id} />
         )}
         <CaseViewTabContent
-          caseData={caseWithFilteredAttachments}
+          caseData={caseData}
           searchTerm={searchTerm}
           onSearch={onSearch}
           onUpdateField={onUpdateField}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_view_tab_content.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_view_tab_content.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { CASE_VIEW_PAGE_TABS } from '../../../../../common/types';
@@ -17,6 +17,7 @@ import { CaseViewTabs } from '../../../case_view/case_view_tabs';
 import { CaseViewActivity } from './activity/case_view_activity';
 import { CaseViewSimilarCases } from '../../../case_view/components/case_view_similar_cases';
 import { CaseViewAttachments } from '../../../case_view/components/case_view_attachments';
+import { filterCaseAttachmentsBySearchTerm } from '../../../case_view/components/helpers';
 import { CaseViewSidebar } from './sidebar/case_view_sidebar';
 import { SidebarProvider, useSidebar } from './sidebar/sidebar_context';
 import { SavedObjectInAppUrlsProvider } from '../../../attachments/common/saved_object/saved_object_in_app_urls_context';
@@ -57,9 +58,14 @@ const CaseViewTabContentInner: FC<CaseViewTabContentProps> = ({
 
   const { isSidebarOpen } = useSidebar();
 
+  const caseWithFilteredAttachments = useMemo(
+    () => filterCaseAttachmentsBySearchTerm(caseData, searchTerm),
+    [caseData, searchTerm]
+  );
+
   return (
-    <SavedObjectInAppUrlsProvider caseData={caseData}>
-      <CaseViewTabs caseData={caseData} activeTab={activeTabId} searchTerm={searchTerm} />
+    <SavedObjectInAppUrlsProvider caseData={caseWithFilteredAttachments}>
+      <CaseViewTabs caseData={caseData} activeTab={activeTabId} />
       <EuiFlexGroup data-test-subj={`case-view-tab-content-${activeTabId}`}>
         <EuiFlexItem
           grow={isSidebarOpen ? 6 : true}
@@ -68,17 +74,19 @@ const CaseViewTabContentInner: FC<CaseViewTabContentProps> = ({
             transition: max-width 300ms ease;
           `}
         >
-          {activeTabId === CASE_VIEW_PAGE_TABS.ACTIVITY && <CaseViewActivity caseData={caseData} />}
+          {activeTabId === CASE_VIEW_PAGE_TABS.ACTIVITY && (
+            <CaseViewActivity caseData={caseWithFilteredAttachments} />
+          )}
           {ATTACHMENT_TAB_ALIASES.has(activeTabId) && (
             <CaseViewAttachments
-              caseData={caseData}
+              caseData={caseWithFilteredAttachments}
               onSearch={onSearch}
               searchTerm={searchTerm}
               onUpdateField={onUpdateField}
             />
           )}
           {activeTabId === CASE_VIEW_PAGE_TABS.SIMILAR_CASES && (
-            <CaseViewSimilarCases caseData={caseData} />
+            <CaseViewSimilarCases caseData={caseWithFilteredAttachments} />
           )}
         </EuiFlexItem>
         {/* Hidden rather than unmounted when collapsed, so pending unconfirmed field edits
@@ -89,7 +97,7 @@ const CaseViewTabContentInner: FC<CaseViewTabContentProps> = ({
             display: ${isSidebarOpen ? 'contents' : 'none'};
           `}
         >
-          <CaseViewSidebar caseData={caseData} />
+          <CaseViewSidebar caseData={caseWithFilteredAttachments} />
         </div>
       </EuiFlexGroup>
     </SavedObjectInAppUrlsProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/timeline/case_view_timelines.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/timeline/case_view_timelines.test.tsx
@@ -101,7 +101,7 @@ describe('CaseViewTimelines', () => {
     expect(screen.getByTestId('timelines-table')).toBeInTheDocument();
   });
 
-  it('forwards the outer search term to the hook', () => {
+  it('does not forward the tab search term to the hook (attachments are filtered client-side)', () => {
     render(
       <TestProviders>
         <CaseViewTimelines
@@ -114,6 +114,6 @@ describe('CaseViewTimelines', () => {
     );
 
     const args = mockedUseGetTimelinesByIds.mock.calls[0][0];
-    expect(args.search).toBe('phishing');
+    expect(args.search).toBeUndefined();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/timeline/case_view_timelines.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/timeline/case_view_timelines.tsx
@@ -43,10 +43,7 @@ const extractTimelineIds = (caseData: CommonAttachmentTabViewProps['caseData']):
   return ids;
 };
 
-export const CaseViewTimelines: React.FC<CommonAttachmentTabViewProps> = ({
-  caseData,
-  searchTerm,
-}) => {
+export const CaseViewTimelines: React.FC<CommonAttachmentTabViewProps> = ({ caseData }) => {
   const timelineIds = useMemo(() => extractTimelineIds(caseData), [caseData]);
 
   const [pageIndex, setPageIndex] = useState(1);
@@ -63,7 +60,6 @@ export const CaseViewTimelines: React.FC<CommonAttachmentTabViewProps> = ({
   const { timelines, totalCount, loading } = useGetTimelinesByIds({
     ids: timelineIds,
     pageInfo,
-    search: searchTerm,
     sort,
   });
 


### PR DESCRIPTION
## Summary

This PR added persistence to attachments tab filters, fixed the inconsistent search results and updated attach file label.

Before:
- Author and type filters are not persisted
- Attach dropdown listed "Upload file" while others are "Saved object", "Timeline"
- No attachment matches search but timeline accordion shows

<img width="529" height="298" alt="image" src="https://github.com/user-attachments/assets/a5c711d7-9178-4a34-96d0-8cf3b833d2a0" />



After
- Both filters are persisted
- Removed "Upload" to be consistent with other options
  
<img width="385" height="202" alt="image" src="https://github.com/user-attachments/assets/79d50f9b-0ca0-4155-9153-0f2a0c2c74b2" />

- No result properly shows the empty message


https://github.com/user-attachments/assets/5af6caeb-e9dd-4a45-b49a-400c620434f3



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->