### PR TITLE
[KI skill] Enrich ki-workflow-generation skill (sampling, confidence, scheduling, repair)

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -173,6 +173,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
 
   // Platform – Workflows
   'workflow-authoring',
+  'ki-workflow-generation',
 
   // Security Solution
   'entity-analytics-leads',

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/plugin.ts
@@ -22,6 +22,7 @@ import { createWorkflowSmlType } from './sml_types/workflow';
 import { registerWorkflowYamlAttachment } from './attachment_types/workflow_yaml_attachment';
 import { registerWorkflowYamlDiffAttachment } from './attachment_types/workflow_yaml_diff_attachment';
 import { workflowAuthoringSkill } from './skills/workflow_authoring_skill';
+import { kiWorkflowGenerationSkill } from './skills/ki_workflow_generation_skill';
 import { registerGetConnectorsTool } from './tools/get_connectors_tool';
 import { registerGetExamplesTool } from './tools/get_examples_tool';
 import { registerGetStepDefinitionsTool } from './tools/get_step_definitions_tool';
@@ -79,6 +80,9 @@ export class AgentBuilderWorkflowsPlugin
 
     // Workflow authoring skill
     agentBuilder.skills.register(workflowAuthoringSkill);
+
+    // KI-generation workflow skill
+    agentBuilder.skills.register(kiWorkflowGenerationSkill);
 
     // Workflow SML type for the agent context layer
     agentBuilderSml.registerType(createWorkflowSmlType(api));

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation.skill.md.text
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation.skill.md.text
@@ -49,6 +49,13 @@ for any dataset, not just the built-in strategy below.
    This collapses the asker's job from "author ES|QL from scratch" to "pick a map, fill the
    params, run it" — removing one of the two expensive ES|QL-generation steps.
 
+   **Strategy 2 exception — detection condition KIs** carry `query.esql` (a complete, runnable
+   query rather than a parameterized template), because the detection condition — not a volatile
+   threshold value — is the stable thing. The threshold was set from observed distribution data
+   at generation time and stored verbatim. Both forms are legitimate: `maps[]` templates for
+   fill-in-the-blank question-classes; a complete `query.esql` for named detection conditions
+   whose thresholds were grounded in real data at generation time.
+
 4. **Maps must be grounded and validated at generation time.** Build every query from the
    index's real mapping and sample documents — never invented field names. Dry-run each
    `esql_example` before writing the KI; a broken call number is worse than none.
@@ -88,7 +95,7 @@ fallback) — not something you save directly.
 ## Strategy catalog
 
 Each strategy is a concrete recipe built on the first principles above. More will be added
-(atomic-case KIs, theme/entity-class KIs); today the implemented strategy is:
+(atomic-case KIs, theme/entity-class KIs). Currently implemented:
 
 ### Strategy 1 — Index-selection KIs (one KI per index)
 
