### PR TITLE
[One Workflow] Fix missing workflow YAML type icons

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/step_icons/hardcoded_icons.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/step_icons/hardcoded_icons.ts
@@ -9,7 +9,9 @@
 
 import beta from './icons/beta.svg';
 import bolt from './icons/bolt.svg';
+import branch from './icons/branch.svg';
 import clock from './icons/clock.svg';
+import console from './icons/console.svg';
 import database from './icons/database.svg';
 import email from './icons/email.svg';
 import fail from './icons/fail.svg';
@@ -17,10 +19,12 @@ import flask from './icons/flask.svg';
 import glyph from './icons/glyph.svg';
 import elasticsearchLogoSvg from './icons/logo_elasticsearch.svg';
 import kibanaLogoSvg from './icons/logo_kibana.svg';
+import slackLogoSvg from './icons/logo_slack.svg';
 import output from './icons/output.svg';
 import parallel from './icons/parallel.svg';
 import plugs from './icons/plugs.svg';
 import productStreamsWired from './icons/product_streams_wired.svg';
+import refresh from './icons/refresh.svg';
 import sparkles from './icons/sparkles.svg';
 import union from './icons/union.svg';
 import user from './icons/user.svg';
@@ -54,4 +58,19 @@ export const HardcodedIcons: Record<string, string> = {
   flask,
   beta,
   default: plugs,
+};
+
+/**
+ * Data URL variants for contexts that render icons through CSS rather than EuiIcon.
+ * Keep EUI icon names in HardcodedIcons for React views, but never pass those names
+ * directly to background-image or mask-image.
+ */
+export const HardcodedIconDataUrls: Record<string, string> = {
+  ...HardcodedIcons,
+  '.slack': slackLogoSvg,
+  '.slack_api': slackLogoSvg,
+  console,
+  foreach: refresh,
+  while: refresh,
+  if: branch,
 };

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/step_icons/index.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/step_icons/index.ts
@@ -15,7 +15,7 @@ export {
   type ImageComponent,
 } from './icon_to_data_url';
 export { getStepIconType, getTriggerTypeIconType } from './get_step_icon_type';
