### PR TITLE
[Cases] Templates v2: fix default title/description handling + field library label column

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.test.ts
@@ -365,6 +365,14 @@ describe('ParsedTemplateDefinitionSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('allows a null case-default name (a cleared `name:` in the YAML)', () => {
+    // Typing `name:` with no value in the editor parses to `{ name: null }`. This must behave like
+    // the other cleared case defaults (description/severity/category) and not fail validation.
+    const result = ParsedTemplateDefinitionSchema.safeParse({ name: null, fields: [] });
+
+    expect(result.success).toBe(true);
+  });
+
   it('rejects a case-default name longer than the max case title length', () => {
     const result = ParsedTemplateDefinitionSchema.safeParse({
       name: 'a'.repeat(MAX_TITLE_LENGTH + 1),

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
@@ -138,9 +138,11 @@ export const ParsedTemplateDefinitionSchema = z.object({
    * canonicalized to `name` before validation — see normalize_template_case_defaults). Every case
    * default here is optional — the only thing required to create a template is the template identity
    * name, which lives on the saved-object attributes (edited in "Template details"), not in this
-   * YAML. An empty/`null` value parses to `undefined`.
+   * YAML. Like the other case defaults below, `name` stays lenient and accepts `null` (an empty YAML
+   * value, e.g. `name:` with no value): a cleared title must behave like the other cleared case
+   * defaults and not fail validation. A provided string must still be non-empty (`.min(1)`).
    */
-  name: z.string().min(1).max(MAX_TITLE_LENGTH).optional(),
+  name: z.string().min(1).max(MAX_TITLE_LENGTH).nullable().optional(),
   // Case-default values are optional. The runtime schema intentionally stays lenient and still
   // accepts `null` (an empty YAML value / legacy "no default"): it validates migrated and
   // already-stored definitions, not just newly-authored editor YAML. `buildTemplateYaml` emits

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/pages/all_field_definitions_page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/pages/all_field_definitions_page.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen, within } from '@testing-library/react';
+import { renderWithTestingProviders } from '../../../common/mock';
+import type { FieldDefinition } from '../../../../common/types/domain/field_definition/v1';
+import { AllFieldDefinitionsPage } from './all_field_definitions_page';
+
+const mockGetFieldDefinitions = jest.fn();
+
+jest.mock('../hooks/use_get_field_definitions', () => ({
+  useGetFieldDefinitions: () => mockGetFieldDefinitions(),
+}));
+
+jest.mock('../hooks/use_create_field_definition', () => ({
+  useCreateFieldDefinition: () => ({ mutate: jest.fn(), isLoading: false }),
+}));
+
+jest.mock('../hooks/use_update_field_definition', () => ({
+  useUpdateFieldDefinition: () => ({ mutate: jest.fn(), isLoading: false }),
+}));
+
+jest.mock('../hooks/use_delete_field_definition', () => ({
+  useDeleteFieldDefinition: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock('../../../common/navigation', () => ({
+  useCasesTemplatesNavigation: () => ({
+    getCasesTemplatesUrl: () => '/templates',
+    navigateToCasesTemplates: jest.fn(),
+  }),
+}));
+
+const buildFieldDefinition = (overrides: Partial<FieldDefinition>): FieldDefinition => ({
+  fieldDefinitionId: 'id-1',
+  name: 'my_field',
+  definition: 'name: my_field\ncontrol: INPUT_TEXT\ntype: keyword\n',
+  owner: 'securitySolution',
+  ...overrides,
+});
+
+describe('AllFieldDefinitionsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFieldDefinitions.mockReturnValue({ data: { fieldDefinitions: [] }, isLoading: false });
+  });
+
+  it('renders the Label column immediately after the Name column', () => {
+    renderWithTestingProviders(<AllFieldDefinitionsPage />);
+
+    const headerCells = screen.getAllByRole('columnheader').map((cell) => cell.textContent);
+
+    expect(headerCells[0]).toContain('Name');
+    expect(headerCells[1]).toContain('Label');
+  });
+
+  it("shows the field's label parsed from its definition YAML", () => {
+    mockGetFieldDefinitions.mockReturnValue({
+      data: {
+        fieldDefinitions: [
+          buildFieldDefinition({
+            fieldDefinitionId: 'labeled',
+            name: 'summary',
+            definition: 'name: summary\nlabel: Summary\ncontrol: INPUT_TEXT\ntype: keyword\n',
+          }),
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(<AllFieldDefinitionsPage />);
+
+    expect(
+      within(screen.getByTestId('fieldDefinitionLabelCell')).getByText('Summary')
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to a placeholder when the definition has no label', () => {
+    mockGetFieldDefinitions.mockReturnValue({
+      data: {
+        fieldDefinitions: [
+          buildFieldDefinition({
+            definition: 'name: my_field\ncontrol: INPUT_TEXT\ntype: keyword\n',
+          }),
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(<AllFieldDefinitionsPage />);
+
+    expect(
+      within(screen.getByTestId('fieldDefinitionLabelCell')).getByText('—')
+    ).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/pages/all_field_definitions_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/pages/all_field_definitions_page.tsx
@@ -18,8 +18,10 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
+import { parse as parseYaml } from 'yaml';
 import type { Owner } from '../../../../common/bundled-types.gen';
 import type { FieldDefinition } from '../../../../common/types/domain/field_definition/v1';
+import { FieldSchema, isRefField } from '../../../../common/types/domain/template/fields';
 import { useCasesContext } from '../../cases_context/use_cases_context';
 import { useCasesTemplatesNavigation } from '../../../common/navigation';
 import { useGetFieldDefinitions } from '../hooks/use_get_field_definitions';
@@ -33,6 +35,24 @@ import { CasesAppHeader } from '../../app/cases_app_header';
 import { CasesPageBody } from '../../app/cases_page_body';
 
 export type AllFieldDefinitionsPageProps = Record<string, never>;
+
+/**
+ * The field library table stores each field's `label` inside its `definition` YAML (a single
+ * FieldSchema entry), not as a top-level attribute. Parse it out for the Label column, tolerating
+ * malformed/legacy definitions by returning `undefined` so the row still renders.
+ */
+const getFieldDefinitionLabel = (definition: string): string | undefined => {
+  try {
+    const result = FieldSchema.safeParse(parseYaml(definition));
+    // `$ref` entries carry no label; only inline field definitions do.
+    if (!result.success || isRefField(result.data)) {
+      return undefined;
+    }
+    return result.data.label;
+  } catch {
+    return undefined;
+  }
+};
 
 export const AllFieldDefinitionsPage: React.FC<AllFieldDefinitionsPageProps> = () => {
   const { owner } = useCasesContext();
@@ -111,6 +131,19 @@ export const AllFieldDefinitionsPage: React.FC<AllFieldDefinitionsPageProps> = (
       sortable: true,
       truncateText: true,
       'data-test-subj': 'fieldDefinitionNameCell',
+    },
+    {
+      name: i18n.LABEL_COLUMN,
+      truncateText: true,
+      'data-test-subj': 'fieldDefinitionLabelCell',
+      render: (fd: FieldDefinition) => {
+        const label = getFieldDefinitionLabel(fd.definition);
+        return (
+          <EuiText size="s" color={label ? 'default' : 'subdued'}>
+            {label ?? '—'}
+          </EuiText>
+        );
+      },
     },
     {
       field: 'description',

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/translations.ts
@@ -105,6 +105,10 @@ export const NAME_COLUMN = i18n.translate('xpack.cases.fieldLibrary.nameColumn',
   defaultMessage: 'Name',
 });
 
+export const LABEL_COLUMN = i18n.translate('xpack.cases.fieldLibrary.labelColumn', {
+  defaultMessage: 'Label',
+});
+
 export const DESCRIPTION_COLUMN = i18n.translate('xpack.cases.fieldLibrary.descriptionColumn', {
   defaultMessage: 'Description',
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/debounced_template_markdown_field.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/debounced_template_markdown_field.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { ReactNode } from 'react';
+import { EuiFormRow } from '@elastic/eui';
+import { MarkdownEditor } from '../../markdown_editor';
+import { ID as LensPluginId } from '../../markdown_editor/plugins/lens/constants';
+import { useDebouncedFieldValue } from '../hooks/use_debounced_field_value';
+
+interface DebouncedTemplateMarkdownFieldProps {
+  label: ReactNode;
+  ariaLabel: string;
+  /** Source-of-truth value; the field re-syncs when it changes from outside (YAML edit, load). */
+  value: string;
+  /** Debounced — fired after the user pauses; also flushed on blur. */
+  onChange: (value: string) => void;
+  editorId: string;
+  dataTestSubj: string;
+}
+
+// The case description is authored as markdown everywhere else in Cases (create case, legacy
+// templates), so the default description must offer the same markdown editing experience rather than
+// a plain textarea — otherwise migrated markdown defaults render as escaped plain text. The Lens
+// plugin is disabled to match the create-case description editor (its embeds are not resolvable in a
+// template default).
+const disabledUiPlugins = [LensPluginId];
+
+/**
+ * A markdown editor whose keystrokes stay local to this component and only propagate (debounced) to
+ * the parent on pause / blur — mirroring DebouncedTemplateTextField. Isolating the field this way
+ * keeps typing instant even when the surrounding form is heavy (async comboboxes, YAML
+ * re-serialization on change).
+ */
+export const DebouncedTemplateMarkdownField: React.FC<DebouncedTemplateMarkdownFieldProps> = ({
+  label,
+  ariaLabel,
+  value,
+  onChange,
+  editorId,
+  dataTestSubj,
+}) => {
+  const { value: localValue, setValue, flush } = useDebouncedFieldValue<string>(value, onChange);
+
+  return (
+    <EuiFormRow label={label} fullWidth>
+      {/* React's onBlur bubbles from the inner textarea, so it flushes any pending debounced change
+          the moment focus leaves the editor — guaranteeing Save sees the latest markdown. */}
+      <div onBlur={flush}>
+        <MarkdownEditor
+          ariaLabel={ariaLabel}
+          editorId={editorId}
+          value={localValue}
+          onChange={setValue}
+          disabledUiPlugins={disabledUiPlugins}
+          data-test-subj={dataTestSubj}
+        />
+      </div>
+    </EuiFormRow>
+  );
+};
+
+DebouncedTemplateMarkdownField.displayName = 'DebouncedTemplateMarkdownField';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_case_defaults_form.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_case_defaults_form.test.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderWithTestingProviders } from '../../../common/mock';
 import { CaseSeverity } from '../../../../common/types/domain';
 import type { ParsedTemplateDefinition } from '../../../../common/types/domain/template/v1';
 import { TemplateCaseDefaultsForm } from './template_case_defaults_form';
@@ -57,8 +58,25 @@ describe('TemplateCaseDefaultsForm', () => {
     fields: [],
   };
 
+  it('renders the case-default description in a markdown editor populated with the template markdown', () => {
+    const markdownDescription = '# Runbook\n\n1. Review the **source** host';
+
+    renderWithTestingProviders(
+      <TemplateCaseDefaultsForm
+        parsedTemplate={{ ...baseTemplate, description: markdownDescription }}
+      />
+    );
+
+    // EuiMarkdownEditor renders a real textarea inside its container, confirming the default
+    // description is an editable markdown field rather than a plain textarea.
+    const editorContainer = screen.getByTestId('caseDefaultsDescriptionInput');
+    const textarea = within(editorContainer).getByRole('textbox');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea).toHaveValue(markdownDescription);
+  });
+
   it('renders only the canonical severities — no empty / "null" option', () => {
-    render(<TemplateCaseDefaultsForm parsedTemplate={baseTemplate} />);
+    renderWithTestingProviders(<TemplateCaseDefaultsForm parsedTemplate={baseTemplate} />);
 
     const severitySelect = screen.getByTestId('caseDefaultsSeverityInput');
     const options = within(severitySelect).getAllByRole('option');
@@ -76,7 +94,7 @@ describe('TemplateCaseDefaultsForm', () => {
   });
 
   it('defaults severity to "low" when the template does not specify one', () => {
-    render(<TemplateCaseDefaultsForm parsedTemplate={baseTemplate} />);
+    renderWithTestingProviders(<TemplateCaseDefaultsForm parsedTemplate={baseTemplate} />);
 
     expect(screen.getByTestId('caseDefaultsSeverityInput')).toHaveValue(CaseSeverity.LOW);
   });
@@ -85,7 +103,9 @@ describe('TemplateCaseDefaultsForm', () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
 
-    render(<TemplateCaseDefaultsForm parsedTemplate={baseTemplate} onChange={onChange} />);
+    renderWithTestingProviders(
+      <TemplateCaseDefaultsForm parsedTemplate={baseTemplate} onChange={onChange} />
+    );
 
     await user.selectOptions(screen.getByTestId('caseDefaultsSeverityInput'), CaseSeverity.HIGH);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_case_defaults_form.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_case_defaults_form.tsx
@@ -28,6 +28,7 @@ import { useGetCategories } from '../../../containers/use_get_categories';
 import { CategoryComponent } from '../../category/category_component';
 import type { OnCaseDefaultChange } from '../case_default_fields';
 import { DebouncedTemplateTextField } from './debounced_template_text_field';
+import { DebouncedTemplateMarkdownField } from './debounced_template_markdown_field';
 import * as i18n from '../translations';
 
 interface TemplateCaseDefaultsFormProps {
@@ -224,11 +225,12 @@ export const TemplateCaseDefaultsForm: React.FC<TemplateCaseDefaultsFormProps> =
         dataTestSubj="caseDefaultsTitleInput"
       />
 
-      <DebouncedTemplateTextField
-        multiline
+      <DebouncedTemplateMarkdownField
         label={commonI18n.DESCRIPTION}
+        ariaLabel={i18n.CASE_DEFAULT_DESCRIPTION_ARIA_LABEL}
         value={parsedTemplate.description ?? ''}
         onChange={handleDescriptionChange}
+        editorId="caseDefaultsDescription"
         dataTestSubj="caseDefaultsDescriptionInput"
       />
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
@@ -103,6 +103,13 @@ export const CASE_DEFAULT_ASSIGNEES = i18n.translate('xpack.cases.templates.case
   defaultMessage: 'Assignees',
 });
 
+export const CASE_DEFAULT_DESCRIPTION_ARIA_LABEL = i18n.translate(
+  'xpack.cases.templates.caseDefaultDescriptionAriaLabel',
+  {
+    defaultMessage: 'Default case description markdown editor',
+  }
+);
+
 export const CASE_DEFAULTS_SECTION_TITLE = i18n.translate(
   'xpack.cases.templates.caseDefaultsSectionTitle',
   {

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_template_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/build_template_yaml.test.ts
@@ -77,6 +77,40 @@ describe('buildTemplateYaml', () => {
       });
     });
 
+    it('preserves multiline markdown in the case-default description through the YAML round-trip', () => {
+      // Legacy case descriptions are authored as markdown; the migration must carry the raw markdown
+      // (headings, lists, code fences, links) into the v2 definition unchanged so it renders in the
+      // markdown editor rather than as escaped plain text.
+      const markdownDescription = [
+        '# Investigation steps',
+        '',
+        '1. Review the **source** host',
+        '2. Check `auth.log` for anomalies',
+        '',
+        'See [the runbook](https://example.com/runbook).',
+      ].join('\n');
+
+      const yaml = buildTemplateYaml(
+        {
+          key: 'k',
+          name: 'T',
+          caseFields: {
+            title: 'Case title',
+            description: markdownDescription,
+          },
+        },
+        new Map()
+      );
+
+      expect(parse(yaml).description).toBe(markdownDescription);
+
+      const result = ParsedTemplateDefinitionSchema.safeParse(parse(yaml));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.description).toBe(markdownDescription);
+      }
+    });
+
     it('keeps an explicit empty assignees list in YAML', () => {
       const yaml = buildTemplateYaml(
         {


### PR DESCRIPTION
## Summary

A few small fixes/polish items I hit while working on templates v2. Grouping them since they're all in the same area.

### 1. Allow clearing the default case title (`name`) in the YAML
Deleting the `name` value but keeping the key (`name:`) parses to `null`, which was failing preview/save validation and blocking the preview panel — even though doing the same for the other case defaults (description, severity, category) worked fine. The `name` field was the only case default missing `.nullable()`. I made it consistent with the others: `null` (a cleared value) is accepted, and a provided title is still required to be non-empty.

### 2. Render the default case description as a markdown editor
The default description was a plain textarea, so descriptions migrated from v1 (which are markdown) showed up as escaped plain text. It now uses the same markdown editor we use everywhere else in Cases, wired through the existing debounce-and-flush behavior so the YAML round-trip is unchanged. I also added a migration test that runs multiline markdown through `buildTemplateYaml` to confirm it survives the v1 → v2 conversion intact.

### 3. Add a "Label" column to the field library
The field library table only showed Name / Description. I added a **Label** column (second, right after Name) that surfaces the label parsed from each field definition's YAML, falling back to `—` when a definition has no label.

## Testing
- Updated/added Jest coverage for each change (schema null-name case, markdown-description rendering, migration markdown round-trip, and the new label column).
- `node scripts/type_check` and `node scripts/eslint` pass for the Cases plugin.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->