### PR TITLE
[9.5] [Fleet] Add EBT telemetry for AWS onboarding funnel

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/index.ts
@@ -255,6 +255,29 @@ export { ElasticsearchAssetType } from './types';
 
 export { FleetError } from './errors';
 
+export {
+  AWS_ONBOARDING_EVENTS,
+  AWS_ONBOARDING_TELEMETRY_STORAGE_KEY,
+  AWS_ONBOARDING_PACKAGE_NAME,
+  AWS_ONBOARDING_FLOW_ENTERED_EVENT,
+  AWS_ONBOARDING_CREDENTIALS_ADDED_EVENT,
+  AWS_ONBOARDING_DEPLOY_CLICKED_EVENT,
+  AWS_ONBOARDING_AGENTLESS_ENROLLMENT_SUCCEEDED_EVENT,
+  AWS_ONBOARDING_FIRST_DATA_ARRIVED_EVENT,
+  AWS_ONBOARDING_FIRST_DATA_TIMEOUT_EVENT,
+  registerAwsOnboardingEvents,
+  reportAwsOnboardingFlowEntered,
+  reportAwsOnboardingCredentialsAdded,
+  reportAwsOnboardingDeployClicked,
+  reportAwsOnboardingEnrollmentSucceeded,
+  reportAwsOnboardingFirstDataArrived,
+  reportAwsOnboardingFirstDataTimeout,
+} from './telemetry/aws_onboarding_events';
+export type {
+  AwsOnboardingDeployPath,
+  AwsOnboardingAnalyticsClient,
+} from './telemetry/aws_onboarding_events';
+
 // Cloud connector test subjects - needed by E2E tests and unit tests
 export {
   AWS_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ,

--- a/x-pack/platform/plugins/shared/fleet/common/telemetry/aws_onboarding_events.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/telemetry/aws_onboarding_events.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AWS_ONBOARDING_FLOW_ENTERED_EVENT,
+  AWS_ONBOARDING_CREDENTIALS_ADDED_EVENT,
+  AWS_ONBOARDING_DEPLOY_CLICKED_EVENT,
+  AWS_ONBOARDING_AGENTLESS_ENROLLMENT_SUCCEEDED_EVENT,
+  AWS_ONBOARDING_FIRST_DATA_ARRIVED_EVENT,
+  AWS_ONBOARDING_FIRST_DATA_TIMEOUT_EVENT,
+  AWS_ONBOARDING_TELEMETRY_STORAGE_KEY,
+  reportAwsOnboardingFlowEntered,
+  reportAwsOnboardingCredentialsAdded,
+  reportAwsOnboardingDeployClicked,
+  reportAwsOnboardingEnrollmentSucceeded,
+  reportAwsOnboardingFirstDataArrived,
+  reportAwsOnboardingFirstDataTimeout,
+} from './aws_onboarding_events';
+
+function makeStorage(initial: Record<string, string> = {}): Storage {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as unknown as Storage;
+}
+
+function makeAnalytics() {
+  return { reportEvent: jest.fn() };
+}
+
+function readState(storage: Storage) {
+  return JSON.parse(storage.getItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY) ?? '{}');
+}
+
+function writeState(storage: Storage, state: object) {
+  storage.setItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY, JSON.stringify(state));
+}
+
+describe('reportAwsOnboardingFlowEntered', () => {
+  it('emits flow_entered with package_version', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    reportAwsOnboardingFlowEntered(analytics, storage, '0.5.0');
+    expect(analytics.reportEvent).toHaveBeenCalledWith(
+      AWS_ONBOARDING_FLOW_ENTERED_EVENT.eventType,
+      { package_version: '0.5.0' }
+    );
+  });
+
+  it('stamps flowEnteredAt and sets flow_entered guard in storage', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    const before = Date.now();
+    reportAwsOnboardingFlowEntered(analytics, storage, '0.5.0');
+    const after = Date.now();
+    const state = readState(storage);
+    expect(state.flowEnteredAt).toBeGreaterThanOrEqual(before);
+    expect(state.flowEnteredAt).toBeLessThanOrEqual(after);
+    expect(state.reported?.flow_entered).toBe(true);
+  });
+
+  it('always fires (not guarded — resets state on each new flow entry)', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    reportAwsOnboardingFlowEntered(analytics, storage, '0.5.0');
+    reportAwsOnboardingFlowEntered(analytics, storage, '0.5.0');
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reportAwsOnboardingCredentialsAdded', () => {
+  it('emits credentials_added with non-negative duration_ms', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() - 1000 });
+    reportAwsOnboardingCredentialsAdded(analytics, storage);
+    expect(analytics.reportEvent).toHaveBeenCalledWith(
+      AWS_ONBOARDING_CREDENTIALS_ADDED_EVENT.eventType,
+      expect.objectContaining({ duration_ms: expect.any(Number) })
+    );
+    const [, payload] = analytics.reportEvent.mock.calls[0];
+    expect(payload.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not fire when flowEnteredAt is missing', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    const result = reportAwsOnboardingCredentialsAdded(analytics, storage);
+    expect(result).toBe(false);
+    expect(analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not double-fire (single-fire guard)', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() - 1000 });
+    reportAwsOnboardingCredentialsAdded(analytics, storage);
+    reportAwsOnboardingCredentialsAdded(analytics, storage);
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets credentials_added guard in storage after firing', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() });
+    reportAwsOnboardingCredentialsAdded(analytics, storage);
+    expect(readState(storage).reported?.credentials_added).toBe(true);
+  });
+});
+
+describe('reportAwsOnboardingDeployClicked', () => {
+  it('emits deploy_clicked with path and duration_ms for agentless', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() - 2000 });
+    reportAwsOnboardingDeployClicked(analytics, storage, {
+      path: 'agentless',
+      services: ['cloudwatch', 'elb'],
+    });
+    expect(analytics.reportEvent).toHaveBeenCalledWith(
+      AWS_ONBOARDING_DEPLOY_CLICKED_EVENT.eventType,
+      expect.objectContaining({ path: 'agentless', services: ['cloudwatch', 'elb'] })
+    );
+    const [, payload] = analytics.reportEvent.mock.calls[0];
+    expect(payload.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits deploy_clicked without services for cloudformation path', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() });
+    reportAwsOnboardingDeployClicked(analytics, storage, { path: 'aws_cloudformation' });
+    const [, payload] = analytics.reportEvent.mock.calls[0];
+    expect(payload.path).toBe('aws_cloudformation');
+    expect(payload.services).toBeUndefined();
+  });
+
+  it('stamps deployClickedAt in storage', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    const before = Date.now();
+    writeState(storage, { flowEnteredAt: before - 100 });
+    reportAwsOnboardingDeployClicked(analytics, storage, { path: 'agentless' });
+    const state = readState(storage);
+    expect(state.deployClickedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('does not fire when flowEnteredAt is missing', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    const result = reportAwsOnboardingDeployClicked(analytics, storage, { path: 'agentless' });
+    expect(result).toBe(false);
+    expect(analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not double-fire the same path (single-fire guard per path)', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() });
+    reportAwsOnboardingDeployClicked(analytics, storage, { path: 'agentless' });
+    reportAwsOnboardingDeployClicked(analytics, storage, { path: 'agentless' });
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows firing for a different path after one path is guarded', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() });
+    reportAwsOnboardingDeployClicked(analytics, storage, { path: 'agentless' });
+    reportAwsOnboardingDeployClicked(analytics, storage, { path: 'aws_cloudformation' });
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reportAwsOnboardingEnrollmentSucceeded', () => {
+  it('emits enrollment_succeeded with duration_ms since deploy clicked', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() - 5000, deployClickedAt: Date.now() - 2000 });
+    reportAwsOnboardingEnrollmentSucceeded(analytics, storage);
+    expect(analytics.reportEvent).toHaveBeenCalledWith(
+      AWS_ONBOARDING_AGENTLESS_ENROLLMENT_SUCCEEDED_EVENT.eventType,
+      expect.objectContaining({ duration_ms: expect.any(Number) })
+    );
+    const [, payload] = analytics.reportEvent.mock.calls[0];
+    expect(payload.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not fire when deployClickedAt is missing', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() });
+    const result = reportAwsOnboardingEnrollmentSucceeded(analytics, storage);
+    expect(result).toBe(false);
+    expect(analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not double-fire', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { flowEnteredAt: Date.now() - 3000, deployClickedAt: Date.now() - 1000 });
+    reportAwsOnboardingEnrollmentSucceeded(analytics, storage);
+    reportAwsOnboardingEnrollmentSucceeded(analytics, storage);
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reportAwsOnboardingFirstDataArrived', () => {
+  it('emits first_data_arrived with package_name and duration_ms', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { deployClickedAt: Date.now() - 3000 });
+    reportAwsOnboardingFirstDataArrived(analytics, storage, 'aws_cloudwatch_input_otel');
+    expect(analytics.reportEvent).toHaveBeenCalledWith(
+      AWS_ONBOARDING_FIRST_DATA_ARRIVED_EVENT.eventType,
+      expect.objectContaining({
+        package_name: 'aws_cloudwatch_input_otel',
+        duration_ms: expect.any(Number),
+      })
+    );
+  });
+
+  it('does not fire when deployClickedAt is missing', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    const result = reportAwsOnboardingFirstDataArrived(
+      analytics,
+      storage,
+      'aws_cloudwatch_input_otel'
+    );
+    expect(result).toBe(false);
+    expect(analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not double-fire for the same service', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { deployClickedAt: Date.now() });
+    reportAwsOnboardingFirstDataArrived(analytics, storage, 'aws_cloudwatch_input_otel');
+    reportAwsOnboardingFirstDataArrived(analytics, storage, 'aws_cloudwatch_input_otel');
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reportAwsOnboardingFirstDataTimeout', () => {
+  it('emits first_data_timeout with package_name', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { deployClickedAt: Date.now() });
+    reportAwsOnboardingFirstDataTimeout(analytics, storage, 'aws_cloudwatch_input_otel');
+    expect(analytics.reportEvent).toHaveBeenCalledWith(
+      AWS_ONBOARDING_FIRST_DATA_TIMEOUT_EVENT.eventType,
+      { package_name: 'aws_cloudwatch_input_otel' }
+    );
+  });
+
+  it('does not fire when deployClickedAt is missing', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    const result = reportAwsOnboardingFirstDataTimeout(
+      analytics,
+      storage,
+      'aws_cloudwatch_input_otel'
+    );
+    expect(result).toBe(false);
+    expect(analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not double-fire for the same package', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { deployClickedAt: Date.now() });
+    reportAwsOnboardingFirstDataTimeout(analytics, storage, 'aws_cloudwatch_input_otel');
+    reportAwsOnboardingFirstDataTimeout(analytics, storage, 'aws_cloudwatch_input_otel');
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires independently per package', () => {
+    const analytics = makeAnalytics();
+    const storage = makeStorage();
+    writeState(storage, { deployClickedAt: Date.now() });
+    reportAwsOnboardingFirstDataTimeout(analytics, storage, 'package_a');
+    reportAwsOnboardingFirstDataTimeout(analytics, storage, 'package_b');
+    expect(analytics.reportEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/common/telemetry/aws_onboarding_events.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/telemetry/aws_onboarding_events.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EventTypeOpts } from '@elastic/ebt/client';
+
+/**
+ * Shared EBT event definitions + report helpers for the AWS onboarding funnel (ingest-dev#7625).
+ *
+ * These live in Fleet `common/` because the funnel spans multiple plugins — the entry redirect and the
+ * ELB "Launch stack in AWS" button are owned by `observability_onboarding`, while credentials and the
+ * agentless "Save and continue" happen in Fleet's create-package-policy page. Both `observability_onboarding`
+ * and (later) `ingest_hub` already depend on `@kbn/fleet-plugin`, so defining the events + helpers here
+ * lets every flow emit the identical events with no schema drift. The events are registered once from
+ * Fleet's public `setup()` (core analytics is global).
+ *
+ * The helpers are framework-agnostic (they take an `analytics` client and a `Storage` instance) so they can
+ * be called from Fleet (`useStartServices().analytics`) or the onboarding plugins (`useKibana().services.analytics`).
+ */
+
+/** sessionStorage key holding the cross-plugin funnel state (timestamps + single-fire guards). */
+export const AWS_ONBOARDING_TELEMETRY_STORAGE_KEY = 'aws_onboarding.telemetry';
+
+/** The package whose add-integration page the AWS quickstart routes to. */
+export const AWS_ONBOARDING_PACKAGE_NAME = 'aws_cloudwatch_input_otel';
+
+export type AwsOnboardingDeployPath = 'agentless' | 'aws_cloudformation';
+
+interface FlowEnteredFields {
+  package_version: string;
+}
+interface CredentialsAddedFields {
+  duration_ms: number;
+}
+interface DeployClickedFields {
+  duration_ms: number;
+  path: AwsOnboardingDeployPath;
+  services?: string[];
+}
+interface AgentlessEnrollmentSucceededFields {
+  duration_ms: number;
+}
+interface FirstDataArrivedFields {
+  duration_ms: number;
+  package_name: string;
+}
+interface FirstDataTimeoutFields {
+  package_name: string;
+}
+
+export const AWS_ONBOARDING_FLOW_ENTERED_EVENT: EventTypeOpts<FlowEnteredFields> = {
+  eventType: 'aws_onboarding_flow_entered',
+  schema: {
+    package_version: {
+      type: 'keyword',
+      _meta: {
+        description: 'Version of the aws_cloudwatch_input_otel package the user was routed to.',
+      },
+    },
+  },
+};
+
+export const AWS_ONBOARDING_CREDENTIALS_ADDED_EVENT: EventTypeOpts<CredentialsAddedFields> = {
+  eventType: 'aws_onboarding_credentials_added',
+  schema: {
+    duration_ms: {
+      type: 'long',
+      _meta: {
+        description: 'Milliseconds between entering the flow and committing AWS credentials.',
+      },
+    },
+  },
+};
+
+export const AWS_ONBOARDING_DEPLOY_CLICKED_EVENT: EventTypeOpts<DeployClickedFields> = {
+  eventType: 'aws_onboarding_deploy_clicked',
+  schema: {
+    duration_ms: {
+      type: 'long',
+      _meta: { description: 'Milliseconds between entering the flow and clicking to deploy.' },
+    },
+    path: {
+      type: 'keyword',
+      _meta: {
+        description:
+          "Deploy path taken: 'agentless' (in-product) or 'aws_cloudformation' (Launch stack in AWS).",
+      },
+    },
+    services: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description: 'Internal id of an AWS service/source activated on the agentless path.',
+        },
+      },
+      _meta: { description: 'AWS services activated on the agentless path.', optional: true },
+    },
+  },
+};
+
+export const AWS_ONBOARDING_AGENTLESS_ENROLLMENT_SUCCEEDED_EVENT: EventTypeOpts<AgentlessEnrollmentSucceededFields> =
+  {
+    eventType: 'aws_onboarding_agentless_enrollment_succeeded',
+    schema: {
+      duration_ms: {
+        type: 'long',
+        _meta: {
+          description: 'Milliseconds between clicking deploy and agentless enrollment succeeding.',
+        },
+      },
+    },
+  };
+
+export const AWS_ONBOARDING_FIRST_DATA_ARRIVED_EVENT: EventTypeOpts<FirstDataArrivedFields> = {
+  eventType: 'aws_onboarding_first_data_arrived',
+  schema: {
+    duration_ms: {
+      type: 'long',
+      _meta: {
+        description:
+          'Milliseconds between clicking deploy and first data arriving for the package.',
+      },
+    },
+    package_name: {
+      type: 'keyword',
+      _meta: { description: 'Name of the AWS integration package the first data arrived for.' },
+    },
+  },
+};
+
+export const AWS_ONBOARDING_FIRST_DATA_TIMEOUT_EVENT: EventTypeOpts<FirstDataTimeoutFields> = {
+  eventType: 'aws_onboarding_first_data_timeout',
+  schema: {
+    package_name: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'Name of the AWS integration package whose first data did not arrive within the expected window.',
+      },
+    },
+  },
+};
+
+export const AWS_ONBOARDING_EVENTS: Array<EventTypeOpts<any>> = [
+  AWS_ONBOARDING_FLOW_ENTERED_EVENT,
+  AWS_ONBOARDING_CREDENTIALS_ADDED_EVENT,
+  AWS_ONBOARDING_DEPLOY_CLICKED_EVENT,
+  AWS_ONBOARDING_AGENTLESS_ENROLLMENT_SUCCEEDED_EVENT,
+  AWS_ONBOARDING_FIRST_DATA_ARRIVED_EVENT,
+  AWS_ONBOARDING_FIRST_DATA_TIMEOUT_EVENT,
+];
+
+/** Minimal structural type for the core analytics client, to avoid importing `@kbn/core` into `common/`. */
+export interface AwsOnboardingAnalyticsClient {
+  reportEvent: (eventType: string, data: Record<string, unknown>) => void;
+}
+interface AwsOnboardingAnalyticsRegistrar {
+  registerEventType: <T>(opts: EventTypeOpts<T>) => void;
+}
+type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
+
+interface FunnelState {
+  flowEnteredAt?: number;
+  deployClickedAt?: number;
+  reported?: Record<string, boolean>;
+}
+
+function readState(storage: StorageLike): FunnelState {
+  try {
+    return JSON.parse(storage.getItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY) ?? '{}');
+  } catch {
+    return {};
+  }
+}
+
+function writeState(storage: StorageLike, state: FunnelState): void {
+  storage.setItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY, JSON.stringify(state));
+}
+
+/** Register every AWS onboarding event type. Call once (Fleet public `setup()`); core analytics is global. */
+export function registerAwsOnboardingEvents(analytics: AwsOnboardingAnalyticsRegistrar): void {
+  AWS_ONBOARDING_EVENTS.forEach((event) => analytics.registerEventType(event));
+}
+
+/**
+ * Start of the funnel. Resets funnel state, stamps `flowEnteredAt`, and emits `flow_entered`.
+ * Call from the AWS quickstart entry point (the redirect) before navigating into the flow.
+ */
+export function reportAwsOnboardingFlowEntered(
+  analytics: AwsOnboardingAnalyticsClient,
+  storage: StorageLike,
+  packageVersion: string
+): void {
+  writeState(storage, { flowEnteredAt: Date.now(), reported: { flow_entered: true } });
+  analytics.reportEvent(AWS_ONBOARDING_FLOW_ENTERED_EVENT.eventType, {
+    package_version: packageVersion,
+  });
+}
+
+/** Emit `credentials_added` once, with `duration_ms` since flow entry. No-op if already reported or no flow start. */
+export function reportAwsOnboardingCredentialsAdded(
+  analytics: AwsOnboardingAnalyticsClient,
+  storage: StorageLike
+): boolean {
+  const state = readState(storage);
+  if (state.reported?.credentials_added || state.flowEnteredAt == null) {
+    return false;
+  }
+  analytics.reportEvent(AWS_ONBOARDING_CREDENTIALS_ADDED_EVENT.eventType, {
+    duration_ms: Math.max(0, Date.now() - state.flowEnteredAt),
+  });
+  writeState(storage, {
+    ...state,
+    reported: { ...state.reported, credentials_added: true },
+  });
+  return true;
+}
+
+/**
+ * Emit `deploy_clicked` once per path, with `duration_ms` since flow entry. Stamps `deployClickedAt`
+ * (used later by the deferred post-deploy events). No-op if this path was already reported or no flow start.
+ */
+export function reportAwsOnboardingDeployClicked(
+  analytics: AwsOnboardingAnalyticsClient,
+  storage: StorageLike,
+  fields: { path: AwsOnboardingDeployPath; services?: string[] }
+): boolean {
+  const state = readState(storage);
+  const guardKey = `deploy_clicked_${fields.path}`;
+  if (state.reported?.[guardKey] || state.flowEnteredAt == null) {
+    return false;
+  }
+  const now = Date.now();
+  analytics.reportEvent(AWS_ONBOARDING_DEPLOY_CLICKED_EVENT.eventType, {
+    duration_ms: Math.max(0, now - state.flowEnteredAt),
+    path: fields.path,
+    ...(fields.services && fields.services.length > 0 ? { services: fields.services } : {}),
+  });
+  writeState(storage, {
+    ...state,
+    deployClickedAt: now,
+    reported: { ...state.reported, [guardKey]: true },
+  });
+  return true;
+}
+
+/** Emit `agentless_enrollment_succeeded` once, with `duration_ms` since deploy clicked. No-op if already reported or no deploy timestamp. */
+export function reportAwsOnboardingEnrollmentSucceeded(
+  analytics: AwsOnboardingAnalyticsClient,
+  storage: StorageLike
+): boolean {
+  const state = readState(storage);
+  if (state.reported?.enrollment_succeeded || state.deployClickedAt == null) {
+    return false;
+  }
+  analytics.reportEvent(AWS_ONBOARDING_AGENTLESS_ENROLLMENT_SUCCEEDED_EVENT.eventType, {
+    duration_ms: Math.max(0, Date.now() - state.deployClickedAt),
+  });
+  writeState(storage, {
+    ...state,
+    reported: { ...state.reported, enrollment_succeeded: true },
+  });
+  return true;
+}
+
+/** Emit `first_data_arrived` once per package, with `duration_ms` since deploy clicked. No-op if already reported for this package or no deploy timestamp. */
+export function reportAwsOnboardingFirstDataArrived(
+  analytics: AwsOnboardingAnalyticsClient,
+  storage: StorageLike,
+  packageName: string
+): boolean {
+  const state = readState(storage);
+  const guardKey = `first_data_arrived_${packageName}`;
+  if (state.reported?.[guardKey] || state.deployClickedAt == null) {
+    return false;
+  }
+  analytics.reportEvent(AWS_ONBOARDING_FIRST_DATA_ARRIVED_EVENT.eventType, {
+    duration_ms: Math.max(0, Date.now() - state.deployClickedAt),
+    package_name: packageName,
+  });
+  writeState(storage, {
+    ...state,
+    reported: { ...state.reported, [guardKey]: true },
+  });
+  return true;
+}
+
+/** Emit `first_data_timeout` once per package. No-op if already reported for this package or no deploy timestamp. */
+export function reportAwsOnboardingFirstDataTimeout(
+  analytics: AwsOnboardingAnalyticsClient,
+  storage: StorageLike,
+  packageName: string
+): boolean {
+  const state = readState(storage);
+  const guardKey = `first_data_timeout_${packageName}`;
+  if (state.reported?.[guardKey] || state.deployClickedAt == null) {
+    return false;
+  }
+  analytics.reportEvent(AWS_ONBOARDING_FIRST_DATA_TIMEOUT_EVENT.eventType, {
+    package_name: packageName,
+  });
+  writeState(storage, {
+    ...state,
+    reported: { ...state.reported, [guardKey]: true },
+  });
+  return true;
+}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/aws_onboarding_telemetry.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/aws_onboarding_telemetry.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+
+import {
+  reportAwsOnboardingCredentialsAdded,
+  reportAwsOnboardingDeployClicked,
+  reportAwsOnboardingEnrollmentSucceeded,
+  AWS_ONBOARDING_TELEMETRY_STORAGE_KEY,
+} from '../../../../../../../../common/telemetry/aws_onboarding_events';
+import { useStartServices } from '../../../../../../../hooks';
+import { useIntraAppState } from '../../../../../../../hooks/use_intra_app_state';
+
+import { useAwsOnboardingTelemetry } from './aws_onboarding_telemetry';
+
+jest.mock('../../../../../../../../common/telemetry/aws_onboarding_events', () => ({
+  ...jest.requireActual('../../../../../../../../common/telemetry/aws_onboarding_events'),
+  reportAwsOnboardingCredentialsAdded: jest.fn(),
+  reportAwsOnboardingDeployClicked: jest.fn(),
+  reportAwsOnboardingEnrollmentSucceeded: jest.fn(),
+}));
+
+jest.mock('../../../../../../../hooks', () => ({
+  ...jest.requireActual('../../../../../../../hooks'),
+  useStartServices: jest.fn(),
+}));
+
+jest.mock('../../../../../../../hooks/use_intra_app_state', () => ({
+  useIntraAppState: jest.fn(),
+}));
+
+const mockAnalytics = { reportEvent: jest.fn() };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.removeItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY);
+  (useStartServices as jest.Mock).mockReturnValue({ analytics: mockAnalytics });
+  (useIntraAppState as jest.Mock).mockReturnValue({
+    telemetrySource: 'aws_quickstart',
+  });
+});
+
+describe('useAwsOnboardingTelemetry — gating', () => {
+  it('calls helpers when source is aws_quickstart and package matches', () => {
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'aws_cloudwatch_input_otel' })
+    );
+    act(() => result.current.reportCredentialsAdded());
+    expect(reportAwsOnboardingCredentialsAdded).toHaveBeenCalledWith(mockAnalytics, sessionStorage);
+  });
+
+  it('no-ops when telemetrySource is not aws_quickstart', () => {
+    (useIntraAppState as jest.Mock).mockReturnValue({ telemetrySource: undefined });
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'aws_cloudwatch_input_otel' })
+    );
+    act(() => result.current.reportCredentialsAdded());
+    expect(reportAwsOnboardingCredentialsAdded).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when pkgName does not match AWS_ONBOARDING_PACKAGE_NAME', () => {
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'some_other_package' })
+    );
+    act(() => result.current.reportCredentialsAdded());
+    expect(reportAwsOnboardingCredentialsAdded).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when pkgName is undefined', () => {
+    const { result } = renderHook(() => useAwsOnboardingTelemetry({ pkgName: undefined }));
+    act(() => result.current.reportCredentialsAdded());
+    expect(reportAwsOnboardingCredentialsAdded).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when analytics is unavailable', () => {
+    (useStartServices as jest.Mock).mockReturnValue({ analytics: undefined });
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'aws_cloudwatch_input_otel' })
+    );
+    act(() => result.current.reportCredentialsAdded());
+    expect(reportAwsOnboardingCredentialsAdded).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAwsOnboardingTelemetry — reportDeployClicked', () => {
+  it('passes path and services to the helper', () => {
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'aws_cloudwatch_input_otel' })
+    );
+    act(() => result.current.reportDeployClicked('agentless', ['cloudwatch']));
+    expect(reportAwsOnboardingDeployClicked).toHaveBeenCalledWith(mockAnalytics, sessionStorage, {
+      path: 'agentless',
+      services: ['cloudwatch'],
+    });
+  });
+
+  it('passes cloudformation path without services', () => {
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'aws_cloudwatch_input_otel' })
+    );
+    act(() => result.current.reportDeployClicked('aws_cloudformation'));
+    expect(reportAwsOnboardingDeployClicked).toHaveBeenCalledWith(mockAnalytics, sessionStorage, {
+      path: 'aws_cloudformation',
+      services: undefined,
+    });
+  });
+});
+
+describe('useAwsOnboardingTelemetry — reportEnrollmentSucceeded', () => {
+  it('calls the helper when conditions are met', () => {
+    const { result } = renderHook(() =>
+      useAwsOnboardingTelemetry({ pkgName: 'aws_cloudwatch_input_otel' })
+    );
+    act(() => result.current.reportEnrollmentSucceeded());
+    expect(reportAwsOnboardingEnrollmentSucceeded).toHaveBeenCalledWith(
+      mockAnalytics,
+      sessionStorage
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/aws_onboarding_telemetry.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/aws_onboarding_telemetry.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+
+import {
+  AWS_ONBOARDING_PACKAGE_NAME,
+  reportAwsOnboardingCredentialsAdded,
+  reportAwsOnboardingDeployClicked,
+  reportAwsOnboardingEnrollmentSucceeded,
+} from '../../../../../../../../common/telemetry/aws_onboarding_events';
+import type { AwsOnboardingDeployPath } from '../../../../../../../../common/telemetry/aws_onboarding_events';
+import { useStartServices } from '../../../../../../../hooks';
+import { useIntraAppState } from '../../../../../../../hooks/use_intra_app_state';
+import type { CreatePackagePolicyRouteState } from '../../../../../../../types';
+
+/**
+ * Returns telemetry report callbacks for the AWS onboarding funnel, to be called at key moments in
+ * the create-package-policy flow. All helpers no-op silently when:
+ * - The page was NOT reached from the AWS quickstart (telemetrySource ≠ 'aws_quickstart').
+ * - The package is not aws_cloudwatch_input_otel.
+ * - The event was already reported in this session (single-fire guard, stored in sessionStorage).
+ *
+ * Helpers are framework-agnostic; they read analytics from core start-services so callers don't
+ * need to plumb it themselves.
+ */
+export function useAwsOnboardingTelemetry({ pkgName }: { pkgName: string | undefined }) {
+  const { analytics } = useStartServices();
+  const routeState = useIntraAppState<CreatePackagePolicyRouteState>();
+  const isAwsQuickstart =
+    routeState?.telemetrySource === 'aws_quickstart' && pkgName === AWS_ONBOARDING_PACKAGE_NAME;
+
+  /**
+   * Emit `credentials_added` once (single-fire, guarded in sessionStorage).
+   * Fires ONLY for the AWS quickstart funnel.
+   */
+  const reportCredentialsAdded = useCallback(() => {
+    if (!isAwsQuickstart || !analytics) return;
+    reportAwsOnboardingCredentialsAdded(analytics, sessionStorage);
+  }, [isAwsQuickstart, analytics]);
+
+  /**
+   * Emit `deploy_clicked` once per path (single-fire, guarded in sessionStorage).
+   * Fires ONLY for the AWS quickstart funnel.
+   *
+   * @param path - 'agentless' or 'aws_cloudformation'
+   * @param services - service ids activated on the agentless path (omit for cloudformation)
+   */
+  const reportDeployClicked = useCallback(
+    (path: AwsOnboardingDeployPath, services?: string[]) => {
+      if (!isAwsQuickstart || !analytics) return;
+      reportAwsOnboardingDeployClicked(analytics, sessionStorage, { path, services });
+    },
+    [isAwsQuickstart, analytics]
+  );
+
+  /** Emit `agentless_enrollment_succeeded` once. Fires ONLY for the AWS quickstart funnel. */
+  const reportEnrollmentSucceeded = useCallback(() => {
+    if (!isAwsQuickstart || !analytics) return;
+    reportAwsOnboardingEnrollmentSucceeded(analytics, sessionStorage);
+  }, [isAwsQuickstart, analytics]);
+
+  return { reportCredentialsAdded, reportDeployClicked, reportEnrollmentSucceeded };
+}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -18,8 +18,21 @@ import { ExperimentalFeaturesService } from '../../../../../services';
 import { SelectedPolicyTab } from '../../components';
 
 import { useOnSubmit, updateAgentlessCloudConnectorConfig } from './form';
+import { useAwsOnboardingTelemetry } from './aws_onboarding_telemetry';
 
 type MockFn = jest.MockedFunction<any>;
+
+jest.mock('./aws_onboarding_telemetry', () => ({
+  useAwsOnboardingTelemetry: jest.fn(() => ({
+    reportCredentialsAdded: jest.fn(),
+    reportDeployClicked: jest.fn(),
+    reportEnrollmentSucceeded: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../../../../../hooks/use_request/agentless_policy', () => ({
+  sendCreateAgentlessPolicy: jest.fn().mockRejectedValue(new Error('mocked agentless api')),
+}));
 
 jest.mock('../../../../../hooks', () => {
   return {
@@ -1212,6 +1225,107 @@ describe('useOnSubmit', () => {
 
       expect(setNewAgentPolicy).not.toHaveBeenCalled();
       expect(setPackagePolicy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AWS onboarding telemetry on agentless submit', () => {
+    const mockReportCredentialsAdded = jest.fn();
+    const mockReportDeployClicked = jest.fn();
+
+    const awsPackageInfo: PackageInfo = {
+      name: 'aws_cloudwatch_input_otel',
+      version: '0.5.0',
+      description: '',
+      format_version: '',
+      release: 'ga',
+      owner: { github: '' },
+      title: 'AWS CloudWatch (OpenTelemetry)',
+      latestVersion: '0.5.0',
+      assets: {} as any,
+      status: 'not_installed',
+      policy_templates: [
+        {
+          name: 'aws',
+          title: 'AWS',
+          description: '',
+          deployment_modes: {
+            default: { enabled: true },
+            agentless: { enabled: true },
+          },
+          inputs: [
+            {
+              type: 'cloudwatch',
+              title: 'CloudWatch',
+              description: '',
+              deployment_modes: ['agentless'],
+            },
+          ],
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (useConfig as MockFn).mockReturnValue({ agentless: { enabled: true } } as any);
+      (useAwsOnboardingTelemetry as jest.Mock).mockReturnValue({
+        reportCredentialsAdded: mockReportCredentialsAdded,
+        reportDeployClicked: mockReportDeployClicked,
+        reportEnrollmentSucceeded: jest.fn(),
+      });
+    });
+
+    it('calls reportCredentialsAdded and reportDeployClicked with enabled input types on agentless submit', async () => {
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: awsPackageInfo,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '', supports_agentless: true },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+
+      act(() => {
+        renderResult.result.current.handleSetupTechnologyChange('agentless' as any);
+      });
+
+      await act(async () => {
+        await renderResult.result.current.onSubmit();
+      });
+
+      expect(mockReportCredentialsAdded).toHaveBeenCalledTimes(1);
+      expect(mockReportDeployClicked).toHaveBeenCalledWith('agentless', expect.any(Array));
+    });
+
+    it('does not call telemetry when submitting in non-agentless mode', async () => {
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: awsPackageInfo,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '' },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+
+      await act(async () => {
+        await renderResult.result.current.onSubmit();
+      });
+
+      expect(mockReportCredentialsAdded).not.toHaveBeenCalled();
+      expect(mockReportDeployClicked).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -77,6 +77,7 @@ import { ensurePackageKibanaAssetsInstalled } from '../../../../../services/ensu
 import { useYaml } from '../../../../../../../services';
 
 import { useAgentless, useSetupTechnology } from './setup_technology';
+import { useAwsOnboardingTelemetry } from './aws_onboarding_telemetry';
 
 const DEFAULT_AGENTLESS_LIMIT = 50;
 
@@ -272,6 +273,8 @@ export function useOnSubmit({
   defaultPolicyData?: Partial<NewPackagePolicy>;
 }) {
   const { notifications, docLinks } = useStartServices();
+  const { reportCredentialsAdded, reportDeployClicked, reportEnrollmentSucceeded } =
+    useAwsOnboardingTelemetry({ pkgName: packageInfo?.name });
   const { spaceId } = useFleetStatus();
   const yaml = useYaml();
   const confirmForceInstall = useConfirmForceInstall();
@@ -605,6 +608,18 @@ export function useOnSubmit({
         return;
       }
 
+      // AWS onboarding funnel telemetry — fire only when coming from the AWS quickstart.
+      // Credentials are guaranteed valid at this point (validation gate above already returned if not).
+      // Both events are emitted together here because "credentials added" is a prerequisite for
+      // reaching Save and doesn't have its own discrete UI commit action.
+      if (isAgentlessSelected) {
+        const enabledInputTypes = (packagePolicy.inputs ?? [])
+          .filter((input) => input.enabled)
+          .map((input) => input.type);
+        reportCredentialsAdded();
+        reportDeployClicked('agentless', enabledInputTypes);
+      }
+
       let createdPolicy = overrideCreatedAgentPolicy;
       if (!overrideCreatedAgentPolicy) {
         try {
@@ -788,6 +803,7 @@ export function useOnSubmit({
           }
 
           if (isAgentlessConfigured) {
+            reportEnrollmentSucceeded();
             onSaveNavigate(savedPolicyResult, ['openEnrollmentFlyout']);
           } else {
             onSaveNavigate(savedPolicyResult);
@@ -839,6 +855,7 @@ export function useOnSubmit({
       getAgentlessStatusForPackage,
       packageInfo,
       isAgentlessAgentPolicy,
+      isAgentlessSelected,
       packagePolicy,
       newAgentPolicy,
       withSysMonitoring,
@@ -851,6 +868,9 @@ export function useOnSubmit({
       onSaveNavigate,
       confirmForceInstall,
       createDatasetTemplates,
+      reportCredentialsAdded,
+      reportDeployClicked,
+      reportEnrollmentSucceeded,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/index.tsx
@@ -8,3 +8,4 @@
 export { useDevToolsRequest } from './devtools_request';
 export { useOnSubmit } from './form';
 export { useSetupTechnology } from './setup_technology';
+export { useAwsOnboardingTelemetry } from './aws_onboarding_telemetry';

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+
+import { useStartServices } from '../../hooks';
+import { usePollingIncomingData } from '../agent_enrollment_flyout/use_get_agent_incoming_data';
+import {
+  reportAwsOnboardingFirstDataArrived,
+  reportAwsOnboardingFirstDataTimeout,
+  AWS_ONBOARDING_PACKAGE_NAME,
+  AWS_ONBOARDING_TELEMETRY_STORAGE_KEY,
+} from '../../../common/telemetry/aws_onboarding_events';
+
+import { AgentlessStepConfirmData } from './step_confirm_data';
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useStartServices: jest.fn(),
+}));
+
+jest.mock('../agent_enrollment_flyout/use_get_agent_incoming_data', () => ({
+  usePollingIncomingData: jest.fn(),
+  POLLING_TIMEOUT_MS: 300_000,
+}));
+
+jest.mock('../../../common/telemetry/aws_onboarding_events', () => ({
+  ...jest.requireActual('../../../common/telemetry/aws_onboarding_events'),
+  reportAwsOnboardingFirstDataArrived: jest.fn(),
+  reportAwsOnboardingFirstDataTimeout: jest.fn(),
+}));
+
+// Avoid pulling in EUI/i18n dependencies from NextSteps
+jest.mock('./next_steps', () => ({ NextSteps: () => null }));
+
+const mockAnalytics = { reportEvent: jest.fn() };
+
+const mockAgent = { id: 'test-agent-id' } as any;
+
+const defaultProps = {
+  agent: mockAgent,
+  packageName: AWS_ONBOARDING_PACKAGE_NAME,
+  packageVersion: '0.5.0',
+  setConfirmDataStatus: jest.fn(),
+};
+
+function renderComponent(props = defaultProps) {
+  return render(
+    <I18nProvider>
+      <AgentlessStepConfirmData {...props} />
+    </I18nProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.removeItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY);
+  (useStartServices as jest.Mock).mockReturnValue({
+    analytics: mockAnalytics,
+    docLinks: { links: { fleet: { troubleshooting: 'https://example.com' } } },
+  });
+  (usePollingIncomingData as jest.Mock).mockReturnValue({
+    incomingData: [],
+    hasReachedTimeout: false,
+  });
+});
+
+describe('AgentlessStepConfirmData — first_data_arrived telemetry', () => {
+  it('emits first_data_arrived when incoming data is detected for the AWS package', () => {
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [{ 'test-agent-id': { data: true } }],
+      hasReachedTimeout: false,
+    });
+    renderComponent();
+    expect(reportAwsOnboardingFirstDataArrived).toHaveBeenCalledWith(
+      mockAnalytics,
+      sessionStorage,
+      AWS_ONBOARDING_PACKAGE_NAME
+    );
+  });
+
+  it('does not emit first_data_arrived for a different package', () => {
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [{ 'test-agent-id': { data: true } }],
+      hasReachedTimeout: false,
+    });
+    renderComponent({ ...defaultProps, packageName: 'some_other_package' });
+    expect(reportAwsOnboardingFirstDataArrived).not.toHaveBeenCalled();
+  });
+
+  it('does not emit first_data_arrived when analytics is unavailable', () => {
+    (useStartServices as jest.Mock).mockReturnValue({
+      analytics: undefined,
+      docLinks: { links: { fleet: { troubleshooting: 'https://example.com' } } },
+    });
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [{ 'test-agent-id': { data: true } }],
+      hasReachedTimeout: false,
+    });
+    renderComponent();
+    expect(reportAwsOnboardingFirstDataArrived).not.toHaveBeenCalled();
+  });
+
+  it('does not emit first_data_arrived when there is no incoming data', () => {
+    renderComponent();
+    expect(reportAwsOnboardingFirstDataArrived).not.toHaveBeenCalled();
+  });
+});
+
+describe('AgentlessStepConfirmData — first_data_timeout telemetry', () => {
+  it('emits first_data_timeout when polling times out for the AWS package', () => {
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [],
+      hasReachedTimeout: true,
+    });
+    renderComponent();
+    expect(reportAwsOnboardingFirstDataTimeout).toHaveBeenCalledWith(
+      mockAnalytics,
+      sessionStorage,
+      AWS_ONBOARDING_PACKAGE_NAME
+    );
+  });
+
+  it('does not emit first_data_timeout for a different package', () => {
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [],
+      hasReachedTimeout: true,
+    });
+    renderComponent({ ...defaultProps, packageName: 'some_other_package' });
+    expect(reportAwsOnboardingFirstDataTimeout).not.toHaveBeenCalled();
+  });
+
+  it('does not emit first_data_timeout when analytics is unavailable', () => {
+    (useStartServices as jest.Mock).mockReturnValue({
+      analytics: undefined,
+      docLinks: { links: { fleet: { troubleshooting: 'https://example.com' } } },
+    });
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [],
+      hasReachedTimeout: true,
+    });
+    renderComponent();
+    expect(reportAwsOnboardingFirstDataTimeout).not.toHaveBeenCalled();
+  });
+
+  it('emits timeout but not arrived when both timeout and no data', () => {
+    (usePollingIncomingData as jest.Mock).mockReturnValue({
+      incomingData: [],
+      hasReachedTimeout: true,
+    });
+    renderComponent();
+    expect(reportAwsOnboardingFirstDataArrived).not.toHaveBeenCalled();
+    expect(reportAwsOnboardingFirstDataTimeout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.tsx
@@ -17,6 +17,11 @@ import {
   usePollingIncomingData,
   POLLING_TIMEOUT_MS,
 } from '../agent_enrollment_flyout/use_get_agent_incoming_data';
+import {
+  AWS_ONBOARDING_PACKAGE_NAME,
+  reportAwsOnboardingFirstDataArrived,
+  reportAwsOnboardingFirstDataTimeout,
+} from '../../../common/telemetry/aws_onboarding_events';
 
 import { NextSteps } from './next_steps';
 
@@ -33,7 +38,7 @@ export const AgentlessStepConfirmData = ({
   setConfirmDataStatus: (status: EuiStepStatus) => void;
   policyTemplates?: RegistryPolicyTemplate[];
 }) => {
-  const { docLinks } = useStartServices();
+  const { docLinks, analytics } = useStartServices();
   const [overallState, setOverallState] = useState<'pending' | 'success' | 'failure'>('pending');
 
   // Fetch integration data for the given agent and package
@@ -43,19 +48,26 @@ export const AgentlessStepConfirmData = ({
     pkgVersion: packageVersion,
   });
 
-  // Calculate overall UI state from polling data
+  // Calculate overall UI state from polling data; emit telemetry on terminal transitions.
   useEffect(() => {
     if (incomingData.length > 0) {
       setConfirmDataStatus('complete');
       setOverallState('success');
+
+      if (analytics && packageName === AWS_ONBOARDING_PACKAGE_NAME) {
+        reportAwsOnboardingFirstDataArrived(analytics, sessionStorage, packageName);
+      }
     } else if (hasReachedTimeout) {
       setConfirmDataStatus('danger');
       setOverallState('failure');
+      if (analytics && packageName === AWS_ONBOARDING_PACKAGE_NAME) {
+        reportAwsOnboardingFirstDataTimeout(analytics, sessionStorage, packageName);
+      }
     } else {
       setConfirmDataStatus('loading');
       setOverallState('pending');
     }
-  }, [incomingData, hasReachedTimeout, setConfirmDataStatus]);
+  }, [incomingData, hasReachedTimeout, setConfirmDataStatus, analytics, packageName]);
 
   if (overallState === 'success') {
     return (

--- a/x-pack/platform/plugins/shared/fleet/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/plugin.ts
@@ -60,7 +60,13 @@ import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { ReportingStart } from '@kbn/reporting-plugin/public';
 
 import type { FleetAuthz } from '../common';
-import { appRoutesService, INTEGRATIONS_PLUGIN_ID, PLUGIN_ID, setupRouteService } from '../common';
+import {
+  appRoutesService,
+  INTEGRATIONS_PLUGIN_ID,
+  PLUGIN_ID,
+  setupRouteService,
+  registerAwsOnboardingEvents,
+} from '../common';
 import {
   calculateAuthz,
   calculateEndpointExceptionsPrivilegesFromCapabilities,
@@ -178,6 +184,9 @@ export class FleetPlugin implements Plugin<FleetSetup, FleetStart, FleetSetupDep
     const config = this.config;
     const kibanaVersion = this.kibanaVersion;
     const extensions = this.extensions;
+
+    // registerEventType is on AnalyticsServiceSetup (setup), not AnalyticsServiceStart (start).
+    registerAwsOnboardingEvents(core.analytics);
 
     setCustomIntegrations(deps.customIntegrations);
 

--- a/x-pack/platform/plugins/shared/fleet/public/types/intra_app_route_state.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/types/intra_app_route_state.ts
@@ -35,6 +35,15 @@ export interface CreatePackagePolicyRouteState {
   onSaveQueryParams?: {
     [key in OnSaveQueryParamKeys]?: OnSaveQueryParamOpts;
   };
+  /**
+   * Optional marker indicating that this add-integration page was reached via a known onboarding
+   * quick-start flow. Used to gate funnel telemetry — events are only emitted for instrumented
+   * flows, not for every direct integration install.
+   *
+   * Current values:
+   * - 'aws_quickstart': navigated from the observability_onboarding AWS CloudWatch quick-start card.
+   */
+  telemetrySource?: 'aws_quickstart';
 }
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.test.ts
@@ -11,10 +11,14 @@ import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 
 import { appContextService } from '../../services';
 
-import { getAgentStatusForAgentPolicy } from '../../services/agents/status';
+import {
+  getAgentStatusForAgentPolicy,
+  getIncomingDataByAgentsId,
+} from '../../services/agents/status';
 import { fetchAndAssignAgentMetrics } from '../../services/agents/agent_metrics';
+import { getPackageInfo } from '../../services/epm/packages';
 
-import { getAgentEffectiveConfigHandler } from './handlers';
+import { getAgentEffectiveConfigHandler, getAgentDataHandler } from './handlers';
 
 import {
   getAgentStatusForAgentPolicyHandler,
@@ -44,10 +48,15 @@ jest.mock('../../services/spaces/helpers', () => ({
 
 jest.mock('../../services/agents/status', () => ({
   getAgentStatusForAgentPolicy: jest.fn(),
+  getIncomingDataByAgentsId: jest.fn(),
 }));
 
 jest.mock('../../services/agents/agent_metrics', () => ({
   fetchAndAssignAgentMetrics: jest.fn(),
+}));
+
+jest.mock('../../services/epm/packages', () => ({
+  getPackageInfo: jest.fn(),
 }));
 
 describe('Handlers', () => {
@@ -421,6 +430,91 @@ describe('Handlers', () => {
       await expect(
         getAgentEffectiveConfigHandler(mockContext, request as any, mockResponse)
       ).rejects.toThrow('agent-1 not found in namespace');
+    });
+  });
+
+  describe('getAgentDataHandler', () => {
+    let mockResponse: any;
+    let mockContext: any;
+
+    beforeEach(() => {
+      (getIncomingDataByAgentsId as jest.Mock).mockResolvedValue({ items: [], dataPreview: [] });
+      mockResponse = httpServerMock.createResponseFactory();
+      mockContext = {
+        core: Promise.resolve({
+          elasticsearch: { client: { asCurrentUser: {} } },
+          savedObjects: { client: { getCurrentNamespace: jest.fn().mockReturnValue('default') } },
+        }),
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('passes dataStreamPattern: undefined when the package has empty data_streams (prevents empty string reaching hasPrivileges)', async () => {
+      (getPackageInfo as jest.Mock).mockResolvedValue({ data_streams: [] });
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'aws_cloudwatch_input_otel',
+            pkgVersion: '0.5.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+        expect.objectContaining({ dataStreamPattern: undefined })
+      );
+    });
+
+    it('passes dataStreamPattern: undefined when data_streams is absent from the package info', async () => {
+      (getPackageInfo as jest.Mock).mockResolvedValue({});
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'aws_cloudwatch_input_otel',
+            pkgVersion: '0.5.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      expect(getIncomingDataByAgentsId).toHaveBeenCalledWith(
+        expect.objectContaining({ dataStreamPattern: undefined })
+      );
+    });
+
+    it('passes a non-empty dataStreamPattern when the package has data_streams', async () => {
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        data_streams: [{ type: 'logs', dataset: 'aws.cloudwatch' }],
+      });
+
+      await getAgentDataHandler(
+        mockContext,
+        {
+          query: {
+            agentsIds: ['agent-1'],
+            pkgName: 'aws',
+            pkgVersion: '1.0.0',
+            previewData: false,
+          },
+        } as any,
+        mockResponse
+      );
+
+      const [[{ dataStreamPattern }]] = (getIncomingDataByAgentsId as jest.Mock).mock.calls;
+      expect(dataStreamPattern).toBeDefined();
+      expect(dataStreamPattern).not.toBe('');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent/handlers.ts
@@ -390,9 +390,9 @@ export const getAgentDataHandler: RequestHandler<
       pkgName,
       pkgVersion,
     });
-    dataStreamPattern = (packageInfo.data_streams || [])
-      .map((ds) => generateTemplateIndexPattern(ds))
-      .join(',');
+    dataStreamPattern =
+      (packageInfo.data_streams || []).map((ds) => generateTemplateIndexPattern(ds)).join(',') ||
+      undefined;
   }
 
   const { items, dataPreview } = await AgentService.getIncomingDataByAgentsId({

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/cloudwatch_integration_redirect.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/cloudwatch_integration_redirect.test.tsx
@@ -61,6 +61,7 @@ describe('CloudwatchIntegrationRedirect', () => {
         state: {
           onCancelNavigateTo: ['observabilityOnboarding', { path: '?category=cloud' }],
           onCancelUrl: '/app/observabilityOnboarding?category=cloud',
+          telemetrySource: 'aws_quickstart',
         },
         replace: true,
       })

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/cloudwatch_integration_redirect.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/cloudwatch_integration_redirect.tsx
@@ -12,6 +12,10 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { OBSERVABILITY_ONBOARDING_APP_ID } from '@kbn/deeplinks-observability';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
 import type { CreatePackagePolicyRouteState } from '@kbn/fleet-plugin/public';
+import {
+  reportAwsOnboardingFlowEntered,
+  AWS_ONBOARDING_TELEMETRY_STORAGE_KEY,
+} from '@kbn/fleet-plugin/common';
 import type { ObservabilityOnboardingAppServices } from '..';
 
 const AWS_CLOUDWATCH_OTEL_PACKAGE = 'aws_cloudwatch_input_otel';
@@ -20,7 +24,7 @@ const RESOLVE_TIMEOUT_MS = 30_000;
 
 export const CloudwatchIntegrationRedirect: React.FC = () => {
   const {
-    services: { http, application },
+    services: { http, application, analytics },
   } = useKibana<ObservabilityOnboardingAppServices>();
 
   const [hasError, setHasError] = useState(false);
@@ -65,10 +69,19 @@ export const CloudwatchIntegrationRedirect: React.FC = () => {
         const routeState: CreatePackagePolicyRouteState = {
           onCancelNavigateTo: [OBSERVABILITY_ONBOARDING_APP_ID, { path: BACK_LINK_PATH }],
           onCancelUrl,
+          telemetrySource: 'aws_quickstart',
         };
         const [, addIntegrationPath] = pagePathGetters.add_integration_to_policy({
           pkgkey: `${AWS_CLOUDWATCH_OTEL_PACKAGE}-${version}`,
         });
+
+        // Stamp flowEnteredAt and emit flow_entered before navigating — this captures the true
+        // top-of-funnel moment (survives even if the Fleet page fails to load).
+        // sessionStorage is cleared here so re-entries don't inherit stale duration timestamps.
+        if (analytics) {
+          sessionStorage.removeItem(AWS_ONBOARDING_TELEMETRY_STORAGE_KEY);
+          reportAwsOnboardingFlowEntered(analytics, sessionStorage, version);
+        }
 
         application.navigateToApp('fleet', {
           path: addIntegrationPath,
@@ -90,7 +103,7 @@ export const CloudwatchIntegrationRedirect: React.FC = () => {
       clearTimeout(timeout);
       controller.abort();
     };
-  }, [http, application, attempt]);
+  }, [http, application, attempt, analytics]);
 
   if (hasError) {
     return (

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/fleet_extensions/elb_logs_cloud_forwarder/elb_logs_panel.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/fleet_extensions/elb_logs_cloud_forwarder/elb_logs_panel.test.tsx
@@ -9,7 +9,20 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { HttpStart } from '@kbn/core-http-browser';
+import type { AnalyticsServiceStart } from '@kbn/core/public';
+import { useLocation } from 'react-router-dom';
+import { reportAwsOnboardingDeployClicked } from '@kbn/fleet-plugin/common';
 import { ElbLogsPanel } from './elb_logs_panel';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(() => ({ state: null })),
+}));
+
+jest.mock('@kbn/fleet-plugin/common', () => ({
+  ...jest.requireActual('@kbn/fleet-plugin/common'),
+  reportAwsOnboardingDeployClicked: jest.fn(),
+}));
 
 const mockFlowData = {
   onboardingId: 'test-id',
@@ -146,5 +159,51 @@ describe('ElbLogsPanel', () => {
       expect(screen.getByTestId('fleetIntegrationElbLogsRetryButton')).toBeInTheDocument();
     });
     expect(screen.getByText('Unable to load ELB logs configuration')).toBeInTheDocument();
+  });
+});
+
+describe('ElbLogsPanel — CloudFormation path telemetry', () => {
+  const mockAnalytics = { reportEvent: jest.fn() } as unknown as AnalyticsServiceStart;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useLocation as jest.Mock).mockReturnValue({ state: null });
+  });
+
+  it('emits deploy_clicked (cloudformation path) when launch button is clicked on quickstart entry', async () => {
+    (useLocation as jest.Mock).mockReturnValue({ state: { telemetrySource: 'aws_quickstart' } });
+    const http = createMockHttp();
+    render(<ElbLogsPanel http={http} analytics={mockAnalytics} />);
+
+    await userEvent.click(screen.getByTestId('fleetIntegrationElbLogsSwitch'));
+    await waitFor(() =>
+      expect(screen.getByTestId('fleetIntegrationElbLogsS3BucketNameInput')).toBeInTheDocument()
+    );
+    await userEvent.type(
+      screen.getByTestId('fleetIntegrationElbLogsS3BucketNameInput'),
+      'my-logs-bucket'
+    );
+    await userEvent.click(screen.getByTestId('fleetIntegrationElbLogsLaunchStackButton'));
+
+    expect(reportAwsOnboardingDeployClicked).toHaveBeenCalledWith(mockAnalytics, sessionStorage, {
+      path: 'aws_cloudformation',
+    });
+  });
+
+  it('does not emit telemetry helpers when entered from a non-quickstart path', async () => {
+    const http = createMockHttp();
+    render(<ElbLogsPanel http={http} analytics={mockAnalytics} />);
+
+    await userEvent.click(screen.getByTestId('fleetIntegrationElbLogsSwitch'));
+    await waitFor(() =>
+      expect(screen.getByTestId('fleetIntegrationElbLogsS3BucketNameInput')).toBeInTheDocument()
+    );
+    await userEvent.type(
+      screen.getByTestId('fleetIntegrationElbLogsS3BucketNameInput'),
+      'my-logs-bucket'
+    );
+    await userEvent.click(screen.getByTestId('fleetIntegrationElbLogsLaunchStackButton'));
+
+    expect(reportAwsOnboardingDeployClicked).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/fleet_extensions/elb_logs_cloud_forwarder/elb_logs_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/fleet_extensions/elb_logs_cloud_forwarder/elb_logs_panel.tsx
@@ -21,6 +21,10 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import type { HttpStart } from '@kbn/core-http-browser';
+import type { AnalyticsServiceStart } from '@kbn/core/public';
+import { useLocation } from 'react-router-dom';
+import type { CreatePackagePolicyRouteState } from '@kbn/fleet-plugin/public';
+import { reportAwsOnboardingDeployClicked } from '@kbn/fleet-plugin/common';
 import {
   buildCloudFormationUrl,
   buildS3BucketArn,
@@ -35,9 +39,13 @@ interface CloudForwarderFlowResponse {
 
 interface ElbLogsPanelProps {
   http: Pick<HttpStart, 'post'>;
+  analytics?: AnalyticsServiceStart;
 }
 
-export const ElbLogsPanel: React.FC<ElbLogsPanelProps> = ({ http }) => {
+export const ElbLogsPanel: React.FC<ElbLogsPanelProps> = ({ http, analytics }) => {
+  const location = useLocation();
+  const routeState = location.state as CreatePackagePolicyRouteState | undefined;
+  const isAwsQuickstart = routeState?.telemetrySource === 'aws_quickstart';
   const [isEnabled, setIsEnabled] = useState(false);
   const [s3BucketName, setS3BucketName] = useState('');
   const [flowData, setFlowData] = useState<CloudForwarderFlowResponse | null>(null);
@@ -89,6 +97,14 @@ export const ElbLogsPanel: React.FC<ElbLogsPanelProps> = ({ http }) => {
           buildS3BucketArn(trimmedBucketName)
         )
       : undefined;
+
+  const handleLaunchStack = useCallback(() => {
+    if (!isAwsQuickstart || !analytics) return;
+    // S3 bucket name is user input (PII risk) — we do NOT include it in the payload.
+    // credentials_added is NOT emitted here: on the CloudFormation path the user enters
+    // AWS credentials directly in the AWS console, not in Kibana.
+    reportAwsOnboardingDeployClicked(analytics, sessionStorage, { path: 'aws_cloudformation' });
+  }, [isAwsQuickstart, analytics]);
 
   return (
     <>
@@ -197,10 +213,12 @@ export const ElbLogsPanel: React.FC<ElbLogsPanelProps> = ({ http }) => {
                     data-test-subj="fleetIntegrationElbLogsLaunchStackButton"
                     href={cloudFormationHref}
                     target="_blank"
+                    rel="noopener noreferrer"
                     iconSide="right"
                     iconType="external"
                     size="s"
                     isDisabled={!isValidS3BucketName(trimmedBucketName)}
+                    onClick={handleLaunchStack}
                   >
                     {i18n.translate(
                       'xpack.observability_onboarding.fleetIntegration.elbLogs.launchStackButtonLabel',

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/fleet_extensions/elb_logs_cloud_forwarder/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/fleet_extensions/elb_logs_cloud_forwarder/index.tsx
@@ -23,7 +23,7 @@ export const getLazyElbLogsCloudForwarderExtension = (
     const { ElbLogsPanel } = await import('./elb_logs_panel');
 
     const Component: PackagePolicyCreateBottomExtensionComponent = ({ newPolicy: _ }) => (
-      <ElbLogsPanel http={coreStart.http} />
+      <ElbLogsPanel http={coreStart.http} analytics={coreStart.analytics} />
     );
     Component.displayName = 'ElbLogsCloudForwarderExtension';
 


### PR DESCRIPTION
## Summary

Backport of #278482 to 9.5.

**Original PR description:**

Adds EBT (Event-Based Telemetry) instrumentation for the AWS quickstart onboarding funnel (ingest-dev#7625). Tracks entry, credential submission, and deployment across both the agentless and CloudFormation paths.

Events instrumented:
- `aws_onboarding_flow_entered` — fired when the AWS quickstart card is clicked
- `aws_onboarding_credentials_added` — fired on first valid credential entry (agentless path)
- `aws_onboarding_deploy_clicked` — fired on Save (agentless) or Launch Stack (CloudFormation)
- `aws_onboarding_agentless_enrollment_succeeded` — fired when managed enrollment confirms success
- `aws_onboarding_first_data_arrived` — fired when incoming data is detected post-deploy
- `aws_onboarding_first_data_timeout` — fired when the data polling window expires

All events use sessionStorage guards to prevent double-firing within a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)