### PR TITLE
[data fed] Localize product names

### DIFF
--- a/x-pack/platform/plugins/private/data_federation/public/get_data_source_type_label.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/get_data_source_type_label.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import type { DataSourceType } from '../common/datasource_types';
 
 /**
@@ -14,9 +15,14 @@ export function getDataSourceTypeVerbose(type: DataSourceType): string {
   return messages[type];
 }
 
-// todo localize
 const messages: Record<DataSourceType, string> = {
-  s3: 'Amazon S3',
-  gcs: 'Google Cloud Storage',
-  azure: 'Azure',
+  s3: i18n.translate('xpack.dataFederation.dataSourceType.s3Label', {
+    defaultMessage: 'Amazon S3',
+  }),
+  gcs: i18n.translate('xpack.dataFederation.dataSourceType.gcsLabel', {
+    defaultMessage: 'Google Cloud Storage',
+  }),
+  azure: i18n.translate('xpack.dataFederation.dataSourceType.azureLabel', {
+    defaultMessage: 'Azure',
+  }),
 };


### PR DESCRIPTION
## Summary

Simply localizes cloud service product names. Initially we hesitated because we weren't certain whether they're translated but we should leave that decision in the hands of the translators.

Part of https://github.com/elastic/kibana/issues/275777