### PR TITLE
[Dashboard][Controls][a11y] Restore focus after panel removal

### DIFF
--- a/src/platform/packages/private/kbn-controls-renderer/src/components/control_panel.tsx
+++ b/src/platform/packages/private/kbn-controls-renderer/src/components/control_panel.tsx
@@ -200,6 +200,8 @@ export const ControlPanel = ({
       }}
       grow={Boolean(grow)}
       data-test-subj="control-frame"
+      id={`panel-${id}`}
+      tabIndex={-1}
       css={css([isDragging && styles.draggingItem, styles.controlWidthStyles])}
       className={`controlFrameWrapper--${width}`}
     >

--- a/src/platform/packages/shared/controls/control-group-renderer/moon.yml
+++ b/src/platform/packages/shared/controls/control-group-renderer/moon.yml
@@ -25,6 +25,7 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/esql-types'
   - '@kbn/presentation-publishing'
+  - '@kbn/presentation-util'
   - '@kbn/es-query'
   - '@kbn/kibana-react-plugin'
   - '@kbn/std'

--- a/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.test.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.test.tsx
@@ -123,6 +123,28 @@ describe('control group renderer', () => {
     });
   });
 
+  test('focuses the control group after removing its final control', async () => {
+    const { component, api } = await mountControlGroupRenderer({
+      getCreationOptions: jest.fn().mockResolvedValue({
+        initialState: {
+          initialChildControlState: {
+            test: {
+              type: 'test_control',
+            },
+          },
+        },
+      }),
+    });
+    await waitFor(() => expect(component.queryByTestId('testControl')).not.toBeNull());
+    jest.useFakeTimers();
+
+    act(() => api.removePanel('test', { restoreFocus: true }));
+    act(() => jest.runAllTimers());
+
+    expect(document.activeElement).toBe(component.getByTestId('control-group-focus-fallback'));
+    jest.useRealTimers();
+  });
+
   test('filter changes are dispatched to control parent API if they are different', async () => {
     const initialFilters: Filter[] = [
       { meta: { alias: 'test', disabled: false, negate: false, index: 'test' } },

--- a/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.tsx
@@ -7,11 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BehaviorSubject, Subject, Subscription, combineLatest, map } from 'rxjs';
 
 import { ControlsRenderer, type ControlsRendererParentApi } from '@kbn/controls-renderer';
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
   apiHasSerializableState,
@@ -80,7 +81,14 @@ export const ControlGroupRenderer = ({
   }, [initialState]);
 
   const { childrenApi, currentChildState$Ref } = useChildrenApi(initialState, lastSavedState$Ref);
-  const layoutApi = useLayoutApi(initialState, childrenApi, lastSavedState$Ref);
+  const removalFocusFallbackRef = useRef<HTMLDivElement>(null);
+  const getRemovalFocusFallback = useCallback(() => removalFocusFallbackRef.current, []);
+  const layoutApi = useLayoutApi(
+    initialState,
+    childrenApi,
+    lastSavedState$Ref,
+    getRemovalFocusFallback
+  );
   const [controls, setControls] = useState(layoutApi?.layout$.getValue().controls);
 
   /** Props management */
@@ -223,12 +231,23 @@ export const ControlGroupRenderer = ({
 
   /** Wait for parent API, which relies on the async creation options, before rendering */
   return !parentApi || !controls ? null : (
-    <ControlsRenderer
-      parentApi={parentApi as ControlsRendererParentApi}
-      controls={{ controls }}
-      onControlsChanged={(newControls) => {
-        parentApi.layout$.next(newControls);
-      }}
-    />
+    <>
+      <ControlsRenderer
+        parentApi={parentApi as ControlsRendererParentApi}
+        controls={{ controls }}
+        onControlsChanged={(newControls) => {
+          parentApi.layout$.next(newControls);
+        }}
+      />
+      <div
+        ref={removalFocusFallbackRef}
+        role="group"
+        aria-label={i18n.translate('controls.controlGroupRenderer.groupAriaLabel', {
+          defaultMessage: 'Controls',
+        })}
+        tabIndex={-1}
+        data-test-subj="control-group-focus-fallback"
+      />
+    </>
   );
 };

--- a/src/platform/packages/shared/controls/control-group-renderer/src/control_removal_focus.test.ts
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/control_removal_focus.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ControlsLayout } from '@kbn/controls-renderer';
+import { getRemovalFocusTarget } from '@kbn/presentation-util';
+import { getControlIdsInOrder, restoreFocusAfterControlRemoval } from './control_removal_focus';
+
+const createLayout = (controls: ControlsLayout['controls']): ControlsLayout => ({ controls });
+
+describe('control removal focus', () => {
+  describe('getControlIdsInOrder', () => {
+    it('orders controls by their order field', () => {
+      expect(
+        getControlIdsInOrder(
+          createLayout({
+            second: { order: 1, width: 'medium', grow: false, type: 'optionsListControl' },
+            first: { order: 0, width: 'medium', grow: false, type: 'optionsListControl' },
+          })
+        )
+      ).toEqual(['first', 'second']);
+    });
+  });
+
+  describe('getRemovalFocusTarget', () => {
+    it('prefers the predecessor', () => {
+      expect(getRemovalFocusTarget(['first', 'removed', 'last'], 'removed')).toBe('first');
+    });
+
+    it('uses the next control when removing the first', () => {
+      expect(getRemovalFocusTarget(['removed', 'next'], 'removed')).toBe('next');
+    });
+
+    it('returns undefined when removing the only control', () => {
+      expect(getRemovalFocusTarget(['removed'], 'removed')).toBeUndefined();
+    });
+  });
+
+  it('focuses the predecessor control container after removal', () => {
+    jest.useFakeTimers();
+    const layout = createLayout({
+      previous: { order: 0, width: 'medium', grow: false, type: 'optionsListControl' },
+      removed: { order: 1, width: 'medium', grow: false, type: 'optionsListControl' },
+    });
+    const previousControl = document.createElement('div');
+    previousControl.id = 'panel-previous';
+    previousControl.tabIndex = -1;
+    document.body.appendChild(previousControl);
+
+    restoreFocusAfterControlRemoval(layout, 'removed', () => null);
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(previousControl);
+    previousControl.remove();
+    jest.useRealTimers();
+  });
+
+  it('focuses the supplied fallback after removing the only control', () => {
+    jest.useFakeTimers();
+    const layout = createLayout({
+      removed: { order: 0, width: 'medium', grow: false, type: 'optionsListControl' },
+    });
+    const fallback = document.createElement('div');
+    fallback.tabIndex = -1;
+    document.body.appendChild(fallback);
+
+    restoreFocusAfterControlRemoval(layout, 'removed', () => fallback);
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(fallback);
+    fallback.remove();
+    jest.useRealTimers();
+  });
+});

--- a/src/platform/packages/shared/controls/control-group-renderer/src/control_removal_focus.ts
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/control_removal_focus.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { focusFirstFocusable, getRemovalFocusTarget } from '@kbn/presentation-util';
+import type { ControlsLayout } from '@kbn/controls-renderer';
+
+export const getControlIdsInOrder = (layout: ControlsLayout): string[] =>
+  Object.entries(layout.controls)
+    .sort(([, a], [, b]) => (a.order ?? 0) - (b.order ?? 0))
+    .map(([id]) => id);
+
+export const restoreFocusAfterControlRemoval = (
+  layout: ControlsLayout,
+  removedControlId: string,
+  getFallback: () => Element | null
+) => {
+  const focusTargetControlId = getRemovalFocusTarget(
+    getControlIdsInOrder(layout),
+    removedControlId
+  );
+
+  focusFirstFocusable(() => {
+    if (!focusTargetControlId) {
+      return getFallback();
+    }
+
+    return document.getElementById(`panel-${focusTargetControlId}`) ?? getFallback();
+  });
+};

--- a/src/platform/packages/shared/controls/control-group-renderer/src/use_layout_api.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/use_layout_api.tsx
@@ -15,15 +15,17 @@ import { v4 as uuidv4 } from 'uuid';
 import { DEFAULT_PINNED_CONTROL_STATE } from '@kbn/controls-constants';
 import type { PinnedControlLayoutState, PinnedControlState } from '@kbn/controls-schemas';
 import type { ControlsLayout } from '@kbn/controls-renderer/src/types';
-import type { PanelPackage } from '@kbn/presentation-publishing';
+import type { PanelPackage, RemovePanelOptions } from '@kbn/presentation-publishing';
 
+import { restoreFocusAfterControlRemoval } from './control_removal_focus';
 import type { ControlGroupCreationOptions, ControlPanelsState } from './types';
 import type { useChildrenApi } from './use_children_api';
 
 export const useLayoutApi = (
   state: ControlGroupCreationOptions['initialState'] | undefined,
   childrenApi: ReturnType<typeof useChildrenApi>['childrenApi'],
-  lastSavedState$Ref: React.MutableRefObject<BehaviorSubject<ControlPanelsState>>
+  lastSavedState$Ref: React.MutableRefObject<BehaviorSubject<ControlPanelsState>>,
+  getRemovalFocusFallback: () => Element | null
 ) => {
   const layout$Ref = useRef(new BehaviorSubject<ControlsLayout>({ controls: {} }));
 
@@ -115,8 +117,11 @@ export const useLayoutApi = (
         layout$Ref.current.next({ ...currentLayout, controls });
         return uuid;
       },
-      removePanel: (idToRemove: string) => {
+      removePanel: (idToRemove: string, options?: RemovePanelOptions) => {
         const currentLayout = layout$Ref.current.value;
+        if (options?.restoreFocus) {
+          restoreFocusAfterControlRemoval(currentLayout, idToRemove, getRemovalFocusFallback);
+        }
         const controls = { ...currentLayout.controls };
         if (controls[idToRemove]) {
           delete controls[idToRemove];
@@ -134,7 +139,7 @@ export const useLayoutApi = (
         distinctUntilChanged()
       ),
     };
-  }, [state, childrenApi]);
+  }, [state, childrenApi, getRemovalFocusFallback]);
 
   return layoutApi;
 };

