### PR TITLE
[8.19] [ResponseOps][Alerting] Add limits to all of the alerting internal APIs (#273304)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/constants/index.ts
@@ -12,6 +12,7 @@ export {
   MAX_SCHEDULE_BACKFILL_LOOKBACK_WINDOW_DAYS,
   MAX_SCHEDULE_BACKFILL_LOOKBACK_WINDOW_MS,
 } from './backfill';
+export * from './limits';
 export { PLUGIN } from './plugin';
 export { gapStatus } from './gap_status';
 export type { GapStatus } from './gap_status';

--- a/x-pack/platform/plugins/shared/alerting/common/constants/limits.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/constants/limits.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const MAX_RULE_IDS_BULK = 1000;
+export const MAX_BULK_EDIT_OPERATIONS = 100;
+export const MAX_BULK_EDIT_ACTIONS = 50;
+export const MAX_BULK_EDIT_TAGS = 200;
+export const MAX_TAG_LENGTH = 512;
+export const MAX_ID_LENGTH = 512;
+export const MAX_NAME_LENGTH = 512;
+export const MAX_FIELD_NAME_LENGTH = 512;
+export const MAX_SAVED_OBJECT_TYPE_LENGTH = 512;
+export const MAX_KQL_FILTER_LENGTH = 100_000;
+export const MAX_EXECUTION_FILTER_LENGTH = 10000;
+export const MAX_SEARCH_LENGTH = 1_000;
+export const MAX_PER_PAGE = 1000;
+export const MAX_TAGS_PER_PAGE = 10000;
+export const MAX_ARRAY_FIELDS = 100;
+export const MAX_SNOOZE_SCHEDULE_IDS = 100;
+export const MAX_SUGGESTION_TEXT_LENGTH = 1024;
+export const MAX_SORT_FIELDS = 10;
+export const MAX_DURATION_STRING_LENGTH = 100;
+export const MAX_BULK_UNTRACK_QUERIES = 10;
+export const MAX_BULK_UNTRACK_INDICES = 100;
+export const MAX_BULK_UNTRACK_ALERT_UUIDS = 100;
+export const MAX_INDEX_NAME_LENGTH = 500;
+export const MAX_SPACE_IDS = 100;
+export const MAX_PER_PAGE_LOGS = 1000;
+export const MAX_NAMESPACES = 1000;
+export const MAX_NUMBER_OF_EXECUTIONS = 10000;
+export const ISO_DATE_MAX_LENGTH = 100;

--- a/x-pack/platform/plugins/shared/alerting/common/routes/alert_delete/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/alert_delete/schemas/v1.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { alertDeleteCategoryIds } from '../../../constants';
+import { MAX_SPACE_IDS, MAX_ID_LENGTH } from '../../../constants';
 
 const MAX_ALERT_DELETE_THRESHOLD_DAYS = 3 * 365; // 3 years
 const MIN_ALERT_DELETE_THRESHOLD_DAYS = 1;
@@ -64,8 +65,9 @@ export const alertDeletePreviewResponseSchema = schema.object({
 export const alertDeleteScheduleQuerySchema = schema.object({
   ...alertDeleteSettingsSchema,
   space_ids: schema.maybe(
-    schema.arrayOf(schema.string(), {
+    schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), {
       minSize: 1,
+      maxSize: MAX_SPACE_IDS,
       meta: {
         description: 'Kibana space IDs to delete alerts from',
       },

--- a/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/fill/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/fill/schemas/v1.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 import { schema } from '@kbn/config-schema';
+import { MAX_ID_LENGTH } from '../../../../../constants';
 
 export const fillGapByIdQuerySchema = schema.object({
-  rule_id: schema.string(),
-  gap_id: schema.string(),
+  rule_id: schema.string({ maxLength: MAX_ID_LENGTH }),
+  gap_id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/find/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/find/schemas/v1.ts
@@ -6,14 +6,15 @@
  */
 import { schema } from '@kbn/config-schema';
 import { gapsResponseSchemaV1 } from '../../../response';
+import { MAX_ID_LENGTH, ISO_DATE_MAX_LENGTH } from '../../../../../constants';
 
 export const findGapsBodySchema = schema.object(
   {
-    end: schema.string(),
+    end: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
     page: schema.number({ defaultValue: 1, min: 1 }),
     per_page: schema.number({ defaultValue: 10, min: 1, max: 10000 }),
-    rule_id: schema.string(),
-    start: schema.string(),
+    rule_id: schema.string({ maxLength: MAX_ID_LENGTH }),
+    start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
     sort_field: schema.maybe(
       schema.oneOf([
         schema.literal('@timestamp'),
@@ -28,7 +29,8 @@ export const findGapsBodySchema = schema.object(
           schema.literal('partially_filled'),
           schema.literal('unfilled'),
           schema.literal('filled'),
-        ])
+        ]),
+        { maxSize: 3 }
       )
     ),
   },

--- a/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/get_gaps_summary_by_rule_ids/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/get_gaps_summary_by_rule_ids/schemas/v1.ts
@@ -5,12 +5,15 @@
  * 2.0.
  */
 import { schema } from '@kbn/config-schema';
+import { MAX_ID_LENGTH, MAX_ARRAY_FIELDS, ISO_DATE_MAX_LENGTH } from '../../../../../constants';
 
 export const getGapsSummaryByRuleIdsBodySchema = schema.object(
   {
-    end: schema.string(),
-    start: schema.string(),
-    rule_ids: schema.arrayOf(schema.string(), { maxSize: 100 }),
+    end: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+    start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+    rule_ids: schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), {
+      maxSize: MAX_ARRAY_FIELDS,
+    }),
   },
   {
     validate({ start, end }) {

--- a/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/get_rules_with_gaps/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/get_rules_with_gaps/schemas/v1.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 import { schema } from '@kbn/config-schema';
-import { gapStatus } from '../../../../../constants';
+import { gapStatus, ISO_DATE_MAX_LENGTH } from '../../../../../constants';
 
 export const getRuleIdsWithGapBodySchema = schema.object(
   {
-    end: schema.string(),
-    start: schema.string(),
+    end: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+    start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
     // Filters the underlying gap documents before aggregation. Matches the raw
     // per-gap statuses.
     statuses: schema.maybe(
@@ -19,7 +19,8 @@ export const getRuleIdsWithGapBodySchema = schema.object(
           schema.literal(gapStatus.UNFILLED),
           schema.literal(gapStatus.PARTIALLY_FILLED),
           schema.literal(gapStatus.FILLED),
-        ])
+        ]),
+        { maxSize: 3 }
       )
     ),
     has_unfilled_intervals: schema.maybe(schema.boolean()),

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/aggregate/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/aggregate/schemas/v1.ts
@@ -6,26 +6,44 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import {
+  MAX_KQL_FILTER_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_FIELD_NAME_LENGTH,
+  MAX_NAME_LENGTH,
+  MAX_SAVED_OBJECT_TYPE_LENGTH,
+  MAX_ARRAY_FIELDS,
+} from '../../../../../constants';
 
 export const aggregateRulesRequestBodySchema = schema.object({
-  search: schema.maybe(schema.string()),
+  search: schema.maybe(schema.string({ maxLength: MAX_KQL_FILTER_LENGTH })),
   default_search_operator: schema.oneOf([schema.literal('OR'), schema.literal('AND')], {
     defaultValue: 'OR',
   }),
-  search_fields: schema.maybe(schema.arrayOf(schema.string())),
+  search_fields: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_FIELD_NAME_LENGTH }), {
+      maxSize: MAX_ARRAY_FIELDS,
+    })
+  ),
   has_reference: schema.maybe(
     // use nullable as maybe is currently broken
     // in config-schema
     schema.nullable(
       schema.object({
-        type: schema.string(),
-        id: schema.string(),
+        type: schema.string({ maxLength: MAX_SAVED_OBJECT_TYPE_LENGTH }),
+        id: schema.string({ maxLength: MAX_ID_LENGTH }),
       })
     )
   ),
-  filter: schema.maybe(schema.string()),
-  rule_type_ids: schema.maybe(schema.arrayOf(schema.string())),
-  consumers: schema.maybe(schema.arrayOf(schema.string())),
+  filter: schema.maybe(schema.string({ maxLength: MAX_KQL_FILTER_LENGTH })),
+  rule_type_ids: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), { maxSize: MAX_ARRAY_FIELDS })
+  ),
+  consumers: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_NAME_LENGTH }), {
+      maxSize: MAX_ARRAY_FIELDS,
+    })
+  ),
 });
 
 export const aggregateRulesResponseBodySchema = schema.object({

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/bulk_edit/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/bulk_edit/schemas/v1.ts
@@ -8,8 +8,18 @@
 import { schema } from '@kbn/config-schema';
 import { validateDurationV1 } from '../../../validation';
 import { rRuleRequestSchemaV1 } from '../../../../r_rule';
-import { notifyWhenSchemaV1, scheduleIdsSchemaV1 } from '../../../response';
+import { notifyWhenSchemaV1 } from '../../../response';
 import { ruleSnoozeScheduleSchemaV1 } from '../../../request';
+import {
+  MAX_RULE_IDS_BULK,
+  MAX_BULK_EDIT_OPERATIONS,
+  MAX_BULK_EDIT_ACTIONS,
+  MAX_BULK_EDIT_TAGS,
+  MAX_TAG_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_KQL_FILTER_LENGTH,
+  MAX_SNOOZE_SCHEDULE_IDS,
+} from '../../../../../constants';
 
 export const scheduleIdsSchema = schema.maybe(schema.arrayOf(schema.string()));
 
@@ -20,10 +30,10 @@ export const ruleSnoozeScheduleSchema = schema.object({
 });
 
 const ruleActionSchema = schema.object({
-  group: schema.maybe(schema.string()),
-  id: schema.string(),
+  group: schema.maybe(schema.string({ maxLength: MAX_ID_LENGTH })),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
   params: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
-  uuid: schema.maybe(schema.string()),
+  uuid: schema.maybe(schema.string({ maxLength: MAX_ID_LENGTH })),
   frequency: schema.maybe(
     schema.object({
       summary: schema.boolean(),
@@ -42,12 +52,14 @@ export const bulkEditOperationsSchema = schema.arrayOf(
         schema.literal('set'),
       ]),
       field: schema.literal('tags'),
-      value: schema.arrayOf(schema.string()),
+      value: schema.arrayOf(schema.string({ maxLength: MAX_TAG_LENGTH }), {
+        maxSize: MAX_BULK_EDIT_TAGS,
+      }),
     }),
     schema.object({
       operation: schema.oneOf([schema.literal('add'), schema.literal('set')]),
       field: schema.literal('actions'),
-      value: schema.arrayOf(ruleActionSchema),
+      value: schema.arrayOf(ruleActionSchema, { maxSize: MAX_BULK_EDIT_ACTIONS }),
     }),
     schema.object({
       operation: schema.literal('set'),
@@ -72,18 +84,27 @@ export const bulkEditOperationsSchema = schema.arrayOf(
     schema.object({
       operation: schema.oneOf([schema.literal('delete')]),
       field: schema.literal('snoozeSchedule'),
-      value: schema.maybe(scheduleIdsSchemaV1),
+      value: schema.maybe(
+        schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), {
+          maxSize: MAX_SNOOZE_SCHEDULE_IDS,
+        })
+      ),
     }),
     schema.object({
       operation: schema.literal('set'),
       field: schema.literal('apiKey'),
     }),
   ]),
-  { minSize: 1 }
+  { minSize: 1, maxSize: MAX_BULK_EDIT_OPERATIONS }
 );
 
 export const bulkEditRulesRequestBodySchema = schema.object({
-  filter: schema.maybe(schema.string()),
-  ids: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+  filter: schema.maybe(schema.string({ maxLength: MAX_KQL_FILTER_LENGTH })),
+  ids: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), {
+      minSize: 1,
+      maxSize: MAX_RULE_IDS_BULK,
+    })
+  ),
   operations: bulkEditOperationsSchema,
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/bulk_untrack/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/bulk_untrack/schemas/v1.ts
@@ -6,8 +6,17 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import {
+  MAX_BULK_UNTRACK_INDICES,
+  MAX_BULK_UNTRACK_ALERT_UUIDS,
+  MAX_INDEX_NAME_LENGTH,
+} from '../../../../../constants';
 
 export const bulkUntrackBodySchema = schema.object({
-  indices: schema.arrayOf(schema.string()),
-  alert_uuids: schema.arrayOf(schema.string()),
+  indices: schema.arrayOf(schema.string({ maxLength: MAX_INDEX_NAME_LENGTH }), {
+    maxSize: MAX_BULK_UNTRACK_INDICES,
+  }),
+  alert_uuids: schema.arrayOf(schema.string({ maxLength: 100 }), {
+    maxSize: MAX_BULK_UNTRACK_ALERT_UUIDS,
+  }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/bulk_untrack_by_query/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/bulk_untrack_by_query/schemas/v1.ts
@@ -6,8 +6,15 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import {
+  MAX_BULK_UNTRACK_QUERIES,
+  MAX_ARRAY_FIELDS,
+  MAX_ID_LENGTH,
+} from '../../../../../constants';
 
 export const bulkUntrackByQueryBodySchema = schema.object({
-  query: schema.arrayOf(schema.any()),
-  rule_type_ids: schema.arrayOf(schema.string()),
+  query: schema.arrayOf(schema.any(), { maxSize: MAX_BULK_UNTRACK_QUERIES }),
+  rule_type_ids: schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), {
+    maxSize: MAX_ARRAY_FIELDS,
+  }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/clone/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/clone/schemas/v1.ts
@@ -6,8 +6,9 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { MAX_ID_LENGTH } from '../../../../../constants';
 
 export const cloneRuleRequestParamsSchema = schema.object({
-  id: schema.string(),
-  newId: schema.maybe(schema.string()),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
+  newId: schema.maybe(schema.string({ maxLength: MAX_ID_LENGTH })),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/find/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/find/schemas/v1.ts
@@ -6,6 +6,16 @@
  */
 import { schema } from '@kbn/config-schema';
 import { stringOrStringArraySchema } from '../../../../../schemas';
+import {
+  MAX_PER_PAGE,
+  MAX_KQL_FILTER_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_FIELD_NAME_LENGTH,
+  MAX_NAME_LENGTH,
+  MAX_SAVED_OBJECT_TYPE_LENGTH,
+  MAX_ARRAY_FIELDS,
+  MAX_SEARCH_LENGTH,
+} from '../../../../../constants';
 
 export const findRulesRequestQuerySchema = schema.object({
   per_page: schema.number({
@@ -106,30 +116,48 @@ export const findRulesInternalRequestBodySchema = schema.object({
   per_page: schema.number({
     defaultValue: 10,
     min: 0,
+    max: MAX_PER_PAGE,
   }),
   page: schema.number({
     defaultValue: 1,
     min: 1,
   }),
-  search: schema.maybe(schema.string()),
+  search: schema.maybe(schema.string({ maxLength: MAX_SEARCH_LENGTH })),
   default_search_operator: schema.oneOf([schema.literal('OR'), schema.literal('AND')], {
     defaultValue: 'OR',
   }),
-  search_fields: schema.maybe(stringOrStringArraySchema()),
-  sort_field: schema.maybe(schema.string()),
+  search_fields: schema.maybe(
+    schema.oneOf([
+      schema.arrayOf(schema.string({ maxLength: MAX_FIELD_NAME_LENGTH }), {
+        maxSize: MAX_ARRAY_FIELDS,
+      }),
+      schema.string({ maxLength: MAX_FIELD_NAME_LENGTH }),
+    ])
+  ),
+  sort_field: schema.maybe(schema.string({ maxLength: MAX_FIELD_NAME_LENGTH })),
   sort_order: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
   has_reference: schema.maybe(
     // use nullable as maybe is currently broken
     // in config-schema
     schema.nullable(
       schema.object({
-        type: schema.string(),
-        id: schema.string(),
+        type: schema.string({ maxLength: MAX_SAVED_OBJECT_TYPE_LENGTH }),
+        id: schema.string({ maxLength: MAX_ID_LENGTH }),
       })
     )
   ),
-  fields: schema.maybe(schema.arrayOf(schema.string())),
-  filter: schema.maybe(schema.string()),
-  rule_type_ids: schema.maybe(schema.arrayOf(schema.string())),
-  consumers: schema.maybe(schema.arrayOf(schema.string())),
+  fields: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_FIELD_NAME_LENGTH }), {
+      maxSize: MAX_ARRAY_FIELDS,
+    })
+  ),
+  filter: schema.maybe(schema.string({ maxLength: MAX_KQL_FILTER_LENGTH })),
+  rule_type_ids: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), { maxSize: MAX_ARRAY_FIELDS })
+  ),
+  consumers: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_NAME_LENGTH }), {
+      maxSize: MAX_ARRAY_FIELDS,
+    })
+  ),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/get/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/get/index.ts
@@ -8,7 +8,10 @@
 export { getRuleRequestParamsSchema } from './schemas/latest';
 export type { GetRuleRequestParams, GetRuleResponse } from './types/latest';
 
-export { getRuleRequestParamsSchema as getRuleRequestParamsSchemaV1 } from './schemas/v1';
+export {
+  getRuleRequestParamsSchema as getRuleRequestParamsSchemaV1,
+  getInternalRuleRequestParamsSchema as getInternalRuleRequestParamsSchemaV1,
+} from './schemas/v1';
 export type {
   GetRuleRequestParams as GetRuleRequestParamsV1,
   GetRuleResponse as GetRuleResponseV1,

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/get/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/get/schemas/v1.ts
@@ -6,9 +6,19 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { MAX_ID_LENGTH } from '../../../../../constants';
 
 export const getRuleRequestParamsSchema = schema.object({
   id: schema.string({
+    meta: {
+      description: 'The identifier for the rule.',
+    },
+  }),
+});
+
+export const getInternalRuleRequestParamsSchema = schema.object({
+  id: schema.string({
+    maxLength: MAX_ID_LENGTH,
     meta: {
       description: 'The identifier for the rule.',
     },

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/resolve/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/resolve/schemas/v1.ts
@@ -6,7 +6,8 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { MAX_ID_LENGTH } from '../../../../../constants';
 
 export const resolveParamsSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/snooze/internal/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/snooze/internal/schemas/v1.ts
@@ -7,9 +7,10 @@
 
 import { schema } from '@kbn/config-schema';
 import { ruleSnoozeScheduleSchemaV1 } from '../../../../request';
+import { MAX_ID_LENGTH } from '../../../../../../constants';
 
 export const snoozeParamsInternalSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 export const snoozeBodyInternalSchema = schema.object({

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/tags/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/tags/schemas/v1.ts
@@ -6,12 +6,27 @@
  */
 import { schema } from '@kbn/config-schema';
 import { DEFAULT_TAGS_PER_PAGEV1 } from '../constants/v1';
+import {
+  MAX_TAGS_PER_PAGE,
+  MAX_SEARCH_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_ARRAY_FIELDS,
+} from '../../../../../constants';
 
 export const ruleTagsRequestQuerySchema = schema.object({
   page: schema.number({ defaultValue: 1, min: 1 }),
-  per_page: schema.maybe(schema.number({ defaultValue: DEFAULT_TAGS_PER_PAGEV1, min: 1 })),
-  search: schema.maybe(schema.string()),
-  rule_type_ids: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+  per_page: schema.maybe(
+    schema.number({ defaultValue: DEFAULT_TAGS_PER_PAGEV1, min: 1, max: MAX_TAGS_PER_PAGE })
+  ),
+  search: schema.maybe(schema.string({ maxLength: MAX_SEARCH_LENGTH })),
+  rule_type_ids: schema.maybe(
+    schema.oneOf([
+      schema.string({ maxLength: MAX_ID_LENGTH }),
+      schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), {
+        maxSize: MAX_ARRAY_FIELDS,
+      }),
+    ])
+  ),
 });
 
 export const ruleTagsFormattedResponseSchema = schema.object({

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/unsnooze/internal/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/unsnooze/internal/schemas/v1.ts
@@ -6,12 +6,15 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { MAX_ID_LENGTH, MAX_SNOOZE_SCHEDULE_IDS } from '../../../../../../constants';
 
 export const unsnoozeParamsInternalSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
-const scheduleIdsSchema = schema.maybe(schema.arrayOf(schema.string()));
+const scheduleIdsSchema = schema.maybe(
+  schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), { maxSize: MAX_SNOOZE_SCHEDULE_IDS })
+);
 
 export const unsnoozeBodyInternalSchema = schema.object({
   schedule_ids: scheduleIdsSchema,

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_action_error_log.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_action_error_log.ts
@@ -14,9 +14,16 @@ import { verifyAccessAndContext } from './lib';
 import type { AlertingRequestHandlerContext } from '../types';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import {
+  MAX_PER_PAGE_LOGS,
+  MAX_EXECUTION_FILTER_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_SORT_FIELDS,
+  ISO_DATE_MAX_LENGTH,
+} from '../../common/constants';
 
 const paramSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 const sortOrderSchema = schema.oneOf([schema.literal('asc'), schema.literal('desc')]);
@@ -28,16 +35,17 @@ const sortFieldSchema = schema.oneOf([
 
 const sortFieldsSchema = schema.arrayOf(sortFieldSchema, {
   defaultValue: [{ '@timestamp': { order: 'desc' } }],
+  maxSize: MAX_SORT_FIELDS,
 });
 
 const querySchema = schema.object({
-  date_start: schema.string(),
-  date_end: schema.maybe(schema.string()),
-  filter: schema.maybe(schema.string()),
-  per_page: schema.number({ defaultValue: 10, min: 1 }),
+  date_start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+  date_end: schema.maybe(schema.string({ maxLength: ISO_DATE_MAX_LENGTH })),
+  filter: schema.maybe(schema.string({ maxLength: MAX_EXECUTION_FILTER_LENGTH })),
+  per_page: schema.number({ defaultValue: 10, min: 1, max: MAX_PER_PAGE_LOGS }),
   page: schema.number({ defaultValue: 1, min: 1 }),
   sort: sortFieldsSchema,
-  namespace: schema.maybe(schema.string()),
+  namespace: schema.maybe(schema.string({ maxLength: MAX_ID_LENGTH })),
   with_auth: schema.maybe(schema.boolean()),
 });
 

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_global_execution_kpi.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_global_execution_kpi.ts
@@ -13,12 +13,20 @@ import { verifyAccessAndContext, rewriteNamespaces } from './lib';
 import type { GetGlobalExecutionKPIParams } from '../rules_client';
 import type { ILicenseState } from '../lib';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import {
+  MAX_EXECUTION_FILTER_LENGTH,
+  MAX_NAMESPACES,
+  MAX_ID_LENGTH,
+  ISO_DATE_MAX_LENGTH,
+} from '../../common/constants';
 
 const querySchema = schema.object({
-  date_start: schema.string(),
-  date_end: schema.maybe(schema.string()),
-  filter: schema.maybe(schema.string()),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  date_start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+  date_end: schema.maybe(schema.string({ maxLength: ISO_DATE_MAX_LENGTH })),
+  filter: schema.maybe(schema.string({ maxLength: MAX_EXECUTION_FILTER_LENGTH })),
+  namespaces: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), { maxSize: MAX_NAMESPACES })
+  ),
 });
 
 const rewriteReq: RewriteRequestCase<GetGlobalExecutionKPIParams> = ({

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_global_execution_logs.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_global_execution_logs.ts
@@ -14,6 +14,14 @@ import { verifyAccessAndContext, rewriteNamespaces } from './lib';
 import type { AlertingRequestHandlerContext } from '../types';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import {
+  MAX_PER_PAGE_LOGS,
+  MAX_EXECUTION_FILTER_LENGTH,
+  MAX_NAMESPACES,
+  MAX_ID_LENGTH,
+  MAX_SORT_FIELDS,
+  ISO_DATE_MAX_LENGTH,
+} from '../../common/constants';
 
 const sortOrderSchema = schema.oneOf([schema.literal('asc'), schema.literal('desc')]);
 
@@ -32,16 +40,19 @@ const sortFieldSchema = schema.oneOf([
 
 const sortFieldsSchema = schema.arrayOf(sortFieldSchema, {
   defaultValue: [{ timestamp: { order: 'desc' } }],
+  maxSize: MAX_SORT_FIELDS,
 });
 
 const querySchema = schema.object({
-  date_start: schema.string(),
-  date_end: schema.maybe(schema.string()),
-  filter: schema.maybe(schema.string()),
-  per_page: schema.number({ defaultValue: 10, min: 1 }),
+  date_start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+  date_end: schema.maybe(schema.string({ maxLength: ISO_DATE_MAX_LENGTH })),
+  filter: schema.maybe(schema.string({ maxLength: MAX_EXECUTION_FILTER_LENGTH })),
+  per_page: schema.number({ defaultValue: 10, min: 1, max: MAX_PER_PAGE_LOGS }),
   page: schema.number({ defaultValue: 1, min: 1 }),
   sort: sortFieldsSchema,
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  namespaces: schema.maybe(
+    schema.arrayOf(schema.string({ maxLength: MAX_ID_LENGTH }), { maxSize: MAX_NAMESPACES })
+  ),
 });
 
 const rewriteReq: RewriteRequestCase<GetGlobalExecutionLogParams> = ({

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_alert_summary.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_alert_summary.ts
@@ -14,14 +14,19 @@ import { verifyAccessAndContext } from './lib';
 import type { AlertingRequestHandlerContext, AlertSummary } from '../types';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import {
+  MAX_ID_LENGTH,
+  MAX_NUMBER_OF_EXECUTIONS,
+  ISO_DATE_MAX_LENGTH,
+} from '../../common/constants';
 
 const paramSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 const querySchema = schema.object({
-  date_start: schema.maybe(schema.string()),
-  number_of_executions: schema.maybe(schema.number()),
+  date_start: schema.maybe(schema.string({ maxLength: ISO_DATE_MAX_LENGTH })),
+  number_of_executions: schema.maybe(schema.number({ min: 1, max: MAX_NUMBER_OF_EXECUTIONS })),
 });
 
 const rewriteReq: RewriteRequestCase<GetAlertSummaryParams> = ({

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_execution_kpi.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_execution_kpi.ts
@@ -13,15 +13,20 @@ import { verifyAccessAndContext } from './lib';
 import type { GetRuleExecutionKPIParams } from '../rules_client';
 import type { ILicenseState } from '../lib';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import {
+  MAX_EXECUTION_FILTER_LENGTH,
+  MAX_ID_LENGTH,
+  ISO_DATE_MAX_LENGTH,
+} from '../../common/constants';
 
 const paramSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 const querySchema = schema.object({
-  date_start: schema.string(),
-  date_end: schema.maybe(schema.string()),
-  filter: schema.maybe(schema.string()),
+  date_start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+  date_end: schema.maybe(schema.string({ maxLength: ISO_DATE_MAX_LENGTH })),
+  filter: schema.maybe(schema.string({ maxLength: MAX_EXECUTION_FILTER_LENGTH })),
 });
 
 const rewriteReq: RewriteRequestCase<GetRuleExecutionKPIParams> = ({

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_execution_log.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_execution_log.ts
@@ -14,9 +14,16 @@ import { verifyAccessAndContext } from './lib';
 import type { AlertingRequestHandlerContext } from '../types';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import {
+  MAX_PER_PAGE_LOGS,
+  MAX_EXECUTION_FILTER_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_SORT_FIELDS,
+  ISO_DATE_MAX_LENGTH,
+} from '../../common/constants';
 
 const paramSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 const sortOrderSchema = schema.oneOf([schema.literal('asc'), schema.literal('desc')]);
@@ -36,13 +43,14 @@ const sortFieldSchema = schema.oneOf([
 
 const sortFieldsSchema = schema.arrayOf(sortFieldSchema, {
   defaultValue: [{ timestamp: { order: 'desc' } }],
+  maxSize: MAX_SORT_FIELDS,
 });
 
 const querySchema = schema.object({
-  date_start: schema.string(),
-  date_end: schema.maybe(schema.string()),
-  filter: schema.maybe(schema.string()),
-  per_page: schema.number({ defaultValue: 10, min: 1 }),
+  date_start: schema.string({ maxLength: ISO_DATE_MAX_LENGTH }),
+  date_end: schema.maybe(schema.string({ maxLength: ISO_DATE_MAX_LENGTH })),
+  filter: schema.maybe(schema.string({ maxLength: MAX_EXECUTION_FILTER_LENGTH })),
+  per_page: schema.number({ defaultValue: 10, min: 1, max: MAX_PER_PAGE_LOGS }),
   page: schema.number({ defaultValue: 1, min: 1 }),
   sort: sortFieldsSchema,
 });

--- a/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_state.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/get_rule_state.ts
@@ -13,9 +13,10 @@ import { verifyAccessAndContext } from './lib';
 import type { AlertingRequestHandlerContext, RuleTaskState } from '../types';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import { MAX_ID_LENGTH } from '../../common/constants';
 
 const paramSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 const rewriteBodyRes: RewriteResponseCase<RuleTaskState> = ({

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/get/get_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/get/get_rule_route.ts
@@ -19,7 +19,10 @@ import type {
   GetRuleRequestParamsV1,
   GetRuleResponseV1,
 } from '../../../../../common/routes/rule/apis/get';
-import { getRuleRequestParamsSchemaV1 } from '../../../../../common/routes/rule/apis/get';
+import {
+  getRuleRequestParamsSchemaV1,
+  getInternalRuleRequestParamsSchemaV1,
+} from '../../../../../common/routes/rule/apis/get';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from '../../../constants';
 
 interface BuildGetRulesRouteParams {
@@ -27,6 +30,7 @@ interface BuildGetRulesRouteParams {
   path: string;
   router: IRouter<AlertingRequestHandlerContext>;
   excludeFromPublicApi?: boolean;
+  paramsSchema?: typeof getRuleRequestParamsSchemaV1;
   options?: RouteConfigOptions<RouteMethod>;
 }
 const buildGetRuleRoute = ({
@@ -34,6 +38,7 @@ const buildGetRuleRoute = ({
   path,
   router,
   excludeFromPublicApi = false,
+  paramsSchema = getRuleRequestParamsSchemaV1,
   options,
 }: BuildGetRulesRouteParams) => {
   router.get(
@@ -43,7 +48,7 @@ const buildGetRuleRoute = ({
       security: DEFAULT_ALERTING_ROUTE_SECURITY,
       validate: {
         request: {
-          params: getRuleRequestParamsSchemaV1,
+          params: paramsSchema,
         },
         response: {
           200: {
@@ -110,5 +115,6 @@ export const getInternalRuleRoute = (
     licenseState,
     path: `${INTERNAL_BASE_ALERTING_API_PATH}/rule/{id}`,
     router,
+    paramsSchema: getInternalRuleRequestParamsSchemaV1,
     options: { access: 'internal' },
   });

--- a/x-pack/platform/plugins/shared/alerting/server/routes/run_soon.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/run_soon.ts
@@ -12,9 +12,10 @@ import { verifyAccessAndContext } from './lib';
 import type { AlertingRequestHandlerContext } from '../types';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from './constants';
+import { MAX_ID_LENGTH } from '../../common/constants';
 
 const paramSchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_ID_LENGTH }),
 });
 
 export const runSoonRoute = (

--- a/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/fields_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/fields_rules.ts
@@ -22,6 +22,7 @@ import { verifyAccessAndContext } from '../lib';
 import type { ILicenseState } from '../../lib';
 import type { AlertingRequestHandlerContext } from '../../types';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from '../constants';
+import { MAX_ARRAY_FIELDS, MAX_SUGGESTION_TEXT_LENGTH } from '../../../common/constants';
 
 export function registerFieldsRoute(
   router: IRouter<AlertingRequestHandlerContext>,
@@ -36,7 +37,14 @@ export function registerFieldsRoute(
       validate: {
         body: schema.nullable(
           schema.object({
-            fields: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+            fields: schema.maybe(
+              schema.oneOf([
+                schema.string({ maxLength: MAX_SUGGESTION_TEXT_LENGTH }),
+                schema.arrayOf(schema.string({ maxLength: MAX_SUGGESTION_TEXT_LENGTH }), {
+                  maxSize: MAX_ARRAY_FIELDS,
+                }),
+              ])
+            ),
           })
         ),
       },

--- a/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_alerts.ts
@@ -23,6 +23,7 @@ import { AlertingAuthorizationEntity, AlertingAuthorizationFilterType } from '..
 import type { AlertingRequestHandlerContext } from '../../types';
 import type { GetAlertIndicesAlias, ILicenseState } from '../../lib';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from '../constants';
+import { MAX_SUGGESTION_TEXT_LENGTH } from '../../../common/constants';
 
 const alertingAuthorizationFilterOpts: AlertingAuthorizationFilterOpts = {
   type: AlertingAuthorizationFilterType.ESDSL,
@@ -31,8 +32,8 @@ const alertingAuthorizationFilterOpts: AlertingAuthorizationFilterOpts = {
 
 export const AlertsSuggestionsSchema = {
   body: schema.object({
-    field: schema.string(),
-    query: schema.string(),
+    field: schema.string({ maxLength: MAX_SUGGESTION_TEXT_LENGTH }),
+    query: schema.string({ maxLength: MAX_SUGGESTION_TEXT_LENGTH }),
     filters: schema.maybe(schema.any()),
     fieldMeta: schema.maybe(schema.any()),
   }),

--- a/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_rules.ts
@@ -24,6 +24,7 @@ import type { AlertingAuthorizationFilterOpts } from '../../authorization';
 import { AlertingAuthorizationEntity, AlertingAuthorizationFilterType } from '../../authorization';
 import { RuleAuditAction, ruleAuditEvent } from '../../rules_client/common/audit_events';
 import { DEFAULT_ALERTING_ROUTE_SECURITY } from '../constants';
+import { MAX_SUGGESTION_TEXT_LENGTH } from '../../../common/constants';
 
 const alertingAuthorizationFilterOpts: AlertingAuthorizationFilterOpts = {
   type: AlertingAuthorizationFilterType.ESDSL,
@@ -32,8 +33,8 @@ const alertingAuthorizationFilterOpts: AlertingAuthorizationFilterOpts = {
 
 export const RulesSuggestionsSchema = {
   body: schema.object({
-    field: schema.string(),
-    query: schema.string(),
+    field: schema.string({ maxLength: MAX_SUGGESTION_TEXT_LENGTH }),
+    query: schema.string({ maxLength: MAX_SUGGESTION_TEXT_LENGTH }),
     filters: schema.maybe(schema.any()),
     fieldMeta: schema.maybe(schema.any()),
   }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Alerting] Add limits to all of the alerting internal APIs (#273304)](https://github.com/elastic/kibana/pull/273304)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2026-07-16T04:18:04Z","message":"[ResponseOps][Alerting] Add limits to all of the alerting internal APIs (#273304)\n\nCloses https://github.com/elastic/kibana/issues/271199\n\n## Summary\n\n- Adds request validation limits to all internal alerting API schemas\n(access: 'internal') across the alerting plugin.\n\nEndpoint / schema | Field | Limit | Notes\n-- | -- | -- | --\nPOST /internal/alerting/rules/_find | per_page | max: 100 (MAX_PER_PAGE)\n| Standard listing cap\n| search, filter | maxLength: 65536 (MAX_KQL_FILTER_LENGTH) | Serialized\nKueryNode JSON\n  | sort_field | maxLength: 256 (MAX_FIELD_NAME_LENGTH) |\n  | has_reference.type | maxLength: 256 (MAX_SAVED_OBJECT_TYPE_LENGTH) |\n  | has_reference.id | maxLength: 256 (MAX_ID_LENGTH) |\n| fields / fields[] | maxSize: 100 / maxLength: 256 | MAX_ARRAY_FIELDS,\nMAX_FIELD_NAME_LENGTH\n| rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\nMAX_ARRAY_FIELDS, MAX_ID_LENGTH\n| consumers / consumers[] | maxSize: 100 / maxLength: 256 |\nMAX_ARRAY_FIELDS, MAX_NAME_LENGTH\nPOST /internal/alerting/rules/_aggregate | search, filter | maxLength:\n65536 |\n| search_fields[] | maxLength: 256 / maxSize: 100 |\nMAX_FIELD_NAME_LENGTH, MAX_ARRAY_FIELDS\n  | has_reference.type | maxLength: 256 |\n  | has_reference.id | maxLength: 256 |\n  | rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\n  | consumers / consumers[] | maxSize: 100 / maxLength: 256 |\nGET /internal/alerting/rules/_tags | per_page | max: 10000\n(MAX_TAGS_PER_PAGE) | UI fetches full tag list\n  | search | maxLength: 256 (MAX_SEARCH_LENGTH) |\n  | rule_type_ids (string \\| string[]) | maxLength: 256 / maxSize: 100 |\nPOST /internal/alerting/rules/_bulk_edit | ids array | maxSize: 1000\n(MAX_RULE_IDS_BULK) |\n  | operations array | maxSize: 50 (MAX_BULK_EDIT_OPERATIONS) |\n| tags op value / value[] | maxSize: 200 / maxLength: 100 |\nMAX_BULK_EDIT_TAGS, MAX_TAG_LENGTH\n  | actions op value array | maxSize: 20 (MAX_BULK_EDIT_ACTIONS) |\n| action.id, action.group, action.uuid | maxLength: 256 (MAX_ID_LENGTH)\n| Local ruleActionSchema\n| snoozeSchedule delete value[] | maxSize: 100 / maxLength: 256 |\nInlined to avoid touching public scheduleIdsSchemaV1\n  | filter | maxLength: 65536 |\nPOST /internal/alerting/_bulk_untrack | indices / indices[] | maxSize:\n100 / maxLength: 255 | MAX_BULK_UNTRACK_INDICES, MAX_INDEX_NAME_LENGTH\n  | alert_uuids array | maxSize: 1000 (MAX_BULK_UNTRACK_ALERT_UUIDS) |\nPOST /internal/alerting/_bulk_untrack_by_query | query array | maxSize:\n10 (MAX_BULK_UNTRACK_QUERIES) |\n  | rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\nPOST /internal/alerting/rules/_bulk_mute_alerts, _bulk_unmute_alerts |\nrule_id, alert_instance_ids[] | maxLength: 256 |\nGET /internal/alerting/rule/{id} | params.id | maxLength: 256 |\nPOST /internal/alerting/rule/{id}/_clone/{newId} | params.id,\nparams.newId | maxLength: 256 |\nGET /internal/alerting/rule/{id}/_resolve | params.id | maxLength: 256 |\nPOST /internal/alerting/rule/{id}/_run_soon | params.id | maxLength: 256\n|\nPOST /internal/alerting/rule/{id}/_snooze | params.id | maxLength: 256 |\nBody uses shared public schema, untouched\nPOST /internal/alerting/rule/{id}/_unsnooze | params.id | maxLength: 256\n|\n| schedule_ids / schedule_ids[] | maxSize: 100 / maxLength: 256 |\nMAX_SNOOZE_SCHEDULE_IDS, MAX_ID_LENGTH\nGET /internal/alerting/rule/{id}/state | params.id | maxLength: 256 |\nGET /internal/alerting/rule/{id}/_alert_summary | params.id | maxLength:\n256 |\n| number_of_executions | min: 1, max: 10000 (MAX_NUMBER_OF_EXECUTIONS) |\nGET /internal/alerting/rule_templates/_find | search | maxLength: 65536\n|\n  | rule_type_id | maxLength: 256 |\nGET /internal/alerting/rule_template/{id} | params.id | maxLength: 256 |\nGET /internal/alerting/_global_execution_logs | filter | maxLength:\n65536 |\n  | per_page | max: 1000 (MAX_PER_PAGE_LOGS) |\n  | sort array | maxSize: 10 (MAX_SORT_FIELDS) |\n| namespaces / namespaces[] | maxSize: 100 / maxLength: 256 |\nMAX_NAMESPACES, MAX_ID_LENGTH\nGET /internal/alerting/_global_execution_kpi | filter | maxLength: 65536\n|\n  | namespaces / namespaces[] | maxSize: 100 / maxLength: 256 |\nGET /internal/alerting/rule/{id}/_execution_log | params.id | maxLength:\n256 |\n  | filter | maxLength: 65536 |\n  | per_page | max: 1000 |\n  | sort array | maxSize: 10 |\nGET /internal/alerting/rule/{id}/_execution_kpi | params.id | maxLength:\n256 |\n  | filter | maxLength: 65536 |\nGET /internal/alerting/rule/{id}/_action_error_log | params.id |\nmaxLength: 256 |\n  | filter | maxLength: 65536 |\n  | per_page | max: 1000 |\n  | sort array | maxSize: 10 |\n  | namespace | maxLength: 256 |\nPOST /internal/alerting/rules/_suggestions/values | field, query |\nmaxLength: 1024 (MAX_SUGGESTION_TEXT_LENGTH) |\nPOST /internal/alerting/alerts/_suggestions/values | field, query |\nmaxLength: 1024 |\nPOST /internal/alerting/rules/_suggestions/fields | fields (string \\|\nstring[]) | maxLength: 1024 / maxSize: 100 |\nPOST /internal/alerting/rules/gaps/_find | rule_id | maxLength: 256 |\n  | statuses array | maxSize: 3 | Exact enum cardinality\nPOST /internal/alerting/rules/gaps/_get_rules_with_gaps | statuses array\n| maxSize: 3 |\n  | highest_priority_gap_fill_statuses array | maxSize: 4 |\n  | gap_auto_fill_scheduler_id | maxLength: 256 |\nPOST /internal/alerting/rules/gaps/_get_gaps_summary_by_rule_ids |\nrule_ids[] | maxLength: 256 | Array maxSize was already 100\n  | gap_auto_fill_scheduler_id | maxLength: 256 |\nGET /internal/alerting/rules/gaps/_fill_by_id | rule_id, gap_id |\nmaxLength: 256 |\nGET /internal/alerting/rules/gap_auto_fill_scheduler/{id} | params.id |\nmaxLength: 256 |\nPOST /internal/alerting/rules/gap_auto_fill_scheduler (create/update) |\nid | maxLength: 256 |\n  | name | maxLength: 256 (MAX_NAME_LENGTH) |\n| gap_fill_range, schedule.interval | maxLength: 32\n(MAX_DURATION_STRING_LENGTH) |\n  | scope / scope[] | maxSize: 100 / maxLength: 256 |\n  | rule_types array | maxSize: 100 |\n  | rule_types[].type | maxLength: 256 (MAX_FIELD_NAME_LENGTH) |\n  | rule_types[].consumer | maxLength: 256 (MAX_NAME_LENGTH) |\nGET /internal/alerting/rules/gap_auto_fill_scheduler/{id}/_logs |\nparams.id | maxLength: 256 |\n  | statuses array | maxSize: 4 |\nPOST /internal/alerting/_alert_delete_schedule | space_ids / space_ids[]\n| maxSize: 100 / maxLength: 256 | MAX_SPACE_IDS, MAX_ID_LENGTH\n\n---------\n\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"07f2bd3e793042d07c15addb2f41a04d1295dcba","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:all-open","v9.5.0","v9.4.4","v9.6.0","v8.19.19","v9.3.8"],"title":"[ResponseOps][Alerting] Add limits to all of the alerting internal APIs","number":273304,"url":"https://github.com/elastic/kibana/pull/273304","mergeCommit":{"message":"[ResponseOps][Alerting] Add limits to all of the alerting internal APIs (#273304)\n\nCloses https://github.com/elastic/kibana/issues/271199\n\n## Summary\n\n- Adds request validation limits to all internal alerting API schemas\n(access: 'internal') across the alerting plugin.\n\nEndpoint / schema | Field | Limit | Notes\n-- | -- | -- | --\nPOST /internal/alerting/rules/_find | per_page | max: 100 (MAX_PER_PAGE)\n| Standard listing cap\n| search, filter | maxLength: 65536 (MAX_KQL_FILTER_LENGTH) | Serialized\nKueryNode JSON\n  | sort_field | maxLength: 256 (MAX_FIELD_NAME_LENGTH) |\n  | has_reference.type | maxLength: 256 (MAX_SAVED_OBJECT_TYPE_LENGTH) |\n  | has_reference.id | maxLength: 256 (MAX_ID_LENGTH) |\n| fields / fields[] | maxSize: 100 / maxLength: 256 | MAX_ARRAY_FIELDS,\nMAX_FIELD_NAME_LENGTH\n| rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\nMAX_ARRAY_FIELDS, MAX_ID_LENGTH\n| consumers / consumers[] | maxSize: 100 / maxLength: 256 |\nMAX_ARRAY_FIELDS, MAX_NAME_LENGTH\nPOST /internal/alerting/rules/_aggregate | search, filter | maxLength:\n65536 |\n| search_fields[] | maxLength: 256 / maxSize: 100 |\nMAX_FIELD_NAME_LENGTH, MAX_ARRAY_FIELDS\n  | has_reference.type | maxLength: 256 |\n  | has_reference.id | maxLength: 256 |\n  | rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\n  | consumers / consumers[] | maxSize: 100 / maxLength: 256 |\nGET /internal/alerting/rules/_tags | per_page | max: 10000\n(MAX_TAGS_PER_PAGE) | UI fetches full tag list\n  | search | maxLength: 256 (MAX_SEARCH_LENGTH) |\n  | rule_type_ids (string \\| string[]) | maxLength: 256 / maxSize: 100 |\nPOST /internal/alerting/rules/_bulk_edit | ids array | maxSize: 1000\n(MAX_RULE_IDS_BULK) |\n  | operations array | maxSize: 50 (MAX_BULK_EDIT_OPERATIONS) |\n| tags op value / value[] | maxSize: 200 / maxLength: 100 |\nMAX_BULK_EDIT_TAGS, MAX_TAG_LENGTH\n  | actions op value array | maxSize: 20 (MAX_BULK_EDIT_ACTIONS) |\n| action.id, action.group, action.uuid | maxLength: 256 (MAX_ID_LENGTH)\n| Local ruleActionSchema\n| snoozeSchedule delete value[] | maxSize: 100 / maxLength: 256 |\nInlined to avoid touching public scheduleIdsSchemaV1\n  | filter | maxLength: 65536 |\nPOST /internal/alerting/_bulk_untrack | indices / indices[] | maxSize:\n100 / maxLength: 255 | MAX_BULK_UNTRACK_INDICES, MAX_INDEX_NAME_LENGTH\n  | alert_uuids array | maxSize: 1000 (MAX_BULK_UNTRACK_ALERT_UUIDS) |\nPOST /internal/alerting/_bulk_untrack_by_query | query array | maxSize:\n10 (MAX_BULK_UNTRACK_QUERIES) |\n  | rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\nPOST /internal/alerting/rules/_bulk_mute_alerts, _bulk_unmute_alerts |\nrule_id, alert_instance_ids[] | maxLength: 256 |\nGET /internal/alerting/rule/{id} | params.id | maxLength: 256 |\nPOST /internal/alerting/rule/{id}/_clone/{newId} | params.id,\nparams.newId | maxLength: 256 |\nGET /internal/alerting/rule/{id}/_resolve | params.id | maxLength: 256 |\nPOST /internal/alerting/rule/{id}/_run_soon | params.id | maxLength: 256\n|\nPOST /internal/alerting/rule/{id}/_snooze | params.id | maxLength: 256 |\nBody uses shared public schema, untouched\nPOST /internal/alerting/rule/{id}/_unsnooze | params.id | maxLength: 256\n|\n| schedule_ids / schedule_ids[] | maxSize: 100 / maxLength: 256 |\nMAX_SNOOZE_SCHEDULE_IDS, MAX_ID_LENGTH\nGET /internal/alerting/rule/{id}/state | params.id | maxLength: 256 |\nGET /internal/alerting/rule/{id}/_alert_summary | params.id | maxLength:\n256 |\n| number_of_executions | min: 1, max: 10000 (MAX_NUMBER_OF_EXECUTIONS) |\nGET /internal/alerting/rule_templates/_find | search | maxLength: 65536\n|\n  | rule_type_id | maxLength: 256 |\nGET /internal/alerting/rule_template/{id} | params.id | maxLength: 256 |\nGET /internal/alerting/_global_execution_logs | filter | maxLength:\n65536 |\n  | per_page | max: 1000 (MAX_PER_PAGE_LOGS) |\n  | sort array | maxSize: 10 (MAX_SORT_FIELDS) |\n| namespaces / namespaces[] | maxSize: 100 / maxLength: 256 |\nMAX_NAMESPACES, MAX_ID_LENGTH\nGET /internal/alerting/_global_execution_kpi | filter | maxLength: 65536\n|\n  | namespaces / namespaces[] | maxSize: 100 / maxLength: 256 |\nGET /internal/alerting/rule/{id}/_execution_log | params.id | maxLength:\n256 |\n  | filter | maxLength: 65536 |\n  | per_page | max: 1000 |\n  | sort array | maxSize: 10 |\nGET /internal/alerting/rule/{id}/_execution_kpi | params.id | maxLength:\n256 |\n  | filter | maxLength: 65536 |\nGET /internal/alerting/rule/{id}/_action_error_log | params.id |\nmaxLength: 256 |\n  | filter | maxLength: 65536 |\n  | per_page | max: 1000 |\n  | sort array | maxSize: 10 |\n  | namespace | maxLength: 256 |\nPOST /internal/alerting/rules/_suggestions/values | field, query |\nmaxLength: 1024 (MAX_SUGGESTION_TEXT_LENGTH) |\nPOST /internal/alerting/alerts/_suggestions/values | field, query |\nmaxLength: 1024 |\nPOST /internal/alerting/rules/_suggestions/fields | fields (string \\|\nstring[]) | maxLength: 1024 / maxSize: 100 |\nPOST /internal/alerting/rules/gaps/_find | rule_id | maxLength: 256 |\n  | statuses array | maxSize: 3 | Exact enum cardinality\nPOST /internal/alerting/rules/gaps/_get_rules_with_gaps | statuses array\n| maxSize: 3 |\n  | highest_priority_gap_fill_statuses array | maxSize: 4 |\n  | gap_auto_fill_scheduler_id | maxLength: 256 |\nPOST /internal/alerting/rules/gaps/_get_gaps_summary_by_rule_ids |\nrule_ids[] | maxLength: 256 | Array maxSize was already 100\n  | gap_auto_fill_scheduler_id | maxLength: 256 |\nGET /internal/alerting/rules/gaps/_fill_by_id | rule_id, gap_id |\nmaxLength: 256 |\nGET /internal/alerting/rules/gap_auto_fill_scheduler/{id} | params.id |\nmaxLength: 256 |\nPOST /internal/alerting/rules/gap_auto_fill_scheduler (create/update) |\nid | maxLength: 256 |\n  | name | maxLength: 256 (MAX_NAME_LENGTH) |\n| gap_fill_range, schedule.interval | maxLength: 32\n(MAX_DURATION_STRING_LENGTH) |\n  | scope / scope[] | maxSize: 100 / maxLength: 256 |\n  | rule_types array | maxSize: 100 |\n  | rule_types[].type | maxLength: 256 (MAX_FIELD_NAME_LENGTH) |\n  | rule_types[].consumer | maxLength: 256 (MAX_NAME_LENGTH) |\nGET /internal/alerting/rules/gap_auto_fill_scheduler/{id}/_logs |\nparams.id | maxLength: 256 |\n  | statuses array | maxSize: 4 |\nPOST /internal/alerting/_alert_delete_schedule | space_ids / space_ids[]\n| maxSize: 100 / maxLength: 256 | MAX_SPACE_IDS, MAX_ID_LENGTH\n\n---------\n\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"07f2bd3e793042d07c15addb2f41a04d1295dcba"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","8.19","9.3"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/278650","number":278650,"state":"MERGED","mergeCommit":{"sha":"c6f875c18e1d21c95ed9e43258b00c81e286ed8c","message":"[9.5] [ResponseOps][Alerting] Add limits to all of the alerting internal APIs (#273304) (#278650)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[ResponseOps][Alerting] Add limits to all of the alerting internal\nAPIs (#273304)](https://github.com/elastic/kibana/pull/273304)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Georgiana-Andreea Onoleață <georgiana.onoleata@elastic.co>\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273304","number":273304,"mergeCommit":{"message":"[ResponseOps][Alerting] Add limits to all of the alerting internal APIs (#273304)\n\nCloses https://github.com/elastic/kibana/issues/271199\n\n## Summary\n\n- Adds request validation limits to all internal alerting API schemas\n(access: 'internal') across the alerting plugin.\n\nEndpoint / schema | Field | Limit | Notes\n-- | -- | -- | --\nPOST /internal/alerting/rules/_find | per_page | max: 100 (MAX_PER_PAGE)\n| Standard listing cap\n| search, filter | maxLength: 65536 (MAX_KQL_FILTER_LENGTH) | Serialized\nKueryNode JSON\n  | sort_field | maxLength: 256 (MAX_FIELD_NAME_LENGTH) |\n  | has_reference.type | maxLength: 256 (MAX_SAVED_OBJECT_TYPE_LENGTH) |\n  | has_reference.id | maxLength: 256 (MAX_ID_LENGTH) |\n| fields / fields[] | maxSize: 100 / maxLength: 256 | MAX_ARRAY_FIELDS,\nMAX_FIELD_NAME_LENGTH\n| rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\nMAX_ARRAY_FIELDS, MAX_ID_LENGTH\n| consumers / consumers[] | maxSize: 100 / maxLength: 256 |\nMAX_ARRAY_FIELDS, MAX_NAME_LENGTH\nPOST /internal/alerting/rules/_aggregate | search, filter | maxLength:\n65536 |\n| search_fields[] | maxLength: 256 / maxSize: 100 |\nMAX_FIELD_NAME_LENGTH, MAX_ARRAY_FIELDS\n  | has_reference.type | maxLength: 256 |\n  | has_reference.id | maxLength: 256 |\n  | rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\n  | consumers / consumers[] | maxSize: 100 / maxLength: 256 |\nGET /internal/alerting/rules/_tags | per_page | max: 10000\n(MAX_TAGS_PER_PAGE) | UI fetches full tag list\n  | search | maxLength: 256 (MAX_SEARCH_LENGTH) |\n  | rule_type_ids (string \\| string[]) | maxLength: 256 / maxSize: 100 |\nPOST /internal/alerting/rules/_bulk_edit | ids array | maxSize: 1000\n(MAX_RULE_IDS_BULK) |\n  | operations array | maxSize: 50 (MAX_BULK_EDIT_OPERATIONS) |\n| tags op value / value[] | maxSize: 200 / maxLength: 100 |\nMAX_BULK_EDIT_TAGS, MAX_TAG_LENGTH\n  | actions op value array | maxSize: 20 (MAX_BULK_EDIT_ACTIONS) |\n| action.id, action.group, action.uuid | maxLength: 256 (MAX_ID_LENGTH)\n| Local ruleActionSchema\n| snoozeSchedule delete value[] | maxSize: 100 / maxLength: 256 |\nInlined to avoid touching public scheduleIdsSchemaV1\n  | filter | maxLength: 65536 |\nPOST /internal/alerting/_bulk_untrack | indices / indices[] | maxSize:\n100 / maxLength: 255 | MAX_BULK_UNTRACK_INDICES, MAX_INDEX_NAME_LENGTH\n  | alert_uuids array | maxSize: 1000 (MAX_BULK_UNTRACK_ALERT_UUIDS) |\nPOST /internal/alerting/_bulk_untrack_by_query | query array | maxSize:\n10 (MAX_BULK_UNTRACK_QUERIES) |\n  | rule_type_ids / rule_type_ids[] | maxSize: 100 / maxLength: 256 |\nPOST /internal/alerting/rules/_bulk_mute_alerts, _bulk_unmute_alerts |\nrule_id, alert_instance_ids[] | maxLength: 256 |\nGET /internal/alerting/rule/{id} | params.id | maxLength: 256 |\nPOST /internal/alerting/rule/{id}/_clone/{newId} | params.id,\nparams.newId | maxLength: 256 |\nGET /internal/alerting/rule/{id}/_resolve | params.id | maxLength: 256 |\nPOST /internal/alerting/rule/{id}/_run_soon | params.id | maxLength: 256\n|\nPOST /internal/alerting/rule/{id}/_snooze | params.id | maxLength: 256 |\nBody uses shared public schema, untouched\nPOST /internal/alerting/rule/{id}/_unsnooze | params.id | maxLength: 256\n|\n| schedule_ids / schedule_ids[] | maxSize: 100 / maxLength: 256 |\nMAX_SNOOZE_SCHEDULE_IDS, MAX_ID_LENGTH\nGET /internal/alerting/rule/{id}/state | params.id | maxLength: 256 |\nGET /internal/alerting/rule/{id}/_alert_summary | params.id | maxLength:\n256 |\n| number_of_executions | min: 1, max: 10000 (MAX_NUMBER_OF_EXECUTIONS) |\nGET /internal/alerting/rule_templates/_find | search | maxLength: 65536\n|\n  | rule_type_id | maxLength: 256 |\nGET /internal/alerting/rule_template/{id} | params.id | maxLength: 256 |\nGET /internal/alerting/_global_execution_logs | filter | maxLength:\n65536 |\n  | per_page | max: 1000 (MAX_PER_PAGE_LOGS) |\n  | sort array | maxSize: 10 (MAX_SORT_FIELDS) |\n| namespaces / namespaces[] | maxSize: 100 / maxLength: 256 |\nMAX_NAMESPACES, MAX_ID_LENGTH\nGET /internal/alerting/_global_execution_kpi | filter | maxLength: 65536\n|\n  | namespaces / namespaces[] | maxSize: 100 / maxLength: 256 |\nGET /internal/alerting/rule/{id}/_execution_log | params.id | maxLength:\n256 |\n  | filter | maxLength: 65536 |\n  | per_page | max: 1000 |\n  | sort array | maxSize: 10 |\nGET /internal/alerting/rule/{id}/_execution_kpi | params.id | maxLength:\n256 |\n  | filter | maxLength: 65536 |\nGET /internal/alerting/rule/{id}/_action_error_log | params.id |\nmaxLength: 256 |\n  | filter | maxLength: 65536 |\n  | per_page | max: 1000 |\n  | sort array | maxSize: 10 |\n  | namespace | maxLength: 256 |\nPOST /internal/alerting/rules/_suggestions/values | field, query |\nmaxLength: 1024 (MAX_SUGGESTION_TEXT_LENGTH) |\nPOST /internal/alerting/alerts/_suggestions/values | field, query |\nmaxLength: 1024 |\nPOST /internal/alerting/rules/_suggestions/fields | fields (string \\|\nstring[]) | maxLength: 1024 / maxSize: 100 |\nPOST /internal/alerting/rules/gaps/_find | rule_id | maxLength: 256 |\n  | statuses array | maxSize: 3 | Exact enum cardinality\nPOST /internal/alerting/rules/gaps/_get_rules_with_gaps | statuses array\n| maxSize: 3 |\n  | highest_priority_gap_fill_statuses array | maxSize: 4 |\n  | gap_auto_fill_scheduler_id | maxLength: 256 |\nPOST /internal/alerting/rules/gaps/_get_gaps_summary_by_rule_ids |\nrule_ids[] | maxLength: 256 | Array maxSize was already 100\n  | gap_auto_fill_scheduler_id | maxLength: 256 |\nGET /internal/alerting/rules/gaps/_fill_by_id | rule_id, gap_id |\nmaxLength: 256 |\nGET /internal/alerting/rules/gap_auto_fill_scheduler/{id} | params.id |\nmaxLength: 256 |\nPOST /internal/alerting/rules/gap_auto_fill_scheduler (create/update) |\nid | maxLength: 256 |\n  | name | maxLength: 256 (MAX_NAME_LENGTH) |\n| gap_fill_range, schedule.interval | maxLength: 32\n(MAX_DURATION_STRING_LENGTH) |\n  | scope / scope[] | maxSize: 100 / maxLength: 256 |\n  | rule_types array | maxSize: 100 |\n  | rule_types[].type | maxLength: 256 (MAX_FIELD_NAME_LENGTH) |\n  | rule_types[].consumer | maxLength: 256 (MAX_NAME_LENGTH) |\nGET /internal/alerting/rules/gap_auto_fill_scheduler/{id}/_logs |\nparams.id | maxLength: 256 |\n  | statuses array | maxSize: 4 |\nPOST /internal/alerting/_alert_delete_schedule | space_ids / space_ids[]\n| maxSize: 100 / maxLength: 256 | MAX_SPACE_IDS, MAX_ID_LENGTH\n\n---------\n\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"07f2bd3e793042d07c15addb2f41a04d1295dcba"}},{"branch":"8.19","label":"v8.19.19","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->