### PR TITLE
Fix classic background live reload

### DIFF
--- a/src/core/packages/theme/browser-internal/src/theme_service.test.ts
+++ b/src/core/packages/theme/browser-internal/src/theme_service.test.ts
@@ -81,6 +81,11 @@ describe('ThemeService', () => {
         expect(setDarkModeMock).toHaveBeenCalledWith(false);
       });
 
+      it('reflects the color mode on the root background', async () => {
+        themeService.setup({ injectedMetadata });
+        expect(document.documentElement.style.backgroundColor).toEqual('rgb(246, 249, 252)'); // borealis light page background
+      });
+
       it('does not call onSystemThemeChange', async () => {
         themeService.setup({ injectedMetadata });
         expect(onSystemThemeChangeMock).not.toHaveBeenCalled();
@@ -124,6 +129,11 @@ describe('ThemeService', () => {
         themeService.setup({ injectedMetadata });
         expect(setDarkModeMock).toHaveBeenCalledTimes(1);
         expect(setDarkModeMock).toHaveBeenCalledWith(true);
+      });
+
+      it('reflects the color mode on the root background', async () => {
+        themeService.setup({ injectedMetadata });
+        expect(document.documentElement.style.backgroundColor).toEqual('rgb(7, 16, 31)'); // borealis dark page background
       });
 
       it('does not call onSystemThemeChange', async () => {
@@ -301,6 +311,7 @@ describe('ThemeService', () => {
 
       expect(window.__kbnThemeTag__).toEqual('borealisdark');
       expect(getTheme()).toEqual({ darkMode: true, name: 'borealis' });
+      expect(document.documentElement.style.backgroundColor).toEqual('rgb(7, 16, 31)');
     });
 
     it('emits the updated theme on `theme$`', () => {

--- a/src/core/packages/theme/browser-internal/src/theme_service.ts
+++ b/src/core/packages/theme/browser-internal/src/theme_service.ts
@@ -8,7 +8,7 @@
  */
 
 import { BehaviorSubject } from 'rxjs';
-import { _setDarkMode } from '@kbn/ui-theme';
+import { _setDarkMode, getEuiThemeVars } from '@kbn/ui-theme';
 import type { InjectedMetadataTheme } from '@kbn/core-injected-metadata-common-internal';
 import type { InternalInjectedMetadataSetup } from '@kbn/core-injected-metadata-browser-internal';
 import type { CoreTheme } from '@kbn/core-theme-browser';
@@ -94,9 +94,27 @@ export class ThemeService {
     });
 
     _setDarkMode(darkMode);
+    updateRootBackground(theme);
     updateKbnThemeTag(theme);
   }
 }
+
+// Keeps the root `<html>` background (painted by the server-rendered boot
+// splash) in sync with the active color mode on reload-less theme switches.
+// The splash paints the root background only for the color mode resolved at
+// render time, so on a live switch we recolor the real root element from the
+// reactive EUI page-background token instead of leaving it frozen at the SSR
+// color.
+const updateRootBackground = (theme: CoreTheme) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const { euiPageBackgroundColor } = getEuiThemeVars({
+    name: theme.name,
+    darkMode: theme.darkMode,
+  });
+  document.documentElement.style.backgroundColor = euiPageBackgroundColor;
+};
 
 const updateKbnThemeTag = (theme: CoreTheme) => {
   const globals: any = typeof window === 'undefined' ? {} : window;


### PR DESCRIPTION
## Summary

This PR makes the classic app background react to reload-less theme switches.

Previously the whole-app background was painted only by the server-rendered boot splash's static `html { background-color }` rule, which is injected once at SSR from the initial color mode and never updated. On a live theme switch the root background stayed frozen at the load-time color.

**Fix:** the theme service now recolors the real root element on every theme change. In `applyTheme` (which runs on setup and on each `setDarkMode`), it sets `document.documentElement.style.backgroundColor` from the reactive EUI page-background token. 
