### PR TITLE
[9.5] [APM] Migrate team ownership to @elastic/obs-signals-traces (#278046)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -518,10 +518,10 @@ src/platform/packages/shared/kbn-alerts-ui-shared @elastic/response-ops
 src/platform/packages/shared/kbn-ambient-storybook-types @elastic/kibana-operations
 src/platform/packages/shared/kbn-ambient-ui-types @elastic/kibana-operations
 src/platform/packages/shared/kbn-analytics @elastic/kibana-core
-src/platform/packages/shared/kbn-apm-data-view @elastic/obs-presentation-team @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-presentation-team @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-presentation-team @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-apm-utils @elastic/obs-presentation-team @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-apm-data-view @elastic/obs-signals-traces
+src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-signals-traces
+src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-signals-traces
+src/platform/packages/shared/kbn-apm-utils @elastic/obs-signals-traces
 src/platform/packages/shared/kbn-avc-banner @elastic/security-defend-workflows
 src/platform/packages/shared/kbn-axe-config @elastic/appex-qa
 src/platform/packages/shared/kbn-babel-register @elastic/kibana-operations
@@ -1042,9 +1042,9 @@ x-pack/platform/packages/shared/kbn-ai-assistant @elastic/search-kibana @elastic
 x-pack/platform/packages/shared/kbn-ai-tools @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-ai-tools-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
-x-pack/platform/packages/shared/kbn-apm-api-shared @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/kbn-apm-common @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/kbn-apm-api-shared @elastic/obs-signals-traces
+x-pack/platform/packages/shared/kbn-apm-common @elastic/obs-signals-traces
+x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-signals-traces
 x-pack/platform/packages/shared/kbn-change-history @elastic/security-detection-engineering
 x-pack/platform/packages/shared/kbn-change-history-ui @elastic/workflows-eng
 x-pack/platform/packages/shared/kbn-classic-stream-flyout @elastic/kibana-management
@@ -1195,7 +1195,7 @@ x-pack/platform/plugins/shared/aiops @elastic/ml-ui
 x-pack/platform/plugins/shared/alerting @elastic/response-ops
 x-pack/platform/plugins/shared/alerting_v2 @elastic/rna-project-team
 x-pack/platform/plugins/shared/anonymization @elastic/workchat-eng @elastic/security-threat-hunting
-x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-signals-traces
 x-pack/platform/plugins/shared/automatic_import @elastic/integration-experience
 x-pack/platform/plugins/shared/cases @elastic/kibana-cases
 x-pack/platform/plugins/shared/cloud @elastic/kibana-core
@@ -1298,7 +1298,7 @@ x-pack/solutions/observability/packages/alert-details @elastic/actionable-obs-te
 x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
-x-pack/solutions/observability/packages/kbn-apm-embeddable-common @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/solutions/observability/packages/kbn-apm-embeddable-common @elastic/obs-signals-traces
 x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai @elastic/nightshift-context-and-research-team
 x-pack/solutions/observability/packages/kbn-genai-cli @elastic/nightshift-context-and-research-team
@@ -1314,9 +1314,9 @@ x-pack/solutions/observability/packages/synthetics-test-data @elastic/actionable
 x-pack/solutions/observability/packages/utils-browser @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-common @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-server @elastic/observability-ui
-x-pack/solutions/observability/plugins/apm @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/solutions/observability/plugins/apm @elastic/obs-signals-traces
+x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-signals-traces
+x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-signals-traces
 x-pack/solutions/observability/plugins/exploratory_view @elastic/actionable-obs-team
 x-pack/solutions/observability/plugins/infra @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/metrics_data_access @elastic/obs-presentation-team
@@ -1806,11 +1806,11 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## This should allow the infra team to work without dependencies on the @elastic/obs-exploration-team, which will maintain ownership of the Logs UI code only.
 
 ## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-signals-traces
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/infra/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.serverless.config.ts @elastic/obs-presentation-team
@@ -1999,12 +1999,12 @@ x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/significa
 /x-pack/platform/test/serverless/api_integration/services/default_fleet_setup.ts @elastic/fleet
 
 # APM
-/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-presentation-team
+/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-signals-traces
 /src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-signals-traces
 #CC# /src/plugins/apm_oss/ @elastic/apm-ui
 #CC# /x-pack/plugins/observability_solution/observability/ @elastic/apm-ui
 
@@ -2022,7 +2022,7 @@ x-pack/platform/plugins/shared/significant_events/test/scout/api/tests/significa
 /src/platform/test/functional/apps/discover/observability @elastic/obs-exploration-team
 
 # obs-exploration-team
-/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links @elastic/obs-exploration-team
+/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links @elastic/obs-signals-traces
 /x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/ @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/serverless/functional/utils/ @elastic/obs-exploration-team
 /src/platform/test/functional/apps/discover/observability/logs/ @elastic/obs-exploration-team

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.test.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.test.ts
@@ -63,6 +63,7 @@ const LEGACY_CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-knowledge-team',
     'elastic/obs-onboarding-team',
     'elastic/obs-presentation-team',
+    'elastic/obs-signals-traces',
     'elastic/obs-ux-management-team',
     'elastic/observability-bi',
     'elastic/observability-design',

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -591,6 +591,23 @@
     ]
   },
   {
+    "id": "obs-signals-traces",
+    "name": "Obs UX: Signals & Traces",
+    "areas": [
+      "observability"
+    ],
+    "github": {
+      "team": "elastic/obs-signals-traces",
+      "label": "Team:obs-signals-traces"
+    },
+    "responsibilities": [
+      "APM",
+      "Distributed tracing",
+      "Service maps",
+      "APM data access"
+    ]
+  },
+  {
     "id": "obs-sig-events-team",
     "name": "Obs Sig Events Team",
     "areas": [

--- a/src/platform/packages/shared/kbn-apm-data-view/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-data-view/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-data-view",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-data-view/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-data-view/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-data-view'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-data-view'
   description: Moon project for @kbn/apm-data-view
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: src/platform/packages/shared/kbn-apm-data-view
 tags:
   - shared-common

--- a/src/platform/packages/shared/kbn-apm-types-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-types-shared/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-types-shared",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-types-shared/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-types-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-types-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-types-shared'
   description: Moon project for @kbn/apm-types-shared
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: src/platform/packages/shared/kbn-apm-types-shared
 dependsOn: []
 tags:

--- a/src/platform/packages/shared/kbn-apm-ui-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/apm-ui-shared",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-ui-shared/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-ui-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-ui-shared'
   description: Moon project for @kbn/apm-ui-shared
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: src/platform/packages/shared/kbn-apm-ui-shared
 dependsOn:
   - '@kbn/i18n'

--- a/src/platform/packages/shared/kbn-apm-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-utils/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-utils",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-utils'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-utils'
   description: Moon project for @kbn/apm-utils
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: src/platform/packages/shared/kbn-apm-utils
 dependsOn:
   - '@kbn/tracing-utils'

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-api-shared",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-api-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-api-shared'
   description: Moon project for @kbn/apm-api-shared
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/platform/packages/shared/kbn-apm-api-shared
 dependsOn:
   - '@kbn/server-route-repository-utils'

--- a/x-pack/platform/packages/shared/kbn-apm-common/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-apm-common/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-common",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-apm-common/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-apm-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-common'
   description: Moon project for @kbn/apm-common
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/platform/packages/shared/kbn-apm-common
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/platform/packages/shared/kbn-apm-types/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-apm-types/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-types",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-apm-types/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-apm-types/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-types'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-types'
   description: Moon project for @kbn/apm-types
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/platform/packages/shared/kbn-apm-types
 dependsOn:
   - '@kbn/elastic-agent-utils'

--- a/x-pack/platform/plugins/shared/apm_sources_access/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/apm_sources_access/kibana.jsonc
@@ -1,10 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-sources-access-plugin",
-  "owner": [
-    "@elastic/obs-presentation-team",
-    "@elastic/obs-exploration-team"
-  ],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/apm_sources_access/moon.yml
+++ b/x-pack/platform/plugins/shared/apm_sources_access/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-sources-access-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-sources-access-plugin'
   description: Moon project for @kbn/apm-sources-access-plugin
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/platform/plugins/shared/apm_sources_access
 dependsOn:
   - '@kbn/config-schema'

--- a/x-pack/solutions/observability/packages/kbn-apm-embeddable-common/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-apm-embeddable-common/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-embeddable-common",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/kbn-apm-embeddable-common/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-apm-embeddable-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-embeddable-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-embeddable-common'
   description: Moon project for @kbn/apm-embeddable-common
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/solutions/observability/packages/kbn-apm-embeddable-common
 dependsOn: []
 tags:

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/apm-ftr-e2e",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-ftr-e2e'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-ftr-e2e'
   description: Moon project for @kbn/apm-ftr-e2e
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/solutions/observability/plugins/apm/ftr_e2e
 dependsOn:
   - '@kbn/test'

--- a/x-pack/solutions/observability/plugins/apm/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-plugin",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "observability",
   "visibility": "private",
   "description": "The user interface for Elastic APM",

--- a/x-pack/solutions/observability/plugins/apm/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-plugin'
   description: Moon project for @kbn/apm-plugin
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/solutions/observability/plugins/apm
 dependsOn:
   - '@kbn/synthtrace'

--- a/x-pack/solutions/observability/plugins/apm_data_access/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm_data_access/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-data-access-plugin",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/apm_data_access/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm_data_access/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-data-access-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-data-access-plugin'
   description: Moon project for @kbn/apm-data-access-plugin
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces'
   sourceRoot: x-pack/solutions/observability/plugins/apm_data_access
 dependsOn:
   - '@kbn/config-schema'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[APM] Migrate team ownership to @elastic/obs-signals-traces (#278046)](https://github.com/elastic/kibana/pull/278046)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

---

#### Conflict resolution notes

`apm_shared` does not exist on this branch (newer plugin) and was dropped. Some APM paths that still exist on this release branch but were already removed from `main` before the squash merged (`apm/ftr_e2e`, `test/functional/apps/apm/`, `test/apm_cypress/`) were also migrated to `@elastic/obs-signals-traces` to keep the migration consistent. `CODEOWNERS` and all `moon.yml` files were verified against `node scripts/generate codeowners` and `node scripts/regenerate_moon_projects.js` (zero drift).