--- a/src/platform/packages/shared/controls/control-group-renderer/tsconfig.json
+++ b/src/platform/packages/shared/controls/control-group-renderer/tsconfig.json
@@ -15,6 +15,7 @@
     "@kbn/data-views-plugin",
     "@kbn/esql-types",
     "@kbn/presentation-publishing",
+    "@kbn/presentation-util",
     "@kbn/es-query",
     "@kbn/kibana-react-plugin",
     "@kbn/std",

--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -276,6 +276,7 @@ export {
   listenForCompatibleApi,
   apiHasSections,
   type PanelPackage,
+  type RemovePanelOptions,
   type PresentationContainer,
   type HasSections,
 } from './interfaces/containers/presentation_container';

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/containers/presentation_container.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/containers/presentation_container.ts
@@ -26,11 +26,19 @@ export interface PanelPackage<SerializedState extends object = object> {
   serializedState?: SerializedState;
 }
 
+export interface RemovePanelOptions {
+  /**
+   * Restore keyboard focus after a user removes a panel. Internal operations such
+   * as replacing a panel should omit this option.
+   */
+  restoreFocus?: boolean;
+}
+
 export interface PresentationContainer<ApiType extends unknown = unknown> extends CanAddNewPanel {
   /**
    * Removes a panel from the container.
    */
-  removePanel: (panelId: string) => void;
+  removePanel: (panelId: string, options?: RemovePanelOptions) => void;
 
   /**
    * Determines whether or not a container is capable of removing panels.

--- a/src/platform/packages/shared/presentation/presentation_util/src/focus_helpers.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/focus_helpers.tsx
@@ -12,6 +12,21 @@
 export const getPanelContextMenuTriggerId = (panelId: string) =>
   `presentationPanelContextMenu-${panelId}`;
 
+/**
+ * Returns the id of the item that should receive focus after an item is removed from an
+ * ordered list (e.g. controls or dashboard panels). Prefers the predecessor; falls back
+ * to the successor when removing the first item. Returns undefined when the list becomes
+ * empty (WCAG 2.4.3 Focus Order).
+ */
+export const getRemovalFocusTarget = (
+  orderedIds: readonly string[],
+  removedId: string
+): string | undefined => {
+  const removedIndex = orderedIds.indexOf(removedId);
+  if (removedIndex < 0) return undefined;
+  return orderedIds[removedIndex - 1] ?? orderedIds[removedIndex + 1];
+};
+
 const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]';
 
 const getFirstFocusable = (el: HTMLElement | null): HTMLElement | null => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/focus_targets.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/focus_targets.ts