-export { HardcodedIcons } from './hardcoded_icons';
+export { HardcodedIconDataUrls, HardcodedIcons } from './hardcoded_icons';
 export { ParallelIcon } from './parallel_icon';
 export {
   resolveRegisteredStepIcon,

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_yaml_preview/get_type_icon_data_url.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_yaml_preview/get_type_icon_data_url.ts
@@ -11,7 +11,7 @@ import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-action
 import type { WorkflowsExtensionsPublicPluginStart } from '@kbn/workflows-extensions/public';
 import {
   getBaseConnectorType,
-  HardcodedIcons,
+  HardcodedIconDataUrls,
   resolveIconToDataUrl,
   resolveRegisteredStepIcon,
 } from '../../../components/step_icons';
@@ -39,12 +39,12 @@ export async function getTypeIconDataUrl({
   actionTypeRegistry,
 }: GetTypeIconDataUrlParams): Promise<string> {
   if (kind === 'trigger') {
-    const hardcoded = HardcodedIcons[type];
+    const hardcoded = HardcodedIconDataUrls[type];
     if (hardcoded) {
       return hardcoded;
     }
     const extensionIcon = workflowsExtensions.getTriggerDefinition(type)?.icon;
-    return resolveIconToDataUrl(extensionIcon, HardcodedIcons.trigger);
+    return resolveIconToDataUrl(extensionIcon, HardcodedIconDataUrls.trigger);
   }
 
   const baseType = getBaseConnectorType(type);
@@ -61,10 +61,12 @@ export async function getTypeIconDataUrl({
   }
 
   const hardcoded =
-    HardcodedIcons[type] ?? HardcodedIcons[baseType] ?? HardcodedIcons[`.${baseType}`];
+    HardcodedIconDataUrls[type] ??
+    HardcodedIconDataUrls[baseType] ??
+    HardcodedIconDataUrls[`.${baseType}`];
   if (hardcoded) {
     return hardcoded;
   }
 
-  return HardcodedIcons.default;
+  return HardcodedIconDataUrls.default;
 }

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts
@@ -9,7 +9,7 @@
 
 import type React from 'react';
 
-import { getStepIconType, HardcodedIcons } from '@kbn/workflows-ui';
+import { getStepIconType, HardcodedIconDataUrls, HardcodedIcons } from '@kbn/workflows-ui';
 import {
   getDataUrlFromReactComponent,
   getIconBase64,
@@ -194,13 +194,13 @@ describe('getIconBase64', () => {
       expect(result).toBe(dataUrl);
     });
 
-    it('returns HardcodedIcons.trigger as fallback when no icon is provided for a trigger', async () => {
+    it('returns the hardcoded trigger data URL when no icon is provided', async () => {
       const result = await getIconBase64({
         actionTypeId: 'unique-trigger-id-2',
         kind: 'trigger',
       });
 
-      expect(result).toBe(HardcodedIcons.trigger);
+      expect(result).toBe(HardcodedIconDataUrls.trigger);
     });
 
     it('caches trigger icons by actionTypeId', async () => {
@@ -244,7 +244,7 @@ describe('getIconBase64', () => {
         kind: 'step',
       });
 
-      expect(result).toBe(HardcodedIcons['.slack']);
+      expect(result).toBe(HardcodedIconDataUrls['.slack']);
     });
 
     it('prefers hardcoded icon for email over EUI name string', async () => {
@@ -254,7 +254,7 @@ describe('getIconBase64', () => {
         kind: 'step',
       });
 
-      expect(result).toBe(HardcodedIcons['.email']);
+      expect(result).toBe(HardcodedIconDataUrls['.email']);
     });
 
     it('prefers hardcoded icon for inference over EUI name string', async () => {
@@ -264,7 +264,7 @@ describe('getIconBase64', () => {
         kind: 'step',
       });
 
-      expect(result).toBe(HardcodedIcons['.inference']);
+      expect(result).toBe(HardcodedIconDataUrls['.inference']);
     });
 
     it('returns hardcoded icon when actionTypeId matches a known type without icon', async () => {
@@ -273,7 +273,7 @@ describe('getIconBase64', () => {
         kind: 'step',
       });
 
-      expect(result).toBe(HardcodedIcons['.slack']);
+      expect(result).toBe(HardcodedIconDataUrls['.slack']);
     });
 
     it('returns connector spec icon for v2 actionTypeIds', async () => {
@@ -294,17 +294,17 @@ describe('getIconBase64', () => {
         kind: 'step',
       });
 
-      expect(result).toBe(HardcodedIcons.default);
+      expect(result).toBe(HardcodedIconDataUrls.default);
     });
 
-    it('returns HardcodedIcons.kibana as fallback when fromRegistry is true', async () => {
+    it('returns the hardcoded Kibana data URL when fromRegistry is true', async () => {
       const result = await getIconBase64({
         actionTypeId: 'some-registry-step',
         kind: 'step',
         fromRegistry: true,
       });
 
-      expect(result).toBe(HardcodedIcons.kibana);
+      expect(result).toBe(HardcodedIconDataUrls.kibana);
     });
 
     it('handles elasticsearch actionTypeId', async () => {
@@ -332,21 +332,21 @@ describe('getIconBase64', () => {
 });
 
 describe('getTriggerBoltFallbackDataUrl', () => {
-  it('returns HardcodedIcons.trigger', () => {
-    expect(getTriggerBoltFallbackDataUrl()).toBe(HardcodedIcons.trigger);
+  it('returns the hardcoded trigger data URL', () => {
+    expect(getTriggerBoltFallbackDataUrl()).toBe(HardcodedIconDataUrls.trigger);
   });
 });
 
-describe('getIconBase64 – every HardcodedIcons entry resolves to its hardcoded value', () => {
+describe('getIconBase64 – every hardcoded step icon resolves to its data URL', () => {
   const NON_STEP_KEYS = ['trigger', 'flask', 'beta', 'default'];
   const REACT_COMPONENT_KEYS = ['elasticsearch', 'kibana'];
 
-  const stepEntries = Object.entries(HardcodedIcons).filter(
+  const stepEntries = Object.entries(HardcodedIconDataUrls).filter(
     ([key]) => !NON_STEP_KEYS.includes(key) && !REACT_COMPONENT_KEYS.includes(key)
   );
 
   it.each(stepEntries)(
-    'returns hardcoded icon for actionTypeId "%s"',
+    'returns the hardcoded data URL for actionTypeId "%s"',
     async (actionTypeId, expectedIcon) => {
       const result = await getIconBase64({ actionTypeId, kind: 'step' });
       expect(result).toBe(expectedIcon);
@@ -381,7 +381,8 @@ describe('getIconBase64 – hardcoded icon wins over EUI name strings', () => {
         icon: euiIconName,
         kind: 'step',
       });
-      expect(result).toBe(HardcodedIcons[actionTypeId]);
+      expect(result).toBe(HardcodedIconDataUrls[actionTypeId]);
+      expect(result).not.toBe(euiIconName);
     }
   );
 });
@@ -394,7 +395,7 @@ describe('getIconBase64 – error handling', () => {
       kind: 'step',
     });
 
-    expect(result).toBe(HardcodedIcons.default);
+    expect(result).toBe(HardcodedIconDataUrls.default);
   });
 
   it('returns kibana fallback for registry step with non-resolvable icon', async () => {
@@ -405,7 +406,7 @@ describe('getIconBase64 – error handling', () => {
       fromRegistry: true,
     });
 
-    expect(result).toBe(HardcodedIcons.kibana);
+    expect(result).toBe(HardcodedIconDataUrls.kibana);
   });
 
   it('returns bolt fallback for trigger with non-resolvable icon', async () => {
@@ -415,7 +416,7 @@ describe('getIconBase64 – error handling', () => {
       kind: 'trigger',
     });
 
-    expect(result).toBe(HardcodedIcons.trigger);
+    expect(result).toBe(HardcodedIconDataUrls.trigger);
   });
 
   it('returns plugs fallback when icon is a throwing function component', async () => {
@@ -430,7 +431,7 @@ describe('getIconBase64 – error handling', () => {
       kind: 'step',
     });
 
-    expect(result).toBe(HardcodedIcons.default);
+    expect(result).toBe(HardcodedIconDataUrls.default);
   });
 });
 
@@ -458,8 +459,8 @@ describe('getStepIconType and getIconBase64 consistency', () => {
       expect(euiIcon).not.toBe('info');
 
       const dataUrl = await getIconBase64({ actionTypeId: stepType, kind: 'step' });
-      expect(dataUrl).toBe(HardcodedIcons[stepType]);
-      expect(HardcodedIcons[stepType]).toBeDefined();
+      expect(dataUrl).toBe(HardcodedIconDataUrls[stepType]);
+      expect(HardcodedIconDataUrls[stepType]).toBeDefined();
     }
   );
 
@@ -482,6 +483,6 @@ describe('getStepIconType and getIconBase64 consistency', () => {
     expect(HardcodedIcons.http).toBeUndefined();
 
     const dataUrl = await getIconBase64({ actionTypeId: 'http', kind: 'step' });
-    expect(dataUrl).toBe(HardcodedIcons.default);
+    expect(dataUrl).toBe(HardcodedIconDataUrls.default);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.ts
@@ -11,7 +11,7 @@ import { type IconType } from '@elastic/eui';
 import {
   getConnectorSpecIcon,
   getDataUrlFromReactComponent,
-  HardcodedIcons,
+  HardcodedIconDataUrls,
   resolveIconToDataUrl,
 } from '@kbn/workflows-ui';
 
@@ -28,13 +28,13 @@ export interface GetIconBase64Params {
   kind: 'trigger' | 'step';
 }
 
-const DEFAULT_CONNECTOR_DATA_URL = HardcodedIcons.default;
+const DEFAULT_CONNECTOR_DATA_URL = HardcodedIconDataUrls.default;
 
 const triggerIconDataUrlCache = new Map<string, string>();
 
 function defaultFallbackForStep(params: GetIconBase64Params): string {
   if (params.fromRegistry) {
-    return HardcodedIcons.kibana;
+    return HardcodedIconDataUrls.kibana;
   }
   return DEFAULT_CONNECTOR_DATA_URL;
 }
@@ -61,10 +61,10 @@ export async function getIconBase64(params: GetIconBase64Params): Promise<string
       return value;
     };
     try {
-      const resolved = await resolveIconToDataUrl(icon, HardcodedIcons.trigger);
+      const resolved = await resolveIconToDataUrl(icon, HardcodedIconDataUrls.trigger);
       return setCacheAndReturn(resolved);
     } catch {
-      return setCacheAndReturn(HardcodedIcons.trigger);
+      return setCacheAndReturn(HardcodedIconDataUrls.trigger);
     }
   }
 
@@ -75,7 +75,7 @@ export async function getIconBase64(params: GetIconBase64Params): Promise<string
     if (actionTypeId === 'kibana') {
       return getDataUrlFromReactComponent(KibanaLogo, DEFAULT_CONNECTOR_DATA_URL);
     }
-    const hardcodedIcon = HardcodedIcons[actionTypeId];
+    const hardcodedIcon = HardcodedIconDataUrls[actionTypeId];
     if (hardcodedIcon) {
       return hardcodedIcon;
     }
@@ -94,5 +94,5 @@ export async function getIconBase64(params: GetIconBase64Params): Promise<string
 
 /** Sync bolt fallback data URL for default trigger styling (e.g. when async resolution is not needed). */
 export function getTriggerBoltFallbackDataUrl(): string {
-  return HardcodedIcons.trigger;
+  return HardcodedIconDataUrls.trigger;
 }

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
@@ -284,6 +284,23 @@ export class WorkflowEditorPage {
     );
   }
 
+  async getStepTypeIconStyles(stepType: string): Promise<{
+    backgroundImage: string;
+    maskImage: string;
+  }> {
+    const typeClass = stepType.replaceAll('.', '-');
+    const typeDecoration = this.yamlEditor.locator(`.type-inline-highlight.type-${typeClass}`);
+    await typeDecoration.waitFor({ state: 'visible' });
+
+    return typeDecoration.evaluate((element) => {
+      const iconStyles = getComputedStyle(element, '::after');
+      return {
+        backgroundImage: iconStyles.backgroundImage,
+        maskImage: iconStyles.maskImage,
+      };
+    });
+  }
+
   /**
    * Save the workflow
    */

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor.spec.ts
@@ -92,6 +92,21 @@ test.describe(
       await expect(validationAccordion).toContainText('No validation errors');
     });
 
+    test('should render step type icons from data URLs', async ({ pageObjects }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+      await pageObjects.workflowEditor.setYamlEditorValue(
+        getDummyWorkflowYaml('Step Type Icon Test')
+      );
+
+      await expect
+        .poll(async () => {
+          const { backgroundImage, maskImage } =
+            await pageObjects.workflowEditor.getStepTypeIconStyles('console');
+          return backgroundImage.includes('data:image') || maskImage.includes('data:image');
+        })
+        .toBe(true);
+    });
+
     test('should show step type autocompletion suggestions', async ({ pageObjects, page }) => {
       await pageObjects.workflowEditor.gotoNewWorkflow();
       const workflowName = 'Autocomplete Test';


### PR DESCRIPTION
## Summary

- Keep EUI icon names for React graph views while exposing SVG data URLs for CSS-based icon rendering.
- Restore inline type icons in the workflow YAML editor and template YAML previews.
- Add unit and Scout regression coverage for CSS icon URLs.

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts --no-coverage`
- [x] `node scripts/jest src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_yaml_preview/workflow_yaml_preview.test.tsx --no-coverage`
- [x] Type-check `kbn-workflows-ui` and `workflows_management`
- [x] Verify the console type decoration uses an embedded data URL in a running Kibana instance
- [ ] Run the added Scout test in CI (the existing local Scout server on port 5620 rejected its configured credentials)

## References

Closes elastic/security-team#18301

Made with [Cursor](https://cursor.com)