### PR TITLE
[Alerting v2] [Create Rule Form] Add title sections for Alert conditions, Rule execution and Rule details

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -473,7 +473,7 @@ describe('shell shared fields', () => {
     );
 
     expect(screen.getByTestId('composeDiscoverModeSelect')).toBeInTheDocument();
-    expect(screen.getByText('Alert conditions')).toBeInTheDocument();
+    expect(screen.queryByText('Alert conditions')).not.toBeInTheDocument();
     expect(screen.getByText('Rule execution')).toBeInTheDocument();
     expect(screen.queryByTestId('alertDelayFormRow')).not.toBeInTheDocument();
     expect(screen.getByText('Schedule')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -261,7 +261,7 @@ describe('step validation', () => {
     it('renders runbook and related dashboard artifact fields', () => {
       renderComposeDiscoverDetailsStep();
 
-      expect(screen.getByText('Rule details')).toBeTruthy();
+      expect(screen.getByText('Rule details')).toBeInTheDocument();
       expect(screen.getByText('Artifacts')).toBeTruthy();
       expect(screen.getByText('Runbook')).toBeTruthy();
       expect(screen.getByTestId('addRunbookButton')).toBeTruthy();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -15,7 +15,12 @@ import type { UseFormReturn } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ComposeDiscoverForm, getSteps } from '.';
 import { validateStep } from '../validate_step';
-import { Comparator, Aggregation } from '../rule_builder/threshold/form_types';
+import {
+  Comparator,
+  Aggregation,
+  DEFAULT_THRESHOLD_FORM_VALUES,
+} from '../rule_builder/threshold/form_types';
+import { BuilderStateProvider } from '../rule_builder/builder_state_context';
 import { RuleFormProvider, type RuleFormServices } from '../../../form/contexts';
 import { createMockServices, createTestQueryClient } from '../../../test_utils';
 import type { FormValues } from '../../../form/types';
@@ -256,6 +261,7 @@ describe('step validation', () => {
     it('renders runbook and related dashboard artifact fields', () => {
       renderComposeDiscoverDetailsStep();
 
+      expect(screen.getByText('Rule details')).toBeTruthy();
       expect(screen.getByText('Artifacts')).toBeTruthy();
       expect(screen.getByText('Runbook')).toBeTruthy();
       expect(screen.getByTestId('addRunbookButton')).toBeTruthy();
@@ -453,6 +459,8 @@ describe('shell shared fields', () => {
     renderShell({ step: 0 }, { kind: 'alert' });
 
     expect(screen.getByTestId('composeDiscoverModeSelect')).toBeInTheDocument();
+    expect(screen.getByText('Alert conditions')).toBeInTheDocument();
+    expect(screen.getByText('Rule execution')).toBeInTheDocument();
     expect(screen.getByTestId('alertDelayFormRow')).toBeInTheDocument();
     expect(screen.getByText('Schedule')).toBeInTheDocument();
     expect(screen.getByText('Lookback Window')).toBeInTheDocument();
@@ -465,9 +473,33 @@ describe('shell shared fields', () => {
     );
 
     expect(screen.getByTestId('composeDiscoverModeSelect')).toBeInTheDocument();
+    expect(screen.getByText('Alert conditions')).toBeInTheDocument();
+    expect(screen.getByText('Rule execution')).toBeInTheDocument();
     expect(screen.queryByTestId('alertDelayFormRow')).not.toBeInTheDocument();
     expect(screen.getByText('Schedule')).toBeInTheDocument();
     expect(screen.getByText('Lookback Window')).toBeInTheDocument();
+  });
+
+  it('renders section titles on the threshold builder alert condition step', () => {
+    const services = { ...createMockServices(), dashboard: mockDashboard };
+    const builderState = DEFAULT_THRESHOLD_FORM_VALUES;
+    render(
+      <BuilderStateProvider builderState={builderState} setBuilderState={jest.fn()}>
+        <ComposeDiscoverForm
+          state={createState({ queryCommitted: true, step: 0 })}
+          dispatch={jest.fn()}
+          services={services}
+          onRecoveryTypeChange={jest.fn()}
+          onKindChange={jest.fn()}
+          isEditing={false}
+          builderType="threshold"
+        />
+      </BuilderStateProvider>,
+      { wrapper: createComposeFormWrapper({ ...BASE_COMPOSE_VALUES }, services) }
+    );
+
+    expect(screen.getByText('Alert conditions')).toBeInTheDocument();
+    expect(screen.getByText('Rule execution')).toBeInTheDocument();
   });
 
   it('does not render shared fields on non-alert-condition steps', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -209,16 +209,29 @@ export const ComposeDiscoverForm = ({
         data-test-subj="composeDiscoverModeSelect"
       />
       <EuiSpacer size="m" />
-      <EuiTitle size="xs">
-        <h3>
-          <FormattedMessage
-            id="xpack.alertingV2.composeDiscover.alertCondition.alertConditionsTitle"
-            defaultMessage="Alert conditions"
-          />
-        </h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
       {stepContent}
+      {isAlert && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiTitle size="xs">
+            <h3>
+              <FormattedMessage
+                id="xpack.alertingV2.composeDiscover.alertCondition.alertConditionsTitle"
+                defaultMessage="Alert conditions"
+              />
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <AlertDelayField />
+          <EuiSpacer size="m" />
+          <NoDataStrategySelect
+            value={noDataStrategy ?? 'none'}
+            onChange={(strategy) => setValue('noDataStrategy', strategy, { shouldDirty: true })}
+            compressed
+            data-test-subj="composeDiscoverNoDataStrategy"
+          />
+        </>
+      )}
       <EuiSpacer size="m" />
       <EuiTitle size="xs">
         <h3>
@@ -229,19 +242,6 @@ export const ComposeDiscoverForm = ({
         </h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      {isAlert && (
-        <>
-          <AlertDelayField />
-          <EuiSpacer size="m" />
-          <NoDataStrategySelect
-            value={noDataStrategy ?? 'none'}
-            onChange={(strategy) => setValue('noDataStrategy', strategy, { shouldDirty: true })}
-            compressed
-            data-test-subj="composeDiscoverNoDataStrategy"
-          />
-          <EuiSpacer size="m" />
-        </>
-      )}
       <ScheduleField />
       <EuiSpacer size="m" />
       <LookbackWindowField />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -212,7 +212,7 @@ export const ComposeDiscoverForm = ({
       {stepContent}
       {isAlert && (
         <>
-          <EuiSpacer size="m" />
+          <EuiHorizontalRule margin="m" />
           <EuiTitle size="xs">
             <h3>
               <FormattedMessage
@@ -232,7 +232,7 @@ export const ComposeDiscoverForm = ({
           />
         </>
       )}
-      <EuiSpacer size="m" />
+      <EuiHorizontalRule margin="m" />
       <EuiTitle size="xs">
         <h3>
           <FormattedMessage

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -7,8 +7,9 @@
 
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
+import { EuiHorizontalRule, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type {
   ComposeDiscoverState,
   ComposeDiscoverAction,
@@ -208,10 +209,28 @@ export const ComposeDiscoverForm = ({
         data-test-subj="composeDiscoverModeSelect"
       />
       <EuiSpacer size="m" />
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.alertCondition.alertConditionsTitle"
+            defaultMessage="Alert conditions"
+          />
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
       {stepContent}
+      <EuiSpacer size="m" />
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.alertCondition.ruleExecutionTitle"
+            defaultMessage="Rule execution"
+          />
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
       {isAlert && (
         <>
-          <EuiSpacer size="m" />
           <AlertDelayField />
           <EuiSpacer size="m" />
           <NoDataStrategySelect
@@ -220,9 +239,9 @@ export const ComposeDiscoverForm = ({
             compressed
             data-test-subj="composeDiscoverNoDataStrategy"
           />
+          <EuiSpacer size="m" />
         </>
       )}
-      <EuiSpacer size="m" />
       <ScheduleField />
       <EuiSpacer size="m" />
       <LookbackWindowField />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/details_and_artifacts_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/details_and_artifacts_step.tsx
@@ -14,6 +14,16 @@ import { RelatedDashboardSelector, RunbookArtifactField } from '../../../form/fi
 export function DetailsAndArtifactsStep() {
   return (
     <>
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.detailsAndArtifacts.ruleDetailsTitle"
+            defaultMessage="Rule details"
+          />
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+
       {/* Name, description, tags -- connected to RHF via useFormContext() internally */}
       <RuleDetailsFieldGroup />
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -20,6 +20,7 @@ import {
   EuiFlexItem,
   EuiFormErrorText,
   EuiFormRow,
+  EuiHorizontalRule,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
@@ -544,7 +545,7 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
       </EuiFormRow>
 
       {/* ── Stats ── */}
-      <EuiSpacer size="m" />
+      <EuiHorizontalRule margin="m" />
       <EuiTitle size="xxs">
         <h4>
           <FormattedMessage id="xpack.alertingV2.ruleBuilder.statsTitle" defaultMessage="Stats" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -417,13 +417,13 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
       {/* ── Header with preview icon ── */}
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiTitle size="xs">
-            <h3>
+          <EuiTitle size="xxs">
+            <h4>
               <FormattedMessage
                 id="xpack.alertingV2.ruleBuilder.dataSource.title"
                 defaultMessage="Data source"
               />
-            </h3>
+            </h4>
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -417,13 +417,13 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
       {/* ── Header with preview icon ── */}
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiTitle size="xxs">
-            <h4>
+          <EuiTitle size="xs">
+            <h3>
               <FormattedMessage
                 id="xpack.alertingV2.ruleBuilder.dataSource.title"
                 defaultMessage="Data source"
               />
-            </h4>
+            </h3>
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

Adds section titles to the v2 rule authoring flyout to match the M2 design audit.

Closes [#rna-543](https://github.com/elastic/rna-program/issues/543) & closes [#rna-545](https://github.com/elastic/rna-program/issues/545)

## Test plan

- [ ] Open **Create ES|QL rule** flyout (alert kind) and verify step 1 shows **Alert conditions** above query fields and **Rule execution** above alert delay / schedule / lookback
- [ ] Repeat step 1 check for **signal** kind — **Rule execution** should still appear; alert delay should not
- [ ] Open **Create threshold rule** flyout and verify step 1 shows the same section titles, with **Data source** visually smaller than **Alert conditions**
- [ ] On step 3 (Details & Artifacts), verify **Rule details** appears above name/description/tags and **Artifacts** remains below the horizontal rule
- [ ] Confirm create and edit flows for both rule types
- [ ] Confirm you see `EuiHorizontalRule` between major blocks in the flyouts (both compose discover & rule builder)
- [x] Unit tests pass:
  ```bash
  node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx```
  
  
<img width="1238" height="642" alt="image" src="https://github.com/user-attachments/assets/bf18673c-54e7-41b0-8c34-f8ce0ee6c91c" />
<img width="481" height="656" alt="image" src="https://github.com/user-attachments/assets/f27e8ac8-de8f-4f8b-b22d-cb39397e83b0" />

Threshold rule: 

<img width="485" height="651" alt="image" src="https://github.com/user-attachments/assets/2fd4b7f4-9630-42f6-b271-79dd64f64228" />

