### PR TITLE
[Alerting v2] Defer task execution until plugin start

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { Global } from '@kbn/core-di-internal';
+import { Request } from '@kbn/core-di-server';
+import type { CoreDiServiceStart } from '@kbn/core-di';
+import type { RunContext, RunResult } from '@kbn/task-manager-plugin/server/task';
+import { createTaskRunnerFactory, type AlertingTaskRunner } from './create_task_runner';
+
+class TestTaskRunner implements AlertingTaskRunner {
+  public async run(): Promise<RunResult> {
+    return { state: {} };
+  }
+}
+
+const flushMicrotasks = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const createMockScope = (runner: AlertingTaskRunner) => {
+  const scopeBinding = {
+    inRequestScope: jest.fn(),
+    inTransientScope: jest.fn(),
+  };
+  const bindResult = {
+    toConstantValue: jest.fn(),
+    toSelf: jest.fn().mockReturnValue(scopeBinding),
+  };
+
+  return {
+    bind: jest.fn().mockReturnValue(bindResult),
+    get: jest.fn().mockReturnValue(runner),
+    unbindAll: jest.fn().mockResolvedValue(undefined),
+    _scopeBinding: scopeBinding,
+  };
+};
+
+const createMockInjection = (scope: ReturnType<typeof createMockScope>): CoreDiServiceStart =>
+  ({
+    fork: jest.fn().mockReturnValue(scope),
+    getContainer: jest.fn(),
+  } as unknown as CoreDiServiceStart);
+
+const createRunContext = (overrides: Partial<RunContext> = {}): RunContext =>
+  ({
+    taskInstance: { id: 'task-1' },
+    abortController: new AbortController(),
+    ...overrides,
+  } as unknown as RunContext);
+
+describe('createTaskRunnerFactory', () => {
+  it('waits for the injection promise to resolve before forking the container', async () => {
+    let resolveInjection!: (value: CoreDiServiceStart) => void;
+    const injectionPromise = new Promise<CoreDiServiceStart>((resolve) => {
+      resolveInjection = resolve;
+    });
+
+    const runner = new TestTaskRunner();
+    const scope = createMockScope(runner);
+    const injection = createMockInjection(scope);
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'test',
+      requiresFakeRequest: false,
+    });
+
+    const runPromise = createTaskRunner(createRunContext()).run();
+
+    // The plugin has not started yet, so the container must not be forked.
+    await flushMicrotasks();
+    expect(injection.fork).not.toHaveBeenCalled();
+
+    resolveInjection(injection);
+    await runPromise;
+
+    expect(injection.fork).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects without forking when the run is already aborted', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const scope = createMockScope(new TestTaskRunner());
+    const injection = createMockInjection(scope);
+    const injectionPromise = Promise.resolve(injection);
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'test',
+      requiresFakeRequest: false,
+    });
+
+    await expect(createTaskRunner(createRunContext({ abortController })).run()).rejects.toThrow(
+      'Aborted test task while waiting for the alerting_v2 plugin to start (task id: task-1)'
+    );
+    expect(injection.fork).not.toHaveBeenCalled();
+  });
+
+  it('rejects without forking when the run is aborted before the plugin starts', async () => {
+    let resolveInjection!: (value: CoreDiServiceStart) => void;
+    const injectionPromise = new Promise<CoreDiServiceStart>((resolve) => {
+      resolveInjection = resolve;
+    });
+    const abortController = new AbortController();
+
+    const scope = createMockScope(new TestTaskRunner());
+    const injection = createMockInjection(scope);
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'test',
+      requiresFakeRequest: false,
+    });
+
+    const runPromise = createTaskRunner(createRunContext({ abortController })).run();
+
+    abortController.abort();
+
+    await expect(runPromise).rejects.toThrow(
+      'Aborted test task while waiting for the alerting_v2 plugin to start (task id: task-1)'
+    );
+    expect(injection.fork).not.toHaveBeenCalled();
+
+    // A late-resolving injection (after abort) must not resurrect the run.
+    resolveInjection(injection);
+    await flushMicrotasks();
+    expect(injection.fork).not.toHaveBeenCalled();
+  });
+
+  it('throws when a fakeRequest is required but not provided, without resolving the injection', async () => {
+    const injectionPromise = Promise.resolve(
+      createMockInjection(createMockScope(new TestTaskRunner()))
+    );
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'my-task',
+      requiresFakeRequest: true,
+    });
+
+    await expect(createTaskRunner(createRunContext()).run()).rejects.toThrow(
+      'Cannot execute my-task task without Task Manager fakeRequest. Ensure the task is scheduled with an API key (task id: task-1)'
+    );
+  });
+
+  it('binds the fakeRequest into a request scope and runs the task runner', async () => {
+    const runResult: RunResult = { state: { foo: 'bar' } };
+    const runner = new TestTaskRunner();
+    jest.spyOn(runner, 'run').mockResolvedValue(runResult);
+
+    const scope = createMockScope(runner);
+    const injectionPromise = Promise.resolve(createMockInjection(scope));
+    const fakeRequest = httpServerMock.createKibanaRequest();
+    const runContext = createRunContext({ fakeRequest });
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'test',
+      requiresFakeRequest: true,
+    });
+
+    const result = await createTaskRunner(runContext).run();
+
+    expect(scope.bind).toHaveBeenCalledWith(Request);
+    expect(scope.bind).toHaveBeenCalledWith(Global);
+    expect(scope.bind).toHaveBeenCalledWith(TestTaskRunner);
+    expect(scope._scopeBinding.inRequestScope).toHaveBeenCalledTimes(1);
+    expect(scope._scopeBinding.inTransientScope).not.toHaveBeenCalled();
+    expect(runner.run).toHaveBeenCalledWith({
+      taskInstance: runContext.taskInstance,
+      abortController: runContext.abortController,
+    });
+    expect(result).toEqual(runResult);
+    expect(scope.unbindAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds the task runner in a transient scope when a fakeRequest is not required', async () => {
+    const runner = new TestTaskRunner();
+    const scope = createMockScope(runner);
+    const injectionPromise = Promise.resolve(createMockInjection(scope));
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'test',
+      requiresFakeRequest: false,
+    });
+
+    await createTaskRunner(createRunContext()).run();
+
+    expect(scope.bind).not.toHaveBeenCalledWith(Request);
+    expect(scope.bind).toHaveBeenCalledWith(TestTaskRunner);
+    expect(scope._scopeBinding.inTransientScope).toHaveBeenCalledTimes(1);
+    expect(scope._scopeBinding.inRequestScope).not.toHaveBeenCalled();
+    expect(scope.unbindAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('unbinds the scope even when the task runner throws', async () => {
+    const runner = new TestTaskRunner();
+    const failure = new Error('boom');
+    jest.spyOn(runner, 'run').mockRejectedValue(failure);
+
+    const scope = createMockScope(runner);
+    const injectionPromise = Promise.resolve(createMockInjection(scope));
+
+    const createTaskRunner = createTaskRunnerFactory({ injectionPromise })({
+      taskRunnerClass: TestTaskRunner,
+      taskType: 'test',
+      requiresFakeRequest: false,
+    });
+
+    await expect(createTaskRunner(createRunContext()).run()).rejects.toThrow(failure);
+    expect(scope.unbindAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
@@ -68,7 +68,55 @@ export const TaskRunnerFactoryToken = Symbol.for(
 ) as ServiceIdentifier<TaskRunnerFactory>;
 
 /**
+ * Waits for the injection service to become available (i.e. the plugin has
+ * started), while remaining responsive to Task Manager cancellation.
+ *
+ * Task Manager aborts a run's `abortController` on timeout or shutdown. Racing
+ * the abort signal ensures a run does not wait indefinitely if the plugin never
+ * finishes starting: instead of leaving a pending promise dangling, the run
+ * rejects and Task Manager handles it as a normal task failure.
+ */
+async function waitForInjection(
+  injectionPromise: Promise<CoreDiServiceStart>,
+  signal: AbortSignal,
+  taskType: string,
+  taskId: string
+): Promise<CoreDiServiceStart> {
+  const abortError = () =>
+    new Error(
+      `Aborted ${taskType} task while waiting for the alerting_v2 plugin to start (task id: ${taskId})`
+    );
+
+  if (signal.aborted) {
+    throw abortError();
+  }
+
+  return new Promise<CoreDiServiceStart>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    injectionPromise.then(
+      (injection) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(injection);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+/**
  * Factory for task runners that creates scoped DI containers for each task execution.
+ *
+ * Task Manager is a dependency of this plugin, so it can start polling and run a
+ * task before this plugin's start lifecycle has bound `CoreStart('injection')`.
+ * To avoid resolving the injection service too early, the factory waits on
+ * `injectionPromise`, which resolves once the plugin's `OnStart` hook fires. This
+ * guarantees a task run only forks the container after the plugin has started.
+ * The wait is aborted if Task Manager cancels the run (see {@link waitForInjection}).
  *
  * For tasks with `requiresFakeRequest: true` (default):
  * - Forks the DI container and binds the fakeRequest to Request scope
@@ -81,9 +129,9 @@ export const TaskRunnerFactoryToken = Symbol.for(
  * - Task runner can only use internal/singleton-scoped services
  */
 export function createTaskRunnerFactory({
-  getInjection,
+  injectionPromise,
 }: {
-  getInjection: () => CoreDiServiceStart;
+  injectionPromise: Promise<CoreDiServiceStart>;
 }): TaskRunnerFactory {
   return ({ taskRunnerClass, taskType, requiresFakeRequest = true }) => {
     return ({ taskInstance, abortController, fakeRequest }: RunContext) => ({
@@ -94,7 +142,13 @@ export function createTaskRunnerFactory({
           );
         }
 
-        const scope = getInjection().fork();
+        const injection = await waitForInjection(
+          injectionPromise,
+          abortController.signal,
+          taskType,
+          taskInstance.id
+        );
+        const scope = injection.fork();
 
         if (fakeRequest) {
           scope.bind(Request).toConstantValue(fakeRequest);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
@@ -95,16 +95,9 @@ async function waitForInjection(
     const onAbort = () => reject(abortError());
     signal.addEventListener('abort', onAbort, { once: true });
 
-    injectionPromise.then(
-      (injection) => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(injection);
-      },
-      (error) => {
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
-      }
-    );
+    injectionPromise
+      .finally(() => signal.removeEventListener('abort', onAbort))
+      .then(resolve, reject);
   });
 }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { PluginSetup, PluginStart } from '@kbn/core-di';
+import { once } from 'lodash';
+import type { CoreDiServiceStart } from '@kbn/core-di';
+import { OnStart, PluginSetup, PluginStart } from '@kbn/core-di';
 import { CoreStart, Request, SavedObjectsClientFactory } from '@kbn/core-di-server';
 import type { ContainerModuleLoadOptions } from 'inversify';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/maintenance-windows-plugin/common';
@@ -163,11 +165,20 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
     })
     .inRequestScope();
 
-  bind(TaskRunnerFactoryToken).toFactory((context) =>
-    createTaskRunnerFactory({
-      getInjection: () => context.get(CoreStart('injection')),
-    })
-  );
+  // Task Manager is a dependency of this plugin, so it can begin polling and run
+  // a task before this plugin's start lifecycle binds `CoreStart('injection')`.
+  // Resolving it eagerly would throw when the binding is not yet available. The
+  // promise resolves on the plugin's `OnStart` hook, at which point the injection
+  // service is guaranteed to be bound, so task runs wait until the plugin starts.
+  const injectionPromise = new Promise<CoreDiServiceStart>((resolve) => {
+    bind(OnStart).toConstantValue(
+      once((container) => {
+        resolve(container.get(CoreStart('injection')));
+      })
+    );
+  });
+
+  bind(TaskRunnerFactoryToken).toFactory(() => createTaskRunnerFactory({ injectionPromise }));
 
   bind(RuleSavedObjectsClientToken)
     .toResolvedValue(


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/rna-program/issues/683

`taskManager` is a dependency of the `alerting_v2` plugin, so it can begin polling and run a task **before** `alerting_v2`'s `start` lifecycle binds `CoreStart('injection')` into the DI container. The task runner factory resolved the injection service eagerly (`context.get(CoreStart('injection'))`), which threw `No matching bindings found for serviceIdentifier: Symbol(core.start.injection)` and failed the run during the startup window.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->