### PR TITLE
[Discover] Clear runtime field name before renaming in data view editing FTR test

### DIFF
--- a/src/platform/test/functional/apps/discover/tabs7/_data_view_editing.ts
+++ b/src/platform/test/functional/apps/discover/tabs7/_data_view_editing.ts
@@ -48,7 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   const editRuntimeField = async (oldName: string, newName: string) => {
     await discover.editField(oldName);
-    await fieldEditor.setName(newName);
+    await fieldEditor.setName(newName, true);
     await fieldEditor.save();
     await fieldEditor.confirmSave();
     await fieldEditor.waitUntilClosed();


### PR DESCRIPTION
Fixes #272963

### Summary
- The `ad-hoc data view can create runtime fields ... in both tabs` test renames a runtime field from `_test_new_field` to `_test_new_field_edited` via `editRuntimeField`, but `fieldEditor.setName(newName)` never cleared the pre-populated old name, so the input became `_test_new_field_test_new_field_edited`. The sidebar never showed `_test_new_field_edited`, so `checkFieldIsInSidebar`'s 120s `retry.try` timed out.
- Pass `clearFirst = true` to `setName`, which clears via select-all + Backspace (`clearWithKeyboard`) before typing, so the new name replaces the old one instead of being appended.

### Context
- Follows the [Failed Test Investigator's proposed fix](https://github.com/elastic/kibana/issues/272963#issuecomment-4726847223) exactly. Its evidence still holds against the current code: the observed `_test_new_field_test_new_field_edited` is the old value + new value concatenated, which only happens when typing into a non-cleared input — so the failure is deterministic within a run and a timeout bump would not help.
- This helper was the lone rename outlier. Every other runtime-field rename in the Discover FTR suite already passes `true`: `group7/_runtime_fields_editor.ts` ("allows editing of a newly created field"), `group4/_adhoc_data_views.ts` ("should update id after data view field edit"), and `tabs/_restorable_state.ts`. The `create` helpers correctly omit the flag because they type into an empty input.
- First failure: [kibana-on-merge - 9.4](https://buildkite.com/elastic/kibana-on-merge/builds/99419#019e9b54-b60b-4192-839e-139c83b958f7), in Chrome UI Functional Tests (`discover/tabs7/_data_view_editing`). The test file was relocated into `tabs7/` by the mechanical FTR-config split #258429; the buggy helper predates that move, so blame does not point to a meaningful feature PR and no introducing PR is claimed.

<details>
<summary>Verification</summary>

#### Verified locally

`✅ Passed: node scripts/eslint src/platform/test/functional/apps/discover/tabs7/_data_view_editing.ts`

#### Not verified locally

- `node scripts/type_check` could not complete here: the local checkout is bootstrapped for `main` (9.6.0) while this branch is `9.5`, so an unrelated package (`kbn-tracing-utils`) fails to resolve `@opentelemetry/sdk-trace` (`TS2307`). The error is not in the changed file; the one-line change is type-safe — `setName(name: string, clearFirst = false, typeCharByChar = false)` accepts a boolean second argument. Relying on `9.5` CI for the type check.
- The FTR spec needs a live Elasticsearch + Kibana and cannot run in this environment; behavior under CI parallel load was not reproduced here.

</details>

<details>
<summary>Backporting guidance</summary>

Applied `backport:version` + `v9.4.4`. The failing test file (`src/platform/test/functional/apps/discover/tabs7/_data_view_editing.ts`) exists **identically** on `9.5` and `9.4` (same blob SHA), so this patch applies unchanged to both — the PR targets `9.5` and backports to `9.4`, where the failure was reported. The file is absent from `main` (9.6.0), `9.3`, and `8.19` (the Discover tabs suite was reorganized and `tabs7` does not exist there), so those branches are intentionally excluded.

</details>

> [!NOTE]
> Recreated manually to recover the Flaky Test Fixer run for #272963, whose `safe-outputs` step timed out so no PR was opened automatically. This is the same test-side fix that run would have proposed. Share feedback in #kibana-qa.
