### PR TITLE
[Fleet] Hide agent based policies table if the count is zero

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.test.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 
+import { screen } from '@testing-library/react';
+
 import { createIntegrationsTestRendererMock } from '../../../../../../../mock';
 import { allowedExperimentalValues } from '../../../../../../../../common/experimental_features';
 import { ExperimentalFeaturesService } from '../../../../../services';
@@ -173,5 +175,61 @@ describe('PackagePoliciesPage agentless table source', () => {
     const legacyCall = legacyAgentlessCall();
     expect(legacyCall).toBeDefined();
     expect(legacyCall![1]).toEqual({ enabled: true });
+  });
+});
+
+describe('PackagePoliciesPage agent-based section visibility', () => {
+  beforeEach(() => {
+    useGetPackageInfoByKeyQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+    jest.mocked(useAgentlessPolicies).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      resendRequest: jest.fn(),
+    } as unknown as ReturnType<typeof useAgentlessPolicies>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('hides the Agent-based section when the agent-based policy count is zero', () => {
+    jest.mocked(usePackagePoliciesWithAgentPolicy).mockReturnValue({
+      data: { items: [], total: 0, page: 1, perPage: 10 },
+      isLoading: false,
+      error: null,
+      resendRequest: jest.fn(),
+    } as unknown as ReturnType<typeof usePackagePoliciesWithAgentPolicy>);
+
+    renderPage();
+
+    expect(screen.queryByText('Agent-based')).toBeNull();
+  });
+
+  it('shows the Agent-based section when the agent-based policy count is greater than zero', () => {
+    jest.mocked(usePackagePoliciesWithAgentPolicy).mockReturnValue({
+      data: { items: [], total: 2, page: 1, perPage: 10 },
+      isLoading: false,
+      error: null,
+      resendRequest: jest.fn(),
+    } as unknown as ReturnType<typeof usePackagePoliciesWithAgentPolicy>);
+
+    renderPage();
+
+    expect(screen.getByText('Agent-based')).toBeDefined();
+  });
+
+  it('hides the Agent-based section while the agent-based data is still loading (data is undefined)', () => {
+    jest.mocked(usePackagePoliciesWithAgentPolicy).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      resendRequest: jest.fn(),
+    } as unknown as ReturnType<typeof usePackagePoliciesWithAgentPolicy>);
+
+    renderPage();
+
+    expect(screen.queryByText('Agent-based')).toBeNull();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -178,6 +178,7 @@ export const PackagePoliciesPage = ({
       : agentBasedData.items.map(mapPoliciesData);
     setAgentBasedPackageAndAgentPolicies(mappedPoliciesData);
   }, [agentBasedData, mapPoliciesData]);
+  const hasAgentBasedPolicies = (agentBasedData?.total ?? 0) > 0;
 
   // States and data for agentless policies table
   // If agentless is not supported or not an agentless integration, this block and
@@ -366,53 +367,57 @@ export const PackagePoliciesPage = ({
                   />
                 </EuiPanel>
               </EuiAccordion>
-              <EuiSpacer size="l" />
-              <EuiAccordion
-                id="agentBasedAccordion"
-                initialIsOpen={true}
-                buttonContent={
-                  <EuiFlexGroup
-                    justifyContent="center"
-                    alignItems="center"
-                    gutterSize="s"
-                    responsive={false}
+              {hasAgentBasedPolicies && (
+                <>
+                  <EuiSpacer size="l" />
+                  <EuiAccordion
+                    id="agentBasedAccordion"
+                    initialIsOpen={true}
+                    buttonContent={
+                      <EuiFlexGroup
+                        justifyContent="center"
+                        alignItems="center"
+                        gutterSize="s"
+                        responsive={false}
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="m">
+                            <h4>
+                              <FormattedMessage
+                                id="xpack.fleet.epm.packageDetails.integrationList.agentBasedHeader"
+                                defaultMessage="Agent-based"
+                              />
+                            </h4>
+                          </EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiNotificationBadge color="subdued" size="m">
+                            <h4>{agentBasedData?.total ?? 0}</h4>
+                          </EuiNotificationBadge>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    }
                   >
-                    <EuiFlexItem grow={false}>
-                      <EuiText size="m">
-                        <h4>
-                          <FormattedMessage
-                            id="xpack.fleet.epm.packageDetails.integrationList.agentBasedHeader"
-                            defaultMessage="Agent-based"
-                          />
-                        </h4>
-                      </EuiText>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiNotificationBadge color="subdued" size="m">
-                        <h4>{agentBasedData?.total ?? 0}</h4>
-                      </EuiNotificationBadge>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                }
-              >
-                <EuiSpacer size="m" />
-                <EuiPanel hasBorder={true} hasShadow={false}>
-                  <AgentBasedPackagePoliciesTable
-                    isLoading={agentBasedIsLoading}
-                    packagePolicies={agentBasedPackageAndAgentPolicies}
-                    packagePoliciesTotal={agentBasedData?.total ?? 0}
-                    refreshPackagePolicies={refreshAgentBasedPolicies}
-                    pagination={{
-                      pagination: agentBasedPagination,
-                      pageSizeOptions: agentBasedPageSizeOptions,
-                      setPagination: agentBasedSetPagination,
-                    }}
-                    addAgentToPolicyIdFromParams={addAgentToPolicyIdFromParams}
-                    showAddAgentHelpForPolicyId={showAddAgentHelpForPolicyId}
-                    from={embedded ? 'installed-integrations' : undefined}
-                  />
-                </EuiPanel>
-              </EuiAccordion>
+                    <EuiSpacer size="m" />
+                    <EuiPanel hasBorder={true} hasShadow={false}>
+                      <AgentBasedPackagePoliciesTable
+                        isLoading={agentBasedIsLoading}
+                        packagePolicies={agentBasedPackageAndAgentPolicies}
+                        packagePoliciesTotal={agentBasedData?.total ?? 0}
+                        refreshPackagePolicies={refreshAgentBasedPolicies}
+                        pagination={{
+                          pagination: agentBasedPagination,
+                          pageSizeOptions: agentBasedPageSizeOptions,
+                          setPagination: agentBasedSetPagination,
+                        }}
+                        addAgentToPolicyIdFromParams={addAgentToPolicyIdFromParams}
+                        showAddAgentHelpForPolicyId={showAddAgentHelpForPolicyId}
+                        from={embedded ? 'installed-integrations' : undefined}
+                      />
+                    </EuiPanel>
+                  </EuiAccordion>
+                </>
+              )}
             </>
           )}
         </EuiFlexItem>


### PR DESCRIPTION
Closes https://github.com/elastic/ingest-dev/issues/8744

## Summary
Don't show the agent based policies table when the count is zero

Before
<img width="1141" height="404" alt="Screenshot 2026-07-16 at 16 42 27" src="https://github.com/user-attachments/assets/fa4735a2-45ab-4968-af2b-7afd9e3967a0" />

After
<img width="1618" height="304" alt="Screenshot 2026-07-16 at 16 42 56" src="https://github.com/user-attachments/assets/ab3f643e-83fa-403e-b199-6b60573ce777" />
<img width="1712" height="893" alt="Screenshot 2026-07-16 at 16 38 48" src="https://github.com/user-attachments/assets/97c65b54-cb2d-4ee6-b1bb-43b5aab3b86c" />



### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



