### PR TITLE
[Security Solution][Flyout] improve resolver stats to take cold/frozen tier into account

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/queries/stats.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/queries/stats.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StatsQuery } from './stats';
+
+describe('StatsQuery', () => {
+  const schema = {
+    id: 'process.entity_id',
+    parent: 'process.parent.entity_id',
+    agentId: 'agent.id',
+  };
+
+  it('excludes cold and frozen tiers when shouldExcludeColdAndFrozenTiers is true', () => {
+    const query = new StatsQuery({
+      schema,
+      indexPatterns: [''],
+      timeRange: undefined,
+      isInternalRequest: false,
+      shouldExcludeColdAndFrozenTiers: true,
+      agentId: undefined,
+    });
+
+    expect(query.getColdAndFrozenTierFilter()).toEqual([
+      {
+        bool: {
+          must_not: {
+            terms: {
+              _tier: ['data_frozen', 'data_cold'],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('does not exclude cold and frozen tiers when shouldExcludeColdAndFrozenTiers is false or omitted', () => {
+    const query = new StatsQuery({
+      schema,
+      indexPatterns: [''],
+      timeRange: undefined,
+      isInternalRequest: false,
+      agentId: undefined,
+    });
+
+    expect(query.getColdAndFrozenTierFilter()).toEqual([]);
+  });
+
+  it('applies the provided timeRange as a range filter', () => {
+    const timeRange = { from: 'now-1d', to: 'now' };
+    const query = new StatsQuery({
+      schema,
+      indexPatterns: [''],
+      timeRange,
+      isInternalRequest: false,
+      agentId: undefined,
+    });
+
+    expect(query.getRangeFilter()).toEqual([
+      {
+        range: {
+          '@timestamp': {
+            gte: 'now-1d',
+            lte: 'now',
+            format: 'strict_date_optional_time',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('returns no range filter when timeRange is undefined', () => {
+    const query = new StatsQuery({
+      schema,
+      indexPatterns: [''],
+      timeRange: undefined,
+      isInternalRequest: false,
+      agentId: undefined,
+    });
+
+    expect(query.getRangeFilter()).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/queries/stats.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/queries/stats.ts
@@ -38,9 +38,17 @@ export class StatsQuery extends BaseResolverQuery {
     indexPatterns,
     timeRange,
     isInternalRequest,
+    shouldExcludeColdAndFrozenTiers,
     agentId,
   }: ResolverQueryParams) {
-    super({ schema, indexPatterns, timeRange, isInternalRequest, agentId });
+    super({
+      schema,
+      indexPatterns,
+      timeRange,
+      isInternalRequest,
+      shouldExcludeColdAndFrozenTiers,
+      agentId,
+    });
   }
 
   private query(nodes: NodeID[]): JsonObject {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/utils/fetch.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/utils/fetch.test.ts
@@ -847,4 +847,34 @@ describe('fetcher test', () => {
       );
     });
   });
+
+  describe('stats query options', () => {
+    it('forwards timeRange and shouldExcludeColdAndFrozenTiers to the StatsQuery constructor', async () => {
+      LifecycleQuery.prototype.search = jest.fn().mockImplementationOnce(async () => []);
+      DescendantsQuery.prototype.search = jest.fn().mockImplementationOnce(async () => []);
+
+      const timeRange = { from: 'now-1d', to: 'now' };
+      const options: TreeOptions = {
+        agentId: 'agent-1',
+        descendantLevels: 0,
+        descendants: 0,
+        ancestors: 0,
+        timeRange,
+        shouldExcludeColdAndFrozenTiers: true,
+        schema: schemaIDParent,
+        indexPatterns: [''],
+        nodes: ['0'],
+      };
+
+      const fetcher = new Fetcher(client);
+      await fetcher.tree(options);
+
+      const StatsQueryMock = StatsQuery as jest.MockedClass<typeof StatsQuery>;
+      const lastCallArgs = StatsQueryMock.mock.calls[StatsQueryMock.mock.calls.length - 1][0];
+      expect(lastCallArgs).toMatchObject({
+        timeRange,
+        shouldExcludeColdAndFrozenTiers: true,
+      });
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/utils/fetch.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/resolver/tree/utils/fetch.ts
@@ -98,6 +98,7 @@ export class Fetcher {
       timeRange: options.timeRange,
       isInternalRequest,
       agentId: options.agentId,
+      shouldExcludeColdAndFrozenTiers: !!options.shouldExcludeColdAndFrozenTiers,
     });
 
     const { eventStats, alertIds } = await query.search(


### PR DESCRIPTION
## Summary

### Problem

The Resolver `tree` API (`/api/endpoint/resolver/tree`) supports excluding cold/frozen tier data via `shouldExcludeColdAndFrozenTiers` (surfaced through the `securitySolution:excludeColdAndFrozenTiersInAnalyzer` advanced setting), but the alert-hits/event-stats sub-query (`StatsQuery`, used whenever `includeHits: true`) never honored it:

- `Fetcher.formatResponse` (`utils/fetch.ts`) constructed `StatsQuery` without passing `shouldExcludeColdAndFrozenTiers` at all, even though the sibling `LifecycleQuery` (ancestors) and `DescendantsQuery` (descendants) constructions right above it already did.
- Even if it had been passed, `StatsQuery`'s constructor (`queries/stats.ts`) didn't destructure `shouldExcludeColdAndFrozenTiers` from its params, so it was silently dropped before reaching `super(...)` and never reached `BaseResolverQuery`, where `getColdAndFrozenTierFilter()` reads it.

Net effect: enabling the "exclude cold/frozen tiers" setting had no effect on the alert-hits query specifically, so that part of the `tree` request kept scanning cold/frozen tier data regardless of the setting.

### Solution

- `fetch.ts`: pass `shouldExcludeColdAndFrozenTiers: !!options.shouldExcludeColdAndFrozenTiers` into the `StatsQuery` constructor, matching the existing `LifecycleQuery`/`DescendantsQuery` call sites.
- `stats.ts`: forward `shouldExcludeColdAndFrozenTiers` through the constructor to `super(...)` so `BaseResolverQuery` actually stores it.

### How to test

1. Enable `securitySolution:excludeColdAndFrozenTiersInAnalyzer`.
2. Call `POST /api/endpoint/resolver/tree` with `includeHits: true` against data that spans cold/frozen tiers.
3. Before the fix, alert hits/event stats include cold/frozen tier docs regardless of the setting; after the fix, they're excluded — same as the ancestors/descendants portions of the tree already were.
4. Unit tests added: `queries/stats.test.ts` asserts `getColdAndFrozenTierFilter()`/`getRangeFilter()` reflect constructor params; `utils/fetch.test.ts` asserts `Fetcher` forwards `shouldExcludeColdAndFrozenTiers` (and `timeRange`) into the `StatsQuery` constructor.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->