### PR TITLE
[Entity Analytics] Fix truncated table cells

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/helpers.ts
@@ -49,11 +49,54 @@ export interface TableEntityRow {
   entity: Record<string, unknown>;
 }
 
+/**
+ * Truncates cell content with an ellipsis within the table column bounds.
+ * Apply to the text-bearing element (`EuiText` / `EuiLink`).
+ *
+ * For `EuiToolTip` + `EuiLink`: the tooltip defaults to inline-block and
+ * shrink-wraps to the full string, so `width: 100%` on the link alone is
+ * useless. Constrain the anchor with `fullWidthCellCss` (size only), and put
+ * this helper on the link (ellipsis on the text).
+ */
 export const truncatedCellCss = css`
-  max-width: 150px;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+/**
+ * Makes a wrapper (e.g. tooltip anchor) fill the table cell width so a child
+ * with truncatedCellCss has a definite containing block. No ellipsis here —
+ * that belongs on the text-bearing child.
+ */
+export const fullWidthCellCss = css`
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+`;
+
+/**
+ * Primary name + icon row: the flex container's default min-width is the
+ * content size, so it overflows the cell unless it is forced to the cell
+ * width. Apply to the EuiFlexGroup.
+ */
+export const truncatedFlexGroupCss = css`
+  width: 100%;
+  min-width: 0;
+`;
+
+/**
+ * Primary name + icon row: flex items default to min-width: auto and will not
+ * shrink below the text width. Apply to the name EuiFlexItem so truncatedCellCss
+ * on the child can ellipsize.
+ */
+export const truncatedFlexItemCss = css`
+  min-width: 0;
 `;
 
 export const getEntityLastSeen = (entity: Record<string, unknown>): string | undefined => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/helpers.ts
@@ -49,15 +49,7 @@ export interface TableEntityRow {
   entity: Record<string, unknown>;
 }
 
-/**
- * Truncates cell content with an ellipsis within the table column bounds.
- * Apply to the text-bearing element (`EuiText` / `EuiLink`).
- *
- * For `EuiToolTip` + `EuiLink`: the tooltip defaults to inline-block and
- * shrink-wraps to the full string, so `width: 100%` on the link alone is
- * useless. Constrain the anchor with `fullWidthCellCss` (size only), and put
- * this helper on the link (ellipsis on the text).
- */
+/** Ellipsis truncation for text-bearing cell content (`EuiText` / `EuiLink`). */
 export const truncatedCellCss = css`
   display: block;
   width: 100%;
@@ -68,33 +60,13 @@ export const truncatedCellCss = css`
   white-space: nowrap;
 `;
 
