### PR TITLE
[Cases][Templates] Label required-on-close fields as "Required on close"

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -69,6 +69,8 @@ export type Validation = z.infer<typeof ValidationSchema>;
  */
 export interface ConditionRenderProps {
   isRequired?: boolean;
+  /** Field must be filled before the case can be closed (not required now). Drives the field label. */
+  isRequiredOnClose?: boolean;
   patternValidation?: { regex: string; message?: string };
   min?: number;
   max?: number;

--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -143,6 +143,10 @@ export const OPTIONAL = i18n.translate('xpack.cases.caseView.optional', {
   defaultMessage: 'Optional',
 });
 
+export const REQUIRED_ON_CLOSE = i18n.translate('xpack.cases.caseView.requiredOnClose', {
+  defaultMessage: 'Required on close',
+});
+
 export const PAGE_TITLE = i18n.translate('xpack.cases.pageTitle', {
   defaultMessage: 'Cases',
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/optional_field_label/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/optional_field_label/index.tsx
@@ -15,3 +15,25 @@ export const OptionalFieldLabel = (
     {i18n.OPTIONAL}
   </EuiText>
 );
+
+export const RequiredOnCloseFieldLabel = (
+  <EuiText color="subdued" size="xs" data-test-subj="form-required-on-close-field-label">
+    {i18n.REQUIRED_ON_CLOSE}
+  </EuiText>
+);
+
+/**
+ * The label append node for a template/case field, given its requirement state:
+ * - required now → no append (the field is already marked required)
+ * - required only on close → "Required on close" (accurate: fillable now, mandatory before closing)
+ * - otherwise → "Optional"
+ */
+export const getFieldRequirementLabel = (
+  isRequired?: boolean,
+  isRequiredOnClose?: boolean
+): React.ReactNode => {
+  if (isRequired) {
+    return undefined;
+  }
+  return isRequiredOnClose ? RequiredOnCloseFieldLabel : OptionalFieldLabel;
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
@@ -17,7 +17,7 @@ import type {
   ConditionRenderProps,
 } from '../../../../../common/types/domain/template/fields';
 import { FIELD_REQUIRED } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type CheckboxGroupProps = z.infer<typeof CheckboxGroupFieldSchema> & ConditionRenderProps;
 
@@ -43,6 +43,7 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
   type,
   metadata,
   isRequired,
+  isRequiredOnClose,
   onConfirm,
   isSaving,
   isSaveDisabled,
@@ -91,7 +92,7 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
           <>
             <EuiFormRow
               label={label}
-              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
               error={fieldState.error?.message}
               isInvalid={Boolean(fieldState.error)}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -19,7 +19,7 @@ import {
   type ConditionRenderProps,
 } from '../../../../../common/types/domain/template/fields';
 import { FIELD_REQUIRED } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type DatePickerProps = z.infer<typeof DatePickerFieldSchema> & ConditionRenderProps;
 
@@ -41,6 +41,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   type,
   metadata,
   isRequired,
+  isRequiredOnClose,
   onConfirm,
   isSaving,
   isSaveDisabled,
@@ -74,7 +75,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         <>
           <EuiFormRow
             label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+            labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
             error={fieldState.error?.message}
             isInvalid={Boolean(fieldState.error)}
             fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -17,7 +17,7 @@ import type {
   ConditionRenderProps,
 } from '../../../../../common/types/domain/template/fields';
 import { FIELD_REQUIRED, FIELD_MIN_VALUE, FIELD_MAX_VALUE } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type InputNumberProps = z.infer<typeof InputNumberFieldSchema> & ConditionRenderProps;
 
@@ -33,6 +33,7 @@ export const InputNumber = ({
   name,
   type,
   isRequired,
+  isRequiredOnClose,
   min,
   max,
   onConfirm,
@@ -85,7 +86,7 @@ export const InputNumber = ({
           <>
             <EuiFormRow
               label={label}
-              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
               isInvalid={Boolean(fieldState.error)}
               error={fieldState.error?.message}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -22,7 +22,7 @@ import {
   FIELD_PATTERN_MISMATCH,
   FIELD_PATTERN_INVALID,
 } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 import { InlineFieldActions } from './inline_field_actions';
 
 type InputTextProps = z.infer<typeof InputTextFieldSchema> & ConditionRenderProps;
@@ -32,6 +32,7 @@ export const InputText = ({
   name,
   type,
   isRequired,
+  isRequiredOnClose,
   patternValidation,
   minLength,
   maxLength,
@@ -92,7 +93,7 @@ export const InputText = ({
           <>
             <EuiFormRow
               label={label}
-              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
               isInvalid={Boolean(fieldState.error)}
               error={fieldState.error?.message}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
@@ -17,7 +17,7 @@ import type {
   ConditionRenderProps,
 } from '../../../../../common/types/domain/template/fields';
 import * as i18n from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type RadioGroupProps = z.infer<typeof RadioGroupFieldSchema> & ConditionRenderProps;
 
@@ -27,6 +27,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   type,
   metadata,
   isRequired,
+  isRequiredOnClose,
   onConfirm,
   isSaving,
   isSaveDisabled,
@@ -68,6 +69,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
             path={path}
             label={label ?? ''}
             isRequired={isRequired ?? false}
+            isRequiredOnClose={isRequiredOnClose ?? false}
             options={options}
             firstOption={firstOption}
             value={typeof field.value === 'string' ? field.value : ''}
@@ -101,6 +103,7 @@ interface RadioGroupRenderProps {
   path: string;
   label: string;
   isRequired: boolean;
+  isRequiredOnClose: boolean;
   options: Array<{ id: string; label: string }>;
   firstOption: string;
   value: string;
@@ -116,6 +119,7 @@ const RadioGroupRender: React.FC<RadioGroupRenderProps> = ({
   path,
   label,
   isRequired,
+  isRequiredOnClose,
   options,
   firstOption,
   value,
@@ -140,7 +144,7 @@ const RadioGroupRender: React.FC<RadioGroupRenderProps> = ({
   return (
     <EuiFormRow
       label={label}
-      labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+      labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
       error={errorMessage}
       isInvalid={isInvalid}
       fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
@@ -17,7 +17,7 @@ import type {
   ConditionRenderProps,
 } from '../../../../../common/types/domain/template/fields';
 import { FIELD_REQUIRED } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type SelectBasicProps = z.infer<typeof SelectBasicFieldSchema> & ConditionRenderProps;
 
@@ -27,6 +27,7 @@ export const SelectBasic = ({
   name,
   type,
   isRequired,
+  isRequiredOnClose,
   onConfirm,
   isSaving,
   isSaveDisabled,
@@ -69,7 +70,7 @@ export const SelectBasic = ({
         <>
           <EuiFormRow
             label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+            labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
             isInvalid={Boolean(fieldState.error)}
             error={fieldState.error?.message}
             fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -23,7 +23,7 @@ import {
   FIELD_PATTERN_MISMATCH,
   FIELD_PATTERN_INVALID,
 } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type TextareaProps = z.infer<typeof TextareaFieldSchema> & ConditionRenderProps;
 
@@ -33,6 +33,7 @@ export const Textarea = ({
   type,
   metadata,
   isRequired,
+  isRequiredOnClose,
   patternValidation,
   minLength,
   maxLength,
@@ -94,7 +95,7 @@ export const Textarea = ({
           <>
             <EuiFormRow
               label={label}
-              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
               isInvalid={Boolean(fieldState.error)}
               error={fieldState.error?.message}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/toggle.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/toggle.tsx
@@ -16,7 +16,7 @@ import type {
   ConditionRenderProps,
 } from '../../../../../common/types/domain/template/fields';
 import { FIELD_REQUIRED, TOGGLE_ON, TOGGLE_OFF } from '../../translations';
-import { OptionalFieldLabel } from '../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../optional_field_label';
 
 type ToggleProps = z.infer<typeof ToggleFieldSchema> & ConditionRenderProps;
 
@@ -25,7 +25,14 @@ const isChecked = (value: unknown): boolean => value === true || value === 'true
 const isDefinedToggleValue = (value: unknown): boolean =>
   value === true || value === false || value === 'true' || value === 'false';
 
-export const Toggle = ({ label, name, type, metadata, isRequired }: ToggleProps) => {
+export const Toggle = ({
+  label,
+  name,
+  type,
+  metadata,
+  isRequired,
+  isRequiredOnClose,
+}: ToggleProps) => {
   const { control } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
   const defaultValue =
@@ -60,7 +67,7 @@ export const Toggle = ({ label, name, type, metadata, isRequired }: ToggleProps)
         return (
           <EuiFormRow
             label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+            labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
             isInvalid={!!fieldState.error}
             error={fieldState.error?.message}
             fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -37,6 +37,7 @@ export const UserPicker: React.FC<UserPickerProps> = ({
   type,
   metadata,
   isRequired,
+  isRequiredOnClose,
   onConfirm,
   isSaving,
   isSaveDisabled,
@@ -111,6 +112,7 @@ export const UserPicker: React.FC<UserPickerProps> = ({
               isLoading={isLoading}
               isMultiple={isMultiple}
               isRequired={isRequired ?? false}
+              isRequiredOnClose={isRequiredOnClose ?? false}
               isDisabled={isSaving}
               selectedUsers={selectedUsers}
               suggestedProfiles={suggestedProfiles}
@@ -147,6 +149,7 @@ interface UserPickerComboboxWithProfilesProps {
   isLoading: boolean;
   isMultiple: boolean;
   isRequired: boolean;
+  isRequiredOnClose?: boolean;
   isDisabled?: boolean;
   selectedUsers: SelectedUser[];
   suggestedProfiles: UserProfileWithAvatar[];

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker_combobox.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker_combobox.tsx
@@ -21,7 +21,7 @@ import { UserAvatar, getUserDisplayName } from '@kbn/user-profile-components';
 import { bringCurrentUserToFrontAndSort } from '../../../../user_profiles/sort';
 import type { SelectedUser, UserProfileOption } from './utils';
 import { profileToOption } from './utils';
-import { OptionalFieldLabel } from '../../../../optional_field_label';
+import { getFieldRequirementLabel } from '../../../../optional_field_label';
 
 export interface UserPickerComboboxProps {
   label?: string;
@@ -32,6 +32,7 @@ export interface UserPickerComboboxProps {
   isLoadingBulk: boolean;
   isMultiple: boolean;
   isRequired: boolean;
+  isRequiredOnClose?: boolean;
   isDisabled?: boolean;
   selectedUsers: SelectedUser[];
   allKnownProfiles: UserProfileWithAvatar[];
@@ -48,6 +49,7 @@ export const UserPickerCombobox: React.FC<UserPickerComboboxProps> = ({
   isLoadingBulk,
   isMultiple,
   isRequired,
+  isRequiredOnClose,
   isDisabled,
   selectedUsers,
   allKnownProfiles,
@@ -125,7 +127,7 @@ export const UserPickerCombobox: React.FC<UserPickerComboboxProps> = ({
   return (
     <EuiFormRow
       label={label}
-      labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+      labelAppend={getFieldRequirementLabel(isRequired, isRequiredOnClose)}
       error={errorMessage}
       isInvalid={isInvalid}
       fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { parse as parseYaml } from 'yaml';
-import { render, renderHook, screen, waitFor, act } from '@testing-library/react';
+import { render, renderHook, screen, waitFor, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { useForm, FormProvider, useFormContext } from 'react-hook-form';
@@ -403,5 +403,35 @@ describe('FieldsRenderer — field isolation', () => {
     render(<TestForm />);
 
     expect(screen.queryByRole('button', { name: /Confirm/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('FieldsRenderer — required-on-close label', () => {
+  const templateWithRequirementLabels = `
+name: Test
+fields:
+  - name: optional_field
+    control: INPUT_TEXT
+    type: keyword
+    label: Optional Field
+  - name: close_field
+    control: INPUT_TEXT
+    type: keyword
+    label: Close Field
+    validation:
+      required_on_close: true
+`;
+
+  it('labels a required_on_close field "Required on close" instead of "Optional"', () => {
+    render(<FormWrapper templateDef={templateWithRequirementLabels} onSubmitResult={jest.fn()} />);
+
+    // The plain optional field keeps the "Optional" label.
+    const optionalField = within(screen.getByTestId('template-field-optional_field'));
+    expect(optionalField.getByTestId('form-optional-field-label')).toBeInTheDocument();
+
+    // The required-on-close field shows "Required on close" and NOT "Optional".
+    const closeField = within(screen.getByTestId('template-field-close_field'));
+    expect(closeField.getByTestId('form-required-on-close-field-label')).toBeInTheDocument();
+    expect(closeField.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
@@ -35,6 +35,7 @@ interface TemplateFieldRowProps {
   Control: FC<Record<string, unknown>>;
   value: unknown;
   isRequired: boolean;
+  isRequiredOnClose: boolean;
   onFieldConfirm?: (fieldName: string, fieldType: string) => void;
   isSaving: boolean;
   isSaveDisabled: boolean;
@@ -68,6 +69,7 @@ const TemplateFieldRow: FC<TemplateFieldRowProps> = React.memo(
     Control,
     value,
     isRequired,
+    isRequiredOnClose,
     onFieldConfirm,
     isSaving,
     isSaveDisabled,
@@ -82,6 +84,7 @@ const TemplateFieldRow: FC<TemplateFieldRowProps> = React.memo(
       label: field.label ?? field.name,
       value,
       isRequired,
+      isRequiredOnClose,
       patternValidation: field.validation?.pattern,
       min: field.validation?.min,
       max: field.validation?.max,
@@ -154,6 +157,10 @@ export const FieldsRenderer: FC<{
               )
             : false);
 
+        // Required-on-close is not required *now* (so the field stays fillable), but the label must
+        // say so rather than "Optional". Only surfaced when the field isn't already required.
+        const isRequiredOnClose = !isRequired && field.validation?.required_on_close === true;
+
         const Control = controlRegistry[field.control] as unknown as FC<Record<string, unknown>>;
         if (!Control) return null;
 
@@ -164,6 +171,7 @@ export const FieldsRenderer: FC<{
             Control={Control}
             value={fieldValues[field.name]}
             isRequired={isRequired}
+            isRequiredOnClose={isRequiredOnClose}
             onFieldConfirm={onFieldConfirm}
             isSaving={savingFieldKey === getFieldSnakeKey(field.name, field.type)}
             isSaveDisabled={savingFieldKey != null}


### PR DESCRIPTION
## Summary

A field configured as `required_on_close` was showing up as **"Optional"** on the case, which is misleading — it's not required *right now*, but it does have to be filled in before the case can be closed. It now reads **"Required on close"** instead.

## Why

This came out of testing-party feedback: a `required_on_close` field shouldn't read as "Optional" — it should carry a label that tells you it's mandatory before close. The field-control label logic only knew `isRequired` (required now) vs. not, so `required_on_close` fields quietly fell through to "Optional".

## What changed

- New `getFieldRequirementLabel(isRequired, isRequiredOnClose)` helper plus a `RequiredOnCloseFieldLabel` in `optional_field_label`, so the label decision lives in one place.
- `ConditionRenderProps` gains `isRequiredOnClose`. `FieldsRenderer` computes it (`!isRequired && validation.required_on_close === true`) and threads it through `TemplateFieldRow` to every control — input text/number, textarea, select, checkbox/radio group, toggle, date picker, and user picker.
- Display-only change: server-side close-time enforcement is untouched.

## Test plan

- `node scripts/jest x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types` — 211 tests pass.
- Added a `FieldsRenderer` test asserting a `required_on_close` field renders the "Required on close" label and not "Optional".


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->