### PR TITLE
[9.4] [Fleet] Centralize version-specific policy_id filter construction (#277016)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -76,7 +76,7 @@ pageLoadAssetSize:
   files: 6037
   filesManagement: 5208
   fileUpload: 22957
-  fleet: 213000
+  fleet: 214000
   genAiSettings: 6400
   globalSearch: 6890
   globalSearchBar: 26122

--- a/src/platform/packages/shared/kbn-cypress-config/index.ts
+++ b/src/platform/packages/shared/kbn-cypress-config/index.ts
@@ -168,6 +168,10 @@ export function defineCypressConfig(options?: Cypress.ConfigOptions<any>) {
                       },
                     },
                   },
+                  {
+                    test: /\.peggy$/,
+                    use: [require.resolve('@kbn/peggy-loader')],
+                  },
                 ],
               },
               plugins: [new NodeLibsBrowserPlugin()],

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
@@ -351,6 +351,50 @@ describe('AgentlessConnectorsInfraService', () => {
       expect(policies.length).toBe(2);
     });
   });
+  describe('getAgentPolicyForConnectorId', () => {
+    const getMockPolicyFetchAllItems = (pages: PackagePolicy[][]) => {
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const page of pages) {
+            yield page;
+          }
+        },
+      } as AsyncIterable<PackagePolicy[]>;
+    };
+
+    test('queries agents with a kuery that also matches version-specific policy variants', async () => {
+      const packagePolicy = createPackagePolicyMock();
+      packagePolicy.policy_ids = ['this-is-agent-policy-id'];
+      packagePolicy.supports_agentless = true;
+      packagePolicy.inputs = [
+        {
+          type: 'connectors-py',
+          compiled_input: {
+            connector_id: 'connector-1',
+            connector_name: 'Connector One',
+            service_type: 'sharepoint_online',
+          },
+        } as PackagePolicyInput,
+      ];
+
+      packagePolicyService.fetchAllItems.mockResolvedValue(
+        getMockPolicyFetchAllItems([[packagePolicy]])
+      );
+      (agentService.asInternalUser.listAgents as jest.Mock).mockResolvedValue({
+        agents: [],
+        total: 0,
+      });
+
+      await service.getAgentPolicyForConnectorId({ connectorId: 'connector-1' });
+
+      expect(agentService.asInternalUser.listAgents as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kuery:
+            '(fleet-agents.policy_id:"this-is-agent-policy-id" or fleet-agents.policy_id:this-is-agent-policy-id#*)',
+        })
+      );
+    });
+  });
   describe('deployConnector', () => {
     let agentPolicy: AgentPolicy;
     let sharepointOnlinePackagePolicy: PackagePolicy;

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
@@ -7,7 +7,10 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Agent, AgentPolicy } from '@kbn/fleet-plugin/common';
-import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+import {
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  buildPolicyIdOrVariantsKuery,
+} from '@kbn/fleet-plugin/common';
 import type {
   AgentlessPoliciesService,
   AgentService,
@@ -270,7 +273,7 @@ export class AgentlessConnectorsInfraService {
       const policyId = policy!.agent_policy_ids[0];
 
       const listAgentsResponse = await this.agentService.asInternalUser.listAgents({
-        kuery: `fleet-agents.policy_id:${policyId}`,
+        kuery: buildPolicyIdOrVariantsKuery(policyId, 'fleet-agents.policy_id'),
         showInactive: false,
       });
 

--- a/x-pack/platform/plugins/shared/fleet/common/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/index.ts
@@ -106,6 +106,11 @@ export {
   getAllVarKeys,
   getAllSupportedVarNames,
   findFirstVarEntry,
+  // Version-specific policies helpers
+  hasVersionSuffix,
+  removeVersionSuffixFromPolicyId,
+  buildPolicyIdOrVariantsKuery,
+  buildPolicyIdsOrVariantsKuery,
 } from './services';
 
 export type {

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -154,3 +154,10 @@ export {
   packagePolicyHasOtelInputs,
   OTEL_INPUTS_MINIMUM_VERSION,
 } from './otelcol_helpers';
+
+export {
+  hasVersionSuffix,
+  removeVersionSuffixFromPolicyId,
+  buildPolicyIdOrVariantsKuery,
+  buildPolicyIdsOrVariantsKuery,
+} from './version_specific_policies_utils';

--- a/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.test.ts
@@ -9,6 +9,12 @@ import {
   hasVersionSuffix,
   removeVersionSuffixFromPolicyId,
   splitVersionSuffixFromPolicyId,
+  buildVersionVariantsKueryFragment,
+  buildPolicyIdOrVariantsKuery,
+  buildPolicyIdsOrVariantsKuery,
+  buildVersionVariantsEsFilter,
+  buildPolicyIdOrVariantsEsFilter,
+  buildPolicyIdsOrVariantsEsFilter,
 } from './version_specific_policies_utils';
 
 describe('removeVersionSuffixFromPolicyId', () => {
@@ -101,5 +107,145 @@ describe('hasVersionSuffix', () => {
     const policyIdWithHashButNoVersion = 'policy#123';
     const result = hasVersionSuffix(policyIdWithHashButNoVersion);
     expect(result).toBe(false);
+  });
+});
+
+describe('buildVersionVariantsKueryFragment', () => {
+  it('should build a kuery fragment matching only version-suffixed variants', () => {
+    expect(buildVersionVariantsKueryFragment('my-policy')).toBe('policy_id:my-policy#*');
+  });
+
+  it('should use the provided field name', () => {
+    expect(buildVersionVariantsKueryFragment('my-policy', 'fleet-agents.policy_id')).toBe(
+      'fleet-agents.policy_id:my-policy#*'
+    );
+  });
+
+  it('should escape special KQL characters in the base id', () => {
+    expect(buildVersionVariantsKueryFragment('my policy:1')).toBe('policy_id:my policy\\:1#*');
+  });
+});
+
+describe('buildPolicyIdOrVariantsKuery', () => {
+  it('should build a kuery matching the base id or any version-suffixed variant', () => {
+    expect(buildPolicyIdOrVariantsKuery('my-policy')).toBe(
+      '(policy_id:"my-policy" or policy_id:my-policy#*)'
+    );
+  });
+
+  it('should use the provided field name for both clauses', () => {
+    expect(buildPolicyIdOrVariantsKuery('my-policy', 'fleet-agents.policy_id')).toBe(
+      '(fleet-agents.policy_id:"my-policy" or fleet-agents.policy_id:my-policy#*)'
+    );
+  });
+
+  it('should escape quotes in both the exact-match and variant clauses', () => {
+    expect(buildPolicyIdOrVariantsKuery('my"policy')).toBe(
+      '(policy_id:"my\\"policy" or policy_id:my\\"policy#*)'
+    );
+  });
+});
+
+describe('buildPolicyIdsOrVariantsKuery', () => {
+  it('should build a kuery matching any of the exact ids or their version-suffixed variants', () => {
+    expect(buildPolicyIdsOrVariantsKuery(['policy-1', 'policy-2'])).toBe(
+      '(policy_id:(policy-1 or policy-2) or policy_id:policy-1#* or policy_id:policy-2#*)'
+    );
+  });
+
+  it('should work with a single id', () => {
+    expect(buildPolicyIdsOrVariantsKuery(['policy-1'])).toBe(
+      '(policy_id:(policy-1) or policy_id:policy-1#*)'
+    );
+  });
+
+  it('should use the provided field name', () => {
+    expect(buildPolicyIdsOrVariantsKuery(['policy-1'], 'fleet-agents.policy_id')).toBe(
+      '(fleet-agents.policy_id:(policy-1) or fleet-agents.policy_id:policy-1#*)'
+    );
+  });
+
+  it('should de-duplicate repeated ids', () => {
+    expect(buildPolicyIdsOrVariantsKuery(['policy-1', 'policy-1', 'policy-2'])).toBe(
+      '(policy_id:(policy-1 or policy-2) or policy_id:policy-1#* or policy_id:policy-2#*)'
+    );
+  });
+
+  it('should return a valid, never-matching kuery for an empty array instead of invalid syntax', () => {
+    expect(buildPolicyIdsOrVariantsKuery([])).toBe('policy_id:""');
+  });
+});
+
+describe('buildVersionVariantsEsFilter', () => {
+  it('should build a prefix filter matching only version-suffixed variants', () => {
+    expect(buildVersionVariantsEsFilter('my-policy')).toEqual({
+      prefix: { policy_id: 'my-policy#' },
+    });
+  });
+
+  it('should use the provided field name', () => {
+    expect(buildVersionVariantsEsFilter('my-policy', 'other_field')).toEqual({
+      prefix: { other_field: 'my-policy#' },
+    });
+  });
+});
+
+describe('buildPolicyIdOrVariantsEsFilter', () => {
+  it('should build a bool.should filter matching the exact id or any variant', () => {
+    expect(buildPolicyIdOrVariantsEsFilter('my-policy')).toEqual({
+      bool: {
+        should: [{ term: { policy_id: 'my-policy' } }, { prefix: { policy_id: 'my-policy#' } }],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it('should use the provided field name', () => {
+    expect(buildPolicyIdOrVariantsEsFilter('my-policy', 'other_field')).toEqual({
+      bool: {
+        should: [{ term: { other_field: 'my-policy' } }, { prefix: { other_field: 'my-policy#' } }],
+        minimum_should_match: 1,
+      },
+    });
+  });
+});
+
+describe('buildPolicyIdsOrVariantsEsFilter', () => {
+  it('should build a bool.should filter matching any of the exact ids or their variants', () => {
+    expect(buildPolicyIdsOrVariantsEsFilter(['policy-a', 'policy-b'])).toEqual({
+      bool: {
+        should: [
+          { terms: { policy_id: ['policy-a', 'policy-b'] } },
+          { prefix: { policy_id: 'policy-a#' } },
+          { prefix: { policy_id: 'policy-b#' } },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it('should use the provided field name', () => {
+    expect(buildPolicyIdsOrVariantsEsFilter(['policy-a'], 'other_field')).toEqual({
+      bool: {
+        should: [
+          { terms: { other_field: ['policy-a'] } },
+          { prefix: { other_field: 'policy-a#' } },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it('should de-duplicate repeated ids', () => {
+    expect(buildPolicyIdsOrVariantsEsFilter(['policy-a', 'policy-a'])).toEqual({
+      bool: {
+        should: [{ terms: { policy_id: ['policy-a'] } }, { prefix: { policy_id: 'policy-a#' } }],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it('should return match_none for an empty array instead of an empty terms clause', () => {
+    expect(buildPolicyIdsOrVariantsEsFilter([])).toEqual({ match_none: {} });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/version_specific_policies_utils.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
+import { escapeKuery, escapeQuotes } from '@kbn/es-query';
+
 import { AGENT_POLICY_VERSION_SEPARATOR } from '../constants';
+
+const DEFAULT_POLICY_ID_FIELD = 'policy_id';
 
 export function hasVersionSuffix(policyId: string): boolean {
   if (!policyId) {
@@ -30,4 +34,103 @@ export function splitVersionSuffixFromPolicyId(policyId: string): {
 
 export function removeVersionSuffixFromPolicyId(policyId: string): string {
   return splitVersionSuffixFromPolicyId(policyId).baseId;
+}
+
+/**
+ * KQL fragment matching only the version-specific variants of a base policy id
+ * (e.g. `policy_id:my-policy#*`) — NOT the base id itself.
+ */
+export function buildVersionVariantsKueryFragment(
+  baseId: string,
+  fieldName: string = DEFAULT_POLICY_ID_FIELD
+): string {
+  return `${fieldName}:${escapeKuery(baseId)}${AGENT_POLICY_VERSION_SEPARATOR}*`;
+}
+
+/**
+ * KQL matching a base policy id or any of its version-specific variants, e.g.
+ * `(policy_id:"my-policy" or policy_id:my-policy#*)`. Canonical replacement for hand-rolled
+ * copies of this query across Fleet.
+ */
+export function buildPolicyIdOrVariantsKuery(
+  baseId: string,
+  fieldName: string = DEFAULT_POLICY_ID_FIELD
+): string {
+  return `(${fieldName}:"${escapeQuotes(baseId)}" or ${buildVersionVariantsKueryFragment(
+    baseId,
+    fieldName
+  )})`;
+}
+
+/**
+ * Same as {@link buildPolicyIdOrVariantsKuery}, for multiple base policy ids at once, e.g.
+ * `(policy_id:(policy-1 or policy-2) or policy_id:policy-1#* or policy_id:policy-2#*)`.
+ */
+export function buildPolicyIdsOrVariantsKuery(
+  baseIds: string[],
+  fieldName: string = DEFAULT_POLICY_ID_FIELD
+): string {
+  const uniqueIds = Array.from(new Set(baseIds));
+  if (uniqueIds.length === 0) {
+    // No ids to match. `${fieldName}:()` is invalid KQL syntax (parse error), so return a
+    // valid kuery that never matches instead — a real policy_id is never an empty string.
+    return `${fieldName}:""`;
+  }
+  const exactClause = `${fieldName}:(${uniqueIds
+    .map((baseId) => escapeKuery(baseId))
+    .join(' or ')})`;
+  const variantClauses = uniqueIds.map((baseId) =>
+    buildVersionVariantsKueryFragment(baseId, fieldName)
+  );
+  return `(${[exactClause, ...variantClauses].join(' or ')})`;
+}
+
+/**
+ * ES query DSL fragment matching only the version-specific variants of a base policy id —
+ * NOT the base id itself.
+ */
+export function buildVersionVariantsEsFilter(
+  baseId: string,
+  fieldName: string = DEFAULT_POLICY_ID_FIELD
+) {
+  return { prefix: { [fieldName]: `${baseId}${AGENT_POLICY_VERSION_SEPARATOR}` } };
+}
+
+/**
+ * ES query DSL filter matching a base policy id or any of its version-specific variants.
+ * Canonical replacement for hand-rolled `bool.should[{term},{prefix}]` queries.
+ */
+export function buildPolicyIdOrVariantsEsFilter(
+  baseId: string,
+  fieldName: string = DEFAULT_POLICY_ID_FIELD
+) {
+  return {
+    bool: {
+      should: [{ term: { [fieldName]: baseId } }, buildVersionVariantsEsFilter(baseId, fieldName)],
+      minimum_should_match: 1,
+    },
+  };
+}
+
+/**
+ * Same as {@link buildPolicyIdOrVariantsEsFilter}, for multiple base policy ids at once
+ * (e.g. for a `terms` lookup across several agent policies).
+ */
+export function buildPolicyIdsOrVariantsEsFilter(
+  baseIds: string[],
+  fieldName: string = DEFAULT_POLICY_ID_FIELD
+) {
+  const uniqueIds = Array.from(new Set(baseIds));
+  if (uniqueIds.length === 0) {
+    return { match_none: {} };
+  }
+  return {
+    bool: {
+      should: [
+        { terms: { [fieldName]: uniqueIds } },
+        ...uniqueIds.map((baseId) => buildVersionVariantsEsFilter(baseId, fieldName)),
+      ],
+      minimum_should_match: 1,
+    },
+  };
 }

--- a/x-pack/platform/plugins/shared/fleet/public/components/linked_agent_count.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/linked_agent_count.tsx
@@ -10,13 +10,10 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiLinkAnchorProps } from '@elastic/eui';
 import { EuiLink } from '@elastic/eui';
 
+import { buildPolicyIdOrVariantsKuery } from '../../common/services/version_specific_policies_utils';
+
 import { useLink } from '../hooks';
-import {
-  AGENTS_PREFIX,
-  AGENT_POLICY_VERSION_SEPARATOR,
-  UNPRIVILEGED_AGENT_KUERY,
-  PRIVILEGED_AGENT_KUERY,
-} from '../constants';
+import { AGENTS_PREFIX, UNPRIVILEGED_AGENT_KUERY, PRIVILEGED_AGENT_KUERY } from '../constants';
 
 /**
  * Displays the provided `count` number as a link to the Agents list if it is greater than zero
@@ -39,22 +36,24 @@ export const LinkedAgentCount = memo<
   ) : (
     count
   );
-  // Same as server: exact parent policy or wildcard for version-specific (policy_id: id#*).
-  // encodeURIComponent below ensures # in kuery doesn't break the URL.
-  const policyKuery = `(${AGENTS_PREFIX}.policy_id:"${agentPolicyId}" or ${AGENTS_PREFIX}.policy_id:${agentPolicyId}${AGENT_POLICY_VERSION_SEPARATOR}*)`;
-  const kuery = `${policyKuery}${
-    privilegeMode
-      ? ` and ${
-          privilegeMode === 'unprivileged' ? UNPRIVILEGED_AGENT_KUERY : PRIVILEGED_AGENT_KUERY
-        }`
-      : ''
-  }`;
 
-  return count > 0 ? (
+  return count > 0 && agentPolicyId ? (
     <EuiLink
       {...otherEuiLinkProps}
       href={getHref('agent_list', {
-        kuery: encodeURIComponent(kuery),
+        // Same as server: exact parent policy or wildcard for version-specific (policy_id: id#*).
+        // encodeURIComponent below ensures # in kuery doesn't break the URL.
+        kuery: encodeURIComponent(
+          `${buildPolicyIdOrVariantsKuery(agentPolicyId, `${AGENTS_PREFIX}.policy_id`)}${
+            privilegeMode
+              ? ` and ${
+                  privilegeMode === 'unprivileged'
+                    ? UNPRIVILEGED_AGENT_KUERY
+                    : PRIVILEGED_AGENT_KUERY
+                }`
+              : ''
+          }`
+        ),
         showInactive: true,
       })}
       data-test-subj="LinkedAgentCountLink"

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -7,24 +7,17 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import type { KibanaRequest, RequestHandler, ResponseHeaders } from '@kbn/core/server';
-import {
-  escapeKuery,
-  escapeQuotes,
-  fromKueryExpression,
-  toElasticsearchQuery,
-} from '@kbn/es-query';
+import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 
 import { isEmpty, uniq } from 'lodash';
 
 import yaml from 'yaml';
 
+import { ALL_SPACES_ID, FIPS_AGENT_KUERY, inputsFormat } from '../../../common/constants';
 import {
-  ALL_SPACES_ID,
-  AGENT_POLICY_VERSION_SEPARATOR,
-  FIPS_AGENT_KUERY,
-  inputsFormat,
-} from '../../../common/constants';
-import { removeVersionSuffixFromPolicyId } from '../../../common/services/version_specific_policies_utils';
+  removeVersionSuffixFromPolicyId,
+  buildPolicyIdOrVariantsKuery,
+} from '../../../common/services/version_specific_policies_utils';
 
 import { fullAgentPolicyToYaml } from '../../../common/services';
 import {
@@ -87,12 +80,6 @@ import { getLatestAgentAvailableDockerImageVersion } from '../../services/agents
 
 const deduplicateIds = (ids: string[]) => uniq(ids);
 
-function getPolicyOrVersionSpecificKuery(policyId: string): string {
-  return `(policy_id:"${escapeQuotes(policyId)}" or policy_id:${escapeKuery(
-    policyId
-  )}${AGENT_POLICY_VERSION_SEPARATOR}*)`;
-}
-
 interface AssignedAgentsCountAggregation {
   buckets: Record<
     string,
@@ -120,7 +107,7 @@ export async function populateAssignedAgentsCount(
   const policyKueryById = new Map(
     agentPolicies.map((agentPolicy) => [
       agentPolicy.id,
-      getPolicyOrVersionSpecificKuery(agentPolicy.id),
+      buildPolicyIdOrVariantsKuery(agentPolicy.id),
     ])
   );
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/agent_policy_agent_count.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/agent_policy_agent_count.ts
@@ -8,8 +8,8 @@
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 
-import { AGENT_POLICY_VERSION_SEPARATOR } from '../../../common/constants';
 import { AGENTS_INDEX } from '../../../common';
+import { buildPolicyIdOrVariantsEsFilter } from '../../../common/services/version_specific_policies_utils';
 
 /**
  * Given a list of Agent Policy IDs (parent policy ids), returns the count of active agents
@@ -27,15 +27,7 @@ export const getAgentCountForAgentPolicies = async (
 
   const filters: Record<string, QueryDslQueryContainer> = {};
   for (const policyId of agentPolicyIds) {
-    filters[policyId] = {
-      bool: {
-        should: [
-          { term: { policy_id: policyId } },
-          { prefix: { policy_id: `${policyId}${AGENT_POLICY_VERSION_SEPARATOR}` } },
-        ],
-        minimum_should_match: 1,
-      },
-    };
+    filters[policyId] = buildPolicyIdOrVariantsEsFilter(policyId);
   }
 
   const searchPromise = esClient.search<

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -6,7 +6,6 @@
  */
 import apm from 'elastic-apm-node';
 import { withActiveSpan } from '@kbn/tracing-utils';
-import { escapeKuery, escapeQuotes } from '@kbn/es-query';
 import { groupBy, isEqual, keyBy, omit, pick, uniq } from 'lodash';
 import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
 import pMap from 'p-map';
@@ -77,7 +76,6 @@ import type { AgentPolicyAgentVersionCondition } from '../../common/types/models
 import {
   AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT,
   AGENT_POLICY_INDEX,
-  AGENT_POLICY_VERSION_SEPARATOR,
   agentPolicyStatuses,
   FLEET_ELASTIC_AGENT_PACKAGE,
   UUID_V5_NAMESPACE,
@@ -130,6 +128,8 @@ import {
 import {
   hasVersionSuffix,
   removeVersionSuffixFromPolicyId,
+  buildPolicyIdOrVariantsKuery,
+  buildPolicyIdOrVariantsEsFilter,
 } from '../../common/services/version_specific_policies_utils';
 
 import { VERIFY_PERMISSIONS_TASK } from '../tasks/agentless/verify_permissions_task';
@@ -970,11 +970,10 @@ class AgentPolicyService {
               (await packagePolicyService.findAllForAgentPolicy(soClient, agentPolicy.id)) || [];
           }
           if (options.withAgentCount) {
-            const policyKuery = `(${AGENTS_PREFIX}.policy_id:"${escapeQuotes(
-              agentPolicy.id
-            )}" or ${AGENTS_PREFIX}.policy_id:${escapeKuery(
-              agentPolicy.id
-            )}${AGENT_POLICY_VERSION_SEPARATOR}*)`;
+            const policyKuery = buildPolicyIdOrVariantsKuery(
+              agentPolicy.id,
+              `${AGENTS_PREFIX}.policy_id`
+            );
             await getAgentsByKuery(appContextService.getInternalUserESClient(), soClient, {
               showInactive: true,
               perPage: 0,
@@ -1647,12 +1646,14 @@ class AgentPolicyService {
       throw new HostedAgentPolicyRestrictionRelatedError(`Cannot delete hosted agent policy ${id}`);
     }
 
-    // Prevent deleting policy when assigned agents are inactive
+    // Prevent deleting policy when assigned agents are inactive. Also matches agents on
+    // version-specific variants of this policy (e.g. `id#9.2`), which would otherwise be
+    // missed since their policy_id is not an exact match.
     const { total } = await getAgentsByKuery(esClient, soClient, {
       showInactive: true,
       perPage: 0,
       page: 1,
-      kuery: `${AGENTS_PREFIX}.policy_id:"${escapeQuotes(id)}"`,
+      kuery: buildPolicyIdOrVariantsKuery(id, `${AGENTS_PREFIX}.policy_id`),
     });
 
     if (total > 0 && !agentPolicy?.supports_agentless) {
@@ -2085,15 +2086,7 @@ class AgentPolicyService {
         ignore_unavailable: true,
         scroll_size: SO_SEARCH_LIMIT,
         refresh: true,
-        query: {
-          bool: {
-            should: [
-              { term: { policy_id: agentPolicyId } },
-              { prefix: { policy_id: `${agentPolicyId}${AGENT_POLICY_VERSION_SEPARATOR}` } },
-            ],
-            minimum_should_match: 1,
-          },
-        },
+        query: buildPolicyIdOrVariantsEsFilter(agentPolicyId),
       });
       hasMore = (res.deleted ?? 0) === SO_SEARCH_LIMIT;
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.test.ts
@@ -32,6 +32,7 @@ import {
   getByIds,
   getAgentsById,
   fetchAllAgentsByKuery,
+  getAgentVersionsForAgentPolicyIds,
 } from './crud';
 
 jest.mock('../audit_logging');
@@ -804,5 +805,84 @@ describe('Agents CRUD test', () => {
 
       expect(searchMock).toHaveBeenCalledTimes(3);
     });
+  });
+});
+
+describe('getAgentVersionsForAgentPolicyIds', () => {
+  it('returns an empty array when no policy ids are provided', async () => {
+    const searchMock = jest.fn();
+    const esClientMock = { search: searchMock } as unknown as ElasticsearchClient;
+
+    const result = await getAgentVersionsForAgentPolicyIds(
+      esClientMock,
+      savedObjectsClientMock.create(),
+      []
+    );
+
+    expect(result).toEqual([]);
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it('queries with a term-or-variant filter and rolls up version-specific variants under their base policy id', async () => {
+    const searchMock = jest.fn().mockResolvedValue({
+      hits: {
+        hits: [
+          {
+            _source: {
+              policy_id: 'policy-a',
+              local_metadata: { elastic: { agent: { version: '8.15.0' } } },
+            },
+          },
+          {
+            // version-specific variant of policy-a — must roll up under 'policy-a'
+            _source: {
+              policy_id: 'policy-a#8.16',
+              local_metadata: { elastic: { agent: { version: '8.16.0' } } },
+            },
+          },
+          {
+            _source: {
+              policy_id: 'policy-b',
+              local_metadata: { elastic: { agent: { version: '8.15.0' } } },
+            },
+          },
+        ],
+      },
+    });
+    const esClientMock = { search: searchMock } as unknown as ElasticsearchClient;
+
+    const result = await getAgentVersionsForAgentPolicyIds(
+      esClientMock,
+      savedObjectsClientMock.create(),
+      ['policy-a', 'policy-b']
+    );
+
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          bool: {
+            filter: [
+              {
+                bool: {
+                  should: [
+                    { terms: { policy_id: ['policy-a', 'policy-b'] } },
+                    { prefix: { policy_id: 'policy-a#' } },
+                    { prefix: { policy_id: 'policy-b#' } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { policyId: 'policy-a', versionCounts: { '8.15.0': 1, '8.16.0': 1 } },
+        { policyId: 'policy-b', versionCounts: { '8.15.0': 1 } },
+      ])
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
@@ -20,6 +20,10 @@ import type { AgentStatus, FleetServerAgent } from '../../../common/types';
 import { ALL_SPACES_ID, SO_SEARCH_LIMIT } from '../../../common/constants';
 import { getSortConfig } from '../../../common';
 import { isAgentUpgradeAvailable } from '../../../common/services';
+import {
+  buildPolicyIdsOrVariantsEsFilter,
+  removeVersionSuffixFromPolicyId,
+} from '../../../common/services/version_specific_policies_utils';
 import { AGENTS_INDEX, LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE } from '../../constants';
 import {
   FleetError,
@@ -681,13 +685,9 @@ export async function getAgentVersionsForAgentPolicyIds(
       >({
         query: {
           bool: {
-            filter: [
-              {
-                terms: {
-                  policy_id: agentPolicyIds,
-                },
-              },
-            ],
+            // Also matches agents on version-specific variants of the given policies
+            // (e.g. `id#9.2`), which would otherwise be missed by an exact terms match.
+            filter: [buildPolicyIdsOrVariantsEsFilter(agentPolicyIds)],
           },
         },
         index: AGENTS_INDEX,
@@ -695,7 +695,10 @@ export async function getAgentVersionsForAgentPolicyIds(
       })
     );
 
-    const groupedHits = groupBy(hits, (hit) => hit._source?.policy_id);
+    // Group by base policy id so version-specific variants roll up under their parent policy.
+    const groupedHits = groupBy(hits, (hit) =>
+      hit._source?.policy_id ? removeVersionSuffixFromPolicyId(hit._source.policy_id) : undefined
+    );
 
     for (const [policyId, policyHits] of Object.entries(groupedHits)) {
       const versionCounts: Record<string, number> = {};

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.test.ts
@@ -215,8 +215,13 @@ describe('getAgentStatusForAgentPolicy', () => {
           bool: expect.objectContaining({
             must: expect.arrayContaining([
               expect.objectContaining({
-                terms: {
-                  policy_id: agentPolicyIds,
+                bool: {
+                  should: [
+                    { terms: { policy_id: agentPolicyIds } },
+                    { prefix: { policy_id: 'agentPolicyId1#' } },
+                    { prefix: { policy_id: 'agentPolicyId2#' } },
+                  ],
+                  minimum_should_match: 1,
                 },
               }),
             ]),
@@ -231,6 +236,46 @@ describe('getAgentStatusForAgentPolicy', () => {
           }),
         }),
         timeout: expect.any(String),
+      })
+    );
+  });
+
+  it('matches version-specific policy variants when a single agentPolicyId is provided', async () => {
+    const esClient = {
+      search: jest.fn().mockResolvedValue({
+        aggregations: {
+          status: {
+            buckets: [{ key: 'online', doc_count: 1 }],
+          },
+        },
+      }),
+    };
+
+    const soClient = {
+      find: jest.fn().mockResolvedValue({
+        saved_objects: [{ id: 'agentPolicyId', attributes: { name: 'Policy 1' } }],
+      }),
+    };
+
+    await getAgentStatusForAgentPolicy(esClient as any, soClient as any, 'agentPolicyId');
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          bool: expect.objectContaining({
+            must: expect.arrayContaining([
+              expect.objectContaining({
+                bool: {
+                  should: [
+                    { term: { policy_id: 'agentPolicyId' } },
+                    { prefix: { policy_id: 'agentPolicyId#' } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              }),
+            ]),
+          }),
+        }),
       })
     );
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/status.ts
@@ -17,6 +17,10 @@ import type {
 
 import { ALL_SPACES_ID } from '../../../common/constants';
 import { agentStatusesToSummary } from '../../../common/services';
+import {
+  buildPolicyIdOrVariantsEsFilter,
+  buildPolicyIdsOrVariantsEsFilter,
+} from '../../../common/services/version_specific_policies_utils';
 import { AGENTS_INDEX } from '../../constants';
 import type { AgentStatus } from '../../types';
 import { FleetError, FleetUnauthorizedError } from '../../errors';
@@ -86,19 +90,12 @@ export async function getAgentStatusForAgentPolicy(
     );
     clauses.push(kueryAsElasticsearchQuery);
   }
-  // If agentPolicyIds is provided, we filter by those, otherwise we filter by depreciated agentPolicyId
+  // If agentPolicyIds is provided, we filter by those, otherwise we filter by deprecated agentPolicyId.
+  // Also matches agents on version-specific variants of the given policies (e.g. `id#9.2`).
   if (agentPolicyIds) {
-    clauses.push({
-      terms: {
-        policy_id: agentPolicyIds,
-      },
-    });
+    clauses.push(buildPolicyIdsOrVariantsEsFilter(agentPolicyIds));
   } else if (agentPolicyId) {
-    clauses.push({
-      term: {
-        policy_id: agentPolicyId,
-      },
-    });
+    clauses.push(buildPolicyIdOrVariantsEsFilter(agentPolicyId));
   }
 
   const query =

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/rollback.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/rollback.ts
@@ -16,14 +16,16 @@ import type {
 } from '@kbn/core/server';
 import semverGt from 'semver/functions/gt';
 
-import { escapeKuery } from '@kbn/es-query';
-
 import {
   PACKAGES_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
   AGENT_POLICY_INDEX,
 } from '../../../../common';
 import { AGENT_POLICY_VERSION_SEPARATOR } from '../../../../common/constants/agent_policy';
+import {
+  buildVersionVariantsKueryFragment,
+  buildVersionVariantsEsFilter,
+} from '../../../../common/services/version_specific_policies_utils';
 import type { RollbackResult } from '../../package_policy_service';
 import { getAgentsByKuery, reassignAgents } from '../../agents';
 
@@ -355,7 +357,7 @@ async function cleanupVersionSpecificPoliciesAfterRollback(
     );
     if (stillHasVersionConditions) continue;
 
-    const variantKuery = `policy_id:${escapeKuery(parentId)}${AGENT_POLICY_VERSION_SEPARATOR}*`;
+    const variantKuery = buildVersionVariantsKueryFragment(parentId);
     const { total: variantAgentCount } = await getAgentsByKuery(esClient, soClient, {
       kuery: variantKuery,
       showInactive: false,
@@ -391,7 +393,7 @@ async function cleanupVersionSpecificPoliciesAfterRollback(
       await esClient.deleteByQuery({
         index: AGENT_POLICY_INDEX,
         ignore_unavailable: true,
-        query: { prefix: { policy_id: `${parentId}${AGENT_POLICY_VERSION_SEPARATOR}` } },
+        query: buildVersionVariantsEsFilter(parentId),
         refresh: true,
       });
     }

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/version_specific_policy_assignment_task.ts
@@ -19,7 +19,7 @@ import type {
 import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
 import type { LoggerFactory } from '@kbn/core/server';
 import { errors } from '@elastic/elasticsearch';
-import { escapeKuery, escapeQuotes } from '@kbn/es-query';
+import { escapeQuotes } from '@kbn/es-query';
 import { coerce } from 'semver';
 import pMap from 'p-map';
 
@@ -31,7 +31,10 @@ import { getAgentTemplateAssetsMap } from '../services/epm/packages/get';
 import { hasAgentVersionConditionInInputTemplate } from '../services/utils/version_specific_policies';
 import { fetchAllAgentsByKuery, getAgentsByKuery } from '../services/agents';
 import { reassignAgents } from '../services/agents/reassign';
-import { splitVersionSuffixFromPolicyId } from '../../common/services/version_specific_policies_utils';
+import {
+  splitVersionSuffixFromPolicyId,
+  buildVersionVariantsKueryFragment,
+} from '../../common/services/version_specific_policies_utils';
 import { AGENT_POLICY_VERSION_SEPARATOR } from '../../common/constants';
 
 import { throwIfAborted } from './utils';
@@ -301,9 +304,9 @@ export class VersionSpecificPolicyAssignmentTask {
     // Query 2: Agents on any versioned policy derived from this parent that:
     //   - Were recently upgraded (version might have changed)
     //   - May need to move to a different versioned policy
-    const versionedPolicyKuery = `policy_id:${escapeKuery(
+    const versionedPolicyKuery = `${buildVersionVariantsKueryFragment(
       agentPolicyId
-    )}${AGENT_POLICY_VERSION_SEPARATOR}* AND upgraded_at >= "${recentlyUpgradedTime}"`;
+    )} AND upgraded_at >= "${recentlyUpgradedTime}"`;
 
     // Note: We intentionally do NOT query for agents with outdated policy revisions.
     // Agents already on the correct versioned policy will receive updated revisions

--- a/x-pack/platform/plugins/shared/osquery/server/lib/parse_agent_groups.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/parse_agent_groups.test.ts
@@ -451,7 +451,10 @@ describe('parseAgentSelection', () => {
         selection: { allAgentsSelected: true },
         expectedFragments: [
           'status:online',
-          'policy_id:("policy-1" or policy-1#* or "policy-2" or policy-2#* or "policy-3" or policy-3#*)',
+          'policy_id:(policy-1 or policy-2 or policy-3)',
+          'policy_id:policy-1#*',
+          'policy_id:policy-2#*',
+          'policy_id:policy-3#*',
         ],
       },
       {
@@ -460,7 +463,8 @@ describe('parseAgentSelection', () => {
         expectedFragments: [
           'status:online',
           'local_metadata.os.platform:(linux or darwin)',
-          'policy_id:("policy-1" or policy-1#*)',
+          'policy_id:(policy-1)',
+          'policy_id:policy-1#*',
         ],
       },
     ])('$name', async ({ selection, expectedFragments }) => {
@@ -488,6 +492,33 @@ describe('parseAgentSelection', () => {
 
       const callArgs = mockAgentService.listAgents.mock.calls[0][0];
       expect(callArgs.showInactive).toBe(false);
+    });
+
+    it('should also match agents on version-specific variants of osquery-enabled policies', async () => {
+      mockAgentService.listAgents = createSimpleMockResponse(['agent-1']);
+
+      await parseAgentSelection(mockSoClient, mockElasticsearchClient, mockContextWithServices, {
+        allAgentsSelected: true,
+        spaceId: 'default',
+      });
+
+      const kueryCall = mockAgentService.listAgents.mock.calls[0][0].kuery;
+      expect(kueryCall).toContain('policy_id:policy-1#*');
+      expect(kueryCall).toContain('policy_id:policy-2#*');
+      expect(kueryCall).toContain('policy_id:policy-3#*');
+    });
+
+    it('should also match agents on version-specific variants of explicitly selected policies', async () => {
+      mockAgentService.listAgents = createSimpleMockResponse(['agent-1']);
+
+      await parseAgentSelection(mockSoClient, mockElasticsearchClient, mockContextWithServices, {
+        policiesSelected: ['policy-1'],
+        spaceId: 'default',
+      });
+
+      const kueryCall = mockAgentService.listAgents.mock.calls[0][0].kuery;
+      expect(kueryCall).toContain('policy_id:(policy-1)');
+      expect(kueryCall).toContain('policy_id:policy-1#*');
     });
   });
 

--- a/x-pack/platform/plugins/shared/osquery/server/lib/parse_agent_groups.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/parse_agent_groups.ts
@@ -7,10 +7,13 @@
 
 import { uniq } from 'lodash';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
-import { AGENTS_INDEX, PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+import {
+  AGENTS_INDEX,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  buildPolicyIdsOrVariantsKuery,
+} from '@kbn/fleet-plugin/common';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import { OSQUERY_INTEGRATION_NAME } from '../../common';
-import { buildPolicyIdKuery } from '../../common/utils/build_policy_id_kuery';
 import type { OsqueryAppContext } from './osquery_app_context_services';
 
 export interface AgentSelection {
@@ -158,7 +161,7 @@ export const parseAgentSelection = async (
       esClient,
       context
     );
-    kueryFragments.push(buildPolicyIdKuery(osqueryPolicies));
+    kueryFragments.push(buildPolicyIdsOrVariantsKuery(osqueryPolicies));
     if (allAgentsSelected) {
       const kuery = kueryFragments.join(' and ');
       const fetchedAgents = await aggregateResults(
@@ -194,7 +197,7 @@ export const parseAgentSelection = async (
         }
 
         if (policiesSelected.length) {
-          groupFragments.push(buildPolicyIdKuery(policiesSelected));
+          groupFragments.push(buildPolicyIdsOrVariantsKuery(policiesSelected));
         }
 
         kueryFragments.push(`(${groupFragments.join(' or ')})`);

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/version_specific_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/version_specific_policies.ts
@@ -117,11 +117,23 @@ export default function (providerContext: FtrProviderContext) {
         );
       });
       after(async () => {
+        // Agents get reassigned to version-specific policy variants during the tests, so their
+        // policy_id no longer exactly matches agentPolicyWithPPId — delete them explicitly first
+        // (deleting the policy directly would otherwise correctly fail while agents remain assigned).
+        await supertest.delete(`/api/fleet/agents/${agentId}`).set('kbn-xsrf', 'xxxx').expect(200);
         await supertest
-          .post(`/api/fleet/agent_policies/delete`)
+          .delete(`/api/fleet/agents/${upgradedAgentId}`)
           .set('kbn-xsrf', 'xxxx')
-          .send({ agentPolicyId: agentPolicyWithPPId })
           .expect(200);
+        // Retry to tolerate the unenroll updates above not being immediately visible to the
+        // policy delete guard's search.
+        await retry.tryForTime(20000, async () => {
+          await supertest
+            .post(`/api/fleet/agent_policies/delete`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({ agentPolicyId: agentPolicyWithPPId })
+            .expect(200);
+        });
       });
       it('should include agents on version-specific policies in agent count when getting policy', async () => {
         const { body } = await supertest
@@ -302,11 +314,23 @@ export default function (providerContext: FtrProviderContext) {
         );
       });
       after(async () => {
+        // Agents get reassigned to version-specific policy variants during the tests, so their
+        // policy_id no longer exactly matches agentPolicyWithPPId — delete them explicitly first
+        // (deleting the policy directly would otherwise correctly fail while agents remain assigned).
+        await supertest.delete(`/api/fleet/agents/${agentId}`).set('kbn-xsrf', 'xxxx').expect(200);
         await supertest
-          .post(`/api/fleet/agent_policies/delete`)
+          .delete(`/api/fleet/agents/${upgradedAgentId}`)
           .set('kbn-xsrf', 'xxxx')
-          .send({ agentPolicyId: agentPolicyWithPPId })
           .expect(200);
+        // Retry to tolerate the unenroll updates above not being immediately visible to the
+        // policy delete guard's search.
+        await retry.tryForTime(20000, async () => {
+          await supertest
+            .post(`/api/fleet/agent_policies/delete`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({ agentPolicyId: agentPolicyWithPPId })
+            .expect(200);
+        });
       });
       it('should create version specific policies with common agent versions and template level agent version condition', async () => {
         const { body } = await supertest
@@ -493,9 +517,18 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       after(async () => {
-        await es.delete({ index: '.fleet-agents', id: 'agent-vspc-telemetry-1' }).catch(() => {});
-        await es.delete({ index: '.fleet-agents', id: 'agent-vspc-telemetry-2' }).catch(() => {});
-        await es.delete({ index: '.fleet-agents', id: 'agent-vspc-telemetry-3' }).catch(() => {});
+        // refresh: true ensures these deletes are visible to the agent policy delete guard's
+        // search below — otherwise it can still see these agents (assigned via their versioned
+        // policy_id) and correctly refuse to delete the policy while they appear assigned.
+        await es
+          .delete({ index: '.fleet-agents', id: 'agent-vspc-telemetry-1', refresh: true })
+          .catch(() => {});
+        await es
+          .delete({ index: '.fleet-agents', id: 'agent-vspc-telemetry-2', refresh: true })
+          .catch(() => {});
+        await es
+          .delete({ index: '.fleet-agents', id: 'agent-vspc-telemetry-3', refresh: true })
+          .catch(() => {});
         await supertest
           .post(`/api/fleet/agent_policies/delete`)
           .set('kbn-xsrf', 'xxxx')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Fleet] Centralize version-specific policy_id filter construction (#277016)](https://github.com/elastic/kibana/pull/277016)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":277016,"url":"https://github.com/elastic/kibana/pull/277016","title":"[Fleet] Centralize version-specific policy_id filter construction"},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"sourceCommit":{"sha":"2f3ba91dc0724392010654afb2fef89638212c0d"}}] BACKPORT-->