### PR TITLE
[Cases] Analytics V2: project global and $ref template fields as runtime fields

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/__test_helpers__/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/__test_helpers__/index.ts
@@ -23,7 +23,9 @@ import type {
 import type { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import type { DataView, DataViewSpec, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
 import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
+import { stringify as stringifyYaml } from 'yaml';
 import {
+  CASE_FIELD_DEFINITION_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_TEMPLATE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
@@ -124,25 +126,68 @@ export const makeUserAction = (
   } as SavedObject<UserActionPersistedAttributes>);
 
 /**
- * Build a `cases-templates` SO with the persisted shape the
- * analytics-v2 data view service reads. Only `attributes.fieldDefinitions`
- * is consumed, so the factory leaves everything else minimal.
+ * Build a `cases-templates` SO with the persisted shape the analytics-v2
+ * data view service reads. The service parses `attributes.definition` (the
+ * raw YAML) and resolves `$ref` fields against the field library, so the
+ * factory renders the given field entries into a valid YAML definition.
+ *
+ * Field entries are either inline (`{ name, type, control }`) or references
+ * (`{ $ref, name? }`) so tests can exercise both resolution paths.
  */
-export interface TemplateLike {
-  fieldDefinitions?: Array<{ name: string; label?: string; type: string; control?: string }>;
+export interface TemplateFieldLike {
+  name?: string;
+  label?: string;
+  type?: string;
+  control?: string;
+  $ref?: string;
 }
 
-export const makeTemplate = (
-  id: string,
-  fieldDefinitions: NonNullable<TemplateLike['fieldDefinitions']>
-): SavedObject<TemplateLike> =>
+export interface TemplateLike {
+  definition?: string;
+}
+
+export const makeTemplate = (id: string, fields: TemplateFieldLike[]): SavedObject<TemplateLike> =>
   ({
     type: CASE_TEMPLATE_SAVED_OBJECT,
     id,
     namespaces: ['default'],
     references: [],
-    attributes: { fieldDefinitions },
+    attributes: { definition: stringifyYaml({ fields }) },
   } as unknown as SavedObject<TemplateLike>);
+
+/**
+ * Build a `cases-field-definitions` SO the analytics-v2 data view service
+ * reads for runtime projection. The service consumes `attributes.name`
+ * (what a template `$ref` points at), `attributes.definition` (a YAML
+ * string of a single field entry), and `attributes.isGlobal`, so the
+ * factory derives the YAML from `{ name, type, control }`.
+ */
+export interface FieldDefinitionLike {
+  name: string;
+  definition: string;
+  isGlobal?: boolean;
+}
+
+export const makeFieldDefinition = (
+  id: string,
+  {
+    name,
+    type,
+    control = 'INPUT_TEXT',
+    isGlobal = true,
+  }: { name: string; type: string; control?: string; isGlobal?: boolean }
+): SavedObject<FieldDefinitionLike> =>
+  ({
+    type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
+    id,
+    namespaces: ['default'],
+    references: [],
+    attributes: {
+      name,
+      isGlobal,
+      definition: stringifyYaml({ name, type, control }),
+    },
+  } as unknown as SavedObject<FieldDefinitionLike>);
 
 // ----- SO client `find` stub -----
 
@@ -178,15 +223,61 @@ export const stubFindWithPages = <T>(
   perPage = 100
 ): void => {
   let callIdx = 0;
-  client.find.mockImplementation(async () => {
+  client.find.mockImplementation(async (options) => {
+    // The data view service reads two SO types per ensure cycle
+    // (templates + field definitions). This legacy stub only feeds the
+    // template/case page sequence; field-definition reads return empty so
+    // they don't consume a page meant for the next cycle. Suites that
+    // exercise global fields use `stubFindByType` instead.
+    const type = (options as { type?: string })?.type;
+    if (type === CASE_FIELD_DEFINITION_SAVED_OBJECT) {
+      return emptyPage<T>(perPage);
+    }
     const page = pages[callIdx] ?? [];
     callIdx++;
-    return {
-      saved_objects: page.map((so, idx) => ({ ...so, score: 1, sort: [idx] })) as never,
-      total: page.length,
-      per_page: perPage,
-      page: 1,
-    } as SavedObjectsFindResponse<T>;
+    return toFindResponse(page, perPage);
+  });
+};
+
+const emptyPage = <T>(perPage: number): SavedObjectsFindResponse<T> =>
+  toFindResponse<T>([], perPage);
+
+const toFindResponse = <T>(
+  page: Array<SavedObject<T>>,
+  perPage: number
+): SavedObjectsFindResponse<T> =>
+  ({
+    saved_objects: page.map((so, idx) => ({ ...so, score: 1, sort: [idx] })) as never,
+    total: page.length,
+    per_page: perPage,
+    page: 1,
+  } as SavedObjectsFindResponse<T>);
+
+/**
+ * Route the SO client's `find` by requested `type`, each type serving its
+ * own single populated page then empty pages thereafter. Use when a test
+ * needs templates and field definitions to resolve independently (the
+ * data view service reads both per ensure cycle).
+ */
+export const stubFindByType = (
+  client: ReturnType<typeof savedObjectsClientMock.create>,
+  results: {
+    templates?: Array<SavedObject<TemplateLike>>;
+    fieldDefinitions?: Array<SavedObject<FieldDefinitionLike>>;
+  },
+  perPage = 100
+): void => {
+  const served = { templates: false, fieldDefinitions: false };
+  client.find.mockImplementation(async (options) => {
+    const type = (options as { type?: string })?.type;
+    if (type === CASE_FIELD_DEFINITION_SAVED_OBJECT) {
+      if (served.fieldDefinitions) return emptyPage(perPage);
+      served.fieldDefinitions = true;
+      return toFindResponse(results.fieldDefinitions ?? [], perPage);
+    }
+    if (served.templates) return emptyPage(perPage);
+    served.templates = true;
+    return toFindResponse(results.templates ?? [], perPage);
   });
 };
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/__test_helpers__/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/__test_helpers__/index.ts
@@ -128,8 +128,9 @@ export const makeUserAction = (
 /**
  * Build a `cases-templates` SO with the persisted shape the analytics-v2
  * data view service reads. The service parses `attributes.definition` (the
- * raw YAML) and resolves `$ref` fields against the field library, so the
- * factory renders the given field entries into a valid YAML definition.
+ * raw YAML) and resolves `$ref` fields against the template owner's field
+ * library, so the factory renders the given field entries into a valid YAML
+ * definition and carries an `owner`.
  *
  * Field entries are either inline (`{ name, type, control }`) or references
  * (`{ $ref, name? }`) so tests can exercise both resolution paths.
@@ -144,26 +145,33 @@ export interface TemplateFieldLike {
 
 export interface TemplateLike {
   definition?: string;
+  owner?: string;
 }
 
-export const makeTemplate = (id: string, fields: TemplateFieldLike[]): SavedObject<TemplateLike> =>
+export const makeTemplate = (
+  id: string,
+  fields: TemplateFieldLike[],
+  { owner = 'securitySolution' }: { owner?: string } = {}
+): SavedObject<TemplateLike> =>
   ({
     type: CASE_TEMPLATE_SAVED_OBJECT,
     id,
     namespaces: ['default'],
     references: [],
-    attributes: { definition: stringifyYaml({ fields }) },
+    attributes: { owner, definition: stringifyYaml({ fields }) },
   } as unknown as SavedObject<TemplateLike>);
 
 /**
  * Build a `cases-field-definitions` SO the analytics-v2 data view service
  * reads for runtime projection. The service consumes `attributes.name`
- * (what a template `$ref` points at), `attributes.definition` (a YAML
- * string of a single field entry), and `attributes.isGlobal`, so the
- * factory derives the YAML from `{ name, type, control }`.
+ * (what a template `$ref` points at), `attributes.owner` (scopes `$ref`
+ * resolution), `attributes.definition` (a YAML string of a single field
+ * entry), and `attributes.isGlobal`, so the factory derives the YAML from
+ * `{ name, type, control }`.
  */
 export interface FieldDefinitionLike {
   name: string;
+  owner: string;
   definition: string;
   isGlobal?: boolean;
 }
@@ -175,7 +183,8 @@ export const makeFieldDefinition = (
     type,
     control = 'INPUT_TEXT',
     isGlobal = true,
-  }: { name: string; type: string; control?: string; isGlobal?: boolean }
+    owner = 'securitySolution',
+  }: { name: string; type: string; control?: string; isGlobal?: boolean; owner?: string }
 ): SavedObject<FieldDefinitionLike> =>
   ({
     type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
@@ -184,6 +193,7 @@ export const makeFieldDefinition = (
     references: [],
     attributes: {
       name,
+      owner,
       isGlobal,
       definition: stringifyYaml({ name, type, control }),
     },

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
@@ -9,13 +9,18 @@ import type { ElasticsearchClient, KibanaRequest, SavedObject } from '@kbn/core/
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
-import { CASE_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+import {
+  CASE_FIELD_DEFINITION_SAVED_OBJECT,
+  CASE_TEMPLATE_SAVED_OBJECT,
+} from '../../../common/constants';
 import {
   asDataView,
   makeDataViewsPluginStart,
   makeDataViewWithRuntime,
+  makeFieldDefinition,
   makeMockDvService,
   makeTemplate,
+  stubFindByType,
   stubFindOnePage,
   stubFindWithPages,
   type MockDvService,
@@ -73,10 +78,10 @@ describe('CasesAnalyticsV2DataViewService', () => {
   };
 
   describe('ensureForSpace', () => {
-    it('reads template field metadata from attributes.fieldDefinitions (not the YAML definition string)', async () => {
-      // The persisted contract is `attributes.fieldDefinitions`; reaching for
-      // `attributes.definition.fields` would be `undefined` (definition
-      // is a YAML string), silently emptying the runtime field map.
+    it('derives runtime fields from the template YAML definition (inline fields)', async () => {
+      // Templates persist their field set as a YAML `definition` string;
+      // the service parses it and resolves fields against the library so
+      // that both inline and `$ref` fields are projected.
       const { service, dvService, deps } = setup([
         makeTemplate('tpl-1', [{ name: 'risk', type: 'long', control: 'INPUT_NUMBER' }]),
       ]);
@@ -306,7 +311,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
      * runtime fields forever and the data view would accumulate
      * ghost fields silently.
      */
-    it('filters templates by isLatest=true AND deletedAt=null and only requests the fieldDefinitions attribute', async () => {
+    it('filters templates by isLatest=true AND deletedAt=null and only requests the definition attribute', async () => {
       const { service, dvService, deps, internalSoClient } = setup([]);
       stubMissingDataView(dvService);
 
@@ -316,13 +321,255 @@ describe('CasesAnalyticsV2DataViewService', () => {
         expect.objectContaining({
           type: CASE_TEMPLATE_SAVED_OBJECT,
           namespaces: [spaceId],
-          fields: ['fieldDefinitions'],
+          fields: ['definition'],
           filter: expect.stringContaining('isLatest: true'),
         })
       );
-      const findArgs = internalSoClient.find.mock.calls[0]?.[0] as { filter: string };
-      expect(findArgs.filter).toContain('NOT');
-      expect(findArgs.filter).toContain('deletedAt');
+      const templateFindArgs = internalSoClient.find.mock.calls.find(
+        (call) => (call[0] as { type?: string })?.type === CASE_TEMPLATE_SAVED_OBJECT
+      )?.[0] as { filter: string };
+      expect(templateFindArgs.filter).toContain('NOT');
+      expect(templateFindArgs.filter).toContain('deletedAt');
+    });
+  });
+
+  describe('template $ref library fields', () => {
+    /**
+     * A template can reference a field-library entry by `$ref` instead of
+     * defining it inline. Those refs are dropped from the denormalized
+     * `fieldDefinitions` at save time, but their values are still stored in
+     * `case.extended_fields` (the write path resolves them). The data view
+     * must resolve the same way so those values are typed and discoverable.
+     */
+    it('resolves $ref fields against the library and projects them', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [makeTemplate('tpl-1', [{ $ref: 'analyst_tier' }])],
+        fieldDefinitions: [
+          // Non-global library field, referenced purely via $ref.
+          makeFieldDefinition('fd-1', {
+            name: 'analyst_tier',
+            type: 'keyword',
+            isGlobal: false,
+          }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.analyst_tier_as_keyword']);
+    });
+
+    it('applies a $ref name override to the projected snake-key', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [makeTemplate('tpl-1', [{ $ref: 'analyst_tier', name: 'tier_override' }])],
+        fieldDefinitions: [
+          makeFieldDefinition('fd-1', {
+            name: 'analyst_tier',
+            type: 'keyword',
+            isGlobal: false,
+          }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.tier_override_as_keyword']);
+    });
+
+    it('resolves inline and $ref fields together on the same template', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [
+          makeTemplate('tpl-1', [
+            { name: 'risk', type: 'long', control: 'INPUT_NUMBER' },
+            { $ref: 'analyst_tier' },
+          ]),
+        ],
+        fieldDefinitions: [
+          makeFieldDefinition('fd-1', {
+            name: 'analyst_tier',
+            type: 'keyword',
+            isGlobal: false,
+          }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(new Set(Object.keys(spec.runtimeFieldMap ?? {}))).toEqual(
+        new Set(['case.risk_as_long', 'case.analyst_tier_as_keyword'])
+      );
+    });
+
+    it('drops a $ref that has no matching library field', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [
+          makeTemplate('tpl-1', [
+            { name: 'risk', type: 'long', control: 'INPUT_NUMBER' },
+            { $ref: 'missing_field' },
+          ]),
+        ],
+        fieldDefinitions: [],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.risk_as_long']);
+    });
+
+    it('does not break projection for other templates when one has a malformed definition', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      // A template whose YAML definition can't be parsed must be skipped
+      // without aborting the walk for the rest of the space.
+      const malformed = makeTemplate('tpl-bad', []);
+      (malformed.attributes as { definition?: string }).definition = '{invalid: [unclosed';
+      stubFindByType(internalSoClient, {
+        templates: [
+          malformed,
+          makeTemplate('tpl-1', [{ name: 'risk', type: 'long', control: 'INPUT_NUMBER' }]),
+        ],
+        fieldDefinitions: [],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.risk_as_long']);
+    });
+  });
+
+  describe('global field-library fields', () => {
+    /**
+     * Global fields (`isGlobal: true`) apply to every case regardless of
+     * template, so their values land in `case.extended_fields` even when
+     * the case uses no template. The data view must publish a runtime field
+     * for them — otherwise those values sit in the analytics index untyped
+     * and undiscoverable in Lens / Discover.
+     */
+    it('publishes runtime fields for global fields even when no template references them', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [],
+        fieldDefinitions: [
+          makeFieldDefinition('fd-1', {
+            name: 'risk_score',
+            type: 'long',
+            control: 'INPUT_NUMBER',
+          }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      expect(dvService.createAndSave).toHaveBeenCalledTimes(1);
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.risk_score_as_long']);
+    });
+
+    it('ignores non-global field definitions', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [],
+        fieldDefinitions: [
+          makeFieldDefinition('fd-1', { name: 'global_one', type: 'keyword', isGlobal: true }),
+          makeFieldDefinition('fd-2', { name: 'scoped_one', type: 'keyword', isGlobal: false }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.global_one_as_keyword']);
+    });
+
+    it('merges template and global field runtime fields, deduping identical snake-keys', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [
+          makeTemplate('tpl-1', [
+            { name: 'risk_score', type: 'long', control: 'INPUT_NUMBER' },
+            { name: 'severity_label', type: 'keyword', control: 'INPUT_TEXT' },
+          ]),
+        ],
+        fieldDefinitions: [
+          // Same snake-key as a template field — must collapse to one entry.
+          makeFieldDefinition('fd-1', {
+            name: 'risk_score',
+            type: 'long',
+            control: 'INPUT_NUMBER',
+          }),
+          makeFieldDefinition('fd-2', { name: 'analyst_tier', type: 'keyword' }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(new Set(Object.keys(spec.runtimeFieldMap ?? {}))).toEqual(
+        new Set([
+          'case.risk_score_as_long',
+          'case.severity_label_as_keyword',
+          'case.analyst_tier_as_keyword',
+        ])
+      );
+    });
+
+    it('skips display-only (MARKDOWN) global fields, which hold no value', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [],
+        fieldDefinitions: [
+          makeFieldDefinition('fd-1', { name: 'notes', type: 'keyword', control: 'MARKDOWN' }),
+          makeFieldDefinition('fd-2', { name: 'analyst_tier', type: 'keyword' }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.analyst_tier_as_keyword']);
+    });
+
+    it('reads the field-definitions SO type scoped to the requesting space', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, { templates: [], fieldDefinitions: [] });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      expect(internalSoClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
+          namespaces: [spaceId],
+        })
+      );
+    });
+
+    it('does not read field definitions when the templates feature flag is off', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([], { templatesEnabled: false });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      expect(internalSoClient.find).not.toHaveBeenCalled();
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual([]);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts
@@ -311,7 +311,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
      * runtime fields forever and the data view would accumulate
      * ghost fields silently.
      */
-    it('filters templates by isLatest=true AND deletedAt=null and only requests the definition attribute', async () => {
+    it('filters templates by isLatest=true AND deletedAt=null and only requests the definition and owner attributes', async () => {
       const { service, dvService, deps, internalSoClient } = setup([]);
       stubMissingDataView(dvService);
 
@@ -321,7 +321,7 @@ describe('CasesAnalyticsV2DataViewService', () => {
         expect.objectContaining({
           type: CASE_TEMPLATE_SAVED_OBJECT,
           namespaces: [spaceId],
-          fields: ['definition'],
+          fields: ['definition', 'owner'],
           filter: expect.stringContaining('isLatest: true'),
         })
       );
@@ -447,6 +447,49 @@ describe('CasesAnalyticsV2DataViewService', () => {
 
       const [spec] = dvService.createAndSave.mock.calls[0];
       expect(Object.keys(spec.runtimeFieldMap ?? {})).toEqual(['case.risk_as_long']);
+    });
+
+    /**
+     * Library field names are unique only per owner. Two owners in the same
+     * space can define a same-named library field with different types, each
+     * referenced by that owner's template. Resolution must be owner-scoped
+     * (like the write path), or a space-wide name match would bind both refs
+     * to whichever owner's field paged in first — projecting the wrong type
+     * for the other owner and reintroducing the untyped-value gap.
+     */
+    it('scopes $ref resolution to the template owner when owners share a field name', async () => {
+      const { service, dvService, internalSoClient, deps } = setup([]);
+      stubFindByType(internalSoClient, {
+        templates: [
+          makeTemplate('tpl-sec', [{ $ref: 'shared' }], { owner: 'securitySolution' }),
+          makeTemplate('tpl-obs', [{ $ref: 'shared' }], { owner: 'observability' }),
+        ],
+        fieldDefinitions: [
+          makeFieldDefinition('fd-sec', {
+            name: 'shared',
+            type: 'keyword',
+            isGlobal: false,
+            owner: 'securitySolution',
+          }),
+          makeFieldDefinition('fd-obs', {
+            name: 'shared',
+            type: 'long',
+            control: 'INPUT_NUMBER',
+            isGlobal: false,
+            owner: 'observability',
+          }),
+        ],
+      });
+      stubMissingDataView(dvService);
+
+      await service.ensureForSpace(deps);
+
+      const [spec] = dvService.createAndSave.mock.calls[0];
+      // Each owner's ref resolves to its own type — both snake-keys present.
+      // A space-wide (name-only) resolution would yield just one.
+      expect(new Set(Object.keys(spec.runtimeFieldMap ?? {}))).toEqual(
+        new Set(['case.shared_as_keyword', 'case.shared_as_long'])
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
@@ -12,13 +12,27 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 import { isEqual } from 'lodash';
+import { parse as parseYaml } from 'yaml';
 import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { DataView, RuntimeField, RuntimeFieldSpec } from '@kbn/data-views-plugin/common';
-import { CASE_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+import {
+  CASE_FIELD_DEFINITION_SAVED_OBJECT,
+  CASE_TEMPLATE_SAVED_OBJECT,
+} from '../../../common/constants';
+import type { InlineField } from '../../../common/types/domain/template/fields';
+import { isDisplayOnlyField } from '../../../common/types/domain/template/fields';
+import { ParsedTemplateDefinitionSchema } from '../../../common/types/domain/template/latest';
+import type { FieldDefinition } from '../../../common/types/domain/field_definition/latest';
+import {
+  getFieldSnakeKey,
+  parseFieldDefinitionsToInlineFields,
+  resolveTemplateFields,
+} from '../../../common/utils/template_fields';
 import { buildCaseDataViewSpec, getCaseDataViewId } from './data_view_specs';
 import { buildRuntimeFieldEntry, computeRuntimeFieldsFingerprint } from './runtime_fields';
 
 const TEMPLATES_PAGE_SIZE = 100;
+const FIELD_DEFINITIONS_PAGE_SIZE = 100;
 
 /**
  * How long an "ensured" entry stays trusted before the next request in
@@ -55,25 +69,26 @@ interface CasesAnalyticsV2DataViewServiceDeps {
   logger: Logger;
   dataViewsService: DataViewsServerPluginStart;
   /**
-   * Internal (no-request) SO client used for template reads. Templates are
-   * a hidden SO type, and the request-scoped client passed at ensure time
-   * may not include them in `includedHiddenTypes`. The internal client is
-   * opted in to both `cases` and `cases-templates` at plugin start —
-   * the latter only when `templatesEnabled` is true (see below).
+   * Internal (no-request) SO client used for template and field-library
+   * reads. Both are hidden SO types, and the request-scoped client passed
+   * at ensure time may not include them in `includedHiddenTypes`. The
+   * internal client is opted in to `cases`, `cases-templates`, and
+   * `cases-field-definitions` at plugin start — the latter two only when
+   * `templatesEnabled` is true (see below).
    *
    * `namespaces: [spaceId]` on the find call scopes results to a single
    * space even though the client itself is unscoped.
    */
   internalSavedObjectsClient: SavedObjectsClientContract;
   /**
-   * Resolved value of `xpack.cases.templates.enabled`. Gates the
-   * per-space `cases-templates` SO walk inside `collectSnakeKeysForSpace`.
-   * When false the SO type is not registered with core, so calling
-   * `internalSavedObjectsClient.find({ type: 'cases-templates' })` would
-   * throw "Missing mappings for saved objects types: 'cases-templates'";
+   * Resolved value of `xpack.cases.templates.enabled`. Gates the per-space
+   * `cases-templates` and `cases-field-definitions` SO walks inside
+   * `collectSnakeKeysForSpace`. When false neither SO type is registered
+   * with core, so calling `internalSavedObjectsClient.find({ type })` for
+   * either would throw "Missing mappings for saved objects types: ...";
    * the walk short-circuits to an empty list and the data view is
    * bootstrapped with no runtime field overlay (which is the correct
-   * shape when there are no templates to project).
+   * shape when there are no templates or global fields to project).
    */
   templatesEnabled: boolean;
 }
@@ -108,8 +123,35 @@ interface EnsureForSpaceDeps {
  * (e.g. `metadata`, `display`, `validation`) that this service doesn't
  * read can land without changing this interface.
  */
+/**
+ * Subset of the template SO this service reads. `attributes.definition` is
+ * the raw YAML the user submitted; it's parsed here (rather than reading the
+ * denormalized `attributes.fieldDefinitions`) because `fieldDefinitions`
+ * omits `$ref` library fields — `toFieldDefinitions` persists inline fields
+ * only. Resolving the YAML against the field library instead recovers both
+ * inline and `$ref` fields, matching the case write path
+ * (`v2_template_utils.buildTemplateExtendedFieldsDefaults`).
+ */
 interface TemplateAttributesLike {
-  fieldDefinitions?: Array<{ name?: unknown; type?: unknown }>;
+  definition?: unknown;
+}
+
+/**
+ * Subset of the field-library SO this service reads. Unlike templates, a
+ * field definition stores its field entry as a raw YAML string in
+ * `attributes.definition`; the `{ name, type }` needed for a snake-key is
+ * recovered by parsing that YAML. `attributes.name` is the library field's
+ * identifier — it's what a template `$ref` points at, so it's needed to
+ * resolve refs against this library.
+ *
+ * `isGlobal` is read from `_source` and filtered in application code — the
+ * boolean isn't reliably indexed for documents created before the mapping
+ * existed, mirroring `FieldDefinitionsService.getFieldDefinitions`.
+ */
+interface FieldDefinitionAttributesLike {
+  name?: unknown;
+  definition?: unknown;
+  isGlobal?: unknown;
 }
 
 /**
@@ -133,7 +175,8 @@ interface BootstrapEntry {
 
 /**
  * Manages per-space Cases data views. One data view per space, each
- * carrying a runtime field map derived from that space's templates only.
+ * carrying a runtime field map derived from that space's templates and
+ * its global field-library fields (`isGlobal: true`).
  *
  * Lazy bootstrap: a space's data view is created on the first Cases
  * request in that space; subsequent in-process requests short-circuit via
@@ -419,11 +462,103 @@ export class CasesAnalyticsV2DataViewService {
   // ----- Internals -----
 
   /**
-   * Pages through every active template SO in the given space and extracts
-   * `<name>_as_<type>` snake-keys from each template's persisted
-   * `attributes.fieldDefinitions` array. `attributes.definition` is YAML on
-   * disk; structured `{ name, type }` only exists as transient parser
-   * output during create / update.
+   * Collects the `<name>_as_<type>` snake-keys that the per-space data view
+   * must project as runtime fields. Two sources feed this set, both of
+   * which land their values in `case.extended_fields`:
+   *   1. Template fields — every live template's resolved field set, inline
+   *      fields plus `$ref` library fields (see `collectTemplateSnakeKeys`).
+   *   2. Global field-library fields (`isGlobal: true`) — applied to every
+   *      case regardless of template, so their runtime fields must be
+   *      published even when no template references them (see
+   *      `collectGlobalFieldSnakeKeys`).
+   *
+   * The field library is loaded once and shared: templates resolve their
+   * `$ref` fields against it, and global fields are filtered out of it. The
+   * resulting lists are concatenated; `buildRuntimeFieldMap` dedupes
+   * identical snake-keys, so a field a template references via `$ref` and a
+   * global field pointing at the same library entry collapse to one runtime
+   * field.
+   */
+  private async collectSnakeKeysForSpace(spaceId: string): Promise<string[]> {
+    // Templates feature flag is off — neither the `cases-templates` nor the
+    // `cases-field-definitions` SO type is registered with core, so naming
+    // either in `find({ type })` would throw "Missing mappings for saved
+    // objects types: ...". Returning empty here is also semantically
+    // correct: with the feature off there are no extended fields to project
+    // as runtime fields.
+    if (!this.deps.templatesEnabled) return [];
+
+    // The field library is needed twice — to resolve template `$ref` fields
+    // and to project global fields — so it's loaded once and passed to both
+    // collectors.
+    const fieldLibrary = await this.collectFieldLibrary(spaceId);
+
+    const templateSnakeKeys = await this.collectTemplateSnakeKeys(spaceId, fieldLibrary);
+    const globalFieldSnakeKeys = this.collectGlobalFieldSnakeKeys(fieldLibrary);
+
+    return [...templateSnakeKeys, ...globalFieldSnakeKeys];
+  }
+
+  /**
+   * Pages through every field-library SO in the given space and returns the
+   * ones with a string `definition`, shaped as `FieldDefinition`s for the
+   * shared parser / resolver utilities.
+   *
+   * `attributes.name` is read because a template `$ref` points at a library
+   * field by that name (see `resolveTemplateFields`); `attributes.isGlobal`
+   * is read so `collectGlobalFieldSnakeKeys` can filter without a second SO
+   * read. `owner` is not needed here — a per-space data view spans every
+   * owner in the space — so it's left blank.
+   *
+   * Uses the internal SO client because the field-library type is hidden and
+   * the request-scoped client may not include it.
+   */
+  private async collectFieldLibrary(spaceId: string): Promise<FieldDefinition[]> {
+    const library: FieldDefinition[] = [];
+    let page = 1;
+
+    while (true) {
+      const response =
+        await this.deps.internalSavedObjectsClient.find<FieldDefinitionAttributesLike>({
+          type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
+          perPage: FIELD_DEFINITIONS_PAGE_SIZE,
+          page,
+          // Single-space scope: this view's runtime fields cover only the
+          // field library in this space (across every owner in it).
+          namespaces: [spaceId],
+          fields: ['name', 'definition', 'isGlobal'],
+        });
+
+      const defs = response.saved_objects
+        .filter((fd) => typeof fd.attributes?.definition === 'string')
+        .map((fd) => ({
+          fieldDefinitionId: fd.id,
+          name: typeof fd.attributes?.name === 'string' ? fd.attributes.name : '',
+          owner: '',
+          definition: fd.attributes.definition as string,
+          isGlobal: fd.attributes?.isGlobal === true,
+        }));
+      library.push(...defs);
+
+      if (response.saved_objects.length < FIELD_DEFINITIONS_PAGE_SIZE) break;
+      page++;
+    }
+
+    return library;
+  }
+
+  /**
+   * Pages through every active template SO in the given space and derives
+   * `<name>_as_<type>` snake-keys from each template's resolved field set.
+   *
+   * Reads `attributes.definition` (the raw YAML) rather than the
+   * denormalized `attributes.fieldDefinitions`: the latter is produced by
+   * `toFieldDefinitions`, which persists inline fields only and drops
+   * `$ref` library references. Parsing the YAML and resolving it against the
+   * field library (`resolveTemplateFields`) recovers both inline and `$ref`
+   * fields — the same resolution the case write path uses to compute
+   * `extended_fields`, so the runtime fields match the values actually
+   * stored. Display-only fields (MARKDOWN) hold no value and are excluded.
    *
    * Uses the internal SO client because templates are a hidden type the
    * request-scoped client may not include.
@@ -432,20 +567,15 @@ export class CasesAnalyticsV2DataViewService {
    *   - `isLatest: true` excludes old versions that a renamed template no
    *     longer publishes.
    *   - `NOT deletedAt: *` excludes soft-deleted templates.
-   * `fields: ['fieldDefinitions']` keeps the payload limited to the only
-   * attribute this method reads. The SO API skips migrations for
-   * partial-field reads, which is safe here because both filter fields
-   * and `fieldDefinitions` have been on the template SO since its first model
-   * version.
+   * `fields: ['definition']` keeps the payload limited to the only attribute
+   * this method reads. The SO API skips migrations for partial-field reads,
+   * which is safe here because the filter fields and `definition` have all
+   * been on the template SO since its first model version.
    */
-  private async collectSnakeKeysForSpace(spaceId: string): Promise<string[]> {
-    // Templates feature flag is off — the `cases-templates` SO type is not
-    // registered with core, so naming it in `find({ type })` would throw
-    // "Missing mappings for saved objects types: 'cases-templates'".
-    // Returning empty here is also semantically correct: with no templates
-    // there are no extended fields to project as runtime fields.
-    if (!this.deps.templatesEnabled) return [];
-
+  private async collectTemplateSnakeKeys(
+    spaceId: string,
+    fieldLibrary: readonly FieldDefinition[]
+  ): Promise<string[]> {
     const out: string[] = [];
     let page = 1;
 
@@ -458,18 +588,19 @@ export class CasesAnalyticsV2DataViewService {
         // only from templates in this space.
         namespaces: [spaceId],
         filter: `${CASE_TEMPLATE_SAVED_OBJECT}.attributes.isLatest: true AND NOT ${CASE_TEMPLATE_SAVED_OBJECT}.attributes.deletedAt: *`,
-        fields: ['fieldDefinitions'],
+        fields: ['definition'],
       });
 
       for (const tpl of response.saved_objects) {
-        const fieldDefinitions = tpl.attributes?.fieldDefinitions ?? [];
-        for (const f of fieldDefinitions) {
-          const name = typeof f?.name === 'string' ? f.name : undefined;
-          const type = typeof f?.type === 'string' ? f.type : undefined;
-          if (name && type) {
-            out.push(`${name}_as_${type}`);
-          }
-        }
+        const snakeKeys = this.resolveTemplateFieldsFromDefinition(
+          tpl.attributes?.definition,
+          fieldLibrary
+        )
+          // Display-only fields (MARKDOWN) hold no value and are never
+          // stored on a case, so they get no runtime field.
+          .filter((field) => !isDisplayOnlyField(field))
+          .map((field) => getFieldSnakeKey(field.name, field.type));
+        out.push(...snakeKeys);
       }
 
       if (response.saved_objects.length < TEMPLATES_PAGE_SIZE) break;
@@ -477,6 +608,46 @@ export class CasesAnalyticsV2DataViewService {
     }
 
     return out;
+  }
+
+  /**
+   * Parses a template's raw YAML `definition` and resolves its `fields`
+   * (inline + `$ref`) against the field library into a flat inline-field
+   * list. A malformed or non-string definition yields an empty list — a
+   * single bad template must never break runtime field projection for the
+   * rest of the space.
+   */
+  private resolveTemplateFieldsFromDefinition(
+    definition: unknown,
+    fieldLibrary: readonly FieldDefinition[]
+  ): InlineField[] {
+    if (typeof definition !== 'string') return [];
+    try {
+      const parsed = ParsedTemplateDefinitionSchema.safeParse(parseYaml(definition));
+      if (!parsed.success) return [];
+      return resolveTemplateFields(parsed.data.fields, fieldLibrary);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Derives `<name>_as_<type>` snake-keys from the global (`isGlobal: true`)
+   * entries of the already-loaded field library. Global fields apply to
+   * every case regardless of template, so their values land in
+   * `case.extended_fields` even when the case uses no template — without
+   * this projection those values would sit in the analytics index untyped
+   * and undiscoverable in Lens / Discover.
+   *
+   * Display-only fields (MARKDOWN) hold no value and are never stored on a
+   * case, so they're excluded to match the write path
+   * (`buildExtendedFieldsDefaults`).
+   */
+  private collectGlobalFieldSnakeKeys(fieldLibrary: readonly FieldDefinition[]): string[] {
+    const globalDefinitions = fieldLibrary.filter((fd) => fd.isGlobal === true);
+    return parseFieldDefinitionsToInlineFields(globalDefinitions)
+      .filter((field) => !isDisplayOnlyField(field))
+      .map((field) => getFieldSnakeKey(field.name, field.type));
   }
 
   private buildRuntimeFieldMap(snakeKeys: string[]): Record<string, RuntimeFieldSpec> {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.ts
@@ -113,17 +113,6 @@ interface EnsureForSpaceDeps {
 }
 
 /**
- * Subset of the template SO this service reads. Persisted
- * `attributes.definition` is the raw YAML the user submitted; structured
- * field metadata lives on `attributes.fieldDefinitions`, populated at create /
- * update time by `toFieldDefinitions(parsedDefinition.fields)` (see
- * `services/templates/index.ts`).
- *
- * Typed loosely with `unknown` per element so a future template-field type
- * (e.g. `metadata`, `display`, `validation`) that this service doesn't
- * read can land without changing this interface.
- */
-/**
  * Subset of the template SO this service reads. `attributes.definition` is
  * the raw YAML the user submitted; it's parsed here (rather than reading the
  * denormalized `attributes.fieldDefinitions`) because `fieldDefinitions`
@@ -131,9 +120,14 @@ interface EnsureForSpaceDeps {
  * only. Resolving the YAML against the field library instead recovers both
  * inline and `$ref` fields, matching the case write path
  * (`v2_template_utils.buildTemplateExtendedFieldsDefaults`).
+ *
+ * `attributes.owner` scopes `$ref` resolution to the template's owner:
+ * library field names are unique only per owner, so refs must resolve
+ * against that owner's library subset (see `collectTemplateSnakeKeys`).
  */
 interface TemplateAttributesLike {
   definition?: unknown;
+  owner?: unknown;
 }
 
 /**
@@ -142,7 +136,8 @@ interface TemplateAttributesLike {
  * `attributes.definition`; the `{ name, type }` needed for a snake-key is
  * recovered by parsing that YAML. `attributes.name` is the library field's
  * identifier — it's what a template `$ref` points at, so it's needed to
- * resolve refs against this library.
+ * resolve refs against this library. `attributes.owner` scopes that
+ * resolution, since library names are unique only per owner.
  *
  * `isGlobal` is read from `_source` and filtered in application code — the
  * boolean isn't reliably indexed for documents created before the mapping
@@ -151,6 +146,7 @@ interface TemplateAttributesLike {
 interface FieldDefinitionAttributesLike {
   name?: unknown;
   definition?: unknown;
+  owner?: unknown;
   isGlobal?: unknown;
 }
 
@@ -493,7 +489,24 @@ export class CasesAnalyticsV2DataViewService {
     // collectors.
     const fieldLibrary = await this.collectFieldLibrary(spaceId);
 
-    const templateSnakeKeys = await this.collectTemplateSnakeKeys(spaceId, fieldLibrary);
+    // Group by owner for `$ref` resolution. Library field names are unique
+    // only per owner, so a template must resolve refs against its own
+    // owner's subset — matching the owner-scoped resolution the case write
+    // path uses (`getFieldDefinitions({ owner })`). Resolving against the
+    // merged space-wide library could pick another owner's same-named field
+    // with a different type, producing a snake-key that never matches the
+    // stored value.
+    const libraryByOwner = new Map<string, FieldDefinition[]>();
+    for (const def of fieldLibrary) {
+      const forOwner = libraryByOwner.get(def.owner);
+      if (forOwner) {
+        forOwner.push(def);
+      } else {
+        libraryByOwner.set(def.owner, [def]);
+      }
+    }
+
+    const templateSnakeKeys = await this.collectTemplateSnakeKeys(spaceId, libraryByOwner);
     const globalFieldSnakeKeys = this.collectGlobalFieldSnakeKeys(fieldLibrary);
 
     return [...templateSnakeKeys, ...globalFieldSnakeKeys];
@@ -504,11 +517,11 @@ export class CasesAnalyticsV2DataViewService {
    * ones with a string `definition`, shaped as `FieldDefinition`s for the
    * shared parser / resolver utilities.
    *
-   * `attributes.name` is read because a template `$ref` points at a library
-   * field by that name (see `resolveTemplateFields`); `attributes.isGlobal`
-   * is read so `collectGlobalFieldSnakeKeys` can filter without a second SO
-   * read. `owner` is not needed here — a per-space data view spans every
-   * owner in the space — so it's left blank.
+   * Reads `attributes.name` (what a template `$ref` points at, see
+   * `resolveTemplateFields`), `attributes.owner` (so `$ref` resolution can
+   * be scoped per owner — library names are unique only per owner), and
+   * `attributes.isGlobal` (so `collectGlobalFieldSnakeKeys` can filter
+   * without a second SO read).
    *
    * Uses the internal SO client because the field-library type is hidden and
    * the request-scoped client may not include it.
@@ -526,7 +539,7 @@ export class CasesAnalyticsV2DataViewService {
           // Single-space scope: this view's runtime fields cover only the
           // field library in this space (across every owner in it).
           namespaces: [spaceId],
-          fields: ['name', 'definition', 'isGlobal'],
+          fields: ['name', 'owner', 'definition', 'isGlobal'],
         });
 
       const defs = response.saved_objects
@@ -534,7 +547,7 @@ export class CasesAnalyticsV2DataViewService {
         .map((fd) => ({
           fieldDefinitionId: fd.id,
           name: typeof fd.attributes?.name === 'string' ? fd.attributes.name : '',
-          owner: '',
+          owner: typeof fd.attributes?.owner === 'string' ? fd.attributes.owner : '',
           definition: fd.attributes.definition as string,
           isGlobal: fd.attributes?.isGlobal === true,
         }));
@@ -560,6 +573,12 @@ export class CasesAnalyticsV2DataViewService {
    * `extended_fields`, so the runtime fields match the values actually
    * stored. Display-only fields (MARKDOWN) hold no value and are excluded.
    *
+   * `$ref` fields resolve against the template owner's library subset
+   * (`libraryByOwner`), not the merged space-wide library: library names are
+   * unique only per owner, so a space-wide `.find` by name could bind a ref
+   * to another owner's same-named field with a different type. `attributes.owner`
+   * is read for this scoping.
+   *
    * Uses the internal SO client because templates are a hidden type the
    * request-scoped client may not include.
    *
@@ -567,14 +586,15 @@ export class CasesAnalyticsV2DataViewService {
    *   - `isLatest: true` excludes old versions that a renamed template no
    *     longer publishes.
    *   - `NOT deletedAt: *` excludes soft-deleted templates.
-   * `fields: ['definition']` keeps the payload limited to the only attribute
-   * this method reads. The SO API skips migrations for partial-field reads,
-   * which is safe here because the filter fields and `definition` have all
-   * been on the template SO since its first model version.
+   * `fields: ['definition', 'owner']` keeps the payload limited to the only
+   * attributes this method reads. The SO API skips migrations for
+   * partial-field reads, which is safe here because the filter fields,
+   * `definition`, and `owner` have all been on the template SO since its
+   * first model version.
    */
   private async collectTemplateSnakeKeys(
     spaceId: string,
-    fieldLibrary: readonly FieldDefinition[]
+    libraryByOwner: ReadonlyMap<string, FieldDefinition[]>
   ): Promise<string[]> {
     const out: string[] = [];
     let page = 1;
@@ -588,13 +608,18 @@ export class CasesAnalyticsV2DataViewService {
         // only from templates in this space.
         namespaces: [spaceId],
         filter: `${CASE_TEMPLATE_SAVED_OBJECT}.attributes.isLatest: true AND NOT ${CASE_TEMPLATE_SAVED_OBJECT}.attributes.deletedAt: *`,
-        fields: ['definition'],
+        fields: ['definition', 'owner'],
       });
 
       for (const tpl of response.saved_objects) {
+        const owner = typeof tpl.attributes?.owner === 'string' ? tpl.attributes.owner : '';
+        // Resolve refs only against this owner's library. An unknown owner
+        // (no entry) resolves against an empty library — inline fields still
+        // project; refs drop, which is safe.
+        const ownerLibrary = libraryByOwner.get(owner) ?? [];
         const snakeKeys = this.resolveTemplateFieldsFromDefinition(
           tpl.attributes?.definition,
-          fieldLibrary
+          ownerLibrary
         )
           // Display-only fields (MARKDOWN) hold no value and are never
           // stored on a case, so they get no runtime field.

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -25,6 +25,7 @@ import {
   APP_ID,
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
+  CASE_FIELD_DEFINITION_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_TEMPLATE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
@@ -382,16 +383,17 @@ export class CasePlugin
         //    works regardless of where in the in-flight SO migration
         //    (security-team#15066) a tenant sits — see
         //    `reconciliation/attachments_runner.ts`.
-        //  - The data view sub-service reads `cases-templates` SOs per-space
-        //    to derive runtime fields. Only included when templates is on
-        //    — `cases-templates` is registered with core only when
-        //    `xpack.cases.templates.enabled` is true (see
-        //    `saved_object_types/index.ts`), and naming it here when the
-        //    mapping isn't registered throws "Missing mappings for saved
-        //    objects types: 'cases-templates'" from
-        //    `createInternalRepository`. With templates off, the data view
-        //    sub-service short-circuits its template read and bootstraps
-        //    per-space data views with an empty runtime field overlay.
+        //  - The data view sub-service reads `cases-templates` AND
+        //    `cases-field-definitions` SOs per-space to derive runtime
+        //    fields (template fields plus global `isGlobal` field-library
+        //    fields). Only included when templates is on — both types are
+        //    registered with core only when `xpack.cases.templates.enabled`
+        //    is true (see `saved_object_types/index.ts`), and naming either
+        //    here when the mapping isn't registered throws "Missing mappings
+        //    for saved objects types: ..." from `createInternalRepository`.
+        //    With templates off, the data view sub-service short-circuits
+        //    its reads and bootstraps per-space data views with an empty
+        //    runtime field overlay.
         //  - The `/reset` admin route deletes per-space `index-pattern` SOs
         //    across namespaces. A request-scoped SO client can't do this:
         //    the spaces extension scopes `delete` to the request's namespace,
@@ -412,7 +414,9 @@ export class CasePlugin
           CASE_USER_ACTION_SAVED_OBJECT,
           CASE_COMMENT_SAVED_OBJECT,
           CASE_ATTACHMENT_SAVED_OBJECT,
-          ...(this.caseConfig.templates?.enabled ? [CASE_TEMPLATE_SAVED_OBJECT] : []),
+          ...(this.caseConfig.templates?.enabled
+            ? [CASE_TEMPLATE_SAVED_OBJECT, CASE_FIELD_DEFINITION_SAVED_OBJECT]
+            : []),
           'index-pattern',
         ]);
         const v2InternalSavedObjectsClient = new SavedObjectsClient(v2InternalRepository);


### PR DESCRIPTION
## Summary

The per-space managed **Case Analytics** data view publishes a typed runtime field for every extended (template) field in a space so it's discoverable in Discover/Lens, reading the value out of the `flattened` `case.extended_fields`. That map was derived only from each template's denormalized `fieldDefinitions`, which misses two field sources whose values still land in `case.extended_fields` — so those values sat in the index untyped and undiscoverable:

- **Global fields** (`isGlobal` field-library entries) apply to every case regardless of template, but were never collected.
- **Template `$ref` fields** are dropped from `fieldDefinitions` at save time (`toFieldDefinitions` persists inline fields only), so library fields referenced purely via `$ref` were never projected.

## What changed

- The data view service loads the space's field library once and reuses it: templates resolve their `$ref` fields against it, and global fields are filtered out of it.
- Template runtime fields are now derived from the template's YAML `definition` resolved against the library (`resolveTemplateFields`) — recovering both inline and `$ref` fields — instead of the inline-only `fieldDefinitions`. This matches the resolution the case write path uses to compute `extended_fields`, so the runtime fields line up with the values actually stored.
- Global fields are projected directly, so they're typed and discoverable even when no template references them.
- The v2 internal SO client is opted into `cases-field-definitions` (gated on `xpack.cases.templates.enabled`, same as `cases-templates`).
- A malformed template `definition` is skipped without aborting projection for the rest of the space.

## Testing

- `node scripts/jest x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/service.test.ts` — 30 passing (added coverage for global fields, `$ref` resolution incl. name override, mixed inline+`$ref`, unresolved-`$ref` drop, and malformed-definition isolation).
- `node scripts/jest x-pack/platform/plugins/shared/cases/server/cases_analytics_v2` — 313 passing.
- `node scripts/type_check --project x-pack/platform/plugins/shared/cases/tsconfig.json` — clean.
- `node scripts/eslint` on the changed files — clean.

## Release note

Cases analytics now exposes global fields and template `$ref` library fields as typed, queryable fields in the managed Case Analytics data view.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->