### PR TITLE
[9.4] [query_activity] Register i18n namespace (#278849)

### DIFF
--- a/x-pack/.i18nrc.json
+++ b/x-pack/.i18nrc.json
@@ -114,6 +114,7 @@
       "platform/plugins/shared/osquery"
     ],
     "xpack.painlessLab": "platform/plugins/private/painless_lab",
+    "xpack.queryActivity": "platform/plugins/shared/query_activity",
     "xpack.profiling": [
       "solutions/observability/plugins/profiling"
     ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[query_activity] Register i18n namespace (#278849)](https://github.com/elastic/kibana/pull/278849)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-17T08:40:06Z","message":"[query_activity] Register i18n namespace (#278849)\n\n## Summary\n\nThe `query_activity` module used `xpack.queryActivity` i18n strings\nwhose namespace was never registered in `x-pack/.i18nrc.json`. Because\nextraction is namespace-driven, those strings were silently skipped by\n`i18n_extract` — they had no entries in any locale file and only\nrendered their English `defaultMessage` in non-English Kibana.\n\nThis PR:\n- Added the missing `xpack.queryActivity` i18n namespace to\n`x-pack/.i18nrc.json` for `query_activity`, so its strings are now\nextracted and eligible for translation.","sha":"50bcd3e8cf8478e8c66dede910bf0d96b096d19e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:version","v9.5.0","v9.4.4","v9.6.0"],"title":"[query_activity] Register i18n namespace","number":278849,"url":"https://github.com/elastic/kibana/pull/278849","mergeCommit":{"message":"[query_activity] Register i18n namespace (#278849)\n\n## Summary\n\nThe `query_activity` module used `xpack.queryActivity` i18n strings\nwhose namespace was never registered in `x-pack/.i18nrc.json`. Because\nextraction is namespace-driven, those strings were silently skipped by\n`i18n_extract` — they had no entries in any locale file and only\nrendered their English `defaultMessage` in non-English Kibana.\n\nThis PR:\n- Added the missing `xpack.queryActivity` i18n namespace to\n`x-pack/.i18nrc.json` for `query_activity`, so its strings are now\nextracted and eligible for translation.","sha":"50bcd3e8cf8478e8c66dede910bf0d96b096d19e"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279127","number":279127,"state":"OPEN"},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278849","number":278849,"mergeCommit":{"message":"[query_activity] Register i18n namespace (#278849)\n\n## Summary\n\nThe `query_activity` module used `xpack.queryActivity` i18n strings\nwhose namespace was never registered in `x-pack/.i18nrc.json`. Because\nextraction is namespace-driven, those strings were silently skipped by\n`i18n_extract` — they had no entries in any locale file and only\nrendered their English `defaultMessage` in non-English Kibana.\n\nThis PR:\n- Added the missing `xpack.queryActivity` i18n namespace to\n`x-pack/.i18nrc.json` for `query_activity`, so its strings are now\nextracted and eligible for translation.","sha":"50bcd3e8cf8478e8c66dede910bf0d96b096d19e"}}]}] BACKPORT-->