### PR TITLE
[SigEvents] Install memory workflows globally and gate Memory UI actions

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/lib/workflows/setup/managed_workflows_installer.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/workflows/setup/managed_workflows_installer.test.ts
@@ -9,8 +9,12 @@ import { loggerMock } from '@kbn/logging-mocks';
 import {
   SIGNIFICANT_EVENTS_DETECTION_WORKFLOW_ID,
   SIGNIFICANT_EVENTS_INVESTIGATION_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_CONSOLIDATION_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_GAP_DETECTION_WORKFLOW_ID,
   SIGNIFICANT_EVENTS_MEMORY_SYNTHESIS_WORKFLOW_ID,
 } from '@kbn/workflows/managed';
+import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
 import type { PluginScopedManagedWorkflowsApi } from '@kbn/workflows/server/types';
 import { createManagedWorkflowsInstaller } from './managed_workflows_installer';
 
@@ -102,12 +106,23 @@ describe('createManagedWorkflowsInstaller', () => {
     expect(installCountAtReady).toBe(TOTAL_WORKFLOW_COUNT);
   });
 
-  it('installs memory workflows when available', async () => {
+  it('installs memory workflows globally when available', async () => {
     const { client, installer } = createInstaller();
 
     await installer.install();
 
-    expect(installedIds(client)).toContain(SIGNIFICANT_EVENTS_MEMORY_SYNTHESIS_WORKFLOW_ID);
+    const memoryWorkflowIds = [
+      SIGNIFICANT_EVENTS_MEMORY_SYNTHESIS_WORKFLOW_ID,
+      SIGNIFICANT_EVENTS_MEMORY_CONSOLIDATION_WORKFLOW_ID,
+      SIGNIFICANT_EVENTS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
+      SIGNIFICANT_EVENTS_MEMORY_GAP_DETECTION_WORKFLOW_ID,
+    ];
+
+    for (const workflowId of memoryWorkflowIds) {
+      expect(client.install).toHaveBeenCalledWith(workflowId, {
+        spaceId: GLOBAL_WORKFLOW_SPACE_ID,
+      });
+    }
   });
 
   it('installs the investigation workflow when available', async () => {

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/install_managed_workflows.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/install_managed_workflows.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  SIGNIFICANT_EVENTS_MEMORY_CONSOLIDATION_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_GAP_DETECTION_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_SYNTHESIS_WORKFLOW_ID,
+} from '@kbn/workflows/managed';
+import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
+import type { PluginScopedManagedWorkflowsApi } from '@kbn/workflows/server/types';
+import { installMemoryWorkflows } from './install_managed_workflows';
+
+const MEMORY_WORKFLOW_IDS = [
+  SIGNIFICANT_EVENTS_MEMORY_SYNTHESIS_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_CONSOLIDATION_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
+  SIGNIFICANT_EVENTS_MEMORY_GAP_DETECTION_WORKFLOW_ID,
+] as const;
+
+const createClientMock = () =>
+  ({
+    install: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<Pick<PluginScopedManagedWorkflowsApi, 'install'>>);
+
+describe('installMemoryWorkflows', () => {
+  it('installs all four memory workflows globally', async () => {
+    const client = createClientMock();
+
+    await installMemoryWorkflows({
+      client: client as unknown as PluginScopedManagedWorkflowsApi,
+    });
+
+    expect(client.install).toHaveBeenCalledTimes(MEMORY_WORKFLOW_IDS.length);
+    for (const workflowId of MEMORY_WORKFLOW_IDS) {
+      expect(client.install).toHaveBeenCalledWith(workflowId, {
+        spaceId: GLOBAL_WORKFLOW_SPACE_ID,
+      });
+    }
+  });
+
+  it('aggregates install failures instead of failing on the first rejection', async () => {
+    const client = createClientMock();
+    client.install
+      .mockRejectedValueOnce(new Error('synthesis boom'))
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('scraper boom'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      installMemoryWorkflows({
+        client: client as unknown as PluginScopedManagedWorkflowsApi,
+      })
+    ).rejects.toThrow(
+      `Failed to install memory workflows: [${SIGNIFICANT_EVENTS_MEMORY_SYNTHESIS_WORKFLOW_ID} (synthesis boom); ${SIGNIFICANT_EVENTS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID} (scraper boom)]`
+    );
+
+    expect(client.install).toHaveBeenCalledTimes(MEMORY_WORKFLOW_IDS.length);
+  });
+});

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/install_managed_workflows.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/lib/memory/install_managed_workflows.ts
@@ -11,7 +11,7 @@ import {
   SIGNIFICANT_EVENTS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
   SIGNIFICANT_EVENTS_MEMORY_GAP_DETECTION_WORKFLOW_ID,
 } from '@kbn/workflows/managed';
-import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
+import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
 import type { PluginScopedManagedWorkflowsApi } from '@kbn/workflows/server/types';
 
 const MEMORY_WORKFLOW_IDS = [
@@ -27,7 +27,7 @@ export const installMemoryWorkflows = async ({
   client: PluginScopedManagedWorkflowsApi;
 }): Promise<void> => {
   const results = await Promise.allSettled(
-    MEMORY_WORKFLOW_IDS.map((id) => client.install(id, { spaceId: DEFAULT_SPACE_ID }))
+    MEMORY_WORKFLOW_IDS.map((id) => client.install(id, { spaceId: GLOBAL_WORKFLOW_SPACE_ID }))
   );
 
   const failures = results.flatMap((result, index) =>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/memory/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/memory/tab.tsx
@@ -22,6 +22,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiToolTip,
   EuiTreeView,
 } from '@elastic/eui';
 import { css } from '@emotion/css';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/memory/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events/significant_events_discovery/components/memory/tab.tsx
@@ -68,6 +68,8 @@ export function MemoryTab() {
     useMemoryWorkflowsEnabled();
   const toggleWorkflows = useToggleMemoryWorkflows();
   const workflowsEnabled = workflowsEnabledData?.enabled ?? false;
+  const areWorkflowActionsDisabled =
+    isWorkflowsEnabledLoading || !workflowsEnabled || toggleWorkflows.isLoading;
 
   const workflowActions: Array<{
     key: string;
@@ -183,27 +185,41 @@ export function MemoryTab() {
                 </EuiFlexItem>
                 {canManage && (
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="plusInCircle"
-                      aria-label={i18n.translate('xpack.streams.memory.newEntryButton', {
+                    <EuiToolTip
+                      content={i18n.translate('xpack.streams.memory.newEntryButton', {
                         defaultMessage: 'New memory entry',
                       })}
-                      onClick={() => setShowCreateFlyout(true)}
-                      data-test-subj="streamsMemoryNewEntryButton"
-                    />
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        iconType="plusInCircle"
+                        aria-label={i18n.translate('xpack.streams.memory.newEntryButton', {
+                          defaultMessage: 'New memory entry',
+                        })}
+                        onClick={() => setShowCreateFlyout(true)}
+                        data-test-subj="streamsMemoryNewEntryButton"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 )}
                 <EuiFlexItem grow={false}>
                   <EuiPopover
                     button={
-                      <EuiButtonIcon
-                        iconType="boxesHorizontal"
-                        aria-label={i18n.translate('xpack.streams.memory.workflowActionsButton', {
+                      <EuiToolTip
+                        content={i18n.translate('xpack.streams.memory.workflowActionsButton', {
                           defaultMessage: 'Workflow actions',
                         })}
-                        onClick={() => setIsActionsPopoverOpen((v) => !v)}
-                        data-test-subj="streamsMemoryWorkflowActionsButton"
-                      />
+                        disableScreenReaderOutput
+                      >
+                        <EuiButtonIcon
+                          iconType="boxesHorizontal"
+                          aria-label={i18n.translate('xpack.streams.memory.workflowActionsButton', {
+                            defaultMessage: 'Workflow actions',
+                          })}
+                          onClick={() => setIsActionsPopoverOpen((v) => !v)}
+                          data-test-subj="streamsMemoryWorkflowActionsButton"
+                        />
+                      </EuiToolTip>
                     }
                     isOpen={isActionsPopoverOpen}
                     closePopover={() => setIsActionsPopoverOpen(false)}
@@ -243,28 +259,44 @@ export function MemoryTab() {
                               </EuiContextMenuItem>,
                             ]
                           : []),
-                        ...workflowActions.map((action) => (
-                          <EuiContextMenuItem
-                            key={action.key}
-                            icon={
-                              action.mutation.isLoading ? (
-                                <EuiLoadingSpinner size="s" />
-                              ) : (
-                                action.icon
-                              )
-                            }
-                            onClick={() => {
-                              action.mutation.mutate();
-                              setIsActionsPopoverOpen(false);
-                            }}
-                            disabled={
-                              action.mutation.isLoading || (action.requiresManage && !canManage)
-                            }
-                            data-test-subj={action.testSubj}
-                          >
-                            {action.label}
-                          </EuiContextMenuItem>
-                        )),
+                        ...workflowActions.map((action) => {
+                          const isDisabled =
+                            action.mutation.isLoading ||
+                            (action.requiresManage && !canManage) ||
+                            areWorkflowActionsDisabled;
+
+                          return (
+                            <EuiContextMenuItem
+                              key={action.key}
+                              icon={
+                                action.mutation.isLoading ? (
+                                  <EuiLoadingSpinner size="s" />
+                                ) : (
+                                  action.icon
+                                )
+                              }
+                              onClick={() => {
+                                action.mutation.mutate();
+                                setIsActionsPopoverOpen(false);
+                              }}
+                              disabled={isDisabled}
+                              toolTipContent={
+                                !workflowsEnabled && !isWorkflowsEnabledLoading
+                                  ? i18n.translate(
+                                      'xpack.streams.memory.workflowActionRequiresEnabledTooltip',
+                                      {
+                                        defaultMessage:
+                                          'Enable background workflows before running this action.',
+                                      }
+                                    )
+                                  : undefined
+                              }
+                              data-test-subj={action.testSubj}
+                            >
+                              {action.label}
+                            </EuiContextMenuItem>
+                          );
+                        }),
                       ]}
                     />
                   </EuiPopover>


### PR DESCRIPTION
## 📓 Summary
Significant Events memory workflows were installed only in the default space, so they were not available across spaces. This PR installs all four memory managed workflows globally and updates the Streams Memory tab so individual workflow actions stay disabled until background workflows are enabled, avoiding immediate failures from the menu.

https://github.com/user-attachments/assets/31df8c79-6565-465f-81d5-a3f5be183f07

- Installs synthesis, consolidation, conversation scraper, and gap detection workflows with `GLOBAL_WORKFLOW_SPACE_ID`.
- Adds/updates installer tests covering global install semantics.
- Disables Memory tab workflow actions (with tooltip) when background workflows are off, loading, or toggling.

## 🧪 Testing
- With Significant Events available, confirm the four memory workflows install once with global space (`*`) and appear in non-default spaces without duplicate installs.
- In the Streams Memory tab, with background workflows disabled, open the actions menu and confirm Scrape / Consolidate / Synthesize / Detect Gaps are disabled and show the enable-workflows tooltip.
- Enable background workflows, then run each action and confirm it queues successfully; disable again and confirm actions return to disabled.