### PR TITLE
[Security Solution][Flyout] enable the advanced setting for the new flyout system

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.test.ts
@@ -44,18 +44,18 @@ describe('useIsNewFlyoutEnabled', () => {
     const { result } = renderHook(() => useIsNewFlyoutEnabled());
 
     expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemDisabled');
-    expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, false);
+    expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, true);
     expect(result.current).toBe(true);
   });
 
-  it('returns false when the flag is off and the advanced setting is off (default)', () => {
+  it('returns false when the flag is off and the advanced setting is explicitly off', () => {
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
     mockUiSettingsGet.mockReturnValue(false);
 
     const { result } = renderHook(() => useIsNewFlyoutEnabled());
 
     expect(useIsExperimentalFeatureEnabled).toHaveBeenCalledWith('newFlyoutSystemDisabled');
-    expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, false);
+    expect(mockUiSettingsGet).toHaveBeenCalledWith(ENABLE_NEW_FLYOUT_SETTING, true);
     expect(result.current).toBe(false);
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_is_new_flyout_enabled.ts
@@ -14,8 +14,8 @@ import { useIsExperimentalFeatureEnabled } from './use_experimental_features';
  *
  * The `newFlyoutSystemDisabled` experimental feature flag controls whether the
  * "Enable new flyout" advanced setting is registered:
- * - when the flag is off (the default), the setting is registered and defaults to `false`, so the
- *   new flyout is disabled unless the user explicitly opts in;
+ * - when the flag is off (the default), the setting is registered and defaults to `true`, so the
+ *   new flyout is enabled unless the user explicitly opts out;
  * - when the flag is on, the setting is unregistered and the new flyout is always disabled —
  *   regardless of any value the user may have previously stored for it.
  */
@@ -29,7 +29,7 @@ export const useIsNewFlyoutEnabled = (): boolean => {
     return false;
   }
 
-  // The advanced setting is registered (and defaults to `false`) whenever the flag is off, so it is
-  // the source of truth for whether the user has opted in to the new flyout.
-  return uiSettings.get<boolean>(ENABLE_NEW_FLYOUT_SETTING, false);
+  // The advanced setting is registered (and defaults to `true`) whenever the flag is off, so it is
+  // the source of truth for whether the user has opted out of the new flyout.
+  return uiSettings.get<boolean>(ENABLE_NEW_FLYOUT_SETTING, true);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/expanded_flyout_response_tab.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/expanded_flyout_response_tab.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { waitForEndpointListPageToBeLoaded } from '../../tasks/response_console';
+import { disableNewFlyout } from '../../tasks/kibana_advanced_settings';
 import { getWithResponseActionsRole } from '../../../../../scripts/endpoint/common/roles_users';
 import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
 import { login } from '../../tasks/login';
@@ -107,6 +108,7 @@ describe(
     });
 
     beforeEach(() => {
+      disableNewFlyout();
       loginWithoutResponseActionsHistory();
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/results.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/results.cy.ts
@@ -13,6 +13,7 @@ import type { ReturnTypeFromChainable } from '../../types';
 import { indexEndpointRuleAlerts } from '../../tasks/index_endpoint_rule_alerts';
 
 import { login, ROLE } from '../../tasks/login';
+import { disableNewFlyout } from '../../tasks/kibana_advanced_settings';
 
 describe('Results', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
@@ -66,6 +67,7 @@ describe('Results', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, (
   });
   describe('do not see results results when does not have RBAC', () => {
     before(() => {
+      disableNewFlyout();
       login(ROLE.t1_analyst);
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
@@ -30,6 +30,7 @@ import { createAgentPolicyTask, getEndpointIntegrationVersion } from '../../task
 import { toggleRuleOffAndOn, visitRuleAlerts } from '../../tasks/isolate';
 
 import { login } from '../../tasks/login';
+import { disableNewFlyout } from '../../tasks/kibana_advanced_settings';
 import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
@@ -45,6 +46,7 @@ describe(
     let ruleId: string;
     let ruleName: string;
     beforeEach(() => {
+      disableNewFlyout();
       login();
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/kibana_advanced_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/kibana_advanced_settings.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ENABLE_NEW_FLYOUT_SETTING } from '../../../../common/constants';
+import { rootRequest } from './common';
+
+export const disableNewFlyout = () => {
+  rootRequest({
+    method: 'POST',
+    url: '/internal/kibana/settings',
+    body: { changes: { [ENABLE_NEW_FLYOUT_SETTING]: false } },
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/kibana_advanced_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/kibana_advanced_settings.ts
@@ -13,5 +13,6 @@ export const disableNewFlyout = () => {
     method: 'POST',
     url: '/internal/kibana/settings',
     body: { changes: { [ENABLE_NEW_FLYOUT_SETTING]: false } },
+    failOnStatusCode: false,
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -108,7 +108,7 @@ describe('initUiSettings', () => {
     expect(registeredSettings[ENABLE_NEW_FLYOUT_SETTING]).toEqual(
       expect.objectContaining({
         name: 'Enable new flyout',
-        value: false,
+        value: true,
         type: 'boolean',
         requiresPageReload: true,
       })

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -355,7 +355,7 @@ export const initUiSettings = (
           }
         ),
         type: 'boolean',
-        value: false,
+        value: true,
         category: [APP_ID],
         requiresPageReload: true,
         schema: schema.boolean(),

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_security_attacks_alignment/ui/parallel_tests/detections/attacks/attack_flyout.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_security_attacks_alignment/ui/parallel_tests/detections/attacks/attack_flyout.spec.ts
@@ -10,6 +10,7 @@ import { expect } from '@kbn/scout-security/ui';
 
 const ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING =
   'securitySolution:enableAlertsAndAttacksAlignment';
+const ENABLE_NEW_FLYOUT_SETTING = 'securitySolution:enableNewFlyout';
 
 spaceTest.describe(
   'Attack details flyout',
@@ -26,6 +27,7 @@ spaceTest.describe(
 
       await scoutSpace.uiSettings.set({
         [ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING]: true,
+        [ENABLE_NEW_FLYOUT_SETTING]: false,
       });
       await browserAuth.loginAsPlatformEngineer();
 
@@ -43,6 +45,7 @@ spaceTest.describe(
 
     spaceTest.afterEach(async ({ scoutSpace }) => {
       await scoutSpace.uiSettings.unset(ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING);
+      await scoutSpace.uiSettings.unset(ENABLE_NEW_FLYOUT_SETTING);
     });
 
     spaceTest.afterAll(async ({ scoutSpace }) => {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group2/pages/findings_alerts.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group2/pages/findings_alerts.ts
@@ -14,6 +14,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
   const toasts = getService('toasts');
+  const kibanaServer = getService('kibanaServer');
   const pageObjects = getPageObjects(['common', 'findings', 'header']);
   const chance = new Chance();
 
@@ -137,6 +138,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       findings = pageObjects.findings;
       latestFindingsTable = findings.latestFindingsTable;
       misconfigurationsFlyout = findings.misconfigurationsFlyout;
+      // Disable the new flyout so the CSP findings flyout uses its legacy selectors
+      await kibanaServer.uiSettings.update({ 'securitySolution:enableNewFlyout': false });
       // Before we start any test we must wait for cloud_security_posture plugin to complete its initialization
       await findings.waitForPluginInitialized();
       // Prepare mocked findings
@@ -147,6 +150,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     after(async () => {
       await findings.index.remove();
       await findings.detectionRuleApi.remove();
+      await kibanaServer.uiSettings.unset('securitySolution:enableNewFlyout');
     });
 
     beforeEach(async () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/cloud_security_posture/misconfiguration_contextual_flyout.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/cloud_security_posture/misconfiguration_contextual_flyout.cy.ts
@@ -10,6 +10,7 @@ import { getNewRule } from '../../objects/rule';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 import { rootRequest, deleteAlertsAndRules } from '../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../tasks/api_calls/kibana_advanced_settings';
 import {
   expandFirstAlertHostFlyout,
   expandFirstAlertUserFlyout,
@@ -198,6 +199,7 @@ describe(
   { tags: ['@ess', '@serverless', '@skipInServerless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/cloud_security_posture/vulnerabilities_contextual_flyout.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/cloud_security_posture/vulnerabilities_contextual_flyout.cy.ts
@@ -11,6 +11,7 @@ import { getNewRule } from '../../objects/rule';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 import { rootRequest, deleteAlertsAndRules } from '../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../tasks/api_calls/kibana_advanced_settings';
 import { expandFirstAlertHostFlyout } from '../../tasks/asset_criticality/common';
 import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { login } from '../../tasks/login';
@@ -138,6 +139,7 @@ const deleteDataStream = () => {
 
 describe('Alert Host details expandable flyout', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
+    disableNewFlyout();
     deleteAlertsAndRules();
     login();
     createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/enrichments/alert_threat_enrichments.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/enrichments/alert_threat_enrichments.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../../tasks/api_calls/kibana_advanced_settings';
 import { getNewThreatIndicatorRule, indicatorRuleMatchingDoc } from '../../../../../objects/rule';
 import { login } from '../../../../../tasks/login';
 import {
@@ -38,6 +39,7 @@ describe('Threat Match Enrichment', { tags: ['@ess', '@serverless', '@skipInServ
   });
 
   beforeEach(() => {
+    disableNewFlyout();
     deleteAlertsAndRules();
 
     cy.task('esArchiverLoad', { archiveName: 'threat_indicator' });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alert_table_action_column.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alert_table_action_column.cy.ts
@@ -19,6 +19,7 @@ import {
   DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_CONTENT,
 } from '../../../screens/expandable_flyout/alert_details_left_panel_analyzer_graph_tab';
+import { disableNewFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 
 describe('Alerts Table Action column', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
@@ -30,6 +31,7 @@ describe('Alerts Table Action column', { tags: ['@ess', '@serverless'] }, () => 
   });
 
   beforeEach(() => {
+    disableNewFlyout();
     login();
     visitWithTimeRange(ALERTS_URL);
     waitForAlertsToPopulate();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_detail_settings_menu.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_detail_settings_menu.cy.ts
@@ -10,6 +10,7 @@ import {
   expandAlertInTimelineAtIndexExpandableFlyout,
 } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -32,6 +33,7 @@ describe('Alert details expandable flyout', { tags: ['@ess', '@serverless'] }, (
   const rule = getNewRule();
 
   beforeEach(() => {
+    disableNewFlyout();
     deleteAlertsAndRules();
     login();
     createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
@@ -15,6 +15,7 @@ import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../ta
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { ANALYZER_NODE } from '../../../../screens/alerts';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -27,6 +28,7 @@ describe(
   { tags: ['@ess', '@skipInServerless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
@@ -27,12 +27,14 @@ import {
 } from '../../../../tasks/expandable_flyout/common';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { ALERTS_URL } from '../../../../urls/navigation';
 
 describe('Expandable flyout left panel correlations', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
+    disableNewFlyout();
     deleteAlertsAndRules();
     login();
     createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
@@ -34,6 +34,7 @@ import { openInsightsTab } from '../../../../tasks/expandable_flyout/alert_detai
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -46,6 +47,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
@@ -13,6 +13,7 @@ import { openInvestigationTab } from '../../../../tasks/expandable_flyout/alert_
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -25,6 +26,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
@@ -36,6 +36,7 @@ import {
   PREVIEW_SECTION,
 } from '../../../../screens/expandable_flyout/alert_details_preview_panel';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -48,6 +49,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule({ ...getNewRule(), investigation_fields: { field_names: ['host.os.name'] } });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
@@ -14,6 +14,7 @@ import { openResponseTab } from '../../../../tasks/expandable_flyout/alert_detai
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -26,6 +27,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
@@ -10,6 +10,7 @@ import { DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB } from '../../../../screens/expan
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -22,6 +23,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
@@ -12,6 +12,7 @@ import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable
 import { INDICATOR_MATCH_ENRICHMENT_SECTION } from '../../../../screens/alerts_details';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { ALERTS_URL } from '../../../../urls/navigation';
@@ -25,6 +26,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel.cy.ts
@@ -8,6 +8,7 @@
 import { openInsightsTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -55,6 +56,7 @@ describe(
     const rule = getNewRule();
 
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_alert_reason_preview.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_alert_reason_preview.cy.ts
@@ -9,6 +9,7 @@ import { DOCUMENT_DETAILS_FLYOUT_ALERT_REASON_PREVIEW_CONTAINER } from '../../..
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { clickAlertReasonButton } from '../../../../tasks/expandable_flyout/alert_details_right_panel_overview_tab';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -23,6 +24,7 @@ describe(
     const rule = getNewRule();
 
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../../tasks/expandable_flyout/alert_details_preview_panel_rule_preview';
 import { clickRuleSummaryButton } from '../../../../tasks/expandable_flyout/alert_details_right_panel_overview_tab';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -40,6 +41,7 @@ describe(
     const rule = getNewRule();
 
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
@@ -58,6 +58,7 @@ import {
   selectTakeActionItem,
 } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -85,6 +86,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
   const rule = getNewRule();
 
   beforeEach(() => {
+    disableNewFlyout();
     deleteAlertsAndRules();
     login(role);
     createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
@@ -12,6 +12,7 @@ import {
   DOCUMENT_DETAILS_FLYOUT_JSON_TAB_COPY_TO_CLIPBOARD_BUTTON,
 } from '../../../../screens/expandable_flyout/alert_details_right_panel_json_tab';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -24,6 +25,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { closeFlyout } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import {
   createNewCaseFromExpandableFlyout,
@@ -95,6 +96,7 @@ describe(
     const rule = { ...getNewRule(), investigation_fields: { field_names: ['host.os.name'] } };
 
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
@@ -26,6 +26,7 @@ import {
   toggleColumnTableTabTable,
 } from '../../../../tasks/expandable_flyout/alert_details_right_panel_table_tab';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -38,6 +39,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       login();
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
@@ -11,6 +11,7 @@ import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../../tasks/api_calls/kibana_advanced_settings';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { closeFlyout } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
@@ -20,6 +21,7 @@ describe('Expandable flyout state sync', { tags: ['@ess', '@serverless'] }, () =
   const rule = getNewRule();
 
   beforeEach(() => {
+    disableNewFlyout();
     deleteAlertsAndRules();
     login();
     createRule(rule);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/investigate_in_timeline.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/investigate_in_timeline.cy.ts
@@ -15,6 +15,7 @@ import { login } from '../../../tasks/login';
 import { visitWithTimeRange } from '../../../tasks/navigation';
 import { ALERTS_URL } from '../../../urls/navigation';
 import { deleteAlertsAndRules } from '../../../tasks/api_calls/common';
+import { disableNewFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import { expandAlertAtIndexExpandableFlyout } from '../../../tasks/expandable_flyout/common';
 import {
   clickAnalyzerPreviewTitle,
@@ -52,6 +53,7 @@ describe(
   },
   () => {
     beforeEach(() => {
+      disableNewFlyout();
       deleteAlertsAndRules();
       createRule(getNewRule());
       login();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/kibana_advanced_settings.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/kibana_advanced_settings.ts
@@ -6,11 +6,11 @@
  */
 
 import {
-  SECURITY_SOLUTION_SHOW_RELATED_INTEGRATIONS_ID,
   AI_CHAT_EXPERIENCE_TYPE,
   SECURITY_SOLUTION_ENABLE_SIEM_READINESS_SETTING,
+  SECURITY_SOLUTION_SHOW_RELATED_INTEGRATIONS_ID,
 } from '@kbn/management-settings-ids';
-import { EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING } from '@kbn/security-solution-plugin/common/constants';
+import { ENABLE_NEW_FLYOUT_SETTING } from '@kbn/security-solution-plugin/common/constants';
 import { rootRequest } from './common';
 
 export const setKibanaSetting = (key: string, value: boolean | number | string) => {
@@ -52,6 +52,6 @@ export const setPreferredChatExperienceToClassic = () => {
   });
 };
 
-export const setExtendedRuleExecutionLoggingMinLevel = (level: string) => {
-  setKibanaSetting(EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING, level);
+export const disableNewFlyout = () => {
+  setKibanaSetting(ENABLE_NEW_FLYOUT_SETTING, false);
 };


### PR DESCRIPTION
## Summary

This PR turns on the advanced setting for the new flyout system in Security Solution.

> [!NOTE]
> I decided to turn off the advanced setting for all the Cypress tests that we have. That way those keep running. We will have Scout tests for the new flyout soon (see this [PR](https://github.com/elastic/kibana/pull/272769) for Discover and that [one](https://github.com/elastic/kibana/pull/274459) for Security Solution)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/269740

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->