### PR TITLE
[Security Solution] Fix entity attachment search: colon notation + pagination

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
@@ -43,8 +43,7 @@ export const EntityTabContent: React.FC<CommonAttachmentTabViewProps> = ({
   const entityIds = useMemo<string[]>(
     () =>
       caseData.comments.flatMap((comment) =>
-        isEntityAttachment(comment) &&
-        (!searchTerm || matchesSearchTerm(comment, searchTerm))
+        isEntityAttachment(comment) && (!searchTerm || matchesSearchTerm(comment, searchTerm))
           ? [comment.attachmentId]
           : []
       ),

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/entity_tab_content.tsx
@@ -44,7 +44,7 @@ export const EntityTabContent: React.FC<CommonAttachmentTabViewProps> = ({
     () =>
       caseData.comments.flatMap((comment) =>
         isEntityAttachment(comment) &&
-        (!searchTerm || matchesSearchTerm(comment.metadata, searchTerm))
+        (!searchTerm || matchesSearchTerm(comment, searchTerm))
           ? [comment.attachmentId]
           : []
       ),

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/hooks/use_entity_local_table_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/hooks/use_entity_local_table_state.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { EntityURLStateResult } from '../../../../entity_analytics/components/home/entities_table';
@@ -61,6 +61,16 @@ export const useEntityLocalTableState = ({
     }),
     [pinnedFilter]
   );
+
+  // Reset to the first page whenever the pinned filter changes (e.g. a search term
+  // narrows the attached entities). The grouped table paginates server-side via an
+  // offset (pageIndex * pageSize); without this reset a stale pageIndex requests an
+  // offset past the end of the narrowed result set, so the match on page 1 is hidden
+  // and the accordion shows zero rows.
+  const filterKey = useMemo(() => JSON.stringify(pinnedFilter), [pinnedFilter]);
+  useEffect(() => {
+    setPageIndex(0);
+  }, [filterKey]);
 
   const onChangeItemsPerPage = useCallback((next: number) => {
     setPageSize(next);

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/utils.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityAttachmentPayload } from '../../../../common/cases/attachments/entity';
+import { matchesSearchTerm } from './utils';
+
+type Attachment = Pick<EntityAttachmentPayload, 'attachmentId' | 'metadata'>;
+
+const buildAttachment = (overrides: Partial<Attachment> = {}): Attachment => ({
+  attachmentId: 'host:web01.acme.com',
+  metadata: {
+    entityName: 'web01.acme.com',
+    entityType: 'host',
+    riskLevel: 'Critical',
+  },
+  ...overrides,
+});
+
+describe('matchesSearchTerm', () => {
+  it('matches on a bare entity name fragment', () => {
+    expect(matchesSearchTerm(buildAttachment(), 'web01')).toBe(true);
+  });
+
+  it('matches colon-notation searches against the entity id (EUID)', () => {
+    // The colon must be treated as a literal, not a field separator.
+    expect(matchesSearchTerm(buildAttachment(), 'host:web01')).toBe(true);
+  });
+
+  it('matches the full entity id', () => {
+    expect(matchesSearchTerm(buildAttachment(), 'host:web01.acme.com')).toBe(true);
+  });
+
+  it('matches on entity type', () => {
+    expect(matchesSearchTerm(buildAttachment(), 'host')).toBe(true);
+  });
+
+  it('matches on risk level', () => {
+    expect(matchesSearchTerm(buildAttachment(), 'critical')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchesSearchTerm(buildAttachment(), 'HOST:WEB01')).toBe(true);
+  });
+
+  it('returns false when nothing matches', () => {
+    expect(matchesSearchTerm(buildAttachment(), 'nonexistent')).toBe(false);
+  });
+
+  it('handles a user EUID with @ segments', () => {
+    const attachment = buildAttachment({
+      attachmentId: 'user:alice@corp@default',
+      metadata: { entityName: 'alice', entityType: 'user' },
+    });
+    expect(matchesSearchTerm(attachment, 'user:alice')).toBe(true);
+  });
+
+  it('does not throw when riskLevel is absent', () => {
+    const attachment = buildAttachment({
+      metadata: { entityName: 'web01.acme.com', entityType: 'host' },
+    });
+    expect(matchesSearchTerm(attachment, 'web01')).toBe(true);
+    expect(matchesSearchTerm(attachment, 'critical')).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/utils.ts
@@ -6,10 +6,7 @@
  */
 
 import { SECURITY_ENTITY_ATTACHMENT_TYPE, type CaseUI } from '@kbn/cases-plugin/common';
-import type {
-  EntityAttachmentMetadata,
-  EntityAttachmentPayload,
-} from '../../../../common/cases/attachments/entity';
+import type { EntityAttachmentPayload } from '../../../../common/cases/attachments/entity';
 import type { EntitiesTableConfig } from '../../../entity_analytics/components/home/entities_table';
 
 export type CaseAttachment = CaseUI['comments'][number];
@@ -31,9 +28,19 @@ export const isEntityAttachment = (
   );
 };
 
-/** Case-insensitive match against an entity's name, type, and risk level. */
-export const matchesSearchTerm = (metadata: EntityAttachmentMetadata, searchTerm: string) => {
-  const searchableText = `${metadata.entityName} ${metadata.entityType} ${
+/**
+ * Case-insensitive match against an entity's id (EUID), name, type, and risk level.
+ *
+ * The EUID is included so colon-notation searches like `host:web01` match: the user is
+ * typing a fragment of the canonical id (e.g. `host:web01.acme.com`). Matching happens on
+ * the raw id string, so the colon is treated as a literal rather than a field separator.
+ */
+export const matchesSearchTerm = (
+  attachment: Pick<EntityAttachmentPayload, 'attachmentId' | 'metadata'>,
+  searchTerm: string
+) => {
+  const { attachmentId, metadata } = attachment;
+  const searchableText = `${attachmentId} ${metadata.entityName} ${metadata.entityType} ${
     metadata.riskLevel ?? ''
   }`.toLowerCase();
   return searchableText.includes(searchTerm.toLowerCase());


### PR DESCRIPTION
### Summary
Fixes two search bugs in a case's Attachments tab → Entities section.

 **colon-notation search returned nothing**. 
 - Searching `host:web01` gave zero results because the matcher only looked at name/type/risk and treated the colon as breaking the match. 
- **It now also searches the entity id (EUID), so host:web01 matches as a literal substring.**
- Bare-name search still works.

**Search broke on page 2+:**+
- With enough attachments to paginate, searching while past page 1 showed zero results.
-  The grouped table paginates by offset, and the page index wasn't reset when the search changed — so it requested rows past the end of the narrowed set. 
- **Now the page resets to 0 whenever the filter changes.**

**Test steps**

**Feature flags:** Turn on the entityAttachmentsEnabled flag and the entity store (with at least one entity).

- Go to entity analytics management page 
- dev tools to manual add an entity: 

```
POST entities-latest-default/_doc?refresh=wait_for
{
  "@timestamp": "2026-07-17T12:00:00.000Z",
  "entity": {
    "id": "host:web01.acme.com",
    "name": "web01.acme.com",
    "type": "host",
    "EngineMetadata": { "Type": "host" }
  },
  "host": { "name": "web01.acme.com" }
}
```
1. Open a case with an entity attachment → Attachments tab → Entities.
2. Search using colon notation (e.g. host:<name>) → the entity shows.
3. With enough entities to paginate, go to page 2, then search for one that's on page 1 → it shows. 

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->