-/**
- * Makes a wrapper (e.g. tooltip anchor) fill the table cell width so a child
- * with truncatedCellCss has a definite containing block. No ellipsis here —
- * that belongs on the text-bearing child.
- */
-export const fullWidthCellCss = css`
-  display: block;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-`;
-
-/**
- * Primary name + icon row: the flex container's default min-width is the
- * content size, so it overflows the cell unless it is forced to the cell
- * width. Apply to the EuiFlexGroup.
- */
-export const truncatedFlexGroupCss = css`
+/** Sizes a container to the cell width so a truncated child can ellipsize (tooltip anchor, flex group). */
+export const truncatedContainerCss = css`
   width: 100%;
   min-width: 0;
 `;
 
-/**
- * Primary name + icon row: flex items default to min-width: auto and will not
- * shrink below the text width. Apply to the name EuiFlexItem so truncatedCellCss
- * on the child can ellipsize.
- */
+/** Allows an `EuiFlexItem` to shrink below its content width so a child can ellipsize. */
 export const truncatedFlexItemCss = css`
   min-width: 0;
 `;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
@@ -25,6 +25,9 @@ import {
   getEntitySource,
   getEntityRiskScore,
   truncatedCellCss,
+  fullWidthCellCss,
+  truncatedFlexGroupCss,
+  truncatedFlexItemCss,
   type TableEntityRow,
 } from './helpers';
 import {
@@ -143,10 +146,10 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
 
           const nameContent =
             onEntityNameClick && !isCurrentEntity && !showActions ? (
-              <EuiToolTip content={name}>
-                <EuiText size="xs" css={truncatedCellCss}>
-                  <EuiLink onClick={() => onEntityNameClick(entity)}>{name}</EuiLink>
-                </EuiText>
+              <EuiToolTip content={name} anchorProps={{ css: fullWidthCellCss }}>
+                <EuiLink css={truncatedCellCss} onClick={() => onEntityNameClick(entity)}>
+                  {name}
+                </EuiLink>
               </EuiToolTip>
             ) : (
               <EuiText size="xs" css={truncatedCellCss}>
@@ -160,11 +163,9 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
                 gutterSize="xs"
                 alignItems="center"
                 responsive={false}
-                css={truncatedCellCss}
+                css={truncatedFlexGroupCss}
               >
-                <EuiFlexItem grow={false} css={truncatedCellCss}>
-                  {nameContent}
-                </EuiFlexItem>
+                <EuiFlexItem css={truncatedFlexItemCss}>{nameContent}</EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiIconTip
                     content={TARGET_ENTITY_TOOLTIP}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
@@ -25,8 +25,7 @@ import {
   getEntitySource,
   getEntityRiskScore,
   truncatedCellCss,
-  fullWidthCellCss,
-  truncatedFlexGroupCss,
+  truncatedContainerCss,
   truncatedFlexItemCss,
   type TableEntityRow,
 } from './helpers';
@@ -146,16 +145,20 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
 
           const nameContent =
             onEntityNameClick && !isCurrentEntity && !showActions ? (
-              <EuiToolTip content={name} anchorProps={{ css: fullWidthCellCss }}>
-                <EuiLink css={truncatedCellCss} onClick={() => onEntityNameClick(entity)}>
-                  {name}
-                </EuiLink>
-              </EuiToolTip>
+              <EuiLink css={truncatedCellCss} onClick={() => onEntityNameClick(entity)}>
+                {name}
+              </EuiLink>
             ) : (
               <EuiText size="xs" css={truncatedCellCss}>
                 {name}
               </EuiText>
             );
+
+          const nameWithTooltip = (
+            <EuiToolTip display="block" content={name} anchorProps={{ css: truncatedContainerCss }}>
+              {nameContent}
+            </EuiToolTip>
+          );
 
           if (isTarget) {
             return (
@@ -163,9 +166,9 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
                 gutterSize="xs"
                 alignItems="center"
                 responsive={false}
-                css={truncatedFlexGroupCss}
+                css={truncatedContainerCss}
               >
-                <EuiFlexItem css={truncatedFlexItemCss}>{nameContent}</EuiFlexItem>
+                <EuiFlexItem css={truncatedFlexItemCss}>{nameWithTooltip}</EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiIconTip
                     content={TARGET_ENTITY_TOOLTIP}
@@ -178,7 +181,7 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
             );
           }
 
-          return nameContent;
+          return nameWithTooltip;
         },
       },
       {


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/275525


The table showed plain text truncating while `EuiLink` did not. fix is to apply the truncation CSS to the element that renders the text (the link, and the tooltip anchor when present). 

| before  | after |
|---|---|
| <img width="1084" height="490" alt="621900373-d1e0594b-7b4c-4a21-9d4c-c2b7daa501c5-1" src="https://github.com/user-attachments/assets/9d3524a0-638f-4cdb-888b-db21bd369448" /> | <img width="621" height="224" alt="Screenshot 2026-07-20 at 13 40 51" src="https://github.com/user-attachments/assets/ada999e3-5345-4b1e-9c51-534733311e40" />  |



also replaced the fixed `150px` max-width with sizing to the container so ellipsis can use a real, actual width, derived from table cells via fixed layout + `width: 100%` and the primary name+icon row via `min-width: 0` on the flex item so it can shrink.

verified all `truncatedCellCss` usages still work properly: 
- `ResolutionGroupTable.ENTITY_NAME_COLUMN`
- `ResolutionGroupTable.ENTITY_ID_COLUMN` 
- `ResolutionGroupTable.SOURCE_COLUMN`

- `AddEntitiesSection.ENTITY_NAME_COLUMN`
- `AddEntitiesSection.ENTITY_ID_COLUMN`
- `AddEntitiesSection.SOURCE_COLUMN`

except `AddEntitiesSection.LAST_SEEN_COLUMN`, which doesn't seem to to be working anyway, as `FormattedRelativePreferenceDate` does not apply the css helper, and it has many consumers, so out of scope for this PR. 


all truncated usages:
<img width="1443" height="725" alt="image" src="https://github.com/user-attachments/assets/d32f3c66-36b4-426e-b00d-957f53a58309" />






<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->