### PR TITLE
Render informational app header badges as static

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/app_badge.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_badge.tsx
@@ -75,6 +75,7 @@ export const AppBadge = ({ badge }: { badge: AppHeaderBadge }) => {
   }
 
   const hasItems = 'items' in badge && badge.items !== undefined;
+  const isClickable = hasItems || badge.onClick !== undefined;
 
   const badgeOnClickAriaLabel =
     badge?.onClickAriaLabel ??
@@ -91,10 +92,13 @@ export const AppBadge = ({ badge }: { badge: AppHeaderBadge }) => {
     badge?.onClick?.();
   };
 
+  const interactionProps = isClickable
+    ? { onClick: handleBadgeClick, onClickAriaLabel: badgeOnClickAriaLabel }
+    : {};
+
   const badgeComponent = (
     <EuiBadge
-      onClick={handleBadgeClick}
-      onClickAriaLabel={badgeOnClickAriaLabel}
+      {...interactionProps}
       color={badge?.color ?? 'hollow'}
       data-test-subj={badge?.['data-test-subj']}
       css={badgeStyle}

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -35,7 +35,10 @@ export interface AppHeaderBadge {
   onClick?: () => void;
   onClickAriaLabel?: string;
   'data-test-subj'?: string;
-  /** @deprecated Used for compatibility with existing breadcrumb badge custom renderers. */
+  /**
+   * @deprecated Escape hatch for badges that cannot be represented with structured props.
+   * Prefer structured badge props for consistent behavior and styling.
+   */
   renderCustomBadge?: (props: { badgeText: string }) => ReactElement;
   /** Popover menu items for badge context menus. When provided, the badge becomes a dropdown trigger. */
   items?: AppHeaderBadgeItem[];


### PR DESCRIPTION
Related to #279386


In #279386 I noticed that badge with just a text was clickable. 

## Summary

App header badges currently render as buttons even when they have no action or menu. Keep informational badges static while preserving click behavior for badges with an action or menu items.