### PR TITLE
[8.19] [selective testing] add moon strategy in triage mode for Scout (#276763)

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/README.md
+++ b/.buildkite/pipeline-utils/affected-packages/README.md
@@ -133,3 +133,9 @@ const filteredFiles = filterFilesByPackages(
 ## PR Jest selective testing
 
 On pull request builds, Jest unit and integration test groups are narrowed to configs under affected packages (see `pick_test_group_run_order` in CI stats). Add the GitHub label `ci:prevent-selective-testing` to run the full Jest suite instead. Touching files listed in `CRITICAL_FILES_JEST_*` in `const.ts` also skips filtering for the relevant test type.
+
+## Scout selective testing: git -> Moon (shadow mode)
+
+`resolve_selective_testing.ts` still uses **git** as the authoritative strategy (written to `.scout/code_changes.json`, no behavior change). In parallel, it runs the **Moon** strategy above for observation only, and writes the result plus a diff of `affectedModules` to `.scout/code_changes.moon_shadow.json` (uploaded as a Buildkite artifact). Mismatches are logged as a warning via `ToolingLog`; a Moon failure is swallowed and logged, never fails the build.
+
+Once shadow-mode data shows git and Moon agree across real PR traffic, Moon will become authoritative and the git path removed (follow-up change, not yet done).

--- a/.buildkite/pipeline-utils/affected-packages/index.ts
+++ b/.buildkite/pipeline-utils/affected-packages/index.ts
@@ -14,6 +14,7 @@ import { getAffectedProjectsMoon } from './strategy_moon';
 export * from './const';
 export * from './utils';
 export { listChangedFiles } from './strategy_git';
+export { getAffectedProjectsMoon } from './strategy_moon';
 
 export interface AffectedPackagesConfig {
   strategy?: 'git' | 'moon';

--- a/.buildkite/pipeline-utils/affected-packages/strategy_moon.test.ts
+++ b/.buildkite/pipeline-utils/affected-packages/strategy_moon.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('child_process');
+jest.mock('fs');
+jest.mock('../utils', () => ({ getKibanaDir: () => '/repo' }));
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { getAffectedProjectsMoon } from './strategy_moon';
+
+const mockExecSync = execSync as jest.Mock;
+const mockExistsSync = existsSync as jest.Mock;
+
+const moonResponse = JSON.stringify({ projects: [{ id: '@kbn/foo' }] });
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getAffectedProjectsMoon', () => {
+  it('invokes the moon binary directly from node_modules/.bin (not via PATH)', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecSync.mockReturnValue(moonResponse);
+
+    const result = getAffectedProjectsMoon('main', false);
+
+    expect(result).toEqual(new Set(['@kbn/foo']));
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('/repo/node_modules/.bin/moon'),
+      expect.objectContaining({ env: expect.objectContaining({ MOON_BASE: 'main' }) })
+    );
+  });
+
+  it('falls back to `yarn which moon` when node_modules/.bin/moon is missing', () => {
+    mockExistsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValueOnce('/resolved/moon\n').mockReturnValueOnce(moonResponse);
+
+    getAffectedProjectsMoon('main', false);
+
+    expect(mockExecSync).toHaveBeenNthCalledWith(1, 'yarn --silent which moon', expect.anything());
+    expect(mockExecSync).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('/resolved/moon'),
+      expect.anything()
+    );
+  });
+});

--- a/.buildkite/pipeline-utils/affected-packages/strategy_moon.ts
+++ b/.buildkite/pipeline-utils/affected-packages/strategy_moon.ts
@@ -8,16 +8,28 @@
  */
 
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import path from 'path';
 import { getKibanaDir } from '../utils';
 
 const REPO_ROOT = getKibanaDir();
