### PR TITLE
[SLO] Add bulk snapshot API endpoint

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/bulk_snapshot.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/bulk_snapshot.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import * as t from 'io-ts';
+import { sloIdSchema } from '../../schema';
+import { allOrAnyString, statusSchema } from '../../schema/common';
+
+const bulkSnapshotRequestItemSchema = t.intersection([
+  t.type({
+    id: sloIdSchema,
+  }),
+  t.partial({
+    instanceId: allOrAnyString,
+  }),
+]);
+
+const snapshotErrorBudgetSchema = t.type({
+  initial: t.number,
+  consumed: t.union([t.number, t.null]),
+  remaining: t.union([t.number, t.null]),
+});
+
+const snapshotSummarySchema = t.type({
+  status: statusSchema,
+  sliValue: t.union([t.number, t.null]),
+  errorBudget: snapshotErrorBudgetSchema,
+  good: t.number,
+  total: t.number,
+});
+
+const snapshotResultSchema = t.intersection([
+  t.type({
+    id: t.string,
+    instanceId: t.string,
+  }),
+  t.union([
+    t.type({ summary: snapshotSummarySchema }),
+    t.type({ error: t.type({ statusCode: t.number, message: t.string }) }),
+  ]),
+]);
+
+const bulkSnapshotParamsSchema = t.type({
+  body: t.type({
+    at: t.string,
+    requests: t.array(bulkSnapshotRequestItemSchema),
+  }),
+});
+
+const bulkSnapshotResponseSchema = t.type({
+  at: t.string,
+  results: t.array(snapshotResultSchema),
+});
+
+type BulkSnapshotRequestItem = t.TypeOf<typeof bulkSnapshotRequestItemSchema>;
+type SnapshotSummary = t.TypeOf<typeof snapshotSummarySchema>;
+type SnapshotResult = t.TypeOf<typeof snapshotResultSchema>;
+type BulkSnapshotParams = t.TypeOf<typeof bulkSnapshotParamsSchema.props.body>;
+type BulkSnapshotResponse = t.TypeOf<typeof bulkSnapshotResponseSchema>;
+
+export {
+  bulkSnapshotParamsSchema,
+  bulkSnapshotRequestItemSchema,
+  bulkSnapshotResponseSchema,
+  snapshotResultSchema,
+  snapshotSummarySchema,
+};
+export type {
+  BulkSnapshotParams,
+  BulkSnapshotRequestItem,
+  BulkSnapshotResponse,
+  SnapshotResult,
+  SnapshotSummary,
+};

--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/index.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/index.ts
@@ -20,6 +20,7 @@ export * from './get_preview_data';
 export * from './reset';
 export * from './manage';
 export * from './delete_instance';
+export * from './bulk_snapshot';
 export * from './fetch_historical_summary';
 export * from './put_settings';
 export * from './get_suggestions';

--- a/x-pack/solutions/observability/plugins/slo/server/routes/bulk_snapshot.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/bulk_snapshot.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { badRequest } from '@hapi/boom';
+import { bulkSnapshotParamsSchema } from '@kbn/slo-schema';
+import { BulkSnapshotClient } from '../services/bulk_snapshot_client';
+import { createSloServerRoute } from './utils/create_slo_server_route';
+import { assertPlatinumLicense } from './utils/assert_platinum_license';
+
+export const bulkSnapshotRoute = createSloServerRoute({
+  endpoint: 'POST /api/observability/slos/_bulk_snapshot 2023-10-31',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
+  },
+  params: bulkSnapshotParamsSchema,
+  handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+    const { at, requests } = params.body;
+
+    if (requests.length > 100) {
+      throw badRequest('`requests` is limited to 100 entries');
+    }
+
+    const atDate = new Date(at);
+    if (isNaN(atDate.getTime())) {
+      throw badRequest('`at` must be a valid ISO datetime string');
+    }
+
+    if (requests.length === 0) {
+      return { at, results: [] };
+    }
+
+    const [{ scopedClusterClient, spaceId, repository }] = await Promise.all([
+      getScopedClients({ request, logger }),
+      assertPlatinumLicense(plugins),
+    ]);
+
+    const client = new BulkSnapshotClient(scopedClusterClient.asCurrentUser, repository, spaceId);
+    return client.compute(atDate, requests);
+  },
+});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { bulkDeleteSLORoute, getBulkDeleteStatusRoute } from './bulk_delete';
+import { bulkSnapshotRoute } from './bulk_snapshot';
 import { bulkPurgeRollupRoute } from './bulk_purge_rollup';
 import { createCompositeSLORoute } from './composite_slo/create_composite_slo';
 import { deleteCompositeSLORoute } from './composite_slo/delete_composite_slo';
