### PR TITLE
[9.4] [Reporting] Pass ES|QL variables to CSV reports (#277916)

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/moon.yml
+++ b/src/platform/packages/private/kbn-generate-csv/moon.yml
@@ -31,6 +31,7 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/search-types'
   - '@kbn/task-manager-plugin'
+  - '@kbn/esql-types'
   - '@kbn/esql-utils'
   - '@kbn/safer-lodash-set'
 tags:

--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv_esql.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv_esql.test.ts
@@ -24,6 +24,7 @@ import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
 import { CancellationToken } from '@kbn/reporting-common';
 import type { ReportingConfigType } from '@kbn/reporting-server';
 import type { ESQLSearchResponse } from '@kbn/es-types';
+import { ESQLVariableType } from '@kbn/esql-types';
 import {
   UI_SETTINGS_CSV_QUOTE_VALUES,
   UI_SETTINGS_CSV_SEPARATOR,
@@ -579,6 +580,124 @@ describe('CsvESQLGenerator', () => {
           },
           abortSignal: expect.any(AbortSignal),
         }
+      );
+    });
+
+    it('passes user-defined variable params to the query', async () => {
+      const query = {
+        esql: 'FROM test_csv_tokens | WHERE TO_STRING(crew.id) == TO_STRING(?crew_id)',
+      };
+      const esqlVariables = [{ key: 'crew_id', value: '123', type: 'values' as any }];
+
+      const generateCsv = new CsvESQLGenerator(
+        createMockJob({ query, esqlVariables }),
+        mockConfig,
+        mockTaskInstanceFields,
+        {
+          es: mockEsClient,
+          data: mockDataClient,
+          uiSettings: uiSettingsClient,
+        },
+        new CancellationToken(),
+        mockLogger,
+        stream,
+        jobId
+      );
+      await generateCsv.generateData();
+
+      expect(mockDataClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            query: `${query.esql}\n| LIMIT 500`,
+            params: expect.arrayContaining([expect.objectContaining({ crew_id: '123' })]),
+          }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('rewrites field variables (?field → ??field) and passes them as params', async () => {
+      const query = {
+        esql: 'FROM test_csv_tokens | STATS COUNT(*) BY ?breakdown_field',
+      };
+      const esqlVariables = [
+        { key: 'breakdown_field', value: 'bytes', type: ESQLVariableType.FIELDS },
+      ];
+
+      const generateCsv = new CsvESQLGenerator(
+        createMockJob({ query, esqlVariables }),
+        mockConfig,
+        mockTaskInstanceFields,
+        {
+          es: mockEsClient,
+          data: mockDataClient,
+          uiSettings: uiSettingsClient,
+        },
+        new CancellationToken(),
+        mockLogger,
+        stream,
+        jobId
+      );
+      await generateCsv.generateData();
+
+      expect(mockDataClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            // identifier-type variables must be sent to ES with the ?? prefix
+            query: 'FROM test_csv_tokens | STATS COUNT(*) BY ??breakdown_field\n| LIMIT 500',
+            params: expect.arrayContaining([expect.objectContaining({ breakdown_field: 'bytes' })]),
+          }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('passes both time params and user variable params together', async () => {
+      const query = {
+        esql: 'FROM test | WHERE @timestamp >= ?_tstart AND TO_STRING(crew.id) == ?crew_id',
+      };
+      const filters = [
+        {
+          meta: {},
+          query: {
+            range: {
+              '@timestamp': {
+                format: 'strict_date_optional_time',
+                gte: 'now-15m',
+                lte: 'now',
+              },
+            },
+          },
+        },
+      ];
+      const esqlVariables = [{ key: 'crew_id', value: 'abc', type: 'values' as any }];
+
+      const generateCsv = new CsvESQLGenerator(
+        createMockJob({ query, filters, esqlVariables }),
+        mockConfig,
+        mockTaskInstanceFields,
+        {
+          es: mockEsClient,
+          data: mockDataClient,
+          uiSettings: uiSettingsClient,
+        },
+        new CancellationToken(),
+        mockLogger,
+        stream,
+        jobId
+      );
+      await generateCsv.generateData();
+
+      expect(mockDataClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            params: expect.arrayContaining([
+              expect.objectContaining({ _tstart: expect.any(String) }),
+              expect.objectContaining({ crew_id: 'abc' }),
+            ]),
+          }),
+        }),
+        expect.any(Object)
       );
     });
 