+
+/** Resolves `moon`'s absolute path — run via `ts-node`, not yarn, so it's not on `PATH`. */
+function getMoonBinPath(): string {
+  const moonBinPath = path.resolve(REPO_ROOT, 'node_modules/.bin/moon');
+  if (existsSync(moonBinPath)) {
+    return moonBinPath;
+  }
+
+  return execSync('yarn --silent which moon', { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+}
 
 export function getAffectedProjectsMoon(
   mergeBase: string,
   includeDownstream: boolean
 ): Set<string> {
   const downstreamFlag = includeDownstream ? '--downstream deep' : '';
-  const command = `moon query projects --affected ${downstreamFlag}`;
+  const command = `"${getMoonBinPath()}" query projects --affected ${downstreamFlag}`;
 
   const output = execSync(command, {
     cwd: REPO_ROOT,

--- a/.buildkite/scripts/steps/test/scout/moon_shadow.test.ts
+++ b/.buildkite/scripts/steps/test/scout/moon_shadow.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('#pipeline-utils', () => ({
+  getAffectedProjectsMoon: jest.fn(),
+}));
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import { getAffectedProjectsMoon } from '#pipeline-utils';
+import { computeMoonShadow } from './moon_shadow';
+
+const mockGetAffectedProjectsMoon = getAffectedProjectsMoon as jest.Mock;
+
+const createMockLog = (): ToolingLog =>
+  ({ info: jest.fn(), warning: jest.fn() } as unknown as ToolingLog);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('computeMoonShadow', () => {
+  it('reports an empty diff when git and moon agree', () => {
+    mockGetAffectedProjectsMoon.mockReturnValue(new Set(['@kbn/foo']));
+    const log = createMockLog();
+
+    const result = computeMoonShadow({
+      mergeBase: 'main',
+      gitChangedFiles: [],
+      gitAffectedModules: new Set(['@kbn/foo']),
+      log,
+    });
+
+    expect(result?.diffFromGit).toEqual({ onlyInGit: [], onlyInMoon: [] });
+    expect(log.warning).not.toHaveBeenCalled();
+  });
+
+  it('reports the diff and logs a warning when git and moon disagree', () => {
+    mockGetAffectedProjectsMoon.mockReturnValue(new Set(['@kbn/moon-only']));
+    const log = createMockLog();
+
+    const result = computeMoonShadow({
+      mergeBase: 'main',
+      gitChangedFiles: [],
+      gitAffectedModules: new Set(['@kbn/git-only']),
+      log,
+    });
+
+    expect(result?.diffFromGit).toEqual({
+      onlyInGit: ['@kbn/git-only'],
+      onlyInMoon: ['@kbn/moon-only'],
+    });
+    expect(log.warning).toHaveBeenCalled();
+  });
+
+  it('returns null and logs a warning instead of throwing when moon fails', () => {
+    mockGetAffectedProjectsMoon.mockImplementation(() => {
+      throw new Error('moon binary not found');
+    });
+    const log = createMockLog();
+
+    const result = computeMoonShadow({
+      mergeBase: 'main',
+      gitChangedFiles: [],
+      gitAffectedModules: new Set(),
+      log,
+    });
+
+    expect(result).toBeNull();
+    expect(log.warning).toHaveBeenCalled();
+  });
+
+  it('overlays implicit consumers from the changed-files list', () => {
+    mockGetAffectedProjectsMoon.mockReturnValue(new Set(['@kbn/ml-plugin']));
+
+    const result = computeMoonShadow({
+      mergeBase: 'main',
+      gitChangedFiles: ['x-pack/plugins/ml/public/embeddables/register.ts'],
+      gitAffectedModules: new Set(),
+      log: createMockLog(),
+    });
+
+    expect(result?.affectedModules).toEqual(expect.arrayContaining(['@kbn/dashboard-plugin']));
+  });
+});

--- a/.buildkite/scripts/steps/test/scout/moon_shadow.ts
+++ b/.buildkite/scripts/steps/test/scout/moon_shadow.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Computes Moon's affected-modules result for comparison against git —
+ * observational only, never influences the actual selective-testing
+ * decision. Swallows Moon failures and returns `null` instead of throwing.
+ * See `affected-packages/README.md`.
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import { expandWithImplicitConsumers } from './scout_implicit_consumers';
+import { getAffectedProjectsMoon } from '#pipeline-utils';
+
+export interface MoonShadowResult {
+  mergeBase: string;
+  affectedModules: string[];
+  diffFromGit: {
+    onlyInGit: string[];
+    onlyInMoon: string[];
+  };
+}
+
+export function computeMoonShadow({
+  mergeBase,
+  gitChangedFiles,
+  gitAffectedModules,
+  log,
+}: {
+  mergeBase: string;
+  gitChangedFiles: readonly string[];
+  gitAffectedModules: ReadonlySet<string>;
+  log: ToolingLog;
+}): MoonShadowResult | null {
+  try {
+    const moonAffectedModules = expandWithImplicitConsumers(
+      getAffectedProjectsMoon(mergeBase, true),
+      gitChangedFiles,
+      log
+    );
+
+    const onlyInGit = [...gitAffectedModules].filter((m) => !moonAffectedModules.has(m)).sort();
+    const onlyInMoon = [...moonAffectedModules].filter((m) => !gitAffectedModules.has(m)).sort();
+
+    if (onlyInGit.length > 0 || onlyInMoon.length > 0) {
+      log.warning(
+        `Selective testing shadow mode: git/moon affected-modules mismatch — ` +
+          `onlyInGit=[${onlyInGit.join(', ')}] onlyInMoon=[${onlyInMoon.join(', ')}]`
+      );
+    } else {
+      log.info('Selective testing shadow mode: git and moon affected-modules match');
+    }
+
+    return {
+      mergeBase,
+      affectedModules: [...moonAffectedModules].sort(),
+      diffFromGit: { onlyInGit, onlyInMoon },
+    };
+  } catch (error) {
+    log.warning(
+      `Selective testing shadow mode: Moon comparison failed, skipping (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    );
+    return null;
+  }
+}

--- a/.buildkite/scripts/steps/test/scout/resolve_selective_testing.ts
+++ b/.buildkite/scripts/steps/test/scout/resolve_selective_testing.ts
@@ -29,12 +29,17 @@
  *     "changedFiles": ["src/...", ...],
  *     "affectedModules": ["@kbn/foo", ...]
  *   }
+ *
+ * Shadow mode: also computes the same result via Moon and writes it to
+ * `<outPath>.moon_shadow.json` for comparison only — never affects the
+ * actual decision. See affected-packages/README.md.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { ToolingLog } from '@kbn/tooling-log';
 import { expandWithImplicitConsumers } from './scout_implicit_consumers';
+import { computeMoonShadow } from './moon_shadow';
 import { getAffectedPackages, listChangedFiles } from '#pipeline-utils';
 
 const log = new ToolingLog({ level: 'info', writeTo: process.stderr });
@@ -72,4 +77,18 @@ if (!mergeBase || !outPath) {
   const resolvedOutPath = path.resolve(outPath);
   fs.mkdirSync(path.dirname(resolvedOutPath), { recursive: true });
   fs.writeFileSync(resolvedOutPath, JSON.stringify(codeChanges, null, 2));
+
+  const moonShadow = computeMoonShadow({
+    mergeBase,
+    gitChangedFiles: changedFiles,
+    gitAffectedModules: affectedPackages,
+    log,
+  });
+  if (moonShadow) {
+    const shadowOutPath = path.join(
+      path.dirname(resolvedOutPath),
+      `${path.basename(resolvedOutPath, path.extname(resolvedOutPath))}.moon_shadow.json`
+    );
+    fs.writeFileSync(shadowOutPath, JSON.stringify(moonShadow, null, 2));
+  }
 })();

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -61,6 +61,12 @@ buildkite-agent artifact upload "$CODE_CHANGES_FILE"
 # this artifact.
 buildkite-agent artifact upload "$TESTING_SCOPE_FILE"
 
+# Moon shadow-mode comparison (observational only); upload if present.
+CODE_CHANGES_MOON_SHADOW_FILE=".scout/code_changes.moon_shadow.json"
+if [[ -f "$CODE_CHANGES_MOON_SHADOW_FILE" ]]; then
+  buildkite-agent artifact upload "$CODE_CHANGES_MOON_SHADOW_FILE"
+fi
+
 SCOUT_TEST_DISTRIBUTION_STRATEGY="${SCOUT_TEST_DISTRIBUTION_STRATEGY:-configs}"
 
 if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then

--- a/src/platform/packages/private/kbn-scout-info/src/paths.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.ts
@@ -194,4 +194,6 @@ export const CRITICAL_FILES_SCOUT: readonly string[] = [
   '.buildkite/scripts/steps/test/scout/**/*',
   '.buildkite/pipeline-utils/affected-packages/**/*.{ts,js,sh}',
   '.buildkite/pipeline-utils/ci-stats/**/*.{ts,js}',
+  // Controls which directories Moon scans for projects.
+  '.moon/workspace.yml',
 ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[selective testing] add moon strategy in triage mode for Scout (#276763)](https://github.com/elastic/kibana/pull/276763)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-09T08:02:27Z","message":"[selective testing] add moon strategy in triage mode for Scout (#276763)\n\n## Summary\n\n- Adds a Moon-based \"shadow\" strategy alongside Scout's existing\ngit-based selective testing. Git remains the one we use in pipelines\n(`code_changes.json`, no behavior change); Moon runs in parallel purely\nfor observation.\n- Writes Moon's affected-modules result + a diff against git to\n`code_changes.moon_shadow.json` (uploaded as a Buildkite artifact), and\nlogs a warning when the two disagree. Any Moon failure is swallowed: it\ncan never fail a build.\n<img width=\"1707\" height=\"424\" alt=\"Screenshot 2026-07-08 at 11 27 45\"\nsrc=\"https://github.com/user-attachments/assets/f8b0c240-7b0c-4c29-8fe6-bd9c1688f580\"\n/>\n\n- Adds `.moon/workspace.yml` to `CRITICAL_FILES_SCOUT` so changes to\nMoon's project-scanning config still trigger a full Scout run.\n\n#### Switching to Moon later:\n\nOnce shadow-mode data across real PRs shows git and Moon are alligned,\nwe should:\n\n1. In `resolve_selective_testing.ts` replace the git-strategy call with\n`getAffectedProjectsMoon` (already used by the shadow path) to build\n`code_changes.json` directly.\n2. Delete `moon_shadow.ts` + its test as it only exists for diff\ntesting.\n3. Remove the `code_changes.moon_shadow.json` upload step from\n`test_run_builder.sh`.","sha":"96faee8eb29cc4a421d4ef82f79e24d1dd1c22f9","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.5.0","v9.4.4","reviewer:scout","v9.3.8"],"title":"[selective testing] add moon strategy in triage mode for Scout","number":276763,"url":"https://github.com/elastic/kibana/pull/276763","mergeCommit":{"message":"[selective testing] add moon strategy in triage mode for Scout (#276763)\n\n## Summary\n\n- Adds a Moon-based \"shadow\" strategy alongside Scout's existing\ngit-based selective testing. Git remains the one we use in pipelines\n(`code_changes.json`, no behavior change); Moon runs in parallel purely\nfor observation.\n- Writes Moon's affected-modules result + a diff against git to\n`code_changes.moon_shadow.json` (uploaded as a Buildkite artifact), and\nlogs a warning when the two disagree. Any Moon failure is swallowed: it\ncan never fail a build.\n<img width=\"1707\" height=\"424\" alt=\"Screenshot 2026-07-08 at 11 27 45\"\nsrc=\"https://github.com/user-attachments/assets/f8b0c240-7b0c-4c29-8fe6-bd9c1688f580\"\n/>\n\n- Adds `.moon/workspace.yml` to `CRITICAL_FILES_SCOUT` so changes to\nMoon's project-scanning config still trigger a full Scout run.\n\n#### Switching to Moon later:\n\nOnce shadow-mode data across real PRs shows git and Moon are alligned,\nwe should:\n\n1. In `resolve_selective_testing.ts` replace the git-strategy call with\n`getAffectedProjectsMoon` (already used by the shadow path) to build\n`code_changes.json` directly.\n2. Delete `moon_shadow.ts` + its test as it only exists for diff\ntesting.\n3. Remove the `code_changes.moon_shadow.json` upload step from\n`test_run_builder.sh`.","sha":"96faee8eb29cc4a421d4ef82f79e24d1dd1c22f9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276763","number":276763,"mergeCommit":{"message":"[selective testing] add moon strategy in triage mode for Scout (#276763)\n\n## Summary\n\n- Adds a Moon-based \"shadow\" strategy alongside Scout's existing\ngit-based selective testing. Git remains the one we use in pipelines\n(`code_changes.json`, no behavior change); Moon runs in parallel purely\nfor observation.\n- Writes Moon's affected-modules result + a diff against git to\n`code_changes.moon_shadow.json` (uploaded as a Buildkite artifact), and\nlogs a warning when the two disagree. Any Moon failure is swallowed: it\ncan never fail a build.\n<img width=\"1707\" height=\"424\" alt=\"Screenshot 2026-07-08 at 11 27 45\"\nsrc=\"https://github.com/user-attachments/assets/f8b0c240-7b0c-4c29-8fe6-bd9c1688f580\"\n/>\n\n- Adds `.moon/workspace.yml` to `CRITICAL_FILES_SCOUT` so changes to\nMoon's project-scanning config still trigger a full Scout run.\n\n#### Switching to Moon later:\n\nOnce shadow-mode data across real PRs shows git and Moon are alligned,\nwe should:\n\n1. In `resolve_selective_testing.ts` replace the git-strategy call with\n`getAffectedProjectsMoon` (already used by the shadow path) to build\n`code_changes.json` directly.\n2. Delete `moon_shadow.ts` + its test as it only exists for diff\ntesting.\n3. Remove the `code_changes.moon_shadow.json` upload step from\n`test_run_builder.sh`.","sha":"96faee8eb29cc4a421d4ef82f79e24d1dd1c22f9"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277124","number":277124,"state":"MERGED","mergeCommit":{"sha":"ff8b7967d30ca8d9af1ded8bda0055fd61b1b6e1","message":"[9.4] [selective testing] add moon strategy in triage mode for Scout (#276763) (#277124)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[selective testing] add moon strategy in triage mode for Scout\n(#276763)](https://github.com/elastic/kibana/pull/276763)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/277123","number":277123,"state":"MERGED","mergeCommit":{"sha":"7fa8d26d07f9d19dfb41edd9282821333d8cf247","message":"[9.3] [selective testing] add moon strategy in triage mode for Scout (#276763) (#277123)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[selective testing] add moon strategy in triage mode for Scout\n(#276763)](https://github.com/elastic/kibana/pull/276763)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->