### PR TITLE
[9.5] [Cases][Shared UX] File modal improvements (#277567)

### DIFF
--- a/src/platform/packages/shared/shared-ux/file/file_upload/impl/src/i18n_texts.ts
+++ b/src/platform/packages/shared/shared-ux/file/file_upload/impl/src/i18n_texts.ts
@@ -39,8 +39,7 @@ export const i18nTexts = {
   }),
   fileTooLarge: (expectedSize: string) =>
     i18n.translate('sharedUXPackages.fileUpload.fileTooLargeErrorMessage', {
-      defaultMessage:
-        'File is too large. Maximum size is {expectedSize, plural, one {# byte} other {# bytes} }.',
+      defaultMessage: 'File is too large. Maximum size is {expectedSize}.',
       values: { expectedSize },
     }),
   mimeTypeNotSupported: (mimeType: string, supportedMimeTypes: string) =>
@@ -48,5 +47,12 @@ export const i18nTexts = {
       defaultMessage:
         'File mime type "{mimeType}" is not supported. Supported mime types are: {supportedMimeTypes}.',
       values: { mimeType, supportedMimeTypes },
+    }),
+  // Variant that omits the (potentially long) list of allowed types
+  // Opt in via the file kind's `listAllowedMimeTypesInError: false`.
+  mimeTypeNotSupportedConcise: (mimeType: string) =>
+    i18n.translate('sharedUXPackages.fileUpload.mimeTypeNotSupportedConciseErrorMessage', {
+      defaultMessage: 'File type "{mimeType}" is not supported.',
+      values: { mimeType },
     }),
 };

--- a/src/platform/packages/shared/shared-ux/file/file_upload/impl/src/upload_state.test.ts
+++ b/src/platform/packages/shared/shared-ux/file/file_upload/impl/src/upload_state.test.ts
@@ -212,9 +212,59 @@ describe('UploadState', () => {
           {
             file,
             status: 'idle',
-            error: new Error('File is too large. Maximum size is 1,000 bytes.'),
+            error: new Error('File is too large. Maximum size is 1000.00 B.'),
           },
         ],
+      });
+    });
+  });
+
+  it('clears a previous error when a valid file is picked', () => {
+    const tooLarge = { name: 'big', size: 1001 } as File;
+    const valid = { name: 'small', size: 1, type: 'text/plain' } as File;
+
+    uploadState.setFiles([tooLarge]);
+    expect(uploadState.error$.getValue()).toEqual(
+      new Error('File is too large. Maximum size is 1000.00 B.')
+    );
+
+    // re-picking a valid file must not retain the previous oversize error
+    uploadState.setFiles([valid]);
+    expect(uploadState.error$.getValue()).toBeUndefined();
+  });
+
+  it('supports a per-file callback for maxSizeBytes', () => {
+    const callbackUploadState = new UploadState(
+      {
+        id: 'test',
+        http: {},
+        maxSizeBytes: (file) => (file.type === 'image/png' ? 500 : 5000),
+      } as FileKindBrowser,
+      filesClient,
+      {},
+      imageMetadataFactory
+    );
+
+    getTestScheduler().run(({ expectObservable }) => {
+      const image = { name: 'image', size: 1000, type: 'image/png' } as File;
+      callbackUploadState.setFiles([image]);
+      expectObservable(callbackUploadState.files$).toBe('a', {
+        a: [
+          {
+            file: image,
+            status: 'idle',
+            error: new Error('File is too large. Maximum size is 500.00 B.'),
+          },
+        ],
+      });
+    });
+
+    getTestScheduler().run(({ expectObservable }) => {
+      // same size passes under the larger non-image limit
+      const doc = { name: 'doc', size: 1000, type: 'text/plain' } as File;
+      callbackUploadState.setFiles([doc]);
+      expectObservable(callbackUploadState.files$).toBe('a', {
+        a: [{ file: doc, status: 'idle' }],
       });
     });
   });
@@ -239,6 +289,45 @@ describe('UploadState', () => {
         ],
       });
     });
