### PR TITLE
[Change History] Disable change history writes for incident-3371

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/change_history/use_workflow_change_history.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/change_history/use_workflow_change_history.ts
@@ -18,10 +18,14 @@ import { selectWorkflow } from '../../entities/workflows/store/workflow_detail/s
 import { loadWorkflowThunk } from '../../entities/workflows/store/workflow_detail/thunks/load_workflow_thunk';
 import { useKibana } from '../../hooks/use_kibana';
 
+/**
+ * Temporarily forced off for incident-3371 while `.kibana_change_history` is
+ * not a SystemDataStream. Hides the history/version button and modal.
+ * Re-enable with capability check after the ES fix ships.
+ * @see https://github.com/elastic/security-team/issues/18291
+ */
 export const useWorkflowChangeHistoryEnabled = (): boolean => {
-  const { canReadWorkflow } = useWorkflowsCapabilities();
-
-  return canReadWorkflow;
+  return false;
 };
 
 export interface UseWorkflowChangeHistoryAdapterResult {

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
@@ -61,4 +61,18 @@ describe('ChangeHistoryClient.initialize', () => {
     ).toBeUndefined();
     expect(client.isInitialized()).toBe(true);
   });
+
+  it('skips initialization when FEATURE_ENABLED is false', async () => {
+    FLAGS.FEATURE_ENABLED = false;
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+
+    await client.initialize(esClient);
+
+    expect(DataStreamClientMock.initialize).not.toHaveBeenCalled();
+    expect(client.isInitialized()).toBe(false);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Change history is disabled. Skipping initialization.'
+    );
+  });
 });

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
@@ -76,3 +76,70 @@ describe('ChangeHistoryClient.initialize', () => {
     );
   });
 });
