### PR TITLE
[9.4] [Lens as code] Fix by-ref annotations with duplicated panels (#276016)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/index.ts
+++ b/src/platform/packages/shared/kbn-lens-common/index.ts
@@ -257,6 +257,7 @@ export {
   isPersistedByReferenceAnnotationsLayer,
   isPersistedByValueAnnotationsLayer,
   isPersistedLinkedByValueAnnotationsLayer,
+  isRuntimeByReferenceAnnotationsLayer,
 } from './visualizations/xy/persistence';
 export type {
   LensEmbeddableInput,

--- a/src/platform/packages/shared/kbn-lens-common/visualizations/xy/persistence.ts
+++ b/src/platform/packages/shared/kbn-lens-common/visualizations/xy/persistence.ts
@@ -9,8 +9,10 @@
 
 import { LENS_LAYER_TYPES } from '../constants';
 import type {
+  XYByReferenceAnnotationLayerConfig,
   XYByValueAnnotationLayerConfig,
   XYDataLayerConfig,
+  XYLayerConfig,
   XYReferenceLineLayerConfig,
   XYVisualizationState,
 } from './types';
@@ -83,3 +85,7 @@ export const isPersistedByValueAnnotationsLayer = (
 ): layer is XYPersistedByValueAnnotationLayerConfig =>
   isPersistedAnnotationsLayer(layer) &&
   (layer.persistanceType === 'byValue' || !layer.persistanceType);
+
+export const isRuntimeByReferenceAnnotationsLayer = (
+  layer: XYLayerConfig | XYPersistedLayerConfig
+): layer is XYByReferenceAnnotationLayerConfig => 'annotationGroupId' in layer;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/annotations.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/annotations.mock.ts
@@ -11,6 +11,7 @@ import type {
   DateHistogramIndexPatternColumn,
   DerivativeIndexPatternColumn,
   MaxIndexPatternColumn,
+  XYByReferenceAnnotationLayerConfig,
   XYPersistedByReferenceAnnotationLayerConfig,
 } from '@kbn/lens-common';
 import type { LensAttributes } from '../../types';
@@ -260,6 +261,139 @@ export const byRefAnnotationXY: LensAttributes = {
       id: 'my-annotation-group-id',
       name: 'ref-16f0980e-4f7a-43d0-b5aa-e8c75c4cd930',
       type: 'event-annotation-group',
+    },
+  ],
+};
+
+export const runtimeByRefAnnotationXY: LensAttributes = {
+  visualizationType: 'lnsXY',
+  title: 'XY with runtime by-ref annotation',
+  state: {
+    adHocDataViews: {},
+    datasourceStates: {
+      formBased: {
+        layers: {
+          'e6f11ede-9943-4073-b9f3-1f69d0e934a8': {
+            columnOrder: [
+              '8362014d-fc6c-4f9e-b63f-c0cd9a3227e6',
+              '8da7e0b1-770d-4f2d-aac8-53a331ac1829',
+            ],
+            columns: {
+              '8362014d-fc6c-4f9e-b63f-c0cd9a3227e6': {
+                dataType: 'date',
+                isBucketed: true,
+                label: '@timestamp',
+                operationType: 'date_histogram',
+                params: {
+                  interval: 'auto',
+                  includeEmptyRows: true,
+                  dropPartials: false,
+                },
+                scale: 'interval',
+                sourceField: '@timestamp',
+              } as DateHistogramIndexPatternColumn,
+              '8da7e0b1-770d-4f2d-aac8-53a331ac1829': {
+                dataType: 'number',
+                isBucketed: false,
+                label: 'Maximum of bytes',
+                operationType: 'max',
+                params: {
+                  emptyAsNull: true,
+                },
+                scale: 'ratio',
+                sourceField: 'bytes',
+              } as MaxIndexPatternColumn,
+            },
+            incompleteColumns: {},
+          },
+        },
+      },
+    },
+    filters: [],
+    internalReferences: [],
+    query: {
+      language: 'kuery',
+      query: '',
+    },
+    visualization: {
+      axisTitlesVisibilitySettings: {
+        x: true,
+        yLeft: true,
+        yRight: true,
+      },
+      layers: [
+        {
+          accessors: ['8da7e0b1-770d-4f2d-aac8-53a331ac1829'],
+          layerId: 'e6f11ede-9943-4073-b9f3-1f69d0e934a8',
+          layerType: 'data',
+          position: 'top',
+          seriesType: 'line',
+          showGridlines: false,
+          xAccessor: '8362014d-fc6c-4f9e-b63f-c0cd9a3227e6',
+          yConfig: [
+            {
+              axisMode: 'left',
+              color: '#009ce0',
+              forAccessor: '8da7e0b1-770d-4f2d-aac8-53a331ac1829',
+            },
+          ],
+        },
+        {
+          layerId: '16f0980e-4f7a-43d0-b5aa-e8c75c4cd930',
+          layerType: 'annotations',
+          indexPatternId: 'metrics-*',
+          ignoreGlobalFilters: true,
+          annotations: [
+            {
+              color: '#ff0000',
+              icon: 'triangle',
+              id: 'cf13a990-6a33-427a-a85a-2f271116776a',
+              key: { type: 'point_in_time' },
+              label: 'Event',
+              type: 'query',
+              timeField: '@timestamp',
+              filter: { type: 'kibana_query', language: 'kuery', query: '' },
+            },
+          ],
+          annotationGroupId: 'my-runtime-annotation-group-id',
+          __lastSaved: {
+            annotations: [
+              {
+                color: '#ff0000',
+                icon: 'triangle',
+                id: 'cf13a990-6a33-427a-a85a-2f271116776a',
+                key: { type: 'point_in_time' },
+                label: 'Event',
+                type: 'query',
+                timeField: '@timestamp',
+                filter: { type: 'kibana_query', language: 'kuery', query: '' },
+              },
+            ],
+            indexPatternId: 'metrics-*',
+            ignoreGlobalFilters: true,
+            title: 'My annotation group',
+            description: '',
+            tags: [],
+          },
+        } as XYByReferenceAnnotationLayerConfig,
+      ],
+      legend: {
+        isVisible: true,
+        position: 'bottom',
+        showSingleSeries: true,
+      },
+      preferredSeriesType: 'line',
+      title: 'Empty XY chart',
+      valueLabels: 'hide',
+      valuesInLegend: true,
+      yTitle: 'Rate',
+    },
+  },
+  references: [
+    {
+      id: 'metrics-*',
+      name: 'indexpattern-datasource-layer-e6f11ede-9943-4073-b9f3-1f69d0e934a8',
+      type: 'index-pattern',
     },
   ],
 };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
