### PR TITLE
[Fleet] Fix escape_string double-quote values corrupting surrounding YAML

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -276,6 +276,29 @@ text_var: {{escape_string text_var}}
       });
     });
 
+    it('should preserve double quotes inside escape_string values without corrupting surrounding YAML', () => {
+      // Regression: https://github.com/elastic/kibana/issues/279388
+      // escape_string wraps single-line values in YAML single quotes: 'user"name'
+      // The newline-collapse regex was incorrectly treating the `"` inside the
+      // single-quoted scalar as a double-quote delimiter, matching across lines
+      // and collapsing subsequent YAML keys onto one line.
+      const template = `
+username: {{escape_string username}}
+password: {{escape_string password}}
+interval: 24h
+`;
+      const vars = {
+        username: { type: 'text', value: 'user"name' },
+        password: { type: 'password', value: 'p@ss"word' },
+      };
+      const output = compileTemplate(vars, getMockedMetaVariable(), template);
+      expect(output).toEqual({
+        username: 'user"name',
+        password: 'p@ss"word',
+        interval: '24h',
+      });
+    });
+
     it('should respect new lines and literal escapes', () => {
       const vars = {
         text_var: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -113,14 +113,17 @@ export function compileTemplate(
     throw new PackageInvalidArchiveError(`Error while compiling agent template: ${err.message}`);
   }
 
-  // Must run before replaceRootLevelYamlVariables: stringify output may contain
-  // unquoted `"` chars (e.g. regexp patterns) that cause this regex to match
-  // across lines and corrupt the YAML structure.
-  compiledTemplate = compiledTemplate.replace(/"(?:[^"\\]|\\.)*"/gs, (match) =>
-    match.includes('\n')
+  // Must run before replaceRootLevelYamlVariables: yaml.stringify output may contain
+  // double-quoted scalars with literal newlines that the yaml parser rejects.
+  // The alternation skips YAML single-quoted scalars first (including any `"` they
+  // contain) so that a `"` inside e.g. `'user"name'` is never treated as a
+  // double-quote delimiter.
+  compiledTemplate = compiledTemplate.replace(/'(?:[^']|'')*'|"(?:[^"\\]|\\.)*"/gs, (match) => {
+    if (match[0] === "'") return match; // single-quoted scalar — no escaping needed
+    return match.includes('\n')
       ? match.replace(/\n+/g, (newlines) => '\\n'.repeat(newlines.length - 1))
-      : match
-  );
+      : match;
+  });
 
   compiledTemplate = replaceRootLevelYamlVariables(yamlValues, compiledTemplate);
 


### PR DESCRIPTION
## Summary

When `escape_string` produces a **single-quoted** YAML scalar containing a literal `"` character (e.g. `'user"name'`), the downstream regex that repairs literal newlines in double-quoted scalars could mistake that embedded `"` for a double-quote delimiter. This breaks the surrounding YAML structure, causing a parse error.

**Root cause**: The original regex `/"(?:[^"\\]|\\.)*"/gs` matched only double-quoted scalars. Because it used the `s` (dotAll) flag, a `"` embedded inside a single-quoted scalar could become a false opening delimiter that spans across the real double-quoted scalar, mangling both.

**Fix**: Alternate over single-quoted scalars _first_ (`'(?:[^']|'')*'`) before double-quoted scalars. Single-quoted scalars are returned unchanged (they need no newline escaping). Double-quoted scalars continue to have literal newlines escaped as before.

Fixes #279388

## Test plan

- [x] New unit test: `escape_string` value containing `"` is preserved after `compileTemplate`
- [x] Existing tests pass
- [x] Manual: create a Fleet integration policy with a `username` or `password` field containing `"`, save policy, verify agent config is correct

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->