### PR TITLE
[SigEvents][Discovery] Optimize judge agent

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/index.ts
@@ -63,7 +63,7 @@ export const SIGNIFICANT_EVENTS_ORCHESTRATOR_WORKFLOW = {
 export const SIGNIFICANT_EVENTS_TRIAGE_WORKFLOW = {
   id: SIGNIFICANT_EVENTS_TRIAGE_WORKFLOW_ID,
   pluginId: 'significant_events',
-  version: 10,
+  version: 11,
   billable: false,
   yaml: TRIAGE_YAML,
   management: SIGNIFICANT_EVENTS_WORKFLOW_MANAGEMENT,

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
@@ -238,6 +238,8 @@ steps:
       - name: foreach_stamp_handled
         type: foreach
         foreach: '${{ steps.collect_discoveries.output.findings }}'
+        iteration-on-failure:
+          continue: true
         steps:
           - name: check_event_written
             type: if

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/significant_events/triage.yaml
@@ -78,6 +78,7 @@ steps:
           field: event_id
         _source:
           includes:
+            - '@timestamp'
             - kind
             - discovery_id
             - event_id
@@ -179,7 +180,7 @@ steps:
         properties:
           significant_events:
             type: array
-            description: 'Compact summary of each processed discovery — used by the workflow to gate trigger_investigation. Full event data is written by the judge via events_write and discovery_write tools.'
+            description: 'Compact summary of each processed discovery. The judge writes event data via events_write; the workflow uses this summary to stamp handled discoveries and gate trigger_investigation.'
             items:
               type: object
               properties:
@@ -206,10 +207,10 @@ steps:
       continue: false
 
   # -----------------------------------------------------------------------
-  # Step 5: Trigger root-cause investigation for newly-opened high-severity events.
-  # The judge writes events (events_write) and stamps discoveries
-  # (discovery_write kind:handled) directly via tools. The workflow only
-  # needs to fire the async investigation for open high-severity events.
+  # Step 5: Stamp successfully written discoveries as handled, then trigger
+  # root-cause investigation for newly-opened high-severity events.
+  # The judge owns the event decision and events_write; deterministic queue
+  # advancement stays in the workflow and does not consume agent turns.
   # -----------------------------------------------------------------------
 
   # Eviction-safe snapshot — ai.agent outputs are evictable; data.set outputs are not.
@@ -221,6 +222,65 @@ steps:
         type: data.set
         with:
           significant_events: '${{ steps.run_judge_agent.output.structured_output.significant_events }}'
+
+      - name: compute_written_event_ids
+        type: data.set
+        with:
+          written_event_ids: >-
+            ${{
+              steps.store_significant_events.output.significant_events
+                | default: []
+                | reject: 'written', false
+                | map: 'event_id'
+                | compact
+                | uniq }}
+
+      - name: foreach_stamp_handled
+        type: foreach
+        foreach: '${{ steps.collect_discoveries.output.findings }}'
+        steps:
+          - name: check_event_written
+            type: if
+            condition: '${{ variables.written_event_ids contains foreach.item.event_id }}'
+            steps:
+              # A newer handled marker already covers this discovery version.
+              - name: check_handled_exists
+                type: elasticsearch.request
+                with:
+                  method: POST
+                  path: '/{{ consts.DISCOVERIES_INDEX }}/_count?ignore_unavailable=true'
+                  body:
+                    query:
+                      bool:
+                        filter:
+                          - term:
+                              kibana.space_ids: '{{ variables.spaceId }}'
+                          - term:
+                              event_id: '{{ foreach.item.event_id }}'
+                          - term:
+                              kind: '{{ consts.KIND_HANDLED }}'
+                          - range:
+                              '@timestamp':
+                                gte: '{{ foreach.item["@timestamp"] }}'
+                on-failure:
+                  continue: true
+
+              - name: write_handled_marker
+                if: '${{ steps.check_handled_exists.output.count == 0 }}'
+                type: elasticsearch.request
+                with:
+                  method: POST
+                  path: '/{{ consts.DISCOVERIES_INDEX }}/_doc'
+                  body:
+                    '@timestamp': '{{ "now" | date: "%Y-%m-%dT%H:%M:%S%:z" }}'
+                    kibana:
+                      space_ids:
+                        - '{{ variables.spaceId }}'
+                    kind: '{{ consts.KIND_HANDLED }}'
+                    event_id: '{{ foreach.item.event_id }}'
+                    previous_discovery_id: '{{ foreach.item.discovery_id }}'
+                on-failure:
+                  continue: true
 
       # Size must be computed in a separate step — comparison operators cannot follow
       # a filter chain in the same expression (see compute_queue_sizes above).

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/data_generators/canonical_discoveries.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/data_generators/canonical_discoveries.ts
@@ -47,7 +47,14 @@ export const canonicalDiscoveryFromGroundTruth = ({
     severity: discovery.severity ?? '20-low',
     confidence: discovery.confidence ?? 0,
     processed: discovery.processed ?? false,
-    ...(discovery.signals ? { signals: discovery.signals } : {}),
+    // Strip `confirmed` from input signals — per Critical Rule #4 in the judge prompt,
+    // input signals arrive without confirmed stamps; the judge stamps confirmed only
+    // from its own execute_esql results.
+    ...(discovery.signals
+      ? {
+          signals: discovery.signals.map(({ confirmed: _omitted, ...rest }) => rest),
+        }
+      : {}),
     ...(discovery.causal_features ? { causal_features: discovery.causal_features } : {}),
     ...(discovery.blast_radius ? { blast_radius: discovery.blast_radius } : {}),
   };

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/datasets/bank_of_anthos/discovery.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/datasets/bank_of_anthos/discovery.ts
@@ -234,7 +234,7 @@ const BENIGN_AUTH_DISCOVERY: Partial<Discovery> = {
   summary:
     'Successful login and account-creation events increased around 14:30 UTC. All sampled events completed successfully, with no observed error signature or blocked user task.',
   severity: '20-low',
-  confidence: 0.68,
+  confidence: 0.35,
   signals: [
     {
       type: 'detection',

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/evaluators/discovery/judge/tool_usage/tool_usage.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/evaluators/discovery/judge/tool_usage/tool_usage.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools, platformSignificantEventsTools } from '@kbn/agent-builder-common';
+import type { ConverseStep } from '@kbn/evals';
+import type { Discovery, SignalEntry } from '@kbn/significant-events-schema';
+import { scoreJudgeToolUsage } from './tool_usage';
+
+const {
+  searchKnowledgeIndicators: TOOL_ID_KI_SEARCH,
+  eventsWrite: TOOL_ID_EVENTS_WRITE,
+  discoveryWrite: TOOL_ID_DISCOVERY_WRITE,
+} = platformSignificantEventsTools;
+const TOOL_ID_EXECUTE_ESQL = platformCoreTools.executeEsql;
+
+const toolCall = (toolId: string): ConverseStep => ({
+  type: 'tool_call',
+  tool_id: toolId,
+  tool_call_id: toolId,
+});
+
+const detectionSignal = (withQuery: boolean): SignalEntry => ({
+  type: 'detection',
+  stream_name: 'logs',
+  description: 'Current-state check',
+  evidence: withQuery ? { esql_query: 'FROM logs | LIMIT 1', result: 'found' } : undefined,
+  metadata: {
+    rule_uuid: 'rule-1',
+    detection_id: 'detection-1',
+    change_point_type: 'spike',
+    p_value: 0.01,
+  },
+});
+
+const discovery = (withQuery: boolean): Pick<Discovery, 'signals'> => ({
+  signals: [detectionSignal(withQuery)],
+});
+
+describe('scoreJudgeToolUsage', () => {
+  it('uses ES|QL and events_write without KI search when evidence has a query', () => {
+    expect(
+      scoreJudgeToolUsage({
+        discoveries: [discovery(true)],
+        steps: [toolCall(TOOL_ID_EXECUTE_ESQL), toolCall(TOOL_ID_EVENTS_WRITE)],
+      })
+    ).toMatchObject({ score: 1, label: 'correct' });
+  });
+
+  it('requires KI search when evidence has no query', () => {
+    expect(
+      scoreJudgeToolUsage({
+        discoveries: [discovery(false)],
+        steps: [
+          toolCall(TOOL_ID_KI_SEARCH),
+          toolCall(TOOL_ID_EXECUTE_ESQL),
+          toolCall(TOOL_ID_EVENTS_WRITE),
+        ],
+      })
+    ).toMatchObject({ score: 1, label: 'correct' });
+  });
+
+  it('fails when events_write is missing', () => {
+    expect(
+      scoreJudgeToolUsage({
+        discoveries: [discovery(true)],
+        steps: [toolCall(TOOL_ID_EXECUTE_ESQL)],
+      })
+    ).toMatchObject({ score: 0, label: 'missing-output-write' });
+  });
+
+  it('penalizes discovery_write because handled stamping belongs to triage', () => {
+    expect(
+      scoreJudgeToolUsage({
+        discoveries: [discovery(true)],
+        steps: [
+          toolCall(TOOL_ID_EXECUTE_ESQL),
+          toolCall(TOOL_ID_EVENTS_WRITE),
+          toolCall(TOOL_ID_DISCOVERY_WRITE),
+        ],
+      })
+    ).toMatchObject({
+      score: 0.5,
+      label: `unnecessary-${TOOL_ID_DISCOVERY_WRITE}`,
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/evaluators/discovery/judge/tool_usage/tool_usage.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/src/evaluators/discovery/judge/tool_usage/tool_usage.ts
@@ -6,7 +6,10 @@
  */
 
 import { platformCoreTools, platformSignificantEventsTools } from '@kbn/agent-builder-common';
+import type { ConverseStep } from '@kbn/evals';
+import type { Discovery } from '@kbn/significant-events-schema';
 import { extractToolCallIds } from '../../utils/tool_usage';
+import type { DiscoveryJudgeEvaluator } from '../../types';
 
 const { executeEsql: TOOL_ID_EXECUTE_ESQL } = platformCoreTools;
 const {
@@ -14,30 +17,101 @@ const {
   eventsWrite: TOOL_ID_EVENTS_WRITE,
   discoveryWrite: TOOL_ID_DISCOVERY_WRITE,
 } = platformSignificantEventsTools;
-import type { DiscoveryJudgeEvaluator } from '../../types';
 
-const OUTPUT_TOOLS = [TOOL_ID_EVENTS_WRITE, TOOL_ID_DISCOVERY_WRITE];
-
-/** Score the output-tool pair (events_write + discovery_write) proportionally. */
-const scoreOutputTools = (
+/** Require the judge-owned event write and reject workflow-owned discovery stamping. */
+const scoreOutputTool = (
   calledTools: Set<string>
 ): { score: number; label: string; explanation: string } | null => {
-  const missing = OUTPUT_TOOLS.filter((toolId) => !calledTools.has(toolId));
-  if (missing.length === 0) {
-    return null; // pass through — let the trajectory score stand
-  }
-  if (missing.length === OUTPUT_TOOLS.length) {
+  if (!calledTools.has(TOOL_ID_EVENTS_WRITE)) {
     return {
       score: 0,
       label: 'missing-output-write',
-      explanation:
-        'Neither events_write nor discovery_write was called — both are required to persist the decision and stamp the event',
+      explanation: `${TOOL_ID_EVENTS_WRITE} was not called — required to persist the decision`,
     };
   }
+  if (calledTools.has(TOOL_ID_DISCOVERY_WRITE)) {
+    return {
+      score: 0.5,
+      label: `unnecessary-${TOOL_ID_DISCOVERY_WRITE}`,
+      explanation: `${TOOL_ID_DISCOVERY_WRITE} was called, but handled stamping belongs to the triage workflow`,
+    };
+  }
+  return null;
+};
+
+export const scoreJudgeToolUsage = ({
+  discoveries,
+  steps,
+}: {
+  discoveries: Array<Pick<Discovery, 'signals'>>;
+  steps: ConverseStep[];
+}): { score: number; label: string; explanation: string } => {
+  // Does at least one discovery need KI search (no pre-populated queries)?
+  // Per-discovery check avoids falsely routing the entire batch to "both tools required"
+  // when only one of several fully-evidenced discoveries is missing queries.
+  const anyDiscoveryNeedsKiSearch = discoveries.some((d) => {
+    const signals = d.signals ?? [];
+    return (
+      signals.length === 0 ||
+      signals.some(
+        (s) => s.evidence == null || s.evidence.esql_query == null || s.evidence.esql_query === ''
+      )
+    );
+  });
+  const allEvidencesHaveQuery = discoveries.length > 0 && !anyDiscoveryNeedsKiSearch;
+
+  const calledTools = new Set(extractToolCallIds(steps));
+  const expected = allEvidencesHaveQuery
+    ? [TOOL_ID_EXECUTE_ESQL]
+    : [TOOL_ID_KI_SEARCH, TOOL_ID_EXECUTE_ESQL];
+  const missing = expected.filter((toolId) => !calledTools.has(toolId));
+  const trajectoryScore = (expected.length - missing.length) / expected.length;
+
+  if (allEvidencesHaveQuery) {
+    // All evidences already carry queries — judge should re-verify directly via execute_esql
+    // and skip search_knowledge_indicators entirely.
+    if (missing.length > 0 && calledTools.has(TOOL_ID_KI_SEARCH)) {
+      return {
+        score: 0,
+        label: 'wrong-tools',
+        explanation: `Called ${TOOL_ID_KI_SEARCH} instead of ${TOOL_ID_EXECUTE_ESQL} — all input evidences had esql_query; KI search should have been skipped`,
+      };
+    }
+    if (missing.length > 0) {
+      return {
+        score: 0,
+        label: `missing-${TOOL_ID_EXECUTE_ESQL}`,
+        explanation: `${TOOL_ID_EXECUTE_ESQL} was not called — required for evidence re-verification before promoting`,
+      };
+    }
+    if (calledTools.has(TOOL_ID_KI_SEARCH)) {
+      return {
+        score: 0.5,
+        label: `unnecessary-${TOOL_ID_KI_SEARCH}`,
+        explanation: `${TOOL_ID_EXECUTE_ESQL} called correctly but ${TOOL_ID_KI_SEARCH} was also called — all input evidences carried esql_query, so KI search was unnecessary`,
+      };
+    }
+    const outputCheck = scoreOutputTool(calledTools);
+    if (outputCheck) {
+      return outputCheck;
+    }
+    return {
+      score: 1,
+      label: 'correct',
+      explanation: `Correctly called ${TOOL_ID_EXECUTE_ESQL} and ${TOOL_ID_EVENTS_WRITE}; ${TOOL_ID_KI_SEARCH} skipped as expected when all evidences have pre-populated esql_query`,
+    };
+  }
+
+  const outputCheck = scoreOutputTool(calledTools);
+  if (outputCheck) {
+    return outputCheck;
+  }
+
   return {
-    score: 0.5,
-    label: 'partial-output-write',
-    explanation: `${missing[0]} was not called — both events_write (persist decision) and discovery_write (stamp episode) are required`,
+    score: trajectoryScore,
+    label: trajectoryScore === 1 ? 'correct' : 'missing-tools',
+    explanation:
+      trajectoryScore === 1 ? 'Correctly called all tools' : `Missing tools: ${missing.join(', ')}`,
   };
 };
 
@@ -46,79 +120,12 @@ export const createJudgeToolUsageEvaluator = (): DiscoveryJudgeEvaluator => ({
   kind: 'CODE',
   evaluate: ({ output }) => {
     // Use output.inputDiscoveries — the actual discoveries fed to the agent — rather than
-    // input.discoveries (canonical ground truth). In snapshot mode the two differ: snapshot
-    // discoveries may have different evidence/query coverage than the canonical dataset, so
-    // allEvidencesHaveQuery must reflect what the agent actually received.
-    const discoveries = output.inputDiscoveries ?? [];
-
-    // Does at least one discovery need KI search (no pre-populated queries)?
-    // Per-discovery check avoids falsely routing the entire batch to "both tools required"
-    // when only one of several fully-evidenced discoveries is missing queries.
-    const anyDiscoveryNeedsKiSearch = discoveries.some((d) => {
-      const signals = d.signals ?? [];
-      return (
-        signals.length === 0 ||
-        signals.some(
-          (s) => s.evidence == null || s.evidence.esql_query == null || s.evidence.esql_query === ''
-        )
-      );
-    });
-    const allEvidencesHaveQuery = discoveries.length > 0 && !anyDiscoveryNeedsKiSearch;
-
-    const calledTools = new Set(extractToolCallIds(output.steps ?? []));
-    const expected = allEvidencesHaveQuery
-      ? [TOOL_ID_EXECUTE_ESQL]
-      : [TOOL_ID_KI_SEARCH, TOOL_ID_EXECUTE_ESQL];
-    const missing = expected.filter((toolId) => !calledTools.has(toolId));
-    const trajectoryScore = (expected.length - missing.length) / expected.length;
-
-    if (allEvidencesHaveQuery) {
-      // All evidences already carry queries — judge should re-verify directly via execute_esql
-      // and skip search_knowledge_indicators entirely.
-      if (missing.length > 0 && calledTools.has(TOOL_ID_KI_SEARCH)) {
-        return Promise.resolve({
-          score: 0,
-          label: 'wrong-tools',
-          explanation: `Called ${TOOL_ID_KI_SEARCH} instead of ${TOOL_ID_EXECUTE_ESQL} — all input evidences had esql_query; KI search should have been skipped`,
-        });
-      }
-      if (missing.length > 0) {
-        return Promise.resolve({
-          score: 0,
-          label: `missing-${TOOL_ID_EXECUTE_ESQL}`,
-          explanation: `${TOOL_ID_EXECUTE_ESQL} was not called — required for evidence re-verification before promoting`,
-        });
-      }
-      if (calledTools.has(TOOL_ID_KI_SEARCH)) {
-        return Promise.resolve({
-          score: 0.5,
-          label: `unnecessary-${TOOL_ID_KI_SEARCH}`,
-          explanation: `${TOOL_ID_EXECUTE_ESQL} called correctly but ${TOOL_ID_KI_SEARCH} was also called — all input evidences carried esql_query, so KI search was unnecessary`,
-        });
-      }
-      const outputCheck = scoreOutputTools(calledTools);
-      if (outputCheck) {
-        return Promise.resolve(outputCheck);
-      }
-      return Promise.resolve({
-        score: 1,
-        label: 'correct',
-        explanation: `Correctly called ${TOOL_ID_EXECUTE_ESQL} only — ${TOOL_ID_KI_SEARCH} skipped as expected when all evidences have pre-populated esql_query`,
-      });
-    }
-
-    const outputCheck = scoreOutputTools(calledTools);
-    if (outputCheck) {
-      return Promise.resolve(outputCheck);
-    }
-
-    return Promise.resolve({
-      score: trajectoryScore,
-      label: trajectoryScore === 1 ? 'correct' : 'missing-tools',
-      explanation:
-        trajectoryScore === 1
-          ? 'Correctly called all tools'
-          : `Missing tools: ${missing.join(', ')}`,
-    });
+    // input.discoveries (canonical ground truth). In snapshot mode the two differ.
+    return Promise.resolve(
+      scoreJudgeToolUsage({
+        discoveries: output.inputDiscoveries ?? [],
+        steps: output.steps ?? [],
+      })
+    );
   },
 });

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
@@ -43,7 +43,9 @@ Use tools only for **fresh** detection signals (see `<inputs>` for the fresh/car
 
 Your queries answer: **is the failure still happening now?** They are current-state checks, not root-cause investigations.
 
-- `platform_sig_events_ki_search` — call when `signals` is absent or empty **OR** when any fresh signal has `evidence == null` or an empty `evidence.esql_query`. Do not call if every fresh signal already carries a non-empty `esql_query`. `kind: ["feature", "query"]`; `stream_names` = discovery `stream_names[]`; extract 1–2 keywords from `causal_features[].name` or the `title`. If 0 query KIs, one follow-up `kind: ["query"]`. Query selection constrained to KIs whose `rule.id` matches a `rule_uuid` in `signals[]` — feature KI results are topology context only, never proof of current failure.
+- `platform_sig_events_ki_search` — apply one hard gate before dispatching any verification. Call at most once for the whole run when `signals` is absent or empty **OR** any fresh entry in `signals[]` has missing/null `evidence` or an empty `evidence.esql_query`.
+    If every fresh signal carries a non-empty `esql_query`, this tool is **FORBIDDEN for the entire run** — do not call it for enrichment, confidence, severity, or corroboration.
+    When required, pass only `kind: ["feature", "query"]` and `stream_names` (the deduplicated union of discovery `stream_names[]`); never pass `search_text`. Do not issue a follow-up search when 0 query KIs are returned — the one-call limit is absolute. Query selection is constrained to KIs whose `rule.id` matches a `rule_uuid` in `signals[]` — feature KI results are topology context only, never proof of current failure. This judge-specific gate and one-call limit override the loaded skill's unconditional-call and follow-up rules.
 - `platform_core_execute_esql` — current-state check only, and a different question than the input evidence answers. Primary: take the input signals's `evidence.esql_query` body (`WHERE` clause), strip its `SORT`/`LIMIT`, and re-append `SORT @timestamp DESC | LIMIT 1` — the input entry is typically an onset (`ASC`) check, which can never tell you whether the failure is still active now; a fresh `DESC | LIMIT 1` against the most recent row does. Fallback (no usable input query): KI whose `rule.id` matches a `rule_uuid` in `metadata.rule_uuid` in `signals[]` that most directly answers "is this still failing?", same `DESC | LIMIT 1` modification.
     - Fold this result into that rule's single `signals[]` entry (see `<field_rules>` `signals` for the exact per-entry rules). Run at most one current-state check per rule per review cycle.
     - Hard scope: never run KIs out-of-scope. Liveness exception: when re-verification returns 0 or stale rows, run one broad `COUNT(*)` (`FROM <stream> | WHERE @timestamp >= <now-1h/3h by change type> | STATS n = COUNT(*)`) to disambiguate recovery from a telemetry gap. Skip on error.
@@ -74,6 +76,7 @@ Example: platform_sig_events_events_write
   "discovery_id": "...", "event_id": "...",
   "status": "open",
   "severity": "80-critical",
+  "stream_names": ["logs.otel"],
   "title": "Payment gRPC — checkout connectivity failure",
   "symptom_hypothesis": "...",
   "summary": "...",
@@ -104,9 +107,13 @@ Response: `{ "event_uuid": "...", "event_id": "...", "status": "open", "written"
 
 <execute_budget>
 
-Verify in uncertainty order: `empty/error` first, then stale, then fresh `found`. Run in **batches of up to 10 calls**. After each batch, stop if the status decision is clear (≥1 `confirmed: true` failure → `open`; a fully settled episode with confirmed recovery, or an active episode with doubly-confirmed recovery (empty re-verification + healthy broad `COUNT(*)`) → `closed`; a low-impact or false-alarm finding → `open`/`low`, or `dismissed` when confidence is also low).
+Build the complete primary verification plan before executing any ES|QL. Order planned checks by their input evidence uncertainty: `empty/error` first, then stale, then fresh `found`.
 
-For each discovery, the maximum is **2 × its fresh-rule count**: one current-state check per fresh rule plus, only when that check returns 0 or stale rows, one liveness `COUNT(*)`. Calls may be batched across discoveries, up to 10 per response. Never query carried rules, retry completed checks, or run another batch after the decision is clear. When a permitted check cannot run, note the unverified rule in `assessment_note` and proceed. `platform_sig_events_ki_search` does not count against this budget.
+Dispatch primary checks in **mandatory parallel waves of up to 10 calls**. In one assistant response, emit one separate `platform_core_execute_esql` call for every check in the current wave; the wave size MUST equal `min(remaining planned primary checks, 10)`. Multiple calls to the same tool in one response are required — never emit one independent primary check and wait for its result before dispatching the rest. A one-call wave is allowed only when exactly one planned check remains.
+
+After a primary wave returns, stop if the status decision is clear (≥1 `confirmed: true` failure → `open`; a fully settled episode with confirmed recovery, or an active episode with doubly-confirmed recovery (empty re-verification + healthy broad `COUNT(*)`) → `closed`; a low-impact or false-alarm finding → `open`/`low`, or `dismissed` when confidence is also low). Otherwise, collect every liveness `COUNT(*)` required by 0-row or stale primary results and dispatch those checks together in a second mandatory parallel wave, again up to 10 separate calls in one response. Liveness checks depend on primary results and MUST NOT be included in the primary wave.
+
+For each discovery, the maximum is **2 × its fresh-rule count**: one current-state check per fresh rule plus, only when that check returns 0 or stale rows, one liveness `COUNT(*)`. Never query carried rules, retry completed checks, or run another wave after the decision is clear. When a permitted check cannot run, note the unverified rule in `assessment_note` and proceed. `platform_sig_events_ki_search` does not count against this budget.
 
 </execute_budget>
 
@@ -170,11 +177,13 @@ Credibility thresholds:
 
 ### Step 2: Build and Dispatch Execute Plan
 
-Dispatch is simultaneous for all items in the batch — classify every item before dispatching any.
+Dispatch is simultaneous for all items in the batch — classify every item and build the complete primary plan before dispatching any. Follow `<execute_budget>` strictly: emit all calls in the current wave in one assistant response, never as sequential one-call turns.
 
 **No pre-stamping**: never stamp `confirmed: true` without running `platform_core_execute_esql` first.
 
 **`platform_sig_events_ki_search`:** call when `signals` is absent or empty **OR** when any fresh signal has `evidence == null` or an empty `evidence.esql_query`. Skip only when every fresh signal already carries a non-empty `esql_query`.
+
+Apply this as a hard binary gate exactly once. When every fresh signal has a query, record `KI search: forbidden` in your plan and do not dispatch `platform_sig_events_ki_search` anywhere in the run. When any fresh signal needs a fallback query, call it once and reuse the result; only checks whose queries are already known may run in parallel with that search.
 
 **`platform_core_execute_esql` calls (carried detection signals are already trusted per `<inputs>` — skip them):**
 - Active episode: re-verify the **fresh** `signals[]` with a failure lens (is it still happening?).
@@ -235,8 +244,10 @@ Apply the `severity` field description in the `platform_sig_events_events_write`
 ### Step 7: Emit Output
 
 **Pre-emit gate — verify for EVERY event before calling any output tool:**
-1. `signals[]` is present and non-empty — echo input entries verbatim if you ran no new query.
-2. Every event carries `symptom_hypothesis`; `open` events also carry `summary`, `assessment_note`, and ≥1 `signals[]` entry (`confirmed: true` required for `severity: "80-critical"`).
+1. Every event carries all required `platform_sig_events_events_write` fields: `event_id`, `title`, `summary`, `severity`, `confidence`, and `stream_names`.
+2. `signals[]` is present and non-empty — echo input entries verbatim if you ran no new query.
+3. Every event carries `symptom_hypothesis`; `open` events also carry `assessment_note`, and a `severity: "80-critical"` event carries ≥1 `signals[]` entry with `confirmed: true`.
+4. Validate every event independently before dispatching parallel writes. One incomplete call invalidates the entire agent request.
 
 Call `platform_sig_events_events_write` once per discovery, in input order, to record each decision.
 
@@ -249,6 +260,8 @@ Apply field rules from `<field_rules>`.
 Emit only fields defined in this schema. Output discipline applies to all narrative fields.
 
 - `discovery_id`, `event_id`: echo verbatim.
+- `title`: required for every event. Preserve the stable input incident label unless same-batch dedup selects a more comprehensive discovery.
+- `stream_names`: required for every event. Echo the input array verbatim.
 - `status`: one of `open`, `closed`, `dismissed`. An active episode (escalation signals) allows `open`, or `closed` only via the doubly-confirmed recovery exception (`<critical_rules>` #5, Step 3); a settled episode (downward/settle signals) allows `closed` via gate #6.
 - `symptom_hypothesis`: exactly one sentence. Reassess against merged signals and fresh queries. Keep it when supported and refine it only within the same operation/path, literal failure point, and mechanism. A different target or operation cannot be added; record it as contradictory or separate in `assessment_note` and lower confidence. Apply the sensitive-value rule from the field description.
 - `severity`: required for all events.
@@ -261,8 +274,8 @@ Emit only fields defined in this schema. Output discipline applies to all narrat
   - **Increase when**: multiple confirmed signals with no contradiction (+0.05); KI backing aligns (+0.05).
   - **Decrease when**: key queries have `signals[]` `evidence.result` ≠ "found" (−0.10 each, not for healthy-row refutations); no confirmed signal entries (−0.15); recovery re-verification contradicts the settled hypothesis (−0.10).
   - **Hard caps**: no `confirmed: true` in merged output `signals[]` → cap at 0.55; stale signals only (all `collected_at` > 1h) → cap at 0.65; no confirmed failure evidence AND no KI backing → cap at 0.65 (refuted discoveries — where queries returned healthy rows confirming a non-event — are exempt from this cap and may reach 0.75 without KI backing).
-  - **Ceiling**: 0.90+ requires discovery confidence ≥ 0.70, multiple confirmed signals, no contradiction. Do not exceed 0.85 when any evidence gap exists. Confidence ≥ 0.85 requires KI backing — `platform_sig_events_ki_search` must have been called and returned at least one matching query KI for the relevant rule.
-- `summary`: per the `summary` field description in the `platform_sig_events_events_write` tool metadata. Never lead with detection mechanics. Required for `open`; optional for `dismissed`/`closed`.
+  - **Ceiling**: 0.90+ requires discovery confidence ≥ 0.70, multiple confirmed signals, no contradiction. Do not exceed 0.85 when any evidence gap exists. Confidence ≥ 0.85 requires KI backing already available from a required `platform_sig_events_ki_search` call — never call KI search solely to raise confidence.
+- `summary`: required for every event. Apply the `summary` field description in the `platform_sig_events_events_write` tool metadata and never lead with detection mechanics.
 - `assessment_note`: your adversarial reasoning trace — what you independently verified, what signals confirmed or contradicted the discovery, and how customer impact and scope determined severity and status. Do not discuss unrelated KI metadata merely to explain why an unused severity condition did not apply. Apply the sensitive-value rule from the field description. Not operator-facing. Required for `open`; brief for `dismissed` and `closed`.
 - `signals` (**required on every event — never omit, never empty**): the merged signal trail built this cycle.
   - Per entry: `type: "detection"`, `stream_name`, `description`, `confirmed` (only when true), `collected_at`, `evidence` (when queried), `metadata`.

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/instructions/judge.md.text
@@ -47,8 +47,7 @@ Your queries answer: **is the failure still happening now?** They are current-st
 - `platform_core_execute_esql` — current-state check only, and a different question than the input evidence answers. Primary: take the input signals's `evidence.esql_query` body (`WHERE` clause), strip its `SORT`/`LIMIT`, and re-append `SORT @timestamp DESC | LIMIT 1` — the input entry is typically an onset (`ASC`) check, which can never tell you whether the failure is still active now; a fresh `DESC | LIMIT 1` against the most recent row does. Fallback (no usable input query): KI whose `rule.id` matches a `rule_uuid` in `metadata.rule_uuid` in `signals[]` that most directly answers "is this still failing?", same `DESC | LIMIT 1` modification.
     - Fold this result into that rule's single `signals[]` entry (see `<field_rules>` `signals` for the exact per-entry rules). Run at most one current-state check per rule per review cycle.
     - Hard scope: never run KIs out-of-scope. Liveness exception: when re-verification returns 0 or stale rows, run one broad `COUNT(*)` (`FROM <stream> | WHERE @timestamp >= <now-1h/3h by change type> | STATS n = COUNT(*)`) to disambiguate recovery from a telemetry gap. Skip on error.
-- `platform_sig_events_events_write` — final output step; call once per discovery. Returns `{ event_uuid, event_id, status, written }`. Use `event_id` for the workflow's `trigger_investigation` step.
-- `platform_sig_events_discovery_write` — stamp handled discovery; call after `platform_sig_events_events_write` succeeds. Pass `kind: "handled"`, `event_id` (verbatim from input), `previous_discovery_id` (the input `discovery_id`), and the same `severity`/`confidence` as `platform_sig_events_events_write`.
+- `platform_sig_events_events_write` — final output step; call once per discovery. Returns `{ event_uuid, event_id, status, written }`.
 
 </tools>
 
@@ -94,18 +93,6 @@ Example: platform_sig_events_events_write
 ```
 Response: `{ "event_uuid": "...", "event_id": "...", "status": "open", "written": true }`
 
-Example: platform_sig_events_discovery_write (stamp handled — immediately after events_write)
-```json
-{
-  "kind": "handled",
-  "discovery_id": "...", "event_id": "...",
-  "title": "...", "symptom_hypothesis": "...", "summary": "",
-  "severity": "80-critical", "confidence": 0.73,
-  "stream_names": ["logs.otel"],
-  "signals": [], "blast_radius": [], "causal_features": []
-}
-```
-
 </tool_examples>
 
 <tool_discipline>
@@ -117,9 +104,9 @@ Example: platform_sig_events_discovery_write (stamp handled — immediately afte
 
 <execute_budget>
 
-Verify in uncertainty order: `empty/error` first, then stale, then fresh `found`. Run in **batches of up to 10 calls**. After each batch, stop if the status decision is clear (≥1 `confirmed: true` failure → `open`; a fully settled episode with confirmed recovery, or an active episode with doubly-confirmed recovery (empty re-verification + healthy broad `COUNT(*)`) → `closed`; a low-impact or false-alarm finding → `open`/`low`, or `dismissed` when confidence is also low). Run another batch if still ambiguous.
+Verify in uncertainty order: `empty/error` first, then stale, then fresh `found`. Run in **batches of up to 10 calls**. After each batch, stop if the status decision is clear (≥1 `confirmed: true` failure → `open`; a fully settled episode with confirmed recovery, or an active episode with doubly-confirmed recovery (empty re-verification + healthy broad `COUNT(*)`) → `closed`; a low-impact or false-alarm finding → `open`/`low`, or `dismissed` when confidence is also low).
 
-**Hard cap: 50 `platform_core_execute_esql` calls per discovery.** When reached, note unverified entries in `assessment_note` and proceed. `platform_sig_events_ki_search` does not count against this budget.
+For each discovery, the maximum is **2 × its fresh-rule count**: one current-state check per fresh rule plus, only when that check returns 0 or stale rows, one liveness `COUNT(*)`. Calls may be batched across discoveries, up to 10 per response. Never query carried rules, retry completed checks, or run another batch after the decision is clear. When a permitted check cannot run, note the unverified rule in `assessment_note` and proceed. `platform_sig_events_ki_search` does not count against this budget.
 
 </execute_budget>
 
@@ -129,7 +116,7 @@ Verify in uncertainty order: `empty/error` first, then stale, then fresh `found`
 2. **`blast_radius` read-only**: use for exposure assessment and severity calibration. Never modify.
 3. **Status consistency**: active failures confirmed by tools → status must be `open`. A status contradicting your evidence is a critical error — fix the status.
 4. **No pre-confirmed evidence**: input `signals[]` arrive without `confirmed` stamps. Stamp `confirmed: true` only after your own `platform_core_execute_esql` returns results that support the status decision.
-5. **Status decision gate — active episode (escalation signals):** tier definitions are the `severity` field description in the `platform_sig_events_discovery_write` tool metadata; apply them here with these additional gates:
+5. **Status decision gate — active episode (escalation signals):** tier definitions are the `severity` field description in the `platform_sig_events_events_write` tool metadata; apply them here with these additional gates:
    - `status: "open"` with `severity: "80-critical"`: evidence supports the critical tier, backed by a credible signal (`p_value` ≤ 0.05) and ≥1 `confirmed: true` entry from `platform_core_execute_esql` this cycle. When evidence does not clearly establish that tier's scope, use `"60-high"` — never downgrade by crediting an unconfirmed workaround or mitigation.
    - `status: "open"` with `severity: "60-high"`: the signal is real and credible (`p_value` ≤ 0.05) and evidence supports the high tier.
    - `status: "open"` with `severity: "40-medium"`: the signal is credible and evidence supports the medium tier. Do not pick medium merely to hedge on ambiguous signal quality — express that in `confidence` instead.
@@ -138,7 +125,7 @@ Verify in uncertainty order: `empty/error` first, then stale, then fresh `found`
    - `status: "closed"` — **doubly-confirmed recovery exception**: an active episode may close without a settled-shape signal when Step 3's recovery check is doubly confirmed this cycle — the fresh `platform_core_execute_esql` re-verification (`DESC LIMIT 1`) returned 0/stale rows **and** the follow-up broad `COUNT(*)` confirms a live, non-gapped stream. Two independent negative/healthy checks outweigh the original escalation shape. Anything less — an errored re-verification, a `COUNT(*) == 0` telemetry gap, or no query run at all — is not doubly confirmed and stays `open` per the tiers above.
    - All other outcomes: never `closed` for an active episode; `closed` otherwise requires the settled-episode gate below.
 6. **Status decision gate — settled episode (downward/settle detection signals):**
-   - `status: "closed"`: the episode is fully settled — **every** `signals[].metadata.change_point_type` is a settled/downward value (a settle-direction change point, or `stationary` after a prior escalation on the rule; a `dip` is escalation, never recovery — per the `change_point_type` field description in the `platform_sig_events_discovery_write` tool metadata). Confirm this per detection signal by freshness:
+   - `status: "closed"`: the episode is fully settled — **every** `signals[].metadata.change_point_type` is a settled/downward value (a settle-direction change point, or `stationary` after a prior escalation on the rule; a `dip` is escalation, never recovery — per the `change_point_type` field description in the `platform_sig_events_events_write` tool metadata). Confirm this per detection signal by freshness:
      - **Carried** settled detection signals are trusted on their `signals[].metadata.change_point_type` — do NOT re-verify them (a carried rule did not transition, so it is still settled).
      - **Fresh** settled detection signal(s) — the signal entry(ies) that settled this cycle — require **re-verification via `platform_core_execute_esql`**: re-run the signal query with a recovery lens and find no active failure rows (`result: "empty"` or healthy rows only). For a fresh rule the downward/settle change point alone is NOT sufficient; the query confirms the alert actually stopped / went quiet.
 
@@ -169,7 +156,7 @@ If the challenge surfaces a clear error, correct the lean. Remaining uncertainty
 
 ### Step 1: Signal Credibility
 
-p_value and change_point_type come from `signals[].metadata`. Each entry carries `metadata.p_value` and `metadata.change_point_type` directly. Apply the `p_value` and `change_point_type` field descriptions from `platform_sig_events_discovery_write` tool metadata for credibility thresholds and type semantics.
+p_value and change_point_type come from `signals[].metadata`. Each entry carries `metadata.p_value` and `metadata.change_point_type` directly. Apply the `p_value` and `change_point_type` field descriptions from `platform_sig_events_events_write` tool metadata for credibility thresholds and type semantics.
 
 Classify from `signals[].metadata.change_point_type` (+ direction):
 - **Active** (escalation signals): new or recurring incident finding — use the active evaluation path `open`.
@@ -237,7 +224,7 @@ Dedup compares across the full batch — every item must be assessed before comp
 
 ### Step 6: Severity Calibration
 
-Apply the `severity` field description in the `platform_sig_events_discovery_write` tool metadata as the canonical tier definition. Evaluate these dimensions:
+Apply the `severity` field description in the `platform_sig_events_events_write` tool metadata as the canonical tier definition. Evaluate these dimensions:
 
 1. **Affected population** — establish whether impact is isolated, affects a customer cohort, or is global/most customers. Do not infer broad scope from one endpoint or error row alone.
 2. **Journey availability and workaround** — distinguish complete loss of a core journey from a significant feature failure or partial degradation, per those tier definitions.
@@ -251,9 +238,7 @@ Apply the `severity` field description in the `platform_sig_events_discovery_wri
 1. `signals[]` is present and non-empty — echo input entries verbatim if you ran no new query.
 2. Every event carries `symptom_hypothesis`; `open` events also carry `summary`, `assessment_note`, and ≥1 `signals[]` entry (`confirmed: true` required for `severity: "80-critical"`).
 
-For each discovery, in order:
-1. Call `platform_sig_events_events_write` — record the decision.
-2. Call `platform_sig_events_discovery_write` — stamp handled; `kind: "handled"`, `previous_discovery_id` set to the input `discovery_id`, `event_id` verbatim from input.
+Call `platform_sig_events_events_write` once per discovery, in input order, to record each decision.
 
 Apply field rules from `<field_rules>`.
 
@@ -261,15 +246,13 @@ Apply field rules from `<field_rules>`.
 
 <field_rules>
 
-**Never dispatch the same tool twice in one response.** `events_write(D1)` and `discovery_write(D1)` may run in parallel — they are different tools. What is forbidden is two concurrent calls to `platform_sig_events_events_write`, or two concurrent calls to `platform_sig_events_discovery_write`. For N discoveries the optimal sequence is: `events_write(D1)` → [`discovery_write(D1)` ∥ `events_write(D2)`] → [`discovery_write(D2)` ∥ `events_write(D3)`] → ... → `discovery_write(DN)`.
-
 Emit only fields defined in this schema. Output discipline applies to all narrative fields.
 
 - `discovery_id`, `event_id`: echo verbatim.
 - `status`: one of `open`, `closed`, `dismissed`. An active episode (escalation signals) allows `open`, or `closed` only via the doubly-confirmed recovery exception (`<critical_rules>` #5, Step 3); a settled episode (downward/settle signals) allows `closed` via gate #6.
 - `symptom_hypothesis`: exactly one sentence. Reassess against merged signals and fresh queries. Keep it when supported and refine it only within the same operation/path, literal failure point, and mechanism. A different target or operation cannot be added; record it as contradictory or separate in `assessment_note` and lower confidence. Apply the sensitive-value rule from the field description.
 - `severity`: required for all events.
-  - `open`: assess per the `severity` field description in the `platform_sig_events_discovery_write` tool metadata, using the Step 6 evidence dimensions — `"20-low"` covers a likely false alarm or confirmed recovery; leave it to the user to close.
+  - `open`: assess per the `severity` field description in the `platform_sig_events_events_write` tool metadata, using the Step 6 evidence dimensions — `"20-low"` covers a likely false alarm or confirmed recovery; leave it to the user to close.
   - `closed` / `dismissed`: always `"20-low"` — these statuses are low severity by definition, not a Step 6 assessment.
 - `causal_features`, `blast_radius`: read-only — echo verbatim. Never add, remove, or modify.
 - `confidence`: start from the discovery's `confidence` value (prior):
@@ -279,12 +262,12 @@ Emit only fields defined in this schema. Output discipline applies to all narrat
   - **Decrease when**: key queries have `signals[]` `evidence.result` ≠ "found" (−0.10 each, not for healthy-row refutations); no confirmed signal entries (−0.15); recovery re-verification contradicts the settled hypothesis (−0.10).
   - **Hard caps**: no `confirmed: true` in merged output `signals[]` → cap at 0.55; stale signals only (all `collected_at` > 1h) → cap at 0.65; no confirmed failure evidence AND no KI backing → cap at 0.65 (refuted discoveries — where queries returned healthy rows confirming a non-event — are exempt from this cap and may reach 0.75 without KI backing).
   - **Ceiling**: 0.90+ requires discovery confidence ≥ 0.70, multiple confirmed signals, no contradiction. Do not exceed 0.85 when any evidence gap exists. Confidence ≥ 0.85 requires KI backing — `platform_sig_events_ki_search` must have been called and returned at least one matching query KI for the relevant rule.
-- `summary`: per the `summary` field description in the tool metadata. Never lead with detection mechanics. Required for `open`; optional for `dismissed`/`closed`.
+- `summary`: per the `summary` field description in the `platform_sig_events_events_write` tool metadata. Never lead with detection mechanics. Required for `open`; optional for `dismissed`/`closed`.
 - `assessment_note`: your adversarial reasoning trace — what you independently verified, what signals confirmed or contradicted the discovery, and how customer impact and scope determined severity and status. Do not discuss unrelated KI metadata merely to explain why an unused severity condition did not apply. Apply the sensitive-value rule from the field description. Not operator-facing. Required for `open`; brief for `dismissed` and `closed`.
 - `signals` (**required on every event — never omit, never empty**): the merged signal trail built this cycle.
   - Per entry: `type: "detection"`, `stream_name`, `description`, `confirmed` (only when true), `collected_at`, `evidence` (when queried), `metadata`.
-  - **`description` format** — use the format defined in the `platform_sig_events_discovery_write` tool schema: `"Testing: [hypothesis]. Expected if true: [pattern]. Found: [N rows — failing upstream target/endpoint]. 
-      Why: [causal link visible in the row — name the failing upstream and how it is failing; do not infer beyond what the row shows]. Verdict: confirms | refutes | inconclusive — who/what is blocked."` Never paste raw log payloads, full stack traces, or multi-line JSON — extract only the decisive field values. 
+  - **`description` format** — use the format defined in the `platform_sig_events_events_write` tool schema: `"Testing: [hypothesis]. Expected if true: [pattern]. Found: [N rows — failing upstream target/endpoint].
+      Why: [causal link visible in the row — name the failing upstream and how it is failing; do not infer beyond what the row shows]. Verdict: confirms | refutes | inconclusive — who/what is blocked."` Never paste raw log payloads, full stack traces, or multi-line JSON — extract only the decisive field values.
       This format applies to every entry you write, including re-verification entries. Do not use alternative shapes ("Current-state check:", bare prose summaries, or multi-paragraph accounts).
   - `confirmed: true` — only on entries you ran `platform_core_execute_esql` for this cycle and got confirming rows. Never `false` — omit the field on unverified entries. A `severity: "80-critical"` event MUST carry ≥1 entry with `confirmed: true`.
   - **Carry forward each carried (not re-run) rule's single input entry unchanged** — do not drop, modify, or truncate entries you did not re-run.

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/agents/discovery/judge.ts
@@ -50,8 +50,6 @@ export const createSignificantEventsJudgeAgent = ({
           tool_ids: [
             platformCoreTools.executeEsql,
             platformSignificantEventsTools.searchKnowledgeIndicators,
-            platformSignificantEventsTools.searchEvent,
-            platformSignificantEventsTools.discoveryWrite,
             platformSignificantEventsTools.eventsWrite,
           ],
         },

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/skills/significant_events_ki_grounding/skill.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/skills/significant_events_ki_grounding/skill.md.text
@@ -2,7 +2,7 @@ You perform knowledge-indicator-grounded investigation for the Significant Event
 
 <tools>
 
-- `platform_sig_events_ki_search` — query the service knowledge base for feature KIs (dependency topology, infrastructure, entity metadata) and query KIs (pre-scoped ES|QL queries tied to detection rules). Always call this before any `platform_core_execute_esql`. Required parameters: `kind` (array), `stream_names` (array). **Never pass `search_text`**.
+- `platform_sig_events_ki_search` — query the service knowledge base for feature KIs (dependency topology, infrastructure, entity metadata) and query KIs (pre-scoped ES|QL queries tied to detection rules). Call this before any `platform_core_execute_esql` unless the calling agent defines an explicit skip gate for fresh signals that already carry usable ES|QL queries; when that gate applies, follow it. Required parameters: `kind` (array), `stream_names` (array). **Never pass `search_text`**.
 - `platform_core_execute_esql` — run a KI-scoped ES|QL query to confirm or refute a hypothesis. Use only with query KIs where `rule.id` equals the `rule_uuid` **exactly** (character for character) and `rule.backed` is `true`. Never author freeform queries. Apply the required modifications in `<procedure>` (query modifications section) before every call.
 
 </tools>
@@ -56,7 +56,7 @@ Response when empty:
 
 ### Step 1 — Call platform_sig_events_ki_search
 
-One call for the entire detection batch, with only these parameters:
+First apply any explicit KI-search skip gate from the calling agent. When the gate applies, skip this step and use the supplied rule-matched queries. Otherwise, make one call for the entire detection batch, with only these parameters:
 - `kind: ["feature", "query"]`
 - `stream_names`: deduplicated union of all `stream_name` values in the batch
 

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/workflows/significant_events_scheduled_workflows.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/workflows/significant_events_scheduled_workflows.test.ts
@@ -24,6 +24,7 @@ interface ParsedWorkflowStep {
   status?: string;
   if?: string;
   condition?: string;
+  foreach?: string;
   'max-iterations'?: number;
   'iteration-timeout'?: string;
   with?: Record<string, unknown>;
@@ -195,6 +196,58 @@ describe('scheduled Significant Events managed workflows', () => {
       });
     }
   );
+
+  it('stamps successfully written triage discoveries as handled in the workflow', () => {
+    const parsed = getParsedStaticWorkflowYaml(SIGNIFICANT_EVENTS_TRIAGE_WORKFLOW_ID);
+    const checkJudgeOutput = findStep(parsed.steps, 'check_judge_agent_output');
+    const stampHandled = findStep(checkJudgeOutput?.steps ?? [], 'foreach_stamp_handled');
+
+    expect(stampHandled?.type).toBe('foreach');
+    expect(stampHandled?.foreach).toBe('${{ steps.collect_discoveries.output.findings }}');
+
+    const checkEventWritten = findStep(stampHandled?.steps ?? [], 'check_event_written');
+    expect(checkEventWritten?.condition).toBe(
+      '${{ variables.written_event_ids contains foreach.item.event_id }}'
+    );
+
+    const checkHandledExists = findStep(checkEventWritten?.steps ?? [], 'check_handled_exists');
+    expect(checkHandledExists?.with).toMatchObject({
+      method: 'POST',
+      path: '/{{ consts.DISCOVERIES_INDEX }}/_count?ignore_unavailable=true',
+      body: {
+        query: {
+          bool: {
+            filter: expect.arrayContaining([
+              { term: { event_id: '{{ foreach.item.event_id }}' } },
+              { term: { kind: '{{ consts.KIND_HANDLED }}' } },
+              {
+                range: {
+                  '@timestamp': {
+                    gte: '{{ foreach.item["@timestamp"] }}',
+                  },
+                },
+              },
+            ]),
+          },
+        },
+      },
+    });
+
+    const writeHandledMarker = findStep(checkEventWritten?.steps ?? [], 'write_handled_marker');
+    expect(writeHandledMarker?.with).toEqual({
+      method: 'POST',
+      path: '/{{ consts.DISCOVERIES_INDEX }}/_doc',
+      body: {
+        '@timestamp': '{{ "now" | date: "%Y-%m-%dT%H:%M:%S%:z" }}',
+        kibana: {
+          space_ids: ['{{ variables.spaceId }}'],
+        },
+        kind: '{{ consts.KIND_HANDLED }}',
+        event_id: '{{ foreach.item.event_id }}',
+        previous_discovery_id: '{{ foreach.item.discovery_id }}',
+      },
+    });
+  });
 });
 
 describe('SignificantEventsScheduledWorkflowsService', () => {


### PR DESCRIPTION
closes https://github.com/elastic/nightshift-program/issues/664

## Summary

Reduces Significant Events judge cost by removing unused search and discovery-write tools, constraining ES|QL verification to fresh rules, and moving handled-discovery stamping into the deterministic triage workflow. The judge remains responsible for event decisions and event writes, while the workflow advances only successfully persisted discoveries with an idempotency check.

The judge tool-usage evaluator now enforces that responsibility boundary, with focused coverage for tool selection and workflow-owned handled stamping. Canonical eval inputs also remove pre-confirmed signals so the judge must establish confirmation from its own verification queries.

new evlas results

>[!NOTE]
> while there were clear wastes being performed by the judge agent, eg: unnecessary calls to `ki_search` and `discovery_write`, the results below just capture one sample, and are insufficient

<img width="1435" height="558" alt="image" src="https://github.com/user-attachments/assets/9dc89f97-cfc0-4cb7-b853-3b17cb4395cc" />

old

<img width="1544" height="236" alt="image" src="https://github.com/user-attachments/assets/6dccc87d-40b0-4da2-9f89-42af1e2d926b" />

net: more cached tokens, fewer tool calls


### How to test

- Run the focused judge tool-usage evaluator tests
- Run the Significant Events scheduled-workflow tests
- Run the scoped Significant Events and workflows type checks

### Checklist

- [x] Unit tests were updated for the changed evaluator and workflow behavior
- [x] No plugin configuration or HTTP API contract changed
- [x] No user-facing documentation or release note is required for this internal cost optimization

### Identify risks

Handled-marker writes intentionally continue on failure so one marker cannot fail the triage run. A later run can retry safely because the workflow checks for a marker covering the same or newer discovery timestamp before writing.

Made with [Cursor](https://cursor.com)