@@ -383,6 +390,398 @@ steps:
       continue: true
 ```
 
+### Strategy 2 — Significant-event / detection KIs
+
+**Goal:** for an Observability index (logs, APM, metrics), generate two complementary KI types
+in a single profiling run:
+
+- **2a — Query (detection) KIs:** one KI per named detection condition. Each carries a
+  *complete, runnable* ES|QL query (not a template), `query_type` (match | stats),
+  `severity_score`, `evidence[]` quoting observed distributions, and a description that
+  explicitly states the threshold and its baseline rationale. The workflow fans out one
+  `elasticsearch.index` doc per detection.
+- **2b — Feature (knowledge) KIs:** one KI per extracted structural feature — entity,
+  dependency, technology, or schema. Each carries `feature.slug`, `feature.subtype`,
+  `feature.confidence`, and `evidence[]` with doc-count or distribution quotes from the samples.
+
+**Why complete queries, not templates:** detection conditions are stable facts — "error rate > 20%
+is anomalous for this index" does not change per question. The threshold was set from observed data
+at generation time. Compare a question-class map for "status of case X": it uses a template because
+`X` changes per question. Detection KIs invert this — the condition is precomputed; only the
+result (match / no-match) varies at run-time.
+
+**Grounding — pre-analysis steps (before `ai.prompt`):**
+
+Run three steps before calling the AI profiler so it can set thresholds from real data:
+
+1. `sample_error_logs` — `FROM <index> METADATA _id, _source | WHERE attributes.processor.event == "error" | LIMIT 50`
+   (adapt the error-level field to the index schema). Gives the LLM realistic error-log shapes.
+2. `stats_distribution` — a `STATS` query for key distributions (e.g. `COUNT(*) BY level` or
+   `COUNT(*) BY http.response.status_code`). Feed the result into the prompt as the distribution
+   summary. Evidence strings in the LLM output **must** quote these observed values (e.g.
+   `"~20% error rate across 500 sampled docs"`).
+3. `sample_docs` — same randomised `function_score + random_score` sample as Strategy 1 (20 docs,
+   general representation).
+
+Both `sample_error_logs` and `stats_distribution` should use `on-failure.continue: true` — not all
+indices have an `attributes.processor.event` field; the profiler will work from what is available.
+
+**ES|QL additions for Strategy 2 queries:**
+
+These patterns are valid ES|QL and may appear in generated detection queries:
+
+- `FROM <index> METADATA _id, _source` — fetches document `_id` and raw `_source` alongside
+  selected fields. Use when surfacing originating document IDs.
+- `WHERE field : "term"` — the full-text `:` match operator (not `==`). Use for text-field lookups
+  where exact-keyword matching is too strict.
+
+Add both to the `profile_index` prompt's ES|QL correctness block alongside the Strategy 1 rules.
+
+**KI document shape — Detection KI (2a):**
+
+```
+id:           <run_id>/<detection_slug>
+type:         ki
+title:        "Elevated error rate in my-logs-*"
+description:  "Detects error rate > 20%. Baseline: ~20% error rate observed in 500 sampled docs."
+content:      "Detection: Elevated error rate in my-logs-*. Detects error rate > 20%. ..."
+query:
+  esql:           'FROM my-logs-* | STATS error_count = COUNT(*) WHERE level == "error", total = COUNT(*) | EVAL error_rate = error_count / total | WHERE error_rate > 0.2'
+  query_type:     stats          # or: match
+  severity_score: 70             # 0–100
+  rule_backed:    false
+evidence:     ["observed error_rate ~20% across 500 sampled docs"]
+run_id:       "2026-07-21T12:00:00Z-abc123"
+excluded:     false
+deleted:      false
+expires_at:   "2026-08-20T00:00:00.000Z"   # ~30d from generation; see lifecycle note
+'@timestamp': "2026-07-21T12:00:00.000Z"
+```
+
+**KI document shape — Feature KI (2b):**
+
+```
+id:           <run_id>/<feature_slug>
+type:         ki
+title:        "Service: payment-service"
+content:      "Feature: Service payment-service. Found in 43% of sampled docs."
+feature:
+  type:             dependency     # entity | dependency | technology | schema
+  subtype:          service
+  slug:             "payment-service"
+  confidence:       0.9            # 0–1
+  evidence_doc_ids: []             # doc _ids from METADATA _id passes, if available
+evidence:     ["found service.name=payment-service in 43% of sampled docs"]
+run_id:       "2026-07-21T12:00:00Z-abc123"
+excluded:     false
+deleted:      false
+expires_at:   "2026-08-20T00:00:00.000Z"
+'@timestamp': "2026-07-21T12:00:00.000Z"
+```
+
+**Target index mapping (extended for significant-events KI schema):**
+
+```yaml
+mappings:
+  dynamic: strict
+  properties:
+    id: { type: keyword }
+    type: { type: keyword }
+    title:
+      type: text
+      fields:
+        semantic: { type: semantic_text }
+    content:
+      type: text
+      fields:
+        semantic: { type: semantic_text }
+    description:
+      type: text
+      fields:
+        semantic: { type: semantic_text }
+    query:
+      properties:
+        esql: { type: keyword, index: false }
+        query_type: { type: keyword }
+        severity_score: { type: integer }
+        rule_backed: { type: boolean }
+    feature:
+      properties:
+        type: { type: keyword }
+        subtype: { type: keyword }
+        slug: { type: keyword }
+        confidence: { type: float }
+        evidence_doc_ids: { type: keyword }
+    evidence: { type: text }
+    run_id: { type: keyword }
+    excluded: { type: boolean }
+    deleted: { type: boolean }
+    expires_at: { type: date }
+    '@timestamp': { type: date }
+```
+
+**Reference YAML (skeleton — feed to `generate_workflow` as spec):**
+
+```yaml
+version: "1"
+name: Significant-event detection + feature KIs
+description: >
+  Profile an Observability index with pre-analysis grounding steps, then fan out
+  one KI doc per detection condition (2a) and one per structural feature (2b).
+enabled: true
+tags:
+  - detection
+  - knowledge-indicators
+  - observability
+consts:
+  target_index: .ai-index-ds-sig-kis   # user-owned; see system-datastream caveat below
+  run_id: "manual-run-1"               # override per execution; see lifecycle note
+  expires_at: "2026-08-20T00:00:00.000Z"  # ~30d; set before launching (Liquid has no date math)
+  indices:
+    - my-logs-*
+    - apm-*
+triggers:
+  - type: manual
+steps:
+  - name: ensure_target_index
+    type: elasticsearch.indices.create
+    with:
+      index: "{{ consts.target_index }}"
+      mappings:
+        dynamic: strict
+        properties:
+          id: { type: keyword }
+          type: { type: keyword }
+          title: { type: text, fields: { semantic: { type: semantic_text } } }
+          content: { type: text, fields: { semantic: { type: semantic_text } } }
+          description: { type: text, fields: { semantic: { type: semantic_text } } }
+          query:
+            properties:
+              esql: { type: keyword, index: false }
+              query_type: { type: keyword }
+              severity_score: { type: integer }
+              rule_backed: { type: boolean }
+          feature:
+            properties:
+              type: { type: keyword }
+              subtype: { type: keyword }
+              slug: { type: keyword }
+              confidence: { type: float }
+              evidence_doc_ids: { type: keyword }
+          evidence: { type: text }
+          run_id: { type: keyword }
+          excluded: { type: boolean }
+          deleted: { type: boolean }
+          expires_at: { type: date }
+          '@timestamp': { type: date }
+    on-failure:
+      continue: true
+  - name: loop_indices
+    type: foreach
+    foreach: "{{ consts.indices | json }}"
+    steps:
+      - name: get_mapping
+        type: elasticsearch.request
+        with:
+          method: GET
+          path: /{{ foreach.item }}/_mapping
+      # Pre-analysis: error-log sample for realistic error shapes
+      - name: sample_error_logs
+        type: elasticsearch.esql.query
+        with:
+          query: 'FROM {{ foreach.item }} METADATA _id, _source | WHERE attributes.processor.event == "error" | LIMIT 50'
+          format: json
+        on-failure:
+          continue: true
+      # Pre-analysis: key distribution for data-driven thresholds
+      - name: stats_distribution
+        type: elasticsearch.esql.query
+        with:
+          query: 'FROM {{ foreach.item }} | STATS doc_count = COUNT(*) BY log_level = level | SORT doc_count DESC | LIMIT 10'
+          format: json
+        on-failure:
+          continue: true
+      # General random sample (same as Strategy 1)
+      - name: sample_docs
+        type: elasticsearch.search
+        with:
+          index: "{{ foreach.item }}"
+          query:
+            function_score:
+              query: { match_all: {} }
+              random_score: {}
+          size: 20
+      - name: profile_index
+        type: ai.prompt
+        connector-id: <your-chat-completion-connector-id>
+        with:
+          prompt: |
+            You are a detection engineer and data analyst. Extract DETECTION CONDITIONS and
+            STRUCTURAL FEATURES from an Observability index.
+
+            You are given: the index name, its Elasticsearch mapping, 20 random sample docs,
+            a sample of error-level logs, and a distribution summary.
+
+            Rules:
+            - Ground everything ONLY in mapping + samples + distribution. Never invent fields.
+            - Do NOT copy literal PII (names, emails, tokens) into output; refer to such fields
+              by name and generalized shape.
+            - detection_kis: produce a COMPLETE, RUNNABLE ES|QL query per condition (not a
+              template with ?params). Set thresholds from the distribution data; quote the
+              observed distribution in evidence[]. Set query_type="stats" for STATS-based
+              conditions, "match" for filter/WHERE-only conditions. description MUST state the
+              threshold AND its baseline rationale (e.g. "Detects error rate > 20%. Baseline:
+              ~20% error rate observed in 500 sampled docs.").
+            - feature_kis: extract entity/dependency/technology/schema features. confidence is
+              0–1 based on frequency in samples. evidence[] must quote observed doc counts or
+              distribution percentages.
+
+            ES|QL correctness (all queries must be VALID ES|QL that runs):
+            - Start with `FROM <index>`. For metadata access: `FROM <index> METADATA _id, _source`.
+            - Full-text search: `WHERE field : "term"` (colon operator, not ==).
+            - ISO-8601 date literals only (e.g. "2024-01-01T00:00:00.000Z").
+            - Quote strings with double quotes; do not quote numbers or booleans.
+            - For relative date ranges prefer `WHERE @timestamp >= NOW() - 30 days`.
+            - End example/runnable queries with a small `| LIMIT n`.
+
+            Index: {{ foreach.item }}
+            Mapping: {{ steps.get_mapping.output | json }}
+            Sample docs: {{ steps.sample_docs.output.hits.hits | map: '_source' | json }}
+            Error log sample: {{ steps.sample_error_logs.output | json }}
+            Distribution: {{ steps.stats_distribution.output | json }}
+          schema:
+            type: object
+            properties:
+              detection_kis:
+                type: array
+                items:
+                  type: object
+                  required: [title, slug, description, query, evidence]
+                  properties:
+                    title: { type: string }
+                    slug: { type: string }
+                    description:
+                      type: string
+                      description: "Must state the threshold and its baseline rationale."
+                    query:
+                      type: object
+                      required: [esql, query_type, severity_score]
+                      properties:
+                        esql: { type: string }
+                        query_type: { type: string, enum: [match, stats] }
+                        severity_score: { type: integer, minimum: 0, maximum: 100 }
+                        rule_backed: { type: boolean }
+                    evidence:
+                      type: array
+                      items: { type: string }
+              feature_kis:
+                type: array
+                items:
+                  type: object
+                  required: [title, slug, feature, evidence]
+                  properties:
+                    title: { type: string }
+                    slug: { type: string }
+                    feature:
+                      type: object
+                      required: [type, subtype, slug, confidence]
+                      properties:
+                        type: { type: string, enum: [entity, dependency, technology, schema] }
+                        subtype: { type: string }
+                        slug: { type: string }
+                        confidence: { type: number, minimum: 0, maximum: 1 }
+                        evidence_doc_ids: { type: array, items: { type: string } }
+                    evidence:
+                      type: array
+                      items: { type: string }
+        timeout: 120s
+      # Fan out: one elasticsearch.index per detection KI (2a)
+      - name: sink_detection_kis
+        type: foreach
+        foreach: "{{ steps.profile_index.output.content.detection_kis | json }}"
+        steps:
+          - name: write_detection_ki
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.target_index }}"
+              id: "{{ consts.run_id }}/{{ foreach.item.slug }}"
+              refresh: wait_for
+              document:
+                id: "{{ consts.run_id }}/{{ foreach.item.slug }}"
+                type: ki
+                title: "{{ foreach.item.title }}"
+                description: "{{ foreach.item.description }}"
+                content: "Detection: {{ foreach.item.title }}. {{ foreach.item.description }}"
+                run_id: "{{ consts.run_id }}"
+                excluded: false
+                deleted: false
+                # expires_at is passed as a const — Liquid cannot compute date arithmetic.
+                # Set consts.expires_at to NOW() + 30d before launching the workflow.
+                expires_at: "{{ consts.expires_at }}"
+                '@timestamp': '{{ "now" | date: "%Y-%m-%dT%H:%M:%S.000Z" }}'
+                # Use ${{ }} (type-preserving) for arrays/objects — same rule as maps in Strategy 1.
+                evidence: "${{ foreach.item.evidence }}"
+                query: "${{ foreach.item.query }}"
+        iteration-on-failure:
+          continue: true
+      # Fan out: one elasticsearch.index per feature KI (2b)
+      - name: sink_feature_kis
+        type: foreach
+        foreach: "{{ steps.profile_index.output.content.feature_kis | json }}"
+        steps:
+          - name: write_feature_ki
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.target_index }}"
+              id: "{{ consts.run_id }}/{{ foreach.item.slug }}"
+              refresh: wait_for
+              document:
+                id: "{{ consts.run_id }}/{{ foreach.item.slug }}"
+                type: ki
+                title: "{{ foreach.item.title }}"
+                content: "Feature: {{ foreach.item.title }}. {{ foreach.item.evidence | join: ' ' }}"
+                run_id: "{{ consts.run_id }}"
+                excluded: false
+                deleted: false
+                expires_at: "{{ consts.expires_at }}"
+                '@timestamp': '{{ "now" | date: "%Y-%m-%dT%H:%M:%S.000Z" }}'
+                evidence: "${{ foreach.item.evidence }}"
+                feature: "${{ foreach.item.feature }}"
+        iteration-on-failure:
+          continue: true
+    iteration-on-failure:
+      continue: true
+```
+
+**Lifecycle and dedup:**
+
+- **`run_id`:** stamp every KI with a `run_id` that identifies the workflow execution (e.g. a
+  timestamp string or a random token passed via a trigger parameter; set as `consts.run_id`
+  before launching). This enables post-run dedup: query for duplicate `title` values across
+  `run_id`s and tombstone the older ones by setting `excluded: true`.
+- **`expires_at`:** set to ~30 days from generation. Liquid cannot compute date arithmetic, so
+  pass `expires_at` as a workflow const (e.g. `consts.expires_at: "2026-08-20T00:00:00.000Z"`)
+  or have the trigger supply it. A scheduled re-run should query for KIs where
+  `expires_at < NOW()` and mark them `excluded: true` before generating fresh ones.
+- **Freshness guard (scheduled runs):** before `profile_index`, query the target index for KIs
+  where `run_id` contains today's date (or `@timestamp > NOW() - <interval>`). Skip the index if
+  fresh KIs exist. This mirrors the `@timestamp` recency guard in Strategy 1 but ties freshness
+  to a specific run rather than raw last-write time — more precise when a partial run failed.
+- **Dedup across runs:** KIs can produce duplicate titles across consecutive runs (same condition,
+  different `run_id`). After each run, query `SELECT title, run_id, expires_at FROM <target_index>
+  GROUP BY title HAVING COUNT(*) > 1` and set `excluded: true` on all but the newest.
+
+**Caveat — system datastream:**
+
+`.significant_events-knowledge_indicators` is a **system-managed datastream** owned by the Kibana
+Streams / Significant Events feature (`significant_events` plugin). Writing to it with a generated
+workflow risks schema conflicts and may be overwritten or rejected by the platform.
+
+**The safe default:** write to a user-owned index (e.g. `.ai-index-ds-sig-kis`) in the shape
+documented above. Only target the system datastream if the user explicitly wants to feed the
+Significant Events detection-and-triage pipeline — and in that case, verify field names against
+the live `@kbn/significant-events-schema` package before generating.
+
 ## Adapting the recipe to a user's data
 
 - **Index list:** ask the user which indices to profile, or discover candidates first. Populate
@@ -451,8 +850,11 @@ YAML themselves via the Workflows UI **Import** (`.yml`/`.yaml`), or programmati
 - **Never precompute volatile values** — hand over a live-data map instead.
 - Defer deep workflow YAML syntax and debugging to the `workflow-authoring` skill.
 
-## First principles beyond Strategy 1 (coming soon)
+## First principles across strategies
 
-The librarian principles above are strategy-agnostic. Future strategy entries (atomic-case KIs,
-theme/entity-class KIs) will reuse the same `maps[]` contract and the precompute-path-not-value
-rule; only the granularity and the profiling prompt change.
+The librarian principles above are strategy-agnostic. Strategy 2 (detection and feature KIs)
+reuses the precompute-path-not-value rule but departs from the `maps[]` contract: detection
+conditions are complete queries rather than fill-in-the-blank templates, because the condition
+itself is the stable thing (see principle 3 exception note). Future strategy entries
+(atomic-case KIs, theme/entity-class KIs) will continue to share the same core principles;
+only the granularity, the profiling prompt, and the KI doc shape change.

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation.skill.md.text
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation.skill.md.text
@@ -104,14 +104,18 @@ Each strategy is a concrete recipe built on the first principles above. More wil
   `discovery_labels` nested, `dynamic: strict`) **plus a `maps` field**.
 - `loop_indices` (`foreach` over `consts.indices`):
   - `get_mapping` (`elasticsearch.request`) — `GET /<index>/_mapping`.
-  - `sample_docs` (`elasticsearch.search`, size 20) — representative docs.
-  - `profile_index` (`ai.prompt`) — produces the structured profile **and** `maps[]`, grounded
-    only in the mapping + samples. Keeps PII out (refer to fields by name/shape, never quote
-    real values).
+  - `sample_docs` (`elasticsearch.search`, size 20, randomised via `function_score +
+    random_score`) — representative docs. A plain `match_all` always returns the
+    first-ingested documents, which misrepresents any large or append-heavy index; the
+    random scorer ensures each run covers different records.
+  - `profile_index` (`ai.prompt`) — produces the structured profile **and** `maps[]` **and a
+    `confidence` score (0–1)**, grounded only in the mapping + samples. Keeps PII out (refer
+    to fields by name/shape, never quote real values).
   - `validate_maps` (`foreach` over the generated maps → `elasticsearch.esql.query` on each
     `esql_example`, `on-failure.continue: true`) — best-effort dry-run so broken queries surface
     in the execution log rather than in a shipped KI.
-  - `sink_index_ki` (`elasticsearch.index`) — writes the KI document, including `maps`.
+  - `sink_index_ki` (`elasticsearch.index`) — writes the KI document, including `maps`,
+    `confidence`, and `@timestamp` (required by the `dynamic: strict` mapping).
 
 (No manual token-tallying step is needed — Workflows surfaces per-step and total token usage
 natively.)
@@ -119,14 +123,16 @@ natively.)
 **KI document shape** (what `sink_index_ki` writes):
 
 ```