@@ -55,6 +56,7 @@ interface RouteRepositoryOptions {
 
 export const getSloRouteRepository = ({ isServerless }: RouteRepositoryOptions = {}) => {
   return {
+    ...bulkSnapshotRoute,
     ...fetchSloHealthRoute,
     ...getSloSettingsRoute,
     ...updateSloSettings(isServerless),

--- a/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.test.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { ALL_VALUE } from '@kbn/slo-schema';
+import { BulkSnapshotClient } from './bulk_snapshot_client';
+import { createSLO, createSLOWithTimeslicesBudgetingMethod } from './fixtures/slo';
+import { thirtyDaysRolling, sevenDaysRolling, weeklyCalendarAligned } from './fixtures/time_window';
+import { createSLORepositoryMock } from './mocks';
+import type { SLODefinitionRepository } from './slo_definition_repository';
+
+const AT = new Date('2024-01-15T12:00:00.000Z');
+
+const buildEsResponse = (aggs: Record<string, unknown> = {}) => ({
+  took: 5,
+  timed_out: false,
+  _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+  hits: { hits: [] },
+  aggregations: aggs,
+});
+
+describe('BulkSnapshotClient', () => {
+  let esClientMock: ElasticsearchClientMock;
+  let repositoryMock: jest.Mocked<SLODefinitionRepository>;
+
+  beforeEach(() => {
+    esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    repositoryMock = createSLORepositoryMock();
+  });
+
+  const createClient = () => new BulkSnapshotClient(esClientMock, repositoryMock, 'default');
+
+  it('returns 404 errors for all unknown SLO ids', async () => {
+    repositoryMock.findAllByIds.mockResolvedValueOnce([]);
+    const client = createClient();
+
+    const result = await client.compute(AT, [
+      { id: 'unknown-1' },
+      { id: 'unknown-2' },
+    ]);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({ id: 'unknown-1', error: { statusCode: 404 } });
+    expect(result.results[1]).toMatchObject({ id: 'unknown-2', error: { statusCode: 404 } });
+    expect(esClientMock.search).not.toHaveBeenCalled();
+  });
+
+  it('returns summary for found SLO and error for missing SLO', async () => {
+    const slo = createSLO({ id: 'found-slo', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        specific_0: { doc_count: 100, good: { value: 90 }, total: { value: 100 } },
+      }) as any
+    );
+
+    const client = createClient();
+    const result = await client.compute(AT, [
+      { id: 'missing-slo' },
+      { id: 'found-slo', instanceId: 'instance-1' },
+    ]);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({ id: 'missing-slo', error: { statusCode: 404 } });
+    expect(result.results[1]).toMatchObject({
+      id: 'found-slo',
+      instanceId: 'instance-1',
+      summary: expect.objectContaining({ sliValue: 0.9 }),
+    });
+  });
+
+  it('returns correct sliValue, good, and total for a specific instanceId with data', async () => {
+    const slo = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        specific_0: { doc_count: 1000, good: { value: 800 }, total: { value: 1000 } },
+      }) as any
+    );
+
+    const client = createClient();
+    const result = await client.compute(AT, [{ id: 'slo-1', instanceId: 'host-1' }]);
+
+    expect(result.results).toHaveLength(1);
+    const item = result.results[0];
+    expect(item).toMatchObject({
+      id: 'slo-1',
+      instanceId: 'host-1',
+    });
+    if ('summary' in item) {
+      expect(item.summary.sliValue).toBe(0.8);
+      expect(item.summary.good).toBe(800);
+      expect(item.summary.total).toBe(1000);
+    }
+  });
+
+  it('returns NO_DATA when specific instanceId has no data', async () => {
+    const slo = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        specific_0: { doc_count: 0, good: { value: 0 }, total: { value: 0 } },
+      }) as any
+    );
+
+    const client = createClient();
+    const result = await client.compute(AT, [{ id: 'slo-1', instanceId: 'host-1' }]);
+
+    const item = result.results[0];
+    expect(item).toMatchObject({ id: 'slo-1', instanceId: 'host-1' });
+    if ('summary' in item) {
+      expect(item.summary.status).toBe('NO_DATA');
+      expect(item.summary.sliValue).toBeNull();
+      expect(item.summary.errorBudget.consumed).toBeNull();
+    }
+  });
+
+  it('returns one result per instance for wildcard request with 2 instances', async () => {
+    const slo = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        wildcard_0: {
+          doc_count: 200,
+          instances: {
+            buckets: [
+              { key: 'host-1', doc_count: 100, good: { value: 90 }, total: { value: 100 } },
+              { key: 'host-2', doc_count: 100, good: { value: 95 }, total: { value: 100 } },
+            ],
+          },
+        },
+      }) as any
+    );
+
+    const client = createClient();
+    const result = await client.compute(AT, [{ id: 'slo-1' }]);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({ id: 'slo-1', instanceId: 'host-1' });
+    expect(result.results[1]).toMatchObject({ id: 'slo-1', instanceId: 'host-2' });
+  });
+
+  it('returns synthetic NO_DATA result for wildcard with no data in window', async () => {
+    const slo = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        wildcard_0: {
+          doc_count: 0,
+          instances: { buckets: [] },
+        },
+      }) as any
+    );
+
+    const client = createClient();
+    const result = await client.compute(AT, [{ id: 'slo-1' }]);
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({ id: 'slo-1', instanceId: ALL_VALUE });
+    if ('summary' in result.results[0]) {
+      expect(result.results[0].summary.status).toBe('NO_DATA');
+      expect(result.results[0].summary.sliValue).toBeNull();
+    }
+  });
+
+  it('issues a single ES query for two SLOs sharing the same time window', async () => {
+    const slo1 = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    const slo2 = createSLO({ id: 'slo-2', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo1, slo2]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        specific_0: { doc_count: 100, good: { value: 90 }, total: { value: 100 } },
+        specific_1: { doc_count: 200, good: { value: 180 }, total: { value: 200 } },
+      }) as any
+    );
+
+    const client = createClient();
+    const result = await client.compute(AT, [
+      { id: 'slo-1', instanceId: 'inst-1' },
+      { id: 'slo-2', instanceId: 'inst-1' },
+    ]);
+
+    expect(esClientMock.search).toHaveBeenCalledTimes(1);
+    expect(result.results).toHaveLength(2);
+  });
+
+  it('issues separate ES queries for two SLOs with different time windows', async () => {
+    const slo1 = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    const slo2 = createSLO({ id: 'slo-2', timeWindow: thirtyDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo1, slo2]);
+
+    esClientMock.search
+      .mockResolvedValueOnce(
+        buildEsResponse({
+          specific_0: { doc_count: 100, good: { value: 90 }, total: { value: 100 } },
+        }) as any
+      )
+      .mockResolvedValueOnce(
+        buildEsResponse({
+          specific_0: { doc_count: 200, good: { value: 180 }, total: { value: 200 } },
+        }) as any
+      );
+
+    const client = createClient();
+    const result = await client.compute(AT, [
+      { id: 'slo-1', instanceId: 'inst-1' },
+      { id: 'slo-2', instanceId: 'inst-1' },
+    ]);
+
+    expect(esClientMock.search).toHaveBeenCalledTimes(2);
+    expect(result.results).toHaveLength(2);
+  });
+
+  it('uses value_count(isGoodSlice) for timeslices budgeting method', async () => {
+    const slo = createSLOWithTimeslicesBudgetingMethod({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        specific_0: { doc_count: 100, good: { value: 90 }, total: { value: 100 } },
+      }) as any
+    );
+
+    const client = createClient();
+    await client.compute(AT, [{ id: 'slo-1', instanceId: 'inst-1' }]);
+
+    expect(esClientMock.search).toHaveBeenCalledTimes(1);
+    const searchCall = esClientMock.search.mock.calls[0][0] as any;
+    expect(searchCall.aggs.specific_0.aggs).toEqual({
+      good: { sum: { field: 'slo.isGoodSlice' } },
+      total: { value_count: { field: 'slo.isGoodSlice' } },
+    });
+  });
+
+  it('uses the correct date range for calendar-aligned time window at a given date', async () => {
+    const slo = createSLO({ id: 'slo-1', timeWindow: weeklyCalendarAligned() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
+
+    esClientMock.search.mockResolvedValueOnce(
+      buildEsResponse({
+        specific_0: { doc_count: 50, good: { value: 45 }, total: { value: 50 } },
+      }) as any
+    );
+
+    const midWeek = new Date('2024-01-10T10:00:00.000Z');
+    const client = createClient();
+    await client.compute(midWeek, [{ id: 'slo-1', instanceId: 'inst-1' }]);
+
+    const searchCall = esClientMock.search.mock.calls[0][0] as any;
+    const rangeFilter = searchCall.query.bool.filter.find(
+      (f: { range?: unknown }) => f.range !== undefined
+    );
+    expect(rangeFilter).toBeDefined();
+    expect(rangeFilter.range['@timestamp'].gte).toContain('2024-01-08');
+    expect(rangeFilter.range['@timestamp'].lte).toContain('2024-01-14');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.test.ts
@@ -243,7 +243,7 @@ describe('BulkSnapshotClient', () => {
     });
   });
 
-  it('uses the correct date range for calendar-aligned time window at a given date', async () => {
+  it('clamps the calendar-aligned date range upper bound to the requested date', async () => {
     const slo = createSLO({ id: 'slo-1', timeWindow: weeklyCalendarAligned() });
     repositoryMock.findAllByIds.mockResolvedValueOnce([slo]);
 
@@ -263,6 +263,40 @@ describe('BulkSnapshotClient', () => {
     );
     expect(rangeFilter).toBeDefined();
     expect(rangeFilter.range['@timestamp'].gte).toContain('2024-01-08');
-    expect(rangeFilter.range['@timestamp'].lte).toContain('2024-01-14');
+    // The calendar week ends 2024-01-14, but a snapshot at `at` must not aggregate
+    // documents newer than the requested point in time.
+    expect(rangeFilter.range['@timestamp'].lte).toBe('2024-01-10T10:00:00.000Z');
+  });
+
+  it('returns per-item errors when a time-window group query fails', async () => {
+    const slo1 = createSLO({ id: 'slo-1', timeWindow: sevenDaysRolling() });
+    const slo2 = createSLO({ id: 'slo-2', timeWindow: thirtyDaysRolling() });
+    repositoryMock.findAllByIds.mockResolvedValueOnce([slo1, slo2]);
+
+    esClientMock.search
+      .mockResolvedValueOnce(
+        buildEsResponse({
+          specific_0: { doc_count: 100, good: { value: 90 }, total: { value: 100 } },
+        }) as any
+      )
+      .mockRejectedValueOnce(new Error('search failed'));
+
+    const client = createClient();
+    const result = await client.compute(AT, [
+      { id: 'slo-1', instanceId: 'inst-1' },
+      { id: 'slo-2', instanceId: 'inst-1' },
+    ]);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      id: 'slo-1',
+      instanceId: 'inst-1',
+      summary: expect.objectContaining({ sliValue: 0.9 }),
+    });
+    expect(result.results[1]).toMatchObject({
+      id: 'slo-2',
+      instanceId: 'inst-1',
+      error: { statusCode: 500, message: 'search failed' },
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import {
+  ALL_VALUE,
+  timeslicesBudgetingMethodSchema,
+} from '@kbn/slo-schema';
+import type {
+  BulkSnapshotRequestItem,
+  BulkSnapshotResponse,
+  SnapshotResult,
+  SnapshotSummary,
+} from '@kbn/slo-schema';
+import { SLI_DESTINATION_INDEX_PATTERN } from '../../common/constants';
+import type { DateRange, SLODefinition } from '../domain/models';
+import { computeSLI, computeSummaryStatus, toErrorBudget, toDateRange } from '../domain/services';
+import type { SLODefinitionRepository } from './slo_definition_repository';
+import { getSlicesFromDateRange } from './utils/get_slices_from_date_range';
+
+interface FoundRequest {
+  originalIndex: number;
+  slo: SLODefinition;
+  req: BulkSnapshotRequestItem;
+}
+
+interface AggBucket {
+  good: { value: number };
+  total: { value: number };
+}
+
+interface TermsBucket extends AggBucket {
+  key: string;
+}
+
+const toTimeWindowKey = (slo: SLODefinition): string =>
+  `${slo.timeWindow.type}_${slo.timeWindow.duration.format()}`;
+
+const buildMetricAggs = (slo: SLODefinition) =>
+  timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)
+    ? {
+        good: { sum: { field: 'slo.isGoodSlice' } },
+        total: { value_count: { field: 'slo.isGoodSlice' } },
+      }
+    : {
+        good: { sum: { field: 'slo.numerator' } },
+        total: { sum: { field: 'slo.denominator' } },
+      };
+
+const toNoDataSummary = (slo: SLODefinition): SnapshotSummary => ({
+  status: 'NO_DATA',
+  sliValue: null,
+  errorBudget: { initial: 1 - slo.objective.target, consumed: null, remaining: null },
+  good: 0,
+  total: 0,
+});
+
+const toSnapshotSummary = (
+  slo: SLODefinition,
+  good: number,
+  total: number,
+  dateRange: DateRange
+): SnapshotSummary => {
+  const sliValue = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)
+    ? computeSLI(good, total, getSlicesFromDateRange(dateRange, slo.objective.timesliceWindow!))
+    : computeSLI(good, total);
+
+  if (sliValue < 0) {
+    return toNoDataSummary(slo);
+  }
+
+  const initial = 1 - slo.objective.target;
+  const consumed = initial === 0 ? 0 : (1 - sliValue) / initial;
+  const errorBudget = toErrorBudget(initial, consumed, false);
+
+  return {
+    status: computeSummaryStatus(slo.objective, sliValue, errorBudget),
+    sliValue,
+    errorBudget: { initial: errorBudget.initial, consumed: errorBudget.consumed, remaining: errorBudget.remaining },
+    good,
+    total,
+  };
+};
+
+const isWildcard = (req: BulkSnapshotRequestItem): boolean =>
+  req.instanceId === undefined || req.instanceId === ALL_VALUE;
+
+export class BulkSnapshotClient {
+  constructor(
+    private readonly esClient: ElasticsearchClient,
+    private readonly repository: SLODefinitionRepository,
+    private readonly spaceId: string
+  ) {}
+
+  async compute(at: Date, requests: BulkSnapshotRequestItem[]): Promise<BulkSnapshotResponse> {
+    const uniqueIds = [...new Set(requests.map((r) => r.id))];
+    const definitions = await this.repository.findAllByIds(uniqueIds);
+    const definitionMap = new Map<string, SLODefinition>(definitions.map((d) => [d.id, d]));
+    const missingIds = new Set(uniqueIds.filter((id) => !definitionMap.has(id)));
+
+    const placeholders: Array<SnapshotResult[]> = new Array(requests.length);
+
+    const foundRequests: FoundRequest[] = [];
+
+    for (let i = 0; i < requests.length; i++) {
+      const req = requests[i];
+      if (missingIds.has(req.id)) {
+        placeholders[i] = [
+          {
+            id: req.id,
+            instanceId: req.instanceId ?? ALL_VALUE,
+            error: { statusCode: 404, message: `SLO [${req.id}] not found` },
+          },
+        ];
+      } else {
+        foundRequests.push({ originalIndex: i, slo: definitionMap.get(req.id)!, req });
+      }
+    }
+
+    if (foundRequests.length === 0) {
+      return { at: at.toISOString(), results: placeholders.flat() };
+    }
+
+    const grouped = new Map<string, FoundRequest[]>();
+    for (const fr of foundRequests) {
+      const key = toTimeWindowKey(fr.slo);
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key)!.push(fr);
+    }
+
+    const groupResults = await Promise.allSettled(
+      [...grouped.values()].map((group) => this.computeGroup(at, group))
+    );
+
+    for (const result of groupResults) {
+      if (result.status === 'fulfilled') {
+        const { assignments } = result.value;
+        for (const { index, results } of assignments) {
+          placeholders[index] = results;
+        }
+      }
+    }
+
+    return { at: at.toISOString(), results: placeholders.flat() };
+  }
+
+  private async computeGroup(
+    at: Date,
+    group: FoundRequest[]
+  ): Promise<{ assignments: Array<{ index: number; results: SnapshotResult[] }> }> {
+    const firstSlo = group[0].slo;
+    const dateRange = toDateRange(firstSlo.timeWindow, at);
+
+    const specifics = group.filter((fr) => !isWildcard(fr.req));
+    const wildcards = group.filter((fr) => isWildcard(fr.req));
+
+    const uniqueSloIds = [...new Set(group.map((fr) => fr.slo.id))];
+
+    const namedAggs: Record<string, unknown> = {};
+
+    for (let i = 0; i < specifics.length; i++) {
+      const { slo, req } = specifics[i];
+      namedAggs[`specific_${i}`] = {
+        filter: {
+          bool: {
+            filter: [
+              { term: { 'slo.id': slo.id } },
+              { term: { 'slo.revision': slo.revision } },
+              { term: { 'slo.instanceId': req.instanceId! } },
+            ],
+          },
+        },
+        aggs: buildMetricAggs(slo),
+      };
+    }
+
+    for (let i = 0; i < wildcards.length; i++) {
+      const { slo } = wildcards[i];
+      namedAggs[`wildcard_${i}`] = {
+        filter: {
+          bool: {
+            filter: [
+              { term: { 'slo.id': slo.id } },
+              { term: { 'slo.revision': slo.revision } },
+            ],
+          },
+        },
+        aggs: {
+          instances: {
+            terms: { field: 'slo.instanceId', size: 1000 },
+            aggs: buildMetricAggs(slo),
+          },
+        },
+      };
+    }
+
+    const response = await this.esClient.search({
+      index: SLI_DESTINATION_INDEX_PATTERN,
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            { term: { spaceId: this.spaceId } },
+            { terms: { 'slo.id': uniqueSloIds } },
+            {
+              range: {
+                '@timestamp': {
+                  gte: dateRange.from.toISOString(),
+                  lte: dateRange.to.toISOString(),
+                },
+              },
+            },
+          ],
+        },
+      },
+      aggs: namedAggs,
+    });
+
+    const aggs = response.aggregations as Record<string, unknown> | undefined;
+    const assignments: Array<{ index: number; results: SnapshotResult[] }> = [];
+
+    for (let i = 0; i < specifics.length; i++) {
+      const { originalIndex, slo, req } = specifics[i];
+      const bucket = aggs?.[`specific_${i}`] as AggBucket | undefined;
+      const good = bucket?.good?.value ?? 0;
+      const total = bucket?.total?.value ?? 0;
+      assignments.push({
+        index: originalIndex,
+        results: [
+          {
+            id: slo.id,
+            instanceId: req.instanceId!,
+            summary: toSnapshotSummary(slo, good, total, dateRange),
+          },
+        ],
+      });
+    }
+
+    for (let i = 0; i < wildcards.length; i++) {
+      const { originalIndex, slo } = wildcards[i];
+      const wildcardAgg = aggs?.[`wildcard_${i}`] as
+        | { instances?: { buckets?: TermsBucket[] } }
+        | undefined;
+      const buckets = wildcardAgg?.instances?.buckets ?? [];
+
+      if (buckets.length === 0) {
+        assignments.push({
+          index: originalIndex,
+          results: [{ id: slo.id, instanceId: ALL_VALUE, summary: toNoDataSummary(slo) }],
+        });
+      } else {
+        assignments.push({
+          index: originalIndex,
+          results: buckets.map((b) => ({
+            id: slo.id,
+            instanceId: b.key,
+            summary: toSnapshotSummary(slo, b.good.value, b.total.value, dateRange),
+          })),
+        });
+      }
+    }
+
+    return { assignments };
+  }
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/bulk_snapshot_client.ts
@@ -65,9 +65,10 @@ const toSnapshotSummary = (
   total: number,
   dateRange: DateRange
 ): SnapshotSummary => {
-  const sliValue = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)
-    ? computeSLI(good, total, getSlicesFromDateRange(dateRange, slo.objective.timesliceWindow!))
-    : computeSLI(good, total);
+  const sliValue =
+    timeslicesBudgetingMethodSchema.is(slo.budgetingMethod) && slo.objective.timesliceWindow
+      ? computeSLI(good, total, getSlicesFromDateRange(dateRange, slo.objective.timesliceWindow))
+      : computeSLI(good, total);
 
   if (sliValue < 0) {
     return toNoDataSummary(slo);
@@ -132,15 +133,29 @@ export class BulkSnapshotClient {
       grouped.get(key)!.push(fr);
     }
 
+    const groups = [...grouped.values()];
     const groupResults = await Promise.allSettled(
-      [...grouped.values()].map((group) => this.computeGroup(at, group))
+      groups.map((group) => this.computeGroup(at, group))
     );
 
-    for (const result of groupResults) {
+    for (let g = 0; g < groupResults.length; g++) {
+      const result = groupResults[g];
       if (result.status === 'fulfilled') {
         const { assignments } = result.value;
         for (const { index, results } of assignments) {
           placeholders[index] = results;
+        }
+      } else {
+        const message =
+          result.reason instanceof Error ? result.reason.message : String(result.reason);
+        for (const { originalIndex, slo, req } of groups[g]) {
+          placeholders[originalIndex] = [
+            {
+              id: slo.id,
+              instanceId: req.instanceId ?? ALL_VALUE,
+              error: { statusCode: 500, message },
+            },
+          ];
         }
       }
     }
@@ -153,7 +168,14 @@ export class BulkSnapshotClient {
     group: FoundRequest[]
   ): Promise<{ assignments: Array<{ index: number; results: SnapshotResult[] }> }> {
     const firstSlo = group[0].slo;
-    const dateRange = toDateRange(firstSlo.timeWindow, at);
+    const fullRange = toDateRange(firstSlo.timeWindow, at);
+    // For calendar-aligned time windows, toDateRange extends `to` to the end of the
+    // calendar period, which may be after the requested `at`. Clamp it so a historical
+    // snapshot never aggregates rollup documents newer than the requested point in time.
+    const dateRange: DateRange = {
+      from: fullRange.from,
+      to: fullRange.to.getTime() > at.getTime() ? at : fullRange.to,
+    };
 
     const specifics = group.filter((fr) => !isWildcard(fr.req));
     const wildcards = group.filter((fr) => isWildcard(fr.req));


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/278796

- Adds `POST /api/observability/slos/_bulk_snapshot` to fetch SLI snapshots for up to 100 SLOs in a single request
- Groups SLOs by time window type+duration to minimise ES round-trips (one query per group, parallel across groups)
- Enforces space isolation via `{ term: { spaceId } }` filter, consistent with other SLO services
- Clamps `dateRange.to` to the requested `at` for calendar-aligned windows so the expected-slice denominator only covers the elapsed portion of the period (avoids penalising timeslices SLOs for future slices that don't exist yet)
- Propagates per-item `500` errors when a time-window group ES query fails, instead of silently dropping result slots

## Schema

**Request** `POST /api/observability/slos/_bulk_snapshot`
```json
{
  "at": "2024-01-15T12:00:00.000Z",
  "requests": [
    { "id": "my-slo-id" },
    { "id": "my-slo-id", "instanceId": "host-1" }
  ]
}
```

**Response**
```json
{
  "at": "2024-01-15T12:00:00.000Z",
  "results": [
    { "id": "my-slo-id", "instanceId": "*", "summary": { "status": "HEALTHY", "sliValue": 0.99, ... } },
    { "id": "unknown-id", "instanceId": "*", "error": { "statusCode": 404, "message": "SLO [unknown-id] not found" } }
  ]
}
```