--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv_esql.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv_esql.ts
@@ -15,7 +15,13 @@ import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-ty
 import { ESQL_SEARCH_STRATEGY, cellHasFormulas, getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { IScopedSearchClient } from '@kbn/data-plugin/server';
 import { type Filter, buildEsQuery, extractTimeRange } from '@kbn/es-query';
-import { getTimeFieldFromESQLQuery, getStartEndParams, appendLimitToQuery } from '@kbn/esql-utils';
+import {
+  getTimeFieldFromESQLQuery,
+  appendLimitToQuery,
+  getNamedParams,
+  fixESQLQueryWithVariables,
+} from '@kbn/esql-utils';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import { i18n } from '@kbn/i18n';
 import type { CancellationToken, ReportingError } from '@kbn/reporting-common';
@@ -38,6 +44,7 @@ export interface JobParamsCsvESQL {
   browserTimezone?: string;
   forceNow?: string;
   timeFieldName?: string;
+  esqlVariables?: ESQLControlVariable[];
 }
 
 interface Clients {
@@ -77,16 +84,17 @@ export class CsvESQLGenerator {
     const { maxSizeBytes, maxRows, bom, escapeFormulaValues, timezone } = settings;
     const builder = new MaxSizeStringBuilder(this.stream, byteSizeValueToNumber(maxSizeBytes), bom);
 
-    // it will return undefined if there are no _tstart, _tend named params in the query
-    const timeFieldName = getTimeFieldFromESQLQuery(this.job.query.esql);
-    const params = [];
+    // Rewrite identifier-type (FIELDS/FUNCTIONS) variables (e.g. ?var → ??var) for ES compatibility
+    const esqlQuery = fixESQLQueryWithVariables(this.job.query.esql, this.job.esqlVariables);
+
+    const timeFieldName = getTimeFieldFromESQLQuery(esqlQuery);
+    let timeRange;
     if (timeFieldName && this.job.filters) {
-      const { timeRange } = extractTimeRange(this.job.filters, timeFieldName);
-      if (timeRange) {
-        const namedParams = getStartEndParams(this.job.query.esql, timeRange);
-        params.push(...namedParams);
-      }
+      ({ timeRange } = extractTimeRange(this.job.filters, timeFieldName));
     }
+
+    // Builds _tstart/_tend params (from time range) and user-defined variable params
+    const params = getNamedParams(esqlQuery, timeRange, this.job.esqlVariables);
 
     let currentFilters = this.job.filters;
     if (this.job.forceNow) {
@@ -119,13 +127,9 @@ export class CsvESQLGenerator {
         getEsQueryConfig(this.clients.uiSettings as Parameters<typeof getEsQueryConfig>[0])
       );
 
-    let query = this.job.query.esql;
-    if (query && maxRows) {
-      query = appendLimitToQuery(this.job.query.esql, maxRows);
-    }
     const searchParams: IKibanaSearchRequest<ESQLSearchParams> = {
       params: {
-        query,
+        query: esqlQuery && maxRows ? appendLimitToQuery(esqlQuery, maxRows) : esqlQuery,
         filter,
         // locale can be used for number/date formatting
         locale: i18n.getLocale(),

--- a/src/platform/packages/private/kbn-generate-csv/tsconfig.json
+++ b/src/platform/packages/private/kbn-generate-csv/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/data-views-plugin",
     "@kbn/search-types",
     "@kbn/task-manager-plugin",
+    "@kbn/esql-types",
     "@kbn/esql-utils",
     "@kbn/safer-lodash-set",
   ]

--- a/src/platform/packages/private/kbn-reporting/export_types/csv/csv_v2.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/csv/csv_v2.ts
@@ -8,6 +8,7 @@
  */
 
 import Boom from '@hapi/boom';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 
 import type { KibanaRequest } from '@kbn/core/server';
 import type { DataPluginStart } from '@kbn/data-plugin/server/plugin';
@@ -131,6 +132,7 @@ export class CsvV2ExportType extends ExportType<
       // this should be addressed here https://github.com/elastic/kibana/issues/151190
       // const columns = await locatorClient.columnsFromLocator(params);
       const columns = params.columns as string[] | undefined;
+      const esqlVariables = params.esqlVariables as ESQLControlVariable[] | undefined;
       const timeFieldName = await locatorClient.timeFieldNameFromLocator(params);
       const filters = await locatorClient.filtersFromLocator(params);
       const es = this.startDeps.esClient.asScoped(request);
@@ -140,6 +142,7 @@ export class CsvV2ExportType extends ExportType<
       const csv = new CsvESQLGenerator(
         {
           columns,
+          esqlVariables,
           query,
           filters,
           timeFieldName,

--- a/src/platform/packages/private/kbn-reporting/export_types/csv/moon.yml
+++ b/src/platform/packages/private/kbn-reporting/export_types/csv/moon.yml
@@ -28,6 +28,7 @@ dependsOn:
   - '@kbn/core-http-request-handler-context-server'
   - '@kbn/field-formats-plugin'
   - '@kbn/licensing-plugin'
+  - '@kbn/esql-types'
 tags:
   - shared-server
   - package

--- a/src/platform/packages/private/kbn-reporting/export_types/csv/tsconfig.json
+++ b/src/platform/packages/private/kbn-reporting/export_types/csv/tsconfig.json
@@ -27,5 +27,6 @@
     "@kbn/core-http-request-handler-context-server",
     "@kbn/field-formats-plugin",
     "@kbn/licensing-plugin",
+    "@kbn/esql-types",
   ]
 }

--- a/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/moon.yml
+++ b/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/moon.yml
@@ -34,6 +34,7 @@ dependsOn:
   - '@kbn/es-query'
   - '@kbn/deeplinks-analytics'
   - '@kbn/licensing-types'
+  - '@kbn/esql-types'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/panel_actions/get_csv_panel_action.test.ts
+++ b/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/panel_actions/get_csv_panel_action.test.ts
@@ -174,6 +174,59 @@ describe('GetCsvReportPanelAction', () => {
     });
   });
 
+  it('includes esqlVariables from parent api in ES|QL CSV job params', async () => {
+    const esqlMockSearchSource = {
+      createCopy: () => esqlMockSearchSource,
+      removeField: jest.fn(),
+      setField: jest.fn(),
+      getField: jest.fn((name: string) => {
+        if (name === 'query') return { esql: 'FROM test | WHERE crew.id == ?crew_id' };
+        return undefined;
+      }),
+      getSerializedFields: jest.fn().mockReturnValue({
+        query: { esql: 'FROM test | WHERE crew.id == ?crew_id' },
+        parent: { filter: [] },
+      }),
+    } as unknown as SearchSource;
+
+    context = {
+      embeddable: {
+        ...(context.embeddable as object),
+        savedSearch$: new BehaviorSubject({
+          searchSource: esqlMockSearchSource,
+          columns: [],
+        } as unknown as SavedSearch),
+        parentApi: {
+          viewMode$: new BehaviorSubject('view'),
+          esqlVariables$: new BehaviorSubject([{ key: 'crew_id', value: '123', type: 'values' }]),
+        },
+      },
+    } as EmbeddableApiContext;
+
+    const panel = new ReportingCsvPanelAction({
+      core,
+      apiClient,
+      startServices$: mockStartServices$,
+      csvConfig,
+    });
+
+    await Rx.firstValueFrom(mockStartServices$);
+    await panel.execute(context);
+
+    expect(apiClient.createReportingJob).toHaveBeenCalledWith(
+      'csv_v2',
+      expect.objectContaining({
+        locatorParams: expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              esqlVariables: [{ key: 'crew_id', value: '123', type: 'values' }],
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
   it('allows csv generation for valid licenses', async () => {
     const panel = new ReportingCsvPanelAction({
       core,

--- a/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/panel_actions/get_csv_panel_action.tsx
+++ b/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/panel_actions/get_csv_panel_action.tsx
@@ -29,6 +29,7 @@ import type {
 } from '@kbn/presentation-publishing';
 import {
   apiCanAccessViewMode,
+  apiHasParentApi,
   apiHasType,
   apiIsOfType,
   apiPublishesTitle,
@@ -36,6 +37,7 @@ import {
   type PublishesSavedObjectId,
   type PublishesUnifiedSearch,
 } from '@kbn/presentation-publishing';
+import { apiPublishesESQLVariables } from '@kbn/esql-types';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { CSV_REPORTING_ACTION } from '@kbn/reporting-export-types-csv-common';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
@@ -199,11 +201,23 @@ export class ReportingCsvPanelAction implements ActionDefinition<EmbeddableApiCo
   ): DiscoverAppLocatorParams => {
     const savedObjectId = api.savedObjectId$?.getValue();
 
+    // Read dashboard-level ES|QL variables so the reporting server can bind named params
+    const esqlVariables =
+      apiHasParentApi(api) && apiPublishesESQLVariables(api.parentApi)
+        ? api.parentApi.esqlVariables$.getValue()
+        : undefined;
+
     return {
       ...(savedObjectId ? { savedSearchId: savedObjectId } : {}),
       query: searchSourceFields.query,
       filters: searchSourceFields.parent?.filter, // time range filter
       columns,
+      // Cast bridges ESQLControlVariable[] to the `& SerializableRecord` field type.
+      ...(esqlVariables?.length
+        ? {
+            esqlVariables: esqlVariables as DiscoverAppLocatorParams['esqlVariables'],
+          }
+        : {}),
     };
   };
 

--- a/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/tsconfig.json
+++ b/src/platform/packages/private/kbn-reporting/get_csv_panel_actions/tsconfig.json
@@ -31,5 +31,6 @@
     "@kbn/es-query",
     "@kbn/deeplinks-analytics",
     "@kbn/licensing-types",
+    "@kbn/esql-types",
   ]
 }

--- a/src/platform/plugins/shared/discover/common/app_locator.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator.ts
@@ -15,6 +15,7 @@ import type { LocatorDefinition, LocatorPublic } from '@kbn/share-plugin/public'
 import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
 import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import type { ControlPanelsState } from '@kbn/control-group-renderer';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { VIEW_MODE, NEW_TAB_ID } from './constants';
 
 export const DISCOVER_APP_LOCATOR = 'DISCOVER_APP_LOCATOR';
@@ -131,6 +132,16 @@ export interface DiscoverAppLocatorParams extends SerializableRecord {
    * Optionally add some ESQL controls
    */
   esqlControls?: ControlPanelsState<OptionsListESQLControlState> & SerializableRecord;
+  /**
+   * Resolved ES|QL control variable values, so the reporting server can bind named
+   * params (e.g. ?crew_id) at export time.
+   *
+   * Note: this overlaps with `esqlControls` (control definitions, from which variable
+   * values could be derived), but it exists separately because some callers — e.g. the
+   * dashboard panel CSV export action — only have access to the resolved variable
+   * values, not the controls state.
+   */
+  esqlVariables?: ESQLControlVariable[] & SerializableRecord;
 }
 
 export type DiscoverAppLocator = LocatorPublic<DiscoverAppLocatorParams>;

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.test.ts
@@ -104,6 +104,9 @@ describe('getShare', () => {
         isEsqlMode: true,
         adHocDataViews: [],
         authorizedRuleTypeIds: [],
+        actions: {
+          updateAdHocDataViews: jest.fn(),
+        },
       },
       currentTab: toolkit.getCurrentTab(),
       persistedDiscoverSession: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../../__mocks__/discover_state.mock';
 import { FetchStatus } from '../../../../types';
 import { internalStateActions } from '../../../state_management/redux';
+import { ESQLVariableType } from '@kbn/esql-types';
 
 const mockDiscoverService = createDiscoverServicesMock();
 
@@ -82,6 +83,45 @@ describe('getShare', () => {
         objectId: undefined,
         objectType: 'search',
         objectTypeAlias: 'Discover session',
+      })
+    );
+  });
+
+  it('should include esqlVariables in locator params when in ES|QL mode with active controls', async () => {
+    const esqlVariables = [{ key: 'crew_id', value: '123', type: ESQLVariableType.VALUES }];
+
+    toolkit.internalState.dispatch(
+      internalStateActions.setEsqlVariables({
+        tabId: toolkit.getCurrentTab().id,
+        esqlVariables,
+      })
+    );
+
+    const shareOptions = await buildShareOptions({
+      services: mockDiscoverService,
+      discoverParams: {
+        dataView: dataViewMock,
+        isEsqlMode: true,
+        adHocDataViews: [],
+        authorizedRuleTypeIds: [],
+      },
+      currentTab: toolkit.getCurrentTab(),
+      persistedDiscoverSession: undefined,
+      totalHitsState: { result: 0, fetchStatus: FetchStatus.COMPLETE },
+      hasUnsavedChanges: false,
+    });
+
+    expect(shareOptions.sharingData.locatorParams[0].params).toEqual(
+      expect.objectContaining({
+        esqlVariables,
+      })
+    );
+
+    // clean up so subsequent tests start with no variables
+    toolkit.internalState.dispatch(
+      internalStateActions.setEsqlVariables({
+        tabId: toolkit.getCurrentTab().id,
+        esqlVariables: undefined,
       })
     );
   });

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -151,7 +151,21 @@ export const buildShareOptions = async ({
     },
     sharingData: {
       isTextBased: isEsqlMode,
-      locatorParams: [{ id: locator.id, version: services.metadata.version, params }],
+      locatorParams: [
+        {
+          id: locator.id,
+          version: services.metadata.version,
+          params:
+            isEsqlMode && currentTab.esqlVariables?.length
+              ? {
+                  ...params,
+                  // Resolved variable values so the reporting server can bind named params (e.g. ?crew_id).
+                  esqlVariables:
+                    currentTab.esqlVariables as DiscoverAppLocatorParams['esqlVariables'],
+                }
+              : params,
+        },
+      ],
       ...searchSourceSharingData,
       // CSV reports can be generated without a saved search so we provide a fallback title
       title:

--- a/src/platform/plugins/shared/discover/public/utils/get_sharing_data.test.ts
+++ b/src/platform/plugins/shared/discover/public/utils/get_sharing_data.test.ts
@@ -222,6 +222,25 @@ describe('getSharingData', () => {
     `);
   });
 
+  test('getSearchSource does not throw when there is no data view (ES|QL dashboard panel)', async () => {
+    // ES|QL saved-search panels on a dashboard can have no resolved data view on the search
+    // source, so `getField('index')` is undefined. getSearchSource must not throw when mapping
+    // columns to fields (nested field roots do not apply in ES|QL mode).
+    const searchSourceMock = createSearchSourceMock({});
+    searchSourceMock.setField('query', {
+      esql: 'from logstash-* | keep cool-field-1, cool-field-2',
+    });
+    const { getSearchSource } = await getSharingData(
+      searchSourceMock,
+      { columns: ['cool-field-1', 'cool-field-2'] },
+      services
+    );
+    expect(getSearchSource({}).fields).toStrictEqual([
+      { field: 'cool-field-1', include_unmapped: true },
+      { field: 'cool-field-2', include_unmapped: true },
+    ]);
+  });
+
   test('fields conditionally do not have prepended timeField', async () => {
     services.uiSettings = {
       get: (key: string) => {

--- a/src/platform/plugins/shared/discover/public/utils/get_sharing_data.ts
+++ b/src/platform/plugins/shared/discover/public/utils/get_sharing_data.ts
@@ -116,8 +116,10 @@ export async function getSharingData(
             let field = column;
 
             // If this column is a nested field, add a wildcard to the field name in order to fetch
-            // all leaf fields for the report, since the fields API doesn't support nested field roots
-            if (isNestedFieldParent(column, index)) {
+            // all leaf fields for the report, since the fields API doesn't support nested field roots.
+            // In ES|QL mode there is no data view (`index` is undefined) and nested field roots do
+            // not apply, so the check is skipped.
+            if (index && isNestedFieldParent(column, index)) {
               field = `${column}.*`;
             }
 

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.test.ts
@@ -375,4 +375,32 @@ describe('validateJobParams', () => {
 
     expect(() => validateJobParams(validParams)).not.toThrow();
   });
+
+  it('preserves esqlVariables nested in locator params', () => {
+    const validParams = {
+      title: 'ES|QL CSV',
+      version: '8.0.0',
+      browserTimezone: 'UTC',
+      objectType: 'search',
+      locatorParams: [
+        {
+          id: 'DISCOVER_APP_LOCATOR',
+          version: '8.0.0',
+          params: {
+            query: { esql: 'FROM test | WHERE crew.id == ?crew_id' },
+            columns: ['crew.id'],
+            esqlVariables: [{ key: 'crew_id', value: '123', type: 'values' }],
+          },
+        },
+      ],
+    } as unknown as BaseParams;
+
+    const result = validateJobParams(validParams) as unknown as {
+      locatorParams: Array<{ params: { esqlVariables: unknown } }>;
+    };
+
+    expect(result.locatorParams[0].params.esqlVariables).toEqual([
+      { key: 'crew_id', value: '123', type: 'values' },
+    ]);
+  });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Reporting] Pass ES|QL variables to CSV reports (#277916)](https://github.com/elastic/kibana/pull/277916)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cameron Banta","email":"cameron.banta@elastic.co"},"sourceCommit":{"committedDate":"2026-07-17T20:53:27Z","message":"[Reporting] Pass ES|QL variables to CSV reports (#277916)\n\nresolves https://github.com/elastic/kibana/issues/266973\n\n## Summary\n\nES|QL user-defined variable controls (e.g. `?crew_id`) work in Discover\nbut were never propagated to the Reporting execution path. As a result,\ngenerating a CSV report from an ES|QL query that references a control\nvariable failed with:\n\n```\nparsing_exception: Unknown query parameter [crew_id]\n```\n\nThis PR threads the resolved variable values through to the reporting\nserver and binds them when the ES|QL query is executed:\n\n- **Discover export (`get_share.tsx`)** and the **dashboard saved-search\npanel action (`get_csv_panel_action.tsx`)** now include the resolved\n`esqlVariables` in the Discover locator params.\n- **`DiscoverAppLocatorParams`** gains an `esqlVariables` field.\n- **`CsvV2ExportType`** reads `esqlVariables` from the locator params\nand passes them to the generator.\n- **`CsvESQLGenerator`** now rewrites the query with\n`fixESQLQueryWithVariables` and binds all named params (time range +\nuser-defined) via `getNamedParams`, replacing the previous\ntime-range-only handling.\n\nThis covers both immediate and scheduled reports, from Discover and from\ndashboard saved-search panels.\n\n## Test plan\n\n- [x] Unit tests added/updated:\n- `generate_csv_esql.test.ts` — user-defined variable params, and time +\nuser variable params together\n  - `csv_v2` export type path\n- `get_share.test.ts` — `esqlVariables` included in ES|QL locator params\n- `get_csv_panel_action.test.ts` — `esqlVariables` from dashboard parent\nAPI\n- `validator.test.ts` — `esqlVariables` preserved through the reporting\njob-params validator\n- [x] Manual: In Discover, create an ES|QL query with a variable control\n(e.g. `WHERE TO_STRING(crew.id) == TO_STRING(?crew_id)`), select a\nvalue, and generate a CSV report — confirm the report succeeds and is\nfiltered by the selected value.\n- [x] Manual: Repeat via the \"Download CSV\" action on a dashboard\nsaved-search panel with a dashboard-level ES|QL control.\n- [x] Manual: Confirm a scheduled report of the same query succeeds.\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"f0436cc1cbe64937431cbfde3fad14a4323c4950","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:all-open","Feature:ES|QL","Feature:Reporting:CSV","v9.6.0"],"title":"[Reporting] Pass ES|QL variables to CSV reports","number":277916,"url":"https://github.com/elastic/kibana/pull/277916","mergeCommit":{"message":"[Reporting] Pass ES|QL variables to CSV reports (#277916)\n\nresolves https://github.com/elastic/kibana/issues/266973\n\n## Summary\n\nES|QL user-defined variable controls (e.g. `?crew_id`) work in Discover\nbut were never propagated to the Reporting execution path. As a result,\ngenerating a CSV report from an ES|QL query that references a control\nvariable failed with:\n\n```\nparsing_exception: Unknown query parameter [crew_id]\n```\n\nThis PR threads the resolved variable values through to the reporting\nserver and binds them when the ES|QL query is executed:\n\n- **Discover export (`get_share.tsx`)** and the **dashboard saved-search\npanel action (`get_csv_panel_action.tsx`)** now include the resolved\n`esqlVariables` in the Discover locator params.\n- **`DiscoverAppLocatorParams`** gains an `esqlVariables` field.\n- **`CsvV2ExportType`** reads `esqlVariables` from the locator params\nand passes them to the generator.\n- **`CsvESQLGenerator`** now rewrites the query with\n`fixESQLQueryWithVariables` and binds all named params (time range +\nuser-defined) via `getNamedParams`, replacing the previous\ntime-range-only handling.\n\nThis covers both immediate and scheduled reports, from Discover and from\ndashboard saved-search panels.\n\n## Test plan\n\n- [x] Unit tests added/updated:\n- `generate_csv_esql.test.ts` — user-defined variable params, and time +\nuser variable params together\n  - `csv_v2` export type path\n- `get_share.test.ts` — `esqlVariables` included in ES|QL locator params\n- `get_csv_panel_action.test.ts` — `esqlVariables` from dashboard parent\nAPI\n- `validator.test.ts` — `esqlVariables` preserved through the reporting\njob-params validator\n- [x] Manual: In Discover, create an ES|QL query with a variable control\n(e.g. `WHERE TO_STRING(crew.id) == TO_STRING(?crew_id)`), select a\nvalue, and generate a CSV report — confirm the report succeeds and is\nfiltered by the selected value.\n- [x] Manual: Repeat via the \"Download CSV\" action on a dashboard\nsaved-search panel with a dashboard-level ES|QL control.\n- [x] Manual: Confirm a scheduled report of the same query succeeds.\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"f0436cc1cbe64937431cbfde3fad14a4323c4950"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/277916","number":277916,"mergeCommit":{"message":"[Reporting] Pass ES|QL variables to CSV reports (#277916)\n\nresolves https://github.com/elastic/kibana/issues/266973\n\n## Summary\n\nES|QL user-defined variable controls (e.g. `?crew_id`) work in Discover\nbut were never propagated to the Reporting execution path. As a result,\ngenerating a CSV report from an ES|QL query that references a control\nvariable failed with:\n\n```\nparsing_exception: Unknown query parameter [crew_id]\n```\n\nThis PR threads the resolved variable values through to the reporting\nserver and binds them when the ES|QL query is executed:\n\n- **Discover export (`get_share.tsx`)** and the **dashboard saved-search\npanel action (`get_csv_panel_action.tsx`)** now include the resolved\n`esqlVariables` in the Discover locator params.\n- **`DiscoverAppLocatorParams`** gains an `esqlVariables` field.\n- **`CsvV2ExportType`** reads `esqlVariables` from the locator params\nand passes them to the generator.\n- **`CsvESQLGenerator`** now rewrites the query with\n`fixESQLQueryWithVariables` and binds all named params (time range +\nuser-defined) via `getNamedParams`, replacing the previous\ntime-range-only handling.\n\nThis covers both immediate and scheduled reports, from Discover and from\ndashboard saved-search panels.\n\n## Test plan\n\n- [x] Unit tests added/updated:\n- `generate_csv_esql.test.ts` — user-defined variable params, and time +\nuser variable params together\n  - `csv_v2` export type path\n- `get_share.test.ts` — `esqlVariables` included in ES|QL locator params\n- `get_csv_panel_action.test.ts` — `esqlVariables` from dashboard parent\nAPI\n- `validator.test.ts` — `esqlVariables` preserved through the reporting\njob-params validator\n- [x] Manual: In Discover, create an ES|QL query with a variable control\n(e.g. `WHERE TO_STRING(crew.id) == TO_STRING(?crew_id)`), select a\nvalue, and generate a CSV report — confirm the report succeeds and is\nfiltered by the selected value.\n- [x] Manual: Repeat via the \"Download CSV\" action on a dashboard\nsaved-search panel with a dashboard-level ES|QL control.\n- [x] Manual: Confirm a scheduled report of the same query succeeds.\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"f0436cc1cbe64937431cbfde3fad14a4323c4950"}},{"url":"https://github.com/elastic/kibana/pull/279335","number":279335,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->