### PR TITLE
Revert "Refactor LogsLocator to use data view spec instead of ID"

### DIFF
--- a/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.test.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.test.ts
@@ -5,12 +5,10 @@
  * 2.0.
  */
 
-import { getAllLogsDataViewSpec } from '@kbn/discover-utils/src';
+import { ALL_LOGS_DATA_VIEW_ID } from '@kbn/discover-utils/src';
 import { LogsLocatorDefinition } from './logs_locator';
 
 const CUSTOM_LOG_PATTERN = 'custom-logs-*,remote:custom-logs-*';
-
-const ALL_LOGS_DATA_VIEW_SPEC = getAllLogsDataViewSpec({ allLogsIndexPattern: CUSTOM_LOG_PATTERN });
 
 const mockGetLocation = jest.fn().mockResolvedValue({
   app: 'discover',
@@ -52,16 +50,17 @@ describe('LogsLocatorDefinition', () => {
       });
     });
 
-    it('delegates with the all-logs data view spec when a query is given', async () => {
+    it('preserves the caller-provided query when one is given', async () => {
       const locator = createLocator(true);
       const callerQuery = { language: 'kuery', query: 'host.name: "my-host"' };
 
       await locator.getLocation({ query: callerQuery });
 
       expect(mockGetLocation).toHaveBeenCalledWith({
-        dataViewSpec: ALL_LOGS_DATA_VIEW_SPEC,
+        dataViewId: ALL_LOGS_DATA_VIEW_ID,
         query: callerQuery,
       });
+      expect(mockGetFlattenedLogSources).not.toHaveBeenCalled();
     });
 
     it('spreads consumer-provided params into the delegated call', async () => {
@@ -81,50 +80,15 @@ describe('LogsLocatorDefinition', () => {
   });
 
   describe('when discover.isEsqlDefault is false', () => {
-    it('delegates to DISCOVER_APP_LOCATOR with the all-logs data view spec', async () => {
+    it('delegates to DISCOVER_APP_LOCATOR with dataViewId', async () => {
       const locator = createLocator(false);
 
       await locator.getLocation({});
 
       expect(mockLocators.get).toHaveBeenCalledWith('DISCOVER_APP_LOCATOR');
-      expect(mockGetFlattenedLogSources).toHaveBeenCalled();
       expect(mockGetLocation).toHaveBeenCalledWith({
-        dataViewSpec: ALL_LOGS_DATA_VIEW_SPEC,
+        dataViewId: ALL_LOGS_DATA_VIEW_ID,
       });
-    });
-
-    it('does not delegate a bare dataViewId that relies on a profile-registered data view', async () => {
-      const locator = createLocator(false);
-
-      await locator.getLocation({});
-
-      const delegatedParams = mockGetLocation.mock.calls[0][0];
-      expect(delegatedParams).not.toHaveProperty('dataViewId');
-      expect(delegatedParams.dataViewSpec.id).toBe(ALL_LOGS_DATA_VIEW_SPEC.id);
-    });
-
-    it('does not shadow a caller-provided dataViewId with the all-logs spec', async () => {
-      const locator = createLocator(false);
-      const callerQuery = { language: 'kuery', query: 'aws.cloudwatch.namespace: AWS/EC2' };
-
-      await locator.getLocation({ dataViewId: 'metrics-*', query: callerQuery } as any);
-
-      const delegatedParams = mockGetLocation.mock.calls[0][0];
-      expect(delegatedParams).toEqual({ dataViewId: 'metrics-*', query: callerQuery });
-      expect(delegatedParams).not.toHaveProperty('dataViewSpec');
-      expect(mockGetFlattenedLogSources).not.toHaveBeenCalled();
-    });
-
-    it('does not shadow a caller-provided dataViewSpec with the all-logs spec', async () => {
-      const locator = createLocator(false);
-      const callerDataViewSpec = { title: 'logs-aws.ec2-*', timeFieldName: '@timestamp' };
-
-      await locator.getLocation({ dataViewSpec: callerDataViewSpec } as any);
-
-      const delegatedParams = mockGetLocation.mock.calls[0][0];
-      expect(delegatedParams).toEqual({ dataViewSpec: callerDataViewSpec });
-      expect(delegatedParams.dataViewSpec).not.toEqual(ALL_LOGS_DATA_VIEW_SPEC);
-      expect(mockGetFlattenedLogSources).not.toHaveBeenCalled();
     });
 
     it('spreads consumer-provided params into the delegated call', async () => {
@@ -137,7 +101,7 @@ describe('LogsLocatorDefinition', () => {
       await locator.getLocation(extraParams as any);
 
       expect(mockGetLocation).toHaveBeenCalledWith({
-        dataViewSpec: ALL_LOGS_DATA_VIEW_SPEC,
+        dataViewId: ALL_LOGS_DATA_VIEW_ID,
         ...extraParams,
       });
     });

--- a/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/common/locators/logs_locator.ts
@@ -6,7 +6,7 @@
  */
 
 import { type DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
-import { getAllLogsDataViewSpec } from '@kbn/discover-utils/src';
+import { ALL_LOGS_DATA_VIEW_ID } from '@kbn/discover-utils/src';
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import type { LocatorDefinition } from '@kbn/share-plugin/common';
 import type { LocatorClient } from '@kbn/share-plugin/common/url_service';
@@ -17,7 +17,7 @@ import type { LocatorClient } from '@kbn/share-plugin/common/url_service';
 export const LOGS_LOCATOR_ID = 'LOGS_LOCATOR';
 
 /**
- * Accepts the same parameters as `DiscoverAppLocatorParams`, but automatically sets the data view to all log sources.
+ * Accepts the same parameters as `DiscoverAppLocatorParams`, but automatically sets the `dataViewId` param to all log sources.
  */
 export type LogsLocatorParams = DiscoverAppLocatorParams;
 
@@ -39,7 +39,8 @@ export class LogsLocatorDefinition implements LocatorDefinition<LogsLocatorParam
     const isEsqlDefault = await this.deps.getIsEsqlDefault();
 
     if (isEsqlDefault && !params.query) {
-      const flattenedLogSources = await this.getFlattenedLogSources();
+      const logSourcesService = await this.deps.getLogSourcesService();
+      const flattenedLogSources = await logSourcesService.getFlattenedLogSources();
 
       return discoverAppLocator.getLocation({
         ...params,
@@ -47,20 +48,9 @@ export class LogsLocatorDefinition implements LocatorDefinition<LogsLocatorParam
       });
     }
 
-    if (params.dataViewId || params.dataViewSpec) {
-      return discoverAppLocator.getLocation(params);
-    }
-
-    const flattenedLogSources = await this.getFlattenedLogSources();
-
     return discoverAppLocator.getLocation({
+      dataViewId: ALL_LOGS_DATA_VIEW_ID,
       ...params,
-      dataViewSpec: getAllLogsDataViewSpec({ allLogsIndexPattern: flattenedLogSources }),
     });
   };
-
-  private async getFlattenedLogSources() {
-    const logSourcesService = await this.deps.getLogSourcesService();
-    return logSourcesService.getFlattenedLogSources();
-  }
 }


### PR DESCRIPTION
Closes: #278626

## Summary

This reverts #276647.

An FTR (Functional Test Runner) test is failing and we still need to analyze whether or not it's a real regression: the serverless Observability Logs Essentials suite (`config.logs_essentials.ts`) times out on the FTR test `redirects to Discover when logs data is present`, which is currently blocking serverless promotions.

- FTR test: [`x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts#L31)

Since the previous PR didn't introduce anything critical, we decided to revert to unblock now and re-create the feature later, once we've properly analyzed whether this is a regression.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



