### PR TITLE
[Security Solution][Flyout] show attack flyout as child (new flyout) or preview (expandable flyout) in correlations

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.test.tsx
@@ -106,10 +106,7 @@ const mockRenderCellActions = jest.fn(({ children }) => <>{children}</>);
  * by type). This walks the unrendered React element tree passed to it looking for the element
  * carrying the given prop, so tests can inspect callbacks it was given without rendering it.
  */
-const findElementWithProp = (
-  node: ReactNode,
-  propName: string
-): React.ReactElement | undefined => {
+const findElementWithProp = (node: ReactNode, propName: string): React.ReactElement | undefined => {
   if (Array.isArray(node)) {
     for (const child of node) {
       const found = findElementWithProp(child, propName);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
@@ -98,6 +98,36 @@ const nonAlertMockHit = createMockHit({
 });
 const onAlertUpdated = jest.fn();
 const mockRenderCellActions = jest.fn(({ children }) => <>{children}</>);
+
+/**
+ * `overlays.openSystemFlyout` is mocked (see `mockOpenSystemFlyout`), so the flyout content it
+ * receives is never actually mounted/rendered (the lazily-loaded `CorrelationsDetails` component
+ * is only ever created as an unrendered element, wrapped in `React.lazy`, so it can't be matched
+ * by type). This walks the unrendered React element tree passed to it looking for the element
+ * carrying the given prop, so tests can inspect callbacks it was given without rendering it.
+ */
+const findElementWithProp = (
+  node: ReactNode,
+  propName: string
+): React.ReactElement | undefined => {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findElementWithProp(child, propName);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+  if (!React.isValidElement(node)) {
+    return undefined;
+  }
+  const props = node.props as Record<string, unknown>;
+  if (propName in props) {
+    return node;
+  }
+  return findElementWithProp((props as { children?: ReactNode }).children, propName);
+};
 
 describe('InsightsSection', () => {
   const mockUseExpandSection = jest.mocked(useExpandSection);
@@ -223,6 +253,36 @@ describe('InsightsSection', () => {
       expect.objectContaining({
         historyKey: documentFlyoutHistoryKey,
         session: 'start',
+      })
+    );
+  });
+
+  it('wires onShowAttack so it opens the attack flyout as a child of the correlations flyout', () => {
+    const { getByTestId } = renderInsightsSection();
+
+    fireEvent.click(getByTestId('correlationsOverviewMock'));
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledTimes(1);
+    const correlationsElement = findElementWithProp(
+      mockOpenSystemFlyout.mock.calls[0][0],
+      'onShowAttack'
+    );
+    expect(correlationsElement).toBeDefined();
+
+    const onShowAttack = correlationsElement?.props.onShowAttack;
+    expect(onShowAttack).toBeInstanceOf(Function);
+
+    act(() => {
+      onShowAttack('attack-id-1', '.alerts-security.attack.discovery.alerts-default', 'Attack 1');
+    });
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledTimes(2);
+    expect(mockOpenSystemFlyout).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: documentFlyoutHistoryKey,
+        session: 'inherit',
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
@@ -58,6 +58,7 @@ export const InsightsSection = memo(
       openDocumentCorrelations,
       openDocumentThreatIntelligence,
       openDocumentPrevalence,
+      openAttackFlyoutAsChild,
     } = useFlyoutApi();
 
     const expanded = useExpandSection({
@@ -104,9 +105,22 @@ export const InsightsSection = memo(
       [openDocumentEntities, hit]
     );
 
+    const onShowAttack = useCallback(
+      (id: string, indexName: string, title?: string) =>
+        openAttackFlyoutAsChild({ attackId: id, indexName, attackTitle: title }),
+      [openAttackFlyoutAsChild]
+    );
+
     const onShowCorrelationsDetails = useCallback(
-      () => openDocumentCorrelations({ hit, scopeId: '', isRulePreview: false, onShowAlert }),
-      [openDocumentCorrelations, hit, onShowAlert]
+      () =>
+        openDocumentCorrelations({
+          hit,
+          scopeId: '',
+          isRulePreview: false,
+          onShowAlert,
+          onShowAttack,
+        }),
+      [openDocumentCorrelations, hit, onShowAlert, onShowAttack]
     );
 
     const renderFlyoutLink = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.tsx
@@ -43,9 +43,8 @@ export interface CorrelationsDetailsViewProps {
   /**
    * Callback to open an attack preview when clicking the expand button in the related attacks table.
    * When not provided, the expand button column is hidden.
-   * // TODO make required once we have an attack flyout in the new flyout system
    */
-  onShowAttack?: (id: string, indexName: string) => void;
+  onShowAttack?: (id: string, indexName: string, title?: string) => void;
   /**
    * Whether to render rule links as PreviewLink (legacy expandable flyout) instead of OpenFlyoutLink (new flyout system)
    */

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_attacks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_attacks.test.tsx
@@ -47,7 +47,9 @@ const TITLE_TEXT = EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(
   CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TEST_ID
 );
 
-const renderRelatedAttacks = (onShowAttack?: (id: string, indexName: string) => void) =>
+const renderRelatedAttacks = (
+  onShowAttack?: (id: string, indexName: string, title?: string) => void
+) =>
   render(
     <TestProviders>
       <DocumentDetailsContext.Provider value={mockContextValue}>
@@ -106,7 +108,7 @@ describe('<RelatedAttacks />', () => {
     getAllByTestId(
       `${CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TEST_ID}AlertPreviewButton`
     )[0].click();
-    expect(mockOnShowAttack).toHaveBeenCalledWith('attack-id-1', 'index');
+    expect(mockOnShowAttack).toHaveBeenCalledWith('attack-id-1', 'index', 'Attack 1');
     expect(
       getByTestId(CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TABLE_TEST_ID)
     ).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_attacks.tsx
@@ -33,9 +33,8 @@ export interface RelatedAttacksProps {
   /**
    * Callback to open an attack preview when clicking the expand button.
    * When not provided, the expand button column is hidden.
-   * // TODO make required once we have an attack flyout in the new flyout system
    */
-  onShowAttack?: (id: string, indexName: string) => void;
+  onShowAttack?: (id: string, indexName: string, title?: string) => void;
 }
 
 /**
@@ -68,7 +67,13 @@ export const RelatedAttacks: React.FC<RelatedAttacksProps> = ({
                   <EuiButtonIcon
                     iconType="expand"
                     data-test-subj={`${CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TEST_ID}AlertPreviewButton`}
-                    onClick={() => onShowAttack(row.id as string, row.index as string)}
+                    onClick={() =>
+                      onShowAttack(
+                        row.id as string,
+                        row.index as string,
+                        row['kibana.alert.attack_discovery.title'] as string | undefined
+                      )
+                    }
                     aria-label={i18n.translate(
                       'xpack.securitySolution.flyout.correlations.relatedAttacksPreviewButtonLabel',
                       {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/index.tsx
@@ -33,9 +33,8 @@ export interface CorrelationsDetailsProps {
   /**
    * Callback to open an attack preview when clicking the expand button in the related attacks table.
    * When not provided, the expand button column is hidden.
-   * // TODO make required once we have an attack flyout in the new flyout system
    */
-  onShowAttack?: (id: string, indexName: string) => void;
+  onShowAttack?: (id: string, indexName: string, title?: string) => void;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -128,7 +128,7 @@ export interface OpenDocumentCorrelationsParams {
   /** Callback to open one of the correlated alerts. */
   onShowAlert: (id: string, indexName: string, title?: string) => void;
   /** Optional callback to open a correlated attack; when omitted the attack column is hidden. */
-  onShowAttack?: (id: string, indexName: string) => void;
+  onShowAttack?: (id: string, indexName: string, title?: string) => void;
 }
 
 export interface OpenDocumentResponseParams {


### PR DESCRIPTION
## Summary

This PR makes a very small addition to the related attack table under the docuement flyout correlations section.

In `main`, we were showing a table of related attack (for an alert) but no interaction possible with the attack documents

https://github.com/user-attachments/assets/e4f2da92-b469-4a33-8e26-5331a7153af6

This PR adds a arrow icon, similar to the other tables in this correlations section. Clicking on the arrow icon will:
- open the preview attack flyout for the legacy expandable flyout
- open the attack flyout as a child for the new flyout system

#### Legacy flyout

https://github.com/user-attachments/assets/c2b658d1-d861-4054-932d-5222c211b347

#### New flyout

https://github.com/user-attachments/assets/75c9ecb2-c10b-4e4f-b232-a07f34b4d7e9

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->