### PR TITLE
[CI] Fix Buildkite Jest runs through Moon

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_build.test.ts
+++ b/.buildkite/scripts/lifecycle/pre_build.test.ts
@@ -113,6 +113,7 @@ const runPreBuildScript = (overrides: Record<string, string> = {}) => {
     PATH: `${binDir}:${process.env.PATH ?? ''}`,
     CALLS_FILE: callsFile,
     KIBANA_GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true',
+    ES_SNAPSHOT_MANIFEST: '',
     ...overrides,
   };
 

--- a/.buildkite/tsconfig.test.json
+++ b/.buildkite/tsconfig.test.json
@@ -3,6 +3,7 @@
     "strict": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "noEmit": true,
     "lib": ["es2020"]

--- a/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts
@@ -60,6 +60,23 @@ describe('parseMoonJestOutput', () => {
     });
   });
 
+  it('parses successful Jest JSON output with a non-scoped project prefix', () => {
+    const output = [
+      'pass RunTask(kibana-buildkite:jest) (1s 200ms, abc123)',
+      'kibana-buildkite:jest | {"success":true,"numTotalTests":5,"numPassedTests":5,"numFailedTests":0,"testResults":[]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.parseFailures).toEqual([]);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      project: 'kibana-buildkite',
+      passed: true,
+      testCount: 5,
+      failures: [],
+    });
+  });
+
   it('marks cached tasks', () => {
     const output = [
       'pass RunTask(@kbn/foo:jest) (cached, 100ms, abc123)',
@@ -72,6 +89,21 @@ describe('parseMoonJestOutput', () => {
     expect(result.tasks[0].passed).toBe(true);
   });
 
+  it('marks cached tasks with a non-scoped project prefix', () => {
+    const output = [
+      'pass RunTask(kibana-buildkite:jest) (cached, 100ms, abc123)',
+      'kibana-buildkite:jest | {"success":true,"numTotalTests":3,"numPassedTests":3,"numFailedTests":0,"testResults":[]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      project: 'kibana-buildkite',
+      cached: true,
+      passed: true,
+    });
+  });
+
   it('creates placeholder for cached tasks without JSON output', () => {
     const output = 'pass RunTask(@kbn/bar:jest) (cached, 50ms, def456)';
 
@@ -79,6 +111,20 @@ describe('parseMoonJestOutput', () => {
     expect(result.tasks).toHaveLength(1);
     expect(result.tasks[0]).toMatchObject({
       project: '@kbn/bar',
+      cached: true,
+      passed: true,
+      testCount: 0,
+      failures: [],
+    });
+  });
+
+  it('creates placeholder for cached tasks with a non-scoped project prefix', () => {
+    const output = 'pass RunTask(kibana-buildkite:jest) (cached, 50ms, def456)';
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      project: 'kibana-buildkite',
       cached: true,
       passed: true,
       testCount: 0,

--- a/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.ts
@@ -104,6 +104,7 @@ const WORKER_OOM_MESSAGE_RE =
  * when the whole Jest process dies before producing any JSON for us to parse.
  */
 const RAW_OOM_SIGNATURE_RE = /heap out of memory|allocation failure;|Last few GCs/i;
+const MOON_JEST_PROJECT_ID_RE = '([^:)\\s]+)';
 
 /** Walk up from a test file to find the nearest jest config. */
 export const findJestConfig = (testFilePath: string): string | undefined => {
@@ -203,14 +204,16 @@ export const parseMoonJestOutput = (output: string): MoonJestParseResult => {
     const stripped = stripAnsi(rawLine).trim();
 
     // "pass RunTask(@kbn/foo:jest) (cached, ...)" from --summary detailed
-    const cachedMatch = stripped.match(/^pass RunTask\((@[^:]+):jest\) \(cached/);
+    const cachedMatch = stripped.match(
+      new RegExp(`^pass RunTask\\(${MOON_JEST_PROJECT_ID_RE}:jest\\) \\(cached`)
+    );
     if (cachedMatch) {
       cachedProjects.add(cachedMatch[1]);
       continue;
     }
 
     // Jest --json output: either prefixed "@kbn/foo:jest | {...}" or unprefixed "{...}"
-    const jsonPrefixMatch = stripped.match(/^(@[^:]+):jest \| \{/);
+    const jsonPrefixMatch = stripped.match(new RegExp(`^${MOON_JEST_PROJECT_ID_RE}:jest \\| \\{`));
     const isUnprefixedJson = !jsonPrefixMatch && stripped.startsWith('{"num');
     if (jsonPrefixMatch || isUnprefixedJson) {
       const project = jsonPrefixMatch ? jsonPrefixMatch[1] : '_single';
@@ -336,17 +339,21 @@ export const buildMoonJestWarnings = ({
 const parseMoonJestProgressProject = (rawLine: string) => {
   const stripped = stripAnsi(rawLine).trim();
 
-  const cachedSummaryMatch = stripped.match(/^pass RunTask\((@[^:]+):jest\) \(cached/);
+  const cachedSummaryMatch = stripped.match(
+    new RegExp(`^pass RunTask\\(${MOON_JEST_PROJECT_ID_RE}:jest\\) \\(cached`)
+  );
   if (cachedSummaryMatch) {
     return cachedSummaryMatch[1];
   }
 
-  const summaryMatch = stripped.match(/^(?:pass|fail) RunTask\((@[^:]+):jest\) \(/);
+  const summaryMatch = stripped.match(
+    new RegExp(`^(?:pass|fail) RunTask\\(${MOON_JEST_PROJECT_ID_RE}:jest\\) \\(`)
+  );
   if (summaryMatch) {
     return summaryMatch[1];
   }
 
-  const jsonPrefixMatch = stripped.match(/^(@[^:]+):jest \| \{/);
+  const jsonPrefixMatch = stripped.match(new RegExp(`^${MOON_JEST_PROJECT_ID_RE}:jest \\| \\{`));
   if (jsonPrefixMatch) {
     return jsonPrefixMatch[1];
   }


### PR DESCRIPTION
## Summary

Extracts the standalone Buildkite Jest-through-Moon fixes from #277950.

- allow Moon Jest output parsing for non-scoped project IDs like `kibana-buildkite`
- add parser coverage for prefixed/cached `kibana-buildkite:jest` output
- make the Buildkite pre-build Jest harness deterministic when `ES_SNAPSHOT_MANIFEST` is unset
- suppress TypeScript 6 deprecation noise for `.buildkite` test tsconfig

## Verification

- `node scripts/jest src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts`
- `npm test -- scripts/lifecycle/pre_build.test.ts` from `.buildkite`
- `npm run typecheck` from `.buildkite`
- `node_modules/.bin/moon run kibana-buildkite:jest -- --runTestsByPath .buildkite/scripts/lifecycle/pre_build.test.ts`