### PR TITLE
[Osquery] Skip flaky cypress specs

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_workflow.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_workflow.cy.ts
@@ -34,7 +34,7 @@ import {
 } from '../../tasks/api_fixtures';
 import { ServerlessRoleName } from '../../support/roles';
 
-describe('ALL - Live Query Workflow', { tags: ['@ess', '@serverless'] }, () => {
+describe.skip('ALL - Live Query Workflow', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     cy.login(ServerlessRoleName.SOC_MANAGER);
   });

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_create_edit.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_create_edit.cy.ts
@@ -39,7 +39,7 @@ import { loadSavedQuery, cleanupSavedQuery, cleanupPack, loadPack } from '../../
 import { request } from '../../tasks/common';
 import { ServerlessRoleName } from '../../support/roles';
 
-describe(
+describe.skip(
   'Packs - Create and Edit',
   // TODO: failing on MKI https://github.com/elastic/kibana/issues/200302
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },


### PR DESCRIPTION
## Summary

Skips two osquery Cypress specs that are failing on `main` in the on-merge pipeline ([build 102657](https://buildkite.com/elastic/kibana-on-merge/builds/102657)):

- `x-pack/platform/plugins/shared/osquery/cypress/e2e/all/packs_create_edit.cy.ts`
- `x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query_workflow.cy.ts`

Both are skipped at the top-level `describe` to unblock on-merge.

### Failing tests
- **packs_create_edit**: `should open lens in new tab`, `should open discover in new tab`, `should verify that packs are triggered`
- **live_query_workflow**: `submits a live query against all agents with a custom timeout`, `runs a query with ECS mapping enabled`, `runs a customized saved query and re-runs it from history` — all timing out on `[data-test-subj="osqueryResultsTable"]` (240s), likely an enrolled-agent/results-table environment issue.

> Note: no tracking issue is referenced yet. A follow-up flaky-test issue should be opened to track re-enabling these specs.
