### PR TITLE
[SigEvents][Detection] Skip stationary detections at the write layer

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/index.ts
@@ -36,7 +36,7 @@ const SIGNIFICANT_EVENTS_WORKFLOW_MANAGEMENT = {
 export const SIGNIFICANT_EVENTS_DETECTION_WORKFLOW = {
   id: SIGNIFICANT_EVENTS_DETECTION_WORKFLOW_ID,
   pluginId: 'significant_events',
-  version: 6,
+  version: 7,
   billable: false,
   yaml: DETECTION_YAML,
   management: SIGNIFICANT_EVENTS_WORKFLOW_MANAGEMENT,

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
@@ -83,8 +83,8 @@ steps:
 
   # -----------------------------------------------------------------------
   # Step 2: Foreach rule bucket — observe the change_point type and write a DETECTION on transition.
-  # A detection is an immutable observation of the rule's change_point_type (the full vocabulary,
-  # including `stationary`/`non_stationary`). We write exactly one detection when the observed type
+  # A detection is an immutable observation of a non-stationary change_point_type (`stationary` is
+  # ambient noise and is never written). We write exactly one detection when the observed type
   # differs from that rule's most recent detection — no lifecycle determination, no per-scan firehose.
   # -----------------------------------------------------------------------
   - name: foreach_rule

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/detection.yaml
@@ -143,10 +143,13 @@ steps:
           # Write only when the observed change_point_type differs from the rule's last detection.
           # A transient lookup error (check_last_detection runs on-failure:continue) must not force a
           # write, so require error == null.
+          # `stationary` (flat alert rate) is overwhelmingly ambient noise and is never written;
+          # post-escalation recovery is handled by the judge's re-evaluation queries instead.
           is_transition: >-
             ${{ steps.compute_rule_context.output.has_rule_uuid
             and steps.check_last_detection.error == null
             and steps.compute_rule_context.output.change_point_type != ''
+            and steps.compute_rule_context.output.change_point_type != 'stationary'
             and steps.compute_rule_context.output.change_point_type != steps.compute_transition.output.last_change_point_type }}
 
       - name: write_detection


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/nightshift-program/issues/661

Implements **Option B** from the issue: add `change_point_type != 'stationary'` to the `compute_write_gate` condition in `detection.yaml` so `stationary` detections are never written to the index in the first place.

`stationary` (flat alert rate) is overwhelmingly ambient noise. Post-escalation recovery is handled by the judge's re-evaluation queries rather than via a `stationary` detection trigger.

Detection workflow version 6 → 7.

## Manually tested e2e on a local Kibana

Ran the detection workflow with a mix of `spike`, `dip`, and `stationary` change-point results: only non-stationary transitions were written to the detections index; `stationary` observations produced no write.

## Checks

`node scripts/check.js --scope=branch`: tsproj/lint/jest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)