### PR TITLE
[Entity Analytics] Prevent duplicate entity attachments to existing cases

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_existing_case.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_existing_case.tsx
@@ -63,10 +63,9 @@ export const AddToExistingCase: FC<AddToExistingCaseProps> = ({
         return generateEntityAttachmentsWithoutOwner(entity);
       },
       noAttachmentsToaster: {
-        title: i18n.translate(
-          'xpack.securitySolution.entityAnalytics.cases.alreadyAttachedTitle',
-          { defaultMessage: 'Entity already attached' }
-        ),
+        title: i18n.translate('xpack.securitySolution.entityAnalytics.cases.alreadyAttachedTitle', {
+          defaultMessage: 'Entity already attached',
+        }),
         content: i18n.translate(
           'xpack.securitySolution.entityAnalytics.cases.alreadyAttachedContent',
           { defaultMessage: 'This entity is already attached to the selected case.' }

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_existing_case.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_existing_case.tsx
@@ -9,9 +9,11 @@ import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { EuiContextMenuItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import type { EntityToAttach } from '..';
 import { generateEntityAttachmentsWithoutOwner } from '..';
 import { useKibana } from '../../../../common/lib/kibana';
+import { isEntityAttachment } from '../utils';
 
 export interface AddToExistingCaseProps {
   /**
@@ -48,7 +50,29 @@ export const AddToExistingCase: FC<AddToExistingCaseProps> = ({
 
   const menuItemClicked = useCallback(() => {
     onClick();
-    selectCaseModal.open({ getAttachments: () => generateEntityAttachmentsWithoutOwner(entity) });
+    selectCaseModal.open({
+      getAttachments: ({ theCase }) => {
+        if (theCase) {
+          const alreadyAttached = theCase.comments
+            .filter(isEntityAttachment)
+            .some((comment) => comment.attachmentId === entity.id);
+          if (alreadyAttached) {
+            return [];
+          }
+        }
+        return generateEntityAttachmentsWithoutOwner(entity);
+      },
+      noAttachmentsToaster: {
+        title: i18n.translate(
+          'xpack.securitySolution.entityAnalytics.cases.alreadyAttachedTitle',
+          { defaultMessage: 'Entity already attached' }
+        ),
+        content: i18n.translate(
+          'xpack.securitySolution.entityAnalytics.cases.alreadyAttachedContent',
+          { defaultMessage: 'This entity is already attached to the selected case.' }
+        ),
+      },
+    });
   }, [entity, onClick, selectCaseModal]);
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
@@ -41,17 +41,16 @@ export const EntityTabContent: React.FC<CommonAttachmentTabViewProps> = ({
   // Filter in-memory first to avoid firing an ES query when no attachments match the search.
   // `attachmentId` holds the canonical entity.id (EUID), so we only need the ids here.
   const entityIds = useMemo<string[]>(
-    () =>
-      [
-        ...new Set(
-          caseData.comments.flatMap((comment) =>
-            isEntityAttachment(comment) &&
-            (!searchTerm || matchesSearchTerm(comment.metadata, searchTerm))
-              ? [comment.attachmentId]
-              : []
-          )
-        ),
-      ],
+    () => [
+      ...new Set(
+        caseData.comments.flatMap((comment) =>
+          isEntityAttachment(comment) &&
+          (!searchTerm || matchesSearchTerm(comment.metadata, searchTerm))
+            ? [comment.attachmentId]
+            : []
+        )
+      ),
+    ],
     [caseData.comments, searchTerm]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
@@ -42,12 +42,16 @@ export const EntityTabContent: React.FC<CommonAttachmentTabViewProps> = ({
   // `attachmentId` holds the canonical entity.id (EUID), so we only need the ids here.
   const entityIds = useMemo<string[]>(
     () =>
-      caseData.comments.flatMap((comment) =>
-        isEntityAttachment(comment) &&
-        (!searchTerm || matchesSearchTerm(comment.metadata, searchTerm))
-          ? [comment.attachmentId]
-          : []
-      ),
+      [
+        ...new Set(
+          caseData.comments.flatMap((comment) =>
+            isEntityAttachment(comment) &&
+            (!searchTerm || matchesSearchTerm(comment.metadata, searchTerm))
+              ? [comment.attachmentId]
+              : []
+          )
+        ),
+      ],
     [caseData.comments, searchTerm]
   );
 


### PR DESCRIPTION
### Summary
When the same entity was added to a case multiple times via "Add to existing case", the Attachments tab showed an inflated badge count (e.g. "Entities 4") while the table correctly showed only 1 entity (ES deduplicates via terms query). The count mismatch was confusing.

**Fix:**

- `add_to_existing_case.tsx` - `getAttachments` now checks the selected case's existing comments before adding.
- If the entity is already attached, it returns an empty list instead, which triggers an info toast: `"Entity already attached - This entity is already attached to the selected case."` 
- The duplicate is never created.
- `entity_tab_content.tsx `- entityIds is now deduplicated via new `Set()` as a defensive measure, so any pre-existing duplicates don't affect the empty state check or the ES query.

### Desk Test 

1. Enable the entity store and ensure at least one entity exists.
2. Add entity user-A to an existing case via the "Add to existing case" context menu item.
3. Try to add the same entity user-A to the same case again.

**Expected:** 
- An info toast appears - **"Entity already attached / This entity is already attached to the selected case."** 
- No new attachment is created. 
- The Entities count in the Attachments tab stays at 1.
- Adding a different entity to the same case should still work as normal.