### PR TITLE
[Dashboard][a11y] Restore focus after AppMenu modals close

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -42,6 +42,7 @@ export interface ShowShareModalProps {
   accessControlClient: AccessControlClient;
   saveDashboard: () => Promise<void>;
   changeAccessMode: (accessMode: SavedObjectAccessControl['accessMode']) => Promise<void>;
+  anchorElement?: HTMLElement;
 }
 
 export const showPublicUrlSwitch = (anonymousUserCapabilities: Capabilities) => {
@@ -63,6 +64,7 @@ export function ShowShareModal({
   accessControlClient,
   saveDashboard,
   changeAccessMode,
+  anchorElement,
 }: ShowShareModalProps) {
   if (!shareService) return;
 
@@ -150,6 +152,7 @@ export function ShowShareModal({
   const showAccessContainer = savedObjectId && !isManaged && showWriteControls;
 
   shareService.toggleShareContextMenu({
+    anchorElement,
     isDirty,
     allowShortUrl,
     shareableUrl,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.test.tsx
@@ -221,6 +221,40 @@ describe('useDashboardMenuItems', () => {
         switchToViewMode!.run?.();
         expect(mockSetViewMode).toHaveBeenCalledWith('view');
       });
+
+      test('should focus Edit after switching to view mode instead of the unmounted Cancel trigger', async () => {
+        const { api } = buildMockDashboardApi({ savedObjectId: 'test-id' });
+        const returnFocus = jest.fn();
+        const editButton = document.createElement('button');
+        editButton.setAttribute('data-test-subj', 'dashboardEditMode');
+        document.body.appendChild(editButton);
+
+        const { result } = renderHook(
+          () =>
+            useDashboardMenuItems({
+              isLabsShown: false,
+              setIsLabsShown: jest.fn(),
+              maybeRedirect: jest.fn(),
+            }),
+          {
+            wrapper: ({ children }) => (
+              <I18nProvider>
+                <DashboardContext.Provider value={api}>{children}</DashboardContext.Provider>
+              </I18nProvider>
+            ),
+          }
+        );
+
+        const switchToViewMode = result.current.editModeTopNavConfig.items?.find(
+          ({ id }) => id === 'cancel'
+        );
+        expect(switchToViewMode).toBeDefined();
+        switchToViewMode!.run?.({ returnFocus, triggerElement: document.createElement('button') });
+
+        expect(returnFocus).not.toHaveBeenCalled();
+        await waitFor(() => expect(document.activeElement).toBe(editButton));
+        editButton.remove();
+      });
     });
 
     describe('dashboard has unsaved changes', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -15,7 +15,7 @@ import useMountedState from 'react-use/lib/useMountedState';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 
 import useObservable from 'react-use/lib/useObservable';
-import { openLazyFlyout } from '@kbn/presentation-util';
+import { focusFirstFocusable, openLazyFlyout } from '@kbn/presentation-util';
 import type {
   AppMenuConfig,
   AppMenuItemType,
@@ -103,7 +103,7 @@ export const useDashboardMenuItems = ({
   ]);
 
   const resetChanges = useCallback(
-    (switchToViewMode: boolean = false) => {
+    (switchToViewMode: boolean = false, returnFocus?: () => void) => {
       dashboardApi.clearOverlays();
       const switchModes = switchToViewMode
         ? () => {
@@ -111,18 +111,35 @@ export const useDashboardMenuItems = ({
             getDashboardBackupService().storeViewMode('view');
           }
         : undefined;
+      // After switching to view mode the Cancel trigger unmounts — focus Edit instead.
+      // When staying in edit (reset only), return focus to the AppMenu trigger.
+      const restoreMenuFocusAfterAction = () => {
+        if (switchToViewMode) {
+          focusFirstFocusable(() =>
+            document.querySelector<HTMLElement>('[data-test-subj="dashboardEditMode"]')
+          );
+          return;
+        }
+        returnFocus?.();
+      };
       if (!hasUnsavedChanges) {
         switchModes?.();
+        restoreMenuFocusAfterAction();
         return;
       }
-      confirmDiscardUnsavedChanges(async () => {
-        setIsResetting(true);
-        await dashboardApi.asyncResetToLastSavedState();
-        if (isMounted()) {
-          setIsResetting(false);
-          switchModes?.();
-        }
-      }, viewMode);
+      confirmDiscardUnsavedChanges(
+        async () => {
+          setIsResetting(true);
+          await dashboardApi.asyncResetToLastSavedState();
+          if (isMounted()) {
+            setIsResetting(false);
+            switchModes?.();
+            restoreMenuFocusAfterAction();
+          }
+        },
+        viewMode,
+        returnFocus
+      );
     },
     [dashboardApi, hasUnsavedChanges, viewMode, isMounted]
   );
@@ -130,13 +147,20 @@ export const useDashboardMenuItems = ({
   /**
    * initiate interactive dashboard copy action
    */
-  const dashboardInteractiveSave = useCallback(async () => {
-    const result = await dashboardApi.runInteractiveSave();
-    maybeRedirect(result);
-    if (result && !result.error) {
-      return result;
-    }
-  }, [maybeRedirect, dashboardApi]);
+  const dashboardInteractiveSave = useCallback(
+    async (returnFocus?: () => void) => {
+      try {
+        const result = await dashboardApi.runInteractiveSave();
+        maybeRedirect(result);
+        if (result && !result.error) {
+          return result;
+        }
+      } finally {
+        returnFocus?.();
+      }
+    },
+    [maybeRedirect, dashboardApi]
+  );
 
   /**
    * Save the dashboard without any UI or popups.
@@ -186,33 +210,37 @@ export const useDashboardMenuItems = ({
   /**
    * Show the Dashboard app's share menu
    */
-  const showShare = useCallback(() => {
-    ShowShareModal({
+  const showShare = useCallback(
+    (anchorElement?: HTMLElement) => {
+      ShowShareModal({
+        anchorElement,
+        dashboardTitle,
+        savedObjectId: lastSavedId,
+        isDirty: Boolean(hasUnsavedChanges) && viewMode === 'edit',
+        canSave: (canManageAccessControl || isInEditAccessMode) && Boolean(hasUnsavedChanges),
+        accessControl,
+        createdBy: dashboardApi.createdBy,
+        isManaged: dashboardApi.isManaged,
+        accessControlClient,
+        saveDashboard: saveFromShareModal,
+        changeAccessMode: dashboardApi.changeAccessMode,
+      });
+    },
+    [
       dashboardTitle,
-      savedObjectId: lastSavedId,
-      isDirty: Boolean(hasUnsavedChanges) && viewMode === 'edit',
-      canSave: (canManageAccessControl || isInEditAccessMode) && Boolean(hasUnsavedChanges),
+      hasUnsavedChanges,
+      lastSavedId,
+      isInEditAccessMode,
+      canManageAccessControl,
       accessControl,
-      createdBy: dashboardApi.createdBy,
-      isManaged: dashboardApi.isManaged,
+      saveFromShareModal,
+      dashboardApi.changeAccessMode,
+      dashboardApi.createdBy,
       accessControlClient,
-      saveDashboard: saveFromShareModal,
-      changeAccessMode: dashboardApi.changeAccessMode,
-    });
-  }, [
-    dashboardTitle,
-    hasUnsavedChanges,
-    lastSavedId,
-    isInEditAccessMode,
-    canManageAccessControl,
-    accessControl,
-    saveFromShareModal,
-    dashboardApi.changeAccessMode,
-    dashboardApi.createdBy,
-    accessControlClient,
-    dashboardApi.isManaged,
-    viewMode,
-  ]);
+      dashboardApi.isManaged,
+      viewMode,
+    ]
+  );
 
   const getEditTooltip = useCallback(() => {
     if (dashboardApi.isManaged) {
@@ -231,7 +259,7 @@ export const useDashboardMenuItems = ({
       : topNavStrings.share.writeRestrictedModeTooltipContent;
   }, [isInEditAccessMode, dashboardApi.isAccessControlEnabled]);
 
-  const resetChangesMenuItem = useMemo(() => {
+  const resetChangesMenuItem = useMemo<AppMenuItemType>(() => {
     return {
       order: viewMode === 'edit' ? 2 : 4,
       label: topNavStrings.resetChanges.label,
@@ -245,7 +273,7 @@ export const useDashboardMenuItems = ({
         (viewMode === 'edit' && (isSaveInProgress || !lastSavedId)) ||
         !lastSavedId, // Disable when on a new dashboard
       isLoading: isResetting,
-      run: () => resetChanges(),
+      run: (params) => resetChanges(false, params?.returnFocus),
     };
   }, [
     hasOverlays,
@@ -296,7 +324,7 @@ export const useDashboardMenuItems = ({
         iconType: 'share',
         testId: 'shareTopNavButton',
         disableButton: disableTopNav,
-        run: () => showShare(),
+        run: (params) => showShare(params?.triggerElement),
       } as AppMenuItemType,
 
       export: exportMenuItem,
@@ -307,7 +335,7 @@ export const useDashboardMenuItems = ({
         id: 'interactive-save',
         testId: 'dashboardInteractiveSaveMenuItem',
         iconType: 'copy',
-        run: dashboardInteractiveSave,
+        run: (params) => dashboardInteractiveSave(params?.returnFocus),
         label: topNavStrings.viewModeInteractiveSave.label,
       } as AppMenuItemType,
 
@@ -342,7 +370,7 @@ export const useDashboardMenuItems = ({
         disableButton: disableTopNav || !lastSavedId || isResetting,
         isLoading: isResetting,
         testId: 'dashboardViewOnlyMode',
-        run: () => resetChanges(true),
+        run: (params) => resetChanges(true, params?.returnFocus),
       } as AppMenuItemType,
 
       add: {
@@ -390,7 +418,8 @@ export const useDashboardMenuItems = ({
         iconType: 'save',
         testId: lastSavedId ? 'dashboardQuickSaveMenuItem' : 'dashboardInteractiveSaveMenuItem',
         disableButton: lastSavedId ? isQuickSaveButtonDisabled : disableTopNav, // Only check disableTopNav for new dashboards
-        run: () => (lastSavedId ? quickSaveDashboard() : dashboardInteractiveSave()),
+        run: (params) =>
+          lastSavedId ? quickSaveDashboard() : dashboardInteractiveSave(params?.returnFocus),
         popoverWidth: 150,
         splitButtonProps: {
           items: [
@@ -401,7 +430,7 @@ export const useDashboardMenuItems = ({
               order: 1,
               testId: 'dashboardInteractiveSaveMenuItem',
               disableButton: isSaveInProgress || !lastSavedId, // Disable when on a new dashboard
-              run: () => dashboardInteractiveSave(),
+              run: (params) => dashboardInteractiveSave(params?.returnFocus),
             },
             resetChangesMenuItem,
           ],

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/confirm_overlays.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/confirm_overlays.tsx
@@ -30,8 +30,9 @@ import { createConfirmStrings, resetConfirmStrings } from './_dashboard_listing_
 export type DiscardOrKeepSelection = 'cancel' | 'discard' | 'keep';
 
 export const confirmDiscardUnsavedChanges = (
-  discardCallback: () => void,
-  viewMode: ViewMode = 'edit' // we want to show the danger modal on the listing page
+  discardCallback: () => void | Promise<void>,
+  viewMode: ViewMode = 'edit', // we want to show the danger modal on the listing page
+  returnFocus?: () => void
 ) => {
   coreServices.overlays
     .openConfirm(resetConfirmStrings.getResetSubtitle(viewMode), {
@@ -41,10 +42,14 @@ export const confirmDiscardUnsavedChanges = (
       defaultFocusedButton: EUI_MODAL_CANCEL_BUTTON,
       title: resetConfirmStrings.getResetTitle(),
     })
-    .then((isConfirmed) => {
+    .then(async (isConfirmed) => {
       if (isConfirmed) {
-        discardCallback();
+        // Caller restores focus after confirm — the AppMenu trigger may unmount
+        // (e.g. switch to view mode), so do not returnFocus here.
+        await discardCallback();
+        return;
       }
+      returnFocus?.();
     });
 };
 


### PR DESCRIPTION
## Summary
- return focus to the invoking AppMenu action after save and discard modal workflows
- anchor the share context menu to the exact element that opened it
- focus the Edit button after switching to view mode, because the Cancel trigger unmounts

Addresses #278558

## Manual verification flows
1. Edit a dashboard, make no changes, and select **Cancel**. The dashboard switches to view mode and focus moves to **Edit**.
2. Edit a dashboard, make a change, select **Cancel**, then dismiss the discard confirmation. Focus returns to **Cancel**.
3. Edit a dashboard, make a change, select **Cancel**, then confirm the discard. The dashboard switches to view mode and focus moves to **Edit**.
4. Open **Save as** or **Duplicate**, then close or complete the modal. Focus returns to the AppMenu action that opened it.
5. Open **Share**, then close the share menu. Focus returns to **Share**.

## Test plan
- [x] Run the focused Dashboard menu-items Jest suite
- [x] Run ESLint on the four changed files