### PR TITLE
[9.4] Make `winlog.event_data.LogonType` optional for `security_auth` jobs (#278500)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_events_ea.json
+++ b/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_events_ea.json
@@ -1,5 +1,5 @@
 {
-  "description": "Security: Authentication - Looks for an unusually large spike in successful authentication events. This can be due to password spraying, user enumeration, or brute force activity. Requires Windows event data, such as from Winlogbeat.",
+  "description": "Security: Authentication - Looks for an unusually large spike in successful authentication events. This can be due to password spraying, user enumeration, or brute force activity.",
   "groups": [
     "security",
     "authentication"
@@ -15,7 +15,7 @@
     ],
     "influencers": [
       "source.ip",
-      "winlog.event_data.LogonType",
+      "winlog_logon_type",
       "user.name",
       "user.id",
       "host.name",
@@ -34,6 +34,8 @@
     "created_by": "ml-module-security-auth",
     "security_app_display_name": "Spike in Logon Events",
     "managed": true,
-    "job_revision": 4
+    "job_revision": 5,
+    "threat_tactics": ["TA0006", "TA0001"],
+    "threat_techniques": ["T1110", "T1110.003", "T1078"]
   }
 }

--- a/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_events_for_a_source_ip_ea.json
+++ b/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_events_for_a_source_ip_ea.json
@@ -1,5 +1,5 @@
 {
-  "description": "Security: Authentication - Looks for an unusually large spike in successful authentication events from a particular source IP address. This can be due to password spraying, user enumeration, or brute force activity. Requires Windows event data, such as from Winlogbeat.",
+  "description": "Security: Authentication - Looks for an unusually large spike in successful authentication events from a particular source IP address. This can be due to password spraying, user enumeration, or brute force activity.",
   "groups": [
     "security",
     "authentication"
@@ -16,7 +16,7 @@
     ],
     "influencers": [
       "source.ip",
-      "winlog.event_data.LogonType",
+      "winlog_logon_type",
       "user.name",
       "user.id",
       "host.name",
@@ -35,6 +35,8 @@
     "created_by": "ml-module-security-auth",
     "security_app_display_name": "Spike in Logon Events from a Source IP",
     "managed": true,
-    "job_revision": 4
+    "job_revision": 5,
+    "threat_tactics": ["TA0006", "TA0005"],
+    "threat_techniques": ["T1110", "T1110.003", "T1078", "T1078.002", "T1078.003"]
   }
 }

--- a/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_ea.json
+++ b/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_ea.json
@@ -4,6 +4,14 @@
     "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
+  "runtime_mappings": {
+    "winlog_logon_type": {
+      "type": "keyword",
+      "script": {
+        "source": "if (doc.containsKey('winlog.event_data.LogonType') && doc['winlog.event_data.LogonType'].size() != 0) { emit(doc['winlog.event_data.LogonType'].value); } else { emit('None'); }"
+      }
+    }
+  },
   "query": {
     "bool": {
       "filter": [

--- a/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_for_a_source_ip_ea.json
+++ b/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_for_a_source_ip_ea.json
@@ -4,6 +4,14 @@
     "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
+  "runtime_mappings": {
+    "winlog_logon_type": {
+      "type": "keyword",
+      "script": {
+        "source": "if (doc.containsKey('winlog.event_data.LogonType') && doc['winlog.event_data.LogonType'].size() != 0) { emit(doc['winlog.event_data.LogonType'].value); } else { emit('None'); }"
+      }
+    }
+  },
   "query": {
     "bool": {
       "filter": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Make `winlog.event_data.LogonType` optional for `security_auth` jobs (#278500)](https://github.com/elastic/kibana/pull/278500)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gus Carlock","email":"10844131+jmcarlock@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-16T14:45:14Z","message":"Make `winlog.event_data.LogonType` optional for `security_auth` jobs (#278500)\n\n## Summary\n\nMakes `winlog.event_data.LogonType` optional in two security\nauthentication anomaly detection jobs:\n- **Spike in Logon Events** (`auth_high_count_logon_events_ea`)\n- **Spike in Logon Events from a Source IP**\n(`auth_high_count_logon_events_for_a_source_ip_ea`)\n\nThis allows these jobs to run on Linux logs. Previously these jobs\nlisted `winlog.event_data.LogonType` as an influencer, which only\npopulated for Windows event data (Winlogbeat). On non-Windows\nauthentication sources (auditbeat, filebeat system module, etc.) the\nfield is absent.\n\nThe fix adds a datafeed `runtime_mappings` field (`winlog_logon_type`)\nusing a Painless script that emits the `winlog.event_data.LogonType`\nvalue when present and `'None'` when absent, similar to the LMD\nintegration package AD job `lmd_rare_file_path_remote_transfer_ea`. The\njob influencer is updated to reference this runtime field.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nThis PR should not introduce significant risk.","sha":"09e23e9e64f92902e26a544ec5320881b813f952","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","v9.5.0","v9.6.0"],"title":"Make `winlog.event_data.LogonType` optional for `security_auth` jobs","number":278500,"url":"https://github.com/elastic/kibana/pull/278500","mergeCommit":{"message":"Make `winlog.event_data.LogonType` optional for `security_auth` jobs (#278500)\n\n## Summary\n\nMakes `winlog.event_data.LogonType` optional in two security\nauthentication anomaly detection jobs:\n- **Spike in Logon Events** (`auth_high_count_logon_events_ea`)\n- **Spike in Logon Events from a Source IP**\n(`auth_high_count_logon_events_for_a_source_ip_ea`)\n\nThis allows these jobs to run on Linux logs. Previously these jobs\nlisted `winlog.event_data.LogonType` as an influencer, which only\npopulated for Windows event data (Winlogbeat). On non-Windows\nauthentication sources (auditbeat, filebeat system module, etc.) the\nfield is absent.\n\nThe fix adds a datafeed `runtime_mappings` field (`winlog_logon_type`)\nusing a Painless script that emits the `winlog.event_data.LogonType`\nvalue when present and `'None'` when absent, similar to the LMD\nintegration package AD job `lmd_rare_file_path_remote_transfer_ea`. The\njob influencer is updated to reference this runtime field.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nThis PR should not introduce significant risk.","sha":"09e23e9e64f92902e26a544ec5320881b813f952"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/278841","number":278841,"state":"MERGED","mergeCommit":{"sha":"db33e44483b133d4913c9200f1d7faa41c5ea0c3","message":"[9.5] Make `winlog.event_data.LogonType` optional for `security_auth` jobs (#278500) (#278841)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [Make `winlog.event_data.LogonType` optional for `security_auth` jobs\n(#278500)](https://github.com/elastic/kibana/pull/278500)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gus Carlock <10844131+jmcarlock@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278500","number":278500,"mergeCommit":{"message":"Make `winlog.event_data.LogonType` optional for `security_auth` jobs (#278500)\n\n## Summary\n\nMakes `winlog.event_data.LogonType` optional in two security\nauthentication anomaly detection jobs:\n- **Spike in Logon Events** (`auth_high_count_logon_events_ea`)\n- **Spike in Logon Events from a Source IP**\n(`auth_high_count_logon_events_for_a_source_ip_ea`)\n\nThis allows these jobs to run on Linux logs. Previously these jobs\nlisted `winlog.event_data.LogonType` as an influencer, which only\npopulated for Windows event data (Winlogbeat). On non-Windows\nauthentication sources (auditbeat, filebeat system module, etc.) the\nfield is absent.\n\nThe fix adds a datafeed `runtime_mappings` field (`winlog_logon_type`)\nusing a Painless script that emits the `winlog.event_data.LogonType`\nvalue when present and `'None'` when absent, similar to the LMD\nintegration package AD job `lmd_rare_file_path_remote_transfer_ea`. The\njob influencer is updated to reference this runtime field.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nThis PR should not introduce significant risk.","sha":"09e23e9e64f92902e26a544ec5320881b813f952"}}]}] BACKPORT-->