### PR TITLE
[Security Solution][Flyout] fix pressing esc closing for timeline andflyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.test.tsx
@@ -9,10 +9,35 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '../../common/mock/react_beautiful_dnd';
-import { TestProviders } from '../../common/mock';
+import { TestProviders, createMockStore, mockGlobalState } from '../../common/mock';
 import { TimelineId } from '../../../common/types/timeline';
 import * as timelineActions from '../store/actions';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { timelineFlyoutHistoryKey } from '../../flyout_v2/shared/constants/flyout_history';
 import { TimelineWrapper } from '.';
+
+/** A `historyKey` unrelated to Timeline, representing a flyout opened before Timeline was shown. */
+const preTimelineHistoryKey = Symbol('pre-timeline-flyout');
+
+/**
+ * Builds a store where the timeline modal is shown (`show: true`), mirroring the
+ * graph "Investigate in Timeline" scenario where the modal is rendered on top of
+ * the expandable flyout.
+ */
+const createVisibleTimelineStore = () =>
+  createMockStore({
+    ...mockGlobalState,
+    timeline: {
+      ...mockGlobalState.timeline,
+      timelineById: {
+        ...mockGlobalState.timeline.timelineById,
+        [TimelineId.test]: {
+          ...mockGlobalState.timeline.timelineById[TimelineId.test],
+          show: true,
+        },
+      },
+    },
+  });
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -27,6 +52,21 @@ jest.mock('../components/timeline', () => ({
   StatefulTimeline: () => <div />,
 }));
 jest.mock('../../common/hooks/timeline/use_timeline_save_prompt');
