### PR TITLE
[One Workflow] fix: disable workflow change-history writes and hide header entry point

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
@@ -546,26 +546,22 @@ describe('WorkflowDetailHeader', () => {
     });
   });
 
-  it('exposes the change history entry point on the workflow tab when a workflow id is present', () => {
+  it('hides the change history entry point while history is disabled', () => {
     const changeHistoryModal = {
       isOpen: false,
       openModal: jest.fn(),
       closeModal: jest.fn(),
     };
-    const { getByTestId } = renderWithProviders(
+    const { queryByTestId } = renderWithProviders(
       <ChangeHistoryModalContext.Provider value={changeHistoryModal}>
         <WorkflowDetailHeader {...defaultProps} />
       </ChangeHistoryModalContext.Provider>
     );
 
-    const historyItem = getByTestId('workflowDetailHistoryButton');
-    expect(historyItem).toBeInTheDocument();
-
-    fireEvent.click(historyItem);
-    expect(changeHistoryModal.openModal).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('workflowDetailHistoryButton')).not.toBeInTheDocument();
   });
 
-  it('moves enabled switch and history into the overflow menu on small screens', () => {
+  it('moves enabled switch into the overflow menu on small screens and keeps history hidden', () => {
     mockIsAppMenuSwitchInline = false;
 
     const changeHistoryModal = {
@@ -582,7 +578,7 @@ describe('WorkflowDetailHeader', () => {
     expect(queryByTestId('workflowDetailHeaderToolbar')).not.toBeInTheDocument();
 
     fireEvent.click(getByTestId('app-menu-overflow-button'));
-    expect(getByTestId('workflowDetailHistoryButton')).toBeInTheDocument();
+    expect(queryByTestId('workflowDetailHistoryButton')).not.toBeInTheDocument();
     expect(getByTestId('workflowEnabledSwitch')).toBeInTheDocument();
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -85,7 +85,6 @@ export const WorkflowDetailHeader = React.memo(
       canCreateWorkflow,
       canUpdateWorkflow,
       canExecuteWorkflow,
-      canReadWorkflow,
       canReadWorkflowExecution,
       canReadManagedWorkflowExecution,
     } = useWorkflowsCapabilities();
@@ -246,7 +245,9 @@ export const WorkflowDetailHeader = React.memo(
     const openHistoryModal = useCallback(() => {
       changeHistoryModal?.openModal();
     }, [changeHistoryModal]);
-    const showHistoryButton = Boolean(canReadWorkflow && !isExecutionsTab && changeHistoryModal);
+    // Incident mitigation: version history is temporarily hidden while the
+    // change-history writes are disabled.
+    const showHistoryButton = false;
     const isAppMenuSwitchInline = useIsWithinBreakpoints([
       ...WORKFLOW_DETAIL_INLINE_TOOLBAR_BREAKPOINTS,
     ]);

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
@@ -153,7 +153,6 @@ export class WorkflowCrudService {
   }): Promise<void> {
     // Incident mitigation: change-history writes to the workflows history data
     // stream are temporarily disabled. Reads still work against existing data.
-    return;
   }
 
   async getWorkflowDocumentSource(

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
@@ -72,7 +72,6 @@ import {
 } from '../lib/bulk_id_helpers';
 import { getAuthenticatedUser } from '../lib/get_user';
 import { assertWorkflowChangeHistoryEnabled } from '../lib/get_workflow_change_history';
-import { logWorkflowChanges } from '../lib/log_workflow_changes';
 import { hasScheduledTriggers } from '../lib/schedule_utils';
 import { WorkflowHistoryEventNotFoundError } from '../lib/workflow_history_event_not_found_error';
 import { resolveUniqueWorkflowIds, validateWorkflowId } from '../lib/workflow_id_resolver';
@@ -152,23 +151,9 @@ export class WorkflowCrudService {
     correlationId?: string;
     restoreMetadata?: WorkflowRestoreMetadata;
   }): Promise<void> {
-    const changeHistoryService = this.deps.changeHistoryService;
-    const scopedChangeHistory = params.request
-      ? changeHistoryService.asScoped(params.request)
-      : changeHistoryService.asSystemUser();
-
-    await logWorkflowChanges({
-      workflows: params.workflows,
-      changeHistoryService,
-      scopedChangeHistory,
-      action: params.action,
-      getAction: params.getAction,
-      spaceId: params.spaceId,
-      timestamp: params.timestamp,
-      correlationId: params.correlationId,
-      restoreMetadata: params.restoreMetadata,
-      logger: this.deps.logger,
-    });
+    // Incident mitigation: change-history writes to the workflows history data
+    // stream are temporarily disabled. Reads still work against existing data.
+    return;
   }
 
   async getWorkflowDocumentSource(


### PR DESCRIPTION
## Summary

Incident mitigation for the ongoing incident in <#C0BHNM44YER>:

- **Stop writing** to the workflows change-history data stream. `WorkflowCrudService.logWorkflowChangesAfterWrite` is short-circuited so none of the existing call sites (create / update / delete / bulk enable / disable / restore, managed workflows) produce new history entries.
- **Hide** the History (version) entry point in the workflow detail header (`showHistoryButton` forced off in `workflow_detail_header.tsx`). The `ChangeHistoryModal` provider stays wired so anything else that might reference it keeps compiling, but users no longer see the trigger in the header.

Reads against previously-written data still work, so the read path (`getHistory`) is intentionally left alone — this is the smallest possible change to stop the bleed.

## Test plan

- [ ] Workflow save / enable-toggle / delete / bulk actions succeed and no documents are written to the change-history data stream.
- [ ] Workflow detail page no longer shows a History button in the header (inline layout and overflow menu).
- [ ] Existing unit tests for `workflow_detail_header` and `workflow_crud_service` pass; the two header tests that asserted the button's presence were flipped to assert its absence.

---
_Created by @1workflow bot on behalf of U0407J177EH_