### PR TITLE
[9.3] [CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -259,6 +259,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -276,6 +276,8 @@ steps:
       - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
         label: 'Defend Workflows Cypress Tests on Serverless'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -70,6 +70,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -88,6 +90,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/node_glibc_217.yml
+++ b/.buildkite/pipelines/node_glibc_217.yml
@@ -483,6 +483,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -501,6 +503,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -234,6 +234,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -256,6 +258,8 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
     branches: main
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -279,6 +279,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -297,6 +299,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -2,6 +2,8 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_burn.sh
     label: '[Soft fail] Defend Workflows Cypress Tests, burning changed specs'
     key: defend-workflows-burn
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
@@ -20,6 +22,8 @@ steps:
     label: '[Soft fail] Defend Workflows Cypress Tests on Serverless, burning changed specs'
     key: defend-workflows-serverless-burn
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -2,6 +2,8 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     key: defend-workflows
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
@@ -23,6 +25,8 @@ steps:
     label: 'Defend Workflows Cypress Tests on Serverless'
     key: defend-workflows-serverless
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -46,7 +46,6 @@ steps:
   - group: "API MKI - Defend Workflows"
     key: api_test_defend_workflows
     steps:
-<<<<<<< HEAD
 #      - label: "API MKI - edr_workflows:artifacts:qa:serverless"
 #        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:artifacts:qa:serverless
 #        key: edr_workflows:artifacts:qa:serverless
@@ -106,107 +105,6 @@ steps:
 #          automatic:
 #            - exit_status: "1"
 #              limit: 1
-=======
-      - label: "API MKI - edr_workflows:artifacts:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:artifacts:qa:serverless
-        key: edr_workflows:artifacts:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
-        agents:
-          image: family/kibana-ubuntu-2404
-          imageProject: elastic-images-prod
-          provider: gcp
-          enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 130
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-        soft_fail:
-          - exit_status: 101
-
-      - label: "API MKI - edr_workflows:authentication:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:authentication:qa:serverless
-        key: edr_workflows:authentication:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
-        agents:
-          image: family/kibana-ubuntu-2404
-          imageProject: elastic-images-prod
-          provider: gcp
-          enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 130
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-        soft_fail:
-          - exit_status: 101
-
-      - label: "API MKI - edr_workflows:metadata:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:metadata:qa:serverless
-        key: edr_workflows:metadata:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
-        agents:
-          image: family/kibana-ubuntu-2404
-          imageProject: elastic-images-prod
-          provider: gcp
-          enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 130
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-        soft_fail:
-          - exit_status: 101
-
-      - label: "API MKI - edr_workflows:package:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:package:qa:serverless
-        key: edr_workflows:package:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
-        agents:
-          image: family/kibana-ubuntu-2404
-          imageProject: elastic-images-prod
-          provider: gcp
-          enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 130
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-        soft_fail:
-          - exit_status: 101
-
-      - label: "API MKI - edr_workflows:policy:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy:qa:serverless
-        key: edr_workflows:policy:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
-        agents:
-          image: family/kibana-ubuntu-2404
-          imageProject: elastic-images-prod
-          provider: gcp
-          enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 130
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-        soft_fail:
-          - exit_status: 101
->>>>>>> e2fc6657be44 ([CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876))
 
       - label: "API MKI - edr_workflows:policy_response:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy_response:qa:serverless

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -5,6 +5,8 @@ steps:
       - label: "Cypress MKI - cypress:dw:qa:serverless:run"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
         key: test_defend_workflows
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -25,6 +27,8 @@ steps:
       - label: "Cypress MKI - Osquery - cypress:qa:serverless:run"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows_osquery.sh cypress:qa:serverless:run
         key: test_osquery_defend_workflows
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -42,6 +46,7 @@ steps:
   - group: "API MKI - Defend Workflows"
     key: api_test_defend_workflows
     steps:
+<<<<<<< HEAD
 #      - label: "API MKI - edr_workflows:artifacts:qa:serverless"
 #        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:artifacts:qa:serverless
 #        key: edr_workflows:artifacts:qa:serverless
@@ -101,16 +106,120 @@ steps:
 #          automatic:
 #            - exit_status: "1"
 #              limit: 1
-
-      - label: "API MKI - edr_workflows:policy_response:qa:serverless"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy_response:qa:serverless
-        key: edr_workflows:policy_response:qa:serverless
+=======
+      - label: "API MKI - edr_workflows:artifacts:qa:serverless"
+        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:artifacts:qa:serverless
+        key: edr_workflows:artifacts:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
+          diskSizeGb: 130
+        timeout_in_minutes: 120
+        retry:
+          automatic:
+            - exit_status: "1"
+              limit: 2
+        soft_fail:
+          - exit_status: 101
+
+      - label: "API MKI - edr_workflows:authentication:qa:serverless"
+        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:authentication:qa:serverless
+        key: edr_workflows:authentication:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
+        agents:
+          image: family/kibana-ubuntu-2404
+          imageProject: elastic-images-prod
+          provider: gcp
+          enableNestedVirtualization: true
+          machineType: n2-standard-4
+          diskSizeGb: 130
+        timeout_in_minutes: 120
+        retry:
+          automatic:
+            - exit_status: "1"
+              limit: 2
+        soft_fail:
+          - exit_status: 101
+
+      - label: "API MKI - edr_workflows:metadata:qa:serverless"
+        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:metadata:qa:serverless
+        key: edr_workflows:metadata:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
+        agents:
+          image: family/kibana-ubuntu-2404
+          imageProject: elastic-images-prod
+          provider: gcp
+          enableNestedVirtualization: true
+          machineType: n2-standard-4
+          diskSizeGb: 130
+        timeout_in_minutes: 120
+        retry:
+          automatic:
+            - exit_status: "1"
+              limit: 2
+        soft_fail:
+          - exit_status: 101
+
+      - label: "API MKI - edr_workflows:package:qa:serverless"
+        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:package:qa:serverless
+        key: edr_workflows:package:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
+        agents:
+          image: family/kibana-ubuntu-2404
+          imageProject: elastic-images-prod
+          provider: gcp
+          enableNestedVirtualization: true
+          machineType: n2-standard-4
+          diskSizeGb: 130
+        timeout_in_minutes: 120
+        retry:
+          automatic:
+            - exit_status: "1"
+              limit: 2
+        soft_fail:
+          - exit_status: 101
+
+      - label: "API MKI - edr_workflows:policy:qa:serverless"
+        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy:qa:serverless
+        key: edr_workflows:policy:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
+        agents:
+          image: family/kibana-ubuntu-2404
+          imageProject: elastic-images-prod
+          provider: gcp
+          enableNestedVirtualization: true
+          machineType: n2-standard-4
+          diskSizeGb: 130
+        timeout_in_minutes: 120
+        retry:
+          automatic:
+            - exit_status: "1"
+              limit: 2
+        soft_fail:
+          - exit_status: 101
+>>>>>>> e2fc6657be44 ([CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876))
+
+      - label: "API MKI - edr_workflows:policy_response:qa:serverless"
+        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy_response:qa:serverless
+        key: edr_workflows:policy_response:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
+        agents:
+          image: family/kibana-ubuntu-2404
+          imageProject: elastic-images-prod
+          provider: gcp
+          enableNestedVirtualization: true
+          machineType: n2-standard-4
+          diskSizeGb: 130
         timeout_in_minutes: 120
         retry:
           automatic:
@@ -120,12 +229,15 @@ steps:
       - label: "API MKI - edr_workflows:resolver:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:resolver:qa:serverless
         key: edr_workflows:resolver:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
+          diskSizeGb: 130
         timeout_in_minutes: 120
         retry:
           automatic:
@@ -135,12 +247,15 @@ steps:
       - label: "API MKI - edr_workflows:response_actions:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:response_actions:qa:serverless
         key: edr_workflows:response_actions:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
+          diskSizeGb: 130
         timeout_in_minutes: 120
         retry:
           automatic:

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
@@ -2,6 +2,8 @@ steps:
   - command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
     label: 'Cypress MKI - Defend Workflows'
     key: test_defend_workflows
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -48,3 +48,11 @@ fi
 if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
   check_for_changed_files 'yarn kbn bootstrap'
 fi
+
+# Opt-in per job (via CLEAR_YARN_CACHE) to free disk space on disk-constrained agents
+if [[ "${CLEAR_YARN_CACHE:-}" ]]; then
+  echo "Clearing yarn cache at /opt/buildkite-agent/.cache/yar..."
+  rm -rf /opt/buildkite-agent/.cache/yarn
+  echo "Available disk space after clearing yarn cache:"
+  df -h . || echo "Failed to get disk space"
+fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)](https://github.com/elastic/kibana/pull/278876)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-07-17T09:13:34Z","message":"[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)\n\n## Summary\n\nFree disk space on the disk-constrained Defend Workflows CI agents by\nclearing the global yarn cache after bootstrap.\n\n- Adds `CLEAR_YARN_CACHE: '1'` env to all Defend Workflows jobs across\nthe pipelines.\n- `.buildkite/scripts/bootstrap.sh` deletes\n`/opt/buildkite-agent/.cache/yarn` when `CLEAR_YARN_CACHE` is set, then\nprints available disk space (`df -h .`).\n\nOpt-in via the env var, so other jobs are unaffected.\n\n## Test plan\n\n- [x] Defend Workflows CI jobs log the cache clear + disk space and stay\ngreen.\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e2fc6657be444a7aea8df4b3bfff3421c26c7039","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","backport:all-open","v9.6.0"],"title":"[CI] Clear yarn cache on defend workflows agents post-bootstrap","number":278876,"url":"https://github.com/elastic/kibana/pull/278876","mergeCommit":{"message":"[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)\n\n## Summary\n\nFree disk space on the disk-constrained Defend Workflows CI agents by\nclearing the global yarn cache after bootstrap.\n\n- Adds `CLEAR_YARN_CACHE: '1'` env to all Defend Workflows jobs across\nthe pipelines.\n- `.buildkite/scripts/bootstrap.sh` deletes\n`/opt/buildkite-agent/.cache/yarn` when `CLEAR_YARN_CACHE` is set, then\nprints available disk space (`df -h .`).\n\nOpt-in via the env var, so other jobs are unaffected.\n\n## Test plan\n\n- [x] Defend Workflows CI jobs log the cache clear + disk space and stay\ngreen.\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e2fc6657be444a7aea8df4b3bfff3421c26c7039"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278876","number":278876,"mergeCommit":{"message":"[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)\n\n## Summary\n\nFree disk space on the disk-constrained Defend Workflows CI agents by\nclearing the global yarn cache after bootstrap.\n\n- Adds `CLEAR_YARN_CACHE: '1'` env to all Defend Workflows jobs across\nthe pipelines.\n- `.buildkite/scripts/bootstrap.sh` deletes\n`/opt/buildkite-agent/.cache/yarn` when `CLEAR_YARN_CACHE` is set, then\nprints available disk space (`df -h .`).\n\nOpt-in via the env var, so other jobs are unaffected.\n\n## Test plan\n\n- [x] Defend Workflows CI jobs log the cache clear + disk space and stay\ngreen.\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e2fc6657be444a7aea8df4b3bfff3421c26c7039"}},{"url":"https://github.com/elastic/kibana/pull/279139","number":279139,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->