@@ -7,10 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { openLazyFlyout } from './src/open_lazy_flyout';
-export {
-  getPanelContextMenuTriggerId,
-  focusFirstFocusable,
-  getRemovalFocusTarget,
-} from './src/focus_helpers';
-export { tracksOverlays, type TracksOverlays } from './src/tracks_overlays';
+const ADD_PANEL_BUTTON_TEST_SUBJ = 'dashboardAddTopNavButton';
+
+export const getAddPanelButton = (): HTMLElement | null =>
+  document.querySelector<HTMLElement>(`[data-test-subj="${ADD_PANEL_BUTTON_TEST_SUBJ}"]`);
+
+export const getPanelElement = (panelId: string): HTMLElement | null =>
+  document.getElementById(`panel-${panelId}`);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
@@ -121,6 +121,33 @@ describe('layout manager', () => {
     expect(layoutManager.api.children$.getValue()[PANEL_ONE_ID]).toBe(panel1Api);
   });
 
+  test('restores focus after a user-initiated panel removal', () => {
+    jest.useFakeTimers();
+    const panelToRemove = {
+      ...panel1,
+      id: 'panelToRemove',
+      grid: { ...panel1.grid, x: 1 },
+    };
+    const layoutManager = initializeLayoutManager(
+      viewModeManagerMock,
+      undefined,
+      [panel1, panelToRemove],
+      [],
+      trackPanelMock
+    );
+    const remainingPanel = document.createElement('div');
+    remainingPanel.id = `panel-${PANEL_ONE_ID}`;
+    remainingPanel.tabIndex = -1;
+    document.body.appendChild(remainingPanel);
+
+    layoutManager.api.removePanel(panelToRemove.id, { restoreFocus: true });
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(remainingPanel);
+    remainingPanel.remove();
+    jest.useRealTimers();
+  });
+
   test('should apply incoming serialized child state during reset when supported', async () => {
     const layoutManager = initializeLayoutManager(
       viewModeManagerMock,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -37,7 +37,11 @@ import type { GridLayoutData, GridPanelData, GridSectionData } from '@kbn/grid-l
 import type { PinnedControlLayoutState as PinnedPanelLayoutState } from '@kbn/controls-schemas';
 import { DEFAULT_PINNED_CONTROL_STATE } from '@kbn/controls-constants';
 import { i18n } from '@kbn/i18n';
-import type { SerializedTitles, PanelPackage } from '@kbn/presentation-publishing';
+import type {
+  SerializedTitles,
+  PanelPackage,
+  RemovePanelOptions,
+} from '@kbn/presentation-publishing';
 import {
   childrenUnsavedChanges$,
   apiHasLibraryTransforms,
@@ -76,6 +80,7 @@ import {
 } from './types';
 import { getPlacementHints } from '../../panel_placement/get_placement_hints';
 import { anyChildrenChanges$ } from './any_children_changes';
+import { restoreFocusAfterPanelRemoval } from './panel_removal_focus';
 
 export function initializeLayoutManager(
   viewModeManager: ReturnType<typeof initializeViewModeManager>,
@@ -339,8 +344,11 @@ export function initializeLayoutManager(
     return (await getChildApi(uuid)) as ApiType;
   };
 
-  const removePanel = (uuid: string) => {
+  const removePanel = (uuid: string, options?: RemovePanelOptions) => {
     const currentLayout = layout$.value;
+    if (options?.restoreFocus) {
+      restoreFocusAfterPanelRemoval(currentLayout, uuid);
+    }
     const panels = { ...currentLayout.panels };
     const pinnedPanels = { ...currentLayout.pinnedPanels };
     if (panels[uuid]) {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/panel_removal_focus.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/panel_removal_focus.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DashboardLayout } from './types';
+import { getRemovalFocusTarget } from '@kbn/presentation-util';
+import { getPanelIdsInVisualOrder, restoreFocusAfterPanelRemoval } from './panel_removal_focus';
+
+const createLayout = (overrides: Partial<DashboardLayout> = {}): DashboardLayout =>
+  ({
+    panels: {},
+    sections: {},
+    pinnedPanels: {},
+    ...overrides,
+  } as DashboardLayout);
+
+describe('panel removal focus', () => {
+  describe('getPanelIdsInVisualOrder', () => {
+    it('orders pinned panels first and grid panels by visual reading order', () => {
+      const layout = createLayout({
+        pinnedPanels: {
+          pinnedSecond: { order: 1, width: 'medium', grow: false, type: 'test' },
+          pinnedFirst: { order: 0, width: 'medium', grow: false, type: 'test' },
+        },
+        panels: {
+          bottom: { type: 'test', grid: { x: 0, y: 10, w: 1, h: 1 } },
+          topRight: { type: 'test', grid: { x: 6, y: 0, w: 1, h: 1 } },
+          topLeft: { type: 'test', grid: { x: 0, y: 0, w: 1, h: 1 } },
+        },
+      });
+
+      expect(getPanelIdsInVisualOrder(layout)).toEqual([
+        'pinnedFirst',
+        'pinnedSecond',
+        'topLeft',
+        'topRight',
+        'bottom',
+      ]);
+    });
+
+    it('places section panels at the section position and skips collapsed sections', () => {
+      const layout = createLayout({
+        sections: {
+          open: {
+            collapsed: false,
+            title: 'Open',
+            grid: { y: 5 },
+          },
+          closed: {
+            collapsed: true,
+            title: 'Closed',
+            grid: { y: 10 },
+          },
+        },
+        panels: {
+          before: { type: 'test', grid: { x: 0, y: 0, w: 1, h: 1 } },
+          openRight: {
+            type: 'test',
+            grid: { x: 6, y: 0, w: 1, h: 1, sectionId: 'open' },
+          },
+          openLeft: {
+            type: 'test',
+            grid: { x: 0, y: 0, w: 1, h: 1, sectionId: 'open' },
+          },
+          hidden: {
+            type: 'test',
+            grid: { x: 0, y: 0, w: 1, h: 1, sectionId: 'closed' },
+          },
+          after: { type: 'test', grid: { x: 0, y: 15, w: 1, h: 1 } },
+        },
+      });
+
+      expect(getPanelIdsInVisualOrder(layout)).toEqual([
+        'before',
+        'openLeft',
+        'openRight',
+        'after',
+      ]);
+    });
+  });
+
+  describe('getRemovalFocusTarget', () => {
+    it('prefers the visual predecessor', () => {
+      expect(getRemovalFocusTarget(['first', 'removed', 'last'], 'removed')).toBe('first');
+    });
+
+    it('uses the next panel when removing the first panel', () => {
+      expect(getRemovalFocusTarget(['removed', 'next'], 'removed')).toBe('next');
+    });
+
+    it('returns undefined when removing the only panel', () => {
+      expect(getRemovalFocusTarget(['removed'], 'removed')).toBeUndefined();
+    });
+  });
+
+  it('focuses the visual predecessor panel container after removal', () => {
+    jest.useFakeTimers();
+    const layout = createLayout({
+      panels: {
+        previous: { type: 'test', grid: { x: 0, y: 0, w: 1, h: 1 } },
+        removed: { type: 'test', grid: { x: 6, y: 0, w: 1, h: 1 } },
+      },
+    });
+    const previousPanel = document.createElement('div');
+    previousPanel.id = 'panel-previous';
+    previousPanel.tabIndex = -1;
+    document.body.appendChild(previousPanel);
+
+    restoreFocusAfterPanelRemoval(layout, 'removed');
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(previousPanel);
+    previousPanel.remove();
+    jest.useRealTimers();
+  });
+
+  it('focuses the visual successor when removing the first panel', () => {
+    jest.useFakeTimers();
+    const layout = createLayout({
+      panels: {
+        removed: { type: 'test', grid: { x: 0, y: 0, w: 1, h: 1 } },
+        next: { type: 'test', grid: { x: 6, y: 0, w: 1, h: 1 } },
+      },
+    });
+    const nextPanel = document.createElement('div');
+    nextPanel.id = 'panel-next';
+    nextPanel.tabIndex = -1;
+    document.body.appendChild(nextPanel);
+
+    restoreFocusAfterPanelRemoval(layout, 'removed');
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(nextPanel);
+    nextPanel.remove();
+    jest.useRealTimers();
+  });
+
+  it('focuses a remaining visible panel when removing a panel from a collapsed section', () => {
+    jest.useFakeTimers();
+    const layout = createLayout({
+      sections: {
+        closed: {
+          collapsed: true,
+          title: 'Closed',
+          grid: { y: 10 },
+        },
+      },
+      panels: {
+        visible: { type: 'test', grid: { x: 0, y: 0, w: 1, h: 1 } },
+        hidden: {
+          type: 'test',
+          grid: { x: 0, y: 0, w: 1, h: 1, sectionId: 'closed' },
+        },
+      },
+    });
+    const visiblePanel = document.createElement('div');
+    visiblePanel.id = 'panel-visible';
+    visiblePanel.tabIndex = -1;
+    document.body.appendChild(visiblePanel);
+
+    restoreFocusAfterPanelRemoval(layout, 'hidden');
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(visiblePanel);
+    visiblePanel.remove();
+    jest.useRealTimers();
+  });
+
+  it('focuses Add when no visible panels remain', () => {
+    jest.useFakeTimers();
+    const layout = createLayout({
+      sections: {
+        closed: {
+          collapsed: true,
+          title: 'Closed',
+          grid: { y: 10 },
+        },
+      },
+      panels: {
+        removed: { type: 'test', grid: { x: 0, y: 0, w: 1, h: 1 } },
+        hidden: {
+          type: 'test',
+          grid: { x: 0, y: 0, w: 1, h: 1, sectionId: 'closed' },
+        },
+      },
+    });
+    const addButton = document.createElement('button');
+    addButton.dataset.testSubj = 'dashboardAddTopNavButton';
+    document.body.appendChild(addButton);
+
+    restoreFocusAfterPanelRemoval(layout, 'removed');
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(addButton);
+    addButton.remove();
+    jest.useRealTimers();
+  });
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/panel_removal_focus.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/panel_removal_focus.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { focusFirstFocusable, getRemovalFocusTarget } from '@kbn/presentation-util';
+import type { DashboardLayout } from './types';
+import { getAddPanelButton, getPanelElement } from './focus_targets';
+
+interface VisualPosition {
+  x: number;
+  y: number;
+}
+
+const compareVisualPosition = (a: VisualPosition, b: VisualPosition) =>
+  a.y === b.y ? a.x - b.x : a.y - b.y;
+
+export const getPanelIdsInVisualOrder = (layout: DashboardLayout): string[] => {
+  const pinnedPanelIds = Object.entries(layout.pinnedPanels)
+    .sort(([, a], [, b]) => (a.order ?? 0) - (b.order ?? 0))
+    .map(([id]) => id);
+
+  const topLevelItems: Array<VisualPosition & { panelIds: string[] }> = [];
+
+  Object.entries(layout.panels).forEach(([id, panel]) => {
+    if (!panel.grid.sectionId) {
+      topLevelItems.push({ x: panel.grid.x, y: panel.grid.y, panelIds: [id] });
+    }
+  });
+
+  Object.entries(layout.sections).forEach(([sectionId, section]) => {
+    if (section.collapsed) {
+      return;
+    }
+
+    const panelIds = Object.entries(layout.panels)
+      .filter(([, panel]) => panel.grid.sectionId === sectionId)
+      .sort(([, a], [, b]) => compareVisualPosition(a.grid, b.grid))
+      .map(([id]) => id);
+
+    if (panelIds.length > 0) {
+      topLevelItems.push({ x: 0, y: section.grid.y, panelIds });
+    }
+  });
+
+  return [
+    ...pinnedPanelIds,
+    ...topLevelItems.sort(compareVisualPosition).flatMap(({ panelIds }) => panelIds),
+  ];
+};
+
+export const restoreFocusAfterPanelRemoval = (layout: DashboardLayout, removedPanelId: string) => {
+  const panelIdsInVisualOrder = getPanelIdsInVisualOrder(layout);
+  // Prefer a visual neighbor. When the removed panel is absent from visual order
+  // (e.g. inside a collapsed section), focus the first remaining visible panel.
+  const focusTargetPanelId =
+    getRemovalFocusTarget(panelIdsInVisualOrder, removedPanelId) ??
+    panelIdsInVisualOrder.find((id) => id !== removedPanelId);
+
+  focusFirstFocusable(() => {
+    if (!focusTargetPanelId) {
+      return getAddPanelButton();
+    }
+
+    return getPanelElement(focusTargetPanelId) ?? getAddPanelButton();
+  });
+};

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx
@@ -165,6 +165,9 @@ export const Item = React.forwardRef<HTMLDivElement, Props>(
         className={[classes, className].join(' ')}
         data-test-subj="dashboardPanel"
         id={`panel-${id}`}
+        // Programmatically focusable (but not in the tab order) so focus can be
+        // restored after another panel is removed (WCAG 2.4.3).
+        tabIndex={-1}
         ref={ref}
         {...rest}
       >
@@ -203,9 +206,12 @@ const dashboardGridItemStyles = {
         '.kbnAppWrapper--hiddenChrome & .dshDashboardGrid__item--expanded': {
           padding: 0,
         },
-        // Call out focused panels with a simple border
-        '&.dshDashboardGrid__item--focused .embPanel': {
+        // Call out both programmatically highlighted and keyboard-focused panels.
+        '&.dshDashboardGrid__item--focused .embPanel, &:focus .embPanel': {
           outline: `${context.euiTheme.border.width.thick} solid ${context.euiTheme.colors.vis.euiColorVis0}`,
+        },
+        '&:focus': {
+          outline: 'none',
         },
         // Call out panels that are selected to indicate their related panels with the same border plus a semitransparent overlay
         '&.dshDashboardGrid__item--selected': {

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_lens_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_lens_by_value.spec.ts
@@ -51,10 +51,13 @@ spaceTest.describe('Lens by-value panels (dashboard)', { tag: tags.deploymentAgn
     await pageObjects.dashboard.removePanel(LENS_BASIC_TITLE);
   };
 
-  spaceTest('by-value panel retains count after edit', async ({ pageObjects }) => {
+  spaceTest('by-value panel retains count after edit', async ({ pageObjects, page }) => {
     await spaceTest.step('add by value panel', async () => {
+      // Helper adds a panel, clones it, then removes the original — focus should land on
+      // the remaining neighbor panel (not the Add button).
       await addByValueLensPanel(pageObjects);
       expect(await pageObjects.dashboard.getPanelCount()).toBe(1);
+      await expect(page.testSubj.locator('dashboardPanel')).toBeFocused();
     });
 
     const originalPanelCount = await pageObjects.dashboard.getPanelCount();

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/empty_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/empty_dashboard.spec.ts
@@ -48,9 +48,10 @@ spaceTest.describe('Empty dashboard', { tag: tags.deploymentAgnostic }, () => {
       await expect.poll(() => pageObjects.dashboard.getPanelCount()).toBe(1);
     });
 
-    await spaceTest.step('reopens the add-panel flyout', async () => {
-      await pageObjects.dashboard.openAddPanelFlyout();
-      await expect(page.testSubj.locator('dashboardPanelSelectionFlyout')).toBeVisible();
+    await spaceTest.step('returns focus to Add when the last panel is removed', async () => {
+      await pageObjects.dashboard.clickPanelAction('embeddablePanelAction-deletePanel');
+      await expect.poll(() => pageObjects.dashboard.getPanelCount()).toBe(0);
+      await expect(page.testSubj.locator('dashboardAddTopNavButton')).toBeFocused();
     });
   });
 });

--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.test.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.test.tsx
@@ -146,7 +146,7 @@ describe('MarkdownEmbeddable', () => {
       });
 
       await userEvent.click(await screen.findByRole('button', { name: /Discard/i }));
-      expect(parentApi.removePanel).toHaveBeenCalledWith('test-uuid');
+      expect(parentApi.removePanel).toHaveBeenCalledWith('test-uuid', { restoreFocus: true });
     });
 
     it('does not remove panel if not new panel when Discard clicked', async () => {

--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.tsx
@@ -232,7 +232,7 @@ export const markdownEmbeddableFactory: EmbeddablePublicDefinition<
               settings$={settings$}
               onCancel={() => {
                 if (isNewPanel$.getValue() && apiIsPresentationContainer(parentApi)) {
-                  parentApi.removePanel(api.uuid);
+                  parentApi.removePanel(api.uuid, { restoreFocus: true });
                 }
                 resetEditingState();
               }}

--- a/src/platform/plugins/shared/embeddable/public/ui_actions/remove_panel_action/remove_panel_action.test.tsx
+++ b/src/platform/plugins/shared/embeddable/public/ui_actions/remove_panel_action/remove_panel_action.test.tsx
@@ -62,9 +62,11 @@ describe('Remove panel action', () => {
   });
 
   describe('execute', () => {
-    it('calls the parent removePanel method on execute', async () => {
+    it('requests focus restoration when removing a panel from the UI', async () => {
       action.execute(context);
-      expect(context.embeddable.parentApi.removePanel).toHaveBeenCalled();
+      expect(context.embeddable.parentApi.removePanel).toHaveBeenCalledWith('superId', {
+        restoreFocus: true,
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/embeddable/public/ui_actions/remove_panel_action/remove_panel_action.ts
+++ b/src/platform/plugins/shared/embeddable/public/ui_actions/remove_panel_action/remove_panel_action.ts
@@ -61,6 +61,6 @@ export class RemovePanelAction implements Action<EmbeddableApiContext> {
 
   public async execute({ embeddable }: EmbeddableApiContext) {
     if (!isApiCompatible(embeddable)) throw new IncompatibleActionError();
-    embeddable.parentApi?.removePanel(embeddable.uuid);
+    embeddable.parentApi?.removePanel(embeddable.uuid, { restoreFocus: true });
   }
 }


### PR DESCRIPTION
## Summary
- restore keyboard focus to the visual predecessor after removing a Dashboard panel or Control
- fall back to the visual successor when removing the first item
- focus Add when no visible Dashboard panels remain, or the Controls group when its final Control is removed
- keep programmatic removals from moving focus through an opt-in `restoreFocus` contract

Addresses #278558

## Manual verification flows
1. Remove the second of multiple Dashboard panels. Focus moves to the previous visual panel.
2. Remove the first Dashboard panel. Focus moves to the next visual panel.
3. Remove the final visible Dashboard panel. Focus moves to **Add**.
4. Remove a Control from the middle of a Controls group. Focus moves to the previous Control.
5. Remove the first Control. Focus moves to the next Control.
6. Remove the final Control. Focus moves to the Controls group fallback.

## Test plan
- [x] Run ESLint on all changed TypeScript files
- [ ] Run focused Dashboard, Controls, Embeddable, and Markdown Jest suites after bootstrapping the standalone worktree
- [ ] Run Dashboard Scout coverage for remaining-panel and final-panel focus