### PR TITLE
[Cases] Preserve cleared template field values in v1→v2 templates migration

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -239,6 +239,11 @@ export const RadioGroupFieldSchema = BaseFieldSchema.extend({
  * `metadata.default` is an optional per-template override for the resolved field's default
  * value. It must satisfy the resolved field's control type — this is enforced when the
  * override is merged onto the inline field at resolve time.
+ *
+ * An explicit `null` is distinct from an absent override: `null` means "this template clears the
+ * field" (do not inherit the library default; the field stays empty), whereas an absent
+ * `metadata.default` inherits the library field's default. This is what the v1→v2 template
+ * migration emits for a legacy template custom field whose value was explicitly cleared.
  */
 export const RefFieldSchema = z.object({
   name: z.string().optional(),
@@ -246,7 +251,14 @@ export const RefFieldSchema = z.object({
   metadata: z
     .object({
       default: z
-        .union([z.string(), z.number(), z.boolean(), z.array(z.string()), UserPickerDefaultSchema])
+        .union([
+          z.string(),
+          z.number(),
+          z.boolean(),
+          z.array(z.string()),
+          UserPickerDefaultSchema,
+          z.null(),
+        ])
         .optional(),
     })
     .optional(),

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
@@ -7,14 +7,16 @@
 
 import { stringify as yamlStringify } from 'yaml';
 import {
+  applyRefFieldOverride,
   buildExtendedFieldsDefaults,
   getFieldCamelKey,
   getFieldSnakeKey,
   getYamlDefaultAsString,
   parseFieldDefinitionsToInlineFields,
+  resolveTemplateFields,
 } from './template_fields';
 import type { FieldDefinition } from '../types/domain/field_definition/latest';
-import type { InlineField } from '../types/domain/template/fields';
+import type { Field, InlineField, RefField } from '../types/domain/template/fields';
 
 describe('template field key utils', () => {
   describe('getFieldSnakeKey', () => {
@@ -112,6 +114,96 @@ describe('template field key utils', () => {
 
     it('serializes arrays as JSON strings', () => {
       expect(getYamlDefaultAsString(['a', 'b'])).toBe('["a","b"]');
+    });
+  });
+
+  describe('applyRefFieldOverride', () => {
+    const libField: InlineField = {
+      name: 'lib_field',
+      type: 'keyword',
+      control: 'INPUT_TEXT',
+      metadata: { default: 'from_lib' },
+    };
+
+    it('applies the $ref name alias', () => {
+      const result = applyRefFieldOverride(libField, { $ref: 'lib_field', name: 'alias' });
+      expect(result.name).toBe('alias');
+      expect(result.metadata?.default).toBe('from_lib');
+    });
+
+    it('overrides the library default with the $ref override', () => {
+      const result = applyRefFieldOverride(libField, {
+        $ref: 'lib_field',
+        metadata: { default: 'override' },
+      });
+      expect(result.metadata?.default).toBe('override');
+    });
+
+    it('inherits the library default when the $ref has no override', () => {
+      const result = applyRefFieldOverride(libField, { $ref: 'lib_field' });
+      expect(result.metadata?.default).toBe('from_lib');
+    });
+
+    it('clears the inherited default when the override is explicitly null', () => {
+      const result = applyRefFieldOverride(libField, {
+        $ref: 'lib_field',
+        metadata: { default: null },
+      });
+      expect(result.metadata?.default).toBeUndefined();
+    });
+  });
+
+  describe('resolveTemplateFields', () => {
+    const makeLibDef = (name: string, defYaml: object): FieldDefinition => ({
+      fieldDefinitionId: `fd-${name}`,
+      name,
+      owner: 'securitySolution',
+      description: '',
+      isGlobal: true,
+      definition: yamlStringify(defYaml),
+    });
+
+    const libDefs: FieldDefinition[] = [
+      makeLibDef('lib_text', {
+        name: 'lib_text',
+        type: 'keyword',
+        control: 'INPUT_TEXT',
+        metadata: { default: 'from_lib' },
+      }),
+    ];
+
+    it('passes inline fields through unchanged', () => {
+      const inline: Field = { name: 'inline', type: 'keyword', control: 'INPUT_TEXT' };
+      expect(resolveTemplateFields([inline], libDefs)).toEqual([inline]);
+    });
+
+    it('resolves a $ref to its library default when no override is present', () => {
+      const ref: RefField = { $ref: 'lib_text' };
+      const [resolved] = resolveTemplateFields([ref], libDefs);
+      expect(resolved.metadata?.default).toBe('from_lib');
+    });
+
+    it('applies a $ref metadata.default override over the library default', () => {
+      const ref: RefField = { $ref: 'lib_text', metadata: { default: 'from_template' } };
+      const [resolved] = resolveTemplateFields([ref], libDefs);
+      expect(resolved.metadata?.default).toBe('from_template');
+    });
+
+    it('clears the library default when the $ref override is explicitly null', () => {
+      const ref: RefField = { $ref: 'lib_text', metadata: { default: null } };
+      const [resolved] = resolveTemplateFields([ref], libDefs);
+      expect(resolved.metadata?.default).toBeUndefined();
+    });
+
+    it('drops a $ref that cannot be resolved in the library', () => {
+      const ref: RefField = { $ref: 'unknown' };
+      expect(resolveTemplateFields([ref], libDefs)).toEqual([]);
+    });
+
+    it('produces an empty extended-fields default for a null-cleared $ref', () => {
+      const ref: RefField = { $ref: 'lib_text', metadata: { default: null } };
+      const resolved = resolveTemplateFields([ref], libDefs);
+      expect(buildExtendedFieldsDefaults(resolved)).toEqual({ lib_text_as_keyword: '' });
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
@@ -68,10 +68,49 @@ export const getYamlDefaultAsString = (rawDefault: unknown): string => {
 };
 
 /**
+ * Applies a `$ref` entry's overrides onto its resolved library (inline) field:
+ * - `name` acts as a local alias replacing the library field's name.
+ * - `metadata.default` overrides the library default. Three cases:
+ *     - absent (`undefined`): inherit the library field's default,
+ *     - explicit `null`: clear the inherited default so the field stays empty (this is what the
+ *       v1→v2 migration emits for a legacy template field whose value was explicitly cleared),
+ *     - any other value: use it as the field's default.
+ *
+ * Shared by `resolveTemplateFields` (server / case-creation) and `useResolvedFields` (editor) so
+ * both paths resolve `$ref` overrides identically.
+ */
+export const applyRefFieldOverride = (
+  inlineField: InlineField,
+  refField: RefField
+): InlineField => {
+  let resolved: InlineField =
+    refField.name && refField.name !== inlineField.name
+      ? { ...inlineField, name: refField.name }
+      : inlineField;
+
+  const overrideDefault = refField.metadata?.default;
+  if (overrideDefault === null) {
+    const { default: _omitted, ...restMetadata } = (resolved.metadata ?? {}) as Record<
+      string,
+      unknown
+    >;
+    resolved = { ...resolved, metadata: restMetadata } as InlineField;
+  } else if (overrideDefault !== undefined) {
+    resolved = {
+      ...resolved,
+      metadata: { ...(resolved.metadata ?? {}), default: overrideDefault },
+    } as InlineField;
+  }
+
+  return resolved;
+};
+
+/**
  * Resolves a template `fields` array into a flat list of inline fields by:
  * - passing inline fields through as-is,
  * - looking up `$ref` fields by name in `libraryDefs`, parsing their YAML definition,
- *   and applying any `name` override from the ref entry.
+ *   and applying the ref entry's `name` alias and `metadata.default` override (see
+ *   {@link applyRefFieldOverride}).
  *
  * Fields that cannot be resolved or that produce another ref are silently dropped.
  */
@@ -88,12 +127,7 @@ export const resolveTemplateFields = (
       const parsed = parseYaml(fd.definition);
       const result = FieldSchema.safeParse(parsed);
       if (!result.success || isRefField(result.data)) return [];
-      const inlineField = result.data as InlineField;
-      return [
-        refField.name && refField.name !== inlineField.name
-          ? { ...inlineField, name: refField.name }
-          : inlineField,
-      ];
+      return [applyRefFieldOverride(result.data as InlineField, refField)];
     } catch {
       return [];
     }

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/hooks/use_resolved_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/hooks/use_resolved_fields.test.ts
@@ -138,6 +138,15 @@ describe('useResolvedFields', () => {
       expect(result.current.resolvedFields[0].metadata).toMatchObject({ default: 'from_lib' });
     });
 
+    it('clears the inherited library default when the override is explicitly null', () => {
+      // A migrated v1 template that cleared this field emits `metadata.default: null` — the field
+      // must resolve to "no default" (empty), not inherit the library default.
+      const refField: Field = { $ref: 'lib_field', metadata: { default: null } };
+      const { result } = renderHook(() => useResolvedFields([refField], 'securitySolution'));
+      expect(result.current.resolvedFields).toHaveLength(1);
+      expect(result.current.resolvedFields[0].metadata?.default).toBeUndefined();
+    });
+
     it('combines name alias and metadata.default override on the same entry', () => {
       const refField: Field = {
         $ref: 'lib_field',

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/hooks/use_resolved_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/hooks/use_resolved_fields.ts
@@ -13,6 +13,7 @@ import {
   isInlineField,
   isRefField,
 } from '../../../../common/types/domain/template/fields';
+import { applyRefFieldOverride } from '../../../../common/utils/template_fields';
 import { useGetFieldDefinitions } from './use_get_field_definitions';
 
 /**
@@ -40,21 +41,7 @@ export const useResolvedFields = (
         const result = FieldSchema.safeParse(parsed);
         if (!result.success || isRefField(result.data)) return [];
 
-        let resolved = result.data as InlineField;
-
-        if (field.name && field.name !== resolved.name) {
-          resolved = { ...resolved, name: field.name };
-        }
-
-        const overrideDefault = field.metadata?.default;
-        if (overrideDefault !== undefined) {
-          resolved = {
-            ...resolved,
-            metadata: { ...(resolved.metadata ?? {}), default: overrideDefault },
-          } as InlineField;
-        }
-
-        return [resolved];
+        return [applyRefFieldOverride(result.data as InlineField, field)];
       } catch {
         return [];
       }

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_template_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_template_yaml.test.ts
@@ -373,7 +373,9 @@ describe('buildTemplateYaml', () => {
       expect(parse(yaml).fields[0].metadata?.default).toBe(true);
     });
 
-    it('omits $ref metadata when value is null', () => {
+    it('emits an explicit null TEXT default when the legacy value is null (cleared field)', () => {
+      // A cleared v1 template field must stay empty in v2, not inherit the field-library default.
+      // `default: null` is the explicit "clear" marker; an absent override would inherit instead.
       const yaml = buildTemplateYaml(
         {
           key: 'k',
@@ -384,7 +386,56 @@ describe('buildTemplateYaml', () => {
         },
         makeRef('cf_text')
       );
+      expect(parse(yaml).fields[0].metadata).toEqual({ default: null });
+    });
+
+    it('emits an explicit null NUMBER default when the legacy value is null (cleared field)', () => {
+      const yaml = buildTemplateYaml(
+        {
+          key: 'k',
+          name: 'T',
+          caseFields: {
+            customFields: [{ key: 'cf_num', type: CustomFieldTypes.NUMBER, value: null }],
+          },
+        },
+        makeRef('cf_num')
+      );
+      expect(parse(yaml).fields[0].metadata).toEqual({ default: null });
+    });
+
+    it('omits $ref metadata for a TOGGLE with a null value (toggles cannot be cleared)', () => {
+      const yaml = buildTemplateYaml(
+        {
+          key: 'k',
+          name: 'T',
+          caseFields: {
+            customFields: [{ key: 'cf_toggle', type: CustomFieldTypes.TOGGLE, value: null }],
+          },
+        },
+        makeRef('cf_toggle')
+      );
       expect(parse(yaml).fields[0].metadata).toBeUndefined();
+    });
+
+    it('emits a null default that round-trips through ParsedTemplateDefinitionSchema', () => {
+      const yaml = buildTemplateYaml(
+        {
+          key: 'k',
+          name: 'T',
+          caseFields: {
+            customFields: [{ key: 'cf_text', type: CustomFieldTypes.TEXT, value: null }],
+          },
+        },
+        makeRef('cf_text')
+      );
+      const result = ParsedTemplateDefinitionSchema.safeParse(parseYaml(yaml));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.fields[0]).toMatchObject({
+          $ref: 'cf_text',
+          metadata: { default: null },
+        });
+      }
     });
 
     it('skips unmatched custom field key and logs a warning', () => {

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_template_yaml.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_template_yaml.ts
@@ -88,10 +88,15 @@ export const buildTemplateYaml = (
 
     const refEntry: Record<string, unknown> = { $ref: refName };
 
-    if (cf.value !== null && cf.value !== undefined) {
-      if (cf.type === CustomFieldTypes.TEXT || cf.type === CustomFieldTypes.NUMBER) {
-        refEntry.metadata = { default: cf.value };
-      } else if (cf.type === CustomFieldTypes.TOGGLE) {
+    if (cf.type === CustomFieldTypes.TEXT || cf.type === CustomFieldTypes.NUMBER) {
+      // A legacy template stores an explicitly-cleared field as `value: null`. In v1 that meant the
+      // field was empty for cases created from the template (the global default was NOT re-applied).
+      // In v2 an omitted `$ref` override inherits the field-library default, so to preserve the v1
+      // intent we emit an explicit `default: null` — "clear, do not inherit the library default".
+      refEntry.metadata = { default: cf.value ?? null };
+    } else if (cf.type === CustomFieldTypes.TOGGLE) {
+      // Legacy toggles are always a concrete boolean, never null — carry the value straight across.
+      if (cf.value !== null && cf.value !== undefined) {
         refEntry.metadata = { default: Boolean(cf.value) };
       }
     }


### PR DESCRIPTION
## Summary

When the Cases templates v2 migration runs, custom fields that a user had **explicitly cleared** in their v1 template were coming back populated with the *global* custom-field default value.

### Problem

A v1 case template stores each custom field it touches under `caseFields.customFields`. When a user clears a field in a v1 template, it is persisted as `value: null`, which in v1 means *"leave this field empty for cases created from this template"* — the global custom-field `defaultValue` is **not** re-applied.

The v2 template model represents template fields as field-library references (`$ref`) whose default can be overridden per template via `metadata.default`. In v2, an **omitted** `metadata.default` means *"inherit the field-library default"*. The library default is itself seeded from the v1 global `defaultValue`.

The migration faithfully omitted `metadata.default` for a cleared (`value: null`) field — but because "omitted" now means "inherit the library default", the cleared field resurfaced the global default. v1 had two independent concepts (global default vs. an explicitly-empty per-template value) that the v2 `$ref` model collapsed into one, so the "explicitly empty" intent was lost.

A second, related gap: the shared `resolveTemplateFields` (used by case creation and the Cases connector) ignored `$ref` `metadata.default` overrides entirely and always used the library default, so it disagreed with the template editor's resolver (`useResolvedFields`, which did apply overrides).

### Solution

- Introduce an explicit **"cleared"** representation: `RefFieldSchema.metadata.default` now accepts `null`, distinct from an absent override. `null` = *clear, do not inherit the library default*; absent = *inherit*; a value = *override*.
- Add a shared `applyRefFieldOverride` helper and use it in **both** `resolveTemplateFields` (case creation / connector) and `useResolvedFields` (editor), so `$ref` name aliases and `metadata.default` overrides — including the `null` clear — resolve identically everywhere.
- Make the migration emit `metadata.default: null` for legacy TEXT/NUMBER template fields whose value was `null`. Toggles are always a concrete boolean in v1, so they are unchanged.

### Notes / follow-ups

- The templates migration is a one-shot, flag-gated task. This change affects migrations that run after it merges; spaces already migrated retain their existing (lossy) template YAML and would need a separate backfill to benefit. Happy to follow up on that if we want to retroactively repair already-migrated templates.

## Test plan

- [ ] `RefFieldSchema` accepts `metadata.default: null` and round-trips through `ParsedTemplateDefinitionSchema`.
- [ ] `applyRefFieldOverride` / `resolveTemplateFields`: absent override inherits the library default; a value overrides it; `null` clears it.
- [ ] `useResolvedFields`: a `$ref` with `metadata.default: null` resolves to no default (empty field).
- [ ] Migration `buildTemplateYaml`: cleared TEXT/NUMBER values emit `default: null`; toggles unaffected.
- [ ] Manual: migrate a v1 template with a cleared field and confirm the field renders empty (not the global default) in the template editor and on a case created from the template.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->