### PR TITLE
[Data lifecycle phases] Fix i18n check failing on FormattedMessage template-literal ids

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx
@@ -82,7 +82,7 @@ export const DefaultSnapshotRepositoryRequiredModal = ({
         <EuiText>
           {shouldManageExisting ? (
             <FormattedMessage
-              id={`${I18N_PREFIX}.descriptionSelectExisting`}
+              id="xpack.dataLifecyclePhases.defaultSnapshotRepositoryRequiredModal.descriptionSelectExisting"
               defaultMessage="To add a frozen phase, you need a default snapshot repository first. Set one of your existing repositories as the default in {snapshotRestoreLink}, then refresh this panel."
               values={{
                 snapshotRestoreLink: (
@@ -94,7 +94,7 @@ export const DefaultSnapshotRepositoryRequiredModal = ({
             />
           ) : (
             <FormattedMessage
-              id={`${I18N_PREFIX}.description`}
+              id="xpack.dataLifecyclePhases.defaultSnapshotRepositoryRequiredModal.description"
               defaultMessage="To add a frozen phase, you need a default snapshot repository first. Create one in {snapshotRestoreLink}, then refresh this panel."
               values={{
                 snapshotRestoreLink: (


### PR DESCRIPTION
## Summary

Quick checks (i18n) started failing on `main` after #278428 because two `i18n.translate(...)` calls in the default snapshot repository modal were converted to `<FormattedMessage id={`${I18N_PREFIX}...`} />`. The i18n extractor cannot resolve template-literal ids that reference a variable: for `i18n.translate` it silently skips them, but for JSX `FormattedMessage` it extracts the message with an **empty id**, which fails the namespace-root validation:

```
ERROR Error in file Message id  must start with the namespace root (xpack.dataLifecyclePhases) ...
```

Fix: use static string-literal ids on the two `FormattedMessage` components. (`I18N_PREFIX` is still used by the remaining `i18n.translate` calls.)

Ref failing build: https://buildkite.com/elastic/kibana-on-merge/builds/102678

## Test plan

- [x] `node scripts/i18n_check` passes locally

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->