### PR TITLE
[9.5] [Alerting v2] Mark rule-management agent builder skill as experimental (#276995)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts
@@ -23,6 +23,12 @@ describe('createRuleManagementSkill', () => {
     expect(skill.basePath).toBe('skills/platform/alerting');
   });
 
+  it('marks the skill as experimental so it is gated behind agent builder experimental features', () => {
+    const skill = createRuleManagementSkill(createDeps());
+
+    expect(skill.experimental).toBe(true);
+  });
+
   it('gates the skill on the alerting:v2:enabled advanced setting', () => {
     const skill = createRuleManagementSkill(createDeps());
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -24,6 +24,7 @@ export const createRuleManagementSkill = (deps: ManageActionPolicyToolDeps) =>
     basePath: 'skills/platform/alerting',
     description:
       'Compose, discover, and modify alerting V2 rules and action policies (notification policies) within a conversation.',
+    experimental: true,
     uiSettingRequired: ALERTING_V2_ENABLED_SETTING_ID,
     referencedContent: [
       {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/action_policy_sml_type.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/action_policy_sml_type.test.ts
@@ -50,6 +50,7 @@ describe('createActionPolicySmlType', () => {
   let getActionPolicy: jest.Mock;
   let getRepoSo: jest.Mock;
   let createFinder: jest.Mock;
+  let getIsAlertingV2Enabled: jest.Mock;
   let repository: ISavedObjectsRepository;
   let actionPolicyClient: ActionPolicyClient;
 
@@ -57,6 +58,7 @@ describe('createActionPolicySmlType', () => {
     getActionPolicy = jest.fn();
     getRepoSo = jest.fn();
     createFinder = jest.fn();
+    getIsAlertingV2Enabled = jest.fn().mockResolvedValue(true);
 
     repository = {
       get: getRepoSo,
@@ -70,6 +72,7 @@ describe('createActionPolicySmlType', () => {
     createActionPolicySmlType({
       getScopedActionPolicyClient: () => actionPolicyClient,
       getInternalRepository: () => repository,
+      getIsAlertingV2Enabled: () => getIsAlertingV2Enabled(),
     });
 
   describe('id and fetchFrequency', () => {
@@ -169,6 +172,15 @@ describe('createActionPolicySmlType', () => {
       await expect(drainList()).rejects.toThrow('boom');
       expect(close).toHaveBeenCalledTimes(1);
     });
+
+    it('yields nothing and never touches the repository when alerting v2 is disabled', async () => {
+      getIsAlertingV2Enabled.mockResolvedValue(false);
+
+      const items = await drainList();
+
+      expect(items).toEqual([]);
+      expect(createFinder).not.toHaveBeenCalled();
+    });
   });
 
   describe('getSmlData', () => {
@@ -225,6 +237,15 @@ describe('createActionPolicySmlType', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("SML action policy: failed to get data for 'policy-missing'")
       );
+    });
+
+    it('returns undefined without reading the saved object when alerting v2 is disabled', async () => {
+      getIsAlertingV2Enabled.mockResolvedValue(false);
+
+      const result = await buildDefinition().getSmlData('policy-1', buildSmlContext());
+
+      expect(result).toBeUndefined();
+      expect(getRepoSo).not.toHaveBeenCalled();
     });
   });
 
@@ -326,6 +347,18 @@ describe('createActionPolicySmlType', () => {
       await buildDefinition().toAttachment(document, buildToAttachmentContext());
 
       expect(getActionPolicy).toHaveBeenCalledWith({ id: '' });
+    });
+
+    it('returns undefined without calling the action policy client when alerting v2 is disabled', async () => {
+      getIsAlertingV2Enabled.mockResolvedValue(false);
+
+      const result = await buildDefinition().toAttachment(
+        buildSmlDocument(),
+        buildToAttachmentContext()
+      );
+
+      expect(result).toBeUndefined();
+      expect(getActionPolicy).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/action_policy_sml_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/action_policy_sml_type.ts
@@ -21,16 +21,29 @@ import type { ActionPolicyClient } from '../../lib/action_policy_client';
 interface CreateActionPolicySmlTypeOptions {
   getScopedActionPolicyClient: (request: KibanaRequest) => ActionPolicyClient;
   getInternalRepository: () => ISavedObjectsRepository;
+  /**
+   * Resolves the `alerting:v2:enabled` global advanced setting. When the engine
+   * is disabled, the SML hooks below become no-ops: `list` yields nothing (so
+   * the crawler's mark-and-sweep removes any previously indexed policy chunks),
+   * and `getSmlData` / `toAttachment` return `undefined`. This gates action
+   * policy data out of the context layer dynamically, without a restart.
+   */
+  getIsAlertingV2Enabled: () => Promise<boolean>;
 }
 
 export const createActionPolicySmlType = ({
   getScopedActionPolicyClient,
   getInternalRepository,
+  getIsAlertingV2Enabled,
 }: CreateActionPolicySmlTypeOptions): SmlTypeDefinition => ({
   id: ACTION_POLICY_SML_TYPE,
   fetchFrequency: () => '1m',
 
   async *list() {
+    if (!(await getIsAlertingV2Enabled())) {
+      return;
+    }
+
     const repository = getInternalRepository();
     const finder = repository.createPointInTimeFinder<ActionPolicySavedObjectAttributes>({
       type: ACTION_POLICY_SAVED_OBJECT_TYPE,
@@ -53,6 +66,10 @@ export const createActionPolicySmlType = ({
   },
 
   getSmlData: async (originId, context) => {
+    if (!(await getIsAlertingV2Enabled())) {
+      return undefined;
+    }
+
     try {
       const repository = getInternalRepository();
       const so = await repository.get<ActionPolicySavedObjectAttributes>(
@@ -101,6 +118,10 @@ export const createActionPolicySmlType = ({
   }),
 
   toAttachment: async (item, context) => {
+    if (!(await getIsAlertingV2Enabled())) {
+      return undefined;
+    }
+
     try {
       const client = getScopedActionPolicyClient(context.request);
       const policy = await client.getActionPolicy({ id: item.origin_id ?? '' });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/rule_sml_type.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/rule_sml_type.test.ts
@@ -54,6 +54,7 @@ describe('createRuleSmlType', () => {
   let getRule: jest.Mock;
   let getRepoSo: jest.Mock;
   let createFinder: jest.Mock;
+  let getIsAlertingV2Enabled: jest.Mock;
   let repository: ISavedObjectsRepository;
   let rulesClient: RulesClient;
 
@@ -61,6 +62,7 @@ describe('createRuleSmlType', () => {
     getRule = jest.fn();
     getRepoSo = jest.fn();
     createFinder = jest.fn();
+    getIsAlertingV2Enabled = jest.fn().mockResolvedValue(true);
 
     repository = {
       get: getRepoSo,
@@ -74,6 +76,7 @@ describe('createRuleSmlType', () => {
     createRuleSmlType({
       getScopedRulesClient: () => rulesClient,
       getInternalRepository: () => repository,
+      getIsAlertingV2Enabled: () => getIsAlertingV2Enabled(),
     });
 
   describe('id and fetchFrequency', () => {
@@ -167,6 +170,15 @@ describe('createRuleSmlType', () => {
       await expect(drainList()).rejects.toThrow('boom');
       expect(close).toHaveBeenCalledTimes(1);
     });
+
+    it('yields nothing and never touches the repository when alerting v2 is disabled', async () => {
+      getIsAlertingV2Enabled.mockResolvedValue(false);
+
+      const items = await drainList();
+
+      expect(items).toEqual([]);
+      expect(createFinder).not.toHaveBeenCalled();
+    });
   });
 
   describe('getSmlData', () => {
@@ -218,6 +230,15 @@ describe('createRuleSmlType', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("SML rule: failed to get data for 'rule-missing'")
       );
+    });
+
+    it('returns undefined without reading the saved object when alerting v2 is disabled', async () => {
+      getIsAlertingV2Enabled.mockResolvedValue(false);
+
+      const result = await buildDefinition().getSmlData('rule-1', buildSmlContext());
+
+      expect(result).toBeUndefined();
+      expect(getRepoSo).not.toHaveBeenCalled();
     });
   });
 
@@ -285,6 +306,18 @@ describe('createRuleSmlType', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+
+    it('returns undefined without calling the rules client when alerting v2 is disabled', async () => {
+      getIsAlertingV2Enabled.mockResolvedValue(false);
+
+      const result = await buildDefinition().toAttachment(
+        buildSmlDocument(),
+        buildToAttachmentContext()
+      );
+
+      expect(result).toBeUndefined();
+      expect(getRule).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/rule_sml_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/rule_sml_type.ts
@@ -22,16 +22,22 @@ import type { RulesClient } from '../../lib/rules_client';
 interface CreateRuleSmlTypeOptions {
   getScopedRulesClient: (request: KibanaRequest) => RulesClient;
   getInternalRepository: () => ISavedObjectsRepository;
+  getIsAlertingV2Enabled: () => Promise<boolean>;
 }
 
 export const createRuleSmlType = ({
   getScopedRulesClient,
   getInternalRepository,
+  getIsAlertingV2Enabled,
 }: CreateRuleSmlTypeOptions): SmlTypeDefinition => ({
   id: RULE_SML_TYPE,
   fetchFrequency: () => '1m',
 
   async *list() {
+    if (!(await getIsAlertingV2Enabled())) {
+      return;
+    }
+
     const repository = getInternalRepository();
     const finder = repository.createPointInTimeFinder<RuleSavedObjectAttributes>({
       type: RULE_SAVED_OBJECT_TYPE,
@@ -54,6 +60,10 @@ export const createRuleSmlType = ({
   },
 
   getSmlData: async (originId, context) => {
+    if (!(await getIsAlertingV2Enabled())) {
+      return undefined;
+    }
+
     try {
       const repository = getInternalRepository();
       const so = await repository.get<RuleSavedObjectAttributes>(RULE_SAVED_OBJECT_TYPE, originId);
@@ -93,6 +103,10 @@ export const createRuleSmlType = ({
   }),
 
   toAttachment: async (item, context) => {
+    if (!(await getIsAlertingV2Enabled())) {
+      return undefined;
+    }
+
     try {
       const rulesClient = getScopedRulesClient(context.request);
       const rule = await rulesClient.getRule({ id: item.origin_id ?? '' });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -8,6 +8,7 @@
 import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
 import { Logger, OnSetup, OnStart, PluginSetup } from '@kbn/core-di';
 import { CoreStart } from '@kbn/core-di-server';
+import { ALERTING_V2_ENABLED_SETTING_ID } from '@kbn/alerting-v2-constants';
 import type { Container, ContainerModuleLoadOptions } from 'inversify';
 import { createActionPolicyAttachmentType } from '../agent_builder/attachments/action_policy_attachment_type';
 import { createRuleAttachmentType } from '../agent_builder/attachments/rule_attachment_type';
@@ -21,6 +22,7 @@ import { ActionPolicyClient } from '../lib/action_policy_client';
 import { WorkflowsManagementApiToken } from '../lib/dispatcher/steps/dispatch_step_tokens';
 import { RulesClient } from '../lib/rules_client';
 import { ACTION_POLICY_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from '../saved_objects';
+import { SettingsServiceToken } from '../lib/services/settings_service/tokens';
 import type { AlertingServerSetupDependencies } from '../types';
 
 type AgentBuilderSetup = NonNullable<AlertingServerSetupDependencies['agentBuilder']>;
@@ -81,6 +83,12 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
 
     const agentContextLayer = container.get(agentContextLayerToken);
 
+    // Resolved lazily at crawl time (start phase) so the SML hooks reflect the
+    // current value of the `alerting:v2:enabled` global advanced setting on
+    // every crawl, rather than a value captured once at setup.
+    const getIsAlertingV2Enabled = () =>
+      container.get(SettingsServiceToken).get(ALERTING_V2_ENABLED_SETTING_ID);
+
     // SML types are registered inline (not via a token registry like attachments):
     // registration happens at setup, but their clients/repositories must be
     // resolved lazily at crawl time (start phase), so deps cannot be eagerly
@@ -93,6 +101,7 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
           container
             .get(CoreStart('savedObjects'))
             .createInternalRepository([RULE_SAVED_OBJECT_TYPE]),
+        getIsAlertingV2Enabled,
       })
     );
     agentContextLayer.registerType(
@@ -103,6 +112,7 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
           container
             .get(CoreStart('savedObjects'))
             .createInternalRepository([ACTION_POLICY_SAVED_OBJECT_TYPE]),
+        getIsAlertingV2Enabled,
       })
     );
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout/.meta/api/standard.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout/.meta/api/standard.json
@@ -1,9 +1,9 @@
 {
-  "sha1": "955ce5426525b2f3b42c92a922f71cc224570dad",
+  "sha1": "24911ba2ed9e60760100838d8acd181467945ff3",
   "tests": [
     {
-      "id": "7235a50d6703290-e91aef77f82ae5d",
-      "title": "Agent Builder — alerting V2 rule-management skill gating does not list the rule-management skill when alerting V2 is disabled",
+      "id": "7235a50d6703290-29ade5b2a387dd7",
+      "title": "Agent Builder — alerting V2 rule-management skill gating does not list the rule-management skill when neither gate is enabled",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -23,13 +23,39 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/alerting_v2/test/scout/api/tests/rule_management_skill_gating.spec.ts",
-        "line": 34,
+        "line": 44,
         "column": 10
       }
     },
     {
-      "id": "7235a50d6703290-c27d0e5e8b68906",
-      "title": "Agent Builder — alerting V2 rule-management skill gating lists the rule-management skill once alerting:v2:enabled is turned on",
+      "id": "7235a50d6703290-d27424eea3d7792",
+      "title": "Agent Builder — alerting V2 rule-management skill gating does not list the rule-management skill when only experimental features are enabled",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic",
+        "@local-stateful-search",
+        "@cloud-stateful-search",
+        "@local-stateful-observability_complete",
+        "@cloud-stateful-observability_complete",
+        "@local-stateful-security_complete",
+        "@cloud-stateful-security_complete",
+        "@local-serverless-search",
+        "@cloud-serverless-search",
+        "@local-serverless-observability_complete",
+        "@cloud-serverless-observability_complete",
+        "@local-serverless-security_complete",
+        "@cloud-serverless-security_complete"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/alerting_v2/test/scout/api/tests/rule_management_skill_gating.spec.ts",
+        "line": 64,
+        "column": 10
+      }
+    },
+    {
+      "id": "7235a50d6703290-b7df2807b2e0561",
+      "title": "Agent Builder — alerting V2 rule-management skill gating does not list the rule-management skill when only alerting:v2:enabled is on",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -37,7 +63,21 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/alerting_v2/test/scout/api/tests/rule_management_skill_gating.spec.ts",
-        "line": 58,
+        "line": 87,
+        "column": 10
+      }
+    },
+    {
+      "id": "7235a50d6703290-26c399118dff63f",
+      "title": "Agent Builder — alerting V2 rule-management skill gating lists the rule-management skill once both gates are enabled",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/alerting_v2/test/scout/api/tests/rule_management_skill_gating.spec.ts",
+        "line": 108,
         "column": 10
       }
     }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout/api/tests/rule_management_skill_gating.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout/api/tests/rule_management_skill_gating.spec.ts
@@ -7,6 +7,7 @@
 
 import { apiTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
+import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
 const SKILLS_API = '/api/agent_builder/skills';
@@ -16,14 +17,23 @@ const RULE_MANAGEMENT_SKILL_ID = 'rule-management';
 
 const getSkillIds = (results: Array<{ id: string }>) => results.map((skill) => skill.id);
 
-// The alerting V2 `rule-management` skill is registered as a built-in Agent
-// Builder skill but gated behind the `alerting:v2:enabled` advanced setting.
+// The alerting V2 `rule-management` skill is a built-in Agent Builder skill that
+// is gated behind BOTH the agent builder experimental-features advanced setting
+// AND the `alerting:v2:enabled` advanced setting. Both must be enabled for the
+// skill to be listed, so this suite exercises each gate independently as well as
+// the combined case.
+//
+// This is the canonical gating suite because the generic Scout config leaves
+// `alerting:v2:enabled` unpinned, so it can be flipped on and off at runtime.
+// The dedicated `scout_alerting_v2` config forces the feature on and therefore
+// cannot cover the disabled cases.
 apiTest.describe('Agent Builder — alerting V2 rule-management skill gating', () => {
-  // `alerting:v2:enabled` is a global (deployment-wide) setting that persists
-  // across suites sharing the same Kibana instance. Reset it to its registered
-  // default after each test via DELETE rather than pinning an explicit value,
-  // matching the convention in custom_branding's settings.spec.ts.
-  apiTest.afterEach(async ({ apiClient, requestAuth }) => {
+  // Reset both gates after every test. `.unset()` / DELETE are safe no-ops when
+  // no user value is set, so we can reset unconditionally — this also guards
+  // against a partial write where an update reaches the server but a later
+  // assertion throws.
+  apiTest.afterEach(async ({ apiClient, kbnClient, requestAuth }) => {
+    await kbnClient.uiSettings.unset(AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID);
     const { apiKeyHeader } = await requestAuth.getApiKeyForAdmin();
     await apiClient.delete(
       `${GLOBAL_SETTINGS_API}/${encodeURIComponent(ALERTING_V2_ENABLED_SETTING)}`,
@@ -32,7 +42,7 @@ apiTest.describe('Agent Builder — alerting V2 rule-management skill gating', (
   });
 
   apiTest(
-    'does not list the rule-management skill when alerting V2 is disabled',
+    'does not list the rule-management skill when neither gate is enabled',
     { tag: tags.deploymentAgnostic },
     async ({ apiClient, requestAuth }) => {
       const { apiKeyHeader } = await requestAuth.getApiKeyForAdmin();
@@ -51,14 +61,58 @@ apiTest.describe('Agent Builder — alerting V2 rule-management skill gating', (
     }
   );
 
-  // Stateful only: the Alerting V2 plugin ships enabled on stateful, and the
-  // default config leaves `alerting:v2:enabled` unpinned so it can be toggled on
-  // at runtime. On serverless the plugin is disabled, so the enabled case cannot
-  // be exercised with the generic config.
   apiTest(
-    'lists the rule-management skill once alerting:v2:enabled is turned on',
+    'does not list the rule-management skill when only experimental features are enabled',
+    { tag: tags.deploymentAgnostic },
+    async ({ apiClient, kbnClient, requestAuth }) => {
+      await kbnClient.uiSettings.update({
+        [AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID]: true,
+      });
+
+      const { apiKeyHeader } = await requestAuth.getApiKeyForAdmin();
+      const response = await apiClient.get(SKILLS_API, {
+        headers: { ...COMMON_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(200);
+      expect(Array.isArray(response.body.results)).toBe(true);
+      expect(response.body.results.length).toBeGreaterThan(0);
+      expect(getSkillIds(response.body.results)).not.toContain(RULE_MANAGEMENT_SKILL_ID);
+    }
+  );
+
+  // Toggling `alerting:v2:enabled` on requires the Alerting V2 plugin, which only
+  // ships enabled on stateful; on serverless the plugin is disabled.
+  apiTest(
+    'does not list the rule-management skill when only alerting:v2:enabled is on',
     { tag: tags.stateful.classic },
     async ({ apiClient, requestAuth }) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForAdmin();
+      const headers = { ...COMMON_HEADERS, ...apiKeyHeader };
+
+      const setResponse = await apiClient.post(
+        `${GLOBAL_SETTINGS_API}/${ALERTING_V2_ENABLED_SETTING}`,
+        { headers, body: { value: true }, responseType: 'json' }
+      );
+      expect(setResponse).toHaveStatusCode(200);
+
+      const response = await apiClient.get(SKILLS_API, { headers, responseType: 'json' });
+      expect(response).toHaveStatusCode(200);
+      expect(Array.isArray(response.body.results)).toBe(true);
+      expect(response.body.results.length).toBeGreaterThan(0);
+      expect(getSkillIds(response.body.results)).not.toContain(RULE_MANAGEMENT_SKILL_ID);
+    }
+  );
+
+  apiTest(
+    'lists the rule-management skill once both gates are enabled',
+    { tag: tags.stateful.classic },
+    async ({ apiClient, kbnClient, requestAuth }) => {
+      await kbnClient.uiSettings.update({
+        [AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID]: true,
+      });
+
       const { apiKeyHeader } = await requestAuth.getApiKeyForAdmin();
       const headers = { ...COMMON_HEADERS, ...apiKeyHeader };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Alerting v2] Mark rule-management agent builder skill as experimental (#276995)](https://github.com/elastic/kibana/pull/276995)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dominique Clarke","email":"dominique.clarke@elastic.co"},"sourceCommit":{"committedDate":"2026-07-10T23:54:05Z","message":"[Alerting v2] Mark rule-management agent builder skill as experimental (#276995)\n\n## Summary\n\nGates the alerting v2 Agent Builder / context-layer surfaces behind the\nalerting v2 feature flags so they are only exposed when the feature is\nenabled:\n\n1. **Rule management skill** — marks the `rule-management` skill\n`experimental: true` so the Agent Builder skill registry only exposes it\nwhen Agent Builder experimental features are enabled. This aligns the\nserver-side skill availability with the existing client-side\n`agentBuilder:experimentalFeatures` gating for the \"Create with agent\"\nflow.\n\n2. **Rule / action policy SML crawler** — makes the rule and action\npolicy SML type hooks no-ops when the `alerting:v2:enabled` global\nadvanced setting is off:\n- `list` yields nothing, so the crawler's mark-and-sweep removes any\npreviously indexed chunks (and with the default-off setting, data is\nnever indexed in the first place).\n- `getSmlData` / `toAttachment` return `undefined`, so search/attach\ncannot resolve stale chunks.\n\nThe setting is resolved lazily at crawl time via the plugin\n`SettingsService`, so toggling takes effect on the next crawl (~1m)\nwithout a restart, keeping context-layer data in lock-step with the\nfeature flag.\n\n## Why not `uiSettingRequired` for the crawler?\n`alerting:v2:enabled` is a **global** advanced setting, while the SML\ncrawler task runner reads UI settings via the namespace-scoped client.\nGating registration at setup would be boot-time only (needs a restart)\nand would also disable unrelated SML search/attach machinery, so the\ngate is applied dynamically inside the SML type hooks instead.\n\n## Changes\n\n- `rule_management_skill.ts`: add `experimental: true`.\n- `rule_sml_type.ts` / `action_policy_sml_type.ts`: add a\n`getIsAlertingV2Enabled` dependency and short-circuit `list` /\n`getSmlData` / `toAttachment` when disabled.\n- `bind_agent_builder.ts`: wire a lazy `getIsAlertingV2Enabled` closure\n(reads `alerting:v2:enabled` via `SettingsService`) into both SML type\nfactories.\n- Unit tests for the skill definition and for the disabled-state\nbehavior of both SML types.\n\n## Behavior note\nFlipping `alerting:v2:enabled` **off** while rules/policies were\npreviously indexed causes the next crawl to delete those chunks;\nflipping it back **on** re-indexes them within a crawl cycle.\n\n## Test plan\n\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts`\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/rule_sml_type.test.ts\nx-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/action_policy_sml_type.test.ts`\n- [ ] CI green\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"fd14f11969a16e5007d63a003a39aa21b3fb5b3b","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","backport:version","author:actionable-obs","v9.5.0","reviewer:scout"],"title":"[Alerting v2] Mark rule-management agent builder skill as experimental","number":276995,"url":"https://github.com/elastic/kibana/pull/276995","mergeCommit":{"message":"[Alerting v2] Mark rule-management agent builder skill as experimental (#276995)\n\n## Summary\n\nGates the alerting v2 Agent Builder / context-layer surfaces behind the\nalerting v2 feature flags so they are only exposed when the feature is\nenabled:\n\n1. **Rule management skill** — marks the `rule-management` skill\n`experimental: true` so the Agent Builder skill registry only exposes it\nwhen Agent Builder experimental features are enabled. This aligns the\nserver-side skill availability with the existing client-side\n`agentBuilder:experimentalFeatures` gating for the \"Create with agent\"\nflow.\n\n2. **Rule / action policy SML crawler** — makes the rule and action\npolicy SML type hooks no-ops when the `alerting:v2:enabled` global\nadvanced setting is off:\n- `list` yields nothing, so the crawler's mark-and-sweep removes any\npreviously indexed chunks (and with the default-off setting, data is\nnever indexed in the first place).\n- `getSmlData` / `toAttachment` return `undefined`, so search/attach\ncannot resolve stale chunks.\n\nThe setting is resolved lazily at crawl time via the plugin\n`SettingsService`, so toggling takes effect on the next crawl (~1m)\nwithout a restart, keeping context-layer data in lock-step with the\nfeature flag.\n\n## Why not `uiSettingRequired` for the crawler?\n`alerting:v2:enabled` is a **global** advanced setting, while the SML\ncrawler task runner reads UI settings via the namespace-scoped client.\nGating registration at setup would be boot-time only (needs a restart)\nand would also disable unrelated SML search/attach machinery, so the\ngate is applied dynamically inside the SML type hooks instead.\n\n## Changes\n\n- `rule_management_skill.ts`: add `experimental: true`.\n- `rule_sml_type.ts` / `action_policy_sml_type.ts`: add a\n`getIsAlertingV2Enabled` dependency and short-circuit `list` /\n`getSmlData` / `toAttachment` when disabled.\n- `bind_agent_builder.ts`: wire a lazy `getIsAlertingV2Enabled` closure\n(reads `alerting:v2:enabled` via `SettingsService`) into both SML type\nfactories.\n- Unit tests for the skill definition and for the disabled-state\nbehavior of both SML types.\n\n## Behavior note\nFlipping `alerting:v2:enabled` **off** while rules/policies were\npreviously indexed causes the next crawl to delete those chunks;\nflipping it back **on** re-indexes them within a crawl cycle.\n\n## Test plan\n\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts`\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/rule_sml_type.test.ts\nx-pack/platform/plugins/shared/alerting_v2/server/agent_builder/sml/action_policy_sml_type.test.ts`\n- [ ] CI green\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"fd14f11969a16e5007d63a003a39aa21b3fb5b3b"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->