### PR TITLE
[9.5] [Streams] Create Import from other Stream flow (#275948)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/failure_store/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/failure_store/index.ts
@@ -148,8 +148,12 @@ export const isDisabledFailureStore = (input: FailureStore): input is FailureSto
   return isSchema(disabledFailureStoreSchema, input);
 };
 
+// Elasticsearch responses include the failure store configuration on the data stream,
+// but the client's `IndicesDataStream` type either omits it or types it with a different
+// shape. This models the fields we rely on. The property is optional so a raw
+// `IndicesDataStream` is directly assignable, avoiding type assertions at call sites.
 export type DataStreamWithFailureStore = IndicesDataStream & {
-  failure_store: {
+  failure_store?: {
     enabled?: boolean;
     lifecycle?: {
       enabled?: boolean;

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
@@ -8,18 +8,22 @@
 import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
 import { z } from '@kbn/zod/v4';
 import type { estypes } from '@elastic/elasticsearch';
-import type { ClassicIngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import type {
+  ClassicIngestStreamEffectiveLifecycle,
+  EffectiveFailureStore,
+} from '@kbn/streams-schema';
 import { Streams } from '@kbn/streams-schema';
 import { OBSERVABILITY_STREAMS_ENABLE_QUERY_STREAMS } from '@kbn/management-settings-ids';
 import { processAsyncInChunks } from '../../../../utils/process_async_in_chunks';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import type { StreamSummary } from '../../../../../common';
 import { createServerRoute } from '../../../create_server_route';
-import { getDataStreamLifecycle } from '../../../../lib/streams/stream_crud';
+import { getDataStreamLifecycle, getFailureStore } from '../../../../lib/streams/stream_crud';
 
 export interface ListStreamDetail {
   stream: Streams.all.Definition;
   effective_lifecycle?: ClassicIngestStreamEffectiveLifecycle;
+  effective_failure_store?: EffectiveFailureStore;
   data_stream?: estypes.IndicesDataStream;
   privileges: {
     read_failure_store: boolean;
@@ -83,12 +87,20 @@ export const listStreamsRoute = createServerRoute({
 
       const match = dataStreams.data_streams.find((dataStream) => dataStream.name === stream.name);
       const privileges = streamPrivilegesMap.get(stream.name);
+      const canReadFailureStore = privileges?.read_failure_store ?? false;
 
       return {
         stream,
         effective_lifecycle: getDataStreamLifecycle(match ?? null),
+        ...(canReadFailureStore
+          ? {
+              effective_failure_store: getFailureStore({
+                dataStream: match ?? null,
+              }),
+            }
+          : {}),
         data_stream: match,
-        privileges: { read_failure_store: privileges?.read_failure_store ?? false },
+        privileges: { read_failure_store: canReadFailureStore },
       };
     });
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/data_lifecycle/compute_successful_lifecycle_flyout_preview.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/data_lifecycle/compute_successful_lifecycle_flyout_preview.ts
@@ -95,7 +95,7 @@ const previewForDlmSelection = ({
   };
 };
 
-const previewFromLifecycle = ({
+export const previewFromLifecycle = ({
   lifecycle,
   ilmPolicies,
   isServerless,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/hooks/lifecycle_flyout_coordination.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/hooks/lifecycle_flyout_coordination.tsx
@@ -138,6 +138,7 @@ export const STREAM_LIFECYCLE_FLYOUT_IDS = {
   downsampleSteps: 'downsample-steps',
   failedLifecycle: 'failed-lifecycle',
   failedDeletePhase: 'failed-delete-phase',
+  importLifecycle: 'import-lifecycle',
 } as const;
 
 export type StreamLifecycleFlyoutId =

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/failure_store/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/failure_store/index.tsx
@@ -4,10 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import type { Streams } from '@kbn/streams-schema';
+import React, { useMemo } from 'react';
+import type { EffectiveFailureStore, Streams } from '@kbn/streams-schema';
+import { isEnabledFailureStore, isEnabledLifecycleFailureStore } from '@kbn/streams-schema';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { isEqual } from 'lodash';
 import { NoFailureStorePanel } from './no_failure_store_panel';
 import { FailureStoreInfo } from './failure_store_info';
 import { useUpdateFailureStore } from '../../../../../hooks/use_update_failure_store';
@@ -17,16 +19,25 @@ import { useTimefilter } from '../../../../../hooks/use_timefilter';
 import type { useDataStreamStats } from '../hooks/use_data_stream_stats';
 import { useFailureStoreConfig } from '../hooks/use_failure_store_config';
 import { LifecyclePreviewProvider } from '../common/hooks/lifecycle_preview';
+import {
+  type EditFlyoutPreviewModel,
+  useEditFlyoutPreviewSyncFromModel,
+} from '../common/hooks/use_edit_flyout_preview_sync';
+import { getImportedFailureStore } from '../import_from_stream/get_imported_failure_store';
 import { useEditFailedLifecycleFlyout } from './hooks/use_edit_failed_lifecycle_flyout';
 
 const StreamDetailFailureStoreInner = ({
   definition,
   data,
   refreshDefinition,
+  isImportFlyoutOpen = false,
+  importPreviewFailureStore = null,
 }: {
   definition: Streams.ingest.all.GetResponse;
   data: ReturnType<typeof useDataStreamStats>;
   refreshDefinition: () => void;
+  isImportFlyoutOpen?: boolean;
+  importPreviewFailureStore?: EffectiveFailureStore | null;
 }) => {
   const kibana = useKibana();
   const { updateFailureStore } = useUpdateFailureStore(definition.stream);
@@ -60,6 +71,57 @@ const StreamDetailFailureStoreInner = ({
     updateFailureStore,
   });
 
+  const importPreviewModel = useMemo<EditFlyoutPreviewModel>(() => {
+    if (!isImportFlyoutOpen) {
+      return null;
+    }
+    if (!importPreviewFailureStore) {
+      return { action: 'clear', hasUnsavedChanges: false };
+    }
+
+    const nextFailureStore = getImportedFailureStore(importPreviewFailureStore);
+    const importHasUnsavedChanges = !isEqual(
+      definition.stream.ingest.failure_store,
+      nextFailureStore
+    );
+
+    if (!isEnabledFailureStore(importPreviewFailureStore)) {
+      return { action: 'clear', hasUnsavedChanges: importHasUnsavedChanges };
+    }
+
+    const retentionPeriod = isEnabledLifecycleFailureStore(importPreviewFailureStore)
+      ? importPreviewFailureStore.lifecycle.enabled.data_retention ?? null
+      : null;
+
+    return {
+      action: 'apply',
+      retentionPeriod,
+      dataPhasesCount: retentionPeriod ? 2 : 1,
+      hasUnsavedChanges: importHasUnsavedChanges,
+    };
+  }, [definition.stream.ingest.failure_store, importPreviewFailureStore, isImportFlyoutOpen]);
+
+  const importPreviewFailureStoreEnabled =
+    isImportFlyoutOpen && importPreviewFailureStore
+      ? isEnabledFailureStore(importPreviewFailureStore)
+      : undefined;
+
+  const effectiveFailureStoreEnabledForUi =
+    importPreviewFailureStoreEnabled ?? failureStoreEnabledForUi;
+
+  const effectivePreviewFailureStoreEnabled = isImportFlyoutOpen
+    ? importPreviewFailureStoreEnabled
+    : previewFailureStoreEnabled;
+
+  const effectivePreviewInheritLifecycle =
+    isImportFlyoutOpen && importPreviewFailureStore ? false : previewInheritLifecycle;
+
+  useEditFlyoutPreviewSyncFromModel({
+    isFlyoutOpen: isImportFlyoutOpen,
+    isExternalFlyoutOpen: isMainFlyoutOpen || isDeletePhaseFlyoutOpen,
+    preview: importPreviewModel,
+  });
+
   return (
     <>
       <EuiFlexItem grow={false}>
@@ -78,7 +140,7 @@ const StreamDetailFailureStoreInner = ({
         <EuiFlexGroup direction="column" gutterSize="m">
           {readFailureStorePrivilege ? (
             <>
-              {failureStoreEnabledForUi ? (
+              {effectiveFailureStoreEnabledForUi ? (
                 <FailureStoreInfo
                   onEditFailedLifecycle={openMainFlyout}
                   onAddDeletePhase={openDeletePhaseFlyout}
@@ -86,9 +148,9 @@ const StreamDetailFailureStoreInner = ({
                   onRemoveDeletePhase={removeDeletePhase}
                   isExternalFlyoutOpen={isAnyFlyoutOpen}
                   isDeletePhaseFlyoutOpen={isDeletePhaseFlyoutOpen}
-                  isHighlighted={isMainFlyoutOpen}
-                  previewInheritLifecycle={previewInheritLifecycle}
-                  previewFailureStoreEnabled={previewFailureStoreEnabled}
+                  isHighlighted={isMainFlyoutOpen || isImportFlyoutOpen}
+                  previewInheritLifecycle={effectivePreviewInheritLifecycle}
+                  previewFailureStoreEnabled={effectivePreviewFailureStoreEnabled}
                   definition={definition}
                   statsError={data.error}
                   isLoadingStats={data.isLoading}
@@ -123,6 +185,8 @@ export const StreamDetailFailureStore = (props: {
   definition: Streams.ingest.all.GetResponse;
   data: ReturnType<typeof useDataStreamStats>;
   refreshDefinition: () => void;
+  isImportFlyoutOpen?: boolean;
+  importPreviewFailureStore?: EffectiveFailureStore | null;
 }) => {
   return (
     <LifecyclePreviewProvider>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/general_data/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/general_data/index.tsx
@@ -8,7 +8,9 @@
 import { EuiFlexGroup, EuiFlexItem, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useAbortController } from '@kbn/react-hooks';
+import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
 import {
+  type IngestStreamEffectiveLifecycle,
   type IngestStreamLifecycle,
   type IngestStreamLifecycleDSL,
   type PhaseName,
@@ -42,6 +44,12 @@ import {
 import { useOverrideSettingsConfirmation } from '../common/hooks/use_override_settings_confirmation';
 import { SectionPanel } from '../common/section_panel';
 import { buildDlmPreviewModel, type IlmPhasesMap } from '../common/data_lifecycle/preview_models';
+import { previewFromLifecycle } from '../common/data_lifecycle/compute_successful_lifecycle_flyout_preview';
+import {
+  type EditFlyoutPreviewModel,
+  useEditFlyoutPreviewSyncFromModel,
+} from '../common/hooks/use_edit_flyout_preview_sync';
+import { getImportedLifecycle } from '../import_from_stream/get_imported_lifecycle';
 import type { EditDeletePhaseFlyoutValue } from '../data_phases/edit_delete_phase_flyout';
 import { EditDeletePhaseFlyout } from '../data_phases/edit_delete_phase_flyout';
 import { EditDlmPhasesFlyout } from '../data_phases/edit_dlm_phases_flyout';
@@ -60,10 +68,16 @@ const StreamDetailGeneralDataInner = ({
   definition,
   refreshDefinition,
   data,
+  isImportFlyoutOpen = false,
+  importPreviewLifecycle = null,
+  importPreviewIlmPolicies = [],
 }: {
   definition: Streams.ingest.all.GetResponse;
   refreshDefinition: () => void;
   data: ReturnType<typeof useDataStreamStats>;
+  isImportFlyoutOpen?: boolean;
+  importPreviewLifecycle?: IngestStreamEffectiveLifecycle | null;
+  importPreviewIlmPolicies?: IlmPolicyForFlyout[];
 }) => {
   const kibana = useKibana();
   const {
@@ -501,7 +515,7 @@ const StreamDetailGeneralDataInner = ({
       return;
     }
 
-    if (isDslDownsampleFlyoutOpen) {
+    if (isDslDownsampleFlyoutOpen || isImportFlyoutOpen) {
       return;
     }
 
@@ -510,6 +524,7 @@ const StreamDetailGeneralDataInner = ({
     isEditSuccessfulDeletePhaseFlyoutOpen,
     isEditDataPhasesFlyoutOpen,
     isDslDownsampleFlyoutOpen,
+    isImportFlyoutOpen,
     clearLifecyclePreview,
     setDeletePhasePreview,
     setDataPhasesPreview,
@@ -517,6 +532,64 @@ const StreamDetailGeneralDataInner = ({
     successfulDeletePhaseInitialPreviewValue,
   ]);
 
+  const importPreviewModel = useMemo<EditFlyoutPreviewModel>(() => {
+    if (!isImportFlyoutOpen) {
+      return null;
+    }
+    if (!importPreviewLifecycle) {
+      return { action: 'clear', hasUnsavedChanges: false };
+    }
+
+    const nextLifecycle = getImportedLifecycle({
+      effectiveLifecycle: importPreviewLifecycle,
+      targetIsTimeSeries: definition.index_mode === 'time_series',
+    });
+    const importHasUnsavedChanges = nextLifecycle
+      ? !isEqual(definition.stream.ingest.lifecycle, nextLifecycle)
+      : false;
+
+    if (
+      isIlmLifecycle(importPreviewLifecycle) &&
+      !importPreviewIlmPolicies.some(
+        (policy) => policy.name === importPreviewLifecycle.ilm.policy && policy.serializedPolicy
+      )
+    ) {
+      return { action: 'clear', hasUnsavedChanges: importHasUnsavedChanges };
+    }
+
+    const preview = previewFromLifecycle({
+      lifecycle: importPreviewLifecycle,
+      ilmPolicies: importPreviewIlmPolicies,
+      isServerless,
+      ilmPhases,
+      hotColor: isServerless ? euiTheme.colors.severity.success : ilmPhases.hot.color,
+      indexMode: definition.index_mode,
+    });
+
+    return {
+      action: 'apply',
+      timelineModel: preview.timelineModel,
+      retentionPeriod: preview.retentionPeriod,
+      dataPhasesCount: preview.dataPhasesCount,
+      downsampleStepsCount: preview.downsampleStepsCount,
+      hasUnsavedChanges: importHasUnsavedChanges,
+    };
+  }, [
+    definition.index_mode,
+    definition.stream.ingest.lifecycle,
+    euiTheme.colors.severity.success,
+    ilmPhases,
+    importPreviewIlmPolicies,
+    importPreviewLifecycle,
+    isImportFlyoutOpen,
+    isServerless,
+  ]);
+
+  useEditFlyoutPreviewSyncFromModel({
+    isFlyoutOpen: isImportFlyoutOpen,
+    isExternalFlyoutOpen: isAnyOtherFlyoutOpen(STREAM_LIFECYCLE_FLYOUT_IDS.importLifecycle),
+    preview: importPreviewModel,
+  });
   return (
     <>
       <EuiFlexGroup direction="column" gutterSize="m" css={{ flexGrow: 0 }}>
@@ -532,7 +605,6 @@ const StreamDetailGeneralDataInner = ({
           </EuiFlexGroup>
         </EuiTitle>
 
-        {/* Retention Section */}
         <SectionPanel
           topCard={<RetentionCard definition={definition} />}
           bottomCard={
@@ -543,7 +615,7 @@ const StreamDetailGeneralDataInner = ({
               statsError={data.error}
             />
           }
-          isHighlighted={successfulLifecycleFlyout.isOpen}
+          isHighlighted={successfulLifecycleFlyout.isOpen || isImportFlyoutOpen}
         >
           {definition.privileges.lifecycle ? (
             <LifecycleSummary
@@ -577,7 +649,6 @@ const StreamDetailGeneralDataInner = ({
           ) : null}
         </SectionPanel>
 
-        {/* Ingestion Section */}
         <SectionPanel
           topCard={
             <IngestionCard
@@ -649,10 +720,16 @@ export const StreamDetailGeneralData = ({
   definition,
   refreshDefinition,
   data,
+  isImportFlyoutOpen,
+  importPreviewLifecycle,
+  importPreviewIlmPolicies,
 }: {
   definition: Streams.ingest.all.GetResponse;
   refreshDefinition: () => void;
   data: ReturnType<typeof useDataStreamStats>;
+  isImportFlyoutOpen?: boolean;
+  importPreviewLifecycle?: IngestStreamEffectiveLifecycle | null;
+  importPreviewIlmPolicies?: IlmPolicyForFlyout[];
 }) => {
   return (
     <LifecycleAfterSaveProvider>
@@ -661,6 +738,9 @@ export const StreamDetailGeneralData = ({
           definition={definition}
           refreshDefinition={refreshDefinition}
           data={data}
+          isImportFlyoutOpen={isImportFlyoutOpen}
+          importPreviewLifecycle={importPreviewLifecycle}
+          importPreviewIlmPolicies={importPreviewIlmPolicies}
         />
       </LifecyclePreviewProvider>
     </LifecycleAfterSaveProvider>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.test.tsx
@@ -39,6 +39,9 @@ const mockDefinition = {
     name: 'test-stream',
   },
   index_mode: 'time_series',
+  privileges: {
+    read_failure_store: true,
+  },
   effective_failure_store: {
     lifecycle: {
       enabled: {
@@ -329,6 +332,54 @@ describe('useDataStreamStats', () => {
           },
         },
       });
+    });
+
+    it('skips the failure store aggregation and still resolves successful data without read_failure_store privilege', async () => {
+      const failureStoreSearchError = new Error(
+        'action [indices:data/read/search] is unauthorized for the failure store'
+      );
+
+      mockDataSearch.search.mockImplementation((request: { params: { index: string } }) => {
+        if (request.params.index.includes('::failures')) {
+          throw failureStoreSearchError;
+        }
+        return of({
+          rawResponse: {
+            aggregations: {
+              sampler: { docs_count: { buckets: [{ key: 1, doc_count: 100 }] } },
+              interval: '30m',
+            },
+          },
+        });
+      });
+
+      const definitionWithoutFsPrivilege = {
+        ...mockDefinition,
+        privileges: { read_failure_store: false },
+      };
+
+      const { result } = renderHook(() =>
+        useDataStreamStats({
+          definition: definitionWithoutFsPrivilege,
+          timeState: mockTimestate,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.stats).toBeDefined();
+      });
+
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.stats?.ds.aggregations).toEqual({
+        buckets: [{ key: 1, doc_count: 100 }],
+        interval: '30m',
+      });
+      expect(result.current.stats?.fs.aggregations).toBeUndefined();
+      // The failure store `::failures` index must never be queried without the privilege.
+      const queriedIndices = mockDataSearch.search.mock.calls.map(
+        ([request]) => request.params.index
+      );
+      expect(queriedIndices.some((index: string) => index.includes('::failures'))).toBe(false);
     });
 
     it('should handles disabled failure store', async () => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
@@ -77,9 +77,10 @@ export const useDataStreamStats = ({
         return undefined;
       }
 
+      const canReadFailureStore = definition.privileges?.read_failure_store ?? false;
       const [dsAggregations, fsAggregations] = await Promise.all([
         getAggregations({ definition, timeState, core, search, signal }),
-        isEnabledFailureStore(definition.effective_failure_store)
+        canReadFailureStore && isEnabledFailureStore(definition.effective_failure_store)
           ? getAggregations({ definition, timeState, core, search, signal, isFailureStore: true })
           : undefined,
       ]);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/build_retention_options.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/build_retention_options.test.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
+import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
+import type { EffectiveFailureStore, IngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import {
+  IMPORT_METHOD_DLM,
+  IMPORT_METHOD_ILM,
+} from '../data_phases/import_lifecycle_flyout/constants';
+import { buildImportRetentionOptions } from './build_retention_options';
+
+const makeStream = (
+  name: string,
+  effectiveLifecycle?: IngestStreamEffectiveLifecycle,
+  effectiveFailureStore?: EffectiveFailureStore,
+  readFailureStore = true
+): ListStreamDetail =>
+  ({
+    stream: { name },
+    effective_lifecycle: effectiveLifecycle,
+    effective_failure_store: effectiveFailureStore,
+    privileges: { read_failure_store: readFailureStore },
+  } as unknown as ListStreamDetail);
+
+describe('buildImportRetentionOptions', () => {
+  it('excludes the current stream', () => {
+    const options = buildImportRetentionOptions({
+      streams: [
+        makeStream('current', { dsl: { data_retention: '30d' } }),
+        makeStream('other', { dsl: { data_retention: '30d' } }),
+      ],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: false,
+    });
+
+    expect(options.map((o) => o.name)).toEqual(['other']);
+  });
+
+  it('excludes streams without a resolvable lifecycle', () => {
+    const options = buildImportRetentionOptions({
+      streams: [
+        makeStream('no-lifecycle'),
+        makeStream('errored', { error: { message: 'boom' } }),
+        makeStream('disabled', { disabled: {} }),
+        makeStream('ok', { dsl: { data_retention: '30d' } }),
+      ],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: false,
+    });
+
+    expect(options.map((o) => o.name)).toEqual(['ok']);
+  });
+
+  it('builds a DSL option with retention, phases, and downsampling summary', () => {
+    const options = buildImportRetentionOptions({
+      streams: [
+        makeStream('dsl-stream', {
+          dsl: {
+            data_retention: '30d',
+            frozen_after: '7d',
+            downsample: [{ after: '1d', fixed_interval: '1h' }],
+          },
+        }),
+      ],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: false,
+    });
+
+    expect(options).toEqual([
+      {
+        name: 'dsl-stream',
+        method: IMPORT_METHOD_DLM,
+        descriptionCategory: 'Success',
+        descriptionParts: ['30d', '3 phases', '1 downsample'],
+        hasDownsampling: true,
+      },
+    ]);
+  });
+
+  it('excludes the frozen phase from the count on serverless', () => {
+    const [option] = buildImportRetentionOptions({
+      streams: [
+        makeStream('dsl-stream', {
+          dsl: { data_retention: '30d', frozen_after: '7d' },
+        }),
+      ],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: true,
+    });
+
+    expect(option.descriptionParts).toEqual(['30d', '2 phases']);
+  });
+
+  it('marks an indefinite DSL stream with a single hot phase', () => {
+    const [option] = buildImportRetentionOptions({
+      streams: [makeStream('dsl-stream', { dsl: {} })],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: false,
+    });
+
+    expect(option.descriptionParts).toEqual(['∞', '1 phase']);
+  });
+
+  it('builds an ILM option with a badge and inspect affordance from policy stats', () => {
+    const policy: IlmPolicyForFlyout = {
+      name: 'my-policy',
+      phases: {
+        hot: { actions: { downsample: { fixed_interval: '1h' } } },
+        delete: { min_age: '60d', actions: { delete: {} } },
+      },
+      serializedPolicy: { name: 'my-policy', phases: {} },
+    };
+
+    const [option] = buildImportRetentionOptions({
+      streams: [makeStream('ilm-stream', { ilm: { policy: 'my-policy' } })],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map([[policy.name, policy]]),
+      isServerless: false,
+    });
+
+    expect(option).toEqual({
+      name: 'ilm-stream',
+      method: IMPORT_METHOD_ILM,
+      descriptionCategory: 'Success',
+      descriptionParts: ['60d', '2 phases', '1 downsample'],
+      badge: 'ILM',
+      inspectable: true,
+      hasDownsampling: true,
+    });
+  });
+
+  it('falls back to the policy name when policy details are unavailable', () => {
+    const [option] = buildImportRetentionOptions({
+      streams: [makeStream('ilm-stream', { ilm: { policy: 'my-policy' } })],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: false,
+    });
+
+    expect(option).toEqual({
+      name: 'ilm-stream',
+      method: IMPORT_METHOD_ILM,
+      descriptionCategory: 'Success',
+      descriptionParts: ['my-policy'],
+      badge: 'ILM',
+    });
+  });
+
+  it('sorts options by stream name', () => {
+    const options = buildImportRetentionOptions({
+      streams: [
+        makeStream('zeta', { dsl: {} }),
+        makeStream('alpha', { dsl: {} }),
+        makeStream('mid', { dsl: {} }),
+      ],
+      currentStreamName: 'current',
+      ilmPoliciesByName: new Map(),
+      isServerless: false,
+    });
+
+    expect(options.map((o) => o.name)).toEqual(['alpha', 'mid', 'zeta']);
+  });
+
+  describe('failure store second line', () => {
+    it('omits the Fail line when the failure store is disabled', () => {
+      const [option] = buildImportRetentionOptions({
+        streams: [makeStream('dsl-stream', { dsl: { data_retention: '30d' } }, { disabled: {} })],
+        currentStreamName: 'current',
+        ilmPoliciesByName: new Map(),
+        isServerless: false,
+      });
+
+      expect(option.descriptionCategorySecondLine).toBeUndefined();
+      expect(option.descriptionPartsSecondLine).toBeUndefined();
+    });
+
+    it('shows a single hot phase when the failure store has no retention configured', () => {
+      const [option] = buildImportRetentionOptions({
+        streams: [
+          makeStream(
+            'dsl-stream',
+            { dsl: { data_retention: '30d' } },
+            { lifecycle: { disabled: {} } }
+          ),
+        ],
+        currentStreamName: 'current',
+        ilmPoliciesByName: new Map(),
+        isServerless: false,
+      });
+
+      expect(option.descriptionCategorySecondLine).toBe('Fail');
+      expect(option.descriptionPartsSecondLine).toEqual(['∞', '1 phase']);
+    });
+
+    it('shows a hot + delete phase when the failure store has a retention period', () => {
+      const [option] = buildImportRetentionOptions({
+        streams: [
+          makeStream(
+            'dsl-stream',
+            { dsl: { data_retention: '30d' } },
+            {
+              lifecycle: { enabled: { data_retention: '60d', is_default_retention: false } },
+            }
+          ),
+        ],
+        currentStreamName: 'current',
+        ilmPoliciesByName: new Map(),
+        isServerless: false,
+      });
+
+      expect(option.descriptionCategorySecondLine).toBe('Fail');
+      expect(option.descriptionPartsSecondLine).toEqual(['60d', '2 phases']);
+    });
+
+    it('excludes streams when the source failure store cannot be read', () => {
+      const options = buildImportRetentionOptions({
+        streams: [
+          makeStream(
+            'dsl-stream',
+            { dsl: { data_retention: '30d' } },
+            {
+              lifecycle: { enabled: { data_retention: '60d', is_default_retention: false } },
+            },
+            false
+          ),
+        ],
+        currentStreamName: 'current',
+        ilmPoliciesByName: new Map(),
+        isServerless: false,
+      });
+
+      expect(options).toEqual([]);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/build_retention_options.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/build_retention_options.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
+import { getIlmPolicySummaryStats } from '@kbn/data-lifecycle-phases';
+import type { EffectiveFailureStore, IngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import {
+  isDslLifecycle,
+  isEnabledFailureStore,
+  isEnabledLifecycleFailureStore,
+  isIlmLifecycle,
+} from '@kbn/streams-schema';
+import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
+import type { ImportLifecycleOption } from '../data_phases/import_lifecycle_flyout';
+import {
+  IMPORT_METHOD_DLM,
+  IMPORT_METHOD_ILM,
+} from '../data_phases/import_lifecycle_flyout/constants';
+import { sourceHasDownsampling } from './get_imported_lifecycle';
+
+const INDEFINITE_RETENTION_LABEL = i18n.translate(
+  'xpack.streams.importLifecycle.retentionSummary.indefinite',
+  { defaultMessage: '∞' }
+);
+
+const getRetentionLabel = (retention?: string | null): string =>
+  retention ?? INDEFINITE_RETENTION_LABEL;
+
+const phasesLabel = (count: number): string =>
+  i18n.translate('xpack.streams.importLifecycle.retentionSummary.phases', {
+    defaultMessage: '{count, plural, one {# phase} other {# phases}}',
+    values: { count },
+  });
+
+const downsamplesLabel = (count: number): string =>
+  i18n.translate('xpack.streams.importLifecycle.retentionSummary.downsamples', {
+    defaultMessage: '{count, plural, one {# downsample} other {# downsamples}}',
+    values: { count },
+  });
+
+const SUCCESS_CATEGORY_LABEL = i18n.translate(
+  'xpack.streams.importLifecycle.retentionSummary.successCategory',
+  { defaultMessage: 'Success' }
+);
+
+const FAIL_CATEGORY_LABEL = i18n.translate(
+  'xpack.streams.importLifecycle.retentionSummary.failCategory',
+  { defaultMessage: 'Fail' }
+);
+
+// Failure store summary (picker row's second line): a hot phase, plus a delete
+// phase once a retention is set. Returns `undefined` when it isn't enabled.
+const getFailureStoreDescriptionParts = (
+  effectiveFailureStore: EffectiveFailureStore | undefined
+): string[] | undefined => {
+  if (!effectiveFailureStore || !isEnabledFailureStore(effectiveFailureStore)) {
+    return undefined;
+  }
+
+  const dataRetention = isEnabledLifecycleFailureStore(effectiveFailureStore)
+    ? effectiveFailureStore.lifecycle.enabled.data_retention
+    : undefined;
+
+  return [getRetentionLabel(dataRetention), phasesLabel(dataRetention ? 2 : 1)];
+};
+
+const getDslDataPhaseCount = (
+  dsl: { data_retention?: string; frozen_after?: string },
+  isServerless: boolean
+): number => 1 + (!isServerless && dsl.frozen_after ? 1 : 0) + (dsl.data_retention ? 1 : 0);
+
+const buildOptionForLifecycle = (
+  streamName: string,
+  effectiveLifecycle: IngestStreamEffectiveLifecycle,
+  ilmPoliciesByName: Map<string, IlmPolicyForFlyout>,
+  isServerless: boolean,
+  effectiveFailureStore: EffectiveFailureStore | undefined
+): ImportLifecycleOption | undefined => {
+  const failureStoreDescriptionParts = getFailureStoreDescriptionParts(effectiveFailureStore);
+  const failureStoreFields = failureStoreDescriptionParts
+    ? {
+        descriptionCategorySecondLine: FAIL_CATEGORY_LABEL,
+        descriptionPartsSecondLine: failureStoreDescriptionParts,
+      }
+    : {};
+
+  if (isIlmLifecycle(effectiveLifecycle)) {
+    const policyName = effectiveLifecycle.ilm.policy;
+    const policy = ilmPoliciesByName.get(policyName);
+
+    if (!policy) {
+      // Policy details unavailable (e.g. missing privileges): show just the name.
+      return {
+        name: streamName,
+        method: IMPORT_METHOD_ILM,
+        descriptionCategory: SUCCESS_CATEGORY_LABEL,
+        descriptionParts: [policyName],
+        badge: IMPORT_METHOD_ILM.toUpperCase(),
+        ...failureStoreFields,
+      };
+    }
+
+    const { deleteAfter, phaseCount, downsampleStepCount } = getIlmPolicySummaryStats(
+      policy.phases
+    );
+    const descriptionParts = [getRetentionLabel(deleteAfter), phasesLabel(phaseCount)];
+    if (downsampleStepCount > 0) {
+      descriptionParts.push(downsamplesLabel(downsampleStepCount));
+    }
+
+    return {
+      name: streamName,
+      method: IMPORT_METHOD_ILM,
+      descriptionCategory: SUCCESS_CATEGORY_LABEL,
+      descriptionParts,
+      badge: IMPORT_METHOD_ILM.toUpperCase(),
+      inspectable: Boolean(policy.serializedPolicy),
+      hasDownsampling: sourceHasDownsampling({ effectiveLifecycle, ilmPoliciesByName }),
+      ...failureStoreFields,
+    };
+  }
+
+  if (isDslLifecycle(effectiveLifecycle)) {
+    const { dsl } = effectiveLifecycle;
+    const downsampleStepCount = dsl.downsample?.length ?? 0;
+    const descriptionParts = [
+      getRetentionLabel(dsl.data_retention),
+      phasesLabel(getDslDataPhaseCount(dsl, isServerless)),
+    ];
+    if (downsampleStepCount > 0) {
+      descriptionParts.push(downsamplesLabel(downsampleStepCount));
+    }
+
+    return {
+      name: streamName,
+      method: IMPORT_METHOD_DLM,
+      descriptionCategory: SUCCESS_CATEGORY_LABEL,
+      descriptionParts,
+      hasDownsampling: sourceHasDownsampling({ effectiveLifecycle, ilmPoliciesByName }),
+      ...failureStoreFields,
+    };
+  }
+
+  return undefined;
+};
+
+export const buildImportRetentionOptions = ({
+  streams,
+  currentStreamName,
+  ilmPoliciesByName,
+  isServerless,
+}: {
+  streams: ListStreamDetail[];
+  currentStreamName: string;
+  ilmPoliciesByName: Map<string, IlmPolicyForFlyout>;
+  isServerless: boolean;
+}): ImportLifecycleOption[] => {
+  return streams
+    .filter((stream) => stream.stream.name !== currentStreamName)
+    .filter((stream) => stream.privileges.read_failure_store)
+    .flatMap((stream) => {
+      const { effective_lifecycle: effectiveLifecycle } = stream;
+      if (!effectiveLifecycle) {
+        return [];
+      }
+      const option = buildOptionForLifecycle(
+        stream.stream.name,
+        effectiveLifecycle,
+        ilmPoliciesByName,
+        isServerless,
+        stream.effective_failure_store
+      );
+      return option ? [option] : [];
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_failure_store.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_failure_store.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getImportedFailureStore } from './get_imported_failure_store';
+
+describe('getImportedFailureStore', () => {
+  it('keeps the failure store disabled', () => {
+    expect(getImportedFailureStore({ disabled: {} })).toEqual({ disabled: {} });
+  });
+
+  it('copies an explicit retention', () => {
+    expect(
+      getImportedFailureStore({
+        lifecycle: { enabled: { data_retention: '60d', is_default_retention: false } },
+      })
+    ).toEqual({ lifecycle: { enabled: { data_retention: '60d' } } });
+  });
+
+  it('copies a default-derived retention explicitly', () => {
+    expect(
+      getImportedFailureStore({
+        lifecycle: { enabled: { data_retention: '30d', is_default_retention: true } },
+      })
+    ).toEqual({ lifecycle: { enabled: { data_retention: '30d' } } });
+  });
+
+  it('keeps an indefinite failure store lifecycle disabled', () => {
+    expect(getImportedFailureStore({ lifecycle: { disabled: {} } })).toEqual({
+      lifecycle: { disabled: {} },
+    });
+  });
+
+  it('falls back to disabled when enabled without a resolvable retention', () => {
+    expect(
+      getImportedFailureStore({
+        lifecycle: { enabled: { is_default_retention: true } },
+      })
+    ).toEqual({ lifecycle: { disabled: {} } });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_failure_store.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_failure_store.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EffectiveFailureStore, FailureStore } from '@kbn/streams-schema';
+import { isEnabledFailureStore, isEnabledLifecycleFailureStore } from '@kbn/streams-schema';
+
+// Importing always persists an explicit value, never `inherit`.
+export const getImportedFailureStore = (
+  effectiveFailureStore: EffectiveFailureStore
+): FailureStore => {
+  if (!isEnabledFailureStore(effectiveFailureStore)) {
+    return { disabled: {} };
+  }
+
+  if (!isEnabledLifecycleFailureStore(effectiveFailureStore)) {
+    return { lifecycle: { disabled: {} } };
+  }
+
+  const { data_retention: dataRetention } = effectiveFailureStore.lifecycle.enabled;
+  return dataRetention
+    ? { lifecycle: { enabled: { data_retention: dataRetention } } }
+    : { lifecycle: { disabled: {} } };
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_lifecycle.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
+import { getImportedLifecycle, sourceHasDownsampling } from './get_imported_lifecycle';
+
+describe('getImportedLifecycle', () => {
+  it('applies an ILM source as an ILM policy', () => {
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { ilm: { policy: 'my-policy' } },
+        targetIsTimeSeries: false,
+      })
+    ).toEqual({ ilm: { policy: 'my-policy' } });
+  });
+
+  it('keeps ILM policy references unchanged for non-time-series targets', () => {
+    // The ILM path always returns the policy reference unchanged, even for
+    // non-time-series targets where any downsampling steps have no effect.
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { ilm: { policy: 'policy-with-downsampling' } },
+        targetIsTimeSeries: false,
+      })
+    ).toEqual({ ilm: { policy: 'policy-with-downsampling' } });
+  });
+
+  it('applies a DSL source as an explicit custom retention', () => {
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { dsl: { data_retention: '30d' } },
+        targetIsTimeSeries: false,
+      })
+    ).toEqual({ dsl: { data_retention: '30d' } });
+  });
+
+  it('copies frozen_after but drops downsampling when target is not a time series', () => {
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: {
+          dsl: {
+            data_retention: '90d',
+            frozen_after: '30d',
+            downsample: [{ after: '7d', fixed_interval: '1h' }],
+          },
+        },
+        targetIsTimeSeries: false,
+      })
+    ).toEqual({ dsl: { data_retention: '90d', frozen_after: '30d' } });
+  });
+
+  it('keeps downsampling when target is a time series', () => {
+    const downsample = [{ after: '7d', fixed_interval: '1h' }];
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { dsl: { data_retention: '90d', downsample } },
+        targetIsTimeSeries: true,
+      })
+    ).toEqual({ dsl: { data_retention: '90d', downsample } });
+  });
+
+  it('returns an empty dsl for an indefinite DSL source', () => {
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { dsl: {} },
+        targetIsTimeSeries: true,
+      })
+    ).toEqual({ dsl: {} });
+  });
+
+  it('returns null for error lifecycles', () => {
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { error: { message: 'boom' } },
+        targetIsTimeSeries: true,
+      })
+    ).toBeNull();
+  });
+
+  it('returns null for disabled lifecycles', () => {
+    expect(
+      getImportedLifecycle({
+        effectiveLifecycle: { disabled: {} },
+        targetIsTimeSeries: true,
+      })
+    ).toBeNull();
+  });
+});
+
+describe('sourceHasDownsampling', () => {
+  const policyWithDownsample: IlmPolicyForFlyout = {
+    name: 'downsample-policy',
+    phases: { hot: { actions: { downsample: { fixed_interval: '1h' } } } },
+  };
+  const policyWithoutDownsample: IlmPolicyForFlyout = {
+    name: 'plain-policy',
+    phases: { hot: {}, delete: { min_age: '30d', actions: { delete: {} } } },
+  };
+  const ilmPoliciesByName = new Map<string, IlmPolicyForFlyout>([
+    [policyWithDownsample.name, policyWithDownsample],
+    [policyWithoutDownsample.name, policyWithoutDownsample],
+  ]);
+
+  it('detects downsampling on a DSL source', () => {
+    expect(
+      sourceHasDownsampling({
+        effectiveLifecycle: { dsl: { downsample: [{ after: '7d', fixed_interval: '1h' }] } },
+        ilmPoliciesByName,
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for a DSL source without downsampling', () => {
+    expect(
+      sourceHasDownsampling({
+        effectiveLifecycle: { dsl: { data_retention: '30d' } },
+        ilmPoliciesByName,
+      })
+    ).toBe(false);
+  });
+
+  it('detects downsampling on an ILM source', () => {
+    expect(
+      sourceHasDownsampling({
+        effectiveLifecycle: { ilm: { policy: 'downsample-policy' } },
+        ilmPoliciesByName,
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for an ILM source whose policy has no downsampling', () => {
+    expect(
+      sourceHasDownsampling({
+        effectiveLifecycle: { ilm: { policy: 'plain-policy' } },
+        ilmPoliciesByName,
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when the ILM policy details are unavailable', () => {
+    expect(
+      sourceHasDownsampling({
+        effectiveLifecycle: { ilm: { policy: 'unknown-policy' } },
+        ilmPoliciesByName,
+      })
+    ).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/get_imported_lifecycle.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  IngestStreamEffectiveLifecycle,
+  IngestStreamLifecycle,
+  IngestStreamLifecycleDSL,
+} from '@kbn/streams-schema';
+import { isDslLifecycle, isIlmLifecycle } from '@kbn/streams-schema';
+import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
+import { getIlmPolicySummaryStats } from '@kbn/data-lifecycle-phases';
+
+export const getImportedLifecycle = ({
+  effectiveLifecycle,
+  targetIsTimeSeries,
+}: {
+  effectiveLifecycle: IngestStreamEffectiveLifecycle;
+  targetIsTimeSeries: boolean;
+}): IngestStreamLifecycle | null => {
+  if (isIlmLifecycle(effectiveLifecycle)) {
+    return { ilm: { policy: effectiveLifecycle.ilm.policy } };
+  }
+
+  if (isDslLifecycle(effectiveLifecycle)) {
+    const {
+      data_retention: dataRetention,
+      frozen_after: frozenAfter,
+      downsample,
+    } = effectiveLifecycle.dsl;
+
+    const dsl: IngestStreamLifecycleDSL['dsl'] = {};
+    if (dataRetention) {
+      dsl.data_retention = dataRetention;
+    }
+    if (frozenAfter) {
+      dsl.frozen_after = frozenAfter;
+    }
+    if (targetIsTimeSeries && downsample && downsample.length > 0) {
+      dsl.downsample = downsample;
+    }
+
+    return { dsl };
+  }
+
+  return null;
+};
+
+export const sourceHasDownsampling = ({
+  effectiveLifecycle,
+  ilmPoliciesByName,
+}: {
+  effectiveLifecycle: IngestStreamEffectiveLifecycle;
+  ilmPoliciesByName: Map<string, IlmPolicyForFlyout>;
+}): boolean => {
+  if (isDslLifecycle(effectiveLifecycle)) {
+    return (effectiveLifecycle.dsl.downsample?.length ?? 0) > 0;
+  }
+
+  if (isIlmLifecycle(effectiveLifecycle)) {
+    const policy = ilmPoliciesByName.get(effectiveLifecycle.ilm.policy);
+    if (!policy) {
+      return false;
+    }
+    return getIlmPolicySummaryStats(policy.phases).downsampleStepCount > 0;
+  }
+
+  return false;
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/import_lifecycle_flyout_context.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/import_lifecycle_flyout_context.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+interface ImportLifecycleFlyoutContextValue {
+  isOpen: boolean;
+  isDisabled: boolean;
+  open: () => void;
+  close: () => void;
+  setIsDisabled: (isDisabled: boolean) => void;
+}
+
+const ImportLifecycleFlyoutContext = createContext<ImportLifecycleFlyoutContextValue | undefined>(
+  undefined
+);
+
+// Shares the import flyout open state between the tab label (trigger) and the
+// tab content (flyout), which live under the same management `Wrapper`.
+export const ImportLifecycleFlyoutProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
+  const open = useCallback(() => {
+    if (isDisabled) {
+      return;
+    }
+    setIsOpen(true);
+  }, [isDisabled]);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  const value = useMemo<ImportLifecycleFlyoutContextValue>(
+    () => ({ isOpen, isDisabled, open, close, setIsDisabled }),
+    [isDisabled, isOpen, open, close]
+  );
+
+  return (
+    <ImportLifecycleFlyoutContext.Provider value={value}>
+      {children}
+    </ImportLifecycleFlyoutContext.Provider>
+  );
+};
+
+export const useImportLifecycleFlyoutContext = ():
+  | ImportLifecycleFlyoutContextValue
+  | undefined => {
+  return useContext(ImportLifecycleFlyoutContext);
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/index.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/index.ts
@@ -5,5 +5,8 @@
  * 2.0.
  */
 
-export { ImportLifecycleFlyout } from './import_lifecycle_flyout';
-export type { ImportLifecycleFlyoutProps, ImportLifecycleOption } from './types';
+export {
+  ImportLifecycleFlyoutProvider,
+  useImportLifecycleFlyoutContext,
+} from './import_lifecycle_flyout_context';
+export { useImportLifecycleFlyout } from './use_import_lifecycle_flyout';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/use_import_lifecycle_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/use_import_lifecycle_flyout.test.tsx
@@ -1,0 +1,456 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { Streams } from '@kbn/streams-schema';
+import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
+import {
+  ImportLifecycleFlyoutProvider,
+  useImportLifecycleFlyoutContext,
+} from './import_lifecycle_flyout_context';
+import { useImportLifecycleFlyout } from './use_import_lifecycle_flyout';
+
+const mockFetch = jest.fn();
+const mockStreamsRepositoryClient = { fetch: mockFetch };
+const mockAddSuccess = jest.fn();
+const mockAddError = jest.fn();
+const mockTrackRetentionChanged = jest.fn();
+const mockGetIlmPolicies = jest.fn();
+
+const mockKibana = {
+  core: {
+    application: { navigateToApp: jest.fn() },
+    http: { get: mockGetIlmPolicies },
+    notifications: {
+      toasts: { addSuccess: mockAddSuccess, addError: mockAddError },
+    },
+  },
+  dependencies: {
+    start: {
+      streams: { streamsRepositoryClient: mockStreamsRepositoryClient },
+    },
+  },
+  services: { telemetryClient: { trackRetentionChanged: mockTrackRetentionChanged } },
+  isServerless: false,
+};
+
+jest.mock('../../../../../hooks/use_kibana', () => ({
+  useKibana: () => mockKibana,
+}));
+
+import { useStreamsAppFetch } from '../../../../../hooks/use_streams_app_fetch';
+
+jest.mock('../../../../../hooks/use_streams_app_fetch', () => ({
+  useStreamsAppFetch: jest.fn(),
+}));
+
+const mockUseStreamsAppFetch = useStreamsAppFetch as jest.Mock;
+
+const otherStream = {
+  stream: { name: 'other-stream' },
+  effective_lifecycle: { dsl: { data_retention: '7d' } },
+  privileges: { read_failure_store: true },
+} as unknown as ListStreamDetail;
+
+const currentStream = {
+  stream: { name: 'current-stream' },
+  effective_lifecycle: { dsl: { data_retention: '30d' } },
+  privileges: { read_failure_store: true },
+} as unknown as ListStreamDetail;
+
+const streamWithFailureStore = {
+  stream: { name: 'with-failure-store' },
+  effective_lifecycle: { dsl: { data_retention: '7d' } },
+  effective_failure_store: {
+    lifecycle: { enabled: { data_retention: '14d', is_default_retention: false } },
+  },
+  privileges: { read_failure_store: true },
+} as unknown as ListStreamDetail;
+
+const ilmStream = {
+  stream: { name: 'ilm-stream' },
+  effective_lifecycle: { ilm: { policy: 'hot-warm-policy' } },
+  privileges: { read_failure_store: true },
+} as unknown as ListStreamDetail;
+
+const ilmStreamWithFailureStore = {
+  stream: { name: 'ilm-stream-with-failure-store' },
+  effective_lifecycle: { ilm: { policy: 'hot-warm-policy' } },
+  effective_failure_store: {
+    lifecycle: { enabled: { data_retention: '21d', is_default_retention: false } },
+  },
+  privileges: { read_failure_store: true },
+} as unknown as ListStreamDetail;
+
+const streamWithoutFailureStoreReadPrivilege = {
+  stream: { name: 'without-failure-store-read' },
+  effective_lifecycle: { dsl: { data_retention: '7d' } },
+  privileges: { read_failure_store: false },
+} as unknown as ListStreamDetail;
+
+const ilmPolicyFromEs = {
+  name: 'hot-warm-policy',
+  policy: {
+    name: 'hot-warm-policy',
+    phases: { hot: {}, delete: { min_age: '30d', actions: { delete: {} } } },
+  },
+};
+
+const definition = {
+  stream: {
+    name: 'current-stream',
+    ingest: {
+      lifecycle: { dsl: { data_retention: '30d' } },
+      processing: { steps: [] },
+    },
+  },
+  privileges: { lifecycle: true, manage_failure_store: true },
+  effective_lifecycle: { dsl: { data_retention: '30d' } },
+  index_mode: 'standard',
+} as unknown as Streams.ingest.all.GetResponse;
+
+describe('useImportLifecycleFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStreamsAppFetch.mockReturnValue({ value: [otherStream], loading: false });
+    mockFetch.mockResolvedValue(undefined);
+    mockGetIlmPolicies.mockReturnValue(new Promise(() => {}));
+  });
+
+  const renderImportFlyout = (
+    refreshDefinition = jest.fn(),
+    streamDefinition: Streams.ingest.all.GetResponse = definition
+  ) =>
+    renderHook(
+      () => {
+        const context = useImportLifecycleFlyoutContext()!;
+        const importFlyout = useImportLifecycleFlyout({
+          definition: streamDefinition,
+          refreshDefinition,
+        });
+        return { context, importFlyout };
+      },
+      {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <ImportLifecycleFlyoutProvider>{children}</ImportLifecycleFlyoutProvider>
+        ),
+      }
+    );
+
+  // Reads the callbacks off the flyout element the hook returns, so tests don't
+  // need to render the RetentionSelector picker. Only valid while the flyout is open.
+  const getFlyoutProps = (result: {
+    current: { importFlyout: { flyout: React.ReactElement | null } };
+  }) => {
+    const flyout = result.current.importFlyout.flyout;
+    if (!flyout) {
+      throw new Error('Expected the import flyout to be open');
+    }
+    const [importLifecycleFlyoutElement] = React.Children.toArray(flyout.props.children);
+    return (importLifecycleFlyoutElement as React.ReactElement).props;
+  };
+
+  const getInspectFlyoutProps = (result: {
+    current: { importFlyout: { flyout: React.ReactElement | null } };
+  }) => {
+    const flyout = result.current.importFlyout.flyout;
+    if (!flyout) {
+      throw new Error('Expected the import flyout to be open');
+    }
+    const [, inspectFlyoutElement] = React.Children.toArray(flyout.props.children);
+    if (!inspectFlyoutElement) {
+      throw new Error('Expected the inspect ILM policy flyout to be open');
+    }
+    return (inspectFlyoutElement as React.ReactElement).props;
+  };
+
+  it('reports whether there are streams available to import from', () => {
+    const { result } = renderImportFlyout();
+
+    expect(result.current.importFlyout.hasImportableStreams).toBe(true);
+  });
+
+  it('reports no importable streams when only the current stream is available', () => {
+    mockUseStreamsAppFetch.mockReturnValue({ value: [currentStream], loading: false });
+
+    const { result } = renderImportFlyout();
+
+    act(() => {
+      result.current.context.open();
+    });
+
+    expect(result.current.importFlyout.hasImportableStreams).toBe(false);
+  });
+
+  it('reports no importable streams when source failure store cannot be read', () => {
+    mockUseStreamsAppFetch.mockReturnValue({
+      value: [streamWithoutFailureStoreReadPrivilege],
+      loading: false,
+    });
+
+    const { result } = renderImportFlyout();
+
+    act(() => {
+      result.current.context.open();
+    });
+
+    expect(result.current.importFlyout.hasImportableStreams).toBe(false);
+    expect(getFlyoutProps(result).options).toEqual([]);
+  });
+
+  it('applies the selected stream lifecycle and closes on success', async () => {
+    const refreshDefinition = jest.fn();
+    const { result } = renderImportFlyout(refreshDefinition);
+
+    await act(async () => {
+      result.current.context.open();
+    });
+
+    act(() => {
+      getFlyoutProps(result).onSelectOption('other-stream');
+    });
+    expect(result.current.importFlyout.previewLifecycle).toEqual({ dsl: { data_retention: '7d' } });
+
+    act(() => {
+      getFlyoutProps(result).onApply();
+    });
+
+    await waitFor(() => expect(mockAddSuccess).toHaveBeenCalled());
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'PUT /api/streams/{name}/_ingest 2023-10-31',
+      expect.objectContaining({
+        params: {
+          path: { name: 'current-stream' },
+          body: {
+            ingest: expect.objectContaining({
+              lifecycle: { dsl: { data_retention: '7d' } },
+            }),
+          },
+        },
+      })
+    );
+    expect(refreshDefinition).toHaveBeenCalled();
+    expect(result.current.importFlyout.isOpen).toBe(false);
+  });
+
+  it('resets the selection each time the flyout is reopened', async () => {
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+    act(() => {
+      getFlyoutProps(result).onSelectOption('other-stream');
+    });
+    expect(getFlyoutProps(result).selectedOptionName).toBe('other-stream');
+    expect(result.current.importFlyout.previewLifecycle).toEqual({ dsl: { data_retention: '7d' } });
+
+    act(() => {
+      result.current.context.close();
+    });
+    expect(result.current.importFlyout.isOpen).toBe(false);
+
+    await act(async () => {
+      result.current.context.open();
+    });
+
+    expect(getFlyoutProps(result).selectedOptionName).toBeUndefined();
+    expect(result.current.importFlyout.previewLifecycle).toBeNull();
+  });
+
+  it('fetches ILM policies at most once per open session', async () => {
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+    expect(mockGetIlmPolicies).toHaveBeenCalledTimes(1);
+
+    // Re-renders while the flyout stays open must not trigger another fetch.
+    act(() => {
+      getFlyoutProps(result).onSelectOption('other-stream');
+    });
+    expect(mockGetIlmPolicies).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.context.close();
+    });
+    await act(async () => {
+      result.current.context.open();
+    });
+
+    expect(mockGetIlmPolicies).toHaveBeenCalledTimes(2);
+  });
+
+  it('previews the inspected ILM policy while its sub-flyout is open, and reverts on close', async () => {
+    mockUseStreamsAppFetch.mockReturnValue({ value: [otherStream, ilmStream], loading: false });
+    mockGetIlmPolicies.mockResolvedValue([ilmPolicyFromEs]);
+
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+    await waitFor(() => expect(result.current.importFlyout.ilmPolicies).toHaveLength(1));
+
+    act(() => {
+      getFlyoutProps(result).onSelectOption('other-stream');
+    });
+    expect(result.current.importFlyout.previewLifecycle).toEqual({ dsl: { data_retention: '7d' } });
+
+    act(() => {
+      getFlyoutProps(result).onInspect('ilm-stream');
+    });
+
+    expect(result.current.importFlyout.previewLifecycle).toEqual({
+      ilm: { policy: 'hot-warm-policy' },
+    });
+    expect(getFlyoutProps(result).selectedOptionName).toBe('other-stream');
+
+    act(() => {
+      getInspectFlyoutProps(result).onBack();
+    });
+
+    expect(result.current.importFlyout.previewLifecycle).toEqual({ dsl: { data_retention: '7d' } });
+  });
+
+  it('imports the inspected stream failure store when applying from the inspect flyout', async () => {
+    mockUseStreamsAppFetch.mockReturnValue({
+      value: [otherStream, ilmStreamWithFailureStore],
+      loading: false,
+    });
+    mockGetIlmPolicies.mockResolvedValue([ilmPolicyFromEs]);
+
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+    await waitFor(() => expect(result.current.importFlyout.ilmPolicies).toHaveLength(1));
+
+    act(() => {
+      getFlyoutProps(result).onInspect('ilm-stream-with-failure-store');
+    });
+
+    expect(result.current.importFlyout.previewFailureStore).toEqual({
+      lifecycle: { enabled: { data_retention: '21d', is_default_retention: false } },
+    });
+
+    act(() => {
+      getInspectFlyoutProps(result).primaryAction.onClick();
+    });
+
+    await waitFor(() => expect(mockAddSuccess).toHaveBeenCalled());
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'PUT /api/streams/{name}/_ingest 2023-10-31',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          body: {
+            ingest: expect.objectContaining({
+              lifecycle: { ilm: { policy: 'hot-warm-policy' } },
+              failure_store: { lifecycle: { enabled: { data_retention: '21d' } } },
+            }),
+          },
+        }),
+      })
+    );
+  });
+
+  it('previews the selected stream failure store and imports it on apply', async () => {
+    mockUseStreamsAppFetch.mockReturnValue({
+      value: [otherStream, streamWithFailureStore],
+      loading: false,
+    });
+
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+    expect(result.current.importFlyout.previewFailureStore).toBeNull();
+
+    act(() => {
+      getFlyoutProps(result).onSelectOption('with-failure-store');
+    });
+    expect(result.current.importFlyout.previewFailureStore).toEqual({
+      lifecycle: { enabled: { data_retention: '14d', is_default_retention: false } },
+    });
+
+    act(() => {
+      getFlyoutProps(result).onApply();
+    });
+
+    await waitFor(() => expect(mockAddSuccess).toHaveBeenCalled());
+
+    // Both fields must land in the same PUT: sequential requests would revert
+    // each other, since each spreads the pre-import `ingest`.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'PUT /api/streams/{name}/_ingest 2023-10-31',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          body: {
+            ingest: expect.objectContaining({
+              lifecycle: { dsl: { data_retention: '7d' } },
+              failure_store: { lifecycle: { enabled: { data_retention: '14d' } } },
+            }),
+          },
+        }),
+      })
+    );
+  });
+
+  it('disables apply when source failure store cannot be read', async () => {
+    mockUseStreamsAppFetch.mockReturnValue({
+      value: [otherStream, streamWithoutFailureStoreReadPrivilege],
+      loading: false,
+    });
+
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+
+    act(() => {
+      getFlyoutProps(result).onSelectOption('without-failure-store-read');
+    });
+
+    expect(getFlyoutProps(result).isApplyDisabled).toBe(true);
+
+    act(() => {
+      getFlyoutProps(result).onApply();
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the failure store when the selected stream has none to import', async () => {
+    const { result } = renderImportFlyout();
+
+    await act(async () => {
+      result.current.context.open();
+    });
+    act(() => {
+      getFlyoutProps(result).onSelectOption('other-stream');
+    });
+
+    act(() => {
+      getFlyoutProps(result).onApply();
+    });
+
+    await waitFor(() => expect(mockAddSuccess).toHaveBeenCalled());
+
+    const failureStoreCalls = mockFetch.mock.calls.filter(
+      ([, options]) => options?.params?.body?.ingest?.failure_store !== undefined
+    );
+    expect(failureStoreCalls).toHaveLength(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/use_import_lifecycle_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/import_from_stream/use_import_lifecycle_flyout.tsx
@@ -1,0 +1,377 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useGeneratedHtmlId } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useAbortController } from '@kbn/react-hooks';
+import { omit } from 'lodash';
+import type {
+  EffectiveFailureStore,
+  FailureStore,
+  IngestStreamEffectiveLifecycle,
+  IngestStreamLifecycle,
+  Streams,
+} from '@kbn/streams-schema';
+import { isIlmLifecycle } from '@kbn/streams-schema';
+import type { CoreStart } from '@kbn/core/public';
+import type { PolicyFromES } from '@kbn/index-lifecycle-management-common-shared';
+import type { IlmPolicyForFlyout } from '@kbn/data-lifecycle-phases';
+import { InspectIlmPolicyFlyout } from '@kbn/data-lifecycle-phases';
+import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
+import { useKibana } from '../../../../../hooks/use_kibana';
+import { useStreamsAppFetch } from '../../../../../hooks/use_streams_app_fetch';
+import { getFormattedError } from '../../../../../util/errors';
+import { getStreamTypeFromDefinition } from '../../../../../util/get_stream_type_from_definition';
+import { getLifecycleFlyoutContainer } from '../common/get_lifecycle_flyout_container';
+import { useOverrideSettingsConfirmation } from '../common/hooks/use_override_settings_confirmation';
+import { ImportLifecycleFlyout } from '../data_phases/import_lifecycle_flyout';
+import type { ImportLifecycleMethod } from '../data_phases/import_lifecycle_flyout/constants';
+import { buildImportRetentionOptions } from './build_retention_options';
+import { getImportedFailureStore } from './get_imported_failure_store';
+import { getImportedLifecycle } from './get_imported_lifecycle';
+import { useImportLifecycleFlyoutContext } from './import_lifecycle_flyout_context';
+
+const EMPTY_STREAMS: ListStreamDetail[] = [];
+
+const getIlmPolicies = async ({
+  http,
+  signal,
+}: {
+  http: CoreStart['http'];
+  signal: AbortSignal;
+}): Promise<PolicyFromES[]> => {
+  return http.get('/api/index_lifecycle_management/policies', {
+    headers: { 'X-Elastic-Internal-Origin': 'Kibana' },
+    signal,
+  });
+};
+
+const mapIlmPolicyToFlyout = (policy: PolicyFromES): IlmPolicyForFlyout => ({
+  name: policy.name,
+  phases: policy.policy.phases,
+  serializedPolicy: policy.policy,
+});
+
+export interface UseImportLifecycleFlyoutArgs {
+  definition: Streams.ingest.all.GetResponse;
+  refreshDefinition: () => void;
+}
+
+export const useImportLifecycleFlyout = ({
+  definition,
+  refreshDefinition,
+}: UseImportLifecycleFlyoutArgs) => {
+  const {
+    core,
+    isServerless,
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient },
+      },
+    },
+    services: { telemetryClient },
+  } = useKibana();
+  const { notifications, http, application } = core;
+  const { signal } = useAbortController();
+
+  const importContext = useImportLifecycleFlyoutContext();
+  const isOpen = importContext?.isOpen ?? false;
+  const close = importContext?.close;
+
+  const titleId = useGeneratedHtmlId({ prefix: 'streamsImportLifecycleFlyoutTitle' });
+
+  const [selectedStreamName, setSelectedStreamName] = useState<string | undefined>(undefined);
+  const [selectedMethods, setSelectedMethods] = useState<ImportLifecycleMethod[]>([]);
+  const [inspectedStreamName, setInspectedStreamName] = useState<string | null>(null);
+  const [ilmPolicies, setIlmPolicies] = useState<IlmPolicyForFlyout[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const hasAttemptedIlmPoliciesFetch = useRef(false);
+
+  const targetIsTimeSeries = definition.index_mode === 'time_series';
+
+  const { value: streamsList, loading: isLoadingStreams } = useStreamsAppFetch(
+    async ({ signal: fetchSignal }) => {
+      if (!isOpen) {
+        return undefined;
+      }
+      const { streams } = await streamsRepositoryClient.fetch('GET /internal/streams', {
+        signal: fetchSignal,
+      });
+      return streams;
+    },
+    [isOpen, streamsRepositoryClient],
+    { withTimeRange: false, withRefresh: false }
+  );
+
+  const streams = streamsList ?? EMPTY_STREAMS;
+
+  const ilmPoliciesByName = useMemo(() => {
+    const map = new Map<string, IlmPolicyForFlyout>();
+    ilmPolicies.forEach((policy) => map.set(policy.name, policy));
+    return map;
+  }, [ilmPolicies]);
+
+  const options = useMemo(
+    () =>
+      buildImportRetentionOptions({
+        streams,
+        currentStreamName: definition.stream.name,
+        ilmPoliciesByName,
+        isServerless,
+      }),
+    [definition.stream.name, ilmPoliciesByName, isServerless, streams]
+  );
+  const hasImportableStreams = !isOpen || options.length > 0;
+
+  useEffect(() => {
+    if (!isOpen || isServerless || hasAttemptedIlmPoliciesFetch.current) {
+      return;
+    }
+    hasAttemptedIlmPoliciesFetch.current = true;
+    getIlmPolicies({ http, signal })
+      .then((policies) => setIlmPolicies(policies.map(mapIlmPolicyToFlyout)))
+      .catch((error) => {
+        setIlmPolicies([]);
+        if (signal.aborted) {
+          hasAttemptedIlmPoliciesFetch.current = false;
+          return;
+        }
+        notifications.toasts.addError(getFormattedError(error), {
+          title: i18n.translate('xpack.streams.importLifecycle.failedToLoadIlmPolicies', {
+            defaultMessage: 'Failed to load ILM policies',
+          }),
+        });
+      });
+  }, [http, isOpen, isServerless, notifications.toasts, signal]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedStreamName(undefined);
+      setSelectedMethods([]);
+      setInspectedStreamName(null);
+    } else {
+      hasAttemptedIlmPoliciesFetch.current = false;
+    }
+  }, [isOpen]);
+
+  const closeFlyout = useCallback(() => {
+    setInspectedStreamName(null);
+    close?.();
+  }, [close]);
+
+  const { confirmOverride, modal: overrideModal } = useOverrideSettingsConfirmation({ definition });
+
+  const selectedStream = selectedStreamName
+    ? streams.find((stream) => stream.stream.name === selectedStreamName)
+    : undefined;
+  const inspectedStream = inspectedStreamName
+    ? streams.find((stream) => stream.stream.name === inspectedStreamName)
+    : undefined;
+  const selectedEffectiveLifecycle = selectedStream?.effective_lifecycle;
+  const inspectedEffectiveLifecycle = inspectedStream?.effective_lifecycle;
+  const inspectedIlmPolicyName =
+    inspectedEffectiveLifecycle && isIlmLifecycle(inspectedEffectiveLifecycle)
+      ? inspectedEffectiveLifecycle.ilm.policy
+      : null;
+
+  const canReadFailureStoreForImport = useCallback(
+    (stream: ListStreamDetail | undefined): boolean => {
+      return Boolean(stream?.privileges.read_failure_store);
+    },
+    []
+  );
+
+  const getImportableFailureStore = useCallback(
+    (stream: ListStreamDetail | undefined): FailureStore | undefined => {
+      if (!stream?.effective_failure_store) {
+        return undefined;
+      }
+
+      if (!canReadFailureStoreForImport(stream)) {
+        return undefined;
+      }
+
+      return getImportedFailureStore(stream.effective_failure_store);
+    },
+    [canReadFailureStoreForImport]
+  );
+
+  const previewLifecycle: IngestStreamEffectiveLifecycle | null = inspectedIlmPolicyName
+    ? { ilm: { policy: inspectedIlmPolicyName } }
+    : selectedEffectiveLifecycle ?? null;
+
+  const previewFailureStore: EffectiveFailureStore | null =
+    (inspectedStream ?? selectedStream)?.effective_failure_store ?? null;
+
+  const onInspect = useCallback(
+    (streamName: string) => {
+      const stream = streams.find((item) => item.stream.name === streamName);
+      const effectiveLifecycle = stream?.effective_lifecycle;
+      if (effectiveLifecycle && isIlmLifecycle(effectiveLifecycle)) {
+        setInspectedStreamName(streamName);
+      }
+    },
+    [streams]
+  );
+
+  const saveImportedLifecycle = useCallback(
+    async (lifecycle: IngestStreamLifecycle, failureStore?: FailureStore) => {
+      try {
+        setIsSaving(true);
+        await streamsRepositoryClient.fetch('PUT /api/streams/{name}/_ingest 2023-10-31', {
+          params: {
+            path: { name: definition.stream.name },
+            body: {
+              ingest: {
+                ...definition.stream.ingest,
+                processing: omit(definition.stream.ingest.processing, 'updated_at'),
+                lifecycle,
+                ...(failureStore ? { failure_store: failureStore } : {}),
+              },
+            },
+          },
+          signal,
+        });
+
+        telemetryClient.trackRetentionChanged(
+          lifecycle,
+          getStreamTypeFromDefinition(definition.stream)
+        );
+        notifications.toasts.addSuccess({
+          title: i18n.translate('xpack.streams.importLifecycle.success', {
+            defaultMessage: 'Stream lifecycle imported',
+          }),
+        });
+        refreshDefinition();
+        closeFlyout();
+      } catch (error) {
+        notifications.toasts.addError(getFormattedError(error), {
+          title: i18n.translate('xpack.streams.importLifecycle.failed', {
+            defaultMessage: 'Failed to import lifecycle',
+          }),
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [
+      closeFlyout,
+      definition.stream,
+      notifications.toasts,
+      refreshDefinition,
+      signal,
+      streamsRepositoryClient,
+      telemetryClient,
+    ]
+  );
+
+  const saveImportedStream = useCallback(
+    (stream: ListStreamDetail | undefined) => {
+      const effectiveLifecycle = stream?.effective_lifecycle;
+      if (!effectiveLifecycle || !canReadFailureStoreForImport(stream)) {
+        return;
+      }
+
+      const lifecycle = getImportedLifecycle({
+        effectiveLifecycle,
+        targetIsTimeSeries,
+      });
+      if (!lifecycle) {
+        return;
+      }
+
+      const failureStore = getImportableFailureStore(stream);
+      const targetMethod = 'ilm' in lifecycle ? 'ilm' : 'dlm';
+      confirmOverride(() => saveImportedLifecycle(lifecycle, failureStore), { targetMethod });
+    },
+    [
+      canReadFailureStoreForImport,
+      confirmOverride,
+      getImportableFailureStore,
+      saveImportedLifecycle,
+      targetIsTimeSeries,
+    ]
+  );
+
+  const onApply = useCallback(() => {
+    saveImportedStream(selectedStream);
+  }, [saveImportedStream, selectedStream]);
+
+  const isApplyDisabled =
+    !definition.privileges.lifecycle ||
+    !selectedStreamName ||
+    isSaving ||
+    !canReadFailureStoreForImport(selectedStream);
+
+  const inspectedPolicy = inspectedIlmPolicyName
+    ? ilmPoliciesByName.get(inspectedIlmPolicyName)
+    : undefined;
+  const inspectFlyout =
+    isOpen && inspectedIlmPolicyName && inspectedPolicy?.serializedPolicy ? (
+      <InspectIlmPolicyFlyout
+        policyName={inspectedIlmPolicyName}
+        policy={inspectedPolicy.serializedPolicy}
+        onBack={() => setInspectedStreamName(null)}
+        onEditPolicy={(policyToEdit) =>
+          application.navigateToApp('management', {
+            path: `data/index_lifecycle_management/policies/edit/${encodeURIComponent(
+              policyToEdit
+            )}`,
+            openInNewTab: true,
+          })
+        }
+        primaryAction={{
+          label: i18n.translate('xpack.streams.importLifecycle.inspectIlmPolicy.applyLabel', {
+            defaultMessage: 'Apply',
+          }),
+          onClick: () => {
+            setInspectedStreamName(null);
+            saveImportedStream(inspectedStream);
+          },
+          'data-test-subj': 'streamsImportLifecycleInspectApplyButton',
+          isDisabled: isSaving || !canReadFailureStoreForImport(inspectedStream),
+        }}
+        type="push"
+        container={getLifecycleFlyoutContainer()}
+        ownFocus={false}
+      />
+    ) : null;
+
+  const flyout = !isOpen ? null : (
+    <>
+      <ImportLifecycleFlyout
+        titleId={titleId}
+        options={options}
+        selectedOptionName={selectedStreamName}
+        onSelectOption={setSelectedStreamName}
+        onInspect={onInspect}
+        isLoadingStreams={isLoadingStreams}
+        selectedMethods={selectedMethods}
+        onChangeSelectedMethods={setSelectedMethods}
+        onApply={onApply}
+        onClose={closeFlyout}
+        isApplyDisabled={isApplyDisabled}
+        canUseDownsampling={targetIsTimeSeries}
+      />
+
+      {inspectFlyout}
+      {overrideModal}
+    </>
+  );
+
+  return {
+    isOpen,
+    flyout,
+    previewLifecycle,
+    previewFailureStore,
+    ilmPolicies,
+    hasImportableStreams,
+    isLoadingStreams,
+  };
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/index.tsx
@@ -15,7 +15,13 @@ import { StreamDetailGeneralData } from './general_data';
 import { useDataStreamStats } from './hooks/use_data_stream_stats';
 import { useTimefilter } from '../../../../hooks/use_timefilter';
 import { getStreamTypeFromDefinition } from '../../../../util/get_stream_type_from_definition';
-import { LifecycleFlyoutCoordinationProvider } from './common/hooks/lifecycle_flyout_coordination';
+import {
+  LifecycleFlyoutCoordinationProvider,
+  STREAM_LIFECYCLE_FLYOUT_IDS,
+  useLifecycleFlyoutCoordination,
+  useRegisterLifecycleFlyoutOpen,
+} from './common/hooks/lifecycle_flyout_coordination';
+import { useImportLifecycleFlyout, useImportLifecycleFlyoutContext } from './import_from_stream';
 
 export function StreamDetailLifecycle({
   definition,
@@ -24,8 +30,43 @@ export function StreamDetailLifecycle({
   definition: Streams.ingest.all.GetResponse;
   refreshDefinition: () => void;
 }) {
+  return (
+    <LifecycleFlyoutCoordinationProvider>
+      <StreamDetailLifecycleInner definition={definition} refreshDefinition={refreshDefinition} />
+    </LifecycleFlyoutCoordinationProvider>
+  );
+}
+
+function StreamDetailLifecycleInner({
+  definition,
+  refreshDefinition,
+}: {
+  definition: Streams.ingest.all.GetResponse;
+  refreshDefinition: () => void;
+}) {
   const { timeState } = useTimefilter();
   const data = useDataStreamStats({ definition, timeState });
+
+  const {
+    isOpen: isImportFlyoutOpen,
+    flyout: importFlyout,
+    previewLifecycle: importPreviewLifecycle,
+    previewFailureStore: importPreviewFailureStore,
+    ilmPolicies: importPreviewIlmPolicies,
+    hasImportableStreams,
+    isLoadingStreams: isLoadingImportStreams,
+  } = useImportLifecycleFlyout({ definition, refreshDefinition });
+  useRegisterLifecycleFlyoutOpen(STREAM_LIFECYCLE_FLYOUT_IDS.importLifecycle, isImportFlyoutOpen);
+  const { isAnyFlyoutOpen } = useLifecycleFlyoutCoordination();
+  const importLifecycleFlyoutContext = useImportLifecycleFlyoutContext();
+  const setImportLifecycleFlyoutDisabled = importLifecycleFlyoutContext?.setIsDisabled;
+  const isImportLifecycleFlyoutDisabled =
+    isAnyFlyoutOpen || isLoadingImportStreams || !hasImportableStreams;
+
+  useEffect(() => {
+    setImportLifecycleFlyoutDisabled?.(isImportLifecycleFlyoutDisabled);
+    return () => setImportLifecycleFlyoutDisabled?.(false);
+  }, [isImportLifecycleFlyoutDisabled, setImportLifecycleFlyoutDisabled]);
 
   const { onPageReady } = usePerformanceContext();
 
@@ -62,20 +103,24 @@ export function StreamDetailLifecycle({
   ]);
 
   return (
-    <LifecycleFlyoutCoordinationProvider>
-      <EuiFlexGroup gutterSize="m" direction="column">
-        <StreamDetailGeneralData
-          definition={definition}
-          refreshDefinition={refreshDefinition}
-          data={data}
-        />
-        <EuiHorizontalRule margin="m" />
-        <StreamDetailFailureStore
-          definition={definition}
-          data={data}
-          refreshDefinition={refreshDefinition}
-        />
-      </EuiFlexGroup>
-    </LifecycleFlyoutCoordinationProvider>
+    <EuiFlexGroup gutterSize="m" direction="column">
+      <StreamDetailGeneralData
+        definition={definition}
+        refreshDefinition={refreshDefinition}
+        data={data}
+        isImportFlyoutOpen={isImportFlyoutOpen}
+        importPreviewLifecycle={importPreviewLifecycle}
+        importPreviewIlmPolicies={importPreviewIlmPolicies}
+      />
+      <EuiHorizontalRule margin="m" />
+      <StreamDetailFailureStore
+        definition={definition}
+        data={data}
+        refreshDefinition={refreshDefinition}
+        isImportFlyoutOpen={isImportFlyoutOpen}
+        importPreviewFailureStore={importPreviewFailureStore}
+      />
+      {importFlyout}
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/classic.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/classic.tsx
@@ -26,6 +26,10 @@ import { StreamDetailAttachments } from '../../../stream_detail_attachments';
 import { ClassicStreamPartitioning } from '../stream_detail_routing/classic_stream_partitioning';
 import { LifecycleTabLabel } from './lifecycle_tab_label_with_actions';
 import { StreamDetailCanvas } from '../stream_detail_canvas';
+import {
+  ImportLifecycleFlyoutProvider,
+  useImportLifecycleFlyoutContext,
+} from '../stream_detail_lifecycle/import_from_stream';
 
 const classicStreamManagementSubTabs = [
   'overview',
@@ -60,6 +64,23 @@ export function ClassicStreamDetailManagement({
   definition: Streams.ClassicStream.GetResponse;
   refreshDefinition: () => void;
 }) {
+  return (
+    <ImportLifecycleFlyoutProvider>
+      <ClassicStreamDetailManagementContent
+        definition={definition}
+        refreshDefinition={refreshDefinition}
+      />
+    </ImportLifecycleFlyoutProvider>
+  );
+}
+
+function ClassicStreamDetailManagementContent({
+  definition,
+  refreshDefinition,
+}: {
+  definition: Streams.ClassicStream.GetResponse;
+  refreshDefinition: () => void;
+}) {
   const {
     core: { notifications },
     dependencies: {
@@ -69,6 +90,7 @@ export function ClassicStreamDetailManagement({
   const {
     path: { key, tab },
   } = useStreamsAppParams('/{key}/management/{tab}');
+  const importLifecycleFlyout = useImportLifecycleFlyoutContext();
 
   const {
     features: { canvas, queryStreams },
@@ -125,6 +147,8 @@ export function ClassicStreamDetailManagement({
         showActions={tab === 'lifecycle'}
         notifications={notifications}
         share={share}
+        onImportFromStream={importLifecycleFlyout?.open}
+        isImportFromStreamDisabled={importLifecycleFlyout?.isDisabled}
       />
     ),
   };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/lifecycle_tab_label_with_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/lifecycle_tab_label_with_actions.test.tsx
@@ -142,11 +142,7 @@ describe('LifecycleTabLabelWithActions', () => {
   it('calls importAction.onClick when enabled', async () => {
     const onClick = jest.fn();
     render(
-      <LifecycleTabLabelWithActions
-        showActions
-        onCopy={jest.fn()}
-        importAction={{ onClick }}
-      />
+      <LifecycleTabLabelWithActions showActions onCopy={jest.fn()} importAction={{ onClick }} />
     );
 
     await openActionsMenu();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/lifecycle_tab_label_with_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/lifecycle_tab_label_with_actions.test.tsx
@@ -138,6 +138,36 @@ describe('LifecycleTabLabelWithActions', () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('calls importAction.onClick when enabled', async () => {
+    const onClick = jest.fn();
+    render(
+      <LifecycleTabLabelWithActions
+        showActions
+        onCopy={jest.fn()}
+        importAction={{ onClick }}
+      />
+    );
+
+    await openActionsMenu();
+    await clickMenuItem('streamsLifecycleTabImportFromStream');
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the import action item when importAction is disabled', async () => {
+    render(
+      <LifecycleTabLabelWithActions
+        showActions
+        onCopy={jest.fn()}
+        importAction={{ disabled: true, onClick: jest.fn() }}
+      />
+    );
+
+    await openActionsMenu();
+
+    expect(screen.getByTestId('streamsLifecycleTabImportFromStream')).toBeDisabled();
+  });
 });
 
 describe('LifecycleTabLabel', () => {
@@ -222,6 +252,66 @@ describe('LifecycleTabLabel', () => {
     await clickMenuItem('streamsLifecycleTabCopyApiRequest');
 
     expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();
+  });
+
+  it('opens the import lifecycle flyout from the import action', async () => {
+    const onImportFromStream = jest.fn();
+
+    render(
+      <LifecycleTabLabel
+        definition={createClassicDefinition()}
+        showActions
+        notifications={createNotifications()}
+        share={createShare()}
+        onImportFromStream={onImportFromStream}
+      />
+    );
+
+    await openActionsMenu();
+    await clickMenuItem('streamsLifecycleTabImportFromStream');
+
+    expect(onImportFromStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not include the import lifecycle action without failure store management privilege', async () => {
+    render(
+      <LifecycleTabLabel
+        definition={createMockClassicStreamDefinition({
+          privileges: {
+            ...createMockClassicStreamDefinition().privileges,
+            lifecycle: true,
+            manage_failure_store: false,
+          },
+        })}
+        showActions
+        notifications={createNotifications()}
+        share={createShare()}
+        onImportFromStream={jest.fn()}
+      />
+    );
+
+    await openActionsMenu();
+
+    expect(screen.queryByTestId('streamsLifecycleTabImportFromStream')).not.toBeInTheDocument();
+  });
+
+  it('disables the import lifecycle action while another lifecycle flyout is open', async () => {
+    const onImportFromStream = jest.fn();
+
+    render(
+      <LifecycleTabLabel
+        definition={createClassicDefinition()}
+        showActions
+        notifications={createNotifications()}
+        share={createShare()}
+        onImportFromStream={onImportFromStream}
+        isImportFromStreamDisabled
+      />
+    );
+
+    await openActionsMenu();
+
+    expect(screen.getByTestId('streamsLifecycleTabImportFromStream')).toBeDisabled();
   });
 
   it('opens the index template edit page in a new tab for classic streams', async () => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/lifecycle_tab_label_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/lifecycle_tab_label_with_actions.tsx
@@ -34,16 +34,23 @@ interface LifecycleTabEditAction {
   'data-test-subj': string;
 }
 
+interface LifecycleTabImportAction {
+  disabled?: boolean;
+  onClick: () => void;
+}
+
 interface LifecycleTabLabelWithActionsProps {
   showActions: boolean;
   onCopy: () => void;
   editAction?: LifecycleTabEditAction;
+  importAction?: LifecycleTabImportAction;
 }
 
 export const LifecycleTabLabelWithActions = ({
   showActions,
   onCopy,
   editAction,
+  importAction,
 }: LifecycleTabLabelWithActionsProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -62,6 +69,26 @@ export const LifecycleTabLabelWithActions = ({
       })}
     </EuiContextMenuItem>,
   ];
+
+  if (importAction) {
+    menuItems.push(
+      <EuiContextMenuItem
+        key="importFromStream"
+        icon="importAction"
+        disabled={importAction.disabled}
+        onClick={() => {
+          if (importAction.disabled) return;
+          setIsOpen(false);
+          importAction.onClick();
+        }}
+        data-test-subj="streamsLifecycleTabImportFromStream"
+      >
+        {i18n.translate('xpack.streams.lifecycleTab.actions.importFromStream', {
+          defaultMessage: 'Import from another stream',
+        })}
+      </EuiContextMenuItem>
+    );
+  }
 
   if (editAction) {
     menuItems.push(
@@ -138,6 +165,8 @@ interface LifecycleTabLabelProps {
   showActions: boolean;
   notifications: CoreStart['notifications'];
   share: SharePublicStart;
+  onImportFromStream?: () => void;
+  isImportFromStreamDisabled?: boolean;
 }
 
 export const LifecycleTabLabel = ({
@@ -145,6 +174,8 @@ export const LifecycleTabLabel = ({
   showActions,
   notifications,
   share,
+  onImportFromStream,
+  isImportFromStreamDisabled = false,
 }: LifecycleTabLabelProps) => {
   const router = useStreamsAppRouter();
   const { rangeFrom, rangeTo } = useTimeRange();
@@ -154,6 +185,27 @@ export const LifecycleTabLabel = ({
 
   const isClassic = StreamsSchema.ClassicStream.GetResponse.is(definition);
   const isWired = StreamsSchema.WiredStream.GetResponse.is(definition);
+
+  const importAction = useMemo((): LifecycleTabImportAction | undefined => {
+    if (!definition.privileges.lifecycle || !definition.privileges.manage_failure_store) {
+      return undefined;
+    }
+
+    return {
+      disabled: !onImportFromStream || isImportFromStreamDisabled,
+      onClick: () => {
+        if (isImportFromStreamDisabled) {
+          return;
+        }
+        onImportFromStream?.();
+      },
+    };
+  }, [
+    definition.privileges.lifecycle,
+    definition.privileges.manage_failure_store,
+    isImportFromStreamDisabled,
+    onImportFromStream,
+  ]);
 
   const editAction = useMemo((): LifecycleTabEditAction | undefined => {
     if (isClassic) {
@@ -229,6 +281,7 @@ export const LifecycleTabLabel = ({
           });
         }
       }}
+      importAction={importAction}
       editAction={editAction}
     />
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wired.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wired.tsx
@@ -26,6 +26,10 @@ import { useKibana } from '../../../../hooks/use_kibana';
 import { useStreamsPrivileges } from '../../../../hooks/use_streams_privileges';
 import { LifecycleTabLabel } from './lifecycle_tab_label_with_actions';
 import { StreamDetailCanvas } from '../stream_detail_canvas';
+import {
+  ImportLifecycleFlyoutProvider,
+  useImportLifecycleFlyoutContext,
+} from '../stream_detail_lifecycle/import_from_stream';
 
 const wiredStreamManagementSubTabs = [
   'overview',
@@ -59,6 +63,23 @@ export function WiredStreamDetailManagement({
   definition: Streams.WiredStream.GetResponse;
   refreshDefinition: () => void;
 }) {
+  return (
+    <ImportLifecycleFlyoutProvider>
+      <WiredStreamDetailManagementContent
+        definition={definition}
+        refreshDefinition={refreshDefinition}
+      />
+    </ImportLifecycleFlyoutProvider>
+  );
+}
+
+function WiredStreamDetailManagementContent({
+  definition,
+  refreshDefinition,
+}: {
+  definition: Streams.WiredStream.GetResponse;
+  refreshDefinition: () => void;
+}) {
   const {
     core: { notifications },
     dependencies: {
@@ -68,6 +89,7 @@ export function WiredStreamDetailManagement({
   const {
     path: { key, tab },
   } = useStreamsAppParams('/{key}/management/{tab}');
+  const importLifecycleFlyout = useImportLifecycleFlyoutContext();
 
   const { processing, isLoading, ...otherTabs } = useStreamsDetailManagementTabs({
     definition,
@@ -192,6 +214,8 @@ export function WiredStreamDetailManagement({
                 showActions={tab === 'lifecycle'}
                 notifications={notifications}
                 share={share}
+                onImportFromStream={importLifecycleFlyout?.open}
+                isImportFromStreamDisabled={importLifecycleFlyout?.isDisabled}
               />
             ),
           },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Streams] Create Import from other Stream flow (#275948)](https://github.com/elastic/kibana/pull/275948)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-07-16T08:19:34Z","message":"[Streams] Create Import from other Stream flow (#275948)\n\nCloses https://github.com/elastic/kibana/issues/267913\n\n## Summary\n- Adds an “Import from another stream” flow to reuse another stream’s\nlifecycle configuration from the Data lifecycle tab.\n- Keeps import behavior privilege-aware: the import action is only\navailable when the target stream can update both successful data\nlifecycle and failure store settings.\n- Avoids partial imports from sources where failure store cannot be\nread: source streams without `read_failure_store` are excluded from\nimport candidates.\n\n### Test plan\nRun this setup in Dev Tools as an admin user:\n\n```http\nPUT _ilm/policy/logs-import-ilm-downsample-policy\n{\n  \"policy\": {\n    \"phases\": {\n      \"hot\": {\n        \"actions\": {\n          \"rollover\": { \"max_primary_shard_size\": \"50gb\" }\n        }\n      },\n      \"warm\": {\n        \"min_age\": \"1d\",\n        \"actions\": {\n          \"downsample\": { \"fixed_interval\": \"1h\" }\n        }\n      },\n      \"delete\": {\n        \"min_age\": \"30d\",\n        \"actions\": { \"delete\": {} }\n      }\n    }\n  }\n}\n\nPUT _index_template/logs-import-tsdb-template\n{\n  \"index_patterns\": [\"logs.import-tsdb-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"index.mode\": \"time_series\",\n      \"index.routing_path\": [\"service.name\"],\n      \"index.lifecycle.prefer_ilm\": false\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"service.name\": { \"type\": \"keyword\", \"time_series_dimension\": true },\n        \"message\": { \"type\": \"match_only_text\" }\n      }\n    }\n  }\n}\n\nPUT _index_template/logs-import-standard-template\n{\n  \"index_patterns\": [\"logs.import-standard-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"index.lifecycle.prefer_ilm\": false\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"message\": { \"type\": \"match_only_text\" }\n      }\n    }\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-source-downsample\",\n  \"description\": \"DSL source with downsampling\",\n  \"ingest\": {\n    \"lifecycle\": {\n      \"dsl\": {\n        \"data_retention\": \"30d\",\n        \"downsample\": [{ \"after\": \"1d\", \"fixed_interval\": \"1h\" }]\n      }\n    },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"14d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-source-ilm-downsample\",\n  \"description\": \"ILM source with downsampling\",\n  \"ingest\": {\n    \"lifecycle\": { \"ilm\": { \"policy\": \"logs-import-ilm-downsample-policy\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"21d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-target\",\n  \"description\": \"Time series target\",\n  \"ingest\": {\n    \"lifecycle\": { \"dsl\": { \"data_retention\": \"7d\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"7d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-standard-target\",\n  \"description\": \"Standard target\",\n  \"ingest\": {\n    \"lifecycle\": { \"dsl\": { \"data_retention\": \"7d\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"7d\" } } },\n    \"classic\": {}\n  }\n}\n```\n\nThen:\n- Open Streams and navigate to `logs.import-tsdb-target`.\n- Go to the Data lifecycle tab.\n- Open the tab actions menu and click Import from another stream.\n- Select `logs.import-tsdb-source-downsample` and verify the import\noption shows the downsampling summary.\n- Click Apply and verify the target stream imports retention,\ndownsampling, and failure store settings.\n- Reopen the import flyout, select\n`logs.import-tsdb-source-ilm-downsample`, inspect the ILM policy, and\nverify the policy includes a downsample action.\n- Apply the ILM source and verify the target stream uses\n`logs-import-ilm-downsample-policy`.\n- Navigate to `logs.import-standard-target`, import from\n`logs.import-tsdb-source-downsample`, and verify downsampling is omitted\nfor the non-time-series target.\n- Optional privilege check: test with a user that has lifecycle\nprivileges but no `manage_failure_store`; verify `Import from another\nstream` is not shown.\n\n### Evidence\n\n\nhttps://github.com/user-attachments/assets/811e6b52-eed2-4426-a0f6-a6161603b8c5\n\n<img width=\"859\" height=\"823\" alt=\"Screenshot 2026-07-10 at 13 55 04\"\nsrc=\"https://github.com/user-attachments/assets/b5d27440-865f-4f7e-9ca6-f038dffaa716\"\n/>","sha":"996baf8bd4390e5ffb2f9293323438dae858791f","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Index Management","release_note:skip","backport:version","Feature:Streams","v9.5.0","v9.6.0"],"title":"[Streams] Create Import from other Stream flow","number":275948,"url":"https://github.com/elastic/kibana/pull/275948","mergeCommit":{"message":"[Streams] Create Import from other Stream flow (#275948)\n\nCloses https://github.com/elastic/kibana/issues/267913\n\n## Summary\n- Adds an “Import from another stream” flow to reuse another stream’s\nlifecycle configuration from the Data lifecycle tab.\n- Keeps import behavior privilege-aware: the import action is only\navailable when the target stream can update both successful data\nlifecycle and failure store settings.\n- Avoids partial imports from sources where failure store cannot be\nread: source streams without `read_failure_store` are excluded from\nimport candidates.\n\n### Test plan\nRun this setup in Dev Tools as an admin user:\n\n```http\nPUT _ilm/policy/logs-import-ilm-downsample-policy\n{\n  \"policy\": {\n    \"phases\": {\n      \"hot\": {\n        \"actions\": {\n          \"rollover\": { \"max_primary_shard_size\": \"50gb\" }\n        }\n      },\n      \"warm\": {\n        \"min_age\": \"1d\",\n        \"actions\": {\n          \"downsample\": { \"fixed_interval\": \"1h\" }\n        }\n      },\n      \"delete\": {\n        \"min_age\": \"30d\",\n        \"actions\": { \"delete\": {} }\n      }\n    }\n  }\n}\n\nPUT _index_template/logs-import-tsdb-template\n{\n  \"index_patterns\": [\"logs.import-tsdb-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"index.mode\": \"time_series\",\n      \"index.routing_path\": [\"service.name\"],\n      \"index.lifecycle.prefer_ilm\": false\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"service.name\": { \"type\": \"keyword\", \"time_series_dimension\": true },\n        \"message\": { \"type\": \"match_only_text\" }\n      }\n    }\n  }\n}\n\nPUT _index_template/logs-import-standard-template\n{\n  \"index_patterns\": [\"logs.import-standard-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"index.lifecycle.prefer_ilm\": false\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"message\": { \"type\": \"match_only_text\" }\n      }\n    }\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-source-downsample\",\n  \"description\": \"DSL source with downsampling\",\n  \"ingest\": {\n    \"lifecycle\": {\n      \"dsl\": {\n        \"data_retention\": \"30d\",\n        \"downsample\": [{ \"after\": \"1d\", \"fixed_interval\": \"1h\" }]\n      }\n    },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"14d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-source-ilm-downsample\",\n  \"description\": \"ILM source with downsampling\",\n  \"ingest\": {\n    \"lifecycle\": { \"ilm\": { \"policy\": \"logs-import-ilm-downsample-policy\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"21d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-target\",\n  \"description\": \"Time series target\",\n  \"ingest\": {\n    \"lifecycle\": { \"dsl\": { \"data_retention\": \"7d\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"7d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-standard-target\",\n  \"description\": \"Standard target\",\n  \"ingest\": {\n    \"lifecycle\": { \"dsl\": { \"data_retention\": \"7d\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"7d\" } } },\n    \"classic\": {}\n  }\n}\n```\n\nThen:\n- Open Streams and navigate to `logs.import-tsdb-target`.\n- Go to the Data lifecycle tab.\n- Open the tab actions menu and click Import from another stream.\n- Select `logs.import-tsdb-source-downsample` and verify the import\noption shows the downsampling summary.\n- Click Apply and verify the target stream imports retention,\ndownsampling, and failure store settings.\n- Reopen the import flyout, select\n`logs.import-tsdb-source-ilm-downsample`, inspect the ILM policy, and\nverify the policy includes a downsample action.\n- Apply the ILM source and verify the target stream uses\n`logs-import-ilm-downsample-policy`.\n- Navigate to `logs.import-standard-target`, import from\n`logs.import-tsdb-source-downsample`, and verify downsampling is omitted\nfor the non-time-series target.\n- Optional privilege check: test with a user that has lifecycle\nprivileges but no `manage_failure_store`; verify `Import from another\nstream` is not shown.\n\n### Evidence\n\n\nhttps://github.com/user-attachments/assets/811e6b52-eed2-4426-a0f6-a6161603b8c5\n\n<img width=\"859\" height=\"823\" alt=\"Screenshot 2026-07-10 at 13 55 04\"\nsrc=\"https://github.com/user-attachments/assets/b5d27440-865f-4f7e-9ca6-f038dffaa716\"\n/>","sha":"996baf8bd4390e5ffb2f9293323438dae858791f"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275948","number":275948,"mergeCommit":{"message":"[Streams] Create Import from other Stream flow (#275948)\n\nCloses https://github.com/elastic/kibana/issues/267913\n\n## Summary\n- Adds an “Import from another stream” flow to reuse another stream’s\nlifecycle configuration from the Data lifecycle tab.\n- Keeps import behavior privilege-aware: the import action is only\navailable when the target stream can update both successful data\nlifecycle and failure store settings.\n- Avoids partial imports from sources where failure store cannot be\nread: source streams without `read_failure_store` are excluded from\nimport candidates.\n\n### Test plan\nRun this setup in Dev Tools as an admin user:\n\n```http\nPUT _ilm/policy/logs-import-ilm-downsample-policy\n{\n  \"policy\": {\n    \"phases\": {\n      \"hot\": {\n        \"actions\": {\n          \"rollover\": { \"max_primary_shard_size\": \"50gb\" }\n        }\n      },\n      \"warm\": {\n        \"min_age\": \"1d\",\n        \"actions\": {\n          \"downsample\": { \"fixed_interval\": \"1h\" }\n        }\n      },\n      \"delete\": {\n        \"min_age\": \"30d\",\n        \"actions\": { \"delete\": {} }\n      }\n    }\n  }\n}\n\nPUT _index_template/logs-import-tsdb-template\n{\n  \"index_patterns\": [\"logs.import-tsdb-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"index.mode\": \"time_series\",\n      \"index.routing_path\": [\"service.name\"],\n      \"index.lifecycle.prefer_ilm\": false\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"service.name\": { \"type\": \"keyword\", \"time_series_dimension\": true },\n        \"message\": { \"type\": \"match_only_text\" }\n      }\n    }\n  }\n}\n\nPUT _index_template/logs-import-standard-template\n{\n  \"index_patterns\": [\"logs.import-standard-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"index.lifecycle.prefer_ilm\": false\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"message\": { \"type\": \"match_only_text\" }\n      }\n    }\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-source-downsample\",\n  \"description\": \"DSL source with downsampling\",\n  \"ingest\": {\n    \"lifecycle\": {\n      \"dsl\": {\n        \"data_retention\": \"30d\",\n        \"downsample\": [{ \"after\": \"1d\", \"fixed_interval\": \"1h\" }]\n      }\n    },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"14d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-source-ilm-downsample\",\n  \"description\": \"ILM source with downsampling\",\n  \"ingest\": {\n    \"lifecycle\": { \"ilm\": { \"policy\": \"logs-import-ilm-downsample-policy\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"21d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-tsdb-target\",\n  \"description\": \"Time series target\",\n  \"ingest\": {\n    \"lifecycle\": { \"dsl\": { \"data_retention\": \"7d\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"7d\" } } },\n    \"classic\": {}\n  }\n}\n\nPOST kbn:/internal/streams/_create_classic\n{\n  \"name\": \"logs.import-standard-target\",\n  \"description\": \"Standard target\",\n  \"ingest\": {\n    \"lifecycle\": { \"dsl\": { \"data_retention\": \"7d\" } },\n    \"processing\": { \"steps\": [] },\n    \"settings\": {},\n    \"failure_store\": { \"lifecycle\": { \"enabled\": { \"data_retention\": \"7d\" } } },\n    \"classic\": {}\n  }\n}\n```\n\nThen:\n- Open Streams and navigate to `logs.import-tsdb-target`.\n- Go to the Data lifecycle tab.\n- Open the tab actions menu and click Import from another stream.\n- Select `logs.import-tsdb-source-downsample` and verify the import\noption shows the downsampling summary.\n- Click Apply and verify the target stream imports retention,\ndownsampling, and failure store settings.\n- Reopen the import flyout, select\n`logs.import-tsdb-source-ilm-downsample`, inspect the ILM policy, and\nverify the policy includes a downsample action.\n- Apply the ILM source and verify the target stream uses\n`logs-import-ilm-downsample-policy`.\n- Navigate to `logs.import-standard-target`, import from\n`logs.import-tsdb-source-downsample`, and verify downsampling is omitted\nfor the non-time-series target.\n- Optional privilege check: test with a user that has lifecycle\nprivileges but no `manage_failure_store`; verify `Import from another\nstream` is not shown.\n\n### Evidence\n\n\nhttps://github.com/user-attachments/assets/811e6b52-eed2-4426-a0f6-a6161603b8c5\n\n<img width=\"859\" height=\"823\" alt=\"Screenshot 2026-07-10 at 13 55 04\"\nsrc=\"https://github.com/user-attachments/assets/b5d27440-865f-4f7e-9ca6-f038dffaa716\"\n/>","sha":"996baf8bd4390e5ffb2f9293323438dae858791f"}}]}] BACKPORT-->