-id:          <index name>
-type:        ki
-title:       <display_name>
-origin: { uri: "ki://<index name>" }     # the real index this KI routes to
-tags:        [ ... ]
-content:     "<purpose> Questions answered: ... When to use: ..."   # semantic surface
-description: "<display_name>. Does NOT contain: ... Key fields: ... Joins: ..."
-maps:                                     # the librarian's call numbers
+id:           <index name>
+type:         ki
+title:        <display_name>
+origin: { uri: "ki://<index name>" }       # the real index this KI routes to
+tags:         [ ... ]
+content:      "<purpose> Questions answered: ... When to use: ..."  # semantic surface
+description:  "<display_name>. Does NOT contain: ... Key fields: ... Joins: ..."
+confidence:   0.85                          # 0–1: fraction of answers_questions covered by validated maps
+'@timestamp': "2024-06-01T12:00:00.000Z"   # when this KI was last profiled; enables recency checks
+maps:                                       # the librarian's call numbers
   - question_type: "Status of a specific support case"
     esql_template: 'FROM raw-cases-all | WHERE case_number == ?case_number | KEEP status, priority, closed_date | LIMIT 1'
     esql_example:  'FROM raw-cases-all | WHERE case_number == "02115676" | KEEP status, priority, closed_date | LIMIT 1'
