### PR TITLE
[kbn-es] Pin serverless ES disk reserve to 1gb for tests

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -298,6 +298,12 @@ const DEFAULT_SERVERLESS_ESARGS: Array<[string, string]> = [
 
   ['xpack.security.operator_privileges.enabled', 'true'],
 
+  // Serverless ES throttles indexing when free disk drops below this reserve (defaults to 20% of total
+  // disk). CI agents share an overlay filesystem that can already sit above 80% full at ES startup, which
+  // trips the throttle immediately and stalls Kibana startup/migrations. Pin to an absolute 1gb for tests.
+  // Note: this must stay above the Lucene indexing buffer (~161mb here) or ES refuses to start; 1gb is safe.
+  ['stateless.indices.disk.reserved_bytes', '1gb'],
+
   ['xpack.security.transport.ssl.enabled', 'true'],
 
   [


### PR DESCRIPTION
Serverless ES throttles indexing when free disk drops below a reserve that defaults to 20% of total disk. CI agents share an overlay filesystem that can already sit above 80% full at ES startup, which trips the IndexingDiskController throttle immediately and stalls Kibana startup/migrations. Pin the reserve to an absolute 1gb so throttling only kicks in when the disk is genuinely nearly full.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->