+  });
+
+  it('omits the allowed mime type list when listAllowedMimeTypesInError is false', () => {
+    const conciseUploadState = new UploadState(
+      {
+        id: 'test',
+        http: {},
+        allowedMimeTypes: ['text/plain', 'image/png'],
+        listAllowedMimeTypesInError: false,
+      } as FileKindBrowser,
+      filesClient,
+      {},
+      imageMetadataFactory
+    );
+
+    getTestScheduler().run(({ expectObservable }) => {
+      const file = { name: 'script.sh', size: 123, type: 'text/x-sh' } as File;
+      conciseUploadState.setFiles([file]);
+      expectObservable(conciseUploadState.files$).toBe('a', {
+        a: [
+          {
+            file,
+            status: 'idle',
+            error: new Error('File type "text/x-sh" is not supported.'),
+          },
+        ],
+      });
+    });
+  });
+
+  it('tags validation errors with a stable code', () => {
+    uploadState.setFiles([{ name: 'empty', size: 0 } as File]);
+    expect((uploadState.error$.getValue() as { code?: string }).code).toBe('fileEmpty');
+
+    uploadState.setFiles([{ name: 'big', size: 1001 } as File]);
+    expect((uploadState.error$.getValue() as { code?: string }).code).toBe('fileTooLarge');
+
+    uploadState.setFiles([{ name: 'script.sh', size: 1, type: 'text/x-sh' } as File]);
+    expect((uploadState.error$.getValue() as { code?: string }).code).toBe('mimeTypeNotSupported');
   });
 
   it('option "allowRepeatedUploads" calls clear after upload is done', () => {

--- a/src/platform/packages/shared/shared-ux/file/file_upload/impl/src/upload_state.ts
+++ b/src/platform/packages/shared/shared-ux/file/file_upload/impl/src/upload_state.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import numeral from '@elastic/numeral';
 import * as Rx from 'rxjs';
 import type { ImageMetadataFactory } from '@kbn/shared-ux-file-util';
 import { getImageMetadata, isImage } from '@kbn/shared-ux-file-util';
@@ -38,6 +39,14 @@ export interface DoneNotification<Meta = unknown> {
 interface UploadOptions {
   allowRepeatedUploads?: boolean;
 }
+
+export type FileUploadErrorCode = 'fileEmpty' | 'fileTooLarge' | 'mimeTypeNotSupported';
+
+const createValidationError = (code: FileUploadErrorCode, message: string): Error => {
+  const error = new Error(message);
+  Object.defineProperty(error, 'code', { value: code });
+  return error;
+};
 
 export class UploadState {
   private readonly abort$ = new Rx.Subject<void>();
@@ -103,20 +112,25 @@ export class UploadState {
     const fileKind = this.fileKind;
 
     if (!file.size) {
-      throw new Error(i18nTexts.fileEmpty);
+      throw createValidationError('fileEmpty', i18nTexts.fileEmpty);
     }
 
-    if (fileKind.maxSizeBytes != null && file.size > this.fileKind.maxSizeBytes!) {
-      const message = i18nTexts.fileTooLarge(String(this.fileKind.maxSizeBytes));
-      throw new Error(message);
+    const maxSizeBytes =
+      typeof fileKind.maxSizeBytes === 'function'
+        ? fileKind.maxSizeBytes(file)
+        : fileKind.maxSizeBytes;
+
+    if (maxSizeBytes != null && file.size > maxSizeBytes) {
+      const message = i18nTexts.fileTooLarge(numeral(maxSizeBytes).format('0.00 b'));
+      throw createValidationError('fileTooLarge', message);
     }
 
     if (fileKind.allowedMimeTypes != null && !fileKind.allowedMimeTypes.includes(file.type)) {
-      const message = i18nTexts.mimeTypeNotSupported(
-        file.type,
-        fileKind.allowedMimeTypes.join(', ')
-      );
-      throw new Error(message);
+      const message =
+        fileKind.listAllowedMimeTypesInError === false
+          ? i18nTexts.mimeTypeNotSupportedConcise(file.type)
+          : i18nTexts.mimeTypeNotSupported(file.type, fileKind.allowedMimeTypes.join(', '));
+      throw createValidationError('mimeTypeNotSupported', message);
     }
   };
 
@@ -125,10 +139,9 @@ export class UploadState {
       throw new Error('Cannot update files while uploading');
     }
 
-    if (!files.length) {
-      this.done$.next(undefined);
-      this.error$.next(undefined);
-    }
+    // Reset any previous outcome so re-picking does not retain a stale error/done state
+    this.done$.next(undefined);
+    this.error$.next(undefined);
 
     let error: undefined | Error;
     try {

--- a/src/platform/packages/shared/shared-ux/file/types/index.ts
+++ b/src/platform/packages/shared/shared-ux/file/types/index.ts
@@ -250,11 +250,19 @@ export interface FileKindBase {
 export interface FileKindBrowser extends FileKindBase {
   /**
    * Max file contents size, in bytes, enforced for this file kind in the upload
-   * component.
+   * component. A function can be provided to derive the limit per file
    *
    * @default 4MiB
    */
-  maxSizeBytes?: number;
+  maxSizeBytes?: number | ((file: File) => number);
+  /**
+   * When `false`, the "unsupported file type" upload error omits the list of
+   * allowed MIME types. Use this when the list would be too long to show inline
+   * and the consumer surfaces supported types elsewhere.
+   *
+   * @default true
+   */
+  listAllowedMimeTypesInError?: boolean;
   /**
    * Allowed actions that can be done in the File Management UI. If not provided, all actions are allowed
    *

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
@@ -17,7 +17,6 @@ import {
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
-import { toMountPoint } from '@kbn/react-kibana-mount';
 import { isValidOwner } from '../../common/utils/owner';
 import type { CaseUI } from '../../common';
 import { AttachmentType } from '../../common/types/domain';

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
@@ -17,6 +17,7 @@ import {
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import { isValidOwner } from '../../common/utils/owner';
 import type { CaseUI } from '../../common';
 import { AttachmentType } from '../../common/types/domain';
@@ -124,7 +125,7 @@ const getErrorMessage = (error: Error | ServerError): string => {
 
 export const useCasesToast = () => {
   const { appId } = useApplication();
-  const { application, i18n, theme, userProfile } = useKibana().services;
+  const { application, i18n, theme, userProfile, rendering } = useKibana().services;
   const { getUrlForApp, navigateToUrl } = application;
 
   const toasts = useToasts();
@@ -184,8 +185,13 @@ export const useCasesToast = () => {
       showSuccessToast: (title: string, text?: ToastInputFields['text']) => {
         toasts.addSuccess({ title, text, className: 'eui-textBreakWord' });
       },
-      showDangerToast: (title: string, text?: string) => {
-        toasts.addDanger({ title, text, className: 'eui-textBreakWord' });
+      showDangerToast: (title: string, text?: React.ReactNode) => {
+        // Rich (non-string) content must be rendered via a mount point.
+        const mountedText =
+          text != null && typeof text !== 'string'
+            ? toMountPoint(text, services.rendering)
+            : text ?? undefined;
+        toasts.addDanger({ title, text: mountedText, className: 'eui-textBreakWord' });
       },
       showInfoToast: (title: string, text?: string) => {
         toasts.addInfo({
@@ -195,7 +201,7 @@ export const useCasesToast = () => {
         });
       },
     }),
-    [i18n, theme, userProfile, appId, getUrlForApp, navigateToUrl, toasts]
+    [i18n, theme, userProfile, appId, getUrlForApp, navigateToUrl, toasts, rendering]
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
@@ -188,7 +188,7 @@ export const useCasesToast = () => {
         // Rich (non-string) content must be rendered via a mount point.
         const mountedText =
           text != null && typeof text !== 'string'
-            ? toMountPoint(text, services.rendering)
+            ? toMountPoint(text, rendering)
             : text ?? undefined;
         toasts.addDanger({ title, text: mountedText, className: 'eui-textBreakWord' });
       },

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/file/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/file/translations.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
+import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 export const FILE_DISPLAY_NAME = i18n.translate('xpack.cases.attachments.file.displayName', {
   defaultMessage: 'Files',
@@ -76,6 +78,60 @@ export const SEARCH_PLACEHOLDER = i18n.translate('xpack.cases.caseView.files.sea
 export const FAILED_UPLOAD = i18n.translate('xpack.cases.caseView.files.failedUpload', {
   defaultMessage: 'Failed to upload file',
 });
+
+export const SUPPORTED_FORMATS = (
+  <FormattedMessage
+    id="xpack.cases.caseView.files.supportedFormats"
+    defaultMessage="<b>Supported formats:</b> Images, Documents, and Archives."
+    values={{ b: (chunks) => <strong>{chunks}</strong> }}
+  />
+);
+
+export const SUPPORTED_FORMATS_TOOLTIP_ARIA_LABEL = i18n.translate(
+  'xpack.cases.caseView.files.supportedFormatsTooltipAriaLabel',
+  {
+    defaultMessage: 'View commonly supported file formats',
+  }
+);
+
+export const SUPPORTED_FORMATS_FULL_LIST = (
+  <>
+    <FormattedMessage
+      id="xpack.cases.caseView.files.supportedFormatsImages"
+      defaultMessage="<b>Images:</b> PNG, JPEG, JPEG 2000, WebP, SVG, TIFF, BMP, AVIF, ICO, APNG, HEIC/HEIF, DjVu, DICOM, DWG, DXF, PSD, and other specialized formats."
+      values={{ b: (chunks) => <strong>{chunks}</strong> }}
+    />
+    <br />
+    <br />
+    <FormattedMessage
+      id="xpack.cases.caseView.files.supportedFormatsDocuments"
+      defaultMessage="<b>Documents:</b> PDF, Text, CSV, JSON."
+      values={{ b: (chunks) => <strong>{chunks}</strong> }}
+    />
+    <br />
+    <br />
+    <FormattedMessage
+      id="xpack.cases.caseView.files.supportedFormatsArchives"
+      defaultMessage="<b>Archives:</b> ZIP, GZIP, BZIP/BZIP2, 7Z, TAR."
+      values={{ b: (chunks) => <strong>{chunks}</strong> }}
+    />
+  </>
+);
+
+export const UNSUPPORTED_FILE_TYPE_TITLE = i18n.translate(
+  'xpack.cases.caseView.files.unsupportedFileTypeTitle',
+  {
+    defaultMessage: 'Unsupported file type',
+  }
+);
+
+export const UNSUPPORTED_FILE_TYPE = (
+  <FormattedMessage
+    id="xpack.cases.caseView.files.unsupportedFileType"
+    defaultMessage="The file type you are trying to upload is not supported.{br}{br}Supported formats include Images, Documents and Archives."
+    values={{ br: <br /> }}
+  />
+);
 
 export const UNKNOWN_MIME_TYPE = i18n.translate('xpack.cases.caseView.files.unknownMimeType', {
   defaultMessage: 'Unknown',

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/file/upload_file_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/file/upload_file_modal.test.tsx
@@ -53,6 +53,17 @@ const mockFileUpload = jest
         >
           {'test'}
         </button>
+        <button
+          data-test-subj="testOnMimeError"
+          type="button"
+          onClick={() => {
+            const mimeError = new Error('File type "application/x-foo" is not supported.');
+            (mimeError as { code?: string }).code = 'mimeTypeNotSupported';
+            onError(mimeError);
+          }}
+        >
+          {'test'}
+        </button>
         <button data-test-subj="testMetadata" type="button" onClick={() => validateMetadata(meta)}>
           {'test'}
         </button>
@@ -71,10 +82,12 @@ jest.mock('@kbn/shared-ux-file-upload', () => {
 describe('UploadFileModal', () => {
   const successMock = jest.fn();
   const errorMock = jest.fn();
+  const dangerMock = jest.fn();
 
   useToastsMock.mockImplementation(() => ({
     addSuccess: successMock,
     addError: errorMock,
+    addDanger: dangerMock,
   }));
 
   const createAttachmentsMock = jest.fn();
@@ -93,6 +106,14 @@ describe('UploadFileModal', () => {
     renderWithTestingProviders(<UploadFileModal caseId="foobar" onClose={onCloseMock} />);
 
     expect(await screen.findByTestId('cases-files-add-modal')).toBeInTheDocument();
+  });
+
+  it('renders the upload hint with max size and supported formats', async () => {
+    renderWithTestingProviders(<UploadFileModal caseId="foobar" onClose={onCloseMock} />);
+
+    const hint = await screen.findByTestId('cases-files-upload-hint');
+    expect(hint).toHaveTextContent(/Maximum file size:/);
+    expect(hint).toHaveTextContent(/Supported formats:/);
   });
 
   it('createAttachments called with the unified `file` attachment shape', async () => {
@@ -149,6 +170,19 @@ describe('UploadFileModal', () => {
       { name: 'upload error name', message: 'upload error message' },
       { title: 'Failed to upload file' }
     );
+  });
+
+  it('shows a categorized notice for unsupported file types instead of the raw mime message', async () => {
+    renderWithTestingProviders(<UploadFileModal caseId="foobar" onClose={onCloseMock} />);
+
+    await userEvent.click(await screen.findByTestId('testOnMimeError'));
+
+    // rich (bolded) content is rendered via a mount point, so assert on the
+    // title and that a danger toast was raised rather than the error toast
+    expect(dangerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Unsupported file type', text: expect.anything() })
+    );
+    expect(errorMock).not.toHaveBeenCalled();
   });
 
   it('forwards `caseId` and the owner from context to FileUpload `meta`', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/file/upload_file_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/file/upload_file_modal.tsx
@@ -5,15 +5,29 @@
  * 2.0.
  */
 
-import { EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle } from '@elastic/eui';
-import React, { useCallback } from 'react';
+import {
+  EuiIconTip,
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import numeral from '@elastic/numeral';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { useCallback, useMemo } from 'react';
 
 import type { UploadedFile } from '@kbn/shared-ux-file-upload/src/file_upload';
 
 import { FILE_SO_TYPE } from '@kbn/files-plugin/common';
 import { FileUpload } from '@kbn/shared-ux-file-upload';
+import { useFilesContext } from '@kbn/shared-ux-file-context';
+import type { FileKindBrowser } from '@kbn/shared-ux-file-types';
 
-import { FILE_ATTACHMENT_TYPE } from '../../../../common/constants';
+import { FILE_ATTACHMENT_TYPE, MAX_FILE_SIZE } from '../../../../common/constants';
 import { constructFileKindIdByOwner } from '../../../../common/files';
 import type { Owner } from '../../../../common/constants/types';
 
@@ -25,22 +39,94 @@ import { useRefreshCaseViewPage } from '../../case_view/use_on_refresh_case_view
 import { deleteFileAttachments } from '../../../containers/api';
 import type { ServerError } from '../../../types';
 
+// Static copy shown below the upload box: the accepted file size limits and
+// supported formats. Kept in this file to ease backports.
+const UploadFileHint = React.memo<{ kind: string }>(({ kind }) => {
+  const { euiTheme } = useEuiTheme();
+  const { client: filesClient } = useFilesContext();
+
+  const maxSizeHint = useMemo(() => {
+    const { maxSizeBytes } = filesClient.getFileKind(kind) as FileKindBrowser;
+    // `maxSizeBytes` may be a per-file callback (Cases derives a smaller limit
+    // for images), so resolve it with a representative image and non-image file.
+    const resolveMax = (file: File): number =>
+      typeof maxSizeBytes === 'function' ? maxSizeBytes(file) : maxSizeBytes ?? MAX_FILE_SIZE;
+    const generalMax = resolveMax({ type: 'application/pdf' } as File);
+    const imageMax = resolveMax({ type: 'image/png' } as File);
+    const format = (bytes: number) => numeral(bytes).format('0,0.[0] b');
+
+    return imageMax !== generalMax ? (
+      <FormattedMessage
+        id="xpack.cases.caseView.files.maxFileSizeHintWithImage"
+        defaultMessage="<b>Maximum file size:</b> {maxSize} for Documents and Archives, {imageMaxSize} for Images."
+        values={{
+          maxSize: format(generalMax),
+          imageMaxSize: format(imageMax),
+          b: (chunks) => <strong>{chunks}</strong>,
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.cases.caseView.files.maxFileSizeHint"
+        defaultMessage="<b>Maximum file size:</b> {maxSize}."
+        values={{ maxSize: format(generalMax), b: (chunks) => <strong>{chunks}</strong> }}
+      />
+    );
+  }, [filesClient, kind]);
+
+  return (
+    <EuiText
+      size="xs"
+      color="subdued"
+      data-test-subj="cases-files-upload-hint"
+      css={css`
+        p {
+          margin-block-end: ${euiTheme.size.xs};
+        }
+        p:last-of-type {
+          margin-block-end: 0;
+        }
+      `}
+    >
+      {maxSizeHint && <p>{maxSizeHint}</p>}
+      <p>
+        {i18n.SUPPORTED_FORMATS}{' '}
+        <EuiIconTip
+          type="info"
+          color="subdued"
+          aria-label={i18n.SUPPORTED_FORMATS_TOOLTIP_ARIA_LABEL}
+          content={i18n.SUPPORTED_FORMATS_FULL_LIST}
+        />
+      </p>
+    </EuiText>
+  );
+});
+UploadFileHint.displayName = 'UploadFileHint';
+
 export interface UploadFileModalProps {
   caseId: string;
   onClose: () => void;
 }
 
 const UploadFileModalComponent: React.FC<UploadFileModalProps> = ({ caseId, onClose }) => {
+  const { euiTheme } = useEuiTheme();
   const { owner } = useCasesContext();
   const { showDangerToast, showErrorToast, showSuccessToast } = useCasesToast();
   const { mutateAsync: createAttachments } = useCreateAttachments();
   const refreshAttachmentsTable = useRefreshCaseViewPage();
+  const kind = constructFileKindIdByOwner(owner[0] as Owner);
 
   const onError = useCallback(
     (error: Error | ServerError) => {
+      // Shared-ux tags an unsupported-type failure with a stable `code`; swap the
+      // raw message for a categorized notice. Other errors pass through unchanged.
+      if ((error as { code?: string }).code === 'mimeTypeNotSupported') {
+        showDangerToast(i18n.UNSUPPORTED_FILE_TYPE_TITLE, i18n.UNSUPPORTED_FILE_TYPE);
+        return;
+      }
       showErrorToast(error, { title: i18n.FAILED_UPLOAD });
     },
-    [showErrorToast]
+    [showDangerToast, showErrorToast]
   );
 
   const onUploadDone = useCallback(
@@ -97,17 +183,26 @@ const UploadFileModalComponent: React.FC<UploadFileModalProps> = ({ caseId, onCl
   );
 
   return (
-    <EuiModal data-test-subj="cases-files-add-modal" onClose={onClose} aria-label={i18n.ADD_FILE}>
+    <EuiModal
+      data-test-subj="cases-files-add-modal"
+      onClose={onClose}
+      aria-label={i18n.ADD_FILE}
+      css={css`
+        inline-size: ${euiTheme.components.forms.maxWidth};
+      `}
+    >
       <EuiModalHeader>
         <EuiModalHeaderTitle>{i18n.ADD_FILE}</EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
         <FileUpload
-          kind={constructFileKindIdByOwner(owner[0] as Owner)}
+          kind={kind}
           onDone={onUploadDone}
           onError={onError}
           meta={{ caseIds: [caseId], owner: [owner[0]] }}
         />
+        <EuiSpacer size="s" />
+        <UploadFileHint kind={kind} />
       </EuiModalBody>
     </EuiModal>
   );

--- a/x-pack/platform/plugins/shared/cases/public/files/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/files/index.test.ts
@@ -5,10 +5,17 @@
  * 2.0.
  */
 
-import { MAX_FILE_SIZE } from '../../common/constants';
+import { MAX_FILE_SIZE, MAX_IMAGE_FILE_SIZE } from '../../common/constants';
 import { createMockFilesSetup } from '@kbn/files-plugin/public/mocks';
 import { registerCaseFileKinds } from '.';
 import type { FilesConfig } from './types';
+
+const resolveMaxSizeBytes = (
+  maxSizeBytes: number | ((file: File) => number) | undefined,
+  file: File
+): number | undefined => (typeof maxSizeBytes === 'function' ? maxSizeBytes(file) : maxSizeBytes);
+
+const asFile = (type: string): File => ({ type } as File);
 
 describe('ui files index', () => {
   describe('registerCaseFileKinds', () => {
@@ -44,7 +51,7 @@ describe('ui files index', () => {
     describe('max file size', () => {
       describe('default max file size', () => {
         const config: FilesConfig = {
-          allowedMimeTypes: [],
+          allowedMimeTypes: ['image/png'],
           maxSize: undefined,
         };
 
@@ -52,28 +59,30 @@ describe('ui files index', () => {
           registerCaseFileKinds(config, mockFilesSetup);
         });
 
-        it('sets cases max file size to 100 mb', () => {
-          expect(mockFilesSetup.registerFileKind.mock.calls[0][0].maxSizeBytes).toEqual(
-            MAX_FILE_SIZE
-          );
+        it.each([
+          ['cases', 0],
+          ['observability', 1],
+          ['securitySolution', 2],
+        ])('sets %s non-image max file size to 100 mb', (_owner, index) => {
+          const { maxSizeBytes } = mockFilesSetup.registerFileKind.mock.calls[index][0];
+          expect(resolveMaxSizeBytes(maxSizeBytes, asFile('text/plain'))).toEqual(MAX_FILE_SIZE);
         });
 
-        it('sets observability max file size to 100 mb', () => {
-          expect(mockFilesSetup.registerFileKind.mock.calls[1][0].maxSizeBytes).toEqual(
-            MAX_FILE_SIZE
-          );
-        });
-
-        it('sets securitySolution max file size to 100 mb', () => {
-          expect(mockFilesSetup.registerFileKind.mock.calls[2][0].maxSizeBytes).toEqual(
-            MAX_FILE_SIZE
+        it.each([
+          ['cases', 0],
+          ['observability', 1],
+          ['securitySolution', 2],
+        ])('sets %s image max file size to 10 mb', (_owner, index) => {
+          const { maxSizeBytes } = mockFilesSetup.registerFileKind.mock.calls[index][0];
+          expect(resolveMaxSizeBytes(maxSizeBytes, asFile('image/png'))).toEqual(
+            MAX_IMAGE_FILE_SIZE
           );
         });
       });
 
       describe('custom file size', () => {
         const config: FilesConfig = {
-          allowedMimeTypes: [],
+          allowedMimeTypes: ['image/png'],
           maxSize: 5,
         };
 
@@ -81,16 +90,14 @@ describe('ui files index', () => {
           registerCaseFileKinds(config, mockFilesSetup);
         });
 
-        it('sets cases max file size to 5', () => {
-          expect(mockFilesSetup.registerFileKind.mock.calls[0][0].maxSizeBytes).toEqual(5);
-        });
-
-        it('sets observability max file size to 5', () => {
-          expect(mockFilesSetup.registerFileKind.mock.calls[1][0].maxSizeBytes).toEqual(5);
-        });
-
-        it('sets securitySolution max file size to 5', () => {
-          expect(mockFilesSetup.registerFileKind.mock.calls[2][0].maxSizeBytes).toEqual(5);
+        it.each([
+          ['cases', 0],
+          ['observability', 1],
+          ['securitySolution', 2],
+        ])('sets %s max file size to the configured value for any file type', (_owner, index) => {
+          const { maxSizeBytes } = mockFilesSetup.registerFileKind.mock.calls[index][0];
+          expect(resolveMaxSizeBytes(maxSizeBytes, asFile('text/plain'))).toEqual(5);
+          expect(resolveMaxSizeBytes(maxSizeBytes, asFile('image/png'))).toEqual(5);
         });
       });
     });

--- a/x-pack/platform/plugins/shared/cases/public/files/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/files/index.ts
@@ -10,14 +10,36 @@ import type { FileKindBrowser } from '@kbn/shared-ux-file-types';
 import {
   GENERAL_CASES_OWNER,
   MAX_FILE_SIZE,
+  MAX_IMAGE_FILE_SIZE,
   OBSERVABILITY_OWNER,
   OWNERS,
   SECURITY_SOLUTION_OWNER,
 } from '../../common/constants';
+import { IMAGE_MIME_TYPES } from '../../common/constants/mime_types';
 import type { Owner } from '../../common/constants/types';
 import { constructFileKindIdByOwner } from '../../common/files';
 import type { CaseFileKinds, FilesConfig } from './types';
 import * as i18n from './translations';
+
+/**
+ * Mirrors the server-side per-file limit (see `createMaxCallback`) so oversized
+ * images are rejected client-side before uploading instead of failing mid-stream.
+ */
+const createMaxSizeBytes =
+  (config: FilesConfig) =>
+  (file: File): number => {
+    if (config.maxSize != null) {
+      return config.maxSize;
+    }
+
+    const allowedMimeTypesSet = new Set(config.allowedMimeTypes);
+
+    if (file.type && allowedMimeTypesSet.has(file.type) && IMAGE_MIME_TYPES.has(file.type)) {
+      return MAX_IMAGE_FILE_SIZE;
+    }
+
+    return MAX_FILE_SIZE;
+  };
 
 const getOwnerUIName = (owner: Owner) => {
   switch (owner) {
@@ -36,7 +58,10 @@ const buildFileKind = (config: FilesConfig, owner: Owner): FileKindBrowser => {
   return {
     id: constructFileKindIdByOwner(owner),
     allowedMimeTypes: config.allowedMimeTypes,
-    maxSizeBytes: config.maxSize ?? MAX_FILE_SIZE,
+    maxSizeBytes: createMaxSizeBytes(config),
+    // The allow-list is long; the upload modal shows the supported categories
+    // itself, so omit the raw MIME list from the shared-ux error.
+    listAllowedMimeTypesInError: false,
     managementUiActions: {
       delete: {
         enabled: false,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Cases][Shared UX] File modal improvements (#277567)](https://github.com/elastic/kibana/pull/277567)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-16T06:01:25Z","message":"[Cases][Shared UX] File modal improvements (#277567)\n\n## Summary\n\nRef: https://github.com/elastic/security-team/issues/16475\n\nThis PR makes some improvements to the file modal\n\n### Before:\n- File size limit is shown in bytes\n  \n<img width=\"434\" height=\"256\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/84b8d9d5-b530-4778-8e2c-80379125b7ba\"\n/>\n\n- Uploading an unsupported type shows a long list of supported types\n<img width=\"881\" height=\"610\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1aea6b5e-8813-4fda-86d9-e4b0d06ed61a\"\n/>\n\n- Upon uploading an oversize file, upload a smaller file does not clear\nthe error state\n\n### After\n- File size limit uses proper unit\n- Added option to opt of of showing supported types\n- Clear error state when a new file is added \n- Added per file size limit check (in Cases, image limit is 10MB, others\nare 100MB)\n- Cases only: added supported file and size limit in the modal\n\n<img width=\"476\" height=\"301\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/62fc620d-d0a4-4aeb-a5c1-2fb264acce18\"\n/>\n\n<img width=\"423\" height=\"349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cdcf1eb2-f6c9-47fc-a511-4f8fc57c7698\"\n/>\n\n<img width=\"547\" height=\"344\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2f844b75-0ce9-40ef-a626-4b92d4cb4388\"\n/>\n\n\nhttps://github.com/user-attachments/assets/4ae75a25-39e7-4c5a-a427-b2ea30723c3d\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"0d0404b3aadae8418498cda078cf57e941c5dd80","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Team:Cases","reviewer:skip-ai","v9.5.0","v9.4.4","v9.6.0"],"title":"[Cases][Shared UX] File modal improvements","number":277567,"url":"https://github.com/elastic/kibana/pull/277567","mergeCommit":{"message":"[Cases][Shared UX] File modal improvements (#277567)\n\n## Summary\n\nRef: https://github.com/elastic/security-team/issues/16475\n\nThis PR makes some improvements to the file modal\n\n### Before:\n- File size limit is shown in bytes\n  \n<img width=\"434\" height=\"256\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/84b8d9d5-b530-4778-8e2c-80379125b7ba\"\n/>\n\n- Uploading an unsupported type shows a long list of supported types\n<img width=\"881\" height=\"610\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1aea6b5e-8813-4fda-86d9-e4b0d06ed61a\"\n/>\n\n- Upon uploading an oversize file, upload a smaller file does not clear\nthe error state\n\n### After\n- File size limit uses proper unit\n- Added option to opt of of showing supported types\n- Clear error state when a new file is added \n- Added per file size limit check (in Cases, image limit is 10MB, others\nare 100MB)\n- Cases only: added supported file and size limit in the modal\n\n<img width=\"476\" height=\"301\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/62fc620d-d0a4-4aeb-a5c1-2fb264acce18\"\n/>\n\n<img width=\"423\" height=\"349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cdcf1eb2-f6c9-47fc-a511-4f8fc57c7698\"\n/>\n\n<img width=\"547\" height=\"344\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2f844b75-0ce9-40ef-a626-4b92d4cb4388\"\n/>\n\n\nhttps://github.com/user-attachments/assets/4ae75a25-39e7-4c5a-a427-b2ea30723c3d\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"0d0404b3aadae8418498cda078cf57e941c5dd80"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277567","number":277567,"mergeCommit":{"message":"[Cases][Shared UX] File modal improvements (#277567)\n\n## Summary\n\nRef: https://github.com/elastic/security-team/issues/16475\n\nThis PR makes some improvements to the file modal\n\n### Before:\n- File size limit is shown in bytes\n  \n<img width=\"434\" height=\"256\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/84b8d9d5-b530-4778-8e2c-80379125b7ba\"\n/>\n\n- Uploading an unsupported type shows a long list of supported types\n<img width=\"881\" height=\"610\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1aea6b5e-8813-4fda-86d9-e4b0d06ed61a\"\n/>\n\n- Upon uploading an oversize file, upload a smaller file does not clear\nthe error state\n\n### After\n- File size limit uses proper unit\n- Added option to opt of of showing supported types\n- Clear error state when a new file is added \n- Added per file size limit check (in Cases, image limit is 10MB, others\nare 100MB)\n- Cases only: added supported file and size limit in the modal\n\n<img width=\"476\" height=\"301\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/62fc620d-d0a4-4aeb-a5c1-2fb264acce18\"\n/>\n\n<img width=\"423\" height=\"349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cdcf1eb2-f6c9-47fc-a511-4f8fc57c7698\"\n/>\n\n<img width=\"547\" height=\"344\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2f844b75-0ce9-40ef-a626-4b92d4cb4388\"\n/>\n\n\nhttps://github.com/user-attachments/assets/4ae75a25-39e7-4c5a-a427-b2ea30723c3d\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"0d0404b3aadae8418498cda078cf57e941c5dd80"}}]}] BACKPORT-->