@@ -199,6 +205,10 @@ steps:
                   type: { type: keyword }
                   example: { type: keyword, index: false }
           ingestion_method: { type: keyword }
+          # Required by dynamic: strict — must be declared or writes fail with a
+          # strict_dynamic_mapping_exception.
+          '@timestamp': { type: date }
+          confidence: { type: float }
       settings:
         analysis:
           normalizer:
@@ -221,8 +231,12 @@ steps:
         type: elasticsearch.search
         with:
           index: "{{ foreach.item }}"
+          # Randomise so each run surfaces different records. match_all always returns the
+          # earliest-ingested documents, which misrepresents large or append-heavy indices.
           query:
-            match_all: {}
+            function_score:
+              query: { match_all: {} }
+              random_score: {}
           size: 20
       - name: profile_index
         type: ai.prompt
@@ -289,6 +303,12 @@ steps:
               when_to_use:
                 type: string
                 description: One crisp routing heuristic (<= 30 words).
+              confidence:
+                type: number
+                description: >-
+                  0–1 score reflecting how fully the generated maps cover the answers_questions list.
+                  1.0 means every listed question has at least one validated map; lower values mean
+                  partial coverage. Used by agents to prefer higher-confidence KIs when routing.
               maps:
                 type: array
                 description: One entry per authoritative question-class. This is the librarian's call numbers.
@@ -317,6 +337,7 @@ steps:
               - answers_questions
               - key_fields
               - when_to_use
+              - confidence
               - maps
         timeout: 120s
       - name: validate_maps
@@ -351,6 +372,10 @@ steps:
               Backing index: {{ foreach.item }}. {{ steps.profile_index.output.content.purpose }} Questions answered: {{ steps.profile_index.output.content.answers_questions | join: " | " }} When to use: {{ steps.profile_index.output.content.when_to_use }}
             description: |
               Index profile: {{ steps.profile_index.output.content.display_name }}. Does NOT contain: {{ steps.profile_index.output.content.does_not_contain | join: "; " }}. Key fields: {{ steps.profile_index.output.content.key_fields | join: "; " }}. Joins: {{ steps.profile_index.output.content.joins | join: "; " }}.
+            # Scalar numeric — use ${{ }} to preserve the float type (not stringify it).
+            confidence: "${{ steps.profile_index.output.content.confidence }}"
+            # Write the profiling timestamp so scheduled re-runs can skip recently-updated KIs.
+            '@timestamp': '{{ "now" | date: "%Y-%m-%dT%H:%M:%S.000Z" }}'
             # maps is a nested ARRAY — use ${{ }} (type-preserving), NOT "{{ }}" (which stringifies
             # and triggers `object mapping for [maps] ... found a concrete value`).
             maps: "${{ steps.profile_index.output.content.maps }}"