+jest.mock('../../common/hooks/use_is_new_flyout_enabled');
+
+const mockGetFlyoutManagerState = jest.fn(() => ({ sessions: [] as unknown[] }));
+const mockCloseFlyout = jest.fn();
+const mockCloseAllFlyouts = jest.fn();
+jest.mock('@elastic/eui', () => ({
+  ...jest.requireActual('@elastic/eui'),
+  getFlyoutManagerStore: jest.fn(() => ({
+    getState: mockGetFlyoutManagerState,
+    closeFlyout: mockCloseFlyout,
+    closeAllFlyouts: mockCloseAllFlyouts,
+    addUnmanagedFlyout: jest.fn(),
+    closeUnmanagedFlyout: jest.fn(),
+  })),
+}));
 
 describe('TimelineWrapper', () => {
   const props = {
@@ -36,6 +76,10 @@ describe('TimelineWrapper', () => {
 
   beforeEach(() => {
     mockDispatch.mockClear();
+    mockCloseFlyout.mockClear();
+    mockCloseAllFlyouts.mockClear();
+    mockGetFlyoutManagerState.mockReturnValue({ sessions: [] });
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(false);
   });
 
   it('should render correctly the main timeline elements', () => {
@@ -84,5 +128,278 @@ describe('TimelineWrapper', () => {
     expect(mockDispatch).toBeCalledWith(
       timelineActions.showTimeline({ id: TimelineId.test, show: false })
     );
+  });
+
+  describe('legacy expandable flyout (new flyout system disabled)', () => {
+    beforeEach(() => {
+      (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(false);
+    });
+
+    it('should not bubble the esc keydown to the underlying flyout when the timeline modal is visible', async () => {
+      // The expandable flyout (e.g. the graph investigation view) registers a window-level
+      // keydown listener too. The timeline wrapper mounts first (persistent app shell), so its
+      // listener runs first and must stop the event before the flyout's listener fires.
+      const underlyingFlyoutHandler = jest.fn();
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      window.addEventListener('keydown', underlyingFlyoutHandler);
+
+      try {
+        await userEvent.keyboard('{Escape}');
+
+        // The timeline modal still closes...
+        expect(mockDispatch).toBeCalledWith(
+          timelineActions.showTimeline({ id: TimelineId.test, show: false })
+        );
+        // ...but the underlying flyout's window-level handler is never reached.
+        expect(underlyingFlyoutHandler).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('keydown', underlyingFlyoutHandler);
+      }
+    });
+
+    it('should let the esc keydown reach the underlying flyout when the timeline modal is not visible', async () => {
+      const underlyingFlyoutHandler = jest.fn();
+
+      render(
+        <TestProviders>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      window.addEventListener('keydown', underlyingFlyoutHandler);
+
+      try {
+        await userEvent.keyboard('{Escape}');
+
+        // When the timeline is collapsed, Esc must keep working on other pages/flyouts.
+        expect(underlyingFlyoutHandler).toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('keydown', underlyingFlyoutHandler);
+      }
+    });
+  });
+
+  describe('new (EUI-managed) flyout system enabled', () => {
+    beforeEach(() => {
+      (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+    });
+
+    it('should close a main-level flyout opened from within Timeline via closeAllFlyouts, and not the timeline itself', async () => {
+      // Mirrors EuiManagedFlyout's own `onClose` for a main-level flyout with no child, which
+      // calls `closeAllFlyouts()` (not `closeFlyout(id)`) so that any sibling session sharing
+      // its historyKey is cascade-closed too.
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [
+          { mainFlyoutId: 'flyout-b', childFlyoutId: null, historyKey: timelineFlyoutHistoryKey },
+        ],
+      });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseAllFlyouts).toHaveBeenCalledTimes(1);
+      expect(mockCloseFlyout).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
+
+    it('should close only its child flyout when one is open, keeping its main flyout and the timeline open', async () => {
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [
+          {
+            mainFlyoutId: 'flyout-b',
+            childFlyoutId: 'flyout-b-child',
+            historyKey: timelineFlyoutHistoryKey,
+          },
+        ],
+      });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseFlyout).toBeCalledWith('flyout-b-child');
+      expect(mockCloseFlyout).not.toBeCalledWith('flyout-b');
+      expect(mockDispatch).not.toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
+
+    it('should close only the topmost flyout opened from within Timeline, leaving the flyout opened before Timeline untouched', async () => {
+      // Regression test: flyout A is opened (e.g. from the alerts table, keeping its own
+      // unrelated historyKey), then "Investigate in Timeline" opens the Timeline modal on top,
+      // then flyout B is opened from within Timeline (tagged with `timelineFlyoutHistoryKey`).
+      // Both are independent main sessions with no child of their own, so EUI's own
+      // (globally-scoped) Esc handling would otherwise close both at once. Only B (the one
+      // opened from within Timeline) should close on this Esc press - `closeAllFlyouts` is
+      // scoped to sessions sharing the *topmost* session's historyKey, so A (a different
+      // historyKey) is unaffected.
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [
+          { mainFlyoutId: 'flyout-a', childFlyoutId: null, historyKey: preTimelineHistoryKey },
+          { mainFlyoutId: 'flyout-b', childFlyoutId: null, historyKey: timelineFlyoutHistoryKey },
+        ],
+      });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseAllFlyouts).toHaveBeenCalledTimes(1);
+      expect(mockCloseFlyout).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
+
+    it('should cascade-close a whole within-Timeline flyout stack (eg a tools flyout opened from a document flyout) in one Esc press, revealing Timeline', async () => {
+      // Regression test for the exact scenario reported: open a document flyout from Timeline
+      // (session A), open its Analyzer tool from it - which opens as its *own* top-level
+      // session (session B) sharing A's historyKey, not as A's child - then open a child
+      // document flyout from Analyzer (joins B as its child). Sessions: [A (no child), B (with
+      // child)], both tagged `timelineFlyoutHistoryKey`.
+      //
+      // 1st Esc: closes B's child.
+      // 2nd Esc: B (now childless) closes via `closeAllFlyouts`, which - because A shares B's
+      // historyKey - cascades to close A too, revealing Timeline directly. Using `closeFlyout`
+      // instead would only remove B, incorrectly revealing A instead of Timeline.
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [
+          {
+            mainFlyoutId: 'document-flyout-a',
+            childFlyoutId: null,
+            historyKey: timelineFlyoutHistoryKey,
+          },
+          {
+            mainFlyoutId: 'analyzer-flyout-b',
+            childFlyoutId: null,
+            historyKey: timelineFlyoutHistoryKey,
+          },
+        ],
+      });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseAllFlyouts).toHaveBeenCalledTimes(1);
+      expect(mockCloseFlyout).not.toHaveBeenCalledWith('document-flyout-a');
+      expect(mockCloseFlyout).not.toHaveBeenCalledWith('analyzer-flyout-b');
+      expect(mockDispatch).not.toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
+
+    it('should close the timeline itself (not the underlying flyout) once nothing opened from within Timeline remains on top', async () => {
+      // Regression test: only flyout A remains, opened *before* Timeline was shown (its
+      // historyKey doesn't match `timelineFlyoutHistoryKey`). Esc should close Timeline next,
+      // leaving A untouched until Timeline is gone.
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [
+          { mainFlyoutId: 'flyout-a', childFlyoutId: null, historyKey: preTimelineHistoryKey },
+        ],
+      });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseFlyout).not.toHaveBeenCalled();
+      expect(mockDispatch).toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
+
+    it('should not let the underlying flyouts own (buggy, globally-scoped) Esc listener also fire', async () => {
+      // Asserts the sibling window keydown listener (representing a managed flyout's own
+      // EuiWindowEvent handler) never runs, since we stop propagation ourselves - even when we
+      // end up closing Timeline rather than the flyout itself.
+      const underlyingFlyoutHandler = jest.fn();
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [
+          { mainFlyoutId: 'flyout-a', childFlyoutId: null, historyKey: preTimelineHistoryKey },
+        ],
+      });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      window.addEventListener('keydown', underlyingFlyoutHandler);
+
+      try {
+        await userEvent.keyboard('{Escape}');
+
+        expect(underlyingFlyoutHandler).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('keydown', underlyingFlyoutHandler);
+      }
+    });
+
+    it('should close the timeline itself when no flyout session is active', async () => {
+      mockGetFlyoutManagerState.mockReturnValue({ sessions: [] });
+
+      render(
+        <TestProviders store={createVisibleTimelineStore()}>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseFlyout).not.toHaveBeenCalled();
+      expect(mockDispatch).toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
+
+    it('should not close a flyout session nor the timeline when the timeline is not visible', async () => {
+      mockGetFlyoutManagerState.mockReturnValue({
+        sessions: [{ mainFlyoutId: 'flyout-a', childFlyoutId: null }],
+      });
+
+      render(
+        <TestProviders>
+          <TimelineWrapper {...props} />
+        </TestProviders>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(mockCloseFlyout).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { EuiFocusTrap, EuiWindowEvent, keys } from '@elastic/eui';
-import React, { useMemo, useCallback, useRef } from 'react';
+import { EuiFocusTrap, EuiWindowEvent, getFlyoutManagerStore, keys } from '@elastic/eui';
+import React, { useCallback, useMemo, useRef } from 'react';
 import type { AppLeaveHandler } from '@kbn/core/public';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
@@ -18,6 +18,8 @@ import { getTimelineShowStatusByIdSelector } from '../store/selectors';
 import { useTimelineSavePrompt } from '../../common/hooks/timeline/use_timeline_save_prompt';
 import { timelineActions } from '../store';
 import { isTimelineFlyoutOpen } from '../../flyout/document_details/shared/hooks/use_which_flyout';
+import { useIsNewFlyoutEnabled } from '../../common/hooks/use_is_new_flyout_enabled';
+import { timelineFlyoutHistoryKey } from '../../flyout_v2/shared/constants/flyout_history';
 
 interface TimelineWrapperProps {
   /**
@@ -45,22 +47,77 @@ export const TimelineWrapper: React.FC<TimelineWrapperProps> = React.memo(
       dispatch(timelineActions.showTimeline({ id: timelineId, show: false }));
     }, [dispatch, timelineId]);
     const { closeFlyout } = useExpandableFlyoutApi();
+    const newFlyoutSystemEnabled = useIsNewFlyoutEnabled();
 
     // pressing the ESC key closes the timeline portal unless a flyout is opened on top of it
     const onKeyDown = useCallback(
       (ev: KeyboardEvent) => {
-        if (ev.key === keys.ESCAPE) {
-          const query = new URLSearchParams(window.location.search);
-          const timelineFlyoutOpen = isTimelineFlyoutOpen(query);
+        if (ev.key !== keys.ESCAPE) {
+          return;
+        }
 
-          if (timelineFlyoutOpen) {
-            closeFlyout();
+        if (newFlyoutSystemEnabled) {
+          if (!show) {
+            // Timeline isn't visible: let flyouts' own Esc handling run normally.
             return;
           }
+
+          const { sessions } = getFlyoutManagerStore().getState();
+          const topSession = sessions[sessions.length - 1];
+          // Flyouts opened from *within* Timeline (eg from its table) are given
+          // `timelineFlyoutHistoryKey`
+          const topSessionOpenedFromTimeline = topSession?.historyKey === timelineFlyoutHistoryKey;
+
+          // Each managed flyout registers its own window-level Esc handler, but its
+          // "should I close on Esc" decision is based on the *globally* topmost session.
+          // Without stopping propagation here, a flyout that was already open *underneath*
+          // Timeline could incorrectly close itself on the same keypress as the block below.
+          ev.stopImmediatePropagation();
+          ev.preventDefault();
+
+          if (topSession && topSessionOpenedFromTimeline) {
+            const store = getFlyoutManagerStore();
+
+            if (topSession.childFlyoutId) {
+              // Drill down into the child flyout first, same as EuiManagedFlyout's own
+              // `onClose` does for a child-level flyout (`closeFlyout(id)`).
+              store.closeFlyout(topSession.childFlyoutId);
+            } else {
+              // No child left: this main flyout closes next. Mirror EuiManagedFlyout's own
+              // `onClose` for a *main*-level flyout
+              store.closeAllFlyouts();
+            }
+            return;
+          }
+
+          // Nothing left on top that was opened from within Timeline: Timeline is now the
+          // topmost surface, so it closes next. Any flyout that was already open underneath it
+          // (before Timeline was shown) is left untouched until the next Esc press.
           handleClose();
+          return;
         }
+
+        const query = new URLSearchParams(window.location.search);
+        const timelineFlyoutOpen = isTimelineFlyoutOpen(query);
+
+        // While the Timeline modal is visible, keep this Esc keydown from reaching the
+        // window-level handler of the underlying expandable flyout (e.g. the graph
+        // investigation view), which would otherwise also close it. Both listeners are
+        // registered on `window`, so `stopImmediatePropagation` (not `stopPropagation`)
+        // is required to suppress the sibling listener. We skip this when the Timeline is
+        // not visible so Esc still closes flyouts on other pages.
+        if (show) {
+          ev.stopImmediatePropagation();
+          ev.preventDefault();
+        }
+
+        if (timelineFlyoutOpen) {
+          closeFlyout();
+          return;
+        }
+        handleClose();
       },
-      [closeFlyout, handleClose]
+      [show, newFlyoutSystemEnabled, closeFlyout, handleClose]
     );
 
     useTimelineSavePrompt(timelineId, onAppLeave);


### PR DESCRIPTION
> [!NOTE]
> This PR takes over the work done in this previous [one](https://github.com/elastic/kibana/pull/273809) which was closed I'm not sure why

## Summary

When the Timeline modal is opened on top of the expandable flyout (e.g. from the graph "Investigate in Timeline" action), pressing Esc closed both the modal and the underlying flyout, dropping the analyst out of the investigation context.

#### Before behavior

Uploading Screen Recording 2026-07-17 at 12.04.49 PM.mov…

#### Behavior fixed by this PR

Legacy expandable flyout

https://github.com/user-attachments/assets/e937de70-c531-48a1-9ec6-50fbd203e081

New flyout system

https://github.com/user-attachments/assets/2a00eb9c-6b53-4cdc-9f29-9196336231b8

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/security-team/issues/17309

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->