### PR TITLE
[dashboard] unskip Failing test: Chrome X-Pack UI Functional Tests.x-pack/platform/test/functional/apps/dashboard/group3/drilldowns/dashboard_to_dashboard_drilldown·ts

### DIFF
--- a/x-pack/platform/test/functional/apps/dashboard/group3/drilldowns/dashboard_to_dashboard_drilldown.ts
+++ b/x-pack/platform/test/functional/apps/dashboard/group3/drilldowns/dashboard_to_dashboard_drilldown.ts
@@ -132,8 +132,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
    *
    * Migration: Migrate to scout
    */
-  // Failing: See https://github.com/elastic/kibana/issues/273502
-  describe.skip('Dashboard to dashboard drilldown', function () {
+  describe('Dashboard to dashboard drilldown', function () {
     describe('Create & use drilldowns', () => {
       before(async () => {
         log.debug('Dashboard Drilldowns:initTests');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/273502

Resolved by https://github.com/elastic/kibana/pull/278414

Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/13175