### PR TITLE
[8.19] [selective-testing] skip scout tests when changes are ftr / jest only (#278583)

### DIFF
--- a/.buildkite/scripts/steps/test/scout/resolve_selective_testing.ts
+++ b/.buildkite/scripts/steps/test/scout/resolve_selective_testing.ts
@@ -39,6 +39,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { ToolingLog } from '@kbn/tooling-log';
 import { expandWithImplicitConsumers } from './scout_implicit_consumers';
+import { shouldSkipScoutTests } from './scout_ftr_modules';
 import { computeMoonShadow } from './moon_shadow';
 import { getAffectedPackages, listChangedFiles } from '#pipeline-utils';
 
@@ -54,6 +55,30 @@ if (!mergeBase || !outPath) {
 (async () => {
   // List changed files once; reuse for both affected-packages and critical-files check.
   const changedFiles = listChangedFiles({ mergeBase, commit: 'HEAD' });
+
+  // Skip Scout when all affected modules are not related.
+  const directlyAffected = await getAffectedPackages(mergeBase, {
+    strategy: 'git',
+    includeDownstream: false,
+    ignoreUncategorizedChanges: true,
+  });
+
+  if (shouldSkipScoutTests(directlyAffected)) {
+    log.info(
+      `Skipping Scout tests — all ${directlyAffected.size} affected module(s) are excluded: ${[
+        ...directlyAffected,
+      ].join(', ')}`
+    );
+    const codeChanges = {
+      mergeBase,
+      changedFiles: [...changedFiles].sort(),
+      affectedModules: [] as string[],
+    };
+    const resolvedOutPath = path.resolve(outPath);
+    fs.mkdirSync(path.dirname(resolvedOutPath), { recursive: true });
+    fs.writeFileSync(resolvedOutPath, JSON.stringify(codeChanges, null, 2));
+    return;
+  }
 
   // Compute affected @kbn/ modules (replaces the legacy `list_affected` binary).
   // Overlay implicit runtime-registry consumers — see scout_implicit_consumers.ts.

--- a/.buildkite/scripts/steps/test/scout/scout_ftr_modules.test.ts
+++ b/.buildkite/scripts/steps/test/scout/scout_ftr_modules.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { SCOUT_EXCLUDED_MODULES, shouldSkipScoutTests } from './scout_ftr_modules';
+
+describe('SCOUT_EXCLUDED_MODULES', () => {
+  const SCOUT_DEPENDENCIES = [
+    '@kbn/test-es-server',
+    '@kbn/test-kibana-server',
+    '@kbn/test-saml-auth',
+    '@kbn/test-subj-selector',
+    '@kbn/test-docker-servers',
+    '@kbn/es-archiver',
+  ];
+
+  it('does not include any modules that @kbn/scout depends on', () => {
+    for (const dep of SCOUT_DEPENDENCIES) {
+      expect(SCOUT_EXCLUDED_MODULES.has(dep)).toBe(false);
+    }
+  });
+
+  it('does not include Scout ecosystem modules', () => {
+    const scoutEcosystem = [
+      '@kbn/scout',
+      '@kbn/scout-oblt',
+      '@kbn/scout-search',
+      '@kbn/scout-security',
+      '@kbn/scout-synthtrace',
+      '@kbn/scout-reporting',
+    ];
+    for (const id of scoutEcosystem) {
+      expect(SCOUT_EXCLUDED_MODULES.has(id)).toBe(false);
+    }
+  });
+
+  it('includes expected FTR core modules', () => {
+    expect(SCOUT_EXCLUDED_MODULES.has('@kbn/test')).toBe(true);
+    expect(SCOUT_EXCLUDED_MODULES.has('@kbn/ftr-common-functional-services')).toBe(true);
+    expect(SCOUT_EXCLUDED_MODULES.has('@kbn/test-suites-src')).toBe(true);
+  });
+});
+
+describe('shouldSkipScoutTests', () => {
+  it('returns false for an empty set', () => {
+    expect(shouldSkipScoutTests(new Set())).toBe(false);
+  });
+
+  it('returns true when all modules are excluded', () => {
+    expect(shouldSkipScoutTests(new Set(['@kbn/test', '@kbn/test-suites-src']))).toBe(true);
+  });
+
+  it('returns true for a single excluded module', () => {
+    expect(shouldSkipScoutTests(new Set(['@kbn/test']))).toBe(true);
+  });
+
+  it('returns false when any module is not in the excluded list', () => {
+    expect(shouldSkipScoutTests(new Set(['@kbn/test', '@kbn/dashboard-plugin']))).toBe(false);
+  });
+
+  it('returns false for a Scout dependency module', () => {
+    expect(shouldSkipScoutTests(new Set(['@kbn/test-saml-auth']))).toBe(false);
+  });
+
+  it('returns false for an unknown module', () => {
+    expect(shouldSkipScoutTests(new Set(['@kbn/some-random-plugin']))).toBe(false);
+  });
+});

--- a/.buildkite/scripts/steps/test/scout/scout_ftr_modules.ts
+++ b/.buildkite/scripts/steps/test/scout/scout_ftr_modules.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Modules that can never affect Scout tests. When a PR only
+ * touches modules in this set, Scout tests are skipped entirely.
+ *
+ * Do NOT add modules that @kbn/scout depends on.
+ */
+
+export const SCOUT_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
+  // FTR framework
+  '@kbn/test',
+  '@kbn/ambient-ftr-types',
+  '@kbn/ftr-benchmarks',
+
+  // Jest test helpers
+  '@kbn/test-eui-helpers',
+  '@kbn/test-jest-helpers',
+
+  // FTR services & helpers
+  '@kbn/ftr-common-functional-services',
+  '@kbn/ftr-common-functional-ui-services',
+  '@kbn/ftr-screenshot-filename',
+  '@kbn/ftr-apis-plugin',
+  '@kbn/detections-response-ftr-services',
+  '@kbn/analytics-ftr-helpers-plugin',
+
+  // FTR suite roots
+  '@kbn/test-suites-src',
+  '@kbn/test-suites-xpack-platform',
+  '@kbn/test-suites-xpack-observability',
+  '@kbn/test-suites-xpack-search',
+  '@kbn/test-suites-xpack-security',
+  '@kbn/test-suites-xpack-security-endpoint',
+  '@kbn/test-suites-xpack-performance',
+  '@kbn/test-suites-xpack-vectordb',
+  '@kbn/test-suites-xpack-workplace-ai',
+  '@kbn/test-suites-security-solution-apis',
+
+  // Other test-only infrastructure
+  '@kbn/journeys',
+  '@kbn/cypress-test-helper',
+  '@kbn/performance-testing-dataset-extractor',
+  '@kbn/migrator-test-kit',
+  '@kbn/web-worker-stub',
+]);
+
+/** Returns true when all affected modules are in the excluded list. */
+export function shouldSkipScoutTests(moduleIds: ReadonlySet<string>): boolean {
+  if (moduleIds.size === 0) return false;
+  for (const id of moduleIds) {
+    if (!SCOUT_EXCLUDED_MODULES.has(id)) return false;
+  }
+  return true;
+}

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts
@@ -431,7 +431,7 @@ describe('identifyTestLoads', () => {
         expect(loads).toHaveLength(0);
       });
 
-      it('includes all configs when ids set is empty', () => {
+      it('excludes all configs when ids set is empty', () => {
         const config = createMockConfig({ path: 'plugin/config.ts' });
         mockTestConfigs = [config];
 
@@ -442,7 +442,7 @@ describe('identifyTestLoads', () => {
           [{ kind: 'modules', ids: new Set() }],
           log
         );
-        expect(loads).toHaveLength(1);
+        expect(loads).toHaveLength(0);
         expect(mockFindPackageForPath).not.toHaveBeenCalled();
       });
     });

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
@@ -103,7 +103,7 @@ export function identifyTestLoads(
             case 'configs':
               return filter.paths.has(config.path);
             case 'modules':
-              if (filter.ids.size === 0) return true;
+              if (filter.ids.size === 0) return false;
               const resolvedModuleID = findPackageForPath(REPO_ROOT, config.path)?.id;
               return resolvedModuleID ? filter.ids.has(resolvedModuleID) : false;
             case 'channels':


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[selective-testing] skip scout tests when changes are ftr / jest only (#278583)](https://github.com/elastic/kibana/pull/278583)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-16T13:52:54Z","message":"[selective-testing] skip scout tests when changes are ftr / jest only (#278583)\n\n## Summary\n\nImprove selective testing on PRs by skipping Scout tests when a PR only\ntouches modules that cannot affect them: FTR framework code, Jest\nhelpers, or FTR test suites.\n\nToday, changes to `@kbn/test` cascade through the dependency graph via\n`@kbn/core` to ~800 modules, triggering all Scout tests even though\nFTR/Jest infrastructure has no relation to production code and Scout\ntests itself.\n\nThis PR adds an early check: if every \"directly-affected\" module belongs\nto an explicit exclusion list, we produce an empty `affectedModules` set\nso no Scout tests are scheduled.\n\nAlso PR fixes `create_test_tracks.ts` where an empty modules filter\nincorrectly meant \"run everything\" instead of \"nothing matched.\"\n\nExample PR where Scout tests should not be triggered:\nhttps://github.com/elastic/kibana/pull/278491\n\n\nFile(s) | Module | In FTR list?\n-- | -- | --\n6 files under kbn-test/src/functional_test_runner/ | @kbn/test | Yes\ndashboard_filtering.ts | @kbn/test-suites-src | Yes\nstreams_heavy_config.ts | @kbn/test-suites-xpack-performance | Yes\n8 security config files | @kbn/test-suites-security-solution-apis | Yes\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"fecdfca79060c192d2fcbc02f7da332360b80789","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","reviewer:claude","v9.5.0","v9.4.4","reviewer:scout","v9.6.0","v9.3.8"],"title":"[selective-testing] skip scout tests when changes are ftr / jest only","number":278583,"url":"https://github.com/elastic/kibana/pull/278583","mergeCommit":{"message":"[selective-testing] skip scout tests when changes are ftr / jest only (#278583)\n\n## Summary\n\nImprove selective testing on PRs by skipping Scout tests when a PR only\ntouches modules that cannot affect them: FTR framework code, Jest\nhelpers, or FTR test suites.\n\nToday, changes to `@kbn/test` cascade through the dependency graph via\n`@kbn/core` to ~800 modules, triggering all Scout tests even though\nFTR/Jest infrastructure has no relation to production code and Scout\ntests itself.\n\nThis PR adds an early check: if every \"directly-affected\" module belongs\nto an explicit exclusion list, we produce an empty `affectedModules` set\nso no Scout tests are scheduled.\n\nAlso PR fixes `create_test_tracks.ts` where an empty modules filter\nincorrectly meant \"run everything\" instead of \"nothing matched.\"\n\nExample PR where Scout tests should not be triggered:\nhttps://github.com/elastic/kibana/pull/278491\n\n\nFile(s) | Module | In FTR list?\n-- | -- | --\n6 files under kbn-test/src/functional_test_runner/ | @kbn/test | Yes\ndashboard_filtering.ts | @kbn/test-suites-src | Yes\nstreams_heavy_config.ts | @kbn/test-suites-xpack-performance | Yes\n8 security config files | @kbn/test-suites-security-solution-apis | Yes\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"fecdfca79060c192d2fcbc02f7da332360b80789"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279120","number":279120,"state":"MERGED","mergeCommit":{"sha":"3c13f906e3b45fcf2217581b434da79c8423aa77","message":"[9.5] [selective-testing] skip scout tests when changes are ftr / jest only (#278583) (#279120)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[selective-testing] skip scout tests when changes are ftr / jest only\n(#278583)](https://github.com/elastic/kibana/pull/278583)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/278868","number":278868,"state":"MERGED","mergeCommit":{"sha":"eeefbdcae2b9ad3208906aced37a7ecfb79801b7","message":"[9.4] [selective-testing] skip scout tests when changes are ftr / jest only (#278583) (#278868)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[selective-testing] skip scout tests when changes are ftr / jest only\n(#278583)](https://github.com/elastic/kibana/pull/278583)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278583","number":278583,"mergeCommit":{"message":"[selective-testing] skip scout tests when changes are ftr / jest only (#278583)\n\n## Summary\n\nImprove selective testing on PRs by skipping Scout tests when a PR only\ntouches modules that cannot affect them: FTR framework code, Jest\nhelpers, or FTR test suites.\n\nToday, changes to `@kbn/test` cascade through the dependency graph via\n`@kbn/core` to ~800 modules, triggering all Scout tests even though\nFTR/Jest infrastructure has no relation to production code and Scout\ntests itself.\n\nThis PR adds an early check: if every \"directly-affected\" module belongs\nto an explicit exclusion list, we produce an empty `affectedModules` set\nso no Scout tests are scheduled.\n\nAlso PR fixes `create_test_tracks.ts` where an empty modules filter\nincorrectly meant \"run everything\" instead of \"nothing matched.\"\n\nExample PR where Scout tests should not be triggered:\nhttps://github.com/elastic/kibana/pull/278491\n\n\nFile(s) | Module | In FTR list?\n-- | -- | --\n6 files under kbn-test/src/functional_test_runner/ | @kbn/test | Yes\ndashboard_filtering.ts | @kbn/test-suites-src | Yes\nstreams_heavy_config.ts | @kbn/test-suites-xpack-performance | Yes\n8 security config files | @kbn/test-suites-security-solution-apis | Yes\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"fecdfca79060c192d2fcbc02f7da332360b80789"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/278842","number":278842,"state":"MERGED","mergeCommit":{"sha":"0cf918f6eb9ec96743c21c2ab9ee13b28856b947","message":"[9.3] [selective-testing] skip scout tests when changes are ftr / jest only (#278583) (#278842)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[selective-testing] skip scout tests when changes are ftr / jest only\n(#278583)](https://github.com/elastic/kibana/pull/278583)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->