@@ -370,6 +395,19 @@ steps:
   per entity) when a single index mixes unrelated question-classes.
 - **Maps:** aim for one map per authoritative question-class from `answers_questions`. Route
   volatile facts to live data; never bake them into `content`.
+- **Scheduling:** if you add a `scheduled` trigger, guard against re-profiling indices that
+  were updated recently. Before `profile_index`, query the target index for a KI with
+  `id == <index_name>` and `@timestamp > NOW() - <interval>` (e.g. 24 h); skip the index if
+  a fresh KI exists. This uses the `@timestamp` field written by `sink_index_ki` — which
+  requires it to be present in the `ensure_target_index` mapping (the reference YAML
+  above includes it). Without `@timestamp`, the `dynamic: strict` mapping rejects the write.
+- **Large or noisy indices (multi-iteration):** when a 20-document sample cannot represent
+  the full breadth of an index, run multiple `sample_docs` + `profile_index` passes (varying
+  the `random_score` seed each time) and accumulate `question_type`s across passes. Stop when
+  two consecutive passes produce no new `question_type`s (convergence) or after a fixed max.
+  Use a `while` loop with a `data.set` step that tracks `known_question_types: []` and a
+  dry-rounds counter, and pass the already-known list to the LLM prompt each iteration so it
+  focuses on gaps. Merge `maps` arrays across passes before writing to `sink_index_ki`.
 
 ## Delivery flow
 
@@ -405,8 +443,11 @@ YAML themselves via the Workflows UI **Import** (`.yml`/`.yaml`), or programmati
   (`title`, `content`, `description`).
 - **Ground every map** in the real mapping/samples and emit only VALID ES|QL (see the ES|QL rules
   in the prompt — especially ISO-8601 date literals). The `validate_maps` step dry-runs each