@@ -26,7 +26,7 @@ import {
   xyWithFormulaRefColumnsAndRankByTermsBucketOperationAttributes,
 } from './basicXY.mock';
 import { dualReferenceLineXY, referenceLineXY } from './referenceLines.mock';
-import { annotationXY, byRefAnnotationXY } from './annotations.mock';
+import { annotationXY, byRefAnnotationXY, runtimeByRefAnnotationXY } from './annotations.mock';
 import {
   esqlChart,
   esqlChartWithBreakdownColorMapping,
@@ -166,6 +166,61 @@ describe('XY', () => {
           validator.xy.fromState(setSeriesType(byRefAnnotationXY, type));
         });
       }
+
+      for (const type of ['bar', 'line', 'area'] as const) {
+        it(`should validate a runtime by-reference annotation with a ${type} chart`, () => {
+          validator.xy.fromState(setSeriesType(runtimeByRefAnnotationXY, type));
+        });
+      }
+
+      it('emits annotation_group with group_id for a runtime by-reference annotation layer', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        const api = builder.toAPIFormat(runtimeByRefAnnotationXY) as XYConfig;
+        const annotationLayer = api.layers.find((l) => l.type === 'annotation_group');
+
+        expect(annotationLayer).toBeDefined();
+        expect(annotationLayer).toEqual({
+          type: 'annotation_group',
+          group_id: 'my-runtime-annotation-group-id',
+        });
+      });
+
+      it('does not emit inline annotations or data_source for a runtime by-reference annotation layer', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        const api = builder.toAPIFormat(runtimeByRefAnnotationXY) as XYConfig;
+        const annotationLayer = api.layers.find((l) => l.type === 'annotation_group');
+
+        expect(annotationLayer).toBeDefined();
+        expect(annotationLayer).not.toHaveProperty('annotations');
+        expect(annotationLayer).not.toHaveProperty('data_source');
+        expect(annotationLayer).not.toHaveProperty('events');
+      });
+
+      it('round-trips a runtime by-reference annotation as a persisted by-reference layer', () => {
+        const builder = new LensConfigBuilder(undefined, true);
+        const api = builder.toAPIFormat(runtimeByRefAnnotationXY);
+        const lensState = builder.fromAPIFormat(api);
+
+        const visualizationLayers = (
+          lensState.state.visualization as { layers: Array<Record<string, unknown>> }
+        ).layers;
+        const annotationLayer = visualizationLayers.find(
+          (layer) => layer.layerType === 'annotations'
+        );
+
+        expect(annotationLayer).toBeDefined();
+        expect(annotationLayer?.persistanceType).toBe('byReference');
+        expect(annotationLayer).toHaveProperty('annotationGroupRef');
+        expect(annotationLayer).not.toHaveProperty('indexPatternId');
+        expect(annotationLayer).not.toHaveProperty('annotations');
+
+        const matchingRef = lensState.references.find(
+          (ref) => ref.name === annotationLayer?.annotationGroupRef
+        );
+        expect(matchingRef).toBeDefined();
+        expect(matchingRef?.id).toBe('my-runtime-annotation-group-id');
+        expect(matchingRef?.type).toBe('event-annotation-group');
+      });
     });
 
     describe('ES|QL panels', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
@@ -25,6 +25,7 @@ import {
   AvailableReferenceLineIcons,
   isPersistedByReferenceAnnotationsLayer,
   isPersistedLinkedByValueAnnotationsLayer,
+  isRuntimeByReferenceAnnotationsLayer,
 } from '@kbn/lens-common';
 import { AS_CODE_DATA_VIEW_SPEC_TYPE } from '@kbn/as-code-data-views-schema';
 import { AS_CODE_DATA_VIEW_REFERENCE_TYPE } from '@kbn/as-code-data-views-schema';
@@ -458,6 +459,13 @@ export function buildAPIAnnotationsLayer(
   references: SavedObjectReference[],
   adhocReferences?: SavedObjectReference[]
 ): AnnotationLayerType {
+  if (isRuntimeByReferenceAnnotationsLayer(layer)) {
+    return {
+      type: 'annotation_group',
+      group_id: layer.annotationGroupId,
+    };
+  }
+
   if (
     isPersistedByReferenceAnnotationsLayer(layer) ||
     isPersistedLinkedByValueAnnotationsLayer(layer)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens as code] Fix by-ref annotations with duplicated panels (#276016)](https://github.com/elastic/kibana/pull/276016)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-07-06T10:31:54Z","message":"[Lens as code] Fix by-ref annotations with duplicated panels (#276016)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/268822\n\nWhen a dashboard panel with a by-reference annotation layer is\n**cloned**, the clone path calls `getSerializedStateByValue`, which\ninvokes the `lens.apiFormat` serialization pipeline (`toAPIFormat` →\n`fromAPIFormat`). This pipeline passes the **runtime** annotation layer\nstate to `buildAPIAnnotationsLayer`.\n\nThe problem is that `buildAPIAnnotationsLayer` only had type guards for\nthe **persisted** by-reference shape (`annotationGroupRef` + no\n`indexPatternId`), but the runtime shape is structurally different: it\ncarries `annotationGroupId`, `indexPatternId`, `annotations`, and\n`__lastSaved`. Because the runtime layer has `indexPatternId`, it fails\nthe `isPersistedAnnotationsLayer` check (which requires\n`!('indexPatternId' in layer)`) and falls through to the **by-value**\nserialization path.\n\nThis causes the cloned panel to embed the annotation data inline, losing\nany reference to the library annotation group. The clone becomes a fully\nindependent copy — deleting the library group has no effect on it\nbecause it no longer points to it.\n\n## Fix\n\nAdded a `isRuntimeByReferenceAnnotationsLayer` type guard that\nidentifies the runtime by-reference shape via the presence of\n`annotationGroupId`, and an early return in `buildAPIAnnotationsLayer`\nthat correctly emits `{ type: 'annotation_group', group_id:\nlayer.annotationGroupId }` — preserving the library link.","sha":"4c4cae3752a38a8fa538482956c3d35773de5305","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Visualizations","release_note:skip","backport missing","backport:version","v9.5.0","v9.4.4"],"title":"[Lens as code] Fix by-ref annotations with duplicated panels","number":276016,"url":"https://github.com/elastic/kibana/pull/276016","mergeCommit":{"message":"[Lens as code] Fix by-ref annotations with duplicated panels (#276016)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/268822\n\nWhen a dashboard panel with a by-reference annotation layer is\n**cloned**, the clone path calls `getSerializedStateByValue`, which\ninvokes the `lens.apiFormat` serialization pipeline (`toAPIFormat` →\n`fromAPIFormat`). This pipeline passes the **runtime** annotation layer\nstate to `buildAPIAnnotationsLayer`.\n\nThe problem is that `buildAPIAnnotationsLayer` only had type guards for\nthe **persisted** by-reference shape (`annotationGroupRef` + no\n`indexPatternId`), but the runtime shape is structurally different: it\ncarries `annotationGroupId`, `indexPatternId`, `annotations`, and\n`__lastSaved`. Because the runtime layer has `indexPatternId`, it fails\nthe `isPersistedAnnotationsLayer` check (which requires\n`!('indexPatternId' in layer)`) and falls through to the **by-value**\nserialization path.\n\nThis causes the cloned panel to embed the annotation data inline, losing\nany reference to the library annotation group. The clone becomes a fully\nindependent copy — deleting the library group has no effect on it\nbecause it no longer points to it.\n\n## Fix\n\nAdded a `isRuntimeByReferenceAnnotationsLayer` type guard that\nidentifies the runtime by-reference shape via the presence of\n`annotationGroupId`, and an early return in `buildAPIAnnotationsLayer`\nthat correctly emits `{ type: 'annotation_group', group_id:\nlayer.annotationGroupId }` — preserving the library link.","sha":"4c4cae3752a38a8fa538482956c3d35773de5305"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276016","number":276016,"mergeCommit":{"message":"[Lens as code] Fix by-ref annotations with duplicated panels (#276016)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/268822\n\nWhen a dashboard panel with a by-reference annotation layer is\n**cloned**, the clone path calls `getSerializedStateByValue`, which\ninvokes the `lens.apiFormat` serialization pipeline (`toAPIFormat` →\n`fromAPIFormat`). This pipeline passes the **runtime** annotation layer\nstate to `buildAPIAnnotationsLayer`.\n\nThe problem is that `buildAPIAnnotationsLayer` only had type guards for\nthe **persisted** by-reference shape (`annotationGroupRef` + no\n`indexPatternId`), but the runtime shape is structurally different: it\ncarries `annotationGroupId`, `indexPatternId`, `annotations`, and\n`__lastSaved`. Because the runtime layer has `indexPatternId`, it fails\nthe `isPersistedAnnotationsLayer` check (which requires\n`!('indexPatternId' in layer)`) and falls through to the **by-value**\nserialization path.\n\nThis causes the cloned panel to embed the annotation data inline, losing\nany reference to the library annotation group. The clone becomes a fully\nindependent copy — deleting the library group has no effect on it\nbecause it no longer points to it.\n\n## Fix\n\nAdded a `isRuntimeByReferenceAnnotationsLayer` type guard that\nidentifies the runtime by-reference shape via the presence of\n`annotationGroupId`, and an early return in `buildAPIAnnotationsLayer`\nthat correctly emits `{ type: 'annotation_group', group_id:\nlayer.annotationGroupId }` — preserving the library link.","sha":"4c4cae3752a38a8fa538482956c3d35773de5305"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->