+
+describe('ChangeHistoryClient.logBulk', () => {
+  const logger = loggingSystemMock.createLogger();
+  const defaultConstructorOpts = {
+    module: 'workflows',
+    dataset: 'definitions',
+    logger,
+    kibanaVersion: '9.4.0',
+  };
+
+  beforeEach(() => {
+    FLAGS.FEATURE_ENABLED = true;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns without throwing when FEATURE_ENABLED is false', async () => {
+    FLAGS.FEATURE_ENABLED = false;
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+
+    await expect(
+      client.logBulk(
+        [
+          {
+            objectId: 'wf-1',
+            objectType: 'workflow',
+            timestamp: new Date().toISOString(),
+            snapshot: { yaml: 'name: test' },
+          },
+        ],
+        {
+          action: 'workflow_update',
+          username: 'elastic',
+          spaceId: 'default',
+        }
+      )
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('throws when the feature is enabled but the client is not initialized', async () => {
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+
+    await expect(
+      client.logBulk(
+        [
+          {
+            objectId: 'wf-1',
+            objectType: 'workflow',
+            timestamp: new Date().toISOString(),
+            snapshot: { yaml: 'name: test' },
+          },
+        ],
+        {
+          action: 'workflow_update',
+          username: 'elastic',
+          spaceId: 'default',
+        }
+      )
+    ).rejects.toThrow(
+      'Change history data stream not initialized for: module [workflows] and dataset [definitions]'
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.test.ts
@@ -143,3 +143,41 @@ describe('ChangeHistoryClient.logBulk', () => {
     );
   });
 });
+
+describe('ChangeHistoryClient.getHistory', () => {
+  const logger = loggingSystemMock.createLogger();
+  const defaultConstructorOpts = {
+    module: 'security',
+    dataset: 'alerting-rules',
+    logger,
+    kibanaVersion: '9.4.0',
+  };
+
+  beforeEach(() => {
+    FLAGS.FEATURE_ENABLED = true;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty result when FEATURE_ENABLED is false', async () => {
+    FLAGS.FEATURE_ENABLED = false;
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+
+    await expect(client.getHistory('default', 'alert', 'rule-1')).resolves.toEqual({
+      total: 0,
+      items: [],
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('throws when the feature is enabled but the client is not initialized', async () => {
+    const client = new ChangeHistoryClient(defaultConstructorOpts);
+
+    await expect(client.getHistory('default', 'alert', 'rule-1')).rejects.toThrow(
+      'Change history data stream not initialized for: module [security] and dataset [alerting-rules]'
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -160,10 +160,16 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
    * @param opts.fieldsToHash - Optional fields whose string values are replaced with a salted SHA-256 digest (high-entropy secrets only).
    * @param opts.fieldsToRedact - Optional fields whose string values are replaced with a `[redacted]` placeholder (low-entropy sensitive data).
    * @param opts.refresh - Optional indicator to force an ES refresh after changes (affects performance)
-   * @returns A promise that resolves when the bulk change is logged.
-   * @throws An error if the data stream is not initialized, or if an error occurs while logging the change.
+   * @returns A promise that resolves when the bulk change is logged, or immediately when change history is disabled.
+   * @throws An error if the data stream is not initialized while the feature is enabled, or if an error occurs while logging the change.
    */
   async logBulk(changes: ObjectChange[], opts: LogChangeHistoryOptions) {
+    // Callers (e.g. alerting) may invoke logBulk without checking isInitialized().
+    // When the feature is off, skip quietly so mutation paths do not error.
+    if (!FLAGS.FEATURE_ENABLED) {
+      return;
+    }
+
     const { module, dataset, client, kibanaVersion } = this;
 
     if (!client) {

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -254,8 +254,8 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
    * @param opts.sort - The sort order for the history query.
    * @param opts.from - The starting index for the history query.
    * @param opts.size - The number of results to return.
-   * @returns The history of the object.
-   * @throws An error if the data stream is not initialized, or if an error occurs while getting the history.
+   * @returns The history of the object, or an empty result when change history is disabled.
+   * @throws An error if the data stream is not initialized while the feature is enabled, or if an error occurs while getting the history.
    */
   async getHistory(
     spaceId: string,
@@ -263,6 +263,12 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
     objectId: string,
     opts?: GetChangeHistoryOptions
   ): Promise<GetHistoryResult> {
+    // Callers (e.g. alerting) may invoke getHistory without checking isInitialized().
+    // When the feature is off, return empty so read paths do not error.
+    if (!FLAGS.FEATURE_ENABLED) {
+      return { total: 0, items: [] };
+    }
+
     const client = this.client;
     if (!client) {
       const err = new Error(

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -102,9 +102,8 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
    */
   async initialize(elasticsearchClient: ElasticsearchClient) {
     if (!FLAGS.FEATURE_ENABLED) {
-      const error = new Error(`Change history is disabled. Skipping initialization.`);
-      this.logger.error(error);
-      throw error;
+      this.logger.info('Change history is disabled. Skipping initialization.');
+      return;
     }
     const definition: DataStreamDefinition<typeof changeHistoryMappings.v1, ChangeHistoryDocument> =
       {

--- a/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
@@ -25,8 +25,12 @@ export const DEFAULT_RESULT_SIZE = 100;
 
 /**
  * Acts like a feature flag for this package as it prevents initialization.
- * Remove this after General Availability
- * */
+ *
+ * Temporarily disabled for incident-3371: `.kibana_change_history` was not
+ * registered as a SystemDataStream, so backing indices are readable across
+ * spaces. Re-enable after the Elasticsearch SystemDataStream fix ships.
+ * @see https://github.com/elastic/security-team/issues/18291
+ */
 export const FLAGS = {
-  FEATURE_ENABLED: true,
+  FEATURE_ENABLED: false,
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
@@ -51,10 +51,13 @@ export default ({ getService }: FtrProviderContext): void => {
     }
   };
 
-  // Skip in Serverless until "xpack.alerting.ruleChangeTracking.enabled" and
+  // Temporarily skipped: @kbn/change-history FEATURE_ENABLED is false for incident-3371
+  // (`.kibana_change_history` not registered as a SystemDataStream). Re-enable after the ES fix.
+  // @see https://github.com/elastic/security-team/issues/18291
+  // Also skip in Serverless until "xpack.alerting.ruleChangeTracking.enabled" and
   // xpack.securitySolution.enableExperimental: [ruleChangesHistoryEnabled] feature flags
   // permanently enabled
-  describe('@ess @skipInServerless rule change history', () => {
+  describe.skip('@ess @skipInServerless rule change history', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllPrebuiltRuleAssets(es, log);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/restore_rule_from_changes_history.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/restore_rule_from_changes_history.ts
@@ -47,7 +47,10 @@ export default ({ getService }: FtrProviderContext): void => {
     }
   };
 
-  describe('@ess @skipInServerless rule restore from changes history', () => {
+  // Temporarily skipped: @kbn/change-history FEATURE_ENABLED is false for incident-3371
+  // (`.kibana_change_history` not registered as a SystemDataStream). Re-enable after the ES fix.
+  // @see https://github.com/elastic/security-team/issues/18291
+  describe.skip('@ess @skipInServerless rule restore from changes history', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllPrebuiltRuleAssets(es, log);


### PR DESCRIPTION
## Summary
- Emergency mitigation for [incident-3371](https://root.ly/i5vu1c) / [security-team#18291](https://github.com/elastic/security-team/issues/18291): `.kibana_change_history` is not registered as a `SystemDataStream`, so history documents are readable across spaces.
- Sets `@kbn/change-history` `FLAGS.FEATURE_ENABLED` to `false` so the data stream is not initialized and no consumers (workflows, alerting) write to it.
- Forces `useWorkflowChangeHistoryEnabled()` off so the workflows detail header History/version button and change-history modal are hidden.
- Skips disabled initialization with an info log instead of throwing, to avoid noisy startup errors during the mitigation window.

**Base:** `deploy-fix@1784101249` (serverless-running Kibana), not `main`.

## Test plan
- [x] Confirm Kibana starts without initializing `.kibana_change_history` (log: `Change history is disabled. Skipping initialization.`)
- [x] Create/update a workflow — no new documents appear in `.kibana_change_history`
- [x] Workflow detail header: History/version button is not shown (inline toolbar and overflow menu)
- [ ] Re-enable after ES `SystemDataStream` fix lands: set `FEATURE_ENABLED` back to `true` and restore the `canReadWorkflow` check in `useWorkflowChangeHistoryEnabled`


Made with [Cursor](https://cursor.com)

## 📸 Demo

### Workflows not showing `History` button anymore

<img width="1834" height="1193" alt="Screenshot 2026-07-16 at 17 21 44" src="https://github.com/user-attachments/assets/daaf7717-660c-4137-86f7-8304fe1944f5" />

### DataStream not created for new deployments

<img width="1839" height="790" alt="Screenshot 2026-07-16 at 17 22 25" src="https://github.com/user-attachments/assets/96ad5c93-2f94-4c44-a9b4-688e0cb7204a" />