-  `esql_example`; a `verification_exception` there means the LLM produced invalid ES|QL — tighten
-  the prompt rather than shipping the broken map.
+  `esql_example`; a `verification_exception` there means the LLM produced invalid ES|QL. **Do
+  not ship broken maps**: use `platform.core.generate_esql` to repair them — pass
+  `"Fix this ES|QL: <esql_example>; error: <verification_exception message>"` and substitute
+  the corrected query before re-running the workflow. Tightening the `profile_index` prompt
+  prevents recurrence; use `platform.core.generate_esql` for one-off repairs.
 - **Never precompute volatile values** — hand over a live-data map instead.
 - Defer deep workflow YAML syntax and debugging to the `workflow-authoring` skill.
 

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation.skill.md.text
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation.skill.md.text
@@ -1,0 +1,417 @@
+## When to Use This Skill
+
+Load this skill when the user wants to make their own Elasticsearch data reliably
+discoverable and answerable by an AI agent — i.e. to **generate Knowledge Indicators (KIs)**
+for their indices. This skill turns a KI-generation *strategy* into a runnable Kibana
+**Workflow** whose output is a searchable KI index the agent can query later.
+
+You produce the Workflow; you do not answer the underlying data questions here.
+
+## What a KI is (the librarian model)
+
+A KI is a **librarian, not a photocopy.** A good librarian does two things: they tell you
+*what kind* of information exists and where it lives, and they hand you the exact *call
+number* to reach it. A KI does the same for an AI agent (the "asker" = user + LLM):
+
+1. It **orients** — describes a class of information (themes, when-to-use, what it does/doesn't
+   contain, joins to sibling data).
+2. It **hands over a map** — one or more precomputed, parameterized **ES|QL queries** that take
+   the asker straight to the live documents that matter.
+
+KIs are written as ordinary documents into a user-searchable `context-eng-*` index (NOT a
+system index), so they can be queried directly with ES|QL.
+
+## First principles of KI generation
+
+Apply these when deciding *what* KIs to generate and *what each one should contain*. They hold
+for any dataset, not just the built-in strategy below.
+
+1. **A KI is an orientation unit at a chosen granularity** — an index, a theme, an entity
+   class, or (rarely) a single document. Prefer the **coarsest** granularity that still answers
+   a whole class of questions. A few high-leverage KIs beat many thin ones.
+
+2. **Precompute the path, not the value.** Cache the *stable* thing — themes, when-to-use,
+   joins, and a query plan. Traverse at ask-time for the *fresh* thing. Materialize a literal
+   answer inside a KI **only for immutable facts** (e.g. a resolved case's root cause).
+   **Never** materialize volatile facts (status, priority, counts, dates) — they rot and produce
+   confidently wrong answers. For those, hand over a map that reads live data.
+
+3. **Every KI carries a `maps[]` contract.** Each map is a precomputed ES|QL query for one
+   question-class:
+   - `question_type` — the kind of question it answers, in plain language.
+   - `esql_template` — runnable ES|QL using **named `?param` placeholders** for the parts that
+     vary per question.
+   - `esql_example` — the same query with example values substituted, so it runs as-is
+     (used for validation and as a worked example).
+   - `params` — one entry per placeholder: `{ name, type, example }`.
+   - `returns` — what columns/shape the query yields.
+
+   This collapses the asker's job from "author ES|QL from scratch" to "pick a map, fill the
+   params, run it" — removing one of the two expensive ES|QL-generation steps.
+
+4. **Maps must be grounded and validated at generation time.** Build every query from the
+   index's real mapping and sample documents — never invented field names. Dry-run each
+   `esql_example` before writing the KI; a broken call number is worse than none.
+
+5. **Keep a cache-miss fallback.** A finite set of maps cannot anticipate every question. If no
+   map fits, the asker falls back to the router KI and queries the raw index directly. KIs
+   accelerate the data; they never replace it.
+
+## Available tools
+
+You do **not** hand-write or persist workflow YAML yourself. The workflow is created by a tool
+and **saved by the user** from the diff card it produces — there is no agent-callable "save
+workflow" API, and you cannot POST to Kibana REST endpoints. Prefer:
+
+- **platform.core.generate_workflow** — the way you create the workflow. Pass a natural-language
+  `query` describing the KI-generation workflow, using this skill's recipe as the spec (include
+  the target index + mapping, the source indices, the `ai.prompt` profile + `maps[]` requirements,
+  the validation step, and the KI doc shape). It knows workflow syntax, step types, and the
+  connectors on this Kibana, so you don't pre-fetch those. It creates a workflow **attachment**
+  and emits a **diff card**; it does NOT save the workflow.
+- **platform.workflows.validate_workflow** — validate a complete YAML string (e.g. the manual
+  fallback below) before presenting it.
+- **platform.core.generate_esql** — author or repair a single ES|QL query from natural language,
+  grounded in an index's fields. Use it to hand-craft a tricky `esql_template`/`esql_example` for a
+  map, or to fix one that failed `validate_maps` (e.g. an ISO-8601 date-literal error), before
+  re-running the workflow. It knows ES|QL syntax, so you don't have to.
+- **platform.workflows.get_step_definitions** / **platform.workflows.get_examples** — only when
+  you need to confirm a step's `with` params or find a pattern.
+- **platform.core.execute_workflow** — run a workflow when the user asks (after they've saved it).
+
+For deep workflow YAML syntax, Liquid templating, and debugging, defer to the
+`workflow-authoring` skill.
+
+The reference YAML below is the **spec** you feed to `generate_workflow` (and a manual-import
+fallback) — not something you save directly.
+
+## Strategy catalog
+
+Each strategy is a concrete recipe built on the first principles above. More will be added
+(atomic-case KIs, theme/entity-class KIs); today the implemented strategy is:
+
+### Strategy 1 — Index-selection KIs (one KI per index)
+
+**Goal:** one KI per index that (a) routes an agent to the right index for a question and
+(b) hands over parameterized ES|QL maps to the live data.
+
+**Workflow anatomy:**
+
+- `consts.target_index` — the searchable KI index to write into (e.g. `context-eng-idx-kis`).
+- `consts.indices` — the list of source indices to profile.
+- `ensure_target_index` (`elasticsearch.indices.create`) — creates `target_index` with a
+  Context-Engine-compatible mapping (`semantic_text` on `title`/`content`/`description`,
+  `discovery_labels` nested, `dynamic: strict`) **plus a `maps` field**.
+- `loop_indices` (`foreach` over `consts.indices`):
+  - `get_mapping` (`elasticsearch.request`) — `GET /<index>/_mapping`.
+  - `sample_docs` (`elasticsearch.search`, size 20) — representative docs.
+  - `profile_index` (`ai.prompt`) — produces the structured profile **and** `maps[]`, grounded
+    only in the mapping + samples. Keeps PII out (refer to fields by name/shape, never quote
+    real values).
+  - `validate_maps` (`foreach` over the generated maps → `elasticsearch.esql.query` on each
+    `esql_example`, `on-failure.continue: true`) — best-effort dry-run so broken queries surface
+    in the execution log rather than in a shipped KI.
+  - `sink_index_ki` (`elasticsearch.index`) — writes the KI document, including `maps`.
+
+(No manual token-tallying step is needed — Workflows surfaces per-step and total token usage
+natively.)
+
+**KI document shape** (what `sink_index_ki` writes):
+
+```
+id:          <index name>
+type:        ki
+title:       <display_name>
+origin: { uri: "ki://<index name>" }     # the real index this KI routes to
+tags:        [ ... ]
+content:     "<purpose> Questions answered: ... When to use: ..."   # semantic surface
+description: "<display_name>. Does NOT contain: ... Key fields: ... Joins: ..."
+maps:                                     # the librarian's call numbers
+  - question_type: "Status of a specific support case"
+    esql_template: 'FROM raw-cases-all | WHERE case_number == ?case_number | KEEP status, priority, closed_date | LIMIT 1'
+    esql_example:  'FROM raw-cases-all | WHERE case_number == "02115676" | KEEP status, priority, closed_date | LIMIT 1'
+    params: [ { name: case_number, type: keyword, example: "02115676" } ]
+    returns: "status, priority, closed_date for one case"
+```
+
+**Reference example — a complete, runnable Workflow YAML for this strategy:**
+
+```yaml
+version: "1"
+name: Index-selection KIs (with ES|QL maps)
+description: Profile each source index (mapping + 20 samples) into a per-index Knowledge Indicator that carries parameterized, validated ES|QL maps, written into a searchable context-eng-* index.
+enabled: true
+tags:
+  - index-selection
+  - knowledge-indicators
+consts:
+  target_index: context-eng-idx-kis
+  indices:
+    - raw-cases-all
+    - raw-articles-all
+    - raw-issues-all
+triggers:
+  - type: manual
+steps:
+  - name: ensure_target_index
+    type: elasticsearch.indices.create
+    with:
+      index: "{{ consts.target_index }}"
+      mappings:
+        dynamic: strict
+        properties:
+          id: { type: keyword }
+          type: { type: keyword }
+          title:
+            type: text
+            fields:
+              semantic: { type: semantic_text }
+          origin:
+            properties:
+              uri: { type: keyword }
+          content:
+            type: text
+            fields:
+              semantic: { type: semantic_text }
+          description:
+            type: text
+            fields:
+              semantic: { type: semantic_text }
+          tags:
+            type: keyword
+            normalizer: lowercase
+          discovery_labels:
+            type: nested
+            properties:
+              value: { type: search_as_you_type }
+              kind: { type: keyword }
+          maps:
+            type: nested
+            properties:
+              question_type: { type: text }
+              esql_template: { type: keyword, index: false }
+              esql_example: { type: keyword, index: false }
+              returns: { type: text }
+              params:
+                type: nested
+                properties:
+                  name: { type: keyword }
+                  type: { type: keyword }
+                  example: { type: keyword, index: false }
+          ingestion_method: { type: keyword }
+      settings:
+        analysis:
+          normalizer:
+            lowercase:
+              type: custom
+              filter:
+                - lowercase
+    on-failure:
+      continue: true
+  - name: loop_indices
+    type: foreach
+    foreach: "{{ consts.indices | json }}"
+    steps:
+      - name: get_mapping
+        type: elasticsearch.request
+        with:
+          method: GET
+          path: /{{ foreach.item }}/_mapping
+      - name: sample_docs
+        type: elasticsearch.search
+        with:
+          index: "{{ foreach.item }}"
+          query:
+            match_all: {}
+          size: 20
+      - name: profile_index
+        type: ai.prompt
+        connector-id: <your-chat-completion-connector-id>
+        with:
+          prompt: |
+            You are a data steward building an INDEX PROFILE and a set of ES|QL "maps" for an
+            AI data catalog. Downstream, an AI agent uses the profile to pick WHICH index to
+            query, and the maps to reach the live documents with minimal query authoring.
+
+            You are given the index name, its Elasticsearch mapping, and sample documents.
+            Rules:
+            - Ground everything ONLY in the provided mapping + samples. Never invent fields.
+            - Do NOT copy literal PII (names, emails, tokens, org names) into the output; refer
+              to such fields by name and generalized shape instead.
+            - For each authoritative question-class, produce one map:
+              * esql_template uses named ?param placeholders for the parts that vary.
+              * esql_example is the SAME query with realistic (non-PII) example values filled in
+                and a small LIMIT so it runs cheaply.
+              * params lists every placeholder as { name, type, example }.
+              * returns describes the output columns.
+            - Prefer maps that read LIVE data over materializing volatile values.
+
+            ES|QL correctness (every esql_template AND esql_example must be VALID ES|QL that runs):
+            - Start with `FROM <index>`; use `|` between commands; use real field names only.
+            - DATE/DATETIME literals must be strict ISO-8601, e.g. "2024-01-01" or
+              "2024-01-01T00:00:00.000Z" — NEVER "2024-01-01 00:00:00" (a space instead of `T`
+              fails with a verification_exception). When comparing a date field, cast explicitly:
+              `WHERE @timestamp >= "2024-01-01T00:00:00.000Z"`. For relative ranges prefer
+              `WHERE @timestamp >= NOW() - 30 days` instead of hardcoded dates.
+            - Quote string literals with double quotes; do not quote numbers or booleans.
+            - Give each `?param` a correct `type` (keyword, long, double, date, boolean) and a
+              matching, correctly-formatted `example` (ISO-8601 for date params).
+            - Keep esql_example runnable and cheap: end it with a small `| LIMIT n`.
+
+            Index name: {{ foreach.item }}
+            Elasticsearch mapping (JSON): {{ steps.get_mapping.output | json }}
+            Sample documents (JSON): {{ steps.sample_docs.output.hits.hits | map: '_source' | json }}
+          schema:
+            type: object
+            properties:
+              display_name:
+                type: string
+                description: Concise human-readable name for this index (<= 8 words).
+              purpose:
+                type: string
+                description: 2-4 sentences on what this index stores and its role. Primary semantic surface for routing.
+              answers_questions:
+                type: array
+                items: { type: string }
+                description: 3-7 representative questions this index can authoritatively answer.
+              does_not_contain:
+                type: array
+                items: { type: string }
+                description: 1-4 things that live in a DIFFERENT index, to prevent mis-routing.
+              key_fields:
+                type: array
+                items: { type: string }
+                description: 3-10 query-relevant fields as "field_name — what it is".
+              joins:
+                type: array
+                items: { type: string }
+                description: Shared keys linking to other indices as "field -> target_index".
+              when_to_use:
+                type: string
+                description: One crisp routing heuristic (<= 30 words).
+              maps:
+                type: array
+                description: One entry per authoritative question-class. This is the librarian's call numbers.
+                items:
+                  type: object
+                  properties:
+                    question_type: { type: string }
+                    esql_template:
+                      type: string
+                      description: Runnable ES|QL using named ?param placeholders. Real index + field names only.
+                    esql_example:
+                      type: string
+                      description: Same query with example values substituted and a small LIMIT so it runs as-is.
+                    params:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name: { type: string }
+                          type: { type: string }
+                          example: { type: string }
+                    returns: { type: string }
+            required:
+              - display_name
+              - purpose
+              - answers_questions
+              - key_fields
+              - when_to_use
+              - maps
+        timeout: 120s
+      - name: validate_maps
+        type: foreach
+        foreach: "{{ steps.profile_index.output.content.maps | json }}"
+        steps:
+          - name: dry_run_map
+            type: elasticsearch.esql.query
+            with:
+              query: "{{ foreach.item.esql_example }}"
+              format: json
+            on-failure:
+              continue: true
+        iteration-on-failure:
+          continue: true
+      - name: sink_index_ki
+        type: elasticsearch.index
+        with:
+          index: "{{ consts.target_index }}"
+          id: "{{ foreach.item }}"
+          refresh: wait_for
+          document:
+            id: "{{ foreach.item }}"
+            type: ki
+            title: "{{ steps.profile_index.output.content.display_name | default: foreach.item }}"
+            origin:
+              uri: "ki://{{ foreach.item }}"
+            ingestion_method: manual
+            tags:
+              - index-selection
+            content: |
+              Backing index: {{ foreach.item }}. {{ steps.profile_index.output.content.purpose }} Questions answered: {{ steps.profile_index.output.content.answers_questions | join: " | " }} When to use: {{ steps.profile_index.output.content.when_to_use }}
+            description: |
+              Index profile: {{ steps.profile_index.output.content.display_name }}. Does NOT contain: {{ steps.profile_index.output.content.does_not_contain | join: "; " }}. Key fields: {{ steps.profile_index.output.content.key_fields | join: "; " }}. Joins: {{ steps.profile_index.output.content.joins | join: "; " }}.
+            # maps is a nested ARRAY — use ${{ }} (type-preserving), NOT "{{ }}" (which stringifies
+            # and triggers `object mapping for [maps] ... found a concrete value`).
+            maps: "${{ steps.profile_index.output.content.maps }}"
+    iteration-on-failure:
+      continue: true
+```
+
+## Adapting the recipe to a user's data
+
+- **Index list:** ask the user which indices to profile, or discover candidates first. Populate
+  `consts.indices`.
+- **Target index:** pick a `context-eng-*` name; the mapping above keeps it searchable and
+  Context-Engine-compatible.
+- **Connector:** set `connector-id` on the `ai.prompt` step to a configured chat_completion
+  connector (call `platform.workflows.get_connectors` or ask the user if unsure).
+- **Granularity:** for most catalogs one KI per index is right. Only go finer (per theme /
+  per entity) when a single index mixes unrelated question-classes.
+- **Maps:** aim for one map per authoritative question-class from `answers_questions`. Route
+  volatile facts to live data; never bake them into `content`.
+
+## Delivery flow
+
+You produce a *proposal*; the **user saves it**. There is no agent-callable save step.
+
+1. **Generate.** Call `platform.core.generate_workflow` with a natural-language `query` built from
+   this skill's recipe as the spec (target index + mapping, source indices, the `ai.prompt`
+   profile + `maps[]` requirements, the `validate_maps` step, and the KI doc shape). Pass a
+   `workflowId` if the KI index/workflow will be referenced elsewhere.
+2. **Show it.** Render the emitted diff card and workflow attachment with
+   `<render_attachment id="{diff_attachment_id}"/>` and
+   `<render_attachment id="{attachment_id}" version="{attachment_version}"/>`, and briefly
+   summarize what it does. **Tell the user to review and Save from the card** — saving is a UI
+   action; you cannot persist it for them.
+3. **Fix if needed.** For edits, call `generate_workflow` again with the `attachmentId`; for a
+   raw YAML you assembled manually, check it with `platform.workflows.validate_workflow` first.
+4. **Run (optional).** After the user has saved, use `platform.core.execute_workflow` if they ask
+   to run it.
+
+**Manual fallback (a human path, not an agent action):** if the user prefers, they can save a raw
+YAML themselves via the Workflows UI **Import** (`.yml`/`.yaml`), or programmatically via
+`POST /api/workflows/workflow` `{ yaml, id? }`. Do not attempt these calls yourself.
+
+## Guardrails
+
+- Sink KIs with
+  `elasticsearch.indices.create` + `elasticsearch.index` into a searchable index.
+- **Templating — strings vs. structured values.** In workflow YAML, `"{{ expr }}"` renders to a
+  **string**; `"${{ expr }}"` (dollar-prefixed) **preserves the native type** (array/object/number/
+  boolean). Any document field that is a JSON array/object/number — above all the `nested` **`maps`**
+  field — MUST use `${{ ... }}`. Writing `maps: "{{ ... }}"` stringifies it and Elasticsearch fails
+  with `object mapping for [maps] ... found a concrete value`. Keep `{{ }}` for text fields
+  (`title`, `content`, `description`).
+- **Ground every map** in the real mapping/samples and emit only VALID ES|QL (see the ES|QL rules
+  in the prompt — especially ISO-8601 date literals). The `validate_maps` step dry-runs each
+  `esql_example`; a `verification_exception` there means the LLM produced invalid ES|QL — tighten
+  the prompt rather than shipping the broken map.
+- **Never precompute volatile values** — hand over a live-data map instead.
+- Defer deep workflow YAML syntax and debugging to the `workflow-authoring` skill.
+
+## First principles beyond Strategy 1 (coming soon)
+
+The librarian principles above are strategy-agnostic. Future strategy entries (atomic-case KIs,
+theme/entity-class KIs) will reuse the same `maps[]` contract and the precompute-path-not-value
+rule; only the granularity and the profiling prompt change.

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation_skill.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation_skill.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isAllowedBuiltinSkill } from '@kbn/agent-builder-server/allow_lists';
+import { platformCoreTools } from '@kbn/agent-builder-common/tools';
+import { workflowTools } from '../../common/constants';
+import { kiWorkflowGenerationSkill } from './ki_workflow_generation_skill';
+
+describe('kiWorkflowGenerationSkill', () => {
+  it('registers under the stable ki-workflow-generation id and name at the workflows base path', () => {
+    expect(kiWorkflowGenerationSkill.id).toBe('ki-workflow-generation');
+    expect(kiWorkflowGenerationSkill.name).toBe('ki-workflow-generation');
+    expect(kiWorkflowGenerationSkill.basePath).toBe('skills/platform/workflows');
+  });
+
+  it('uses a skill id that is present in the built-in skills allow list', () => {
+    expect(isAllowedBuiltinSkill(kiWorkflowGenerationSkill.id)).toBe(true);
+  });
+
+  it('is gated behind the Agent Builder experimental features flag', () => {
+    expect(kiWorkflowGenerationSkill.experimental).toBe(true);
+  });
+
+  it('ships non-empty markdown content covering the librarian model and maps contract', () => {
+    expect(kiWorkflowGenerationSkill.content.length).toBeGreaterThan(0);
+    expect(kiWorkflowGenerationSkill.content).toContain('librarian');
+    expect(kiWorkflowGenerationSkill.content).toContain('maps');
+  });
+
+  it('binds the workflow generation, validation, and execution tools', async () => {
+    const toolIds = (await kiWorkflowGenerationSkill.getRegistryTools?.()) ?? [];
+
+    expect(toolIds).toEqual(
+      expect.arrayContaining([
+        platformCoreTools.generateWorkflow,
+        platformCoreTools.executeWorkflow,
+        platformCoreTools.generateEsql,
+        workflowTools.validateWorkflow,
+        workflowTools.getStepDefinitions,
+        workflowTools.getExamples,
+      ])
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/skills/ki_workflow_generation_skill.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common/tools';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import content from './ki_workflow_generation.skill.md.text';
+import { workflowTools } from '../../common/constants';
+
+export const kiWorkflowGenerationSkill = defineSkillType({
+  id: 'ki-workflow-generation',
+  name: 'ki-workflow-generation',
+  basePath: 'skills/platform/workflows',
+  description:
+    'Generate Kibana Workflows that build Knowledge Indicators (KIs) for a user\'s Elasticsearch data. Grounded in the "librarian" model: each KI both orients an agent to a class of information AND carries precomputed, parameterized, validated ES|QL "maps" to the live documents. Load when the user asks to make their data agent-queryable, generate KIs, or create an index-selection/KI-generation workflow.',
+  experimental: true,
+  content,
+  getRegistryTools: () => [
+    platformCoreTools.generateWorkflow,
+    platformCoreTools.executeWorkflow,
+    platformCoreTools.generateEsql,
+    workflowTools.validateWorkflow,
+    workflowTools.getStepDefinitions,
+    workflowTools.getExamples,
+    workflowTools.getConnectors,
+  ],
+});


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/search-team/issues/14885

Enriches the experimental `ki-workflow-generation` Agent Builder skill (introduced in #278149) with four improvements grounded in how the built-in KI-extraction pipeline in `significant_events` actually works.

### Changes

**1. Randomised document sampling**

Replaces `match_all: {}` in the `sample_docs` step with `function_score + random_score`. A plain `match_all` always returns the first-ingested documents, which misrepresents large or append-heavy indices and produces a skewed LLM profile. The random scorer ensures each run covers different records.

**2. `@timestamp` + `confidence` fields**

- Adds both fields to the `ensure_target_index` mapping (required — `dynamic: strict` rejects undeclared fields; without this the `elasticsearch.index` write fails with a `strict_dynamic_mapping_exception`).
- `confidence` (0–1 float, emitted by `profile_index`) reflects how fully the generated maps cover the index's stated question-classes. Agents can use this to prefer better-covered KIs when routing.
- `@timestamp` records when the KI was last profiled, enabling recency guards (see #3).
- Adds `confidence` to the `profile_index` structured-output schema and to `required`.

**3. Scheduling / recency guard guidance**

New "Scheduling" bullet in "Adapting the recipe" explains how to check `@timestamp` before re-profiling, avoiding wasted LLM tokens on indices whose KI was updated recently — the same pattern used by the `_should_identify` endpoint in the managed KI system.

Also adds a "Large or noisy indices (multi-iteration)" bullet sketching the convergence loop (`while` + `known_question_types` tracking) for indices whose content cannot be captured in a single 20-document sample.

**4. Validate-and-repair guidance**

The guardrail on broken maps now explicitly directs the agent to use `platform.core.generate_esql` to repair a failing `esql_example` (the bound tool that already exists for exactly this) rather than shipping the map silently under `on-failure.continue: true`.

### Stacks on

#278149 (the base skill registration) — the baseline commit in this branch re-applies those file changes so they can be reviewed together. Once #278149 merges this PR can be rebased to show only the incremental diff.

### Checklist

- [x] No API, config, or schema changes — enrichments are confined to the skill markdown
- [x] Existing unit test (`ki_workflow_generation_skill.test.ts`) passes unchanged; content assertions (`'librarian'`, `'maps'`) still hold
- [x] Pre-commit checks passed

### Release Notes

`release_note:skip` — experimental skill, off by default.