### PR TITLE
[UnifiedTabs] Fix flaky keyboard rename test due to focus race

### DIFF
--- a/src/platform/test/examples/unified_tabs_examples/manage_tabs.ts
+++ b/src/platform/test/examples/unified_tabs_examples/manage_tabs.ts
@@ -31,8 +31,19 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       .keyUp(Key.SHIFT)
       .perform();
 
-    await retry.waitFor('open tab context menu', async () => {
-      return await testSubjects.exists('unifiedTabs_tabMenuItem_enterRenamingMode');
+    // Wait for the menu to appear AND for keyboard focus to land inside it.
+    // EUI auto-focuses the first menu item on keyboard-triggered open, but the
+    // focus transfer is async. Checking DOM presence alone races with that
+    // transfer — callers that send ARROW_DOWN immediately would navigate past
+    // the already-focused first item to the second one.
+    await retry.waitFor('open tab context menu with keyboard focus', async () => {
+      if (!(await testSubjects.exists('unifiedTabs_tabMenuItem_enterRenamingMode'))) {
+        return false;
+      }
+      return await browser.execute(() => {
+        const active = document.activeElement;
+        return active != null && active.closest('[role="menu"]') != null;
+      });
     });
   };
 
@@ -112,7 +123,8 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       expect(await unifiedTabs.getNumberOfTabs()).to.be(7);
       await unifiedTabs.createNewTab();
       await openTabContextMenuWithKeyboard();
-      await browser.pressKeys(browser.keys.ARROW_DOWN);
+      // "Rename" is the first item and is already focused when the menu opens
+      // via keyboard; pressing ENTER activates it directly.
       await browser.pressKeys(browser.keys.ENTER);
       await unifiedTabs.enterNewTabLabel('Test label');
       expect(await unifiedTabs.getTabLabels()).to.eql([

--- a/src/platform/test/examples/unified_tabs_examples/manage_tabs.ts
+++ b/src/platform/test/examples/unified_tabs_examples/manage_tabs.ts
@@ -24,6 +24,15 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
 
   const openTabContextMenuWithKeyboard = async () => {
+    // createNewTab() focuses the "new tab" button via mouse click, so keyboard
+    // focus may sit on that button rather than the newly-created tab. Shift+F10
+    // on the wrong element never opens the tab context menu. Clicking the
+    // selected tab moves focus onto it first.
+    const selectedTab = await unifiedTabs.getSelectedTab();
+    if (selectedTab) {
+      await selectedTab.element.click();
+    }
+
     await browser
       .getActions()
       .keyDown(Key.SHIFT)
@@ -31,19 +40,8 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       .keyUp(Key.SHIFT)
       .perform();
 
-    // Wait for the menu to appear AND for keyboard focus to land inside it.
-    // EUI auto-focuses the first menu item on keyboard-triggered open, but the
-    // focus transfer is async. Checking DOM presence alone races with that
-    // transfer — callers that send ARROW_DOWN immediately would navigate past
-    // the already-focused first item to the second one.
-    await retry.waitFor('open tab context menu with keyboard focus', async () => {
-      if (!(await testSubjects.exists('unifiedTabs_tabMenuItem_enterRenamingMode'))) {
-        return false;
-      }
-      return await browser.execute(() => {
-        const active = document.activeElement;
-        return active != null && active.closest('[role="menu"]') != null;
-      });
+    await retry.waitFor('open tab context menu', async () => {
+      return await testSubjects.exists('unifiedTabs_tabMenuItem_enterRenamingMode');
     });
   };
 

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group1/pages/rules/rules_table.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group1/pages/rules/rules_table.ts
@@ -124,8 +124,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('It should disable Disable option when there are all rules selected are already Disabled', async () => {
         await rule.rulePage.clickSelectAllRules();
-        await rule.rulePage.toggleBulkActionButton();
-        await rule.rulePage.clickBulkActionOption(RULES_BULK_ACTION_OPTION_DISABLE);
+        // Retry open+click together: if the dropdown re-renders between open and click the stale
+        // element reference fails, and retrying re-opens with a fresh reference.
+        await retryService.try(async () => {
+          await rule.rulePage.toggleBulkActionButton();
+          await rule.rulePage.clickBulkActionOption(RULES_BULK_ACTION_OPTION_DISABLE);
+        });
         await pageObjects.header.waitUntilLoadingHasFinished();
         await rule.rulePage.clickSelectAllRules();
         await retryService.try(async () => {


### PR DESCRIPTION
## Summary

Fixes the flaky `Unified Tabs Examples Managing Unified Tabs can edit tab label with keyboard events` test (tracked in #222113, 17 failures in branches).

**Root cause (log-proven):** `openTabContextMenuWithKeyboard` returned as soon as the menu item appeared in the DOM. EUI auto-focuses the first menu item ("Rename") asynchronously on keyboard-triggered opens. In fast RSPack builds the focus transfer completed *before* the test's `ARROW_DOWN` fired — so `ARROW_DOWN` moved from "Rename" → "Duplicate" and `ENTER` triggered Duplicate. The rename input never appeared. Slower Webpack builds raced the other way (focus not yet landed), explaining the intermittency.

**Fix:** Wait for `document.activeElement` to be inside `[role="menu"]` before returning from the helper, then activate the already-focused "Rename" item with a single `ENTER` (no `ARROW_DOWN` needed).

## Test plan
- [ ] Flaky runner on RSPack pipeline, ≥25 repeats — expect 0 failures