### PR TITLE
[9.4] [SO migrations] Reduce memory usage on memory-constrained instances (#277714)

### DIFF
--- a/src/core/packages/saved-objects/migration-server-internal/src/low_memory.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/low_memory.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import v8 from 'v8';
+import {
+  LOW_MEMORY_BATCH_SIZE,
+  LOW_MEMORY_HEAP_SIZE_LIMIT_BYTES,
+  isMemoryConstrained,
+} from './low_memory';
+
+describe('isMemoryConstrained', () => {
+  it('returns true when the provided heap size limit is below the threshold', () => {
+    expect(isMemoryConstrained(LOW_MEMORY_HEAP_SIZE_LIMIT_BYTES - 1)).toBe(true);
+    expect(isMemoryConstrained(512 * 1024 * 1024)).toBe(true);
+  });
+
+  it('returns false when the provided heap size limit is at or above the threshold', () => {
+    expect(isMemoryConstrained(LOW_MEMORY_HEAP_SIZE_LIMIT_BYTES)).toBe(false);
+    expect(isMemoryConstrained(2 * 1024 * 1024 * 1024)).toBe(false);
+  });
+
+  it('defaults to the V8 heap size limit of the current process', () => {
+    const spy = jest
+      .spyOn(v8, 'getHeapStatistics')
+      .mockReturnValue({ heap_size_limit: 512 * 1024 * 1024 } as v8.HeapInfo);
+
+    expect(isMemoryConstrained()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockReturnValue({ heap_size_limit: 4 * 1024 * 1024 * 1024 } as v8.HeapInfo);
+    expect(isMemoryConstrained()).toBe(false);
+
+    spy.mockRestore();
+  });
+
+  it('uses a 1GB heap size limit as the threshold', () => {
+    expect(LOW_MEMORY_HEAP_SIZE_LIMIT_BYTES).toBe(1 * 1024 * 1024 * 1024);
+  });
+
+  it('uses a reduced batch size of 100', () => {
+    expect(LOW_MEMORY_BATCH_SIZE).toBe(100);
+  });
+});

--- a/src/core/packages/saved-objects/migration-server-internal/src/low_memory.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/low_memory.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import v8 from 'v8';
+
+/**
+ * The heap size limit (in bytes) below which a Kibana instance is considered
+ * memory-constrained for the purpose of saved object migrations.
+ *
+ * Instances configured with a heap of 1GB or less are the ones observed to OOM
+ * or time out while replaying bulk writes during ECH upgrades, so we make the
+ * migration back off to reduce its peak memory usage.
+ */
+export const LOW_MEMORY_HEAP_SIZE_LIMIT_BYTES = 1 * 1024 * 1024 * 1024;
+
+/**
+ * The bulk-write batch size to use on memory-constrained instances.
+ *
+ * Lowering the batch size reduces the number of documents that are held in
+ * memory at any given time (the read batch, the transformed batch and the bulk
+ * operation body), trading a longer migration for a lower memory footprint.
+ */
+export const LOW_MEMORY_BATCH_SIZE = 100;
+
+/**
+ * Returns `true` when the current Node.js process is running with a heap size
+ * limit small enough that saved object migrations should back off (run
+ * sequentially with a reduced batch size) to lower their peak memory usage.
+ *
+ * @param heapSizeLimit The heap size limit in bytes. Defaults to the limit
+ * reported by V8 for the current process (reflects `--max-old-space-size`).
+ */
+export const isMemoryConstrained = (
+  heapSizeLimit: number = v8.getHeapStatistics().heap_size_limit
+): boolean => heapSizeLimit < LOW_MEMORY_HEAP_SIZE_LIMIT_BYTES;

--- a/src/core/packages/saved-objects/migration-server-internal/src/run_v2_migration.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/run_v2_migration.test.ts
@@ -35,6 +35,15 @@ import {
   savedObjectTypeRegistryMock,
 } from './run_resilient_migrator.fixtures';
 import { getIndexDetails } from './core/get_index_details';
+import { isMemoryConstrained } from './low_memory';
+
+jest.mock('./low_memory', () => {
+  const actual = jest.requireActual('./low_memory');
+  return {
+    ...actual,
+    isMemoryConstrained: jest.fn(() => false),
+  };
+});
 
 jest.mock('./core', () => {
   const actual = jest.requireActual('./core');
@@ -116,6 +125,9 @@ const mockRunResilientMigrator = runResilientMigrator as jest.MockedFunction<
 >;
 
 const mockGetIndexDetails = getIndexDetails as jest.MockedFunction<typeof getIndexDetails>;
+const mockIsMemoryConstrained = isMemoryConstrained as jest.MockedFunction<
+  typeof isMemoryConstrained
+>;
 
 describe('runV2Migration', () => {
   beforeEach(() => {
@@ -123,7 +135,10 @@ describe('runV2Migration', () => {
     mockIndexMapToIndexTypesMap.mockClear();
     mockCreateWaitGroupMap.mockClear();
     mockGetIndicesInvolvedInRelocation.mockClear();
-    mockRunResilientMigrator.mockClear();
+    mockRunResilientMigrator.mockReset();
+    mockRunResilientMigrator.mockResolvedValue(V2_SUCCESSFUL_MIGRATION_RESULT[0]);
+    mockIsMemoryConstrained.mockReset();
+    mockIsMemoryConstrained.mockReturnValue(false);
   });
 
   it('rejects if prepare migrations has not been called on the documentMigrator', async () => {
@@ -285,6 +300,80 @@ describe('runV2Migration', () => {
     options.documentMigrator.prepareMigrations();
 
     await expect(runV2Migration(options)).rejects.toThrowError(myTaskIndexMigratorError);
+  });
+
+  describe('when the instance is memory constrained', () => {
+    beforeEach(() => {
+      mockIsMemoryConstrained.mockReturnValue(true);
+    });
+
+    it('reduces the batch size to 100 and passes it to each migrator', async () => {
+      const options = mockOptions();
+      options.migrationConfig = { ...options.migrationConfig, batchSize: 1000 };
+      options.documentMigrator.prepareMigrations();
+
+      await runV2Migration(options);
+
+      expect(runResilientMigrator).toHaveBeenCalledTimes(3);
+      for (let nth = 1; nth <= 3; nth++) {
+        expect(runResilientMigrator).toHaveBeenNthCalledWith(
+          nth,
+          expect.objectContaining({
+            migrationsConfig: expect.objectContaining({ batchSize: 100 }),
+          })
+        );
+      }
+    });
+
+    it('does not increase the batch size when it is already below the reduced value', async () => {
+      const options = mockOptions();
+      options.migrationConfig = { ...options.migrationConfig, batchSize: 20 };
+      options.documentMigrator.prepareMigrations();
+
+      await runV2Migration(options);
+
+      expect(runResilientMigrator).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          migrationsConfig: expect.objectContaining({ batchSize: 20 }),
+        })
+      );
+    });
+
+    it('runs the migrators sequentially rather than in parallel', async () => {
+      const resolvers: Array<(value: MigrationResult) => void> = [];
+      mockRunResilientMigrator.mockImplementation(
+        () => new Promise<MigrationResult>((resolve) => resolvers.push(resolve))
+      );
+
+      const options = mockOptions();
+      options.documentMigrator.prepareMigrations();
+
+      let migrationResults: MigrationResult[] | undefined;
+      runV2Migration(options).then((results) => (migrationResults = results));
+
+      await nextTick();
+      // only the first migrator should have started
+      expect(runResilientMigrator).toHaveBeenCalledTimes(1);
+
+      resolvers[0](V2_SUCCESSFUL_MIGRATION_RESULT[0]);
+      await nextTick();
+      // the second migrator only starts once the first has resolved
+      expect(runResilientMigrator).toHaveBeenCalledTimes(2);
+
+      resolvers[1](V2_SUCCESSFUL_MIGRATION_RESULT[1]);
+      await nextTick();
+      expect(runResilientMigrator).toHaveBeenCalledTimes(3);
+
+      expect(migrationResults).toBeUndefined();
+      resolvers[2](V2_SUCCESSFUL_MIGRATION_RESULT[2]);
+      await nextTick();
+      expect(migrationResults).toEqual([
+        V2_SUCCESSFUL_MIGRATION_RESULT[0],
+        V2_SUCCESSFUL_MIGRATION_RESULT[1],
+        V2_SUCCESSFUL_MIGRATION_RESULT[2],
+      ]);
+    });
   });
 });
 

--- a/src/core/packages/saved-objects/migration-server-internal/src/run_v2_migration.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/run_v2_migration.ts
@@ -37,6 +37,7 @@ import {
   indexMapToIndexTypesMap,
 } from './kibana_migrator_utils';
 import { runResilientMigrator } from './run_resilient_migrator';
+import { LOW_MEMORY_BATCH_SIZE, isMemoryConstrained } from './low_memory';
 import { migrateRawDocsSafely } from './core/migrate_raw_docs';
 import type { IndexDetails } from './core/get_index_details';
 import { extractVersionFromKibanaIndexAliases, getIndexDetails } from './core/get_index_details';
@@ -169,6 +170,24 @@ export const runV2Migration = async (options: RunV2MigrationOpts): Promise<Migra
     useModelVersionsOnly: true,
   });
 
+  // On memory-constrained instances, migrations are prone to OOM/timeout while
+  // replaying bulk writes. Back off by running index migrators sequentially and
+  // reducing the batch size, trading a longer migration for a lower memory
+  // footprint.
+  const memoryConstrained = isMemoryConstrained();
+  const migrationConfig: SavedObjectsMigrationConfigType = memoryConstrained
+    ? {
+        ...options.migrationConfig,
+        batchSize: Math.min(options.migrationConfig.batchSize, LOW_MEMORY_BATCH_SIZE),
+      }
+    : options.migrationConfig;
+
+  if (memoryConstrained) {
+    options.logger.info(
+      'Kibana is running below the recommended minimum of 2GB of memory. Upgrade migrations will still complete, but will take longer. We recommend running Kibana with at least 2GB of memory.'
+    );
+  }
+
   const migrators = Array.from(migratorIndices).map((indexName, i) => {
     return {
       migrate: (): Promise<MigrationResult> => {
@@ -218,7 +237,7 @@ export const runV2Migration = async (options: RunV2MigrationOpts): Promise<Migra
             includeDeferred: false,
           }),
           indexPrefix: indexName,
-          migrationsConfig: options.migrationConfig,
+          migrationsConfig: migrationConfig,
           typeRegistry: options.typeRegistry,
           docLinks: options.docLinks,
           esCapabilities: options.esCapabilities,
@@ -228,24 +247,34 @@ export const runV2Migration = async (options: RunV2MigrationOpts): Promise<Migra
     };
   });
 
-  return Promise.all(
-    migrators.map(async (migrator) => {
-      const startTime = performance.now();
-      try {
-        const result = await migrator.migrate();
-        const duration = performance.now() - startTime;
-        options.meter.record(duration, {
-          'kibana.saved_objects.migrations.migrator': migrator.indexPrefix,
-        });
-        return result;
-      } catch (error) {
-        const duration = performance.now() - startTime;
-        options.meter.record(duration, {
-          'kibana.saved_objects.migrations.migrator': migrator.indexPrefix,
-          'error.type': error.message, // Ideally, we had codes for each error instead.
-        });
-        throw error;
-      }
-    })
-  );
+  const runMigrator = async (migrator: (typeof migrators)[number]): Promise<MigrationResult> => {
+    const startTime = performance.now();
+    try {
+      const result = await migrator.migrate();
+      const duration = performance.now() - startTime;
+      options.meter.record(duration, {
+        'kibana.saved_objects.migrations.migrator': migrator.indexPrefix,
+      });
+      return result;
+    } catch (error) {
+      const duration = performance.now() - startTime;
+      options.meter.record(duration, {
+        'kibana.saved_objects.migrations.migrator': migrator.indexPrefix,
+        'error.type': error.message, // Ideally, we had codes for each error instead.
+      });
+      throw error;
+    }
+  };
+
+  if (memoryConstrained) {
+    // Run migrators one at a time so that only a single index migration holds
+    // documents in memory at any given time.
+    const results: MigrationResult[] = [];
+    for (const migrator of migrators) {
+      results.push(await runMigrator(migrator));
+    }
+    return results;
+  }
+
+  return Promise.all(migrators.map(runMigrator));
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[SO migrations] Reduce memory usage on memory-constrained instances (#277714)](https://github.com/elastic/kibana/pull/277714)

<!--- Backport version: manual -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Made with [Cursor](https://cursor.com)