### PR TITLE
[Cases] Enable add-to-chat by default

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -33,7 +33,7 @@ describe('config validation', () => {
             "settings": false,
           },
           "chat": Object {
-            "enabled": false,
+            "enabled": true,
           },
           "enabled": true,
           "files": Object {
@@ -161,14 +161,14 @@ describe('config validation', () => {
       expect(config.attachments.enabled).toBe(false);
     });
 
-    it('sets chat.enabled default to false', () => {
+    it('sets chat.enabled default to true', () => {
       const config = ConfigSchema.validate({});
-      expect(config.chat.enabled).toBe(false);
+      expect(config.chat.enabled).toBe(true);
     });
 
-    it('allows chat.enabled to be set to true', () => {
-      const config = ConfigSchema.validate({ chat: { enabled: true } });
-      expect(config.chat.enabled).toBe(true);
+    it('allows chat.enabled to be set to false', () => {
+      const config = ConfigSchema.validate({ chat: { enabled: false } });
+      expect(config.chat.enabled).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -117,7 +117,7 @@ export const ConfigSchema = schema.object({
     enabled: schema.boolean({ defaultValue: false }),
   }),
   chat: schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
+    enabled: schema.boolean({ defaultValue: true }),
   }),
   markdownPlugins: schema.object({
     lens: schema.boolean({ defaultValue: true }),

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -42,7 +42,7 @@ function getConfig(overrides: Partial<ConfigType> = {}): ConfigType {
     templates: { enabled: true },
     casesRedesign: { list: false, details: false, settings: false },
     attachments: { enabled: true },
-    chat: { enabled: false },
+    chat: { enabled: true },
     ...overrides,
   };
 }
@@ -169,7 +169,7 @@ describe('Cases Plugin', () => {
               "settings": false,
             },
             "chat": Object {
-              "enabled": false,
+              "enabled": true,
             },
             "enabled": true,
             "files": Object {


### PR DESCRIPTION
## Summary

Enables the "Add to chat" button by default

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->