### PR TITLE
[Fleet] Enable enableOtelUI feature flag by default

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -33,7 +33,7 @@ const _allowedExperimentalValues = {
   enableOpAMP: true, // When enabled, OpAMP features will be available in the API and UI.
   enableOTelVerifier: true, // When enabled, OTel-based cloud connector permission verification is active.
   enableResolveDependencies: true, // When enabled, the resolve dependencies step will be available during package installation.
-  enableOtelUI: false, // When enabled, OTel-specific UI elements (e.g. Collector Config tab) will be shown.
+  enableOtelUI: true, // When enabled, OTel-specific UI elements (e.g. Collector Config tab) will be shown.
   enableCloudOnboardingDeployments: false, // When enabled, the cloud-onboarding-deployment CRUD API is registered and available.
 };
 


### PR DESCRIPTION
## Summary

Enables the \`enableOtelUI\` experimental feature flag by default, making OTel-specific UI elements (Collector Config tab, collector details view for OPAMP agents) available without requiring manual configuration.

Relates https://github.com/elastic/ingest-dev/issues/7066

## What this does

Sets \`enableOtelUI: true\` in \`experimental_features.ts\`. This flag gates:
- The \`CollectorDetailsContent\` view for agents with \`type === 'OPAMP'\` on the agent details page
- The Collector Config tab and associated OTel UI elements

## Why now

QA has validated this feature on 9.5.0-SNAPSHOT (see ingest-dev#7066 comments) — all test scenarios passed across Linux, Windows, and macOS. The feature is ready to ship without the flag.

## Test plan

- [x] Enroll an OpAMP collector and confirm the Collector Details page (Health / Info / Config tabs) renders without enabling any feature flag
- [x] Confirm regular (non-OPAMP) agents still render the standard \`AgentDetailsContent\` view
- [x] Confirm the existing unit tests pass (\`agent_details_page/index.test.tsx\`)

## Release note

OTel collector UI is now enabled by default in Fleet. When an OpAMP-managed collector is enrolled, its agent details page shows dedicated Health, Info, and Config tabs instead of the standard agent view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->