### PR TITLE
[9.3] [Fleet] Improve saved object ID validation to exclude special characters (#279223)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_fleet_id.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_fleet_id.test.ts
@@ -90,5 +90,36 @@ describe('validateFleetSavedObjectId', () => {
     it('256-character id (over limit)', () => {
       expect(() => validateFleetSavedObjectId('a'.repeat(256))).toThrow('id is not valid');
     });
+
+    // Script metacharacters — no legitimate use in Fleet saved object IDs.
+    it('double quote (Painless string break)', () => {
+      expect(() => validateFleetSavedObjectId('x"); ctx._source.pwned=("true')).toThrow(
+        'id is not valid'
+      );
+    });
+
+    it('single quote (Painless string break in renderUpdatePainlessScript)', () => {
+      expect(() => validateFleetSavedObjectId("x'); ctx._source.pwned=('true")).toThrow(
+        'id is not valid'
+      );
+    });
+
+    it('semicolon (Painless statement separator)', () => {
+      expect(() => validateFleetSavedObjectId('x;ctx._source.pwned=true')).toThrow(
+        'id is not valid'
+      );
+    });
+
+    it('backslash (Painless escape character)', () => {
+      expect(() => validateFleetSavedObjectId('x\\"')).toThrow('id is not valid');
+    });
+
+    it('open parenthesis', () => {
+      expect(() => validateFleetSavedObjectId('x(y')).toThrow('id is not valid');
+    });
+
+    it('close parenthesis', () => {
+      expect(() => validateFleetSavedObjectId('x)y')).toThrow('id is not valid');
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_fleet_id.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_fleet_id.ts
@@ -17,14 +17,21 @@ const isUnsafeId = (id: string): boolean =>
   id.includes('..') ||
   id.includes('/');
 
+// Characters with no legitimate use in Fleet saved object IDs that could act
+// as script metacharacters if an ID were ever interpolated into a script context.
+const PAINLESS_UNSAFE_CHARS_RE = /["';\\()]/;
+
 /**
  * Throws a FleetError if the id contains path separators, traversal sequences,
- * prototype-pollution keys, is empty, or exceeds 255 characters. Only call on
- * create paths so pre-existing stored IDs continue to function.
+ * prototype-pollution keys, Painless script metacharacters, is empty, or
+ * exceeds 255 characters. Only call on create paths so pre-existing stored IDs
+ * continue to function.
  */
 export const validateFleetSavedObjectId = (value: string | undefined): void => {
-  if (value === undefined || !isUnsafeId(value)) return;
-  throw new FleetError(
-    `id is not valid: must be 1–255 characters and must not contain path separators ("/"), traversal sequences (".."), or reserved keys ("__proto__", "constructor", "prototype").`
-  );
+  if (value === undefined) return;
+  if (isUnsafeId(value) || PAINLESS_UNSAFE_CHARS_RE.test(value)) {
+    throw new FleetError(
+      `id is not valid: must be 1–255 characters and must not contain path separators ("/"), traversal sequences (".."), reserved keys ("__proto__", "constructor", "prototype"), or script-injection characters (", ', ;, \\, (, )).`
+    );
+  }
 };

--- a/x-pack/platform/test/fleet_api_integration/apis/uninstall_token/get.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/uninstall_token/get.ts
@@ -317,10 +317,12 @@ export default function (providerContext: FtrProviderContext) {
       describe('when `search` query param is used', () => {
         let generatedManagedPolicyArray: AgentPolicy[];
         let generatedPolicyArray: AgentPolicy[];
-        // '/' and '.' are excluded from IDs: '/' is a path separator and repeated '.' forms '..' (traversal),
-        // both rejected by the Fleet ID validator. They are included in specialCharactersForNameOnly instead.
-        const specialCharactersForNameAndId = `!@#$%^&*-=_+()[]{}:;'\`|<>,?~`.split('');
-        const specialCharactersForNameOnly = `"\\/.`.split('');
+        // Characters excluded from IDs because the Fleet ID validator rejects them:
+        // - '/' path separator, '..' traversal sequence → always rejected
+        // - '"', '\' → rejected (script-injection characters)
+        // - '(', ')', ';', "'" → rejected (script-injection characters)
+        const specialCharactersForNameAndId = `!@#$%^&*-=_+[]{}:\`|<>,?~`.split('');
+        const specialCharactersForNameOnly = `"\\/.;()'`.split('');
 
         before(async () => {
           generatedPolicyArray = [];


### PR DESCRIPTION
## Summary

Backport of #279223 to 9.3.

Conflict resolved: `validate_fleet_id.ts` on 9.3 defines `UNSAFE_IDS`/`isUnsafeId` inline; kept those constants and added `PAINLESS_UNSAFE_CHARS_RE` alongside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)