### PR TITLE
[9.5] [Lens] Fix ES|QL chart filtering. (#277826)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/expressions/defs/map_to_columns/types.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/defs/map_to_columns/types.ts
@@ -20,6 +20,8 @@ export type OriginalColumn = {
 } & (
   | { operationType: 'date_histogram'; sourceField: string; interval: number }
   | { operationType: string; sourceField?: string; interval: never }
+  // text-based ES|QL columns
+  | { operationType?: undefined; sourceField?: string }
 );
 
 export type MapToColumnsExpressionFunction = ExpressionFunctionDefinition<

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/convert_to_text_based_layer.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/convert_to_text_based_layer.ts
@@ -115,7 +115,8 @@ function buildTextBasedState(
         column.customLabel = true; // set always to true so we can use the default label as a custom label
         if (hasCustomLabel) {
           column.label = sourceColumn.label;
-        } else {
+          // This is a sanity check to satisfy TS for the incoming form based column.
+        } else if ('operationType' in sourceColumn && sourceColumn.operationType) {
           // use the generated default label
           column.label = operationDefinitionMap[sourceColumn.operationType].getDefaultLabel(
             layer.columns[sourceColumn.id],

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.test.ts
@@ -1166,7 +1166,7 @@ describe('Textbased Data Source', () => {
             Object {
               "arguments": Object {
                 "idMap": Array [
-                  "{\\"Test 1\\":[{\\"id\\":\\"a\\",\\"label\\":\\"Test 1\\",\\"dataType\\":\\"number\\",\\"operationType\\":\\"literal\\"}],\\"Test 2\\":[{\\"id\\":\\"b\\",\\"label\\":\\"Test 2\\",\\"dataType\\":\\"number\\",\\"operationType\\":\\"literal\\"}]}",
+                  "{\\"Test 1\\":[{\\"id\\":\\"a\\",\\"label\\":\\"Test 1\\",\\"dataType\\":\\"number\\"}],\\"Test 2\\":[{\\"id\\":\\"b\\",\\"label\\":\\"Test 2\\",\\"dataType\\":\\"number\\"}]}",
                 ],
                 "isTextBased": Array [
                   true,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.test.ts
@@ -58,7 +58,6 @@ describe('toExpression', () => {
       id: 'a',
       label: '@timestamp',
       dataType: 'date',
-      operationType: 'literal',
     });
     expect(idMap['@timestamp'][0]).not.toHaveProperty('dropPartials');
   });
@@ -84,7 +83,6 @@ describe('toExpression', () => {
       label: '@timestamp',
       dropPartials: false,
       dataType: 'date',
-      operationType: 'literal',
     });
   });
 
@@ -109,7 +107,6 @@ describe('toExpression', () => {
       label: '@timestamp',
       dropPartials: true,
       dataType: 'date',
-      operationType: 'literal',
     });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
@@ -25,7 +25,7 @@ function getExpressionForLayer(
   layer.columns.forEach((col) => {
     // Only pick fields that OriginalColumn declares; the Omit<> drops the
     // `interval: never` discriminant that doesn't apply to text-based columns.
-    const entry = {
+    const entry: OriginalColumn = {
       id: col.columnId,
       label: col.customLabel ? col.label ?? col.fieldName : col.fieldName,
       variable: col.variable,
@@ -33,8 +33,9 @@ function getExpressionForLayer(
       format: col.params?.format,
       dataType: col.meta?.type as OriginalColumn['dataType'],
       customLabel: col.customLabel,
-      operationType: 'literal',
-    } as OriginalColumn;
+      // no operation type for text-based columns
+      operationType: undefined,
+    };
     if (idMapper[col.fieldName]) {
       idMapper[col.fieldName].push(entry);
     } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Lens] Fix ES|QL chart filtering. (#277826)](https://github.com/elastic/kibana/pull/277826)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Walter M. Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2026-07-14T09:46:49Z","message":"[Lens] Fix ES|QL chart filtering. (#277826)\n\n## Summary\n\nFixes ES|QL chart click filtering which produced `exists` filters\ninstead of value-matching `match_phrase` filters.\n\nThe text-based datasource `to_expression.ts` set `operationType:\n'literal'` on every ES|QL column in the idMap. Downstream,\n`createFilterESQL` uses `operationType` as a routing discriminator:\n\n- `'date_histogram'` / `'histogram'` → range filter ✅\n- `undefined` → phrase filter via raw column path ✅\n- any other string (including `'literal'`) → `buildSimpleExistFilter` ❌\n\nThe `'literal'` value was introduced as a type-satisfying placeholder\nwhen the `OriginalColumn` discriminated union required `operationType:\nstring`. The runtime code in `mapToOriginalColumnsTextBased` already\nguarded with `'operationType' in originalColumn`, so absence was already\nhandled — the type just did not reflect it.\n\n**Changes:**\n- Add a third union variant to `OriginalColumn` (`operationType?:\nundefined`) for text-based columns that have no aggregation operation\n- Remove `operationType: 'literal'` from `to_expression.ts`\n- Guard `convert_to_text_based_layer.ts` against `undefined`\noperationType\n- Update test expectations\n\nThis is a follow-up bugfix to\nhttps://github.com/elastic/kibana/pull/272499\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk: type change to `OriginalColumn` adds a new union variant — all\nexisting consumers already handle the `undefined` case at runtime","sha":"4229965fd4ec745f9d6060c777927ee4f5277b8e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.5.0","v9.6.0"],"title":"[Lens] Fix ES|QL chart filtering.","number":277826,"url":"https://github.com/elastic/kibana/pull/277826","mergeCommit":{"message":"[Lens] Fix ES|QL chart filtering. (#277826)\n\n## Summary\n\nFixes ES|QL chart click filtering which produced `exists` filters\ninstead of value-matching `match_phrase` filters.\n\nThe text-based datasource `to_expression.ts` set `operationType:\n'literal'` on every ES|QL column in the idMap. Downstream,\n`createFilterESQL` uses `operationType` as a routing discriminator:\n\n- `'date_histogram'` / `'histogram'` → range filter ✅\n- `undefined` → phrase filter via raw column path ✅\n- any other string (including `'literal'`) → `buildSimpleExistFilter` ❌\n\nThe `'literal'` value was introduced as a type-satisfying placeholder\nwhen the `OriginalColumn` discriminated union required `operationType:\nstring`. The runtime code in `mapToOriginalColumnsTextBased` already\nguarded with `'operationType' in originalColumn`, so absence was already\nhandled — the type just did not reflect it.\n\n**Changes:**\n- Add a third union variant to `OriginalColumn` (`operationType?:\nundefined`) for text-based columns that have no aggregation operation\n- Remove `operationType: 'literal'` from `to_expression.ts`\n- Guard `convert_to_text_based_layer.ts` against `undefined`\noperationType\n- Update test expectations\n\nThis is a follow-up bugfix to\nhttps://github.com/elastic/kibana/pull/272499\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk: type change to `OriginalColumn` adds a new union variant — all\nexisting consumers already handle the `undefined` case at runtime","sha":"4229965fd4ec745f9d6060c777927ee4f5277b8e"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277826","number":277826,"mergeCommit":{"message":"[Lens] Fix ES|QL chart filtering. (#277826)\n\n## Summary\n\nFixes ES|QL chart click filtering which produced `exists` filters\ninstead of value-matching `match_phrase` filters.\n\nThe text-based datasource `to_expression.ts` set `operationType:\n'literal'` on every ES|QL column in the idMap. Downstream,\n`createFilterESQL` uses `operationType` as a routing discriminator:\n\n- `'date_histogram'` / `'histogram'` → range filter ✅\n- `undefined` → phrase filter via raw column path ✅\n- any other string (including `'literal'`) → `buildSimpleExistFilter` ❌\n\nThe `'literal'` value was introduced as a type-satisfying placeholder\nwhen the `OriginalColumn` discriminated union required `operationType:\nstring`. The runtime code in `mapToOriginalColumnsTextBased` already\nguarded with `'operationType' in originalColumn`, so absence was already\nhandled — the type just did not reflect it.\n\n**Changes:**\n- Add a third union variant to `OriginalColumn` (`operationType?:\nundefined`) for text-based columns that have no aggregation operation\n- Remove `operationType: 'literal'` from `to_expression.ts`\n- Guard `convert_to_text_based_layer.ts` against `undefined`\noperationType\n- Update test expectations\n\nThis is a follow-up bugfix to\nhttps://github.com/elastic/kibana/pull/272499\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk: type change to `OriginalColumn` adds a new union variant — all\nexisting consumers already handle the `undefined` case at runtime","sha":"4229965fd4ec745f9d6060c777927ee4f5277b8e"}}]}] BACKPORT-->