### PR TITLE
[9.5] [ci] Bump diskSizeGb to >= 130gb (#278549)

### DIFF
--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -23,7 +23,7 @@ export const DEFAULT_AGENT_IMAGE_CONFIG: BuildkiteAgentTargetingRule = {
   provider: 'gcp',
   image: 'family/kibana-ubuntu-2404',
   imageProject: ELASTIC_IMAGES_PROD_PROJECT,
-  diskSizeGb: 120,
+  diskSizeGb: 130,
 };
 
 const getFIPSImage = () => {

--- a/.buildkite/pipelines/build_pr_and_deploy_cloud.yml
+++ b/.buildkite/pipelines/build_pr_and_deploy_cloud.yml
@@ -59,7 +59,7 @@ steps:
           provider: gcp
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
-          diskSizeGb: 125
+          diskSizeGb: 130
           machineType: c4d-standard-16
           diskType: hyperdisk-balanced
           zones: us-central1-a,us-central1-b,us-central1-c

--- a/.buildkite/pipelines/build_pr_and_test_entity_store_performance.yml
+++ b/.buildkite/pipelines/build_pr_and_test_entity_store_performance.yml
@@ -61,7 +61,7 @@ steps:
           imageProject: elastic-images-prod
           machineType: n2-standard-8
           preemptible: true
-          diskSizeGb: 125
+          diskSizeGb: 130
         if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
         timeout_in_minutes: 90
         key: build

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -24,7 +24,7 @@ steps:
     soft_fail: true
     agents:
       machineType: n2-highcpu-8
-      diskSizeGb: 120
+      diskSizeGb: 130
 
   - wait
 
@@ -117,7 +117,7 @@ steps:
     label: 'Serverless Investigations - Security Solution Cypress Tests'
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -132,7 +132,7 @@ steps:
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -385,7 +385,7 @@ steps:
     label: 'Investigations - Security Solution Cypress Tests'
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -400,7 +400,7 @@ steps:
     label: 'Osquery Cypress Tests'
     agents:
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -415,7 +415,7 @@ steps:
     label: 'Osquery Cypress Tests on Serverless'
     agents:
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -431,7 +431,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -446,7 +446,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     depends_on:
       - build
     timeout_in_minutes: 75

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -69,7 +69,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
-          diskSizeGb: 120
+          diskSizeGb: 130
         key: build_scout_tests
         timeout_in_minutes: 15
         depends_on:
@@ -125,7 +125,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
-          diskSizeGb: 120
+          diskSizeGb: 130
           preemptible: true
         depends_on: build
         timeout_in_minutes: 60
@@ -143,7 +143,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
-          diskSizeGb: 120
+          diskSizeGb: 130
           preemptible: true
         depends_on: build
         timeout_in_minutes: 60
@@ -281,7 +281,7 @@ steps:
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-highmem-4
-          diskSizeGb: 125
+          diskSizeGb: 130
         depends_on: build
         timeout_in_minutes: 75
         parallelism: 12
@@ -298,7 +298,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-highmem-4
-          diskSizeGb: 120
+          diskSizeGb: 130
           preemptible: true
         depends_on: build
         timeout_in_minutes: 60

--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -39,7 +39,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highcpu-8
-      diskSizeGb: 120
+      diskSizeGb: 130
 
   - label: '🧑‍🏭 Build Kibana Distribution'
     command: .buildkite/scripts/steps/build_kibana.sh

--- a/.buildkite/pipelines/fips.yml
+++ b/.buildkite/pipelines/fips.yml
@@ -8,7 +8,7 @@ steps:
     timeout_in_minutes: 10
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
 
   - wait
 
@@ -21,7 +21,7 @@ steps:
       - terrazzo-initial-pipeline-upload
     agents:
       machineType: n2-highcpu-8
-      diskSizeGb: 120
+      diskSizeGb: 130
 
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution
@@ -54,7 +54,7 @@ steps:
     timeout_in_minutes: 15
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     env:
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
       FTR_EXTRA_ARGS: '$FTR_EXTRA_ARGS'

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -75,7 +75,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     timeout_in_minutes: 75
     parallelism: 22
     key: defend-workflows-stateful
@@ -93,7 +93,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     timeout_in_minutes: 75
     parallelism: 14
     key: defend-workflows-serverless
@@ -110,7 +110,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     timeout_in_minutes: 60
     parallelism: 8
@@ -127,7 +127,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     timeout_in_minutes: 60
     parallelism: 8

--- a/.buildkite/pipelines/node_glibc_217.yml
+++ b/.buildkite/pipelines/node_glibc_217.yml
@@ -108,7 +108,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -126,7 +126,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -433,7 +433,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -451,7 +451,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -469,7 +469,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -488,7 +488,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -506,7 +506,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     depends_on:
       - build
     timeout_in_minutes: 75

--- a/.buildkite/pipelines/node_pointer_compression.yml
+++ b/.buildkite/pipelines/node_pointer_compression.yml
@@ -110,7 +110,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -128,7 +128,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -435,7 +435,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -453,7 +453,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -471,7 +471,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
     depends_on:
       - build
@@ -490,7 +490,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -508,7 +508,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
     depends_on:
       - build
     timeout_in_minutes: 75

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -28,7 +28,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highcpu-8
-      diskSizeGb: 120
+      diskSizeGb: 130
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution
@@ -56,7 +56,7 @@ steps:
       machineType: n2d-standard-8
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: quick_checks
     timeout_in_minutes: 60
     retry:
@@ -73,7 +73,7 @@ steps:
       machineType: n2d-standard-2
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: checks
     timeout_in_minutes: 60
     retry:
@@ -91,7 +91,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: linting
     timeout_in_minutes: 60
     retry:
@@ -109,7 +109,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: linting_with_types
     timeout_in_minutes: 60
     retry:
@@ -127,7 +127,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: linting_with_oxlint
     timeout_in_minutes: 60
     retry:
@@ -145,7 +145,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: check_types
     timeout_in_minutes: 60
     env:
@@ -164,7 +164,7 @@ steps:
       machineType: n2d-highmem-4
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: check_oas_snapshot
     timeout_in_minutes: 60
     retry:
@@ -197,7 +197,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 15
     retry:
       automatic:
@@ -213,7 +213,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -230,7 +230,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
@@ -249,7 +249,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2d-standard-8
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: build_scout_tests
     timeout_in_minutes: 20
     env:
@@ -287,7 +287,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: storybooks
     depends_on:
       - build

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -50,7 +50,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -71,7 +71,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -421,7 +421,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -441,7 +441,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -462,7 +462,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -483,7 +483,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -505,7 +505,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -42,7 +42,7 @@ steps:
       machineType: n2d-standard-8
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: quick_checks
     timeout_in_minutes: 60
     env:
@@ -61,7 +61,7 @@ steps:
       machineType: n2d-standard-2
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -75,7 +75,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: linting
     timeout_in_minutes: 60
     env:
@@ -92,7 +92,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: linting_with_types
     timeout_in_minutes: 60
     env:
@@ -109,7 +109,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: linting_with_oxlint
     timeout_in_minutes: 60
     env:
@@ -143,7 +143,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: check_types
     timeout_in_minutes: 60
     env:
@@ -160,7 +160,7 @@ steps:
     key: pick_test_group_run_order
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'

--- a/.buildkite/pipelines/pull_request/jest_bench.yml
+++ b/.buildkite/pipelines/pull_request/jest_bench.yml
@@ -6,6 +6,6 @@ steps:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
       zones: us-central1-c,us-central1-a
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 60
     soft_fail: true

--- a/.buildkite/pipelines/pull_request/local_check.yml
+++ b/.buildkite/pipelines/pull_request/local_check.yml
@@ -6,7 +6,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: check
     timeout_in_minutes: 35
     env:

--- a/.buildkite/pipelines/pull_request/prompt_changes.yml
+++ b/.buildkite/pipelines/pull_request/prompt_changes.yml
@@ -6,7 +6,7 @@ steps:
       machineType: n2-standard-2
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -5,7 +5,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -23,7 +23,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -54,7 +54,7 @@ steps:
     key: osquery-cypress-burn
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -5,7 +5,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -26,7 +26,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -4,7 +4,7 @@ steps:
     key: security-investigations
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -24,7 +24,7 @@ steps:
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -4,7 +4,7 @@ steps:
     key: osquery-cypress
     agents:
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -24,7 +24,7 @@ steps:
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -5,7 +5,7 @@ steps:
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/store_moon_cache.yml
+++ b/.buildkite/pipelines/pull_request/store_moon_cache.yml
@@ -6,7 +6,7 @@ steps:
     soft_fail: true
     agents:
       machineType: n2-highcpu-8
-      diskSizeGb: 120
+      diskSizeGb: 130
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp

--- a/.buildkite/pipelines/pull_request/storybooks.yml
+++ b/.buildkite/pipelines/pull_request/storybooks.yml
@@ -6,7 +6,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: storybooks
     timeout_in_minutes: 80
     retry:

--- a/.buildkite/pipelines/rspack_e2e_test.yml
+++ b/.buildkite/pipelines/rspack_e2e_test.yml
@@ -28,7 +28,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highcpu-8
-      diskSizeGb: 120
+      diskSizeGb: 130
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution
@@ -54,7 +54,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -70,7 +70,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
@@ -89,7 +89,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2d-standard-8
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: build_scout_tests
     timeout_in_minutes: 20
     env:

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -11,7 +11,7 @@ steps:
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
-          diskSizeGb: 120
+          diskSizeGb: 130
         timeout_in_minutes: 300
         parallelism: 5
         soft_fail:
@@ -29,7 +29,7 @@ steps:
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
-          diskSizeGb: 120
+          diskSizeGb: 130
         timeout_in_minutes: 300
         parallelism: 3
         soft_fail:

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
@@ -8,7 +8,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 300
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/storybooks_from_pr.yml
+++ b/.buildkite/pipelines/storybooks_from_pr.yml
@@ -17,7 +17,7 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 120
+      diskSizeGb: 130
     timeout_in_minutes: 50
     retry:
       automatic:

--- a/.buildkite/pipelines/uiam/verify_and_promote.yml
+++ b/.buildkite/pipelines/uiam/verify_and_promote.yml
@@ -23,7 +23,7 @@ steps:
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
       machineType: n2-standard-8
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
     depends_on: pre-build
@@ -37,7 +37,7 @@ steps:
     label: 'Scout Test Run Builder'
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: build_scout_tests
     timeout_in_minutes: 30
     env:

--- a/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
+++ b/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
@@ -23,7 +23,7 @@ steps:
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
       machineType: n2-standard-8
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
     depends_on: pre-build
@@ -37,7 +37,7 @@ steps:
     label: 'Scout Test Run Builder'
     agents:
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 130
     key: build_scout_tests
     timeout_in_minutes: 30
     env:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ci] Bump diskSizeGb to >= 130gb (#278549)](https://github.com/elastic/kibana/pull/278549)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon","email":"jon@elastic.co"},"sourceCommit":{"committedDate":"2026-07-15T17:35:50Z","message":"[ci] Bump diskSizeGb to >= 130gb (#278549)","sha":"ea714e9dc2ceefdbd27eb6f2c78034704ff91adc","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport:version","v9.5.0","v9.6.0"],"title":"[ci] Bump diskSizeGb to >= 130gb","number":278549,"url":"https://github.com/elastic/kibana/pull/278549","mergeCommit":{"message":"[ci] Bump diskSizeGb to >= 130gb (#278549)","sha":"ea714e9dc2ceefdbd27eb6f2c78034704ff91adc"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278549","number":278549,"mergeCommit":{"message":"[ci] Bump diskSizeGb to >= 130gb (#278549)","sha":"ea714e9dc2ceefdbd27eb6f2c78034704ff91adc"}}]}] BACKPORT-->