### PR TITLE
[9.5] [Discover][Metrics] Fix flaky inspect test by removing conditional Statistics tab assertion (#278794)

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/inspect.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/inspect.spec.ts
@@ -56,18 +56,13 @@ spaceTest.describe(
           await expect(inspector.viewChooser).toBeVisible();
         });
 
-        await spaceTest.step('switch to Requests view and verify statistics', async () => {
+        await spaceTest.step('switch to Requests view and verify request details', async () => {
           await inspector.switchToView('Requests');
-          await inspector.requests.statisticsTab.click();
-          await expect(inspector.requests.timestamp).toBeVisible();
-        });
-
-        await spaceTest.step('view request details', async () => {
           await inspector.requests.requestTab.click();
           await expect(inspector.requests.codeViewer).toBeVisible();
         });
 
-        await spaceTest.step('view response details', async () => {
+        await spaceTest.step('verify response details', async () => {
           await inspector.requests.responseTab.click();
           await expect(inspector.requests.codeViewer).toBeVisible();
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Discover][Metrics] Fix flaky inspect test by removing conditional Statistics tab assertion (#278794)](https://github.com/elastic/kibana/pull/278794)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco Fabregat","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2026-07-16T15:46:32Z","message":"[Discover][Metrics] Fix flaky inspect test by removing conditional Statistics tab assertion (#278794)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/272561\n\nThe `inspect.spec.ts` test was asserting the Statistics tab in the\ninspector, but that tab is only rendered when `request.stats `is\npopulated.\n\nFor a failed ES|QL request, `stats` is never set, so `shouldShow`\nreturns false and the tab is absent from the DOM. The test was not\nasserting bad behaviour, it was hitting a real application 500, but\ntying a navigation test to a data-conditional tab made it unreliable\nregardless of the root cause.\n\nThe fix removes the Statistics step and keeps only the always-present\nRequest and Response tab assertions, which is what a \"navigate through\nviews and tabs\" test should cover. If Statistics-tab rendering needs\nexplicit coverage, that belongs in a dedicated test that guarantees\nrequest success.","sha":"635a0a68508d21e22c8ffbf6b987e4d253cc9580","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Feature:Metrics in Discover","Team:obs-exploration","v9.5.0","reviewer:scout","v9.6.0"],"title":"[Discover][Metrics] Fix flaky inspect test by removing conditional Statistics tab assertion","number":278794,"url":"https://github.com/elastic/kibana/pull/278794","mergeCommit":{"message":"[Discover][Metrics] Fix flaky inspect test by removing conditional Statistics tab assertion (#278794)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/272561\n\nThe `inspect.spec.ts` test was asserting the Statistics tab in the\ninspector, but that tab is only rendered when `request.stats `is\npopulated.\n\nFor a failed ES|QL request, `stats` is never set, so `shouldShow`\nreturns false and the tab is absent from the DOM. The test was not\nasserting bad behaviour, it was hitting a real application 500, but\ntying a navigation test to a data-conditional tab made it unreliable\nregardless of the root cause.\n\nThe fix removes the Statistics step and keeps only the always-present\nRequest and Response tab assertions, which is what a \"navigate through\nviews and tabs\" test should cover. If Statistics-tab rendering needs\nexplicit coverage, that belongs in a dedicated test that guarantees\nrequest success.","sha":"635a0a68508d21e22c8ffbf6b987e4d253cc9580"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278794","number":278794,"mergeCommit":{"message":"[Discover][Metrics] Fix flaky inspect test by removing conditional Statistics tab assertion (#278794)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/272561\n\nThe `inspect.spec.ts` test was asserting the Statistics tab in the\ninspector, but that tab is only rendered when `request.stats `is\npopulated.\n\nFor a failed ES|QL request, `stats` is never set, so `shouldShow`\nreturns false and the tab is absent from the DOM. The test was not\nasserting bad behaviour, it was hitting a real application 500, but\ntying a navigation test to a data-conditional tab made it unreliable\nregardless of the root cause.\n\nThe fix removes the Statistics step and keeps only the always-present\nRequest and Response tab assertions, which is what a \"navigate through\nviews and tabs\" test should cover. If Statistics-tab rendering needs\nexplicit coverage, that belongs in a dedicated test that guarantees\nrequest success.","sha":"635a0a68508d21e22c8ffbf6b987e4d253cc9580"}}]}] BACKPORT-->