### PR TITLE
[Cases] Fix global field search and extended field label bugs

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/search.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/search.test.ts
@@ -92,6 +92,28 @@ describe('search', () => {
       expect(call.namespaces).toEqual(['space1']);
     });
 
+    it('fetches global field definitions for search when templates are enabled', async () => {
+      const argsWithTemplates = {
+        ...clientArgs,
+        config: {
+          ...clientArgs.config,
+          templates: { enabled: true },
+        },
+      };
+      const searchRequest = createCasesClientMockSearchRequest({
+        search: 'team',
+        owner: 'cases',
+      });
+      await search(searchRequest, argsWithTemplates, casesClientMock);
+
+      expect(
+        argsWithTemplates.services.fieldDefinitionsService.getGlobalFieldDefinitionsForSearch
+      ).toHaveBeenCalledWith({ owner: ['cases'] });
+      expect(
+        argsWithTemplates.services.templatesService.getTemplateVersionsForExtendedFieldSearch
+      ).toHaveBeenCalledWith({ owner: ['cases'] });
+    });
+
     it('search with single custom field', async () => {
       const searchRequest = createCasesClientMockSearchRequest({
         customFields: { second_key: [true] },

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/search.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/search.ts
@@ -29,6 +29,7 @@ import {
   resolveFieldLabelSearch,
 } from '../../services/cases/extended_field_search_utils';
 import { enrichCasesWithFieldLabels } from './utils';
+import { parseFieldDefinitionsToInlineFields } from '../../../common/utils';
 
 /**
  * Retrieves a case and optionally its comments.
@@ -41,7 +42,7 @@ export const search = async (
   casesClient: CasesClient
 ): Promise<CasesFindResponse> => {
   const {
-    services: { caseService, licensingService, templatesService },
+    services: { caseService, licensingService, templatesService, fieldDefinitionsService },
     authorization,
     logger,
     spaceId,
@@ -137,11 +138,16 @@ export const search = async (
      *    extended_fields_labels on returned cases, avoiding redundant fetches.
      *
      */
-    const templateSOs = config.templates.enabled
-      ? await templatesService.getTemplateVersionsForExtendedFieldSearch({
-          owner: ownerArray.length > 0 ? ownerArray : undefined,
-        })
-      : [];
+    const [templateSOs, globalFieldDefs] = config.templates.enabled
+      ? await Promise.all([
+          templatesService.getTemplateVersionsForExtendedFieldSearch({
+            owner: ownerArray.length > 0 ? ownerArray : undefined,
+          }),
+          fieldDefinitionsService.getGlobalFieldDefinitionsForSearch({
+            owner: ownerArray.length > 0 ? ownerArray : undefined,
+          }),
+        ])
+      : [[], []];
 
     const templateMetadata = templateSOs.map((so) => ({
       templateId: so.attributes.templateId,
@@ -149,14 +155,20 @@ export const search = async (
       fieldDefinitions: so.attributes.fieldDefinitions,
     }));
 
+    const globalFields = parseFieldDefinitionsToInlineFields(globalFieldDefs);
+
     const rawFilters = paramArgs.extendedFieldFilters;
     const resolvedExtendedFieldFilters =
       rawFilters && rawFilters.length > 0
-        ? resolveExtendedFieldFilters(rawFilters, templateMetadata)
+        ? resolveExtendedFieldFilters(rawFilters, templateMetadata, globalFields)
         : undefined;
 
     const fieldLabelResults = paramArgs.search
-      ? resolveFieldLabelSearch(tokenizeSearchForLabels(paramArgs.search), templateMetadata)
+      ? resolveFieldLabelSearch(
+          tokenizeSearchForLabels(paramArgs.search),
+          templateMetadata,
+          globalFields
+        )
       : [];
     const resolvedFieldLabelFilters = fieldLabelResults.length > 0 ? fieldLabelResults : undefined;
 
@@ -188,7 +200,7 @@ export const search = async (
       countClosedCases: statusStats.closed,
     });
 
-    res.cases = enrichCasesWithFieldLabels(res.cases, templateSOs);
+    res.cases = enrichCasesWithFieldLabels(res.cases, templateSOs, globalFields);
 
     return decodeOrThrow(CasesFindResponseRt)(res);
   } catch (error) {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
@@ -2265,6 +2265,42 @@ describe('enrichCasesWithFieldLabels', () => {
     expect(result[0]).toEqual(baseCase);
   });
 
+  it('populates labels for a template-less case from global field definitions', () => {
+    const caseWithGlobalOnly = {
+      ...baseCase,
+      extended_fields: { team_as_keyword: 'soc' },
+    };
+    const globalFields = [
+      { name: 'team', label: 'Team', control: 'INPUT_TEXT' as const, type: 'keyword' as const },
+    ];
+
+    const result = enrichCasesWithFieldLabels([caseWithGlobalOnly], [], globalFields);
+
+    expect(result[0].extended_fields_labels).toEqual({
+      team_as_keyword: 'Team',
+    });
+  });
+
+  it('merges global and template labels with template winning on key collision', () => {
+    const globalFields = [
+      {
+        name: 'priority',
+        label: 'Global Priority',
+        control: 'INPUT_TEXT' as const,
+        type: 'keyword' as const,
+      },
+      { name: 'team', label: 'Team', control: 'INPUT_TEXT' as const, type: 'keyword' as const },
+    ];
+
+    const result = enrichCasesWithFieldLabels([caseWithTemplate], [templateSO], globalFields);
+
+    expect(result[0].extended_fields_labels).toEqual({
+      priority_as_keyword: 'Priority Level',
+      effort_as_integer: 'Effort Points',
+      team_as_keyword: 'Team',
+    });
+  });
+
   it('returns case unchanged when it has no extended_fields', () => {
     const caseNoExtFields = { ...baseCase, template: { id: 'template-id-1', version: 1 } };
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -49,6 +49,7 @@ import {
   toStringArray,
 } from '../../../common/utils/attachments';
 import { COMMENT_ATTACHMENT_TYPE } from '../../../common/constants/attachments';
+import type { InlineField } from '../../../common/types/domain/template/fields';
 import * as i18n from './translations';
 
 interface CreateIncidentArgs {
@@ -695,31 +696,38 @@ export const processObservables = (
 
 /**
  *
- * For cases that have a template and extended fields, fetches the template definitions
- * and populates `extended_fields_labels` with a mapping from storage keys (e.g.,
- * `priority_as_keyword`) to user-facing labels (e.g., "Priority"). Cases without templates
- * or extended fields, or whose templates cannot be retrieved, are returned unchanged.
+ * For cases that have extended fields, populates `extended_fields_labels` with a mapping from
+ * storage keys (e.g., `priority_as_keyword`) to user-facing labels (e.g., "Priority").
+ * Labels come from the case's template `fieldDefinitions` (when present) merged with global
+ * field-library definitions. Template labels win on key collision. Cases without extended
+ * fields are returned unchanged.
  *
  * @param cases - Array of cases to enrich
  * @param templateSOs - Pre-fetched template saved objects
+ * @param globalFields - Pre-parsed isGlobal inline field definitions (see
+ *   `parseFieldDefinitionsToInlineFields`) — accepted already-parsed since callers typically
+ *   need the same parsed list for extended-field filter/label-search resolution too.
  * @returns The enriched cases array, preserving original order
  */
 export const enrichCasesWithFieldLabels = (
   cases: Case[],
-  templateSOs: Array<SavedObject<Template>>
+  templateSOs: Array<SavedObject<Template>>,
+  globalFields: readonly InlineField[] = []
 ): Case[] => {
   type EligibleCase = Case & {
-    template: NonNullable<Case['template']>;
     extended_fields: NonNullable<Case['extended_fields']>;
   };
-  const isEligible = (c: Case): c is EligibleCase =>
-    c.template?.id != null && c.extended_fields != null;
+  const isEligible = (c: Case): c is EligibleCase => c.extended_fields != null;
 
   const eligibleCases = cases.filter(isEligible);
 
   if (eligibleCases.length === 0) {
     return cases;
   }
+
+  const globalLabelMap = Object.fromEntries(
+    globalFields.map((field) => [`${field.name}_as_${field.type}`, field.label ?? field.name])
+  );
 
   const labelsByTemplateKey = new Map<string, Record<string, string>>();
   for (const so of templateSOs) {
@@ -737,8 +745,15 @@ export const enrichCasesWithFieldLabels = (
 
   const enrichedCasesById = new Map(
     eligibleCases.flatMap((c) => {
-      const fieldKeyToLabel = labelsByTemplateKey.get(`${c.template.id}:${c.template.version}`);
-      return fieldKeyToLabel != null
+      const templateLabelMap =
+        c.template?.id != null
+          ? labelsByTemplateKey.get(`${c.template.id}:${c.template.version}`)
+          : undefined;
+      const fieldKeyToLabel = {
+        ...globalLabelMap,
+        ...(templateLabelMap ?? {}),
+      };
+      return Object.keys(fieldKeyToLabel).length > 0
         ? [[c.id, { ...c, extended_fields_labels: fieldKeyToLabel }]]
         : [];
     })

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -50,6 +50,7 @@ import {
 } from '../../../common/utils/attachments';
 import { COMMENT_ATTACHMENT_TYPE } from '../../../common/constants/attachments';
 import type { InlineField } from '../../../common/types/domain/template/fields';
+import { getFieldSnakeKey } from '../../../common/utils/template_fields';
 import * as i18n from './translations';
 
 interface CreateIncidentArgs {
@@ -726,14 +727,17 @@ export const enrichCasesWithFieldLabels = (
   }
 
   const globalLabelMap = Object.fromEntries(
-    globalFields.map((field) => [`${field.name}_as_${field.type}`, field.label ?? field.name])
+    globalFields.map((field) => [
+      getFieldSnakeKey(field.name, field.type),
+      field.label ?? field.name,
+    ])
   );
 
   const labelsByTemplateKey = new Map<string, Record<string, string>>();
   for (const so of templateSOs) {
     const fieldKeyToLabel = Object.fromEntries(
       (so.attributes.fieldDefinitions ?? []).map((field) => [
-        `${field.name}_as_${field.type}`,
+        getFieldSnakeKey(field.name, field.type),
         field.label,
       ])
     );

--- a/x-pack/platform/plugins/shared/cases/server/client/factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/factory.ts
@@ -276,16 +276,20 @@ export class CasesClientFactory {
         savedObjectsClient: unsecuredSavedObjectsClient,
       });
 
+    const fieldDefinitionsService = new FieldDefinitionsService({
+      unsecuredSavedObjectsClient,
+    });
+
     const templatesService = new TemplatesService({
       unsecuredSavedObjectsClient,
       savedObjectsSerializer,
       esClient,
       namespace,
       refreshAnalyticsV2DataView,
-    });
-
-    const fieldDefinitionsService = new FieldDefinitionsService({
-      unsecuredSavedObjectsClient,
+      getFieldDefinitionsForOwner: (owner) =>
+        fieldDefinitionsService
+          .getFieldDefinitions(owner)
+          .then(({ fieldDefinitions }) => fieldDefinitions),
     });
 
     const caseService = new CasesService({

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -281,6 +281,56 @@ describe('resolveExtendedFieldFilters', () => {
     ]);
   });
 
+  it('resolves a label that only exists on a global field', () => {
+    const result = resolveExtendedFieldFilters(
+      [{ label: 'Team', value: 'soc' }],
+      [],
+      [
+        {
+          name: 'team',
+          label: 'Team',
+          type: 'keyword',
+          control: 'INPUT_TEXT',
+        },
+      ]
+    );
+
+    expect(result).toEqual([
+      [
+        expect.objectContaining({
+          storageKey: 'team_as_keyword',
+          value: 'soc',
+          control: 'INPUT_TEXT',
+          isGlobal: true,
+          templateVersions: [],
+        }),
+      ],
+    ]);
+  });
+
+  it('ORs template and global storage keys when the same label exists on both', () => {
+    const result = resolveExtendedFieldFilters([{ label: 'Priority', value: 'high' }], templates, [
+      {
+        name: 'global_priority',
+        label: 'Priority',
+        type: 'keyword',
+        control: 'INPUT_TEXT',
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storageKey: 'priority_as_keyword', isGlobal: undefined }),
+        expect.objectContaining({
+          storageKey: 'global_priority_as_keyword',
+          isGlobal: true,
+          templateVersions: [],
+        }),
+      ])
+    );
+  });
+
   it('filters by specific template versions when same template ID has different field definitions', () => {
     const templatesWithVersionedFields = [
       {
@@ -610,8 +660,13 @@ describe('buildExtendedFieldRuntimeMappings', () => {
 
     expect(mappings).toHaveProperty('ef_summary_as_keyword');
     expect(mappings.ef_summary_as_keyword.type).toBe('keyword');
-    expect(mappings.ef_summary_as_keyword.script?.source).toContain('emit(raw);');
-    expect(mappings.ef_summary_as_keyword.script?.source).not.toContain("raw.startsWith('[')");
+    const summaryScript = mappings.ef_summary_as_keyword.script;
+    const summarySource =
+      typeof summaryScript === 'object' && summaryScript != null && 'source' in summaryScript
+        ? String(summaryScript.source)
+        : String(summaryScript ?? '');
+    expect(summarySource).toContain('emit(raw);');
+    expect(summarySource).not.toContain("raw.startsWith('[')");
   });
 
   it('builds runtime mapping for TEXTAREA (needs substring matching)', () => {
@@ -629,8 +684,13 @@ describe('buildExtendedFieldRuntimeMappings', () => {
 
     expect(mappings).toHaveProperty('ef_notes_as_keyword');
     expect(mappings.ef_notes_as_keyword.type).toBe('keyword');
-    expect(mappings.ef_notes_as_keyword.script?.source).toContain('emit(raw);');
-    expect(mappings.ef_notes_as_keyword.script?.source).not.toContain("raw.startsWith('[')");
+    const notesScript = mappings.ef_notes_as_keyword.script;
+    const notesSource =
+      typeof notesScript === 'object' && notesScript != null && 'source' in notesScript
+        ? String(notesScript.source)
+        : String(notesScript ?? '');
+    expect(notesSource).toContain('emit(raw);');
+    expect(notesSource).not.toContain("raw.startsWith('[')");
   });
 });
 
@@ -680,6 +740,23 @@ describe('buildExtendedFieldFilterClauses', () => {
         },
       },
     ]);
+  });
+
+  it('omits the template version filter for global fields', () => {
+    const clauses = buildExtendedFieldFilterClauses([
+      [
+        {
+          storageKey: 'team_as_keyword',
+          value: 'soc',
+          esType: 'keyword',
+          control: 'SELECT_BASIC',
+          templateVersions: [],
+          isGlobal: true,
+        },
+      ],
+    ]);
+
+    expect(clauses).toEqual([{ term: { 'cases.extended_fields.team_as_keyword': 'soc' } }]);
   });
 
   it('builds wildcard query for INPUT_TEXT control via runtime field', () => {
@@ -1733,6 +1810,23 @@ describe('buildFieldLabelExistsClauses', () => {
 
   it('returns empty array for empty input', () => {
     expect(buildFieldLabelExistsClauses([])).toEqual([]);
+  });
+
+  it('omits the template version filter for global fields', () => {
+    const clauses = buildFieldLabelExistsClauses([
+      {
+        storageKey: 'team_as_keyword',
+        esType: 'keyword',
+        control: 'INPUT_TEXT',
+        templateVersions: [],
+        isGlobal: true,
+      },
+    ]);
+
+    // Must be a bare exists clause — ANDing an empty template-version filter
+    // (`{ bool: { should: [], minimum_should_match: 1 } }`) would be unsatisfiable
+    // and silently match zero cases.
+    expect(clauses).toEqual([{ exists: { field: 'ef_team_as_keyword' } }]);
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -128,7 +128,10 @@ describe('resolveExtendedFieldFilters', () => {
     ]);
   });
 
-  it('drops unresolved labels silently', () => {
+  it('returns an empty group for an unresolved label instead of dropping it', () => {
+    // The empty group is preserved (rather than omitted) so buildExtendedFieldFilterClauses can
+    // turn it into a match_none clause — filtering by an unknown label should yield zero results,
+    // not silently be ignored.
     const result = resolveExtendedFieldFilters(
       [
         { label: 'Priority', value: 'high' },
@@ -147,16 +150,17 @@ describe('resolveExtendedFieldFilters', () => {
           templateVersions: [{ id: 'tmpl-a', version: 1 }],
         },
       ],
+      [],
     ]);
   });
 
-  it('returns empty for no matches', () => {
+  it('returns a single empty group when no filters match', () => {
     const result = resolveExtendedFieldFilters(
       [{ label: 'nonexistent', value: 'test' }],
       templates
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual([[]]);
   });
 
   it('resolves USER_PICKER fields and carries control through', () => {
@@ -192,7 +196,7 @@ describe('resolveExtendedFieldFilters', () => {
       [{ templateId: 'tmpl-x', templateVersion: 1, fieldDefinitions: undefined }]
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual([[]]);
   });
 
   it('groups multiple storage keys under one label when different templates share the same label but different names', () => {
@@ -974,7 +978,7 @@ describe('buildExtendedFieldFilterClauses', () => {
     ]);
   });
 
-  it('drops DATE_PICKER filter when value is MM/DD/YYYY (non-ISO)', () => {
+  it('returns match_none for DATE_PICKER filter when value is MM/DD/YYYY (non-ISO)', () => {
     const clauses = buildExtendedFieldFilterClauses([
       [
         {
@@ -987,7 +991,7 @@ describe('buildExtendedFieldFilterClauses', () => {
       ],
     ]);
 
-    expect(clauses).toHaveLength(0);
+    expect(clauses).toEqual([{ match_none: {} }]);
   });
 
   it('builds range query for DATE_PICKER using YYYY-MM-DD input on flattened path', () => {
@@ -1044,7 +1048,7 @@ describe('buildExtendedFieldFilterClauses', () => {
     ]);
   });
 
-  it('drops DATE_PICKER filter when the date value cannot be parsed', () => {
+  it('returns match_none for DATE_PICKER filter when the date value cannot be parsed', () => {
     const clauses = buildExtendedFieldFilterClauses([
       [
         {
@@ -1057,10 +1061,10 @@ describe('buildExtendedFieldFilterClauses', () => {
       ],
     ]);
 
-    expect(clauses).toHaveLength(0);
+    expect(clauses).toEqual([{ match_none: {} }]);
   });
 
-  it('drops numeric filter when value is not a valid number', () => {
+  it('returns match_none for numeric filter when value is not a valid number', () => {
     const clauses = buildExtendedFieldFilterClauses([
       [
         {
@@ -1073,10 +1077,10 @@ describe('buildExtendedFieldFilterClauses', () => {
       ],
     ]);
 
-    expect(clauses).toHaveLength(0);
+    expect(clauses).toEqual([{ match_none: {} }]);
   });
 
-  it('drops double filter when value is not a valid number', () => {
+  it('returns match_none for double filter when value is not a valid number', () => {
     const clauses = buildExtendedFieldFilterClauses([
       [
         {
@@ -1089,7 +1093,13 @@ describe('buildExtendedFieldFilterClauses', () => {
       ],
     ]);
 
-    expect(clauses).toHaveLength(0);
+    expect(clauses).toEqual([{ match_none: {} }]);
+  });
+
+  it('returns match_none for an empty group (unresolved label)', () => {
+    const clauses = buildExtendedFieldFilterClauses([[]]);
+
+    expect(clauses).toEqual([{ match_none: {} }]);
   });
 
   it('builds term query for USER_PICKER (runtime field emits name values from {uid,name} objects)', () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -610,6 +610,8 @@ describe('buildExtendedFieldRuntimeMappings', () => {
 
     expect(mappings).toHaveProperty('ef_summary_as_keyword');
     expect(mappings.ef_summary_as_keyword.type).toBe('keyword');
+    expect(mappings.ef_summary_as_keyword.script?.source).toContain('emit(raw);');
+    expect(mappings.ef_summary_as_keyword.script?.source).not.toContain("raw.startsWith('[')");
   });
 
   it('builds runtime mapping for TEXTAREA (needs substring matching)', () => {
@@ -627,6 +629,8 @@ describe('buildExtendedFieldRuntimeMappings', () => {
 
     expect(mappings).toHaveProperty('ef_notes_as_keyword');
     expect(mappings.ef_notes_as_keyword.type).toBe('keyword');
+    expect(mappings.ef_notes_as_keyword.script?.source).toContain('emit(raw);');
+    expect(mappings.ef_notes_as_keyword.script?.source).not.toContain("raw.startsWith('[')");
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -424,18 +424,29 @@ describe('resolveExtendedFieldFilters', () => {
 });
 
 describe('parseDateFilterToRange', () => {
-  it('parses YYYY-MM-DD to a full-day UTC range', () => {
+  it('parses YYYY-MM-DD to a full-day range with bare-date bounds', () => {
     expect(parseDateFilterToRange('2024-01-01')).toEqual({
-      gte: '2024-01-01T00:00:00.000Z',
-      lt: '2024-01-02T00:00:00.000Z',
+      gte: '2024-01-01',
+      lt: '2024-01-02',
     });
   });
 
   it('parses ISO 8601 string by truncating to the day', () => {
     expect(parseDateFilterToRange('2024-01-01T00:00:00.000Z')).toEqual({
-      gte: '2024-01-01T00:00:00.000Z',
-      lt: '2024-01-02T00:00:00.000Z',
+      gte: '2024-01-01',
+      lt: '2024-01-02',
     });
+  });
+
+  it('returns bare-date bounds that lexicographically bracket a full ISO timestamp stored for the same day', () => {
+    // The flattened/keyword field can hold either a bare date or a full ISO timestamp
+    // depending on how the value was stored, and range queries on it compare lexicographically.
+    // A full-ISO `gte` bound (e.g. "2024-01-01T00:00:00.000Z") would sort *after* a bare-date
+    // stored value ("2024-01-01") and never match it. Bare-date bounds match both.
+    const { gte, lt } = parseDateFilterToRange('2024-01-01')!;
+    expect('2024-01-01' >= gte && '2024-01-01' < lt).toBe(true);
+    expect('2024-01-01T13:45:00.000Z' >= gte && '2024-01-01T13:45:00.000Z' < lt).toBe(true);
+    expect('2024-01-02T00:00:00.000Z' >= gte && '2024-01-02T00:00:00.000Z' < lt).toBe(false);
   });
 
   it('returns undefined for unrecognised formats', () => {
@@ -465,8 +476,8 @@ describe('parseDateFilterToRange', () => {
 
   it('accepts valid leap day in February (leap year)', () => {
     expect(parseDateFilterToRange('2024-02-29')).toEqual({
-      gte: '2024-02-29T00:00:00.000Z',
-      lt: '2024-03-01T00:00:00.000Z',
+      gte: '2024-02-29',
+      lt: '2024-03-01',
     });
   });
 
@@ -479,23 +490,23 @@ describe('parseDateFilterToRange', () => {
 
   it('accepts valid last day of 30-day months', () => {
     expect(parseDateFilterToRange('2024-04-30')).toEqual({
-      gte: '2024-04-30T00:00:00.000Z',
-      lt: '2024-05-01T00:00:00.000Z',
+      gte: '2024-04-30',
+      lt: '2024-05-01',
     });
     expect(parseDateFilterToRange('2024-11-30')).toEqual({
-      gte: '2024-11-30T00:00:00.000Z',
-      lt: '2024-12-01T00:00:00.000Z',
+      gte: '2024-11-30',
+      lt: '2024-12-01',
     });
   });
 
   it('accepts valid day 31 in 31-day months', () => {
     expect(parseDateFilterToRange('2024-01-31')).toEqual({
-      gte: '2024-01-31T00:00:00.000Z',
-      lt: '2024-02-01T00:00:00.000Z',
+      gte: '2024-01-31',
+      lt: '2024-02-01',
     });
     expect(parseDateFilterToRange('2024-12-31')).toEqual({
-      gte: '2024-12-31T00:00:00.000Z',
-      lt: '2025-01-01T00:00:00.000Z',
+      gte: '2024-12-31',
+      lt: '2025-01-01',
     });
   });
 });
@@ -1014,8 +1025,8 @@ describe('buildExtendedFieldFilterClauses', () => {
             {
               range: {
                 'cases.extended_fields.start_date_as_date': {
-                  gte: '2024-01-01T00:00:00.000Z',
-                  lt: '2024-01-02T00:00:00.000Z',
+                  gte: '2024-01-01',
+                  lt: '2024-01-02',
                 },
               },
             },

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -8,6 +8,7 @@
 import type { estypes } from '@elastic/elasticsearch';
 import { CASE_SAVED_OBJECT, CASE_EXTENDED_FIELDS } from '../../../common/constants';
 import type { Template } from '../../../common/types/domain/template/v1';
+import type { InlineField } from '../../../common/types/domain/template/fields';
 import { FieldType } from '../../../common/types/domain/template/fields';
 
 export interface ExtendedFieldFilter {
@@ -21,6 +22,7 @@ export interface ResolvedExtendedFieldFilter {
   esType: string;
   control: string;
   templateVersions: Array<{ id: string; version: number }>;
+  isGlobal?: boolean;
 }
 
 export interface LabelSearchToken {
@@ -33,6 +35,7 @@ export interface ResolvedFieldLabelFilter {
   esType: string;
   control: string;
   templateVersions: Array<{ id: string; version: number }>;
+  isGlobal?: boolean;
 }
 
 type RuntimeType = 'keyword' | 'long' | 'double' | 'date';
@@ -142,9 +145,10 @@ const buildPainlessScript = (
 
 export const resolveExtendedFieldFilters = (
   extendedFieldFilters: ExtendedFieldFilter[],
-  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>
+  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>,
+  globalFields: readonly InlineField[] = []
 ): ResolvedExtendedFieldFilter[][] => {
-  const labelToMetas = buildLabelToMetasIndex(templates);
+  const labelToMetas = buildLabelToMetasIndex(templates, globalFields);
 
   return extendedFieldFilters.flatMap(({ label, value }) => {
     const metas = labelToMetas.get(label.toLowerCase());
@@ -155,6 +159,7 @@ export const resolveExtendedFieldFilters = (
       esType: meta.esType,
       control: meta.control,
       templateVersions: meta.templateVersions,
+      isGlobal: meta.isGlobal,
     }));
     return group.length > 0 ? [group] : [];
   });
@@ -212,9 +217,18 @@ export const buildExtendedFieldRuntimeMappings = (
   return runtimeMappings;
 };
 
+/**
+ * Builds the template-version scoping clause, or `null` when the field is global.
+ * Global fields are not tied to a specific template version, so no scoping clause
+ * should be applied — callers must treat a `null` return as "no clause needed",
+ * not as an unsatisfiable filter.
+ */
 const buildTemplateVersionFilter = (
-  templateVersions: Array<{ id: string; version: number }>
-): estypes.QueryDslQueryContainer => {
+  templateVersions: Array<{ id: string; version: number }>,
+  isGlobal?: boolean
+): estypes.QueryDslQueryContainer | null => {
+  if (isGlobal) return null;
+
   const templateVersionFilters = templateVersions.map(({ id, version }) => ({
     bool: {
       must: [
@@ -282,7 +296,7 @@ const buildRuntimeFilterClause = ({
 const buildSingleFilterClause = (
   filter: ResolvedExtendedFieldFilter
 ): estypes.QueryDslQueryContainer | null => {
-  const { esType, control, templateVersions } = filter;
+  const { esType, control, templateVersions, isGlobal } = filter;
 
   const valueClause = needsRuntimeScript(control, esType)
     ? buildRuntimeFilterClause(filter)
@@ -290,7 +304,9 @@ const buildSingleFilterClause = (
 
   if (valueClause == null) return null;
 
-  return { bool: { filter: [valueClause, buildTemplateVersionFilter(templateVersions)] } };
+  const versionFilter = buildTemplateVersionFilter(templateVersions, isGlobal);
+
+  return versionFilter == null ? valueClause : { bool: { filter: [valueClause, versionFilter] } };
 };
 
 export const buildExtendedFieldFilterClauses = (
@@ -346,59 +362,101 @@ type LabelToMetasMap = Map<
       esType: string;
       control: string;
       templateVersions: Array<{ id: string; version: number }>;
+      isGlobal?: boolean;
     }
   >
 >;
 
 const buildLabelToMetasIndex = (
-  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>
+  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>,
+  globalFields: readonly InlineField[] = []
 ): LabelToMetasMap => {
   const labelToMetas: LabelToMetasMap = new Map();
 
+  const upsertMeta = ({
+    label,
+    name,
+    type,
+    control,
+    templateVersion,
+    isGlobal,
+  }: {
+    label: string;
+    name: string;
+    type: string;
+    control: string;
+    templateVersion?: { id: string; version: number };
+    isGlobal?: boolean;
+  }) => {
+    const labelKey = label.toLowerCase();
+    const storageKey = `${name}_as_${type}`;
+
+    let byStorageKey = labelToMetas.get(labelKey);
+    if (byStorageKey == null) {
+      byStorageKey = new Map();
+      labelToMetas.set(labelKey, byStorageKey);
+    }
+
+    let entry = byStorageKey.get(storageKey);
+    if (entry == null) {
+      entry = {
+        storageKey,
+        esType: type,
+        control,
+        templateVersions: [],
+        isGlobal,
+      };
+      byStorageKey.set(storageKey, entry);
+    } else if (isGlobal) {
+      entry.isGlobal = true;
+    }
+
+    if (templateVersion != null) {
+      entry.templateVersions.push(templateVersion);
+    }
+  };
+
   for (const template of templates) {
     for (const field of template.fieldDefinitions ?? []) {
-      const labelKey = field.label.toLowerCase();
-      const storageKey = `${field.name}_as_${field.type}`;
-
-      let byStorageKey = labelToMetas.get(labelKey);
-      if (byStorageKey == null) {
-        byStorageKey = new Map();
-        labelToMetas.set(labelKey, byStorageKey);
-      }
-
-      let entry = byStorageKey.get(storageKey);
-      if (entry == null) {
-        entry = {
-          storageKey,
-          esType: field.type,
-          control: field.control,
-          templateVersions: [],
-        };
-        byStorageKey.set(storageKey, entry);
-      }
-
-      entry.templateVersions.push({
-        id: template.templateId,
-        version: template.templateVersion,
+      upsertMeta({
+        label: field.label,
+        name: field.name,
+        type: field.type,
+        control: field.control,
+        templateVersion: {
+          id: template.templateId,
+          version: template.templateVersion,
+        },
       });
     }
+  }
+
+  for (const field of globalFields) {
+    upsertMeta({
+      label: field.label ?? field.name,
+      name: field.name,
+      type: field.type,
+      control: field.control,
+      isGlobal: true,
+    });
   }
 
   return labelToMetas;
 };
 
 /**
- * Resolves search tokens against template field labels.
+ * Resolves search tokens against template and global field labels.
  * - exact tokens: full label must equal the token text
  * - substring tokens (quoted): label must contain the token text
  */
 export const resolveFieldLabelSearch = (
   tokens: LabelSearchToken[],
-  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>
+  templates: Array<Pick<Template, 'fieldDefinitions' | 'templateId' | 'templateVersion'>>,
+  globalFields: readonly InlineField[] = []
 ): ResolvedFieldLabelFilter[] => {
-  if (tokens.length === 0 || templates.length === 0) return [];
+  if (tokens.length === 0 || (templates.length === 0 && globalFields.length === 0)) return [];
 
-  const labelToMetas = buildLabelToMetasIndex(templates);
+  const labelToMetas = buildLabelToMetasIndex(templates, globalFields);
   const seen = new Set<string>();
   const results: ResolvedFieldLabelFilter[] = [];
 
@@ -408,6 +466,7 @@ export const resolveFieldLabelSearch = (
       esType: string;
       control: string;
       templateVersions: Array<{ id: string; version: number }>;
+      isGlobal?: boolean;
     }> = [];
 
     const normalizedText = token.text.toLowerCase();
@@ -428,6 +487,7 @@ export const resolveFieldLabelSearch = (
           esType: meta.esType,
           control: meta.control,
           templateVersions: meta.templateVersions,
+          isGlobal: meta.isGlobal,
         });
       }
     }
@@ -522,7 +582,9 @@ export const buildFieldLabelExistsClauses = (
       exists: { field: fieldName },
     };
 
+    const versionFilter = buildTemplateVersionFilter(resolved.templateVersions, resolved.isGlobal);
+
     return [
-      { bool: { filter: [existsClause, buildTemplateVersionFilter(resolved.templateVersions)] } },
+      versionFilter == null ? existsClause : { bool: { filter: [existsClause, versionFilter] } },
     ];
   });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -120,6 +120,11 @@ const buildPainlessScript = (
     return `${readRaw}${splitArrayScript}`;
   }
 
+  // Free-text controls can legitimately start with `[`, so preserve their punctuation verbatim.
+  if (control === INPUT_TEXT || control === TEXTAREA) {
+    return `${readRaw}emit(raw);`;
+  }
+
   // Auto-detect JSON arrays for keyword fields (e.g. legacy templates without a control type).
   if (runtimeType === 'keyword') {
     return `${readRaw}if (raw.startsWith('[')) { ${splitArrayScript} } else { emit(raw); }`;

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -10,6 +10,7 @@ import { CASE_SAVED_OBJECT, CASE_EXTENDED_FIELDS } from '../../../common/constan
 import type { Template } from '../../../common/types/domain/template/v1';
 import type { InlineField } from '../../../common/types/domain/template/fields';
 import { FieldType } from '../../../common/types/domain/template/fields';
+import { getFieldSnakeKey } from '../../../common/utils/template_fields';
 
 export interface ExtendedFieldFilter {
   label: string;
@@ -150,10 +151,13 @@ export const resolveExtendedFieldFilters = (
 ): ResolvedExtendedFieldFilter[][] => {
   const labelToMetas = buildLabelToMetasIndex(templates, globalFields);
 
-  return extendedFieldFilters.flatMap(({ label, value }) => {
+  // One entry per input filter — including an empty group `[]` for a label that didn't resolve
+  // to any known field. Preserving the (empty) group lets buildExtendedFieldFilterClauses turn it
+  // into a `match_none` clause instead of the filter being silently dropped (see that function).
+  return extendedFieldFilters.map(({ label, value }) => {
     const metas = labelToMetas.get(label.toLowerCase());
     if (metas == null) return [];
-    const group = [...metas.values()].map((meta) => ({
+    return [...metas.values()].map((meta) => ({
       storageKey: meta.storageKey,
       value,
       esType: meta.esType,
@@ -161,7 +165,6 @@ export const resolveExtendedFieldFilters = (
       templateVersions: meta.templateVersions,
       isGlobal: meta.isGlobal,
     }));
-    return group.length > 0 ? [group] : [];
   });
 };
 
@@ -312,19 +315,23 @@ const buildSingleFilterClause = (
 export const buildExtendedFieldFilterClauses = (
   resolvedFilterGroups: ResolvedExtendedFieldFilter[][]
 ): estypes.QueryDslQueryContainer[] =>
-  resolvedFilterGroups.flatMap((group): estypes.QueryDslQueryContainer[] => {
+  resolvedFilterGroups.map((group): estypes.QueryDslQueryContainer => {
     const clauses = group.flatMap((filter) => {
       const clause = buildSingleFilterClause(filter);
       return clause != null ? [clause] : [];
     });
 
-    if (clauses.length === 0) return [];
+    // An empty group means the filter's label didn't resolve to any known field, or every
+    // candidate value failed to parse (e.g. a non-numeric value for an INPUT_NUMBER field).
+    // Returning match_none makes the filter behave like any other unsatisfiable filter — the
+    // search yields zero results — instead of silently being dropped and matching everything.
+    if (clauses.length === 0) return { match_none: {} };
 
     // Multiple entries in the same group mean the same label resolves to different storage keys
     // across templates — OR them so any matching template's case is returned.
-    if (clauses.length === 1) return clauses;
+    if (clauses.length === 1) return clauses[0];
 
-    return [{ bool: { should: clauses, minimum_should_match: 1 } }];
+    return { bool: { should: clauses, minimum_should_match: 1 } };
   });
 
 /**
@@ -389,7 +396,7 @@ const buildLabelToMetasIndex = (
     isGlobal?: boolean;
   }) => {
     const labelKey = label.toLowerCase();
-    const storageKey = `${name}_as_${type}`;
+    const storageKey = getFieldSnakeKey(name, type);
 
     let byStorageKey = labelToMetas.get(labelKey);
     if (byStorageKey == null) {

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -196,7 +196,13 @@ export const parseDateFilterToRange = (value: string): { gte: string; lt: string
   }
 
   const end = new Date(start.getTime() + 86_400_000);
-  return { gte: start.toISOString(), lt: end.toISOString() };
+  // Both bounds are sliced to bare YYYY-MM-DD: the flattened/keyword field can hold either a
+  // bare date or a full ISO timestamp depending on how it was stored, and range queries on it
+  // compare lexicographically, not chronologically. A bare-date bound still correctly brackets a
+  // full timestamp within the same day (e.g. "2026-08-01" <= "2026-08-01T13:45:00.000Z" < "2026-08-02"
+  // holds lexicographically), whereas a full ISO `gte` bound would sort *after* a bare-date value
+  // for the same day and never match it.
+  return { gte: start.toISOString().slice(0, 10), lt: end.toISOString().slice(0, 10) };
 };
 
 /** Builds ES runtime field mappings only for filters that can't use the flattened mapping directly. */

--- a/x-pack/platform/plugins/shared/cases/server/services/field_definitions/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/field_definitions/index.test.ts
@@ -140,6 +140,65 @@ describe('FieldDefinitionsService', () => {
     });
   });
 
+  describe('getGlobalFieldDefinitionsForSearch', () => {
+    it('returns only isGlobal definitions for the given owners', async () => {
+      const globalField = makeFieldDefinitionSO({ isGlobal: true });
+      const nonGlobalField = makeFieldDefinitionSO({ name: 'non_global', isGlobal: false });
+      soClient.find.mockResolvedValue({
+        saved_objects: [globalField, nonGlobalField],
+        total: 2,
+        per_page: 10000,
+        page: 1,
+      } as SavedObjectsFindResponse<FieldDefinition>);
+
+      const result = await service.getGlobalFieldDefinitionsForSearch({
+        owner: ['securitySolution'],
+      });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: `${CASE_FIELD_DEFINITION_SAVED_OBJECT}.attributes.owner: "securitySolution"`,
+          perPage: 10000,
+        })
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('my_field');
+    });
+
+    it('fetches all owners when owner is omitted', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [makeFieldDefinitionSO({ isGlobal: true })],
+        total: 1,
+        per_page: 10000,
+        page: 1,
+      } as SavedObjectsFindResponse<FieldDefinition>);
+
+      await service.getGlobalFieldDefinitionsForSearch({});
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: undefined,
+          perPage: 10000,
+        })
+      );
+    });
+
+    it('excludes non-global definitions', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [makeFieldDefinitionSO({ isGlobal: false })],
+        total: 1,
+        per_page: 10000,
+        page: 1,
+      } as SavedObjectsFindResponse<FieldDefinition>);
+
+      const result = await service.getGlobalFieldDefinitionsForSearch({
+        owner: ['securitySolution'],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('getFieldDefinition', () => {
     it('retrieves a single field definition by id', async () => {
       const so = makeFieldDefinitionSO();

--- a/x-pack/platform/plugins/shared/cases/server/services/field_definitions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/field_definitions/index.ts
@@ -70,6 +70,33 @@ export class FieldDefinitionsService {
     };
   }
 
+  /**
+   * Fetches `isGlobal: true` field definitions for extended-field search.
+   * When `owner` is omitted or empty, returns global defs for all owners
+   * (mirrors `getTemplateVersionsForExtendedFieldSearch` semantics).
+   */
+  async getGlobalFieldDefinitionsForSearch(params: {
+    owner?: string[];
+  }): Promise<FieldDefinition[]> {
+    const owners = params.owner?.length ? [...new Set(params.owner.filter(Boolean))] : [];
+    const ownerFilter =
+      owners.length > 0
+        ? owners
+            .map(
+              (o) => `${CASE_FIELD_DEFINITION_SAVED_OBJECT}.attributes.owner: "${escapeKuery(o)}"`
+            )
+            .join(' OR ')
+        : undefined;
+
+    const result = await this.dependencies.unsecuredSavedObjectsClient.find<FieldDefinition>({
+      type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
+      filter: ownerFilter,
+      perPage: 10000,
+    });
+
+    return result.saved_objects.map((so) => so.attributes).filter((fd) => fd.isGlobal === true);
+  }
+
   async getFieldDefinition(id: string): Promise<SavedObject<FieldDefinition>> {
     return this.dependencies.unsecuredSavedObjectsClient.get<FieldDefinition>(
       CASE_FIELD_DEFINITION_SAVED_OBJECT,

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -244,6 +244,7 @@ export const createTemplatesServiceMock = (): TemplatesServiceMock => {
 export const createFieldDefinitionsServiceMock = (): FieldDefinitionsServiceMock => {
   const service: PublicMethodsOf<FieldDefinitionsService> = lazyObject({
     getFieldDefinitions: jest.fn().mockResolvedValue({ fieldDefinitions: [], total: 0 }),
+    getGlobalFieldDefinitionsForSearch: jest.fn().mockResolvedValue([]),
     getFieldDefinition: jest.fn(),
     createFieldDefinition: jest.fn(),
     updateFieldDefinition: jest.fn(),

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
@@ -88,6 +88,7 @@ describe('TemplatesService', () => {
   // Spy on the analytics v2 refresh hook so the per-write-path assertions
   // can verify it fires without any wiring.
   const refreshAnalyticsV2DataView = jest.fn();
+  const getFieldDefinitionsForOwner = jest.fn().mockResolvedValue([]);
 
   const createService = () =>
     new TemplatesService({
@@ -96,6 +97,7 @@ describe('TemplatesService', () => {
       esClient,
       namespace: 'default',
       refreshAnalyticsV2DataView,
+      getFieldDefinitionsForOwner,
     });
 
   /** Default getAllTemplates params — override individual fields as needed */
@@ -114,6 +116,7 @@ describe('TemplatesService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     unsecuredSavedObjectsClient.find.mockResolvedValue(createMockFindResponse([]));
+    getFieldDefinitionsForOwner.mockResolvedValue([]);
   });
 
   describe('getAllTemplates', () => {
@@ -886,6 +889,82 @@ describe('TemplatesService', () => {
       }),
       expect.objectContaining({ id: 'generated-id' })
     );
+  });
+
+  it('resolves $ref fields into fieldDefinitions on create', async () => {
+    const definition = yamlStringify({
+      name: 'Case with ref',
+      fields: [{ $ref: 'severity_level' }],
+    });
+    getFieldDefinitionsForOwner.mockResolvedValue([
+      {
+        fieldDefinitionId: 'fd-1',
+        name: 'severity_level',
+        owner: 'securitySolution',
+        description: '',
+        definition: yamlStringify({
+          name: 'severity_level',
+          label: 'Severity Level',
+          type: 'keyword',
+          control: 'SELECT_BASIC',
+          metadata: { options: ['Low', 'High'] },
+        }),
+      },
+    ]);
+    const service = createService();
+
+    unsecuredSavedObjectsClient.create.mockResolvedValue({
+      id: 'template-id',
+      attributes: {} as Template,
+    } as SavedObject<Template>);
+
+    await service.createTemplate(
+      {
+        name: 'Ref Template',
+        owner: 'securitySolution',
+        definition,
+      },
+      'alice',
+      'generated-id'
+    );
+
+    expect(getFieldDefinitionsForOwner).toHaveBeenCalledWith('securitySolution');
+    expect(unsecuredSavedObjectsClient.create).toHaveBeenCalledWith(
+      CASE_TEMPLATE_SAVED_OBJECT,
+      expect.objectContaining({
+        fieldCount: 1,
+        fieldDefinitions: [
+          {
+            name: 'severity_level',
+            label: 'Severity Level',
+            type: 'keyword',
+            control: 'SELECT_BASIC',
+          },
+        ],
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('does not fetch the field library on create when the definition has no $ref fields', async () => {
+    const definition = yamlStringify({
+      name: 'Case without refs',
+      fields: [{ name: 'inline_notes', label: 'Notes', type: 'keyword', control: 'INPUT_TEXT' }],
+    });
+    const service = createService();
+
+    unsecuredSavedObjectsClient.create.mockResolvedValue({
+      id: 'template-id',
+      attributes: {} as Template,
+    } as SavedObject<Template>);
+
+    await service.createTemplate(
+      { name: 'Inline Template', owner: 'securitySolution', definition },
+      'alice',
+      'generated-id'
+    );
+
+    expect(getFieldDefinitionsForOwner).not.toHaveBeenCalled();
   });
 
   it('does not derive template metadata from YAML case defaults on create', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
@@ -22,6 +22,8 @@ import type {
   Template,
   UpdateTemplateInput,
 } from '../../../common/types/domain/template/v1';
+import type { FieldDefinition } from '../../../common/types/domain/field_definition/v1';
+import { isRefField } from '../../../common/types/domain/template/fields';
 import { toFieldDefinitions, trimFieldDefaults } from './utils';
 import { CASE_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
 import type {
@@ -47,6 +49,11 @@ export class TemplatesService {
        * `V2_NOOP_DATA_VIEW_REFRESHER`).
        */
       refreshAnalyticsV2DataView: () => void;
+      /**
+       * Fetches field-library definitions for the given owner so `$ref` fields
+       * can be resolved into the template's cached `fieldDefinitions` summary.
+       */
+      getFieldDefinitionsForOwner: (owner: string) => Promise<FieldDefinition[]>;
     }
   ) {}
 
@@ -354,6 +361,8 @@ export class TemplatesService {
       owner: input.owner,
     });
 
+    const libraryDefs = await this.getLibraryDefsIfReferenced(parsedDefinition.fields, input.owner);
+
     const templateSavedObject = await this.dependencies.unsecuredSavedObjectsClient.create(
       CASE_TEMPLATE_SAVED_OBJECT,
       {
@@ -370,7 +379,7 @@ export class TemplatesService {
         tags: input.tags,
         author,
         fieldCount: parsedDefinition.fields.length,
-        fieldDefinitions: toFieldDefinitions(parsedDefinition.fields),
+        fieldDefinitions: toFieldDefinitions(parsedDefinition.fields, libraryDefs),
         isEnabled: input.isEnabled ?? true,
       } as Template,
       { refresh: true, id }
@@ -409,6 +418,8 @@ export class TemplatesService {
       excludeTemplateId: currentTemplate.attributes.templateId,
     });
 
+    const libraryDefs = await this.getLibraryDefsIfReferenced(parsedDefinition.fields, input.owner);
+
     const templateSavedObject = await this.dependencies.unsecuredSavedObjectsClient.create(
       CASE_TEMPLATE_SAVED_OBJECT,
       {
@@ -425,7 +436,7 @@ export class TemplatesService {
         tags: input.tags,
         author: currentTemplate.attributes.author,
         fieldCount: parsedDefinition.fields.length,
-        fieldDefinitions: toFieldDefinitions(parsedDefinition.fields),
+        fieldDefinitions: toFieldDefinitions(parsedDefinition.fields, libraryDefs),
         usageCount: currentTemplate.attributes.usageCount,
         lastUsedAt: currentTemplate.attributes.lastUsedAt,
         isEnabled: input.isEnabled ?? currentTemplate.attributes.isEnabled ?? true,
@@ -547,6 +558,22 @@ export class TemplatesService {
     // the propagation hook wired so future changes to the template field
     // collection reach the data view without a code change.
     this.dependencies.refreshAnalyticsV2DataView();
+  }
+
+  /**
+   * Fetches the owner's field library only when the definition actually has `$ref` fields to
+   * resolve — avoids an unnecessary SO `find` round-trip on every create/update for templates
+   * that only use inline fields.
+   */
+  private async getLibraryDefsIfReferenced(
+    fields: ParsedTemplate['definition']['fields'],
+    owner: string
+  ): Promise<FieldDefinition[]> {
+    if (!fields.some(isRefField)) {
+      return [];
+    }
+
+    return this.dependencies.getFieldDefinitionsForOwner(owner);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/utils.test.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
+import { stringify as yamlStringify } from 'yaml';
 import { toFieldDefinitions, trimFieldDefaults } from './utils';
+import type { FieldDefinition } from '../../../common/types/domain/field_definition/v1';
 
 describe('toFieldDefinitions', () => {
   it('maps fields to field definitions with label falling back to name', () => {
@@ -27,6 +29,49 @@ describe('toFieldDefinitions', () => {
 
   it('returns an empty array when given no fields', () => {
     expect(toFieldDefinitions([])).toEqual([]);
+  });
+
+  it('resolves $ref fields against the field library', () => {
+    const libraryDefs: FieldDefinition[] = [
+      {
+        fieldDefinitionId: 'fd-1',
+        name: 'severity_level',
+        owner: 'securitySolution',
+        description: '',
+        isGlobal: false,
+        definition: yamlStringify({
+          name: 'severity_level',
+          label: 'Severity Level',
+          type: 'keyword',
+          control: 'SELECT_BASIC',
+          metadata: { options: ['Low', 'High'] },
+        }),
+      },
+    ];
+
+    const fields = [
+      {
+        name: 'inline_notes',
+        label: 'Notes',
+        type: 'keyword' as const,
+        control: 'INPUT_TEXT' as const,
+      },
+      { $ref: 'severity_level' },
+    ];
+
+    expect(toFieldDefinitions(fields, libraryDefs)).toEqual([
+      { name: 'inline_notes', label: 'Notes', type: 'keyword', control: 'INPUT_TEXT' },
+      {
+        name: 'severity_level',
+        label: 'Severity Level',
+        type: 'keyword',
+        control: 'SELECT_BASIC',
+      },
+    ]);
+  });
+
+  it('drops $ref fields whose library definition is missing', () => {
+    expect(toFieldDefinitions([{ $ref: 'missing_field' }], [])).toEqual([]);
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/utils.ts
@@ -7,12 +7,21 @@
 
 import { parseDocument, isMap, isSeq, isScalar } from 'yaml';
 import type { ParsedTemplate } from '../../../common/types/domain/template/v1';
-import { isInlineField } from '../../../common/types/domain/template/fields';
+import type { FieldDefinition } from '../../../common/types/domain/field_definition/v1';
+import { resolveTemplateFields } from '../../../common/utils';
 
 type ParsedField = ParsedTemplate['definition']['fields'][number];
 
-export const toFieldDefinitions = (fields: ParsedField[]) =>
-  fields.filter(isInlineField).map((f) => ({
+/**
+ * Builds the cached `fieldDefinitions` summary stored on a template SO.
+ * Resolves `$ref` fields against the field library so search and label
+ * enrichment can see library-referenced fields.
+ */
+export const toFieldDefinitions = (
+  fields: ParsedField[],
+  libraryDefs: readonly FieldDefinition[] = []
+) =>
+  resolveTemplateFields(fields, libraryDefs).map((f) => ({
     name: f.name,
     label: f.label ?? f.name,
     type: f.type,

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/migrate_configuration.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/migrate_configuration.ts
@@ -22,6 +22,28 @@ import { buildFieldDefinitionYaml } from './build_field_definition_yaml';
 import { buildTemplateYaml } from './build_template_yaml';
 import type { LegacyCustomField, LegacyTemplate, MigrationCounts } from './types';
 
+/**
+ * Fetches every `cases-field-definition` SO for the given owner/namespace.
+ * perPage: 10000 is intentionally unbounded for this one-shot scan — field-definitions per
+ * owner are expected to be O(10s).
+ */
+const findFieldDefinitionsForOwner = async (
+  repo: ISavedObjectsRepository,
+  owner: string,
+  nsOption: string | undefined
+): Promise<Array<SavedObject<FieldDefinition>>> => {
+  const result = await repo.find<FieldDefinition>({
+    type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
+    namespaces: nsOption ? [nsOption] : ['default'],
+    perPage: 10000,
+    page: 1,
+    // owner is one of cases/securitySolution/observability — a controlled enum, not user input
+    filter: `${CASE_FIELD_DEFINITION_SAVED_OBJECT}.attributes.owner: "${owner}"`,
+  });
+
+  return result.saved_objects;
+};
+
 /** Fetches every `cases-configure` SO across all spaces (there are only O(spaces) of them). */
 export const findAllConfigurations = async (
   repo: ISavedObjectsRepository,
@@ -70,24 +92,19 @@ const migrateFieldDefinitions = async (
   legacyCustomFields: LegacyCustomField[],
   executionId: string,
   log: Logger
-): Promise<{ refNamesByKey: Map<string, string>; created: number; reused: number }> => {
+): Promise<{
+  refNamesByKey: Map<string, string>;
+  created: number;
+  reused: number;
+  libraryDefs: FieldDefinition[];
+}> => {
   const refNamesByKey = new Map<string, string>();
+  const libraryDefs: FieldDefinition[] = [];
   let created = 0;
   let reused = 0;
 
-  // perPage: 10000 is intentionally unbounded for this one-shot scan — field-definitions per owner
-  // are expected to be O(10s).
-  const existingFieldDefs = await repo.find<FieldDefinition>({
-    type: CASE_FIELD_DEFINITION_SAVED_OBJECT,
-    namespaces: nsOption ? [nsOption] : ['default'],
-    perPage: 10000,
-    page: 1,
-    // owner is one of cases/securitySolution/observability — a controlled enum, not user input
-    filter: `${CASE_FIELD_DEFINITION_SAVED_OBJECT}.attributes.owner: "${owner}"`,
-  });
-  const existingByName = new Map(
-    existingFieldDefs.saved_objects.map((fd) => [fd.attributes.name, fd])
-  );
+  const existingFieldDefs = await findFieldDefinitionsForOwner(repo, owner, nsOption);
+  const existingByName = new Map(existingFieldDefs.map((fd) => [fd.attributes.name, fd]));
 
   for (const cf of legacyCustomFields) {
     const existingDef = existingByName.get(cf.key);
@@ -114,24 +131,27 @@ const migrateFieldDefinitions = async (
         );
       }
       refNamesByKey.set(cf.key, cf.key);
+      libraryDefs.push(existingDef.attributes);
       reused++;
     } else {
       try {
         const { yaml } = buildFieldDefinitionYaml(cf);
         const fdId = uuidv4();
-        await repo.create<FieldDefinition>(
-          CASE_FIELD_DEFINITION_SAVED_OBJECT,
-          {
-            fieldDefinitionId: fdId,
-            name: cf.key,
-            owner,
-            definition: yaml,
-            description: cf.label,
-            isGlobal: true,
-          },
-          { id: fdId, ...(nsOption ? { namespace: nsOption } : {}), refresh: false }
-        );
+        const attributes: FieldDefinition = {
+          fieldDefinitionId: fdId,
+          name: cf.key,
+          owner,
+          definition: yaml,
+          description: cf.label,
+          isGlobal: true,
+        };
+        await repo.create<FieldDefinition>(CASE_FIELD_DEFINITION_SAVED_OBJECT, attributes, {
+          id: fdId,
+          ...(nsOption ? { namespace: nsOption } : {}),
+          refresh: false,
+        });
         refNamesByKey.set(cf.key, cf.key);
+        libraryDefs.push(attributes);
         created++;
       } catch (err) {
         log.error(
@@ -143,7 +163,12 @@ const migrateFieldDefinitions = async (
     }
   }
 
-  return { refNamesByKey, created, reused };
+  return {
+    refNamesByKey,
+    created,
+    reused,
+    libraryDefs,
+  };
 };
 
 /**
@@ -158,6 +183,7 @@ const migrateTemplates = async (
   nsOption: string | undefined,
   legacyTemplates: LegacyTemplate[],
   refNamesByKey: Map<string, string>,
+  libraryDefs: readonly FieldDefinition[],
   executionId: string,
   log: Logger
 ): Promise<{ created: number; reused: number }> => {
@@ -223,7 +249,7 @@ const migrateTemplates = async (
             tags: legacyTemplate.tags,
             author: 'system',
             fieldCount: parsedDefinition.fields.length,
-            fieldDefinitions: toFieldDefinitions(parsedDefinition.fields),
+            fieldDefinitions: toFieldDefinitions(parsedDefinition.fields, libraryDefs),
             isEnabled: true,
             // Preserve the v1 identity so a rule storing this legacy key resolves back to exactly
             // this migrated template, even when another v1 template shared the same name.
@@ -275,6 +301,7 @@ export const migrateOneConfigure = async (
   let fieldDefsCreated = 0;
   let fieldDefsReused = 0;
   let refNamesByKey = new Map<string, string>();
+  let libraryDefs: FieldDefinition[] = [];
 
   if (!attributes.legacyCustomFieldsMigrated && legacyCustomFields.length > 0) {
     const result = await migrateFieldDefinitions(
@@ -289,10 +316,16 @@ export const migrateOneConfigure = async (
     refNamesByKey = result.refNamesByKey;
     fieldDefsCreated = result.created;
     fieldDefsReused = result.reused;
+    libraryDefs = result.libraryDefs;
   } else {
     // Already migrated or no custom fields — build the ref map from legacy keys for the template phase.
     for (const cf of legacyCustomFields) {
       refNamesByKey.set(cf.key, cf.key);
+    }
+    if (legacyTemplates.length > 0 && legacyCustomFields.length > 0) {
+      // Templates still need the library defs to populate fieldDefinitions for `$ref` fields.
+      const existingFieldDefs = await findFieldDefinitionsForOwner(repo, owner, nsOption);
+      libraryDefs = existingFieldDefs.map((fd) => fd.attributes);
     }
   }
 
@@ -308,6 +341,7 @@ export const migrateOneConfigure = async (
       nsOption,
       legacyTemplates,
       refNamesByKey,
+      libraryDefs,
       executionId,
       log
     );

--- a/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/templates_migration_task_manager.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/templates_migration/templates_migration_task_manager.test.ts
@@ -278,6 +278,13 @@ describe('TemplatesMigrationTaskManager', () => {
         name: 'My Template',
         owner: 'cases',
         isLatest: true,
+        fieldDefinitions: [
+          expect.objectContaining({
+            name: 'cf_text',
+            type: 'keyword',
+            control: 'INPUT_TEXT',
+          }),
+        ],
       });
 
       // The field/template phase writes those two flags together...


### PR DESCRIPTION
## What & Why
Fixes several bugs in extended field search (templates v2). Searching cases by a global (`isGlobal`) field-library field's label returned zero results — the template-version scoping filter produced an unsatisfiable query for fields with no template. Cases with global extended fields but no template never got `extended_fields_labels` populated (enrichment required a template), and templates migrated from legacy custom fields were missing `fieldDefinitions` for their `$ref` fields because the field-library definitions weren't threaded into the migration's template-creation step. An extended field filter whose label didn't resolve to any known field (or whose value failed to parse) was silently dropped instead of matching zero results. Free-text extended field values starting with `[` were misinterpreted as JSON arrays. And `extendedFieldFilters` on a `DATE_PICKER` field always returned zero results — `extended_fields` is an ES `flattened` field, so range queries on it compare lexicographically rather than chronologically, and the date-range bounds were built as full ISO timestamps that sort after the bare `YYYY-MM-DD` values actually stored.

## How to Test
1. Set `xpack.cases.templates.enabled: true`.
2. Create a global field definition via `POST /internal/cases/field_definitions` with `isGlobal: true`.
3. Create a case (no template) with that field's value set in `extended_fields`.
4. Call `POST /internal/cases/_search` with `search: "<field label>"` (or `extendedFieldFilters`) — the case should be returned, with `extended_fields_labels` populated.
5. Search for a free-text extended field value that starts with `[` (e.g. `[foo]`) and confirm it matches as plain text rather than being treated as a JSON array.
6. `extendedFieldFilters` with an unresolvable label, or a non-numeric value on a numeric field, should return `total: 0` rather than all cases.
7. `extendedFieldFilters` with a `DATE_PICKER` field's label and a `YYYY-MM-DD` value should return the case(s) with that due date, whether the stored value is a bare date or a full ISO timestamp.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->