### PR TITLE
Revert "[ci] Disable x-pack/solutions/observability/test/serverless/functional/configs/config.logs_essentials.ts (#278627)"

### DIFF
--- a/.buildkite/ftr-manifests/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr-manifests/ftr_oblt_serverless_configs.yml
@@ -9,9 +9,6 @@ disabled:
   # Empty configs
   - x-pack/solutions/observability/test/serverless/api_integration/configs/config.feature_flags.ts
 
-  # Timing out, see https://github.com/elastic/kibana/issues/278626
-  - x-pack/solutions/observability/test/serverless/functional/configs/config.logs_essentials.ts
-
 defaultQueue: 'n2-4-spot'
 enabled:
   - x-pack/solutions/observability/test/serverless/api_integration/configs/config.ts
@@ -22,6 +19,7 @@ enabled:
   - x-pack/solutions/observability/test/serverless/functional/configs/config.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.cases_and_rules.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.ml_and_discover.ts
+  - x-pack/solutions/observability/test/serverless/functional/configs/config.logs_essentials.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.onboarding.ts
   - x-pack/platform/test/serverless/functional/configs/observability/config.examples.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.feature_flags.ts


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/278845 was reverted.  This re-enables the test that was skipped.