### PR TITLE
[SigEvents][Discovery] Add severity filter to Significant Events tab

### DIFF
--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/index.ts
@@ -100,6 +100,7 @@ export {
   type SignalEntry,
   type Severity,
   severitySchema,
+  SEVERITY_OPTIONS,
   getSeverityLabel,
   detectionSchema,
   discoverySchema,

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/significant_events/common_schemas.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/significant_events/common_schemas.ts
@@ -188,18 +188,26 @@ export const severitySchema = z.enum(['20-low', '40-medium', '60-high', '80-crit
 
 export type Severity = z.infer<typeof severitySchema>;
 
+/** Canonical severity values in descending severity order (critical → low). */
+export const SEVERITY_OPTIONS: [Severity, ...Severity[]] = [
+  '80-critical',
+  '60-high',
+  '40-medium',
+  '20-low',
+];
+
 const SEVERITY_LABELS: Record<Severity, string> = {
   '20-low': i18n.translate('xpack.significantEvents.severity.lowLabel', {
-    defaultMessage: 'low',
+    defaultMessage: 'Low',
   }),
   '40-medium': i18n.translate('xpack.significantEvents.severity.mediumLabel', {
-    defaultMessage: 'medium',
+    defaultMessage: 'Medium',
   }),
   '60-high': i18n.translate('xpack.significantEvents.severity.highLabel', {
-    defaultMessage: 'high',
+    defaultMessage: 'High',
   }),
   '80-critical': i18n.translate('xpack.significantEvents.severity.criticalLabel', {
-    defaultMessage: 'critical',
+    defaultMessage: 'Critical',
   }),
 };
 

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/significant_events/common_schemas.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/significant_events/common_schemas.ts
@@ -171,9 +171,11 @@ const detectionSignalSchema = signalBaseSchema.extend({
 export const signalEntrySchema = z.discriminatedUnion('type', [detectionSignalSchema]);
 export type SignalEntry = z.infer<typeof signalEntrySchema>;
 
+/** Canonical severity values in descending severity order (critical → low). */
+export const SEVERITY_OPTIONS = ['80-critical', '60-high', '40-medium', '20-low'] as const;
+
 /** Canonical sortable severity used by storage, APIs, and tools. */
-export const severitySchema = z.enum(['20-low', '40-medium', '60-high', '80-critical'])
-  .describe(dedent`
+export const severitySchema = z.enum(SEVERITY_OPTIONS).describe(dedent`
     Sortable severity keyword. Higher prefixes indicate greater severity:
     "80-critical" = the most severe outage. Any ONE qualifies independently:
       - a site-wide/global outage affecting most customers;
@@ -187,14 +189,6 @@ export const severitySchema = z.enum(['20-low', '40-medium', '60-high', '80-crit
   `);
 
 export type Severity = z.infer<typeof severitySchema>;
-
-/** Canonical severity values in descending severity order (critical → low). */
-export const SEVERITY_OPTIONS: [Severity, ...Severity[]] = [
-  '80-critical',
-  '60-high',
-  '40-medium',
-  '20-low',
-];
 
 const SEVERITY_LABELS: Record<Severity, string> = {
   '20-low': i18n.translate('xpack.significantEvents.severity.lowLabel', {

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/significant_events/index.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/significant_events/index.ts
@@ -19,6 +19,7 @@ export {
   causalFeatureSchema,
   signalEntrySchema,
   severitySchema,
+  SEVERITY_OPTIONS,
   getSeverityLabel,
   type BlastRadiusEntry,
   type CausalFeature,

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/event_client.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/event_client.test.ts
@@ -151,5 +151,24 @@ describe('EventClient', () => {
       expect(result.hits[0].status).toBe('closed');
       expect(result.total).toBe(1);
     });
+
+    it('filters severity after latest-per-slug reduction', async () => {
+      const { client, query } = createSearchClient({
+        hits: [],
+        total: 0,
+      });
+
+      await client.findLatestByCurrentStatePaginated({
+        severity: ['80-critical', '60-high'],
+      });
+
+      const dataQuery = query.mock.calls
+        .map((call) => (call[0] as { query: string }).query)
+        .find((q) => !q.includes('STATS total'));
+      expect(dataQuery).toContain('severity IN');
+      expect(dataQuery?.indexOf('INLINE STATS latest_ts')).toBeLessThan(
+        dataQuery!.indexOf('severity IN')
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/event_client.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/significant_events/events/event_client.ts
@@ -9,7 +9,7 @@ import type { IDataStreamClient } from '@kbn/data-streams';
 import { esql, type ComposerSortShorthand } from '@elastic/esql';
 import type { ESQLAstExpression } from '@elastic/esql/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { SignificantEvent } from '@kbn/significant-events-schema';
+import type { SignificantEvent, Severity } from '@kbn/significant-events-schema';
 import {
   type BulkCreateOptions,
   type CommonSearchOptions,
@@ -43,6 +43,7 @@ export type EventDataStreamClient = IDataStreamClient<typeof eventsMappings, Sto
 
 export interface EventsFilterOptions {
   status?: SignificantEvent['status'][];
+  severity?: Severity[];
   stream?: string[];
   search?: string;
 }
@@ -130,6 +131,10 @@ export class EventClient {
       ? esql.exp`${esql.col('status')} IN (${options.status.map((s) => esql.str(s))})`
       : undefined;
 
+    const severityWhere = options.severity
+      ? esql.exp`${esql.col('severity')} IN (${options.severity.map((s) => esql.str(s))})`
+      : undefined;
+
     // ComposerQuery is mutable — each chaining call mutates the same object and returns `this`.
     // Build the base query twice via a factory so the data branch and count branch get independent
     // instances; sharing a single reference causes the count pipeline to corrupt the data query.
@@ -143,10 +148,11 @@ export class EventClient {
         from: options.from,
         to: options.to,
       });
-      // stream + search filters run pre-latest; state filter runs post-latest
+      // stream + search filters run pre-latest; status + severity filters run post-latest
       q = withWhere(q, this.buildWhere({ stream: options.stream, search: options.search }));
       q = pickLatestPerGroup(q, FIELD_EVENT_ID);
       q = withWhere(q, statusWhere);
+      q = withWhere(q, severityWhere);
       return q;
     };
 

--- a/x-pack/platform/plugins/shared/significant_events/server/routes/internal/events/route.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/routes/internal/events/route.ts
@@ -9,6 +9,7 @@ import {
   significantEventSchema,
   significantEventInvestigationSchema,
   significantEventStatusSchema,
+  severitySchema,
   type Detection,
   type SignificantEvent,
   type Discovery,
@@ -79,6 +80,7 @@ const eventsSearchRoute = createServerRoute({
         .optional(),
       stream: z.union([z.string().max(255), z.array(z.string().max(255)).max(50)]).optional(),
       search: z.string().max(500).optional(),
+      severity: z.union([severitySchema, z.array(severitySchema).max(4)]).optional(),
     }),
   }),
   handler: async ({
@@ -91,12 +93,13 @@ const eventsSearchRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing });
 
-    const { status, stream, search, ...rest } = params.query;
+    const { status, stream, search, severity, ...rest } = params.query;
 
     return getEventClient().findLatestByCurrentStatePaginated({
       ...rest,
       status: toArray(status),
       stream: toArray(stream),
+      severity: toArray(severity),
       search: search || undefined,
     });
   },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_url_state.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_url_state.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { castArray } from 'lodash';
 import { useDebouncedValue } from '@kbn/react-hooks';
 import { COMPUTED_FEATURE_TYPES } from '@kbn/significant-events-schema';
 import type { KnowledgeIndicator } from '@kbn/streams-ai';
@@ -20,9 +21,6 @@ import { getKnowledgeIndicatorType } from '../../../stream_detail_significant_ev
 
 const SEARCH_DEBOUNCE_MS = 300;
 const COMPUTED_FEATURE_TYPES_SET = new Set<string>(COMPUTED_FEATURE_TYPES);
-
-const toArray = (v: string | string[] | undefined): string[] =>
-  v == null ? [] : Array.isArray(v) ? v : [v];
 
 interface UseKnowledgeIndicatorsUrlStateParams {
   knowledgeIndicators: KnowledgeIndicator[];
@@ -53,10 +51,16 @@ export function useKnowledgeIndicatorsUrlState({
   const [statusFilter, setStatusFilter] = useState<'active' | 'excluded'>(() =>
     query?.status === 'excluded' ? 'excluded' : 'active'
   );
-  const [selectedTypes, setSelectedTypes] = useState<string[]>(() => toArray(query?.type));
-  const [selectedSubtypes, setSelectedSubtypes] = useState<string[]>(() => toArray(query?.subtype));
-  const [selectedStreams, setSelectedStreams] = useState<string[]>(() => toArray(query?.stream));
-  const initialUrlStreamsRef = useRef<string[]>(toArray(query?.stream));
+  const [selectedTypes, setSelectedTypes] = useState<string[]>(() =>
+    query?.type ? castArray(query.type) : []
+  );
+  const [selectedSubtypes, setSelectedSubtypes] = useState<string[]>(() =>
+    query?.subtype ? castArray(query.subtype) : []
+  );
+  const [selectedStreams, setSelectedStreams] = useState<string[]>(() =>
+    query?.stream ? castArray(query.stream) : []
+  );
+  const initialUrlStreamsRef = useRef<string[]>(query?.stream ? castArray(query.stream) : []);
   const [hideComputedTypes, setHideComputedTypes] = useState(() =>
     query?.showComputed === 'true' ? false : true
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/significant_events_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/significant_events_tab/index.tsx
@@ -25,6 +25,7 @@ import useInterval from 'react-use/lib/useInterval';
 import { i18n } from '@kbn/i18n';
 import {
   getSeverityLabel,
+  severitySchema,
   SIGNIFICANT_EVENT_STATUS_OPTIONS,
   SEVERITY_OPTIONS,
 } from '@kbn/significant-events-schema';
@@ -243,8 +244,7 @@ const extractCheckedKeys = (options: EuiSelectableOption[]): string[] =>
 const isSignificantEventStatus = (value: string): value is SignificantEventStatus =>
   SIGNIFICANT_EVENT_STATUS_OPTIONS.some((status) => status === value);
 
-const isSeverity = (value: string): value is Severity =>
-  SEVERITY_OPTIONS.some((severity) => severity === value);
+const isSeverity = (value: string): value is Severity => severitySchema.safeParse(value).success;
 
 const buildSelectableOptions = <T extends string>({
   values,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/significant_events_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/significant_events_tab/index.tsx
@@ -23,8 +23,16 @@ import { css } from '@emotion/react';
 import { capitalize } from 'lodash';
 import useInterval from 'react-use/lib/useInterval';
 import { i18n } from '@kbn/i18n';
-import { getSeverityLabel, SIGNIFICANT_EVENT_STATUS_OPTIONS } from '@kbn/significant-events-schema';
-import type { SignificantEvent, SignificantEventStatus } from '@kbn/significant-events-schema';
+import {
+  getSeverityLabel,
+  SIGNIFICANT_EVENT_STATUS_OPTIONS,
+  SEVERITY_OPTIONS,
+} from '@kbn/significant-events-schema';
+import type {
+  SignificantEvent,
+  SignificantEventStatus,
+  Severity,
+} from '@kbn/significant-events-schema';
 import { useSignificantEventsUrlState } from './use_significant_events_url_state';
 import { useFetchSignificantEventLifecycle } from '../../../../../hooks/significant_events/use_fetch_significant_event_lifecycle';
 import { RUNNING_POLL_INTERVAL_MS } from '../../../constants';
@@ -42,6 +50,8 @@ import { getSignificantEventStatusColor } from '../shared/status_display';
 import { SIGNIFICANT_EVENT_STATUS_LABELS } from '../shared/translations';
 import { useTriggerInvestigation } from '../../../../../hooks/significant_events/use_trigger_investigation';
 import { useUpdateSignificantEvent } from '../../../../../hooks/significant_events/use_update_significant_event';
+
+export const DEFAULT_SIGNIFICANT_EVENT_SEVERITY_FILTER: Severity[] = ['80-critical', '60-high'];
 
 const RUN_ARIA_LABEL = i18n.translate(
   'xpack.streams.sigEventsTab.runInvestigationButton.ariaLabel',
@@ -104,8 +114,6 @@ const CloseEventCell = ({ event }: { event: SignificantEvent }) => {
   );
 };
 
-const MAX_VISIBLE_STREAMS = 3;
-
 const clickableRowCss = css`
   cursor: pointer;
 `;
@@ -125,10 +133,6 @@ const LOADING_MESSAGE = i18n.translate('xpack.streams.sigEventsTab.loadingMessag
 const EMPTY_MESSAGE = i18n.translate('xpack.streams.sigEventsTab.emptyBody', {
   defaultMessage: 'No significant events found.',
 });
-const MORE_LABEL = i18n.translate('xpack.streams.sigEventsTab.moreLabel', {
-  defaultMessage: 'more',
-});
-
 const columns: Array<EuiBasicTableColumn<SignificantEvent>> = [
   {
     field: '@timestamp',
@@ -163,22 +167,43 @@ const columns: Array<EuiBasicTableColumn<SignificantEvent>> = [
       defaultMessage: 'Streams',
     }),
     width: '160px',
+    // Required for the column's `width` to actually constrain the cell — EUI's
+    // `truncateText` only kicks in when the cell is bounded (see tableLayout="fixed" below).
+    truncateText: true,
     render: (streamNames: string[]) => {
       const names = streamNames ?? [];
-      const visible = names.slice(0, MAX_VISIBLE_STREAMS);
-      const remaining = names.length - visible.length;
+      const [first, ...rest] = names;
+      if (!first) return null;
+      const overflowCount = rest.length;
       return (
-        <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
-          {visible.map((name, idx) => (
-            <EuiFlexItem grow={false} key={`${name}-${idx}`}>
-              <EuiBadge color="hollow">{name}</EuiBadge>
-            </EuiFlexItem>
-          ))}
-          {remaining > 0 && (
+        <EuiFlexGroup
+          gutterSize="xs"
+          alignItems="center"
+          responsive={false}
+          css={css`
+            flex-wrap: nowrap;
+            min-width: 0;
+          `}
+        >
+          <EuiFlexItem
+            grow={1}
+            css={css`
+              min-width: 0;
+            `}
+          >
+            <EuiToolTip content={first}>
+              <EuiBadge tabIndex={0} color="hollow">
+                {first}
+              </EuiBadge>
+            </EuiToolTip>
+          </EuiFlexItem>
+          {overflowCount > 0 && (
             <EuiFlexItem grow={false}>
-              <EuiText size="xs" color="subdued">
-                +{remaining} {MORE_LABEL}
-              </EuiText>
+              <EuiToolTip content={rest.join(', ')}>
+                <EuiText tabIndex={0} size="xs" color="subdued">
+                  +{overflowCount}
+                </EuiText>
+              </EuiToolTip>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>
@@ -218,6 +243,9 @@ const extractCheckedKeys = (options: EuiSelectableOption[]): string[] =>
 const isSignificantEventStatus = (value: string): value is SignificantEventStatus =>
   SIGNIFICANT_EVENT_STATUS_OPTIONS.some((status) => status === value);
 
+const isSeverity = (value: string): value is Severity =>
+  SEVERITY_OPTIONS.some((severity) => severity === value);
+
 const buildSelectableOptions = <T extends string>({
   values,
   selected,
@@ -241,6 +269,9 @@ export const SigEventsTab = () => {
   const [statusFilter, setStatusFilter] = useState<SignificantEventStatus[]>(() =>
     SIGNIFICANT_EVENT_STATUS_OPTIONS.filter((status) => status === 'open')
   );
+  const [severityFilter, setSeverityFilter] = useState<Severity[]>(() => [
+    ...DEFAULT_SIGNIFICANT_EVENT_SEVERITY_FILTER,
+  ]);
   const [streamFilter, setStreamFilter] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearch = useDebouncedValue(searchQuery, 300);
@@ -258,6 +289,7 @@ export const SigEventsTab = () => {
       from: timeState.start,
       to: timeState.end,
       status: statusFilter.length > 0 ? statusFilter : undefined,
+      severity: severityFilter.length > 0 ? severityFilter : undefined,
       stream: streamFilter.length > 0 ? streamFilter : undefined,
       search: debouncedSearch || undefined,
     });
@@ -291,6 +323,11 @@ export const SigEventsTab = () => {
     []
   );
 
+  const onSeverityChange = useCallback(
+    (opts: EuiSelectableOption[]) => setSeverityFilter(extractCheckedKeys(opts).filter(isSeverity)),
+    []
+  );
+
   const filters = useMemo(
     () => [
       {
@@ -309,6 +346,22 @@ export const SigEventsTab = () => {
         onChange: onStatusChange,
       },
       {
+        label: i18n.translate('xpack.streams.sigEventsTab.filter.severity', {
+          defaultMessage: 'Severity',
+        }),
+        ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.severityAriaLabel', {
+          defaultMessage: 'Filter by severity',
+        }),
+        options: buildSelectableOptions({
+          values: SEVERITY_OPTIONS,
+          selected: severityFilter,
+          getLabel: getSeverityLabel,
+        }),
+        numFilters: SEVERITY_OPTIONS.length,
+        numActiveFilters: severityFilter.length,
+        onChange: onSeverityChange,
+      },
+      {
         label: i18n.translate('xpack.streams.sigEventsTab.filter.stream', {
           defaultMessage: 'Stream',
         }),
@@ -325,7 +378,15 @@ export const SigEventsTab = () => {
         onChange: onStreamChange,
       },
     ],
-    [statusFilter, streamFilter, streamOptions, onStatusChange, onStreamChange]
+    [
+      statusFilter,
+      severityFilter,
+      streamFilter,
+      streamOptions,
+      onStatusChange,
+      onSeverityChange,
+      onStreamChange,
+    ]
   );
 
   const onTableChange = ({ page }: { page?: { index: number; size: number } }) => {
@@ -397,6 +458,7 @@ export const SigEventsTab = () => {
       )}
       <EuiFlexItem grow={false}>
         <EuiBasicTable<SignificantEvent>
+          tableLayout="fixed"
           tableCaption={TABLE_CAPTION}
           items={data?.hits ?? []}
           columns={columns}

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/significant_events/use_fetch_significant_events.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/significant_events/use_fetch_significant_events.ts
@@ -7,7 +7,11 @@
 
 import { useEffect, useState } from 'react';
 import { type QueryFunctionContext, useQuery } from '@kbn/react-query';
-import type { SignificantEvent, SignificantEventStatus } from '@kbn/significant-events-schema';
+import type {
+  SignificantEvent,
+  SignificantEventStatus,
+  Severity,
+} from '@kbn/significant-events-schema';
 import type { PaginatedResponse } from '@kbn/streams-plugin/common';
 import { useKibana } from '../use_kibana';
 import { useFetchErrorToast } from '../use_fetch_error_toast';
@@ -16,6 +20,7 @@ interface UseFetchSignificantEventsParams {
   from: string | number;
   to: string | number;
   status?: SignificantEventStatus[];
+  severity?: Severity[];
   stream?: string[];
   search?: string;
 }
@@ -24,6 +29,7 @@ export const useFetchSignificantEvents = ({
   from,
   to,
   status,
+  severity,
   stream,
   search,
 }: UseFetchSignificantEventsParams) => {
@@ -40,7 +46,7 @@ export const useFetchSignificantEvents = ({
 
   useEffect(() => {
     setPagination((prev) => (prev.page === 1 ? prev : { ...prev, page: 1 }));
-  }, [from, to, status, stream, search]);
+  }, [from, to, status, severity, stream, search]);
 
   const query = useQuery<PaginatedResponse<SignificantEvent>, Error>({
     queryKey: [
@@ -50,6 +56,7 @@ export const useFetchSignificantEvents = ({
       from,
       to,
       status,
+      severity,
       stream,
       search,
     ],
@@ -64,6 +71,7 @@ export const useFetchSignificantEvents = ({
             from: new Date(from).toISOString(),
             to: new Date(to).toISOString(),
             ...(status?.length ? { status } : {}),
+            ...(severity?.length ? { severity } : {}),
             ...(stream?.length ? { stream } : {}),
             ...(search ? { search } : {}),
           },


### PR DESCRIPTION
closes https://github.com/elastic/nightshift-program/issues/662

## Summary

Adds a **Severity** filter to the Significant Events tab in Discovery so users can narrow the list to the severities they care about. **Critical** and **High** are selected by default; clearing all checkboxes returns every severity (same behavior as the Status filter).

Server-side filtering applies on the **latest** document per event (post-`pickLatestPerGroup`, alongside status). The UI reuses the existing `FilterPopover` pattern and wires severity through `useFetchSignificantEvents`.

<img width="1479" height="499" alt="image" src="https://github.com/user-attachments/assets/072236b2-5ce5-42af-836a-41a1b7c94a9f" />

<img width="1485" height="541" alt="image" src="https://github.com/user-attachments/assets/7ab88c64-1ece-48c3-b986-e62335227d1a" />


### How to test

1. Open **Streams → Discovery → Significant Events** and confirm a **Severity** filter appears next to Status and Stream.
2. On load, only **Critical** and **High** events should appear; the network request should include `severity=80-critical&severity=60-high` (or equivalent array form).
3. Change severity selection and confirm the table refetches and pagination resets to page 1.
4. Clear all severity checkboxes and confirm all severities are returned (no `severity` param sent).
5. Confirm Status, Stream, search, time range, pagination, and flyout deeplink behavior are unchanged.
