### PR TITLE
[Cases] Polish redesign custom fields UX; gate pre-migration fields behind switch

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -17,7 +17,7 @@ pageLoadAssetSize:
   automaticImport: 18629
   banners: 4006
   canvas: 14881
-  cases: 284574
+  cases: 310000
   charts: 40269
   cloud: 11743
   cloudConnect: 9149

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -17,7 +17,7 @@ pageLoadAssetSize:
   automaticImport: 18629
   banners: 4006
   canvas: 14881
-  cases: 242617
+  cases: 284574
   charts: 40269
   cloud: 11743
   cloudConnect: 9149

--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -15802,7 +15802,6 @@
     "xpack.cases.create.confirmModalButton": "Beenden ohne zu speichern",
     "xpack.cases.create.createCaseFlyoutAriaLabel": "Ticket erstellen",
     "xpack.cases.create.defaultEmptyTemplateName": "Keine Vorlage ausgewählt",
-    "xpack.cases.create.extendedFieldsTitle": "Erweiterte Felder",
     "xpack.cases.create.invalidAssignees": "Sie können einem Fall nicht mehr als {maxAssignees} Zuständige zuweisen.",
     "xpack.cases.create.modalTitle": "Fall verwerfen?",
     "xpack.cases.create.solutionSelectorLabel": "Fall erstellen unter:",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -15782,7 +15782,6 @@
     "xpack.cases.create.confirmModalButton": "Quitter sans enregistrer",
     "xpack.cases.create.createCaseFlyoutAriaLabel": "Créer un cas",
     "xpack.cases.create.defaultEmptyTemplateName": "Aucun modèle sélectionné",
-    "xpack.cases.create.extendedFieldsTitle": "Champs étendus",
     "xpack.cases.create.invalidAssignees": "Vous ne pouvez pas affecter plus de {maxAssignees} utilisateurs à un cas.",
     "xpack.cases.create.modalTitle": "Abandonner le cas ?",
     "xpack.cases.create.solutionSelectorLabel": "Créer un cas sous :",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -15855,7 +15855,6 @@
     "xpack.cases.create.confirmModalButton": "保存せずに終了",
     "xpack.cases.create.createCaseFlyoutAriaLabel": "ケースを作成",
     "xpack.cases.create.defaultEmptyTemplateName": "テンプレートが選択されていません",
-    "xpack.cases.create.extendedFieldsTitle": "拡張フィールド",
     "xpack.cases.create.invalidAssignees": "ケースに割り当てられる担当者は{maxAssignees}人以下です。",
     "xpack.cases.create.modalTitle": "ケースを破棄しますか？",
     "xpack.cases.create.solutionSelectorLabel": "次の下にケースを作成：",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -15856,7 +15856,6 @@
     "xpack.cases.create.confirmModalButton": "退出而不保存",
     "xpack.cases.create.createCaseFlyoutAriaLabel": "创建案例",
     "xpack.cases.create.defaultEmptyTemplateName": "未选择模板",
-    "xpack.cases.create.extendedFieldsTitle": "扩展字段",
     "xpack.cases.create.invalidAssignees": "无法向案例分配超过 {maxAssignees} 个被分配人。",
     "xpack.cases.create.modalTitle": "丢弃案例？",
     "xpack.cases.create.solutionSelectorLabel": "在以下项下面创建案例：",

--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -303,6 +303,7 @@ export const LOCAL_STORAGE_KEYS = {
   casesUtilityBarHideMaxLimitWarning: 'cases.utilityBar.hideMaxLimitWarning',
   caseViewSidebarOpen: 'cases.caseView.sidebarOpen',
   caseViewSidebarAccordions: 'cases.caseView.sidebarAccordions',
+  showLegacyCustomFields: 'cases.showLegacyCustomFields',
 };
 
 /**

--- a/x-pack/platform/plugins/shared/cases/public/common/navigation/__mocks__/hooks.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/navigation/__mocks__/hooks.ts
@@ -32,6 +32,11 @@ export const useCasesTemplatesNavigation = jest.fn().mockReturnValue({
   navigateToCasesTemplates: jest.fn(),
 });
 
+export const useCasesFieldLibraryNavigation = jest.fn().mockReturnValue({
+  getCasesFieldLibraryUrl: jest.fn().mockReturnValue('/app/security/cases/configure/field_library'),
+  navigateToCasesFieldLibrary: jest.fn(),
+});
+
 export const useUrlParams = jest.fn().mockReturnValue({
   urlParams: {},
   toUrlParams: jest.fn(),

--- a/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.test.ts
@@ -7,8 +7,34 @@
 
 import { renderHook, act } from '@testing-library/react';
 import { TestProviders } from './mock/test_providers';
-import { useShowLegacyCustomFields } from './use_show_old_custom_fields';
+import {
+  hasRequiredCustomFieldsWithoutDefault,
+  useShowLegacyCustomFields,
+} from './use_show_old_custom_fields';
 import { LOCAL_STORAGE_KEYS } from '../../common/constants';
+
+describe('hasRequiredCustomFieldsWithoutDefault', () => {
+  it('returns false when there are no required fields without defaults', () => {
+    expect(hasRequiredCustomFieldsWithoutDefault([])).toBe(false);
+    expect(
+      hasRequiredCustomFieldsWithoutDefault([
+        { required: false },
+        { required: true, defaultValue: 'x' },
+        { required: true, defaultValue: 0 },
+        { required: true, defaultValue: false },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns true when a required field has no default', () => {
+    expect(
+      hasRequiredCustomFieldsWithoutDefault([
+        { required: true },
+        { required: true, defaultValue: null },
+      ])
+    ).toBe(true);
+  });
+});
 
 describe('useShowLegacyCustomFields', () => {
   const lsKey = `securitySolution.${LOCAL_STORAGE_KEYS.showLegacyCustomFields}`;
@@ -23,6 +49,7 @@ describe('useShowLegacyCustomFields', () => {
     });
 
     expect(result.current.showLegacyCustomFields).toBe(false);
+    expect(result.current.canDisableSwitch).toBe(true);
   });
 
   it('persists when toggled on', () => {
@@ -46,5 +73,22 @@ describe('useShowLegacyCustomFields', () => {
     });
 
     expect(result.current.showLegacyCustomFields).toBe(true);
+  });
+
+  it('forces the switch on when required fields lack defaults', () => {
+    const { result } = renderHook(
+      () => useShowLegacyCustomFields([{ required: true, defaultValue: null }]),
+      { wrapper: TestProviders }
+    );
+
+    expect(result.current.showLegacyCustomFields).toBe(true);
+    expect(result.current.canDisableSwitch).toBe(false);
+
+    act(() => {
+      result.current.setShowLegacyCustomFields(false);
+    });
+
+    expect(result.current.showLegacyCustomFields).toBe(true);
+    expect(result.current.canDisableSwitch).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { TestProviders } from './mock/test_providers';
+import { useShowLegacyCustomFields } from './use_show_old_custom_fields';
+import { LOCAL_STORAGE_KEYS } from '../../common/constants';
+
+describe('useShowLegacyCustomFields', () => {
+  const lsKey = `securitySolution.${LOCAL_STORAGE_KEYS.showLegacyCustomFields}`;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to false', () => {
+    const { result } = renderHook(() => useShowLegacyCustomFields(), {
+      wrapper: TestProviders,
+    });
+
+    expect(result.current.showLegacyCustomFields).toBe(false);
+  });
+
+  it('persists when toggled on', () => {
+    const { result } = renderHook(() => useShowLegacyCustomFields(), {
+      wrapper: TestProviders,
+    });
+
+    act(() => {
+      result.current.setShowLegacyCustomFields(true);
+    });
+
+    expect(result.current.showLegacyCustomFields).toBe(true);
+    expect(localStorage.getItem(lsKey)).toBe('true');
+  });
+
+  it('reads an existing local storage value', () => {
+    localStorage.setItem(lsKey, 'true');
+
+    const { result } = renderHook(() => useShowLegacyCustomFields(), {
+      wrapper: TestProviders,
+    });
+
+    expect(result.current.showLegacyCustomFields).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.ts
@@ -5,22 +5,64 @@
  * 2.0.
  */
 
+import { useCallback } from 'react';
 import { LOCAL_STORAGE_KEYS } from '../../common/constants';
 import { useCasesLocalStorage } from './use_cases_local_storage';
+
+interface LegacyCustomFieldLike {
+  required: boolean;
+  defaultValue?: string | number | boolean | null;
+}
+
+/**
+ * Required legacy custom fields without a configured default must remain visible
+ * on create (server rejects the case otherwise). Matches
+ * `validateRequiredCustomFields` in server/client/cases/validators.ts.
+ */
+export const hasRequiredCustomFieldsWithoutDefault = (
+  customFields: readonly LegacyCustomFieldLike[]
+): boolean =>
+  customFields.some(
+    (field) => field.required && (field.defaultValue === undefined || field.defaultValue === null)
+  );
 
 /**
  * Local-storage-backed switch that gates visibility of legacy (pre-migration)
  * custom fields and templates across Settings, Create Case, and Case Details.
  * Defaults to OFF. Scoped per owner via `useCasesLocalStorage`.
+ *
+ * When `customFields` includes required fields without defaults, the switch is
+ * forced ON and cannot be turned off until those fields are fixed.
  */
-export const useShowLegacyCustomFields = (): {
+export const useShowLegacyCustomFields = (
+  customFields: readonly LegacyCustomFieldLike[] = []
+): {
   showLegacyCustomFields: boolean;
   setShowLegacyCustomFields: (value: boolean | ((prev: boolean) => boolean)) => void;
+  canDisableSwitch: boolean;
 } => {
-  const [showLegacyCustomFields, setShowLegacyCustomFields] = useCasesLocalStorage<boolean>(
+  const [storedValue, setStoredValue] = useCasesLocalStorage<boolean>(
     LOCAL_STORAGE_KEYS.showLegacyCustomFields,
     false
   );
 
-  return { showLegacyCustomFields, setShowLegacyCustomFields };
+  const mustShow = hasRequiredCustomFieldsWithoutDefault(customFields);
+  const showLegacyCustomFields = mustShow || storedValue;
+
+  const setShowLegacyCustomFields = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      const resolved = typeof value === 'function' ? value(storedValue) : value;
+      if (mustShow && !resolved) {
+        return;
+      }
+      setStoredValue(resolved);
+    },
+    [mustShow, setStoredValue, storedValue]
+  );
+
+  return {
+    showLegacyCustomFields,
+    setShowLegacyCustomFields,
+    canDisableSwitch: !mustShow,
+  };
 };

--- a/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_show_old_custom_fields.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LOCAL_STORAGE_KEYS } from '../../common/constants';
+import { useCasesLocalStorage } from './use_cases_local_storage';
+
+/**
+ * Local-storage-backed switch that gates visibility of legacy (pre-migration)
+ * custom fields and templates across Settings, Create Case, and Case Details.
+ * Defaults to OFF. Scoped per owner via `useCasesLocalStorage`.
+ */
+export const useShowLegacyCustomFields = (): {
+  showLegacyCustomFields: boolean;
+  setShowLegacyCustomFields: (value: boolean | ((prev: boolean) => boolean)) => void;
+} => {
+  const [showLegacyCustomFields, setShowLegacyCustomFields] = useCasesLocalStorage<boolean>(
+    LOCAL_STORAGE_KEYS.showLegacyCustomFields,
+    false
+  );
+
+  return { showLegacyCustomFields, setShowLegacyCustomFields };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.test.tsx
@@ -58,6 +58,7 @@ describe('CustomFields', () => {
     );
 
     expect(await screen.findByTestId('legacy-custom-fields-deprecated-badge')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Legacy custom fields');
   });
 
   it('should not show the custom fields if the configuration is empty', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.test.tsx
@@ -37,6 +37,7 @@ describe('CustomFields', () => {
     );
 
     expect(await screen.findByTestId('caseCustomFields')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-custom-fields-deprecated-badge')).not.toBeInTheDocument();
 
     const cf0 = customFieldsConfigurationMock[0];
     const cf1 = customFieldsConfigurationMock[1];
@@ -47,6 +48,16 @@ describe('CustomFields', () => {
     expect(
       await screen.findByTestId(`${cf1.key}-${cf1.type}-create-custom-field`)
     ).toBeInTheDocument();
+  });
+
+  it('renders the deprecated badge next to the heading when requested', async () => {
+    renderWithTestingProviders(
+      <FormTestComponent onSubmit={onSubmit}>
+        <CustomFields {...defaultProps} showDeprecatedBadge />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('legacy-custom-fields-deprecated-badge')).toBeInTheDocument();
   });
 
   it('should not show the custom fields if the configuration is empty', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.tsx
@@ -6,8 +6,9 @@
  */
 
 import React, { useMemo } from 'react';
+import type { ReactNode } from 'react';
 import { sortBy } from 'lodash';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiFormRow } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiFormRow } from '@elastic/eui';
 
 import type { CasesConfigurationUI } from '../../../common/ui';
 import { builderMap as customFieldsBuilderMap } from '../custom_fields/builder';
@@ -18,6 +19,10 @@ interface Props {
   configurationCustomFields: CasesConfigurationUI['customFields'];
   setCustomFieldsOptional?: boolean;
   isEditMode?: boolean;
+  /** Renders a Deprecated badge next to the "Custom fields" heading. */
+  showDeprecatedBadge?: boolean;
+  /** Rendered below the "Custom fields" heading (e.g. deprecation callout). */
+  notice?: ReactNode;
 }
 
 const CustomFieldsComponent: React.FC<Props> = ({
@@ -25,6 +30,8 @@ const CustomFieldsComponent: React.FC<Props> = ({
   setCustomFieldsOptional = false,
   configurationCustomFields,
   isEditMode,
+  showDeprecatedBadge = false,
+  notice,
 }) => {
   const sortedCustomFields = useMemo(
     () => sortCustomFieldsByLabel(configurationCustomFields),
@@ -57,9 +64,26 @@ const CustomFieldsComponent: React.FC<Props> = ({
   return (
     <EuiFormRow fullWidth>
       <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiText size="m">
-          <h3>{i18n.CUSTOM_FIELDS}</h3>
-        </EuiText>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiText size="m">
+              <h3>{i18n.CUSTOM_FIELDS}</h3>
+            </EuiText>
+          </EuiFlexItem>
+          {showDeprecatedBadge ? (
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="warning" data-test-subj="legacy-custom-fields-deprecated-badge">
+                {i18n.DEPRECATED_BADGE}
+              </EuiBadge>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+        {notice ? (
+          <>
+            <EuiSpacer size="s" />
+            {notice}
+          </>
+        ) : null}
         <EuiSpacer size="xs" />
         <EuiFlexItem data-test-subj="caseCustomFields">{customFieldsComponents}</EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/custom_fields.tsx
@@ -19,9 +19,9 @@ interface Props {
   configurationCustomFields: CasesConfigurationUI['customFields'];
   setCustomFieldsOptional?: boolean;
   isEditMode?: boolean;
-  /** Renders a Deprecated badge next to the "Custom fields" heading. */
+  /** Renders a Deprecated badge and "Legacy custom fields" heading. */
   showDeprecatedBadge?: boolean;
-  /** Rendered below the "Custom fields" heading (e.g. deprecation callout). */
+  /** Rendered below the section heading (e.g. deprecation callout). */
   notice?: ReactNode;
 }
 
@@ -61,13 +61,17 @@ const CustomFieldsComponent: React.FC<Props> = ({
     return null;
   }
 
+  const sectionTitle = showDeprecatedBadge
+    ? i18n.LEGACY_CUSTOM_FIELDS_SECTION_TITLE
+    : i18n.CUSTOM_FIELDS;
+
   return (
     <EuiFormRow fullWidth>
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiText size="m">
-              <h3>{i18n.CUSTOM_FIELDS}</h3>
+              <h3>{sectionTitle}</h3>
             </EuiText>
           </EuiFlexItem>
           {showDeprecatedBadge ? (

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
@@ -23,6 +23,7 @@ jest.mock('../../containers/user_profiles/api');
 jest.mock('../create/template_fields', () => ({
   CreateCaseTemplateFields: () => <div data-test-subj="create-case-template-fields" />,
 }));
+jest.mock('../../common/navigation/hooks');
 
 describe('CaseFormFields', () => {
   let user: UserEvent;
@@ -45,6 +46,8 @@ describe('CaseFormFields', () => {
   beforeEach(() => {
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    localStorage.clear();
+    jest.spyOn(KibanaServices, 'getConfig').mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -379,6 +382,58 @@ describe('CaseFormFields', () => {
       );
 
       expect(await screen.findByTestId('create-case-template-fields')).toBeInTheDocument();
+    });
+
+    it('does not render legacy custom fields when templates v2 is enabled and the switch is off', () => {
+      jest
+        .spyOn(KibanaServices, 'getConfig')
+        .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+          typeof KibanaServices.getConfig
+        >);
+
+      renderWithTestingProviders(
+        <FormTestComponent formDefaultValue={formDefaultValue} onSubmit={onSubmit}>
+          <CaseFormFields
+            isLoading={false}
+            configurationCustomFields={customFieldsConfigurationMock}
+          />
+        </FormTestComponent>
+      );
+
+      expect(screen.queryByTestId('caseCustomFields')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('legacy-custom-fields-deprecation-callout')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('legacy-custom-fields-divider')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('legacy-custom-fields-deprecated-badge')).not.toBeInTheDocument();
+    });
+
+    it('renders legacy custom fields, badge, callout, and divider when the switch is on', async () => {
+      jest
+        .spyOn(KibanaServices, 'getConfig')
+        .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+          typeof KibanaServices.getConfig
+        >);
+      localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'true');
+
+      renderWithTestingProviders(
+        <FormTestComponent formDefaultValue={formDefaultValue} onSubmit={onSubmit}>
+          <CaseFormFields
+            isLoading={false}
+            configurationCustomFields={customFieldsConfigurationMock}
+          />
+        </FormTestComponent>
+      );
+
+      expect(await screen.findByTestId('caseCustomFields')).toBeInTheDocument();
+      expect(
+        await screen.findByTestId('legacy-custom-fields-deprecated-badge')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByTestId('legacy-custom-fields-deprecation-callout')
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
+      expect(screen.getByTestId('legacy-custom-fields-divider')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.test.tsx
@@ -433,7 +433,36 @@ describe('CaseFormFields', () => {
         await screen.findByTestId('legacy-custom-fields-deprecation-callout')
       ).toBeInTheDocument();
       expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
+      expect(screen.getByTestId('legacy-custom-fields-view-settings-link')).toBeInTheDocument();
       expect(screen.getByTestId('legacy-custom-fields-divider')).toBeInTheDocument();
+    });
+
+    it('forces legacy custom fields visible when required fields lack defaults', async () => {
+      jest
+        .spyOn(KibanaServices, 'getConfig')
+        .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+          typeof KibanaServices.getConfig
+        >);
+
+      renderWithTestingProviders(
+        <FormTestComponent formDefaultValue={formDefaultValue} onSubmit={onSubmit}>
+          <CaseFormFields
+            isLoading={false}
+            configurationCustomFields={[
+              {
+                ...customFieldsConfigurationMock[0],
+                required: true,
+                defaultValue: undefined,
+              },
+            ]}
+          />
+        </FormTestComponent>
+      );
+
+      expect(await screen.findByTestId('caseCustomFields')).toBeInTheDocument();
+      expect(
+        await screen.findByTestId('legacy-custom-fields-deprecation-callout')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
@@ -52,7 +52,9 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
         configurationCustomFields={configurationCustomFields}
         isEditMode={isEditMode}
       />
-      {isTemplatesV2Enabled && <CreateCaseTemplateFields />}
+      {isTemplatesV2Enabled && (
+        <CreateCaseTemplateFields hasLegacyCustomFields={configurationCustomFields.length > 0} />
+      )}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { memo } from 'react';
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiCallOut, EuiFlexGroup, EuiHorizontalRule, EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { Title } from './title';
 import { Tags } from './tags';
 import { Category } from './category';
@@ -18,6 +19,9 @@ import { CustomFields } from './custom_fields';
 import type { CasesConfigurationUI } from '../../containers/types';
 import { KibanaServices } from '../../common/lib/kibana';
 import { CreateCaseTemplateFields } from '../create/template_fields';
+import { useShowLegacyCustomFields } from '../../common/use_show_old_custom_fields';
+import { useCasesFieldLibraryNavigation } from '../../common/navigation';
+import * as i18n from './translations';
 
 interface Props {
   isLoading: boolean;
@@ -35,8 +39,40 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
   draftStorageKey,
 }) => {
   const { caseAssignmentAuthorized } = useCasesFeatures();
-  const config = KibanaServices.getConfig();
-  const isTemplatesV2Enabled = config?.templates?.enabled ?? false;
+  const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
+  const { showLegacyCustomFields } = useShowLegacyCustomFields();
+  const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
+
+  // When templates v2 is off, always show legacy custom fields (they are the only system).
+  // When templates v2 is on, gate visibility behind the settings local-storage switch.
+  const showLegacyCustomFieldsInputs =
+    configurationCustomFields.length > 0 && (!isTemplatesV2Enabled || showLegacyCustomFields);
+
+  const deprecationNotice = isTemplatesV2Enabled ? (
+    <EuiCallOut
+      announceOnMount
+      color="warning"
+      iconType="warning"
+      size="s"
+      data-test-subj="legacy-custom-fields-deprecation-callout"
+    >
+      <FormattedMessage
+        id="xpack.cases.caseFormFields.legacyCustomFieldsDeprecationBody"
+        defaultMessage="{message} {link}"
+        values={{
+          message: i18n.LEGACY_CUSTOM_FIELDS_DEPRECATION_MESSAGE,
+          link: (
+            <EuiLink
+              href={getCasesFieldLibraryUrl()}
+              data-test-subj="legacy-custom-fields-view-new-link"
+            >
+              {i18n.LEGACY_CUSTOM_FIELDS_VIEW_NEW}
+            </EuiLink>
+          ),
+        }}
+      />
+    </EuiCallOut>
+  ) : undefined;
 
   return (
     <EuiFlexGroup data-test-subj="case-form-fields" direction="column" gutterSize="none">
@@ -46,14 +82,21 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
       <Category isLoading={isLoading} />
       <Severity isLoading={isLoading} />
       <Description isLoading={isLoading} draftStorageKey={draftStorageKey} />
-      <CustomFields
-        isLoading={isLoading}
-        setCustomFieldsOptional={setCustomFieldsOptional}
-        configurationCustomFields={configurationCustomFields}
-        isEditMode={isEditMode}
-      />
+      {showLegacyCustomFieldsInputs ? (
+        <>
+          <CustomFields
+            isLoading={isLoading}
+            setCustomFieldsOptional={setCustomFieldsOptional}
+            configurationCustomFields={configurationCustomFields}
+            isEditMode={isEditMode}
+            showDeprecatedBadge={isTemplatesV2Enabled}
+            notice={deprecationNotice}
+          />
+          <EuiHorizontalRule margin="l" data-test-subj="legacy-custom-fields-divider" />
+        </>
+      ) : null}
       {isTemplatesV2Enabled && (
-        <CreateCaseTemplateFields hasLegacyCustomFields={configurationCustomFields.length > 0} />
+        <CreateCaseTemplateFields addTopSpacing={!showLegacyCustomFieldsInputs} />
       )}
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
@@ -67,7 +67,6 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
   const deprecationNotice = isTemplatesV2Enabled ? (
     <EuiCallOut
       announceOnMount
-      title={i18n.LEGACY_CUSTOM_FIELDS_CALLOUT_TITLE}
       color="warning"
       iconType="warning"
       size="s"

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
+import React, { memo, useEffect } from 'react';
 import { EuiCallOut, EuiFlexGroup, EuiHorizontalRule, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useFormContext } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { Title } from './title';
 import { Tags } from './tags';
 import { Category } from './category';
@@ -42,11 +43,20 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
   const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
   const { showLegacyCustomFields } = useShowLegacyCustomFields();
   const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
+  const { setFieldValue } = useFormContext();
 
   // When templates v2 is off, always show legacy custom fields (they are the only system).
   // When templates v2 is on, gate visibility behind the settings local-storage switch.
   const showLegacyCustomFieldsInputs =
     configurationCustomFields.length > 0 && (!isTemplatesV2Enabled || showLegacyCustomFields);
+
+  // Drop stale create-form values when the legacy section is gated off so they cannot linger
+  // in form state. Edit mode keeps case custom fields intact.
+  useEffect(() => {
+    if (!isEditMode && !showLegacyCustomFieldsInputs) {
+      setFieldValue('customFields', {});
+    }
+  }, [isEditMode, showLegacyCustomFieldsInputs, setFieldValue]);
 
   const deprecationNotice = isTemplatesV2Enabled ? (
     <EuiCallOut

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/index.tsx
@@ -21,8 +21,12 @@ import type { CasesConfigurationUI } from '../../containers/types';
 import { KibanaServices } from '../../common/lib/kibana';
 import { CreateCaseTemplateFields } from '../create/template_fields';
 import { useShowLegacyCustomFields } from '../../common/use_show_old_custom_fields';
-import { useCasesFieldLibraryNavigation } from '../../common/navigation';
+import {
+  useCasesFieldLibraryNavigation,
+  useConfigureCasesNavigation,
+} from '../../common/navigation';
 import * as i18n from './translations';
+import * as configureCasesI18n from '../configure_cases/translations';
 
 interface Props {
   isLoading: boolean;
@@ -41,12 +45,14 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
 }) => {
   const { caseAssignmentAuthorized } = useCasesFeatures();
   const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
-  const { showLegacyCustomFields } = useShowLegacyCustomFields();
+  const { showLegacyCustomFields } = useShowLegacyCustomFields(configurationCustomFields);
   const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
+  const { getConfigureCasesUrl } = useConfigureCasesNavigation();
   const { setFieldValue } = useFormContext();
 
   // When templates v2 is off, always show legacy custom fields (they are the only system).
-  // When templates v2 is on, gate visibility behind the settings local-storage switch.
+  // When templates v2 is on, gate visibility behind the settings local-storage switch
+  // (forced on when required fields lack defaults).
   const showLegacyCustomFieldsInputs =
     configurationCustomFields.length > 0 && (!isTemplatesV2Enabled || showLegacyCustomFields);
 
@@ -61,6 +67,7 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
   const deprecationNotice = isTemplatesV2Enabled ? (
     <EuiCallOut
       announceOnMount
+      title={i18n.LEGACY_CUSTOM_FIELDS_CALLOUT_TITLE}
       color="warning"
       iconType="warning"
       size="s"
@@ -68,15 +75,23 @@ const CaseFormFieldsComponent: React.FC<Props> = ({
     >
       <FormattedMessage
         id="xpack.cases.caseFormFields.legacyCustomFieldsDeprecationBody"
-        defaultMessage="{message} {link}"
+        defaultMessage='These custom fields are deprecated and have already been migrated to the new system, so you may see the same fields in both places. Manage them in {customFieldsLink}. To stop showing them here, disable "{switchLabel}" in {settingsLink}.'
         values={{
-          message: i18n.LEGACY_CUSTOM_FIELDS_DEPRECATION_MESSAGE,
-          link: (
+          customFieldsLink: (
             <EuiLink
               href={getCasesFieldLibraryUrl()}
               data-test-subj="legacy-custom-fields-view-new-link"
             >
-              {i18n.LEGACY_CUSTOM_FIELDS_VIEW_NEW}
+              {i18n.LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS}
+            </EuiLink>
+          ),
+          switchLabel: configureCasesI18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES,
+          settingsLink: (
+            <EuiLink
+              href={getConfigureCasesUrl()}
+              data-test-subj="legacy-custom-fields-view-settings-link"
+            >
+              {i18n.LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS}
             </EuiLink>
           ),
         }}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/translations.ts
@@ -13,8 +13,8 @@ export const CUSTOM_FIELDS = i18n.translate('xpack.cases.customFields', {
   defaultMessage: 'Custom fields',
 });
 
-export const LEGACY_CUSTOM_FIELDS_CALLOUT_TITLE = i18n.translate(
-  'xpack.cases.caseFormFields.legacyCustomFieldsCalloutTitle',
+export const LEGACY_CUSTOM_FIELDS_SECTION_TITLE = i18n.translate(
+  'xpack.cases.caseFormFields.legacyCustomFieldsSectionTitle',
   {
     defaultMessage: 'Legacy custom fields',
   }

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/translations.ts
@@ -13,18 +13,24 @@ export const CUSTOM_FIELDS = i18n.translate('xpack.cases.customFields', {
   defaultMessage: 'Custom fields',
 });
 
-export const LEGACY_CUSTOM_FIELDS_DEPRECATION_MESSAGE = i18n.translate(
-  'xpack.cases.caseFormFields.legacyCustomFieldsDeprecationMessage',
+export const LEGACY_CUSTOM_FIELDS_CALLOUT_TITLE = i18n.translate(
+  'xpack.cases.caseFormFields.legacyCustomFieldsCalloutTitle',
   {
-    defaultMessage:
-      'These fields are from the previous custom fields system and have already been migrated. You may see the same fields again below — that is expected while both systems are shown.',
+    defaultMessage: 'Legacy custom fields',
   }
 );
 
-export const LEGACY_CUSTOM_FIELDS_VIEW_NEW = i18n.translate(
-  'xpack.cases.caseFormFields.legacyCustomFieldsViewNew',
+export const LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS = i18n.translate(
+  'xpack.cases.caseFormFields.legacyCustomFieldsViewCustomFields',
   {
-    defaultMessage: 'View new custom fields',
+    defaultMessage: 'custom fields',
+  }
+);
+
+export const LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS = i18n.translate(
+  'xpack.cases.caseFormFields.legacyCustomFieldsViewSettings',
+  {
+    defaultMessage: 'settings',
   }
 );
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/translations.ts
@@ -12,3 +12,22 @@ export * from '../../common/translations';
 export const CUSTOM_FIELDS = i18n.translate('xpack.cases.customFields', {
   defaultMessage: 'Custom fields',
 });
+
+export const LEGACY_CUSTOM_FIELDS_DEPRECATION_MESSAGE = i18n.translate(
+  'xpack.cases.caseFormFields.legacyCustomFieldsDeprecationMessage',
+  {
+    defaultMessage:
+      'These fields are from the previous custom fields system and have already been migrated. You may see the same fields again below — that is expected while both systems are shown.',
+  }
+);
+
+export const LEGACY_CUSTOM_FIELDS_VIEW_NEW = i18n.translate(
+  'xpack.cases.caseFormFields.legacyCustomFieldsViewNew',
+  {
+    defaultMessage: 'View new custom fields',
+  }
+);
+
+export const DEPRECATED_BADGE = i18n.translate('xpack.cases.caseFormFields.deprecatedBadge', {
+  defaultMessage: 'Deprecated',
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/custom_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/custom_fields.test.tsx
@@ -85,24 +85,12 @@ describe('Case View Page files tab', () => {
 
     expect(customFields.length).toBe(6);
 
-    expect(await within(customFields[0]).findByRole('heading')).toHaveTextContent(
-      'My test label 1'
-    );
-    expect(await within(customFields[1]).findByRole('heading')).toHaveTextContent(
-      'My test label 2'
-    );
-    expect(await within(customFields[2]).findByRole('heading')).toHaveTextContent(
-      'My test label 3'
-    );
-    expect(await within(customFields[3]).findByRole('heading')).toHaveTextContent(
-      'My test label 4'
-    );
-    expect(await within(customFields[4]).findByRole('heading')).toHaveTextContent(
-      'My test label 5'
-    );
-    expect(await within(customFields[5]).findByRole('heading')).toHaveTextContent(
-      'My test label 6'
-    );
+    expect(await within(customFields[0]).findByText('My test label 1')).toBeInTheDocument();
+    expect(await within(customFields[1]).findByText('My test label 2')).toBeInTheDocument();
+    expect(await within(customFields[2]).findByText('My test label 3')).toBeInTheDocument();
+    expect(await within(customFields[3]).findByText('My test label 4')).toBeInTheDocument();
+    expect(await within(customFields[4]).findByText('My test label 5')).toBeInTheDocument();
+    expect(await within(customFields[5]).findByText('My test label 6')).toBeInTheDocument();
   });
 
   it('pass the permissions to custom fields correctly', async () => {
@@ -117,8 +105,8 @@ describe('Case View Page files tab', () => {
     );
 
     expect(
-      screen.queryByTestId('case-text-custom-field-edit-button-test_key_1')
-    ).not.toBeInTheDocument();
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    ).toBeDisabled();
   });
 
   it('removes extra custom fields', async () => {
@@ -195,16 +183,12 @@ describe('Case View Page files tab', () => {
     );
 
     await userEvent.click(
-      await screen.findByTestId(`case-text-custom-field-edit-button-${customFieldsMock[0].key}`)
-    );
-
-    await userEvent.click(
       await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
     );
     await userEvent.paste('!!!');
 
     await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+      await screen.findByTestId(`template-field-confirm-${customFieldsMock[0].key}`)
     );
 
     await waitFor(() => {
@@ -225,21 +209,19 @@ describe('Case View Page files tab', () => {
       />
     );
 
-    await userEvent.click(
-      await screen.findByTestId(`case-text-custom-field-edit-button-${customFieldsMock[0].key}`)
-    );
-
+    const textFormField = await screen.findByTestId('case-text-custom-field-form-field-test_key_1');
+    expect(textFormField).toHaveValue(customFieldsConfigurationMock[0].defaultValue as string);
     expect(
-      await screen.findByText('This field is populated with the default value.')
+      within(await screen.findByTestId('case-text-custom-field-test_key_1')).getByText(
+        'This field is populated with the default value.'
+      )
     ).toBeInTheDocument();
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.click(textFormField);
     await userEvent.paste(' updated!!');
 
     await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+      await screen.findByTestId(`template-field-confirm-${customFieldsMock[0].key}`)
     );
 
     await waitFor(() => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/custom_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/custom_fields.test.tsx
@@ -100,6 +100,7 @@ describe('Case View Page files tab', () => {
         customFields={customFieldsMock}
         customFieldsConfiguration={customFieldsConfigurationMock}
         onSubmit={onSubmit}
+        editVariant="inline"
       />,
       { wrapperProps: { permissions: readCasesPermissions() } }
     );
@@ -179,6 +180,7 @@ describe('Case View Page files tab', () => {
         customFields={customFieldsMock}
         customFieldsConfiguration={customFieldsConfigurationMock}
         onSubmit={onSubmit}
+        editVariant="inline"
       />
     );
 
@@ -206,6 +208,7 @@ describe('Case View Page files tab', () => {
         customFields={[]}
         customFieldsConfiguration={customFieldsConfigurationMock}
         onSubmit={onSubmit}
+        editVariant="inline"
       />
     );
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/custom_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/custom_fields.tsx
@@ -18,6 +18,8 @@ interface Props {
   customFields: CaseUI['customFields'];
   customFieldsConfiguration: CasesConfigurationUI['customFields'];
   onSubmit: (customField: CaseUICustomField) => void;
+  /** Defaults to classic (legacy case view). Redesign passes `inline`. */
+  editVariant?: 'classic' | 'inline';
 }
 
 const CustomFieldsComponent: React.FC<Props> = ({
@@ -25,6 +27,7 @@ const CustomFieldsComponent: React.FC<Props> = ({
   customFields,
   customFieldsConfiguration,
   onSubmit,
+  editVariant = 'classic',
 }) => {
   const { permissions } = useCasesContext();
   const sortedCustomFieldsConfiguration = useMemo(
@@ -59,6 +62,7 @@ const CustomFieldsComponent: React.FC<Props> = ({
           customFieldConfiguration={customFieldConf}
           customField={customField}
           onSubmit={onSubmitCustomField}
+          editVariant={editVariant}
         />
       </EuiFlexItem>
     );

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.test.tsx
@@ -91,7 +91,7 @@ describe('GlobalCaseFields', () => {
     expect(screen.getByTestId('template-fields-form')).toBeInTheDocument();
   });
 
-  it('does not render an Extended fields heading', () => {
+  it('renders an Extended fields heading by default when there is no active template', () => {
     const caseWithoutTemplate = { ...caseData, template: undefined } as unknown as CaseUI;
     mockUseGetFieldDefinitions.mockReturnValue({
       data: { fieldDefinitions: [makeGlobalDef('incident_type')] },
@@ -99,6 +99,24 @@ describe('GlobalCaseFields', () => {
     });
     mockUseGetTemplate.mockReturnValue({ data: undefined, isLoading: false });
     render(<GlobalCaseFields caseData={caseWithoutTemplate} onUpdateField={globalOnUpdateField} />);
+    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.getByTestId('template-fields-form')).toBeInTheDocument();
+  });
+
+  it('does not render an Extended fields heading when showSectionTitle is false', () => {
+    const caseWithoutTemplate = { ...caseData, template: undefined } as unknown as CaseUI;
+    mockUseGetFieldDefinitions.mockReturnValue({
+      data: { fieldDefinitions: [makeGlobalDef('incident_type')] },
+      isLoading: false,
+    });
+    mockUseGetTemplate.mockReturnValue({ data: undefined, isLoading: false });
+    render(
+      <GlobalCaseFields
+        caseData={caseWithoutTemplate}
+        onUpdateField={globalOnUpdateField}
+        showSectionTitle={false}
+      />
+    );
     expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.getByTestId('template-fields-form')).toBeInTheDocument();
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.test.tsx
@@ -91,7 +91,7 @@ describe('GlobalCaseFields', () => {
     expect(screen.getByTestId('template-fields-form')).toBeInTheDocument();
   });
 
-  it('renders the "Extended fields" heading when there is no active template', () => {
+  it('does not render an Extended fields heading', () => {
     const caseWithoutTemplate = { ...caseData, template: undefined } as unknown as CaseUI;
     mockUseGetFieldDefinitions.mockReturnValue({
       data: { fieldDefinitions: [makeGlobalDef('incident_type')] },
@@ -99,11 +99,11 @@ describe('GlobalCaseFields', () => {
     });
     mockUseGetTemplate.mockReturnValue({ data: undefined, isLoading: false });
     render(<GlobalCaseFields caseData={caseWithoutTemplate} onUpdateField={globalOnUpdateField} />);
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.getByTestId('template-fields-form')).toBeInTheDocument();
   });
 
-  it('does not render the "Extended fields" heading when a template is active', () => {
+  it('renders global fields when a template is active', () => {
     const caseWithTemplate = {
       ...caseData,
       template: { id: 'template-1', version: 1 },

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.tsx
@@ -6,19 +6,25 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiSkeletonText } from '@elastic/eui';
+import { EuiSkeletonText, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { CaseUI } from '../../../../common';
 import type { InlineField } from '../../../../common/types/domain/template/fields';
 import { isRefField } from '../../../../common/types/domain/template/fields';
 import { useGetTemplate } from '../../templates_v2/hooks/use_get_template';
 import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
 import { parseFieldDefinitionsToInlineFields } from '../../../../common/utils';
+import * as i18n from '../translations';
 import type { OnUpdateFields } from '../types';
 import { EMPTY_EXTENDED_FIELDS, TemplateFieldsFormReady } from './template_fields_form_ready';
 
 interface GlobalCaseFieldsProps {
   caseData: CaseUI;
   onUpdateField: (args: OnUpdateFields) => void;
+  /**
+   * When false, skips the "Extended fields" heading (redesign accordion already labels the section).
+   * Defaults to true for the legacy case view.
+   */
+  showSectionTitle?: boolean;
 }
 
 /**
@@ -29,61 +35,77 @@ interface GlobalCaseFieldsProps {
  * name/default overrides.
  * Values are stored in `extended_fields` alongside template-specific fields.
  */
-export const GlobalCaseFields = React.memo<GlobalCaseFieldsProps>(({ caseData, onUpdateField }) => {
-  const {
-    data: globalFieldDefsData,
-    isLoading,
-    isError,
-  } = useGetFieldDefinitions({
-    owner: caseData.owner,
-    isGlobal: true,
-    // Prevent a background refetch from producing a new array reference that would
-    // re-trigger memos and potentially reset an in-progress edit. Same rationale as the
-    // create form (create/template_fields.tsx).
-    staleTime: Infinity,
-  });
+export const GlobalCaseFields = React.memo<GlobalCaseFieldsProps>(
+  ({ caseData, onUpdateField, showSectionTitle = true }) => {
+    const {
+      data: globalFieldDefsData,
+      isLoading,
+      isError,
+    } = useGetFieldDefinitions({
+      owner: caseData.owner,
+      isGlobal: true,
+      // Prevent a background refetch from producing a new array reference that would
+      // re-trigger memos and potentially reset an in-progress edit. Same rationale as the
+      // create form (create/template_fields.tsx).
+      staleTime: Infinity,
+    });
 
-  // React Query deduplicates this fetch — TemplateFields makes the same call.
-  const { data: templateData, isLoading: isLoadingTemplate } = useGetTemplate(
-    caseData.template?.id,
-    caseData.template?.version,
-    { includeDeleted: true }
-  );
+    // React Query deduplicates this fetch — TemplateFields makes the same call.
+    const { data: templateData, isLoading: isLoadingTemplate } = useGetTemplate(
+      caseData.template?.id,
+      caseData.template?.version,
+      { includeDeleted: true }
+    );
 
-  const templateRefNames = useMemo<ReadonlySet<string>>(
-    () => new Set((templateData?.definition.fields ?? []).filter(isRefField).map((f) => f.$ref)),
-    [templateData]
-  );
+    const templateRefNames = useMemo<ReadonlySet<string>>(
+      () => new Set((templateData?.definition.fields ?? []).filter(isRefField).map((f) => f.$ref)),
+      [templateData]
+    );
 
-  const visibleGlobalFields = useMemo<InlineField[]>(
-    () =>
-      parseFieldDefinitionsToInlineFields(globalFieldDefsData?.fieldDefinitions ?? []).filter(
-        (f) => !templateRefNames.has(f.name)
-      ),
-    [globalFieldDefsData, templateRefNames]
-  );
+    const visibleGlobalFields = useMemo<InlineField[]>(
+      () =>
+        parseFieldDefinitionsToInlineFields(globalFieldDefsData?.fieldDefinitions ?? []).filter(
+          (f) => !templateRefNames.has(f.name)
+        ),
+      [globalFieldDefsData, templateRefNames]
+    );
 
-  if (isError) return null;
+    if (isError) return null;
 
-  // Show a skeleton while loading to give visual feedback, but still suppress
-  // render of actual fields until both field definitions and (if a template is
-  // active) the template definition have loaded — this prevents a flash of a
-  // global field that will be filtered out once the template definition arrives.
-  const isDataLoading = isLoading || (!!caseData.template?.id && isLoadingTemplate);
+    // Show a skeleton while loading to give visual feedback, but still suppress
+    // render of actual fields until both field definitions and (if a template is
+    // active) the template definition have loaded — this prevents a flash of a
+    // global field that will be filtered out once the template definition arrives.
+    const isDataLoading = isLoading || (!!caseData.template?.id && isLoadingTemplate);
 
-  if (isDataLoading) {
-    return <EuiSkeletonText data-test-subj="global-case-fields-loading" lines={3} size="m" />;
+    if (isDataLoading) {
+      return <EuiSkeletonText data-test-subj="global-case-fields-loading" lines={3} size="m" />;
+    }
+
+    if (!visibleGlobalFields.length) return null;
+
+    // When there's no active template, TemplateFields renders nothing (no heading).
+    // Provide the section heading here so global fields are labelled in the sidebar.
+    const showHeading = showSectionTitle && !caseData.template?.id;
+
+    return (
+      <>
+        {showHeading && (
+          <>
+            <EuiTitle size="xs">
+              <h3>{i18n.EXTENDED_FIELDS_TITLE}</h3>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <TemplateFieldsFormReady
+          resolvedFields={visibleGlobalFields}
+          extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
+          onUpdateField={onUpdateField}
+        />
+      </>
+    );
   }
-
-  if (!visibleGlobalFields.length) return null;
-
-  return (
-    <TemplateFieldsFormReady
-      resolvedFields={visibleGlobalFields}
-      extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
-      onUpdateField={onUpdateField}
-    />
-  );
-});
+);
 
 GlobalCaseFields.displayName = 'GlobalCaseFields';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/global_case_fields.tsx
@@ -6,14 +6,13 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiSkeletonText, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiSkeletonText } from '@elastic/eui';
 import type { CaseUI } from '../../../../common';
 import type { InlineField } from '../../../../common/types/domain/template/fields';
 import { isRefField } from '../../../../common/types/domain/template/fields';
 import { useGetTemplate } from '../../templates_v2/hooks/use_get_template';
 import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
 import { parseFieldDefinitionsToInlineFields } from '../../../../common/utils';
-import * as i18n from '../translations';
 import type { OnUpdateFields } from '../types';
 import { EMPTY_EXTENDED_FIELDS, TemplateFieldsFormReady } from './template_fields_form_ready';
 
@@ -78,26 +77,12 @@ export const GlobalCaseFields = React.memo<GlobalCaseFieldsProps>(({ caseData, o
 
   if (!visibleGlobalFields.length) return null;
 
-  // When there's no active template, TemplateFields renders nothing (no heading).
-  // Provide the section heading here so global fields are labelled in the sidebar.
-  const showHeading = !caseData.template?.id;
-
   return (
-    <>
-      {showHeading && (
-        <>
-          <EuiTitle size="xs">
-            <h3>{i18n.EXTENDED_FIELDS_TITLE}</h3>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-        </>
-      )}
-      <TemplateFieldsFormReady
-        resolvedFields={visibleGlobalFields}
-        extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
-        onUpdateField={onUpdateField}
-      />
-    </>
+    <TemplateFieldsFormReady
+      resolvedFields={visibleGlobalFields}
+      extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
+      onUpdateField={onUpdateField}
+    />
   );
 });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -87,14 +87,21 @@ describe('TemplateFields', () => {
     });
   });
 
-  it('renders all template fields without an Extended fields heading', () => {
+  it('renders the Extended fields heading and all template fields', () => {
     render(<TemplateFields {...defaultProps} />);
 
-    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
+    expect(screen.getByText('Extended fields')).toBeInTheDocument();
     expect(screen.getByText('Summary')).toBeInTheDocument();
     expect(screen.getByText('Effort')).toBeInTheDocument();
     expect(screen.getByText('Notes')).toBeInTheDocument();
     expect(screen.getByText('Priority')).toBeInTheDocument();
+  });
+
+  it('does not render the Extended fields heading when showHeader is false', () => {
+    render(<TemplateFields {...defaultProps} showHeader={false} />);
+
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
+    expect(screen.getByText('Summary')).toBeInTheDocument();
   });
 
   it('fetches the template with the correct id and version', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -87,21 +87,14 @@ describe('TemplateFields', () => {
     });
   });
 
-  it('renders the Extended fields heading and all template fields', () => {
+  it('renders all template fields without an Extended fields heading', () => {
     render(<TemplateFields {...defaultProps} />);
 
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.getByText('Summary')).toBeInTheDocument();
     expect(screen.getByText('Effort')).toBeInTheDocument();
     expect(screen.getByText('Notes')).toBeInTheDocument();
     expect(screen.getByText('Priority')).toBeInTheDocument();
-  });
-
-  it('does not render the Extended fields heading when showHeader is false', () => {
-    render(<TemplateFields {...defaultProps} showHeader={false} />);
-
-    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
-    expect(screen.getByText('Summary')).toBeInTheDocument();
   });
 
   it('fetches the template with the correct id and version', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
@@ -8,6 +8,7 @@
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import type { z } from '@kbn/zod/v4';
+import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { CaseUI } from '../../../../common';
 import type { ParsedTemplateDefinitionSchema } from '../../../../common/types/domain/template/latest';
 import type { InlineField } from '../../../../common/types/domain/template/fields';
@@ -16,6 +17,7 @@ import { useResolvedFields } from '../../field_library/hooks/use_resolved_fields
 import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
 import { parseFieldDefinitionsToInlineFields } from '../../../../common/utils';
 import { isInlineField } from '../../../../common/types/domain/template/fields';
+import * as i18n from '../translations';
 import type { OnUpdateFields } from '../types';
 import { EMPTY_EXTENDED_FIELDS, TemplateFieldsFormReady } from './template_fields_form_ready';
 
@@ -24,6 +26,11 @@ type ParsedTemplateDefinition = z.infer<typeof ParsedTemplateDefinitionSchema>;
 interface TemplateFieldsProps {
   caseData: CaseUI;
   onUpdateField: (args: OnUpdateFields) => void;
+  /**
+   * When false, skips the "Extended fields" heading (redesign accordion already labels the section).
+   * Defaults to true for the legacy case view.
+   */
+  showHeader?: boolean;
 }
 
 const TemplateFieldsForm: FC<{
@@ -56,49 +63,63 @@ const TemplateFieldsForm: FC<{
 
 TemplateFieldsForm.displayName = 'TemplateFieldsForm';
 
-export const TemplateFields = React.memo<TemplateFieldsProps>(({ caseData, onUpdateField }) => {
-  const { data: templateData } = useGetTemplate(caseData.template?.id, caseData.template?.version, {
-    includeDeleted: true,
-  });
+export const TemplateFields = React.memo<TemplateFieldsProps>(
+  ({ caseData, onUpdateField, showHeader = true }) => {
+    const { data: templateData } = useGetTemplate(
+      caseData.template?.id,
+      caseData.template?.version,
+      { includeDeleted: true }
+    );
 
-  const { data: globalFieldDefsData } = useGetFieldDefinitions({
-    owner: caseData.owner,
-    isGlobal: true,
-    // Prevent a background refetch from producing a new Set/array reference that would
-    // re-trigger memos and potentially reset an in-progress edit. Same rationale as the
-    // create form (create/template_fields.tsx).
-    staleTime: Infinity,
-  });
+    const { data: globalFieldDefsData } = useGetFieldDefinitions({
+      owner: caseData.owner,
+      isGlobal: true,
+      // Prevent a background refetch from producing a new Set/array reference that would
+      // re-trigger memos and potentially reset an in-progress edit. Same rationale as the
+      // create form (create/template_fields.tsx).
+      staleTime: Infinity,
+    });
 
-  const globalFieldNames = useMemo<ReadonlySet<string>>(
-    () =>
-      new Set(
-        parseFieldDefinitionsToInlineFields(globalFieldDefsData?.fieldDefinitions ?? []).map(
-          (f) => f.name
-        )
-      ),
-    [globalFieldDefsData]
-  );
+    const globalFieldNames = useMemo<ReadonlySet<string>>(
+      () =>
+        new Set(
+          parseFieldDefinitionsToInlineFields(globalFieldDefsData?.fieldDefinitions ?? []).map(
+            (f) => f.name
+          )
+        ),
+      [globalFieldDefsData]
+    );
 
-  const parsedTemplate = templateData?.definition;
+    const parsedTemplate = templateData?.definition;
 
-  const filteredTemplateFields = useMemo(
-    () =>
-      parsedTemplate?.fields.filter((f) => !isInlineField(f) || !globalFieldNames.has(f.name)) ??
-      [],
-    [parsedTemplate, globalFieldNames]
-  );
+    const filteredTemplateFields = useMemo(
+      () =>
+        parsedTemplate?.fields.filter((f) => !isInlineField(f) || !globalFieldNames.has(f.name)) ??
+        [],
+      [parsedTemplate, globalFieldNames]
+    );
 
-  if (!templateData || !parsedTemplate || filteredTemplateFields.length === 0) return null;
+    if (!templateData || !parsedTemplate || filteredTemplateFields.length === 0) return null;
 
-  return (
-    <TemplateFieldsForm
-      parsedTemplate={{ ...parsedTemplate, fields: filteredTemplateFields }}
-      owner={templateData.owner}
-      extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
-      onUpdateField={onUpdateField}
-    />
-  );
-});
+    return (
+      <>
+        {showHeader && (
+          <>
+            <EuiTitle size="xs">
+              <h3>{i18n.EXTENDED_FIELDS_TITLE}</h3>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <TemplateFieldsForm
+          parsedTemplate={{ ...parsedTemplate, fields: filteredTemplateFields }}
+          owner={templateData.owner}
+          extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
+          onUpdateField={onUpdateField}
+        />
+      </>
+    );
+  }
+);
 
 TemplateFields.displayName = 'TemplateFields';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
@@ -8,7 +8,6 @@
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import type { z } from '@kbn/zod/v4';
-import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { CaseUI } from '../../../../common';
 import type { ParsedTemplateDefinitionSchema } from '../../../../common/types/domain/template/latest';
 import type { InlineField } from '../../../../common/types/domain/template/fields';
@@ -17,7 +16,6 @@ import { useResolvedFields } from '../../field_library/hooks/use_resolved_fields
 import { useGetFieldDefinitions } from '../../field_library/hooks/use_get_field_definitions';
 import { parseFieldDefinitionsToInlineFields } from '../../../../common/utils';
 import { isInlineField } from '../../../../common/types/domain/template/fields';
-import * as i18n from '../translations';
 import type { OnUpdateFields } from '../types';
 import { EMPTY_EXTENDED_FIELDS, TemplateFieldsFormReady } from './template_fields_form_ready';
 
@@ -26,7 +24,6 @@ type ParsedTemplateDefinition = z.infer<typeof ParsedTemplateDefinitionSchema>;
 interface TemplateFieldsProps {
   caseData: CaseUI;
   onUpdateField: (args: OnUpdateFields) => void;
-  showHeader?: boolean;
 }
 
 const TemplateFieldsForm: FC<{
@@ -59,63 +56,49 @@ const TemplateFieldsForm: FC<{
 
 TemplateFieldsForm.displayName = 'TemplateFieldsForm';
 
-export const TemplateFields = React.memo<TemplateFieldsProps>(
-  ({ caseData, onUpdateField, showHeader = true }) => {
-    const { data: templateData } = useGetTemplate(
-      caseData.template?.id,
-      caseData.template?.version,
-      { includeDeleted: true }
-    );
+export const TemplateFields = React.memo<TemplateFieldsProps>(({ caseData, onUpdateField }) => {
+  const { data: templateData } = useGetTemplate(caseData.template?.id, caseData.template?.version, {
+    includeDeleted: true,
+  });
 
-    const { data: globalFieldDefsData } = useGetFieldDefinitions({
-      owner: caseData.owner,
-      isGlobal: true,
-      // Prevent a background refetch from producing a new Set/array reference that would
-      // re-trigger memos and potentially reset an in-progress edit. Same rationale as the
-      // create form (create/template_fields.tsx).
-      staleTime: Infinity,
-    });
+  const { data: globalFieldDefsData } = useGetFieldDefinitions({
+    owner: caseData.owner,
+    isGlobal: true,
+    // Prevent a background refetch from producing a new Set/array reference that would
+    // re-trigger memos and potentially reset an in-progress edit. Same rationale as the
+    // create form (create/template_fields.tsx).
+    staleTime: Infinity,
+  });
 
-    const globalFieldNames = useMemo<ReadonlySet<string>>(
-      () =>
-        new Set(
-          parseFieldDefinitionsToInlineFields(globalFieldDefsData?.fieldDefinitions ?? []).map(
-            (f) => f.name
-          )
-        ),
-      [globalFieldDefsData]
-    );
+  const globalFieldNames = useMemo<ReadonlySet<string>>(
+    () =>
+      new Set(
+        parseFieldDefinitionsToInlineFields(globalFieldDefsData?.fieldDefinitions ?? []).map(
+          (f) => f.name
+        )
+      ),
+    [globalFieldDefsData]
+  );
 
-    const parsedTemplate = templateData?.definition;
+  const parsedTemplate = templateData?.definition;
 
-    const filteredTemplateFields = useMemo(
-      () =>
-        parsedTemplate?.fields.filter((f) => !isInlineField(f) || !globalFieldNames.has(f.name)) ??
-        [],
-      [parsedTemplate, globalFieldNames]
-    );
+  const filteredTemplateFields = useMemo(
+    () =>
+      parsedTemplate?.fields.filter((f) => !isInlineField(f) || !globalFieldNames.has(f.name)) ??
+      [],
+    [parsedTemplate, globalFieldNames]
+  );
 
-    if (!templateData || !parsedTemplate || filteredTemplateFields.length === 0) return null;
+  if (!templateData || !parsedTemplate || filteredTemplateFields.length === 0) return null;
 
-    return (
-      <>
-        {showHeader && (
-          <>
-            <EuiTitle size="xs">
-              <h3>{i18n.EXTENDED_FIELDS_TITLE}</h3>
-            </EuiTitle>
-            <EuiSpacer size="s" />
-          </>
-        )}
-        <TemplateFieldsForm
-          parsedTemplate={{ ...parsedTemplate, fields: filteredTemplateFields }}
-          owner={templateData.owner}
-          extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
-          onUpdateField={onUpdateField}
-        />
-      </>
-    );
-  }
-);
+  return (
+    <TemplateFieldsForm
+      parsedTemplate={{ ...parsedTemplate, fields: filteredTemplateFields }}
+      owner={templateData.owner}
+      extendedFields={caseData.extendedFields ?? EMPTY_EXTENDED_FIELDS}
+      onUpdateField={onUpdateField}
+    />
+  );
+});
 
 TemplateFields.displayName = 'TemplateFields';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
@@ -281,3 +281,7 @@ export const ERROR_CHANGING_TEMPLATE = i18n.translate(
     defaultMessage: 'Error changing template',
   }
 );
+
+export const EXTENDED_FIELDS_TITLE = i18n.translate('xpack.cases.caseView.extendedFieldsTitle', {
+  defaultMessage: 'Extended fields',
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
@@ -281,7 +281,3 @@ export const ERROR_CHANGING_TEMPLATE = i18n.translate(
     defaultMessage: 'Error changing template',
   }
 );
-
-export const EXTENDED_FIELDS_TITLE = i18n.translate('xpack.cases.caseView.extendedFieldsTitle', {
-  defaultMessage: 'Extended fields',
-});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.test.tsx
@@ -26,17 +26,22 @@ import { userProfiles } from '../../../../containers/user_profiles/api.mock';
 import { CUSTOM_FIELD_KEY_PREFIX, VIEW_TOGGLE_TABLE_ID } from '../constants';
 import { useGetCaseConfiguration } from '../../../../containers/configure/use_get_case_configuration';
 import { useCaseConfigureResponse } from '../../../configure_cases/__mock__';
+import { KibanaServices } from '../../../../common/lib/kibana';
+import { useCasesToast } from '../../../../common/use_cases_toast';
 
 jest.mock('../../../../containers/use_get_tags');
 jest.mock('../../../../containers/use_get_categories');
 jest.mock('../../../../containers/user_profiles/use_suggest_user_profiles');
 jest.mock('../../../../containers/configure/use_get_case_configuration');
+jest.mock('../../../../common/use_cases_toast');
 
 const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
+const useCasesToastMock = useCasesToast as jest.Mock;
 const MORE_FILTERS_TEST_ID = 'options-filter-popover-button-more-filters';
 const onFilterChanged = jest.fn();
 /** Extra toolbar buttons: More filters, Columns, view toggle (×2), date range (×2), refresh. */
 const EXTRA_TOOLBAR_BUTTON_COUNT = 7;
+const showInfoToast = jest.fn();
 
 const props: CasesTableFiltersProps = {
   countClosedCases: 1234,
@@ -106,6 +111,13 @@ describe('CasesTableFilters ', () => {
     (useSuggestUserProfiles as jest.Mock).mockReturnValue({ data: userProfiles, isLoading: false });
 
     useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
+    useCasesToastMock.mockReturnValue({
+      showInfoToast,
+      showSuccessToast: jest.fn(),
+      showErrorToast: jest.fn(),
+      showDangerToast: jest.fn(),
+      showSuccessAttach: jest.fn(),
+    });
   });
 
   afterEach(() => {
@@ -203,6 +215,36 @@ describe('CasesTableFilters ', () => {
     await waitFor(() => {
       expect(onFilterChanged.mock.calls[0][0].search).toEqual('My search');
     });
+  });
+
+  it('shows a hidden-fields info toast once when searching with templates enabled', async () => {
+    const getConfigSpy = jest
+      .spyOn(KibanaServices, 'getConfig')
+      .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+        typeof KibanaServices.getConfig
+      >);
+
+    renderWithTestingProviders(<CasesTableFilters {...props} />);
+
+    await userEvent.type(await screen.findByTestId('search-cases'), 'My search{enter}');
+
+    await waitFor(() => {
+      expect(showInfoToast).toHaveBeenCalledTimes(1);
+    });
+    expect(showInfoToast).toHaveBeenCalledWith(
+      'Search may include hidden fields',
+      'Results can match values from template and custom fields that are not shown as columns.'
+    );
+
+    await userEvent.clear(await screen.findByTestId('search-cases'));
+    await userEvent.type(await screen.findByTestId('search-cases'), 'Second search{enter}');
+
+    await waitFor(() => {
+      expect(onFilterChanged).toHaveBeenCalled();
+    });
+    expect(showInfoToast).toHaveBeenCalledTimes(1);
+
+    getConfigSpy.mockRestore();
   });
 
   it('should change the initial value of search when the state changes', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiFilterGroup, useEuiTheme } from '@elastic/eui';
 import { mergeWith, isEqual } from 'lodash';
 import { css } from '@emotion/react';
@@ -27,6 +27,8 @@ import { DateRangeFilter } from '../../../all_cases/date_range_filter';
 import type { CasesColumnSelection } from '../types';
 import { ColumnsPopover } from './columns_popover';
 import { SortFilter } from './sort_filter';
+import { useCasesConfig } from '../../../../common/lib/kibana';
+import { useCasesToast } from '../../../../common/use_cases_toast';
 
 export interface CasesTableFiltersProps {
   countClosedCases: number | null;
@@ -87,14 +89,28 @@ const CasesTableFiltersComponent = ({
     isFetching: isLoadingCasesConfiguration,
   } = useGetCaseConfiguration();
 
+  const { euiTheme } = useEuiTheme();
+  const { templatesEnabled } = useCasesConfig();
+  const { showInfoToast } = useCasesToast();
+  const hasShownHiddenFieldsSearchToast = useRef(false);
+
   const onFilterOptionsChange = useCallback(
     (partialFilterOptions: Partial<FilterOptions>) => {
       const newFilterOptions = mergeWith({}, filterOptions, partialFilterOptions, mergeCustomizer);
       if (!isEqual(newFilterOptions, filterOptions)) {
+        if (
+          templatesEnabled &&
+          !hasShownHiddenFieldsSearchToast.current &&
+          typeof partialFilterOptions.search === 'string' &&
+          partialFilterOptions.search.trim() !== ''
+        ) {
+          hasShownHiddenFieldsSearchToast.current = true;
+          showInfoToast(i18n.SEARCH_HIDDEN_FIELDS_INFO_TITLE, i18n.SEARCH_HIDDEN_FIELDS_INFO_TEXT);
+        }
         onFilterChanged(newFilterOptions);
       }
     },
-    [filterOptions, onFilterChanged]
+    [filterOptions, onFilterChanged, showInfoToast, templatesEnabled]
   );
 
   const isLoadingFilters =
@@ -128,8 +144,6 @@ const CasesTableFiltersComponent = ({
     customFields,
     isLoading: isLoadingFilters,
   });
-
-  const { euiTheme } = useEuiTheme();
 
   const handleOnCreateCasePressed = useCallback(() => {
     if (onCreateCasePressed) {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/translations.ts
@@ -117,3 +117,18 @@ export const LIST_CASE_META_LINK_ARIA = (title: string) =>
     values: { title },
     defaultMessage: 'View case details for {title}',
   });
+
+export const SEARCH_HIDDEN_FIELDS_INFO_TITLE = i18n.translate(
+  'xpack.cases.casesRedesign.tableFilters.searchHiddenFieldsInfoTitle',
+  {
+    defaultMessage: 'Search may include hidden fields',
+  }
+);
+
+export const SEARCH_HIDDEN_FIELDS_INFO_TEXT = i18n.translate(
+  'xpack.cases.casesRedesign.tableFilters.searchHiddenFieldsInfoText',
+  {
+    defaultMessage:
+      'Results can match values from template and custom fields that are not shown as columns.',
+  }
+);

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.test.tsx
@@ -124,6 +124,7 @@ describe('CaseViewSidebar (redesign)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
     useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
     useCasesFeaturesMock.mockReturnValue(useGetCasesFeaturesRes);
   });
@@ -281,6 +282,16 @@ describe('CaseViewSidebar (redesign)', () => {
       .mockReturnValue({ templates: { enabled: true } } as ReturnType<
         typeof KibanaServices.getConfig
       >);
+    localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'true');
+    localStorage.setItem(
+      'securitySolution.cases.caseView.sidebarAccordions',
+      JSON.stringify({
+        attributes: true,
+        legacyCustomFields: true,
+        templateFields: true,
+        connectors: true,
+      })
+    );
     (useGetCaseConfiguration as jest.Mock).mockReturnValue({
       data: {
         customFields: [customFieldsConfigurationMock[1]],
@@ -295,6 +306,8 @@ describe('CaseViewSidebar (redesign)', () => {
 
     renderWithTestingProviders(<CaseViewSidebar caseData={caseDataWithCustomFields} />);
 
+    expect(await screen.findByTestId('case-view-sidebar-legacy-custom-fields')).toBeInTheDocument();
+
     await userEvent.click(await screen.findByRole('switch'));
 
     await waitFor(() => {
@@ -306,6 +319,77 @@ describe('CaseViewSidebar (redesign)', () => {
         customFieldValue: false,
       });
     });
+  });
+
+  it('does not render legacy custom fields accordion when the show-legacy switch is off', async () => {
+    jest
+      .spyOn(KibanaServices, 'getConfig')
+      .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+        typeof KibanaServices.getConfig
+      >);
+    localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'false');
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: {
+        customFields: [customFieldsConfigurationMock[1]],
+        observableTypes: [],
+      },
+    });
+
+    renderWithTestingProviders(
+      <CaseViewSidebar caseData={{ ...caseData, customFields: [customFieldsMock[1]] }} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('case-view-page-sidebar')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('case-view-sidebar-legacy-custom-fields')).not.toBeInTheDocument();
+  });
+
+  it('renders legacy custom fields accordion when templates v2 is disabled and fields are configured', async () => {
+    jest.spyOn(KibanaServices, 'getConfig').mockReturnValue(undefined);
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: {
+        customFields: [customFieldsConfigurationMock[1]],
+        observableTypes: [],
+      },
+    });
+
+    renderWithTestingProviders(
+      <CaseViewSidebar caseData={{ ...caseData, customFields: [customFieldsMock[1]] }} />
+    );
+
+    expect(await screen.findByTestId('case-view-sidebar-legacy-custom-fields')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('legacy-custom-fields-deprecation-callout')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-custom-fields-deprecated-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders legacy custom fields accordion closed by default when the switch is on', async () => {
+    jest
+      .spyOn(KibanaServices, 'getConfig')
+      .mockReturnValue({ templates: { enabled: true } } as ReturnType<
+        typeof KibanaServices.getConfig
+      >);
+    localStorage.setItem('securitySolution.cases.showLegacyCustomFields', 'true');
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: {
+        customFields: [customFieldsConfigurationMock[1]],
+        observableTypes: [],
+      },
+    });
+
+    renderWithTestingProviders(
+      <CaseViewSidebar caseData={{ ...caseData, customFields: [customFieldsMock[1]] }} />
+    );
+
+    const accordion = await screen.findByTestId('case-view-sidebar-legacy-custom-fields');
+    expect(accordion).toBeInTheDocument();
+    expect(screen.getByTestId('case-view-sidebar-legacy-custom-fields-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
   });
 
   it('should show the category correctly', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
@@ -127,12 +127,21 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
                   customFields={caseData.customFields}
                   customFieldsConfiguration={casesConfiguration.customFields}
                   onSubmit={onSubmitCustomField}
+                  editVariant="inline"
                 />
-                {/* Global (isGlobal) fields apply to every case regardless of the template. Renders
-                    nothing when there are none; self-labels when no template owns the heading. */}
-                <GlobalCaseFields caseData={caseData} onUpdateField={onUpdateField} />
+                {/* Global (isGlobal) fields apply to every case regardless of the template.
+                    Redesign accordion already labels this section — hide Extended fields heading. */}
+                <GlobalCaseFields
+                  caseData={caseData}
+                  onUpdateField={onUpdateField}
+                  showSectionTitle={false}
+                />
                 {caseData.template?.id ? (
-                  <TemplateFields caseData={caseData} onUpdateField={onUpdateField} />
+                  <TemplateFields
+                    caseData={caseData}
+                    onUpdateField={onUpdateField}
+                    showHeader={false}
+                  />
                 ) : (
                   <EuiText
                     size="s"

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
@@ -132,11 +132,7 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
                     nothing when there are none; self-labels when no template owns the heading. */}
                 <GlobalCaseFields caseData={caseData} onUpdateField={onUpdateField} />
                 {caseData.template?.id ? (
-                  <TemplateFields
-                    caseData={caseData}
-                    onUpdateField={onUpdateField}
-                    showHeader={false}
-                  />
+                  <TemplateFields caseData={caseData} onUpdateField={onUpdateField} />
                 ) : (
                   <EuiText
                     size="s"

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
@@ -44,7 +44,10 @@ import { useGetSupportedActionConnectors } from '../../../../../containers/confi
 import { useGetTemplate } from '../../../../templates_v2/hooks/use_get_template';
 import { KibanaServices } from '../../../../../common/lib/kibana';
 import { useShowLegacyCustomFields } from '../../../../../common/use_show_old_custom_fields';
-import { useCasesFieldLibraryNavigation } from '../../../../../common/navigation';
+import {
+  useCasesFieldLibraryNavigation,
+  useConfigureCasesNavigation,
+} from '../../../../../common/navigation';
 import * as configureCasesI18n from '../../../../configure_cases/translations';
 
 export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
@@ -60,8 +63,11 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
   const { isLoading: isLoadingAllAvailableConnectors, data: supportedActionConnectors } =
     useGetSupportedActionConnectors();
   const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
-  const { showLegacyCustomFields } = useShowLegacyCustomFields();
+  const { showLegacyCustomFields } = useShowLegacyCustomFields(
+    casesConfiguration?.customFields ?? []
+  );
   const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
+  const { getConfigureCasesUrl } = useConfigureCasesNavigation();
 
   const { data: templateData } = useGetTemplate(caseData.template?.id, caseData.template?.version, {
     includeDeleted: true,
@@ -159,15 +165,23 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
                   >
                     <FormattedMessage
                       id="xpack.cases.casesRedesign.details.legacyCustomFieldsDisclaimerBody"
-                      defaultMessage="{message} {link}"
+                      defaultMessage='These custom fields are deprecated and have already been migrated to the new system, so you may see the same fields in both places. Manage them in {customFieldsLink}. To stop showing them here, disable "{switchLabel}" in {settingsLink}.'
                       values={{
-                        message: redesignI18n.LEGACY_CUSTOM_FIELDS_DISCLAIMER,
-                        link: (
+                        customFieldsLink: (
                           <EuiLink
                             href={getCasesFieldLibraryUrl()}
                             data-test-subj="legacy-custom-fields-view-new-link"
                           >
-                            {redesignI18n.LEGACY_CUSTOM_FIELDS_VIEW_NEW}
+                            {redesignI18n.LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS}
+                          </EuiLink>
+                        ),
+                        switchLabel: configureCasesI18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES,
+                        settingsLink: (
+                          <EuiLink
+                            href={getConfigureCasesUrl()}
+                            data-test-subj="legacy-custom-fields-view-settings-link"
+                          >
+                            {redesignI18n.LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS}
                           </EuiLink>
                         ),
                       }}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/case_view_sidebar.tsx
@@ -6,15 +6,19 @@
  */
 
 import {
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiPanel,
   EuiScreenReaderOnly,
   EuiSpacer,
   EuiText,
+  EuiBadge,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useMemo } from 'react';
 import type { CaseUI } from '../../../../../../common';
 import type { CaseConnector } from '../../../../../../common/types/domain';
@@ -39,6 +43,9 @@ import { useGetCaseConfiguration } from '../../../../../containers/configure/use
 import { useGetSupportedActionConnectors } from '../../../../../containers/configure/use_get_supported_action_connectors';
 import { useGetTemplate } from '../../../../templates_v2/hooks/use_get_template';
 import { KibanaServices } from '../../../../../common/lib/kibana';
+import { useShowLegacyCustomFields } from '../../../../../common/use_show_old_custom_fields';
+import { useCasesFieldLibraryNavigation } from '../../../../../common/navigation';
+import * as configureCasesI18n from '../../../../configure_cases/translations';
 
 export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
   const { euiTheme } = useEuiTheme();
@@ -53,6 +60,8 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
   const { isLoading: isLoadingAllAvailableConnectors, data: supportedActionConnectors } =
     useGetSupportedActionConnectors();
   const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
+  const { showLegacyCustomFields } = useShowLegacyCustomFields();
+  const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
 
   const { data: templateData } = useGetTemplate(caseData.template?.id, caseData.template?.version, {
     includeDeleted: true,
@@ -81,6 +90,13 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
     [isLoadingAllAvailableConnectors, isConnectorFieldUpdating, connectorLoadingKey]
   );
 
+  const hasConfiguredCustomFields = (casesConfiguration?.customFields?.length ?? 0) > 0;
+
+  // Templates v2 off: always show configured legacy custom fields (they are the only system).
+  // Templates v2 on: gate on the Settings local-storage switch.
+  const showLegacyCustomFieldsAccordion =
+    hasConfiguredCustomFields && (!isTemplatesV2Enabled || showLegacyCustomFields);
+
   return (
     <EuiFlexItem grow={2}>
       <EuiSpacer size="s" />
@@ -103,6 +119,75 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
         >
           <AttributesFields caseData={caseData} />
         </SidebarAccordionSection>
+        {showLegacyCustomFieldsAccordion ? (
+          <>
+            <EuiSpacer size="m" />
+            <SidebarAccordionSection
+              id="legacyCustomFields"
+              title={
+                isTemplatesV2Enabled ? (
+                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      {redesignI18n.LEGACY_CUSTOM_FIELDS_TITLE}
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiBadge
+                        color="warning"
+                        data-test-subj="legacy-custom-fields-deprecated-badge"
+                      >
+                        {configureCasesI18n.DEPRECATED_BADGE}
+                      </EuiBadge>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ) : (
+                  redesignI18n.LEGACY_CUSTOM_FIELDS_TITLE
+                )
+              }
+              isOpen={isOpen('legacyCustomFields')}
+              onToggle={onToggle}
+              data-test-subj="case-view-sidebar-legacy-custom-fields"
+            >
+              {isTemplatesV2Enabled ? (
+                <>
+                  <EuiCallOut
+                    announceOnMount
+                    title={redesignI18n.LEGACY_CUSTOM_FIELDS_TITLE}
+                    color="warning"
+                    iconType="warning"
+                    size="s"
+                    data-test-subj="legacy-custom-fields-deprecation-callout"
+                  >
+                    <FormattedMessage
+                      id="xpack.cases.casesRedesign.details.legacyCustomFieldsDisclaimerBody"
+                      defaultMessage="{message} {link}"
+                      values={{
+                        message: redesignI18n.LEGACY_CUSTOM_FIELDS_DISCLAIMER,
+                        link: (
+                          <EuiLink
+                            href={getCasesFieldLibraryUrl()}
+                            data-test-subj="legacy-custom-fields-view-new-link"
+                          >
+                            {redesignI18n.LEGACY_CUSTOM_FIELDS_VIEW_NEW}
+                          </EuiLink>
+                        ),
+                      }}
+                    />
+                  </EuiCallOut>
+                  <EuiSpacer size="m" />
+                </>
+              ) : null}
+              <EuiFlexGroup direction="column" responsive={false} css={fieldsGroupStyles}>
+                <CustomFields
+                  isLoading={isCustomFieldsLoading}
+                  customFields={caseData.customFields}
+                  customFieldsConfiguration={casesConfiguration.customFields}
+                  onSubmit={onSubmitCustomField}
+                  editVariant="inline"
+                />
+              </EuiFlexGroup>
+            </SidebarAccordionSection>
+          </>
+        ) : null}
         {isTemplatesV2Enabled ? (
           <>
             <EuiSpacer size="m" />
@@ -122,13 +207,6 @@ export const CaseViewSidebar = ({ caseData }: { caseData: CaseUI }) => {
               data-test-subj="case-view-sidebar-template-fields"
             >
               <EuiFlexGroup direction="column" responsive={false} css={fieldsGroupStyles}>
-                <CustomFields
-                  isLoading={isCustomFieldsLoading}
-                  customFields={caseData.customFields}
-                  customFieldsConfiguration={casesConfiguration.customFields}
-                  onSubmit={onSubmitCustomField}
-                  editVariant="inline"
-                />
                 {/* Global (isGlobal) fields apply to every case regardless of the template.
                     Redesign accordion already labels this section — hide Extended fields heading. */}
                 <GlobalCaseFields

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/hooks/use_sidebar_accordions_state.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/hooks/use_sidebar_accordions_state.test.ts
@@ -20,6 +20,7 @@ describe('useSidebarAccordionsState', () => {
     mockUseCasesLocalStorage.mockReturnValue([
       {
         attributes: true,
+        legacyCustomFields: false,
         templateFields: false,
         connectors: true,
       },
@@ -34,6 +35,7 @@ describe('useSidebarAccordionsState', () => {
       LOCAL_STORAGE_KEYS.caseViewSidebarAccordions,
       {
         attributes: true,
+        legacyCustomFields: false,
         templateFields: true,
         connectors: true,
       }
@@ -44,6 +46,7 @@ describe('useSidebarAccordionsState', () => {
     const { result } = renderHook(() => useSidebarAccordionsState());
 
     expect(result.current.isOpen('attributes')).toBe(true);
+    expect(result.current.isOpen('legacyCustomFields')).toBe(false);
     expect(result.current.isOpen('templateFields')).toBe(false);
     expect(result.current.isOpen('connectors')).toBe(true);
   });
@@ -53,6 +56,7 @@ describe('useSidebarAccordionsState', () => {
     mockUseCasesLocalStorage.mockReturnValue([
       {
         attributes: true,
+        legacyCustomFields: false,
         templateFields: true,
         connectors: true,
       },
@@ -67,6 +71,7 @@ describe('useSidebarAccordionsState', () => {
 
     expect(setAccordionsState).toHaveBeenCalledWith({
       attributes: true,
+      legacyCustomFields: false,
       templateFields: false,
       connectors: true,
     });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/hooks/use_sidebar_accordions_state.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/sidebar/hooks/use_sidebar_accordions_state.ts
@@ -9,12 +9,17 @@ import { useCallback } from 'react';
 import { LOCAL_STORAGE_KEYS } from '../../../../../../../common/constants';
 import { useCasesLocalStorage } from '../../../../../../common/use_cases_local_storage';
 
-export type SidebarAccordionId = 'attributes' | 'templateFields' | 'connectors';
+export type SidebarAccordionId =
+  | 'attributes'
+  | 'legacyCustomFields'
+  | 'templateFields'
+  | 'connectors';
 
 export type SidebarAccordionsState = Record<SidebarAccordionId, boolean>;
 
 const DEFAULT_ACCORDIONS_STATE: SidebarAccordionsState = {
   attributes: true,
+  legacyCustomFields: false,
   templateFields: true,
   connectors: true,
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
@@ -68,6 +68,7 @@ describe('ConfigureCasesRedesign', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
 
     useGetActionTypesMock.mockImplementation(() => useActionTypesResponse);
     useGetCaseConfigurationMock.mockImplementation(() => ({
@@ -90,6 +91,15 @@ describe('ConfigureCasesRedesign', () => {
       isAtLeastGold: () => true,
       isAtLeastPlatinum: () => true,
     });
+
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: false,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
   });
 
   it('renders the redesigned settings page with the app header title', async () => {
@@ -111,13 +121,88 @@ describe('ConfigureCasesRedesign', () => {
     expect(screen.getByTestId('cases-redesign-observable-types-section')).toBeInTheDocument();
   });
 
-  it('does not render legacy custom fields or templates sections', async () => {
+  it('does not render legacy custom fields or templates sections when templates v2 is disabled', async () => {
     renderWithTestingProviders(<ConfigureCasesRedesign />);
 
     await screen.findByTestId('cases-redesign-settings-panel');
 
+    expect(
+      screen.queryByTestId('cases-redesign-legacy-custom-fields-section')
+    ).not.toBeInTheDocument();
     expect(screen.queryByTestId('custom-fields-form-group')).not.toBeInTheDocument();
     expect(screen.queryByTestId('templates-form-group')).not.toBeInTheDocument();
+  });
+
+  it('renders the legacy section with switch off by default when templates v2 is enabled', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    expect(
+      await screen.findByTestId('cases-redesign-legacy-custom-fields-section')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('show-legacy-custom-fields-switch')).not.toBeChecked();
+    expect(screen.queryByTestId('custom-fields-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('templates-list')).not.toBeInTheDocument();
+  });
+
+  it('shows legacy custom fields and templates lists when the switch is turned on', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
+
+    expect(await screen.findByTestId('custom-fields-list')).toBeInTheDocument();
+    expect(screen.getByTestId('templates-list')).toBeInTheDocument();
+    expect(screen.getByTestId('legacy-custom-fields-view-new-link')).toBeInTheDocument();
+    expect(screen.getByTestId('legacy-templates-view-new-link')).toBeInTheDocument();
+  });
+
+  it('shows add buttons for empty legacy custom fields and templates when the switch is on', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+    useGetCaseConfigurationMock.mockImplementation(() => ({
+      ...useCaseConfigureResponse,
+      data: {
+        ...useCaseConfigureResponse.data,
+        customFields: [],
+        templates: [],
+      },
+    }));
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    expect(
+      await screen.findByTestId('cases-redesign-legacy-custom-fields-section')
+    ).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
+
+    expect(await screen.findByTestId('add-custom-field')).toBeInTheDocument();
+    expect(screen.getByTestId('add-template')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-custom-fields')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-templates')).toBeInTheDocument();
   });
 
   it('renders connector and closure controls', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
 
@@ -203,6 +203,89 @@ describe('ConfigureCasesRedesign', () => {
     expect(screen.getByTestId('add-template')).toBeInTheDocument();
     expect(screen.getByTestId('empty-custom-fields')).toBeInTheDocument();
     expect(screen.getByTestId('empty-templates')).toBeInTheDocument();
+  });
+
+  it('opens add custom field flyout with add header when switch is on', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
+    await userEvent.click(await screen.findByTestId('add-custom-field'));
+
+    expect(await screen.findByTestId('common-flyout')).toBeInTheDocument();
+    expect(await screen.findByTestId('common-flyout-header')).toHaveTextContent(
+      configureCasesI18n.ADD_CUSTOM_FIELD
+    );
+  });
+
+  it('opens add flyout after edit without keeping the previous field', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
+
+    const list = await screen.findByTestId('custom-fields-list');
+    await userEvent.click(
+      within(list).getByTestId(`${customFieldsConfigurationMock[0].key}-custom-field-edit`)
+    );
+
+    expect(await screen.findByTestId('common-flyout-header')).toHaveTextContent(
+      configureCasesI18n.EDIT_CUSTOM_FIELD
+    );
+
+    await userEvent.click(screen.getByTestId('common-flyout-cancel'));
+    await userEvent.click(await screen.findByTestId('add-custom-field'));
+
+    expect(await screen.findByTestId('common-flyout-header')).toHaveTextContent(
+      configureCasesI18n.ADD_CUSTOM_FIELD
+    );
+  });
+
+  it('persists custom field deletion when switch is on', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
+
+    const list = await screen.findByTestId('custom-fields-list');
+    await userEvent.click(
+      within(list).getByTestId(`${customFieldsConfigurationMock[0].key}-custom-field-delete`)
+    );
+
+    expect(await screen.findByTestId('confirm-delete-modal')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Delete'));
+
+    expect(persistCaseConfigure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customFields: expect.not.arrayContaining([
+          expect.objectContaining({ key: customFieldsConfigurationMock[0].key }),
+        ]),
+      })
+    );
   });
 
   it('renders connector and closure controls', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
@@ -173,6 +173,38 @@ describe('ConfigureCasesRedesign', () => {
     expect(screen.getByTestId('legacy-templates-view-new-link')).toBeInTheDocument();
   });
 
+  it('forces the show-legacy switch on when required fields lack defaults', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+    useGetCaseConfigurationMock.mockImplementation(() => ({
+      ...useCaseConfigureResponse,
+      data: {
+        ...useCaseConfigureResponse.data,
+        customFields: [
+          {
+            ...customFieldsConfigurationMock[0],
+            required: true,
+            defaultValue: undefined,
+          },
+        ],
+        templates: templatesConfigurationMock,
+      },
+    }));
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    const toggle = await screen.findByTestId('show-legacy-custom-fields-switch');
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeDisabled();
+    expect(await screen.findByTestId('custom-fields-list')).toBeInTheDocument();
+  });
+
   it('shows add buttons for empty legacy custom fields and templates when the switch is on', async () => {
     const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
     useCasesConfig.mockReturnValue({
@@ -199,10 +231,14 @@ describe('ConfigureCasesRedesign', () => {
 
     await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
 
-    expect(await screen.findByTestId('add-custom-field')).toBeInTheDocument();
-    expect(screen.getByTestId('add-template')).toBeInTheDocument();
-    expect(screen.getByTestId('empty-custom-fields')).toBeInTheDocument();
-    expect(screen.getByTestId('empty-templates')).toBeInTheDocument();
+    expect(await screen.findByTestId('add-custom-field')).toHaveTextContent(
+      configureCasesI18n.ADD_LEGACY_CUSTOM_FIELD
+    );
+    expect(screen.getByTestId('add-template')).toHaveTextContent(
+      configureCasesI18n.ADD_LEGACY_TEMPLATE
+    );
+    expect(screen.queryByTestId('empty-custom-fields')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-templates')).not.toBeInTheDocument();
   });
 
   it('opens add custom field flyout with add header when switch is on', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
@@ -173,7 +173,33 @@ describe('ConfigureCasesRedesign', () => {
     expect(screen.getByTestId('legacy-templates-view-new-link')).toBeInTheDocument();
   });
 
-  it('shows add buttons for empty legacy custom fields and templates when the switch is on', async () => {
+  it('renders the legacy section when only legacy templates exist', async () => {
+    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
+    useCasesConfig.mockReturnValue({
+      attachmentsEnabled: false,
+      chatEnabled: false,
+      templatesEnabled: true,
+      detailsRedesignEnabled: false,
+      casesRedesign: { list: false, details: false, settings: true },
+    });
+    useGetCaseConfigurationMock.mockImplementation(() => ({
+      ...useCaseConfigureResponse,
+      data: {
+        ...useCaseConfigureResponse.data,
+        customFields: [],
+        templates: templatesConfigurationMock,
+      },
+    }));
+
+    renderWithTestingProviders(<ConfigureCasesRedesign />);
+
+    expect(
+      await screen.findByTestId('cases-redesign-legacy-custom-fields-section')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('show-legacy-custom-fields-switch')).not.toBeChecked();
+  });
+
+  it('does not render the legacy section when templates v2 is enabled but no legacy config exists', async () => {
     const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
     useCasesConfig.mockReturnValue({
       attachmentsEnabled: false,
@@ -193,16 +219,12 @@ describe('ConfigureCasesRedesign', () => {
 
     renderWithTestingProviders(<ConfigureCasesRedesign />);
 
+    await screen.findByTestId('cases-redesign-settings-panel');
+
     expect(
-      await screen.findByTestId('cases-redesign-legacy-custom-fields-section')
-    ).toBeInTheDocument();
-
-    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
-
-    expect(await screen.findByTestId('add-custom-field')).toBeInTheDocument();
-    expect(screen.getByTestId('add-template')).toBeInTheDocument();
-    expect(screen.getByTestId('empty-custom-fields')).toBeInTheDocument();
-    expect(screen.getByTestId('empty-templates')).toBeInTheDocument();
+      screen.queryByTestId('cases-redesign-legacy-custom-fields-section')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('show-legacy-custom-fields-switch')).not.toBeInTheDocument();
   });
 
   it('opens add custom field flyout with add header when switch is on', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.test.tsx
@@ -173,33 +173,7 @@ describe('ConfigureCasesRedesign', () => {
     expect(screen.getByTestId('legacy-templates-view-new-link')).toBeInTheDocument();
   });
 
-  it('renders the legacy section when only legacy templates exist', async () => {
-    const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
-    useCasesConfig.mockReturnValue({
-      attachmentsEnabled: false,
-      chatEnabled: false,
-      templatesEnabled: true,
-      detailsRedesignEnabled: false,
-      casesRedesign: { list: false, details: false, settings: true },
-    });
-    useGetCaseConfigurationMock.mockImplementation(() => ({
-      ...useCaseConfigureResponse,
-      data: {
-        ...useCaseConfigureResponse.data,
-        customFields: [],
-        templates: templatesConfigurationMock,
-      },
-    }));
-
-    renderWithTestingProviders(<ConfigureCasesRedesign />);
-
-    expect(
-      await screen.findByTestId('cases-redesign-legacy-custom-fields-section')
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('show-legacy-custom-fields-switch')).not.toBeChecked();
-  });
-
-  it('does not render the legacy section when templates v2 is enabled but no legacy config exists', async () => {
+  it('shows add buttons for empty legacy custom fields and templates when the switch is on', async () => {
     const { useCasesConfig } = jest.requireMock('../../../common/lib/kibana');
     useCasesConfig.mockReturnValue({
       attachmentsEnabled: false,
@@ -219,12 +193,16 @@ describe('ConfigureCasesRedesign', () => {
 
     renderWithTestingProviders(<ConfigureCasesRedesign />);
 
-    await screen.findByTestId('cases-redesign-settings-panel');
-
     expect(
-      screen.queryByTestId('cases-redesign-legacy-custom-fields-section')
-    ).not.toBeInTheDocument();
-    expect(screen.queryByTestId('show-legacy-custom-fields-switch')).not.toBeInTheDocument();
+      await screen.findByTestId('cases-redesign-legacy-custom-fields-section')
+    ).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByTestId('show-legacy-custom-fields-switch'));
+
+    expect(await screen.findByTestId('add-custom-field')).toBeInTheDocument();
+    expect(screen.getByTestId('add-template')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-custom-fields')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-templates')).toBeInTheDocument();
   });
 
   it('opens add custom field flyout with add header when switch is on', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.tsx
@@ -20,7 +20,7 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 
-import { useKibana } from '../../../common/lib/kibana';
+import { useCasesConfig, useKibana } from '../../../common/lib/kibana';
 import { CasesPageBody } from '../../app/cases_page_body';
 import { Connectors } from '../../configure_cases/connectors';
 import * as configureCasesI18n from '../../configure_cases/translations';
@@ -32,6 +32,7 @@ import { ObservableTypes } from '../../observable_types';
 import { AutomaticClosureSwitch } from './automatic_closure_switch';
 import { SettingsSection } from './settings_section';
 import { ConfigureCasesAppHeader } from './configure_cases_app_header';
+import { OldCustomFieldsAndTemplatesSection } from './old_custom_fields_and_templates_section';
 import * as observableTypesI18n from '../../observable_types/translations';
 
 const contentWrapperCss = css`
@@ -48,6 +49,8 @@ const getFormWrapperCss = (euiTheme: EuiThemeComputed) => css`
   }
 `;
 
+type LegacyFlyoutType = 'customField' | 'template';
+
 // This component intentionally mirrors the connector/closure/observable-types logic in
 // `../../configure_cases` (the legacy settings page) via the shared `useConfigureCasesController`
 // hook. Both pages are kept as separate presentational implementations while behind the
@@ -58,15 +61,21 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
   const { euiTheme } = useEuiTheme();
   const { permissions } = useCasesContext();
   const { docLinks } = useKibana().services;
+  const { templatesEnabled } = useCasesConfig();
 
   const {
     hasMinimumLicensePermissions,
     hasMinimumLicensePermissionsForObservables,
     isObservablesFeatureEnabled,
+    configurationId,
+    configurationVersion,
     closureType,
     connector,
     mappings,
+    customFields,
+    templates,
     observableTypes,
+    isPersistingConfiguration,
     isLoadingCaseConfiguration,
     isLoadingConnectors,
     connectors,
@@ -74,8 +83,9 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
     isLoadingAny,
     connectorIsValid,
     updateConnectorDisabled,
+    flyOutVisibility,
     setFlyOutVisibility,
-    isPersistingConfiguration,
+    persistCaseConfigure,
     onClickUpdateConnector,
     onAddNewConnector,
     onChangeConnector,
@@ -85,10 +95,12 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
     onEditObservableType,
     onDeleteObservableType,
     AddOrEditObservableTypeFlyout,
-  } = useConfigureCasesController();
+  } = useConfigureCasesController<LegacyFlyoutType>();
 
   const showObservableTypesSection =
     hasMinimumLicensePermissionsForObservables && isObservablesFeatureEnabled;
+
+  const showLegacySection = templatesEnabled;
 
   return (
     <>
@@ -189,6 +201,22 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
                       handleEditObservableType={onEditObservableType}
                     />
                   </SettingsSection>
+                )}
+
+                {showLegacySection && (
+                  <OldCustomFieldsAndTemplatesSection
+                    configurationId={configurationId}
+                    configurationVersion={configurationVersion}
+                    closureType={closureType}
+                    connector={connector}
+                    customFields={customFields}
+                    templates={templates}
+                    connectors={connectors ?? []}
+                    isLoadingCaseConfiguration={isLoadingCaseConfiguration}
+                    persistCaseConfigure={persistCaseConfigure}
+                    flyOutVisibility={flyOutVisibility}
+                    setFlyOutVisibility={setFlyOutVisibility}
+                  />
                 )}
               </EuiPanel>
             </div>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.tsx
@@ -100,7 +100,7 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
   const showObservableTypesSection =
     hasMinimumLicensePermissionsForObservables && isObservablesFeatureEnabled;
 
-  const showLegacySection = templatesEnabled;
+  const showLegacySection = templatesEnabled && (customFields.length > 0 || templates.length > 0);
 
   return (
     <>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/configure_cases.tsx
@@ -100,8 +100,6 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
   const showObservableTypesSection =
     hasMinimumLicensePermissionsForObservables && isObservablesFeatureEnabled;
 
-  const showLegacySection = templatesEnabled && (customFields.length > 0 || templates.length > 0);
-
   return (
     <>
       <ConfigureCasesAppHeader />
@@ -203,7 +201,7 @@ export const ConfigureCasesRedesign: React.FC = React.memo(() => {
                   </SettingsSection>
                 )}
 
-                {showLegacySection && (
+                {templatesEnabled && (
                   <OldCustomFieldsAndTemplatesSection
                     configurationId={configurationId}
                     configurationVersion={configurationVersion}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
@@ -1,0 +1,430 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiSpacer,
+  EuiSwitch,
+  EuiTitle,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type {
+  CustomFieldConfiguration,
+  TemplateConfiguration,
+  CustomFieldTypes,
+  ActionConnector,
+} from '../../../../common/types/domain';
+import type { CasesConfigurationUI, CaseUI } from '../../../containers/types';
+import { CustomFields } from '../../custom_fields';
+import { Templates } from '../../templates';
+import { CustomFieldsForm } from '../../custom_fields/form';
+import { TemplateForm } from '../../templates/form';
+import type { TemplateFormProps } from '../../templates/types';
+import { CommonFlyout } from '../../configure_cases/flyout';
+import { addOrReplaceField } from '../../utils';
+import { builderMap as customFieldsBuilderMap } from '../../custom_fields/builder';
+import { useShowLegacyCustomFields } from '../../../common/use_show_old_custom_fields';
+import {
+  useCasesFieldLibraryNavigation,
+  useCasesTemplatesNavigation,
+} from '../../../common/navigation';
+import { useCasesContext } from '../../cases_context/use_cases_context';
+import { useGetCaseConfiguration } from '../../../containers/configure/use_get_case_configuration';
+import type { ClosureType } from '../../../containers/configure/types';
+import { SettingsSection } from './settings_section';
+import * as i18n from '../../configure_cases/translations';
+
+type LegacyFlyoutType = 'customField' | 'template';
+
+const addNewCustomFieldToTemplates = ({
+  templates,
+  customFields,
+}: Pick<CasesConfigurationUI, 'templates' | 'customFields'>) => {
+  return templates.map((template) => {
+    const templateCustomFields = template.caseFields?.customFields ?? [];
+
+    customFields.forEach((field) => {
+      if (
+        !templateCustomFields.length ||
+        !templateCustomFields.find((templateCustomField) => templateCustomField.key === field.key)
+      ) {
+        const customFieldFactory = customFieldsBuilderMap[field.type];
+        const { getDefaultValue } = customFieldFactory();
+        const value = getDefaultValue?.() ?? null;
+
+        templateCustomFields.push({
+          key: field.key,
+          type: field.type as CustomFieldTypes,
+          value: field.defaultValue ?? value,
+        } as CaseUI['customFields'][number]);
+      }
+    });
+
+    return {
+      ...template,
+      caseFields: {
+        ...template.caseFields,
+        customFields: [...templateCustomFields],
+      },
+    };
+  });
+};
+
+export interface OldCustomFieldsAndTemplatesSectionProps {
+  configurationId: string;
+  configurationVersion: string;
+  closureType: ClosureType;
+  connector: CasesConfigurationUI['connector'];
+  customFields: CasesConfigurationUI['customFields'];
+  templates: CasesConfigurationUI['templates'];
+  connectors: ActionConnector[];
+  isLoadingCaseConfiguration: boolean;
+  persistCaseConfigure: (params: {
+    connector: CasesConfigurationUI['connector'];
+    customFields: CasesConfigurationUI['customFields'];
+    templates: CasesConfigurationUI['templates'];
+    id: string;
+    version: string;
+    closureType: ClosureType;
+  }) => void;
+  flyOutVisibility: { type: LegacyFlyoutType | string; visible: boolean } | null;
+  setFlyOutVisibility: (value: { type: LegacyFlyoutType; visible: boolean } | null) => void;
+}
+
+export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemplatesSectionProps> =
+  React.memo(
+    ({
+      configurationId,
+      configurationVersion,
+      closureType,
+      connector,
+      customFields,
+      templates,
+      connectors,
+      isLoadingCaseConfiguration,
+      persistCaseConfigure,
+      flyOutVisibility,
+      setFlyOutVisibility,
+    }) => {
+      const { permissions } = useCasesContext();
+      const { showLegacyCustomFields, setShowLegacyCustomFields } = useShowLegacyCustomFields();
+      const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
+      const { getCasesTemplatesUrl } = useCasesTemplatesNavigation();
+      const { data: currentConfiguration } = useGetCaseConfiguration();
+
+      const [customFieldToEdit, setCustomFieldToEdit] = useState<CustomFieldConfiguration | null>(
+        null
+      );
+      const [templateToEdit, setTemplateToEdit] = useState<TemplateConfiguration | null>(null);
+
+      const onDeleteCustomField = useCallback(
+        (key: string) => {
+          const remainingCustomFields = customFields.filter((field) => field.key !== key);
+
+          const templatesWithRemainingCustomFields = templates.map((template) => {
+            const templateCustomFields =
+              template.caseFields?.customFields?.filter((field) => field.key !== key) ?? [];
+
+            return {
+              ...template,
+              caseFields: {
+                ...template.caseFields,
+                customFields: [...templateCustomFields],
+              },
+            };
+          });
+
+          persistCaseConfigure({
+            connector,
+            customFields: [...remainingCustomFields],
+            templates: [...templatesWithRemainingCustomFields],
+            id: configurationId,
+            version: configurationVersion,
+            closureType,
+          });
+        },
+        [
+          closureType,
+          configurationId,
+          configurationVersion,
+          connector,
+          customFields,
+          templates,
+          persistCaseConfigure,
+        ]
+      );
+
+      const onEditCustomField = useCallback(
+        (key: string) => {
+          const selectedCustomField = customFields.find((item) => item.key === key);
+
+          if (selectedCustomField) {
+            setCustomFieldToEdit(selectedCustomField);
+          }
+          setFlyOutVisibility({ type: 'customField', visible: true });
+        },
+        [customFields, setFlyOutVisibility]
+      );
+
+      const onCloseCustomFieldFlyout = useCallback(() => {
+        setFlyOutVisibility({ type: 'customField', visible: false });
+        setCustomFieldToEdit(null);
+      }, [setFlyOutVisibility]);
+
+      const onCustomFieldSave = useCallback(
+        (data: CustomFieldConfiguration) => {
+          const updatedCustomFields = addOrReplaceField(customFields, data);
+          const updatedTemplates = addNewCustomFieldToTemplates({
+            templates,
+            customFields: updatedCustomFields,
+          });
+
+          persistCaseConfigure({
+            connector,
+            customFields: updatedCustomFields,
+            templates: updatedTemplates,
+            id: configurationId,
+            version: configurationVersion,
+            closureType,
+          });
+
+          setFlyOutVisibility({ type: 'customField', visible: false });
+          setCustomFieldToEdit(null);
+        },
+        [
+          closureType,
+          configurationId,
+          configurationVersion,
+          connector,
+          customFields,
+          templates,
+          persistCaseConfigure,
+          setFlyOutVisibility,
+        ]
+      );
+
+      const onDeleteTemplate = useCallback(
+        (key: string) => {
+          const remainingTemplates = templates.filter((field) => field.key !== key);
+
+          persistCaseConfigure({
+            connector,
+            customFields,
+            templates: [...remainingTemplates],
+            id: configurationId,
+            version: configurationVersion,
+            closureType,
+          });
+        },
+        [
+          closureType,
+          configurationId,
+          configurationVersion,
+          connector,
+          customFields,
+          templates,
+          persistCaseConfigure,
+        ]
+      );
+
+      const onEditTemplate = useCallback(
+        (key: string) => {
+          const selectedTemplate = templates.find((item) => item.key === key);
+
+          if (selectedTemplate) {
+            setTemplateToEdit(selectedTemplate);
+          }
+          setFlyOutVisibility({ type: 'template', visible: true });
+        },
+        [templates, setFlyOutVisibility]
+      );
+
+      const onCloseTemplateFlyout = useCallback(() => {
+        setFlyOutVisibility({ type: 'template', visible: false });
+        setTemplateToEdit(null);
+      }, [setFlyOutVisibility]);
+
+      const onTemplateSave = useCallback(
+        (data: TemplateConfiguration) => {
+          const updatedTemplates = addOrReplaceField(templates, data);
+
+          persistCaseConfigure({
+            connector,
+            customFields,
+            templates: updatedTemplates,
+            id: configurationId,
+            version: configurationVersion,
+            closureType,
+          });
+
+          setFlyOutVisibility({ type: 'template', visible: false });
+          setTemplateToEdit(null);
+        },
+        [
+          closureType,
+          configurationId,
+          configurationVersion,
+          connector,
+          customFields,
+          templates,
+          persistCaseConfigure,
+          setFlyOutVisibility,
+        ]
+      );
+
+      const AddOrEditCustomFieldFlyout =
+        flyOutVisibility?.type === 'customField' && flyOutVisibility?.visible ? (
+          <CommonFlyout<CustomFieldConfiguration>
+            isLoading={isLoadingCaseConfiguration}
+            disabled={!permissions.settings || isLoadingCaseConfiguration}
+            onCloseFlyout={onCloseCustomFieldFlyout}
+            onSaveField={onCustomFieldSave}
+            renderHeader={() => (
+              <span>{customFieldToEdit ? i18n.EDIT_CUSTOM_FIELD : i18n.ADD_CUSTOM_FIELD} </span>
+            )}
+          >
+            {({ onChange }) => (
+              <CustomFieldsForm onChange={onChange} initialValue={customFieldToEdit} />
+            )}
+          </CommonFlyout>
+        ) : null;
+
+      const AddOrEditTemplateFlyout =
+        flyOutVisibility?.type === 'template' && flyOutVisibility?.visible ? (
+          <CommonFlyout<TemplateFormProps, TemplateConfiguration>
+            isLoading={isLoadingCaseConfiguration}
+            disabled={!permissions.settings || isLoadingCaseConfiguration}
+            onCloseFlyout={onCloseTemplateFlyout}
+            onSaveField={onTemplateSave}
+            renderHeader={() => (
+              <span>{templateToEdit ? i18n.EDIT_TEMPLATE : i18n.CREATE_TEMPLATE}</span>
+            )}
+          >
+            {({ onChange }) => (
+              <TemplateForm
+                initialValue={templateToEdit}
+                connectors={connectors ?? []}
+                currentConfiguration={currentConfiguration}
+                isEditMode={Boolean(templateToEdit)}
+                onChange={onChange}
+              />
+            )}
+          </CommonFlyout>
+        ) : null;
+
+      return (
+        <>
+          <EuiHorizontalRule margin="l" />
+          <SettingsSection
+            data-test-subj="cases-redesign-legacy-custom-fields-section"
+            title={i18n.LEGACY_CUSTOM_FIELDS_AND_TEMPLATES_TITLE}
+            description={
+              <FormattedMessage
+                id="xpack.cases.configureCases.legacyCustomFieldsAndTemplatesDescription"
+                defaultMessage="A new custom fields and templates system is available. Your old custom fields and templates have been migrated to the new system. {customFieldsLink} or {templatesLink}."
+                values={{
+                  customFieldsLink: (
+                    <EuiLink
+                      href={getCasesFieldLibraryUrl()}
+                      data-test-subj="legacy-custom-fields-view-new-link"
+                    >
+                      {i18n.VIEW_NEW_CUSTOM_FIELDS}
+                    </EuiLink>
+                  ),
+                  templatesLink: (
+                    <EuiLink
+                      href={getCasesTemplatesUrl()}
+                      data-test-subj="legacy-templates-view-new-link"
+                    >
+                      {i18n.VIEW_NEW_TEMPLATES}
+                    </EuiLink>
+                  ),
+                }}
+              />
+            }
+          >
+            <EuiSwitch
+              label={i18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES}
+              checked={showLegacyCustomFields}
+              onChange={(e) => setShowLegacyCustomFields(e.target.checked)}
+              data-test-subj="show-legacy-custom-fields-switch"
+            />
+
+            {showLegacyCustomFields ? (
+              <>
+                <EuiSpacer size="l" />
+                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiTitle size="xs">
+                      <h3>{i18n.LEGACY_CUSTOM_FIELDS_LIST_TITLE}</h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge
+                      color="warning"
+                      data-test-subj="legacy-custom-fields-deprecated-badge"
+                    >
+                      {i18n.DEPRECATED_BADGE}
+                    </EuiBadge>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                <EuiSpacer size="s" />
+                <CustomFields
+                  customFields={customFields}
+                  isLoading={isLoadingCaseConfiguration}
+                  disabled={isLoadingCaseConfiguration}
+                  hideTitle
+                  useLineSeparators
+                  handleAddCustomField={() =>
+                    setFlyOutVisibility({ type: 'customField', visible: true })
+                  }
+                  handleDeleteCustomField={onDeleteCustomField}
+                  handleEditCustomField={onEditCustomField}
+                />
+
+                <EuiSpacer size="l" />
+
+                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiTitle size="xs">
+                      <h3>{i18n.LEGACY_TEMPLATES_LIST_TITLE}</h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="warning" data-test-subj="legacy-templates-deprecated-badge">
+                      {i18n.DEPRECATED_BADGE}
+                    </EuiBadge>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                <EuiSpacer size="s" />
+                <Templates
+                  templates={templates}
+                  isLoading={isLoadingCaseConfiguration}
+                  disabled={isLoadingCaseConfiguration}
+                  hideTitle
+                  useLineSeparators
+                  onAddTemplate={() => setFlyOutVisibility({ type: 'template', visible: true })}
+                  onEditTemplate={onEditTemplate}
+                  onDeleteTemplate={onDeleteTemplate}
+                />
+              </>
+            ) : null}
+          </SettingsSection>
+
+          {AddOrEditCustomFieldFlyout}
+          {AddOrEditTemplateFlyout}
+        </>
+      );
+    }
+  );
+
+OldCustomFieldsAndTemplatesSection.displayName = 'OldCustomFieldsAndTemplatesSection';

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
@@ -340,22 +340,22 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
             description={
               <FormattedMessage
                 id="xpack.cases.configureCases.legacyCustomFieldsAndTemplatesDescription"
-                defaultMessage="A new custom fields and templates system is available. Your old custom fields and templates have been migrated to the new system. {customFieldsLink} or {templatesLink}."
+                defaultMessage="Your custom fields and templates have been migrated to a new YAML-based template system. Manage them in the {templatesLink}. To view your migrated custom fields, visit the {customFieldsLink}. Your legacy configuration is kept here for reference during the transition."
                 values={{
-                  customFieldsLink: (
-                    <EuiLink
-                      href={getCasesFieldLibraryUrl()}
-                      data-test-subj="legacy-custom-fields-view-new-link"
-                    >
-                      {i18n.VIEW_NEW_CUSTOM_FIELDS}
-                    </EuiLink>
-                  ),
                   templatesLink: (
                     <EuiLink
                       href={getCasesTemplatesUrl()}
                       data-test-subj="legacy-templates-view-new-link"
                     >
                       {i18n.VIEW_NEW_TEMPLATES}
+                    </EuiLink>
+                  ),
+                  customFieldsLink: (
+                    <EuiLink
+                      href={getCasesFieldLibraryUrl()}
+                      data-test-subj="legacy-custom-fields-view-new-link"
+                    >
+                      {i18n.VIEW_NEW_CUSTOM_FIELDS}
                     </EuiLink>
                   ),
                 }}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
@@ -163,6 +163,11 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
         ]
       );
 
+      const onAddCustomField = useCallback(() => {
+        setCustomFieldToEdit(null);
+        setFlyOutVisibility({ type: 'customField', visible: true });
+      }, [setFlyOutVisibility]);
+
       const onEditCustomField = useCallback(
         (key: string) => {
           const selectedCustomField = customFields.find((item) => item.key === key);
@@ -235,6 +240,11 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
           persistCaseConfigure,
         ]
       );
+
+      const onAddTemplate = useCallback(() => {
+        setTemplateToEdit(null);
+        setFlyOutVisibility({ type: 'template', visible: true });
+      }, [setFlyOutVisibility]);
 
       const onEditTemplate = useCallback(
         (key: string) => {
@@ -384,9 +394,7 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
                   disabled={isLoadingCaseConfiguration}
                   hideTitle
                   useLineSeparators
-                  handleAddCustomField={() =>
-                    setFlyOutVisibility({ type: 'customField', visible: true })
-                  }
+                  handleAddCustomField={onAddCustomField}
                   handleDeleteCustomField={onDeleteCustomField}
                   handleEditCustomField={onEditCustomField}
                 />
@@ -412,7 +420,7 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
                   disabled={isLoadingCaseConfiguration}
                   hideTitle
                   useLineSeparators
-                  onAddTemplate={() => setFlyOutVisibility({ type: 'template', visible: true })}
+                  onAddTemplate={onAddTemplate}
                   onEditTemplate={onEditTemplate}
                   onDeleteTemplate={onDeleteTemplate}
                 />

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
@@ -15,6 +15,7 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type {
@@ -116,7 +117,8 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
       setFlyOutVisibility,
     }) => {
       const { permissions } = useCasesContext();
-      const { showLegacyCustomFields, setShowLegacyCustomFields } = useShowLegacyCustomFields();
+      const { showLegacyCustomFields, setShowLegacyCustomFields, canDisableSwitch } =
+        useShowLegacyCustomFields(customFields);
       const { getCasesFieldLibraryUrl } = useCasesFieldLibraryNavigation();
       const { getCasesTemplatesUrl } = useCasesTemplatesNavigation();
       const { data: currentConfiguration } = useGetCaseConfiguration();
@@ -362,12 +364,19 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
               />
             }
           >
-            <EuiSwitch
-              label={i18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES}
-              checked={showLegacyCustomFields}
-              onChange={(e) => setShowLegacyCustomFields(e.target.checked)}
-              data-test-subj="show-legacy-custom-fields-switch"
-            />
+            <EuiToolTip
+              content={
+                canDisableSwitch ? undefined : i18n.SHOW_LEGACY_CUSTOM_FIELDS_SWITCH_DISABLED_HELP
+              }
+            >
+              <EuiSwitch
+                label={i18n.SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES}
+                checked={showLegacyCustomFields}
+                disabled={!canDisableSwitch}
+                onChange={(e) => setShowLegacyCustomFields(e.target.checked)}
+                data-test-subj="show-legacy-custom-fields-switch"
+              />
+            </EuiToolTip>
 
             {showLegacyCustomFields ? (
               <>
@@ -394,6 +403,8 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
                   disabled={isLoadingCaseConfiguration}
                   hideTitle
                   useLineSeparators
+                  emptyStateMessage={null}
+                  addButtonLabel={i18n.ADD_LEGACY_CUSTOM_FIELD}
                   handleAddCustomField={onAddCustomField}
                   handleDeleteCustomField={onDeleteCustomField}
                   handleEditCustomField={onEditCustomField}
@@ -420,6 +431,8 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
                   disabled={isLoadingCaseConfiguration}
                   hideTitle
                   useLineSeparators
+                  emptyStateMessage={null}
+                  addButtonLabel={i18n.ADD_LEGACY_TEMPLATE}
                   onAddTemplate={onAddTemplate}
                   onEditTemplate={onEditTemplate}
                   onDeleteTemplate={onDeleteTemplate}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/configure_cases/old_custom_fields_and_templates_section.tsx
@@ -340,7 +340,7 @@ export const OldCustomFieldsAndTemplatesSection: React.FC<OldCustomFieldsAndTemp
             description={
               <FormattedMessage
                 id="xpack.cases.configureCases.legacyCustomFieldsAndTemplatesDescription"
-                defaultMessage="Your custom fields and templates have been migrated to a new YAML-based template system. Manage them in the {templatesLink}. To view your migrated custom fields, visit the {customFieldsLink}. Your legacy configuration is kept here for reference during the transition."
+                defaultMessage="Custom fields and templates you've created have been migrated to the new YAML-based template system. Manage them in the {templatesLink}. To view your migrated custom fields, visit the {customFieldsLink}. Your legacy configuration is kept here for reference during the transition."
                 values={{
                   templatesLink: (
                     <EuiLink

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
@@ -168,7 +168,7 @@ export const LEGACY_CUSTOM_FIELDS_DISCLAIMER = i18n.translate(
   'xpack.cases.casesRedesign.details.legacyCustomFieldsDisclaimer',
   {
     defaultMessage:
-      'These custom fields are from the previous system and have been migrated to the new custom fields system.',
+      'These fields are from the previous custom fields system and have already been migrated. You may see the same fields again in other sections — that is expected while both systems are shown.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
@@ -160,21 +160,20 @@ export const ADD_CONNECTOR = i18n.translate('xpack.cases.casesRedesign.details.a
 export const LEGACY_CUSTOM_FIELDS_TITLE = i18n.translate(
   'xpack.cases.casesRedesign.details.legacyCustomFieldsTitle',
   {
-    defaultMessage: 'Custom fields',
+    defaultMessage: 'Legacy custom fields',
   }
 );
 
-export const LEGACY_CUSTOM_FIELDS_DISCLAIMER = i18n.translate(
-  'xpack.cases.casesRedesign.details.legacyCustomFieldsDisclaimer',
+export const LEGACY_CUSTOM_FIELDS_VIEW_CUSTOM_FIELDS = i18n.translate(
+  'xpack.cases.casesRedesign.details.legacyCustomFieldsViewCustomFields',
   {
-    defaultMessage:
-      'These fields are from the previous custom fields system and have already been migrated. You may see the same fields again in other sections — that is expected while both systems are shown.',
+    defaultMessage: 'custom fields',
   }
 );
 
-export const LEGACY_CUSTOM_FIELDS_VIEW_NEW = i18n.translate(
-  'xpack.cases.casesRedesign.details.legacyCustomFieldsViewNew',
+export const LEGACY_CUSTOM_FIELDS_VIEW_SETTINGS = i18n.translate(
+  'xpack.cases.casesRedesign.details.legacyCustomFieldsViewSettings',
   {
-    defaultMessage: 'View new custom fields',
+    defaultMessage: 'settings',
   }
 );

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
@@ -156,3 +156,25 @@ export const CLICK_TO_SEND_EMAIL = (email: string) =>
 export const ADD_CONNECTOR = i18n.translate('xpack.cases.casesRedesign.details.addConnector', {
   defaultMessage: 'Add connector',
 });
+
+export const LEGACY_CUSTOM_FIELDS_TITLE = i18n.translate(
+  'xpack.cases.casesRedesign.details.legacyCustomFieldsTitle',
+  {
+    defaultMessage: 'Custom fields',
+  }
+);
+
+export const LEGACY_CUSTOM_FIELDS_DISCLAIMER = i18n.translate(
+  'xpack.cases.casesRedesign.details.legacyCustomFieldsDisclaimer',
+  {
+    defaultMessage:
+      'These custom fields are from the previous system and have been migrated to the new custom fields system.',
+  }
+);
+
+export const LEGACY_CUSTOM_FIELDS_VIEW_NEW = i18n.translate(
+  'xpack.cases.casesRedesign.details.legacyCustomFieldsViewNew',
+  {
+    defaultMessage: 'View new custom fields',
+  }
+);

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
@@ -214,3 +214,46 @@ export const SHOW_ALL_TEMPLATES = i18n.translate(
     defaultMessage: 'Show all templates',
   }
 );
+
+export const LEGACY_CUSTOM_FIELDS_AND_TEMPLATES_TITLE = i18n.translate(
+  'xpack.cases.configureCases.legacyCustomFieldsAndTemplatesTitle',
+  {
+    defaultMessage: 'Old custom fields and templates',
+  }
+);
+
+export const SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES = i18n.translate(
+  'xpack.cases.configureCases.showLegacyCustomFieldsAndTemplates',
+  {
+    defaultMessage: 'Show old custom fields and templates',
+  }
+);
+
+export const VIEW_NEW_CUSTOM_FIELDS = i18n.translate(
+  'xpack.cases.configureCases.viewNewCustomFields',
+  {
+    defaultMessage: 'View new custom fields',
+  }
+);
+
+export const VIEW_NEW_TEMPLATES = i18n.translate('xpack.cases.configureCases.viewNewTemplates', {
+  defaultMessage: 'View new templates',
+});
+
+export const LEGACY_CUSTOM_FIELDS_LIST_TITLE = i18n.translate(
+  'xpack.cases.configureCases.legacyCustomFieldsListTitle',
+  {
+    defaultMessage: 'Custom fields',
+  }
+);
+
+export const LEGACY_TEMPLATES_LIST_TITLE = i18n.translate(
+  'xpack.cases.configureCases.legacyTemplatesListTitle',
+  {
+    defaultMessage: 'Templates',
+  }
+);
+
+export const DEPRECATED_BADGE = i18n.translate('xpack.cases.configureCases.deprecatedBadge', {
+  defaultMessage: 'Deprecated',
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
@@ -218,26 +218,26 @@ export const SHOW_ALL_TEMPLATES = i18n.translate(
 export const LEGACY_CUSTOM_FIELDS_AND_TEMPLATES_TITLE = i18n.translate(
   'xpack.cases.configureCases.legacyCustomFieldsAndTemplatesTitle',
   {
-    defaultMessage: 'Old custom fields and templates',
+    defaultMessage: 'Legacy custom fields and templates',
   }
 );
 
 export const SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES = i18n.translate(
   'xpack.cases.configureCases.showLegacyCustomFieldsAndTemplates',
   {
-    defaultMessage: 'Show old custom fields and templates',
+    defaultMessage: 'Show legacy custom fields and templates',
   }
 );
 
 export const VIEW_NEW_CUSTOM_FIELDS = i18n.translate(
   'xpack.cases.configureCases.viewNewCustomFields',
   {
-    defaultMessage: 'View new custom fields',
+    defaultMessage: 'fields library',
   }
 );
 
 export const VIEW_NEW_TEMPLATES = i18n.translate('xpack.cases.configureCases.viewNewTemplates', {
-  defaultMessage: 'View new templates',
+  defaultMessage: 'new templates experience',
 });
 
 export const LEGACY_CUSTOM_FIELDS_LIST_TITLE = i18n.translate(

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
@@ -225,7 +225,15 @@ export const LEGACY_CUSTOM_FIELDS_AND_TEMPLATES_TITLE = i18n.translate(
 export const SHOW_LEGACY_CUSTOM_FIELDS_AND_TEMPLATES = i18n.translate(
   'xpack.cases.configureCases.showLegacyCustomFieldsAndTemplates',
   {
-    defaultMessage: 'Show legacy custom fields and templates',
+    defaultMessage: 'Show deprecated custom fields and templates',
+  }
+);
+
+export const SHOW_LEGACY_CUSTOM_FIELDS_SWITCH_DISABLED_HELP = i18n.translate(
+  'xpack.cases.configureCases.showLegacyCustomFieldsSwitchDisabledHelp',
+  {
+    defaultMessage:
+      'Required custom fields without a default value must stay visible so cases can still be created. Add a default or make them optional to disable this.',
   }
 );
 
@@ -253,6 +261,17 @@ export const LEGACY_TEMPLATES_LIST_TITLE = i18n.translate(
     defaultMessage: 'Templates',
   }
 );
+
+export const ADD_LEGACY_CUSTOM_FIELD = i18n.translate(
+  'xpack.cases.configureCases.addLegacyCustomField',
+  {
+    defaultMessage: 'Add legacy field',
+  }
+);
+
+export const ADD_LEGACY_TEMPLATE = i18n.translate('xpack.cases.configureCases.addLegacyTemplate', {
+  defaultMessage: 'Add legacy template',
+});
 
 export const DEPRECATED_BADGE = i18n.translate('xpack.cases.configureCases.deprecatedBadge', {
   defaultMessage: 'Deprecated',

--- a/x-pack/platform/plugins/shared/cases/public/components/create/form_context.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/form_context.tsx
@@ -36,7 +36,9 @@ export const FormContext: React.FC<FormContextProps> = ({
 }) => {
   const { data: connectors = [] } = useGetSupportedActionConnectors();
   const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
-  const { showLegacyCustomFields } = useShowLegacyCustomFields();
+  const { showLegacyCustomFields } = useShowLegacyCustomFields(
+    currentConfiguration.customFields ?? []
+  );
   const includeLegacyCustomFields = !isTemplatesV2Enabled || showLegacyCustomFields;
 
   const serializer = useCallback(

--- a/x-pack/platform/plugins/shared/cases/public/components/create/form_context.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/form_context.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { schema } from './schema';
 
@@ -16,6 +16,8 @@ import { getInitialCaseValue } from '../../../common/utils/get_initial_case_valu
 import { createFormSerializer, createFormDeserializer } from './utils';
 import type { CaseFormFieldsSchemaProps } from '../case_form_fields/schema';
 import { type UseSubmitCaseValue } from './use_submit_case';
+import { KibanaServices } from '../../common/lib/kibana';
+import { useShowLegacyCustomFields } from '../../common/use_show_old_custom_fields';
 
 export interface FormContextProps {
   children?: JSX.Element | JSX.Element[];
@@ -33,6 +35,23 @@ export const FormContext: React.FC<FormContextProps> = ({
   onSubmitCase,
 }) => {
   const { data: connectors = [] } = useGetSupportedActionConnectors();
+  const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
+  const { showLegacyCustomFields } = useShowLegacyCustomFields();
+  const includeLegacyCustomFields = !isTemplatesV2Enabled || showLegacyCustomFields;
+
+  const serializer = useCallback(
+    (data: CaseFormFieldsSchemaProps) =>
+      createFormSerializer(
+        connectors,
+        {
+          ...currentConfiguration,
+          owner: selectedOwner,
+        },
+        data,
+        { includeLegacyCustomFields }
+      ),
+    [connectors, currentConfiguration, selectedOwner, includeLegacyCustomFields]
+  );
 
   const { form } = useForm({
     defaultValue: {
@@ -50,15 +69,7 @@ export const FormContext: React.FC<FormContextProps> = ({
     options: { stripEmptyFields: false },
     schema,
     onSubmit: onSubmitCase,
-    serializer: (data: CaseFormFieldsSchemaProps) =>
-      createFormSerializer(
-        connectors,
-        {
-          ...currentConfiguration,
-          owner: selectedOwner,
-        },
-        data
-      ),
+    serializer,
     deserializer: createFormDeserializer,
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
@@ -131,7 +131,6 @@ describe('CreateCaseTemplateFields', () => {
 
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
     expect(screen.getByTestId('control-hostname')).toHaveTextContent('Host Name');
     expect(screen.getByTestId('control-effort')).toHaveTextContent('Effort Level');
   });
@@ -193,7 +192,7 @@ describe('CreateCaseTemplateFields', () => {
 
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.getByTestId('control-incident_type')).toBeInTheDocument();
     expect(screen.queryByText('Template not selected')).not.toBeInTheDocument();
   });
@@ -228,7 +227,7 @@ describe('CreateCaseTemplateFields', () => {
 
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.getByTestId('control-incident_type')).toBeInTheDocument();
   });
 
@@ -270,9 +269,8 @@ describe('CreateCaseTemplateFields', () => {
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
     // The template references incident_type via $ref — it should not appear in the global section.
-    // The "Extended fields" heading still appears because the template has its own fields (hostname).
     expect(screen.queryByText('Global fields')).not.toBeInTheDocument();
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.queryByTestId('control-incident_type')).not.toBeInTheDocument();
   });
 
@@ -312,7 +310,7 @@ describe('CreateCaseTemplateFields', () => {
 
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
-    expect(screen.getByText('Extended fields')).toBeInTheDocument();
+    expect(screen.queryByText('Extended fields')).not.toBeInTheDocument();
     expect(screen.getByTestId('control-incident_type')).toBeInTheDocument();
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
@@ -131,6 +131,9 @@ describe('CreateCaseTemplateFields', () => {
 
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
+    expect(screen.getByTestId('create-case-custom-fields-title')).toHaveTextContent(
+      'Custom fields'
+    );
     expect(screen.getByTestId('control-hostname')).toHaveTextContent('Host Name');
     expect(screen.getByTestId('control-effort')).toHaveTextContent('Effort Level');
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
@@ -30,7 +30,14 @@ import { TemplateFieldsValidationContext } from './template_fields_validation_co
 
 type FormShape = Record<string, Record<string, unknown>>;
 
-export const CreateCaseTemplateFields: React.FC = () => {
+interface CreateCaseTemplateFieldsProps {
+  /** When true, adds top spacing so global/template fields don't sit flush against legacy custom fields. */
+  hasLegacyCustomFields?: boolean;
+}
+
+export const CreateCaseTemplateFields: React.FC<CreateCaseTemplateFieldsProps> = ({
+  hasLegacyCustomFields = false,
+}) => {
   const parentForm = useParentFormContext();
   const [{ templateId }] = useFormData<{ templateId?: string }>({ watch: ['templateId'] });
   const { owner } = useCasesContext();
@@ -161,9 +168,8 @@ export const CreateCaseTemplateFields: React.FC = () => {
     <>
       <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />
       <FormProvider {...innerForm}>
-        {/* Separate from legacy custom fields (and other form fields) above —
-            the parent CaseFormFields uses gutterSize="none". */}
-        <EuiSpacer size="m" />
+        {/* Parent CaseFormFields uses gutterSize="none"; only pad when legacy fields sit above. */}
+        {hasLegacyCustomFields && <EuiSpacer size="m" />}
         {globalFieldsFragment}
         {globalFieldsFragment && templateFieldsFragment && <EuiSpacer />}
         {templateFieldsFragment}

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
-import { EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
 import { FormProvider, useForm } from 'react-hook-form';
 import {
   UseField,
@@ -17,7 +17,6 @@ import { HiddenField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { CASE_EXTENDED_FIELDS } from '../../../common/constants';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { useTemplateFormSync } from './use_template_form_sync';
-import * as i18n from './translations';
 import { FieldsRenderer } from '../templates_v2/field_types/field_renderer';
 import { useResolvedFields } from '../field_library/hooks/use_resolved_fields';
 import { useGetFieldDefinitions } from '../field_library/hooks/use_get_field_definitions';
@@ -158,21 +157,13 @@ export const CreateCaseTemplateFields: React.FC = () => {
     return <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />;
   }
 
-  const hasFields = globalFieldsFragment !== null || templateFieldsFragment !== null;
-
   return (
     <>
       <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />
-      {hasFields && (
-        <>
-          <EuiSpacer />
-          <EuiTitle size="s">
-            <h4>{i18n.EXTENDED_FIELDS_TITLE}</h4>
-          </EuiTitle>
-          <EuiSpacer />
-        </>
-      )}
       <FormProvider {...innerForm}>
+        {/* Separate from legacy custom fields (and other form fields) above —
+            the parent CaseFormFields uses gutterSize="none". */}
+        <EuiSpacer size="m" />
         {globalFieldsFragment}
         {globalFieldsFragment && templateFieldsFragment && <EuiSpacer />}
         {templateFieldsFragment}

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
-import { EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
 import { FormProvider, useForm } from 'react-hook-form';
 import {
   UseField,
@@ -27,6 +27,7 @@ import {
 } from '../../../common/utils';
 import { isRefField } from '../../../common/types/domain/template/fields';
 import { TemplateFieldsValidationContext } from './template_fields_validation_context';
+import { CUSTOM_FIELDS } from '../case_form_fields/translations';
 
 type FormShape = Record<string, Record<string, unknown>>;
 
@@ -173,9 +174,21 @@ export const CreateCaseTemplateFields: React.FC<CreateCaseTemplateFieldsProps> =
       <FormProvider {...innerForm}>
         {/* Parent CaseFormFields uses gutterSize="none"; pad when nothing separates us from Description. */}
         {addTopSpacing ? <EuiSpacer size="m" /> : null}
-        {globalFieldsFragment}
-        {globalFieldsFragment && templateFieldsFragment && <EuiSpacer />}
-        {templateFieldsFragment}
+        {globalFieldsFragment || templateFieldsFragment ? (
+          <EuiFormRow fullWidth>
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiText size="m">
+                  <h3 data-test-subj="create-case-custom-fields-title">{CUSTOM_FIELDS}</h3>
+                </EuiText>
+              </EuiFlexItem>
+              <EuiSpacer size="xs" />
+              {globalFieldsFragment}
+              {globalFieldsFragment && templateFieldsFragment && <EuiSpacer />}
+              {templateFieldsFragment}
+            </EuiFlexGroup>
+          </EuiFormRow>
+        ) : null}
       </FormProvider>
     </>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
@@ -31,12 +31,15 @@ import { TemplateFieldsValidationContext } from './template_fields_validation_co
 type FormShape = Record<string, Record<string, unknown>>;
 
 interface CreateCaseTemplateFieldsProps {
-  /** When true, adds top spacing so global/template fields don't sit flush against legacy custom fields. */
-  hasLegacyCustomFields?: boolean;
+  /**
+   * When true, adds top spacing so fields don't sit flush against Description.
+   * Omit (or false) when a divider already separates this block from content above.
+   */
+  addTopSpacing?: boolean;
 }
 
 export const CreateCaseTemplateFields: React.FC<CreateCaseTemplateFieldsProps> = ({
-  hasLegacyCustomFields = false,
+  addTopSpacing = false,
 }) => {
   const parentForm = useParentFormContext();
   const [{ templateId }] = useFormData<{ templateId?: string }>({ watch: ['templateId'] });
@@ -168,8 +171,8 @@ export const CreateCaseTemplateFields: React.FC<CreateCaseTemplateFieldsProps> =
     <>
       <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />
       <FormProvider {...innerForm}>
-        {/* Parent CaseFormFields uses gutterSize="none"; only pad when legacy fields sit above. */}
-        {hasLegacyCustomFields && <EuiSpacer size="m" />}
+        {/* Parent CaseFormFields uses gutterSize="none"; pad when nothing separates us from Description. */}
+        {addTopSpacing ? <EuiSpacer size="m" /> : null}
         {globalFieldsFragment}
         {globalFieldsFragment && templateFieldsFragment && <EuiSpacer />}
         {templateFieldsFragment}

--- a/x-pack/platform/plugins/shared/cases/public/components/create/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/translations.ts
@@ -93,7 +93,3 @@ export const TEMPLATE_NOT_SELECTED_DESCRIPTION = i18n.translate(
     defaultMessage: 'Select a template in the first step above to edit extended fields.',
   }
 );
-
-export const EXTENDED_FIELDS_TITLE = i18n.translate('xpack.cases.create.extendedFieldsTitle', {
-  defaultMessage: 'Extended fields',
-});

--- a/x-pack/platform/plugins/shared/cases/public/components/create/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/utils.test.ts
@@ -261,6 +261,26 @@ describe('utils', () => {
       });
     });
 
+    it('omits legacy custom fields when includeLegacyCustomFields is false', () => {
+      expect(
+        createFormSerializer(
+          [],
+          casesConfigurationsMock,
+          {
+            ...dataToSerialize,
+            customFields: {
+              test_key_1: 'first value',
+              test_key_2: true,
+            },
+          },
+          { includeLegacyCustomFields: false }
+        )
+      ).toEqual({
+        ...serializedFormData,
+        customFields: [],
+      });
+    });
+
     it('trims form data', () => {
       const untrimmedData = {
         title: '  title  ',

--- a/x-pack/platform/plugins/shared/cases/public/components/create/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/utils.ts
@@ -73,10 +73,19 @@ export const createFormDeserializer = (data: CasePostRequest): CaseFormFieldsSch
   };
 };
 
+export interface CreateFormSerializerOptions {
+  /**
+   * When false (templates v2 on + legacy switch off), omit legacy custom fields from the
+   * POST payload even if stale values remain in form state.
+   */
+  includeLegacyCustomFields?: boolean;
+}
+
 export const createFormSerializer = (
   connectors: ActionConnector[],
   currentConfiguration: CasesConfigurationUI,
-  data: CaseFormFieldsSchemaProps
+  data: CaseFormFieldsSchemaProps,
+  { includeLegacyCustomFields = true }: CreateFormSerializerOptions = {}
 ): CasePostRequest => {
   if (data == null || isEmpty(data)) {
     return getInitialCaseValue({
@@ -103,10 +112,11 @@ export const createFormSerializer = (
     ? normalizeActionConnector(caseConnector, serializedConnectorFields.fields)
     : getNoneConnector();
 
-  const transformedCustomFields = customFieldsFormSerializer(
-    customFields,
-    currentConfiguration.customFields
-  );
+  // When legacy inputs are gated off, do not submit config-backed custom fields — requirements
+  // and values live in the migrated Field Library / extended fields path instead.
+  const transformedCustomFields = includeLegacyCustomFields
+    ? customFieldsFormSerializer(customFields, currentConfiguration.customFields)
+    : [];
 
   const trimmedData = trimUserFormData(restData);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/custom_fields_list/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/custom_fields_list/index.test.tsx
@@ -95,10 +95,15 @@ describe('CustomFieldsList', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not show any panel when custom fields', () => {
-    renderWithTestingProviders(<CustomFieldsList {...{ ...props, customFields: [] }} />);
+  it('renders as line-separated rows when useLineSeparators is true', () => {
+    renderWithTestingProviders(<CustomFieldsList {...props} useLineSeparators />);
 
-    expect(screen.queryAllByTestId(`custom-field-`, { exact: false })).toHaveLength(0);
+    const row = screen.getByTestId(
+      `custom-field-${customFieldsConfigurationMock[0].key}-${customFieldsConfigurationMock[0].type}`
+    );
+
+    expect(row.className).not.toContain('euiPanel');
+    expect(screen.getByTestId('custom-fields-list')).toBeInTheDocument();
   });
 
   describe('Delete', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/custom_fields_list/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/custom_fields_list/index.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
 import {
   EuiBadge,
   EuiButtonIcon,
@@ -27,12 +28,25 @@ export interface Props {
   customFields: CustomFieldsConfiguration;
   onDeleteCustomField: (key: string) => void;
   onEditCustomField: (key: string) => void;
+  /**
+   * Renders the list as line-separated rows instead of individual panels.
+   * Only used by the cases redesign settings page.
+   */
+  useLineSeparators?: boolean;
 }
 
 const CustomFieldsListComponent: React.FC<Props> = (props) => {
-  const { customFields, onDeleteCustomField, onEditCustomField } = props;
+  const { customFields, onDeleteCustomField, onEditCustomField, useLineSeparators = false } = props;
   const [selectedItem, setSelectedItem] = useState<CustomFieldsConfiguration[number] | null>(null);
   const { euiTheme } = useEuiTheme();
+
+  const redesignRowCss = useMemo(
+    () => css`
+      padding: ${euiTheme.size.s} 0;
+      border-bottom: ${euiTheme.border.thin};
+    `,
+    [euiTheme]
+  );
 
   const renderTypeLabel = (type?: CustomFieldTypes) => {
     const createdBuilder = type && builderMap[type];
@@ -54,7 +68,82 @@ const CustomFieldsListComponent: React.FC<Props> = (props) => {
 
   const showModal = Boolean(selectedItem);
 
-  return customFields.length ? (
+  const actionButtons = (customField: CustomFieldsConfiguration[number]) => (
+    <>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={`${customField.key}-custom-field-edit`} disableScreenReaderOutput>
+          <EuiButtonIcon
+            data-test-subj={`${customField.key}-custom-field-edit`}
+            aria-label={`${customField.key}-custom-field-edit`}
+            iconType="pencil"
+            color="primary"
+            onClick={() => onEditCustomField(customField.key)}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={`${customField.key}-custom-field-delete`} disableScreenReaderOutput>
+          <EuiButtonIcon
+            data-test-subj={`${customField.key}-custom-field-delete`}
+            aria-label={`${customField.key}-custom-field-delete`}
+            iconType="minusCircle"
+            color="danger"
+            onClick={() => setSelectedItem(customField)}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </>
+  );
+
+  const fieldMeta = (customField: CustomFieldsConfiguration[number]) => (
+    <EuiFlexGroup alignItems="center" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <EuiText size="s">
+          <h4>{customField.label}</h4>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiBadge color={euiTheme.colors.body}>{renderTypeLabel(customField.type)}</EuiBadge>
+      {customField.required && <EuiBadge color={euiTheme.colors.body}>{i18n.REQUIRED}</EuiBadge>}
+    </EuiFlexGroup>
+  );
+
+  const redesignList = (
+    <EuiFlexGroup
+      justifyContent="flexStart"
+      direction="column"
+      gutterSize="none"
+      data-test-subj="custom-fields-list"
+    >
+      <EuiFlexItem>
+        {customFields.map((customField) => (
+          <div
+            key={customField.key}
+            css={redesignRowCss}
+            data-test-subj={`custom-field-${customField.key}-${customField.type}`}
+          >
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={true}>{fieldMeta(customField)}</EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                  {actionButtons(customField)}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        ))}
+      </EuiFlexItem>
+      {showModal && selectedItem ? (
+        <DeleteConfirmationModal
+          title={i18n.DELETE_FIELD_TITLE(selectedItem.label)}
+          message={i18n.DELETE_FIELD_DESCRIPTION}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      ) : null}
+    </EuiFlexGroup>
+  );
+
+  const legacyList = (
     <>
       <EuiSpacer size="s" />
       <EuiFlexGroup justifyContent="flexStart" data-test-subj="custom-fields-list">
@@ -67,51 +156,10 @@ const CustomFieldsListComponent: React.FC<Props> = (props) => {
                 hasShadow={false}
               >
                 <EuiFlexGroup alignItems="center" gutterSize="s">
-                  <EuiFlexItem grow={true}>
-                    <EuiFlexGroup alignItems="center" gutterSize="s">
-                      <EuiFlexItem grow={false}>
-                        <EuiText size="s">
-                          <h4>{customField.label}</h4>
-                        </EuiText>
-                      </EuiFlexItem>
-                      <EuiBadge color={euiTheme.colors.body}>
-                        {renderTypeLabel(customField.type)}
-                      </EuiBadge>
-                      {customField.required && (
-                        <EuiBadge color={euiTheme.colors.body}>{i18n.REQUIRED}</EuiBadge>
-                      )}
-                    </EuiFlexGroup>
-                  </EuiFlexItem>
+                  <EuiFlexItem grow={true}>{fieldMeta(customField)}</EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
-                      <EuiFlexItem grow={false}>
-                        <EuiToolTip
-                          content={`${customField.key}-custom-field-edit`}
-                          disableScreenReaderOutput
-                        >
-                          <EuiButtonIcon
-                            data-test-subj={`${customField.key}-custom-field-edit`}
-                            aria-label={`${customField.key}-custom-field-edit`}
-                            iconType="pencil"
-                            color="primary"
-                            onClick={() => onEditCustomField(customField.key)}
-                          />
-                        </EuiToolTip>
-                      </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <EuiToolTip
-                          content={`${customField.key}-custom-field-delete`}
-                          disableScreenReaderOutput
-                        >
-                          <EuiButtonIcon
-                            data-test-subj={`${customField.key}-custom-field-delete`}
-                            aria-label={`${customField.key}-custom-field-delete`}
-                            iconType="minusCircle"
-                            color="danger"
-                            onClick={() => setSelectedItem(customField)}
-                          />
-                        </EuiToolTip>
-                      </EuiFlexItem>
+                      {actionButtons(customField)}
                     </EuiFlexGroup>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -130,7 +178,9 @@ const CustomFieldsListComponent: React.FC<Props> = (props) => {
         ) : null}
       </EuiFlexGroup>
     </>
-  ) : null;
+  );
+
+  return customFields.length ? (useLineSeparators ? redesignList : legacyList) : null;
 };
 
 CustomFieldsListComponent.displayName = 'CustomFieldsList';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/index.tsx
@@ -38,6 +38,10 @@ export interface Props {
    * rows. Only used by the cases redesign settings page.
    */
   useLineSeparators?: boolean;
+  /** Overrides the default empty-state copy. Pass `null` to hide it. */
+  emptyStateMessage?: string | null;
+  /** Overrides the add-button label. */
+  addButtonLabel?: string;
 }
 const CustomFieldsComponent: React.FC<Props> = ({
   disabled,
@@ -48,6 +52,8 @@ const CustomFieldsComponent: React.FC<Props> = ({
   customFields,
   hideTitle = false,
   useLineSeparators = false,
+  emptyStateMessage,
+  addButtonLabel,
 }) => {
   const [error, setError] = useState<boolean>(false);
 
@@ -84,10 +90,10 @@ const CustomFieldsComponent: React.FC<Props> = ({
         />
       ) : null}
       <EuiSpacer size="s" />
-      {!customFields.length ? (
+      {!customFields.length && emptyStateMessage !== null ? (
         <EuiFlexGroup justifyContent="center">
           <EuiFlexItem grow={false} data-test-subj="empty-custom-fields">
-            {i18n.NO_CUSTOM_FIELDS}
+            {emptyStateMessage ?? i18n.NO_CUSTOM_FIELDS}
             <EuiSpacer size="m" />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -103,7 +109,7 @@ const CustomFieldsComponent: React.FC<Props> = ({
               iconType="plusCircle"
               data-test-subj="add-custom-field"
             >
-              {i18n.ADD_CUSTOM_FIELD}
+              {addButtonLabel ?? i18n.ADD_CUSTOM_FIELD}
             </EuiButtonEmpty>
           ) : (
             <EuiFlexGroup justifyContent="center">

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/index.tsx
@@ -28,6 +28,16 @@ export interface Props {
   handleAddCustomField: () => void;
   handleDeleteCustomField: (key: string) => void;
   handleEditCustomField: (key: string) => void;
+  /**
+   * Hides the described-form-group title/description. Used when the parent
+   * (e.g. redesign SettingsSection) already provides section headings.
+   */
+  hideTitle?: boolean;
+  /**
+   * Renders the list without the surrounding subdued panel, as line-separated
+   * rows. Only used by the cases redesign settings page.
+   */
+  useLineSeparators?: boolean;
 }
 const CustomFieldsComponent: React.FC<Props> = ({
   disabled,
@@ -36,6 +46,8 @@ const CustomFieldsComponent: React.FC<Props> = ({
   handleDeleteCustomField,
   handleEditCustomField,
   customFields,
+  hideTitle = false,
+  useLineSeparators = false,
 }) => {
   const [error, setError] = useState<boolean>(false);
 
@@ -61,60 +73,73 @@ const CustomFieldsComponent: React.FC<Props> = ({
     setError(false);
   }
 
-  return (
+  const listAndFooter = (
+    <>
+      {customFields.length ? (
+        <CustomFieldsList
+          customFields={customFields}
+          onDeleteCustomField={handleDeleteCustomField}
+          onEditCustomField={onEditCustomField}
+          useLineSeparators={useLineSeparators}
+        />
+      ) : null}
+      <EuiSpacer size="s" />
+      {!customFields.length ? (
+        <EuiFlexGroup justifyContent="center">
+          <EuiFlexItem grow={false} data-test-subj="empty-custom-fields">
+            {i18n.NO_CUSTOM_FIELDS}
+            <EuiSpacer size="m" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : null}
+      <EuiFlexGroup justifyContent="center">
+        <EuiFlexItem grow={false}>
+          {customFields.length < MAX_CUSTOM_FIELDS_PER_CASE ? (
+            <EuiButtonEmpty
+              isLoading={isLoading}
+              isDisabled={disabled || error}
+              size="s"
+              onClick={onAddCustomField}
+              iconType="plusCircle"
+              data-test-subj="add-custom-field"
+            >
+              {i18n.ADD_CUSTOM_FIELD}
+            </EuiButtonEmpty>
+          ) : (
+            <EuiFlexGroup justifyContent="center">
+              <EuiFlexItem grow={false}>
+                <EuiText>{i18n.MAX_CUSTOM_FIELD_LIMIT(MAX_CUSTOM_FIELDS_PER_CASE)}</EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+
+  const customFieldsContent = useLineSeparators ? (
+    listAndFooter
+  ) : (
+    <EuiPanel paddingSize="s" color="subdued" hasBorder={false} hasShadow={false}>
+      {listAndFooter}
+      <EuiSpacer size="s" />
+    </EuiPanel>
+  );
+
+  const content = hideTitle ? (
+    customFieldsContent
+  ) : (
     <EuiDescribedFormGroup
       fullWidth
       title={<h2>{i18n.TITLE}</h2>}
       description={<p>{i18n.DESCRIPTION}</p>}
-      data-test-subj="custom-fields-form-group"
       css={{ alignItems: 'flex-start' }}
     >
-      <EuiPanel paddingSize="s" color="subdued" hasBorder={false} hasShadow={false}>
-        {customFields.length ? (
-          <>
-            <CustomFieldsList
-              customFields={customFields}
-              onDeleteCustomField={handleDeleteCustomField}
-              onEditCustomField={onEditCustomField}
-            />
-          </>
-        ) : null}
-        <EuiSpacer size="s" />
-        {!customFields.length ? (
-          <EuiFlexGroup justifyContent="center">
-            <EuiFlexItem grow={false} data-test-subj="empty-custom-fields">
-              {i18n.NO_CUSTOM_FIELDS}
-              <EuiSpacer size="m" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        ) : null}
-        <EuiFlexGroup justifyContent="center">
-          <EuiFlexItem grow={false}>
-            {customFields.length < MAX_CUSTOM_FIELDS_PER_CASE ? (
-              <EuiButtonEmpty
-                isLoading={isLoading}
-                isDisabled={disabled || error}
-                size="s"
-                onClick={onAddCustomField}
-                iconType="plusCircle"
-                data-test-subj="add-custom-field"
-              >
-                {i18n.ADD_CUSTOM_FIELD}
-              </EuiButtonEmpty>
-            ) : (
-              <EuiFlexGroup justifyContent="center">
-                <EuiFlexItem grow={false}>
-                  <EuiText>{i18n.MAX_CUSTOM_FIELD_LIMIT(MAX_CUSTOM_FIELDS_PER_CASE)}</EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            )}
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size="s" />
-      </EuiPanel>
+      {customFieldsContent}
     </EuiDescribedFormGroup>
   );
+
+  return <div data-test-subj="custom-fields-form-group">{content}</div>;
 };
 CustomFieldsComponent.displayName = 'CustomFields';
 

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
@@ -47,6 +47,39 @@ describe('Edit ', () => {
     expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
   });
 
+  it('shows the optional label when the field is not required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('form-optional-field-label')).toBeInTheDocument();
+  });
+
+  it('does not show the optional label when the field is required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
+  });
+
   it('disables the field if the user does not have permissions', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
@@ -23,6 +23,9 @@ describe('Edit ', () => {
 
   const customField = customFieldsMock[4] as CaseCustomFieldNumber;
   const customFieldConfiguration = customFieldsConfigurationMock[4];
+  const formFieldTestId = `case-number-custom-field-form-field-${customFieldConfiguration.key}`;
+  const confirmTestId = `template-field-confirm-${customFieldConfiguration.key}`;
+  const cancelTestId = `template-field-cancel-${customFieldConfiguration.key}`;
 
   it('renders correctly', async () => {
     render(
@@ -38,14 +41,13 @@ describe('Edit ', () => {
     );
 
     expect(await screen.findByTestId('case-number-custom-field-test_key_5')).toBeInTheDocument();
-    expect(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
     expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
-    expect(await screen.findByText('1234')).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(1234);
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
   });
 
-  it('does not shows the edit button if the user does not have permissions', async () => {
+  it('disables the field if the user does not have permissions', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -58,12 +60,11 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(
-      screen.queryByTestId('case-number-custom-field-edit-button-test_key_1')
-    ).not.toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
   });
 
-  it('does not shows the edit button when loading', async () => {
+  it('disables the field when loading', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -76,9 +77,7 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(
-      screen.queryByTestId('case-number-custom-field-edit-button-test_key_1')
-    ).not.toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
   });
 
   it('shows the loading spinner when loading', async () => {
@@ -99,7 +98,7 @@ describe('Edit ', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows the no value number if the custom field is undefined', async () => {
+  it('shows the default value when the custom field is undefined', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -111,7 +110,10 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByText('No value is added')).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(
+      customFieldConfiguration.defaultValue as number
+    );
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
   });
 
   it('uses the required value correctly if a required field is empty', async () => {
@@ -127,85 +129,25 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByText('No value is added')).toBeInTheDocument();
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(
+      customFieldConfiguration.defaultValue as number
+    );
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
+
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
+    await userEvent.type(
+      await screen.findByTestId(formFieldTestId),
+      String((customFieldConfiguration.defaultValue as number) + 1)
     );
 
-    expect(
-      await screen.findByTestId(
-        `case-number-custom-field-form-field-${customFieldConfiguration.key}`
-      )
-    ).toHaveValue(customFieldConfiguration.defaultValue as number);
-    expect(
-      await screen.findByText('This field is populated with the default value.')
-    ).toBeInTheDocument();
-
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    );
+    await userEvent.click(await screen.findByTestId(confirmTestId));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
         ...customField,
-        value: customFieldConfiguration.defaultValue,
+        value: (customFieldConfiguration.defaultValue as number) + 1,
       });
     });
-  });
-
-  it('does not show the value when the custom field is undefined', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(screen.queryByTestId('number-custom-field-view-test_key_5')).not.toBeInTheDocument();
-  });
-
-  it('does not show the value when the value is null', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={{ ...customField, value: null }}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(screen.queryByTestId('number-custom-field-view-test_key_5')).not.toBeInTheDocument();
-  });
-
-  it('does not show the form when the user does not have permissions', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={false}
-        />
-      </FormTestComponent>
-    );
-
-    expect(
-      screen.queryByTestId('case-number-custom-field-form-field-test_key_5')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('case-number-custom-field-submit-button-test_key_5')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('case-number-custom-field-cancel-button-test_key_5')
-    ).not.toBeInTheDocument();
   });
 
   it('calls onSubmit when changing value', async () => {
@@ -221,66 +163,17 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
-    await userEvent.paste('12345');
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
+    await userEvent.type(await screen.findByTestId(formFieldTestId), '12345');
 
-    expect(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    ).not.toBeDisabled();
+    expect(await screen.findByTestId(confirmTestId)).not.toBeDisabled();
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    );
+    await userEvent.click(await screen.findByTestId(confirmTestId));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
         ...customField,
-        value: 123412345,
-      });
-    });
-  });
-
-  it('calls onSubmit with defaultValue if no initialValue exists', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={{
-            ...customField,
-            value: null,
-          }}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-
-    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
-    expect(await screen.findByTestId('case-number-custom-field-form-field-test_key_5')).toHaveValue(
-      customFieldConfiguration.defaultValue as number
-    );
-    expect(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    ).not.toBeDisabled();
-
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    );
-
-    await waitFor(() => {
-      expect(onSubmit).toBeCalledWith({
-        ...customField,
-        value: customFieldConfiguration.defaultValue,
+        value: 12345,
       });
     });
   });
@@ -298,20 +191,11 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
 
-    expect(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    ).not.toBeDisabled();
+    expect(await screen.findByTestId(confirmTestId)).not.toBeDisabled();
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    );
+    await userEvent.click(await screen.findByTestId(confirmTestId));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
@@ -321,7 +205,7 @@ describe('Edit ', () => {
     });
   });
 
-  it('hides the form when clicking the cancel button', async () => {
+  it('hides confirm/cancel after canceling and resets the value', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -334,62 +218,18 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
+    await userEvent.type(await screen.findByTestId(formFieldTestId), '321');
 
-    expect(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId(confirmTestId)).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(321);
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-cancel-button-test_key_5')
-    );
+    await userEvent.click(await screen.findByTestId(cancelTestId));
 
-    expect(
-      screen.queryByTestId('case-number-custom-field-form-field-test_key_5')
-    ).not.toBeInTheDocument();
-  });
-
-  it('reset to initial value when canceling', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
-    await userEvent.paste('321');
-
-    expect(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    ).not.toBeDisabled();
-
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-cancel-button-test_key_5')
-    );
-
-    expect(
-      screen.queryByTestId('case-number-custom-field-form-field-test_key_5')
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    expect(await screen.findByTestId('case-number-custom-field-form-field-test_key_5')).toHaveValue(
-      1234
-    );
+    await waitFor(() => {
+      expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+    });
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(1234);
   });
 
   it('shows validation error if the field is required', async () => {
@@ -405,12 +245,7 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
 
     expect(await screen.findByText('My test label 5 is required.')).toBeInTheDocument();
   });
@@ -428,18 +263,10 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
 
-    expect(
-      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
-    ).not.toBeDisabled();
-
-    expect(screen.queryByText('My test label 1 is required.')).not.toBeInTheDocument();
+    expect(await screen.findByTestId(confirmTestId)).not.toBeDisabled();
+    expect(screen.queryByText('My test label 5 is required.')).not.toBeInTheDocument();
   });
 
   it('shows validation error if the number is too big', async () => {
@@ -455,15 +282,8 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
-    await userEvent.click(
-      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
+    await userEvent.click(await screen.findByTestId(formFieldTestId));
     await userEvent.paste(`${2 ** 53 + 1}`);
 
     expect(

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
@@ -245,6 +245,42 @@ describe('Edit ', () => {
     });
   });
 
+  it('calls onSubmit with 0 when the value is 0', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+    await userEvent.paste('0');
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: 0,
+      });
+    });
+  });
+
   it('calls onSubmit with defaultValue if no initialValue exists', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
@@ -676,6 +712,33 @@ describe('Edit inline variant', () => {
       expect(onSubmit).toBeCalledWith({
         ...customField,
         value: 12345,
+      });
+    });
+  });
+
+  it('calls onSubmit with 0 when the value is 0', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
+    await userEvent.type(await screen.findByTestId(formFieldTestId), '0');
+
+    await userEvent.click(await screen.findByTestId(confirmTestId));
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: 0,
       });
     });
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.test.tsx
@@ -23,9 +23,6 @@ describe('Edit ', () => {
 
   const customField = customFieldsMock[4] as CaseCustomFieldNumber;
   const customFieldConfiguration = customFieldsConfigurationMock[4];
-  const formFieldTestId = `case-number-custom-field-form-field-${customFieldConfiguration.key}`;
-  const confirmTestId = `template-field-confirm-${customFieldConfiguration.key}`;
-  const cancelTestId = `template-field-cancel-${customFieldConfiguration.key}`;
 
   it('renders correctly', async () => {
     render(
@@ -41,46 +38,14 @@ describe('Edit ', () => {
     );
 
     expect(await screen.findByTestId('case-number-custom-field-test_key_5')).toBeInTheDocument();
-    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    ).toBeInTheDocument();
     expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
-    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(1234);
-    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+    expect(await screen.findByText('1234')).toBeInTheDocument();
   });
 
-  it('shows the optional label when the field is not required', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(await screen.findByTestId('form-optional-field-label')).toBeInTheDocument();
-  });
-
-  it('does not show the optional label when the field is required', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
-    expect(screen.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
-  });
-
-  it('disables the field if the user does not have permissions', async () => {
+  it('does not shows the edit button if the user does not have permissions', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -93,11 +58,12 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
-    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-number-custom-field-edit-button-test_key_1')
+    ).not.toBeInTheDocument();
   });
 
-  it('disables the field when loading', async () => {
+  it('does not shows the edit button when loading', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -110,7 +76,9 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+    expect(
+      screen.queryByTestId('case-number-custom-field-edit-button-test_key_1')
+    ).not.toBeInTheDocument();
   });
 
   it('shows the loading spinner when loading', async () => {
@@ -131,10 +99,509 @@ describe('Edit ', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the no value number if the custom field is undefined', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByText('No value is added')).toBeInTheDocument();
+  });
+
+  it('uses the required value correctly if a required field is empty', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{ ...customField, value: null }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByText('No value is added')).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+
+    expect(
+      await screen.findByTestId(
+        `case-number-custom-field-form-field-${customFieldConfiguration.key}`
+      )
+    ).toHaveValue(customFieldConfiguration.defaultValue as number);
+    expect(
+      await screen.findByText('This field is populated with the default value.')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: customFieldConfiguration.defaultValue,
+      });
+    });
+  });
+
+  it('does not show the value when the custom field is undefined', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(screen.queryByTestId('number-custom-field-view-test_key_5')).not.toBeInTheDocument();
+  });
+
+  it('does not show the value when the value is null', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{ ...customField, value: null }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(screen.queryByTestId('number-custom-field-view-test_key_5')).not.toBeInTheDocument();
+  });
+
+  it('does not show the form when the user does not have permissions', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={false}
+        />
+      </FormTestComponent>
+    );
+
+    expect(
+      screen.queryByTestId('case-number-custom-field-form-field-test_key_5')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-number-custom-field-submit-button-test_key_5')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-number-custom-field-cancel-button-test_key_5')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onSubmit when changing value', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+    await userEvent.paste('12345');
+
+    expect(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: 123412345,
+      });
+    });
+  });
+
+  it('calls onSubmit with defaultValue if no initialValue exists', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{
+            ...customField,
+            value: null,
+          }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
+    expect(await screen.findByTestId('case-number-custom-field-form-field-test_key_5')).toHaveValue(
+      customFieldConfiguration.defaultValue as number
+    );
+    expect(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: customFieldConfiguration.defaultValue,
+      });
+    });
+  });
+
+  it('sets the value to null if the number field is empty', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+
+    expect(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: null,
+      });
+    });
+  });
+
+  it('hides the form when clicking the cancel button', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+
+    expect(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-cancel-button-test_key_5')
+    );
+
+    expect(
+      screen.queryByTestId('case-number-custom-field-form-field-test_key_5')
+    ).not.toBeInTheDocument();
+  });
+
+  it('reset to initial value when canceling', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+    await userEvent.paste('321');
+
+    expect(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-cancel-button-test_key_5')
+    );
+
+    expect(
+      screen.queryByTestId('case-number-custom-field-form-field-test_key_5')
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    expect(await screen.findByTestId('case-number-custom-field-form-field-test_key_5')).toHaveValue(
+      1234
+    );
+  });
+
+  it('shows validation error if the field is required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+
+    expect(await screen.findByText('My test label 5 is required.')).toBeInTheDocument();
+  });
+
+  it('does not shows a validation error if the field is not required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+
+    expect(
+      await screen.findByTestId('case-number-custom-field-submit-button-test_key_5')
+    ).not.toBeDisabled();
+
+    expect(screen.queryByText('My test label 1 is required.')).not.toBeInTheDocument();
+  });
+
+  it('shows validation error if the number is too big', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-edit-button-test_key_5')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-number-custom-field-form-field-test_key_5')
+    );
+    await userEvent.paste(`${2 ** 53 + 1}`);
+
+    expect(
+      await screen.findByText(
+        'The value of the My test label 5 should be an integer between -(2^53 - 1) and 2^53 - 1, inclusive.'
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Edit inline variant', () => {
+  const onSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const customField = customFieldsMock[4] as CaseCustomFieldNumber;
+  const customFieldConfiguration = customFieldsConfigurationMock[4];
+  const formFieldTestId = `case-number-custom-field-form-field-${customFieldConfiguration.key}`;
+  const confirmTestId = `template-field-confirm-${customFieldConfiguration.key}`;
+  const cancelTestId = `template-field-cancel-${customFieldConfiguration.key}`;
+
+  it('renders correctly', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('case-number-custom-field-test_key_5')).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(1234);
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+  });
+
+  it('shows the optional label when the field is not required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('form-optional-field-label')).toBeInTheDocument();
+  });
+
+  it('does not show the optional label when the field is required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
+  });
+
+  it('disables the field if the user does not have permissions', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={false}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+  });
+
+  it('disables the field when loading', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={true}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+  });
+
+  it('shows the loading spinner when loading', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={true}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(
+      await screen.findByTestId('case-number-custom-field-loading-test_key_5')
+    ).toBeInTheDocument();
+  });
+
   it('shows the default value when the custom field is undefined', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
           isLoading={false}
@@ -153,6 +620,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={{ ...customField, value: null }}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -187,6 +655,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -215,6 +684,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
           onSubmit={onSubmit}
@@ -242,6 +712,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -269,6 +740,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -287,6 +759,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
           onSubmit={onSubmit}
@@ -306,6 +779,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
@@ -6,7 +6,17 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import {
   useForm,
@@ -19,7 +29,14 @@ import type { CaseCustomFieldNumber } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CasesConfigurationUICustomField } from '../../../../common/ui';
 import type { CustomFieldType } from '../types';
-import { POPULATED_WITH_DEFAULT } from '../translations';
+import { View } from './view';
+import {
+  CANCEL,
+  EDIT_CUSTOM_FIELDS_ARIA_LABEL,
+  NO_CUSTOM_FIELD_SET,
+  SAVE,
+  POPULATED_WITH_DEFAULT,
+} from '../translations';
 import { getNumberFieldConfig } from './config';
 import { InlineFieldActions } from '../../templates_v2/field_types/controls/inline_field_actions';
 import { OptionalFieldLabel } from '../../optional_field_label';
@@ -37,7 +54,8 @@ interface FormState {
 interface FormWrapper {
   initialValue: number | null;
   isLoading: boolean;
-  canUpdate: boolean;
+  canUpdate?: boolean;
+  showFormLabel?: boolean;
   customFieldConfiguration: CasesConfigurationUICustomField;
   onChange: (state: FormState) => void;
 }
@@ -46,7 +64,8 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
   initialValue,
   customFieldConfiguration,
   isLoading,
-  canUpdate,
+  canUpdate = true,
+  showFormLabel = false,
   onChange,
 }) => {
   const defaultValue =
@@ -83,10 +102,10 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         path="value"
         config={formFieldConfig}
         component={NumericField}
-        label={customFieldConfiguration.label}
+        label={showFormLabel ? customFieldConfiguration.label : undefined}
         helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
-          labelAppend:
+          labelAppend: showFormLabel ? (
             !customFieldConfiguration.required || isLoading ? (
               <>
                 {!customFieldConfiguration.required ? OptionalFieldLabel : null}
@@ -96,10 +115,11 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
                   />
                 ) : null}
               </>
-            ) : undefined,
+            ) : undefined
+          ) : undefined,
           euiFieldProps: {
             fullWidth: true,
-            disabled: isLoading || !canUpdate,
+            disabled: isLoading || (showFormLabel && !canUpdate),
             isLoading,
             'data-test-subj': `case-number-custom-field-form-field-${customFieldConfiguration.key}`,
           },
@@ -111,7 +131,143 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
 
 FormWrapperComponent.displayName = 'FormWrapper';
 
-const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
+const ClassicEdit: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
+  customField,
+  customFieldConfiguration,
+  onSubmit,
+  isLoading,
+  canUpdate,
+}) => {
+  const initialValue = customField?.value ?? null;
+  const [isEdit, setIsEdit] = useState(false);
+  const [formState, setFormState] = useState<FormState>({
+    isValid: undefined,
+    submit: async () => ({ isValid: false, data: { value: null } }),
+    value: initialValue,
+  });
+
+  const onEdit = useCallback(() => {
+    setIsEdit(true);
+  }, []);
+
+  const onCancel = useCallback(() => {
+    setIsEdit(false);
+  }, []);
+
+  const onSubmitCustomField = useCallback(async () => {
+    const { isValid, data } = await formState.submit();
+
+    if (isValid) {
+      onSubmit({
+        ...customField,
+        key: customField?.key ?? customFieldConfiguration.key,
+        type: CustomFieldTypes.NUMBER,
+        value: data.value ? Number(data.value) : null,
+      });
+    }
+    setIsEdit(false);
+  }, [customField, customFieldConfiguration.key, formState, onSubmit]);
+
+  const title = customFieldConfiguration.label;
+
+  const isNumberFieldValid =
+    formState.isValid ||
+    (formState.value === customFieldConfiguration.defaultValue && isEmpty(initialValue));
+
+  const isCustomFieldValueDefined = !isEmpty(customField?.value);
+
+  return (
+    <>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="none"
+        justifyContent="spaceBetween"
+        responsive={false}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiText>
+            <h4>{title}</h4>
+          </EuiText>
+        </EuiFlexItem>
+        {isLoading && (
+          <EuiLoadingSpinner
+            data-test-subj={`case-number-custom-field-loading-${customFieldConfiguration.key}`}
+          />
+        )}
+        {!isLoading && canUpdate && (
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)} disableScreenReaderOutput>
+              <EuiButtonIcon
+                data-test-subj={`case-number-custom-field-edit-button-${customFieldConfiguration.key}`}
+                aria-label={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)}
+                iconType={'pencil'}
+                onClick={onEdit}
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+      <EuiHorizontalRule margin="xs" />
+      <EuiFlexGroup
+        gutterSize="m"
+        data-test-subj={`case-number-custom-field-${customFieldConfiguration.key}`}
+        direction="column"
+      >
+        {!isCustomFieldValueDefined && !isEdit && (
+          <p data-test-subj="no-number-custom-field-value">{NO_CUSTOM_FIELD_SET}</p>
+        )}
+        {!isEdit && isCustomFieldValueDefined && (
+          <EuiFlexItem>
+            <View customField={customField} />
+          </EuiFlexItem>
+        )}
+        {isEdit && canUpdate && (
+          <EuiFlexGroup gutterSize="m" direction="column">
+            <EuiFlexItem>
+              <FormWrapperComponent
+                initialValue={initialValue}
+                isLoading={isLoading}
+                onChange={setFormState}
+                customFieldConfiguration={customFieldConfiguration}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    color="primary"
+                    data-test-subj={`case-number-custom-field-submit-button-${customFieldConfiguration.key}`}
+                    fill
+                    iconType="save"
+                    onClick={onSubmitCustomField}
+                    size="s"
+                    disabled={!isNumberFieldValid || isLoading}
+                  >
+                    {SAVE}
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj={`case-number-custom-field-cancel-button-${customFieldConfiguration.key}`}
+                    iconType="cross"
+                    onClick={onCancel}
+                    size="s"
+                  >
+                    {CANCEL}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+ClassicEdit.displayName = 'ClassicEdit';
+
+const InlineEdit: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
   customField,
   customFieldConfiguration,
   onSubmit,
@@ -174,6 +330,7 @@ const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
           initialValue={initialValue}
           isLoading={isLoading}
           canUpdate={canUpdate}
+          showFormLabel
           onChange={setFormState}
           customFieldConfiguration={customFieldConfiguration}
         />
@@ -189,6 +346,19 @@ const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
       )}
     </EuiFlexGroup>
   );
+};
+
+InlineEdit.displayName = 'InlineEdit';
+
+const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
+  editVariant = 'classic',
+  ...props
+}) => {
+  if (editVariant === 'inline') {
+    return <InlineEdit {...props} editVariant={editVariant} />;
+  }
+
+  return <ClassicEdit {...props} editVariant={editVariant} />;
 };
 
 EditComponent.displayName = 'Edit';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
@@ -22,6 +22,7 @@ import type { CustomFieldType } from '../types';
 import { POPULATED_WITH_DEFAULT } from '../translations';
 import { getNumberFieldConfig } from './config';
 import { InlineFieldActions } from '../../templates_v2/field_types/controls/inline_field_actions';
+import { OptionalFieldLabel } from '../../optional_field_label';
 
 const isEmpty = (value: number | null | undefined) => {
   return value == null;
@@ -85,11 +86,17 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         label={customFieldConfiguration.label}
         helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
-          labelAppend: isLoading ? (
-            <EuiLoadingSpinner
-              data-test-subj={`case-number-custom-field-loading-${customFieldConfiguration.key}`}
-            />
-          ) : undefined,
+          labelAppend:
+            !customFieldConfiguration.required || isLoading ? (
+              <>
+                {!customFieldConfiguration.required ? OptionalFieldLabel : null}
+                {isLoading ? (
+                  <EuiLoadingSpinner
+                    data-test-subj={`case-number-custom-field-loading-${customFieldConfiguration.key}`}
+                  />
+                ) : null}
+              </>
+            ) : undefined,
           euiFieldProps: {
             fullWidth: true,
             disabled: isLoading || !canUpdate,

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
@@ -169,7 +169,7 @@ const ClassicEdit: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
         ...customField,
         key: customField?.key ?? customFieldConfiguration.key,
         type: CustomFieldTypes.NUMBER,
-        value: data.value ? Number(data.value) : null,
+        value: normalizeNumber(data.value),
       });
     }
     setIsEdit(false);
@@ -307,7 +307,7 @@ const InlineEdit: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
         ...customField,
         key: customField?.key ?? customFieldConfiguration.key,
         type: CustomFieldTypes.NUMBER,
-        value: data.value ? Number(data.value) : null,
+        value: normalizeNumber(data.value),
       });
     }
   }, [customField, customFieldConfiguration.key, formState, onSubmit]);

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
@@ -45,6 +45,13 @@ const isEmpty = (value: number | null | undefined) => {
   return value == null;
 };
 
+const normalizeNumber = (value: number | null | undefined) => {
+  if (value == null || (value as unknown) === '') {
+    return null;
+  }
+  return Number(value);
+};
+
 interface FormState {
   value: number | null;
   isValid?: boolean;
@@ -305,12 +312,6 @@ const InlineEdit: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
     }
   }, [customField, customFieldConfiguration.key, formState, onSubmit]);
 
-  const normalizeNumber = (value: number | null | undefined) => {
-    if (value == null || (value as unknown) === '') {
-      return null;
-    }
-    return Number(value);
-  };
   const hasPendingChange =
     normalizeNumber(formState.value) !== normalizeNumber(effectiveInitialValue);
 
@@ -320,7 +321,7 @@ const InlineEdit: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
 
   return (
     <EuiFlexGroup
-      gutterSize="m"
+      gutterSize="xs"
       data-test-subj={`case-number-custom-field-${customFieldConfiguration.key}`}
       direction="column"
     >
@@ -355,10 +356,10 @@ const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
   ...props
 }) => {
   if (editVariant === 'inline') {
-    return <InlineEdit {...props} editVariant={editVariant} />;
+    return <InlineEdit {...props} />;
   }
 
-  return <ClassicEdit {...props} editVariant={editVariant} />;
+  return <ClassicEdit {...props} />;
 };
 
 EditComponent.displayName = 'Edit';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/number/edit.tsx
@@ -5,18 +5,8 @@
  * 2.0.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
-import {
-  EuiButton,
-  EuiButtonEmpty,
-  EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiLoadingSpinner,
-  EuiText,
-  EuiToolTip,
-} from '@elastic/eui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import {
   useForm,
@@ -29,15 +19,9 @@ import type { CaseCustomFieldNumber } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CasesConfigurationUICustomField } from '../../../../common/ui';
 import type { CustomFieldType } from '../types';
-import { View } from './view';
-import {
-  CANCEL,
-  EDIT_CUSTOM_FIELDS_ARIA_LABEL,
-  NO_CUSTOM_FIELD_SET,
-  SAVE,
-  POPULATED_WITH_DEFAULT,
-} from '../translations';
+import { POPULATED_WITH_DEFAULT } from '../translations';
 import { getNumberFieldConfig } from './config';
+import { InlineFieldActions } from '../../templates_v2/field_types/controls/inline_field_actions';
 
 const isEmpty = (value: number | null | undefined) => {
   return value == null;
@@ -52,6 +36,7 @@ interface FormState {
 interface FormWrapper {
   initialValue: number | null;
   isLoading: boolean;
+  canUpdate: boolean;
   customFieldConfiguration: CasesConfigurationUICustomField;
   onChange: (state: FormState) => void;
 }
@@ -60,14 +45,17 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
   initialValue,
   customFieldConfiguration,
   isLoading,
+  canUpdate,
   onChange,
 }) => {
+  const defaultValue =
+    customFieldConfiguration?.defaultValue != null && isEmpty(initialValue)
+      ? Number(customFieldConfiguration.defaultValue)
+      : initialValue;
+
   const { form } = useForm<{ value: number | null }>({
     defaultValue: {
-      value:
-        customFieldConfiguration?.defaultValue != null && isEmpty(initialValue)
-          ? Number(customFieldConfiguration.defaultValue)
-          : initialValue,
+      value: defaultValue,
     },
   });
 
@@ -94,11 +82,17 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         path="value"
         config={formFieldConfig}
         component={NumericField}
+        label={customFieldConfiguration.label}
         helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
+          labelAppend: isLoading ? (
+            <EuiLoadingSpinner
+              data-test-subj={`case-number-custom-field-loading-${customFieldConfiguration.key}`}
+            />
+          ) : undefined,
           euiFieldProps: {
             fullWidth: true,
-            disabled: isLoading,
+            disabled: isLoading || !canUpdate,
             isLoading,
             'data-test-subj': `case-number-custom-field-form-field-${customFieldConfiguration.key}`,
           },
@@ -118,19 +112,21 @@ const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
   canUpdate,
 }) => {
   const initialValue = customField?.value ?? null;
-  const [isEdit, setIsEdit] = useState(false);
+  const defaultValueAsNumber =
+    customFieldConfiguration.defaultValue != null
+      ? Number(customFieldConfiguration.defaultValue)
+      : undefined;
+  const effectiveInitialValue =
+    isEmpty(initialValue) && defaultValueAsNumber != null ? defaultValueAsNumber : initialValue;
+  const [formResetKey, setFormResetKey] = useState(0);
   const [formState, setFormState] = useState<FormState>({
     isValid: undefined,
     submit: async () => ({ isValid: false, data: { value: null } }),
-    value: initialValue,
+    value: effectiveInitialValue,
   });
 
-  const onEdit = useCallback(() => {
-    setIsEdit(true);
-  }, []);
-
   const onCancel = useCallback(() => {
-    setIsEdit(false);
+    setFormResetKey((key) => key + 1);
   }, []);
 
   const onSubmitCustomField = useCallback(async () => {
@@ -144,103 +140,47 @@ const EditComponent: CustomFieldType<CaseCustomFieldNumber>['Edit'] = ({
         value: data.value ? Number(data.value) : null,
       });
     }
-    setIsEdit(false);
   }, [customField, customFieldConfiguration.key, formState, onSubmit]);
 
-  const title = customFieldConfiguration.label;
+  const normalizeNumber = (value: number | null | undefined) => {
+    if (value == null || (value as unknown) === '') {
+      return null;
+    }
+    return Number(value);
+  };
+  const hasPendingChange =
+    normalizeNumber(formState.value) !== normalizeNumber(effectiveInitialValue);
 
   const isNumberFieldValid =
     formState.isValid ||
     (formState.value === customFieldConfiguration.defaultValue && isEmpty(initialValue));
 
-  const isCustomFieldValueDefined = !isEmpty(customField?.value);
-
   return (
-    <>
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="none"
-        justifyContent="spaceBetween"
-        responsive={false}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiText>
-            <h4>{title}</h4>
-          </EuiText>
-        </EuiFlexItem>
-        {isLoading && (
-          <EuiLoadingSpinner
-            data-test-subj={`case-number-custom-field-loading-${customFieldConfiguration.key}`}
-          />
-        )}
-        {!isLoading && canUpdate && (
-          <EuiFlexItem grow={false}>
-            <EuiToolTip content={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)} disableScreenReaderOutput>
-              <EuiButtonIcon
-                data-test-subj={`case-number-custom-field-edit-button-${customFieldConfiguration.key}`}
-                aria-label={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)}
-                iconType={'pencil'}
-                onClick={onEdit}
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
-      <EuiHorizontalRule margin="xs" />
-      <EuiFlexGroup
-        gutterSize="m"
-        data-test-subj={`case-number-custom-field-${customFieldConfiguration.key}`}
-        direction="column"
-      >
-        {!isCustomFieldValueDefined && !isEdit && (
-          <p data-test-subj="no-number-custom-field-value">{NO_CUSTOM_FIELD_SET}</p>
-        )}
-        {!isEdit && isCustomFieldValueDefined && (
-          <EuiFlexItem>
-            <View customField={customField} />
-          </EuiFlexItem>
-        )}
-        {isEdit && canUpdate && (
-          <EuiFlexGroup gutterSize="m" direction="column">
-            <EuiFlexItem>
-              <FormWrapperComponent
-                initialValue={initialValue}
-                isLoading={isLoading}
-                onChange={setFormState}
-                customFieldConfiguration={customFieldConfiguration}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    color="primary"
-                    data-test-subj={`case-number-custom-field-submit-button-${customFieldConfiguration.key}`}
-                    fill
-                    iconType="save"
-                    onClick={onSubmitCustomField}
-                    size="s"
-                    disabled={!isNumberFieldValid || isLoading}
-                  >
-                    {SAVE}
-                  </EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty
-                    data-test-subj={`case-number-custom-field-cancel-button-${customFieldConfiguration.key}`}
-                    iconType="cross"
-                    onClick={onCancel}
-                    size="s"
-                  >
-                    {CANCEL}
-                  </EuiButtonEmpty>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        )}
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup
+      gutterSize="m"
+      data-test-subj={`case-number-custom-field-${customFieldConfiguration.key}`}
+      direction="column"
+    >
+      <EuiFlexItem>
+        <FormWrapperComponent
+          key={formResetKey}
+          initialValue={initialValue}
+          isLoading={isLoading}
+          canUpdate={canUpdate}
+          onChange={setFormState}
+          customFieldConfiguration={customFieldConfiguration}
+        />
+      </EuiFlexItem>
+      {hasPendingChange && canUpdate && !isLoading && (
+        <InlineFieldActions
+          name={customFieldConfiguration.key}
+          onConfirm={onSubmitCustomField}
+          onCancel={onCancel}
+          isLoading={isLoading}
+          isDisabled={!isNumberFieldValid}
+        />
+      )}
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.test.tsx
@@ -25,6 +25,9 @@ describe('Edit ', () => {
 
   const customField = customFieldsMock[0] as CaseCustomFieldText;
   const customFieldConfiguration = customFieldsConfigurationMock[0];
+  const formFieldTestId = `case-text-custom-field-form-field-${customFieldConfiguration.key}`;
+  const confirmTestId = `template-field-confirm-${customFieldConfiguration.key}`;
+  const cancelTestId = `template-field-cancel-${customFieldConfiguration.key}`;
 
   it('renders correctly', async () => {
     render(
@@ -40,14 +43,13 @@ describe('Edit ', () => {
     );
 
     expect(await screen.findByTestId('case-text-custom-field-test_key_1')).toBeInTheDocument();
-    expect(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
     expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
-    expect(await screen.findByText('My text test value 1')).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue('My text test value 1');
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
   });
 
-  it('does not shows the edit button if the user does not have permissions', async () => {
+  it('disables the field if the user does not have permissions', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -60,12 +62,11 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(
-      screen.queryByTestId('case-text-custom-field-edit-button-test_key_1')
-    ).not.toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
   });
 
-  it('does not shows the edit button when loading', async () => {
+  it('disables the field when loading', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -78,9 +79,7 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(
-      screen.queryByTestId('case-text-custom-field-edit-button-test_key_1')
-    ).not.toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
   });
 
   it('shows the loading spinner when loading', async () => {
@@ -101,7 +100,7 @@ describe('Edit ', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows the no value text if the custom field is undefined', async () => {
+  it('shows the default value when the custom field is undefined', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -113,7 +112,10 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByText('No value is added')).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(
+      customFieldConfiguration.defaultValue as string
+    );
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
   });
 
   it('uses the required value correctly if a required field is empty', async () => {
@@ -129,83 +131,22 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByText('No value is added')).toBeInTheDocument();
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue(
+      customFieldConfiguration.defaultValue as string
     );
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
 
-    expect(
-      await screen.findByTestId(`case-text-custom-field-form-field-${customFieldConfiguration.key}`)
-    ).toHaveValue(customFieldConfiguration.defaultValue as string);
-    expect(
-      await screen.findByText('This field is populated with the default value.')
-    ).toBeInTheDocument();
+    await userEvent.click(await screen.findByTestId(formFieldTestId));
+    await userEvent.paste('!');
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    );
+    await userEvent.click(await screen.findByTestId(confirmTestId));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
         ...customField,
-        value: customFieldConfiguration.defaultValue,
+        value: `${customFieldConfiguration.defaultValue}!`,
       });
     });
-  });
-
-  it('does not show the value when the custom field is undefined', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(screen.queryByTestId('text-custom-field-view-test_key_1')).not.toBeInTheDocument();
-  });
-
-  it('does not show the value when the value is null', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={{ ...customField, value: null }}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(screen.queryByTestId('text-custom-field-view-test_key_1')).not.toBeInTheDocument();
-  });
-
-  it('does not show the form when the user does not have permissions', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={false}
-        />
-      </FormTestComponent>
-    );
-
-    expect(
-      screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('case-text-custom-field-submit-button-test_key_1')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('case-text-custom-field-cancel-button-test_key_1')
-    ).not.toBeInTheDocument();
   });
 
   it('calls onSubmit when changing value', async () => {
@@ -221,66 +162,17 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.click(await screen.findByTestId(formFieldTestId));
     await userEvent.paste('!!!');
 
-    expect(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    ).not.toBeDisabled();
+    expect(await screen.findByTestId(confirmTestId)).not.toBeDisabled();
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    );
+    await userEvent.click(await screen.findByTestId(confirmTestId));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
         ...customField,
         value: 'My text test value 1!!!',
-      });
-    });
-  });
-
-  it('calls onSubmit with defaultValue if no initialValue exists', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={{
-            ...customField,
-            value: null,
-          }}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-
-    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
-    expect(await screen.findByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
-      customFieldConfiguration.defaultValue as string
-    );
-    expect(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    ).not.toBeDisabled();
-
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    );
-
-    await waitFor(() => {
-      expect(onSubmit).toBeCalledWith({
-        ...customField,
-        value: customFieldConfiguration.defaultValue,
       });
     });
   });
@@ -298,20 +190,11 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
 
-    expect(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    ).not.toBeDisabled();
+    expect(await screen.findByTestId(confirmTestId)).not.toBeDisabled();
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    );
+    await userEvent.click(await screen.findByTestId(confirmTestId));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
@@ -321,7 +204,7 @@ describe('Edit ', () => {
     });
   });
 
-  it('hides the form when clicking the cancel button', async () => {
+  it('hides confirm/cancel after canceling and resets the value', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -334,62 +217,18 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-
-    expect(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    ).toBeInTheDocument();
-
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-cancel-button-test_key_1')
-    );
-
-    expect(
-      screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
-    ).not.toBeInTheDocument();
-  });
-
-  it('reset to initial value when canceling', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.click(await screen.findByTestId(formFieldTestId));
     await userEvent.paste('!!!');
 
-    expect(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    ).not.toBeDisabled();
+    expect(await screen.findByTestId(confirmTestId)).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue('My text test value 1!!!');
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-cancel-button-test_key_1')
-    );
+    await userEvent.click(await screen.findByTestId(cancelTestId));
 
-    expect(
-      screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    expect(await screen.findByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
-      'My text test value 1'
-    );
+    await waitFor(() => {
+      expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+    });
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue('My text test value 1');
   });
 
   it('shows validation error if the field is required', async () => {
@@ -405,12 +244,7 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
 
     expect(await screen.findByText('My test label 1 is required.')).toBeInTheDocument();
   });
@@ -428,17 +262,9 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
 
-    expect(
-      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
-    ).not.toBeDisabled();
-
+    expect(await screen.findByTestId(confirmTestId)).not.toBeDisabled();
     expect(screen.queryByText('My test label 1 is required.')).not.toBeInTheDocument();
   });
 
@@ -455,15 +281,8 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
-    );
-    await userEvent.clear(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
-    await userEvent.click(
-      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
-    );
+    await userEvent.clear(await screen.findByTestId(formFieldTestId));
+    await userEvent.click(await screen.findByTestId(formFieldTestId));
     await userEvent.paste('a'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1));
 
     expect(

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.test.tsx
@@ -49,6 +49,39 @@ describe('Edit ', () => {
     expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
   });
 
+  it('shows the optional label when the field is not required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('form-optional-field-label')).toBeInTheDocument();
+  });
+
+  it('does not show the optional label when the field is required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
+  });
+
   it('disables the field if the user does not have permissions', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.test.tsx
@@ -25,9 +25,6 @@ describe('Edit ', () => {
 
   const customField = customFieldsMock[0] as CaseCustomFieldText;
   const customFieldConfiguration = customFieldsConfigurationMock[0];
-  const formFieldTestId = `case-text-custom-field-form-field-${customFieldConfiguration.key}`;
-  const confirmTestId = `template-field-confirm-${customFieldConfiguration.key}`;
-  const cancelTestId = `template-field-cancel-${customFieldConfiguration.key}`;
 
   it('renders correctly', async () => {
     render(
@@ -43,46 +40,14 @@ describe('Edit ', () => {
     );
 
     expect(await screen.findByTestId('case-text-custom-field-test_key_1')).toBeInTheDocument();
-    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    ).toBeInTheDocument();
     expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
-    expect(await screen.findByTestId(formFieldTestId)).toHaveValue('My text test value 1');
-    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+    expect(await screen.findByText('My text test value 1')).toBeInTheDocument();
   });
 
-  it('shows the optional label when the field is not required', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(await screen.findByTestId('form-optional-field-label')).toBeInTheDocument();
-  });
-
-  it('does not show the optional label when the field is required', async () => {
-    render(
-      <FormTestComponent onSubmit={onSubmit}>
-        <Edit
-          customField={customField}
-          customFieldConfiguration={customFieldConfiguration}
-          onSubmit={onSubmit}
-          isLoading={false}
-          canUpdate={true}
-        />
-      </FormTestComponent>
-    );
-
-    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
-    expect(screen.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
-  });
-
-  it('disables the field if the user does not have permissions', async () => {
+  it('does not shows the edit button if the user does not have permissions', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -95,11 +60,12 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
-    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-text-custom-field-edit-button-test_key_1')
+    ).not.toBeInTheDocument();
   });
 
-  it('disables the field when loading', async () => {
+  it('does not shows the edit button when loading', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -112,7 +78,9 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+    expect(
+      screen.queryByTestId('case-text-custom-field-edit-button-test_key_1')
+    ).not.toBeInTheDocument();
   });
 
   it('shows the loading spinner when loading', async () => {
@@ -133,10 +101,507 @@ describe('Edit ', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the no value text if the custom field is undefined', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByText('No value is added')).toBeInTheDocument();
+  });
+
+  it('uses the required value correctly if a required field is empty', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{ ...customField, value: null }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByText('No value is added')).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+
+    expect(
+      await screen.findByTestId(`case-text-custom-field-form-field-${customFieldConfiguration.key}`)
+    ).toHaveValue(customFieldConfiguration.defaultValue as string);
+    expect(
+      await screen.findByText('This field is populated with the default value.')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: customFieldConfiguration.defaultValue,
+      });
+    });
+  });
+
+  it('does not show the value when the custom field is undefined', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(screen.queryByTestId('text-custom-field-view-test_key_1')).not.toBeInTheDocument();
+  });
+
+  it('does not show the value when the value is null', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{ ...customField, value: null }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(screen.queryByTestId('text-custom-field-view-test_key_1')).not.toBeInTheDocument();
+  });
+
+  it('does not show the form when the user does not have permissions', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={false}
+        />
+      </FormTestComponent>
+    );
+
+    expect(
+      screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('case-text-custom-field-cancel-button-test_key_1')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onSubmit when changing value', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+    await userEvent.paste('!!!');
+
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: 'My text test value 1!!!',
+      });
+    });
+  });
+
+  it('calls onSubmit with defaultValue if no initialValue exists', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{
+            ...customField,
+            value: null,
+          }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
+    expect(await screen.findByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
+      customFieldConfiguration.defaultValue as string
+    );
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: customFieldConfiguration.defaultValue,
+      });
+    });
+  });
+
+  it('sets the value to null if the text field is empty', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: null,
+      });
+    });
+  });
+
+  it('hides the form when clicking the cancel button', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+
+    expect(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-cancel-button-test_key_1')
+    );
+
+    expect(
+      screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
+    ).not.toBeInTheDocument();
+  });
+
+  it('reset to initial value when canceling', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+    await userEvent.paste('!!!');
+
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-cancel-button-test_key_1')
+    );
+
+    expect(
+      screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    expect(await screen.findByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
+      'My text test value 1'
+    );
+  });
+
+  it('shows validation error if the field is required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+
+    expect(await screen.findByText('My test label 1 is required.')).toBeInTheDocument();
+  });
+
+  it('does not shows a validation error if the field is not required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
+
+    expect(screen.queryByText('My test label 1 is required.')).not.toBeInTheDocument();
+  });
+
+  it('shows validation error if the field is too long', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    );
+    await userEvent.clear(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+    await userEvent.click(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    );
+    await userEvent.paste('a'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1));
+
+    expect(
+      await screen.findByText(
+        `The length of the My test label 1 is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Edit inline variant', () => {
+  const onSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const customField = customFieldsMock[0] as CaseCustomFieldText;
+  const customFieldConfiguration = customFieldsConfigurationMock[0];
+  const formFieldTestId = `case-text-custom-field-form-field-${customFieldConfiguration.key}`;
+  const confirmTestId = `template-field-confirm-${customFieldConfiguration.key}`;
+  const cancelTestId = `template-field-cancel-${customFieldConfiguration.key}`;
+
+  it('renders correctly', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('case-text-custom-field-test_key_1')).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
+    expect(await screen.findByTestId(formFieldTestId)).toHaveValue('My text test value 1');
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+  });
+
+  it('shows the optional label when the field is not required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId('form-optional-field-label')).toBeInTheDocument();
+  });
+
+  it('does not show the optional label when the field is required', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId('form-optional-field-label')).not.toBeInTheDocument();
+  });
+
+  it('disables the field if the user does not have permissions', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={false}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+    expect(screen.queryByTestId(confirmTestId)).not.toBeInTheDocument();
+  });
+
+  it('disables the field when loading', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={true}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByTestId(formFieldTestId)).toBeDisabled();
+  });
+
+  it('shows the loading spinner when loading', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={true}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(
+      await screen.findByTestId('case-text-custom-field-loading-test_key_1')
+    ).toBeInTheDocument();
+  });
+
   it('shows the default value when the custom field is undefined', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
           isLoading={false}
@@ -155,6 +620,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={{ ...customField, value: null }}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -186,6 +652,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -214,6 +681,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
           onSubmit={onSubmit}
@@ -241,6 +709,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -268,6 +737,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}
@@ -286,6 +756,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
           onSubmit={onSubmit}
@@ -305,6 +776,7 @@ describe('Edit ', () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
+          editVariant="inline"
           customField={customField}
           customFieldConfiguration={customFieldConfiguration}
           onSubmit={onSubmit}

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
@@ -7,7 +7,17 @@
 
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import {
   useForm,
@@ -20,7 +30,14 @@ import type { CaseCustomFieldText } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CasesConfigurationUICustomField } from '../../../../common/ui';
 import type { CustomFieldType } from '../types';
-import { POPULATED_WITH_DEFAULT } from '../translations';
+import { View } from './view';
+import {
+  CANCEL,
+  EDIT_CUSTOM_FIELDS_ARIA_LABEL,
+  NO_CUSTOM_FIELD_SET,
+  SAVE,
+  POPULATED_WITH_DEFAULT,
+} from '../translations';
 import { getTextFieldConfig } from './config';
 import { InlineFieldActions } from '../../templates_v2/field_types/controls/inline_field_actions';
 import { OptionalFieldLabel } from '../../optional_field_label';
@@ -34,7 +51,8 @@ interface FormState {
 interface FormWrapper {
   initialValue: string;
   isLoading: boolean;
-  canUpdate: boolean;
+  canUpdate?: boolean;
+  showFormLabel?: boolean;
   customFieldConfiguration: CasesConfigurationUICustomField;
   onChange: (state: FormState) => void;
 }
@@ -43,7 +61,8 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
   initialValue,
   customFieldConfiguration,
   isLoading,
-  canUpdate,
+  canUpdate = true,
+  showFormLabel = false,
   onChange,
 }) => {
   const defaultValue =
@@ -79,10 +98,10 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         path="value"
         config={formFieldConfig}
         component={TextField}
-        label={customFieldConfiguration.label}
+        label={showFormLabel ? customFieldConfiguration.label : undefined}
         helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
-          labelAppend:
+          labelAppend: showFormLabel ? (
             !customFieldConfiguration.required || isLoading ? (
               <>
                 {!customFieldConfiguration.required ? OptionalFieldLabel : null}
@@ -92,10 +111,11 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
                   />
                 ) : null}
               </>
-            ) : undefined,
+            ) : undefined
+          ) : undefined,
           euiFieldProps: {
             fullWidth: true,
-            disabled: isLoading || !canUpdate,
+            disabled: isLoading || (showFormLabel && !canUpdate),
             isLoading,
             'data-test-subj': `case-text-custom-field-form-field-${customFieldConfiguration.key}`,
           },
@@ -107,7 +127,144 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
 
 FormWrapperComponent.displayName = 'FormWrapper';
 
-const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
+const ClassicEdit: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
+  customField,
+  customFieldConfiguration,
+  onSubmit,
+  isLoading,
+  canUpdate,
+}) => {
+  const initialValue = customField?.value ?? '';
+  const [isEdit, setIsEdit] = useState(false);
+  const [formState, setFormState] = useState<FormState>({
+    isValid: undefined,
+    submit: async () => ({ isValid: false, data: { value: '' } }),
+    value: initialValue,
+  });
+
+  const onEdit = () => {
+    setIsEdit(true);
+  };
+
+  const onCancel = () => {
+    setIsEdit(false);
+  };
+
+  const onSubmitCustomField = async () => {
+    const { isValid, data } = await formState.submit();
+
+    if (isValid) {
+      const value = isEmpty(data.value) ? null : data.value;
+
+      onSubmit({
+        ...customField,
+        key: customField?.key ?? customFieldConfiguration.key,
+        type: CustomFieldTypes.TEXT,
+        value,
+      });
+    }
+
+    setIsEdit(false);
+  };
+
+  const title = customFieldConfiguration.label;
+  const isTextFieldValid =
+    formState.isValid ||
+    (formState.value === customFieldConfiguration.defaultValue && !initialValue);
+  const isCustomFieldValueDefined = !isEmpty(customField?.value);
+
+  return (
+    <>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="none"
+        justifyContent="spaceBetween"
+        responsive={false}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiText>
+            <h4>{title}</h4>
+          </EuiText>
+        </EuiFlexItem>
+        {isLoading && (
+          <EuiLoadingSpinner
+            data-test-subj={`case-text-custom-field-loading-${customFieldConfiguration.key}`}
+          />
+        )}
+        {!isLoading && canUpdate && (
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)} disableScreenReaderOutput>
+              <EuiButtonIcon
+                data-test-subj={`case-text-custom-field-edit-button-${customFieldConfiguration.key}`}
+                aria-label={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)}
+                iconType={'pencil'}
+                onClick={onEdit}
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+      <EuiHorizontalRule margin="xs" />
+      <EuiFlexGroup
+        gutterSize="m"
+        data-test-subj={`case-text-custom-field-${customFieldConfiguration.key}`}
+        direction="column"
+      >
+        {!isCustomFieldValueDefined && !isEdit && (
+          <p data-test-subj="no-custom-field-value">{NO_CUSTOM_FIELD_SET}</p>
+        )}
+        {!isEdit && isCustomFieldValueDefined && (
+          <EuiFlexItem>
+            <View customField={customField} />
+          </EuiFlexItem>
+        )}
+        {isEdit && canUpdate && (
+          <EuiFlexGroup gutterSize="m" direction="column">
+            <EuiFlexItem>
+              <FormWrapperComponent
+                initialValue={initialValue}
+                isLoading={isLoading}
+                onChange={setFormState}
+                customFieldConfiguration={customFieldConfiguration}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    color="primary"
+                    data-test-subj={`case-text-custom-field-submit-button-${customFieldConfiguration.key}`}
+                    fill
+                    iconType="save"
+                    onClick={onSubmitCustomField}
+                    size="s"
+                    disabled={!isTextFieldValid || isLoading}
+                  >
+                    {SAVE}
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj={`case-text-custom-field-cancel-button-${customFieldConfiguration.key}`}
+                    iconType="cross"
+                    onClick={onCancel}
+                    size="s"
+                  >
+                    {CANCEL}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+ClassicEdit.displayName = 'ClassicEdit';
+
+const InlineEdit: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
   customField,
   customFieldConfiguration,
   onSubmit,
@@ -164,6 +321,7 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
           initialValue={initialValue}
           isLoading={isLoading}
           canUpdate={canUpdate}
+          showFormLabel
           onChange={setFormState}
           customFieldConfiguration={customFieldConfiguration}
         />
@@ -179,6 +337,19 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
       )}
     </EuiFlexGroup>
   );
+};
+
+InlineEdit.displayName = 'InlineEdit';
+
+const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
+  editVariant = 'classic',
+  ...props
+}) => {
+  if (editVariant === 'inline') {
+    return <InlineEdit {...props} editVariant={editVariant} />;
+  }
+
+  return <ClassicEdit {...props} editVariant={editVariant} />;
 };
 
 EditComponent.displayName = 'Edit';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
@@ -23,6 +23,7 @@ import type { CustomFieldType } from '../types';
 import { POPULATED_WITH_DEFAULT } from '../translations';
 import { getTextFieldConfig } from './config';
 import { InlineFieldActions } from '../../templates_v2/field_types/controls/inline_field_actions';
+import { OptionalFieldLabel } from '../../optional_field_label';
 
 interface FormState {
   value: string;
@@ -81,11 +82,17 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         label={customFieldConfiguration.label}
         helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
-          labelAppend: isLoading ? (
-            <EuiLoadingSpinner
-              data-test-subj={`case-text-custom-field-loading-${customFieldConfiguration.key}`}
-            />
-          ) : undefined,
+          labelAppend:
+            !customFieldConfiguration.required || isLoading ? (
+              <>
+                {!customFieldConfiguration.required ? OptionalFieldLabel : null}
+                {isLoading ? (
+                  <EuiLoadingSpinner
+                    data-test-subj={`case-text-custom-field-loading-${customFieldConfiguration.key}`}
+                  />
+                ) : null}
+              </>
+            ) : undefined,
           euiFieldProps: {
             fullWidth: true,
             disabled: isLoading || !canUpdate,

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
@@ -311,7 +311,7 @@ const InlineEdit: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
 
   return (
     <EuiFlexGroup
-      gutterSize="m"
+      gutterSize="xs"
       data-test-subj={`case-text-custom-field-${customFieldConfiguration.key}`}
       direction="column"
     >
@@ -346,10 +346,10 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
   ...props
 }) => {
   if (editVariant === 'inline') {
-    return <InlineEdit {...props} editVariant={editVariant} />;
+    return <InlineEdit {...props} />;
   }
 
-  return <ClassicEdit {...props} editVariant={editVariant} />;
+  return <ClassicEdit {...props} />;
 };
 
 EditComponent.displayName = 'Edit';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/text/edit.tsx
@@ -6,18 +6,8 @@
  */
 
 import { isEmpty } from 'lodash';
-import React, { useEffect, useState } from 'react';
-import {
-  EuiButton,
-  EuiButtonEmpty,
-  EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiLoadingSpinner,
-  EuiText,
-  EuiToolTip,
-} from '@elastic/eui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import {
   useForm,
@@ -30,15 +20,9 @@ import type { CaseCustomFieldText } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CasesConfigurationUICustomField } from '../../../../common/ui';
 import type { CustomFieldType } from '../types';
-import { View } from './view';
-import {
-  CANCEL,
-  EDIT_CUSTOM_FIELDS_ARIA_LABEL,
-  NO_CUSTOM_FIELD_SET,
-  SAVE,
-  POPULATED_WITH_DEFAULT,
-} from '../translations';
+import { POPULATED_WITH_DEFAULT } from '../translations';
 import { getTextFieldConfig } from './config';
+import { InlineFieldActions } from '../../templates_v2/field_types/controls/inline_field_actions';
 
 interface FormState {
   value: string;
@@ -49,6 +33,7 @@ interface FormState {
 interface FormWrapper {
   initialValue: string;
   isLoading: boolean;
+  canUpdate: boolean;
   customFieldConfiguration: CasesConfigurationUICustomField;
   onChange: (state: FormState) => void;
 }
@@ -57,14 +42,17 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
   initialValue,
   customFieldConfiguration,
   isLoading,
+  canUpdate,
   onChange,
 }) => {
+  const defaultValue =
+    customFieldConfiguration?.defaultValue != null && isEmpty(initialValue)
+      ? String(customFieldConfiguration.defaultValue)
+      : initialValue;
+
   const { form } = useForm<{ value: string }>({
     defaultValue: {
-      value:
-        customFieldConfiguration?.defaultValue != null && isEmpty(initialValue)
-          ? String(customFieldConfiguration.defaultValue)
-          : initialValue,
+      value: defaultValue,
     },
   });
   const [{ value }] = useFormData({ form });
@@ -90,11 +78,17 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         path="value"
         config={formFieldConfig}
         component={TextField}
+        label={customFieldConfiguration.label}
         helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
+          labelAppend: isLoading ? (
+            <EuiLoadingSpinner
+              data-test-subj={`case-text-custom-field-loading-${customFieldConfiguration.key}`}
+            />
+          ) : undefined,
           euiFieldProps: {
             fullWidth: true,
-            disabled: isLoading,
+            disabled: isLoading || !canUpdate,
             isLoading,
             'data-test-subj': `case-text-custom-field-form-field-${customFieldConfiguration.key}`,
           },
@@ -114,22 +108,24 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
   canUpdate,
 }) => {
   const initialValue = customField?.value ?? '';
-  const [isEdit, setIsEdit] = useState(false);
+  const defaultValueAsString =
+    customFieldConfiguration.defaultValue != null
+      ? String(customFieldConfiguration.defaultValue)
+      : undefined;
+  const effectiveInitialValue =
+    isEmpty(initialValue) && defaultValueAsString != null ? defaultValueAsString : initialValue;
+  const [formResetKey, setFormResetKey] = useState(0);
   const [formState, setFormState] = useState<FormState>({
     isValid: undefined,
     submit: async () => ({ isValid: false, data: { value: '' } }),
-    value: initialValue,
+    value: effectiveInitialValue,
   });
 
-  const onEdit = () => {
-    setIsEdit(true);
-  };
+  const onCancel = useCallback(() => {
+    setFormResetKey((key) => key + 1);
+  }, []);
 
-  const onCancel = () => {
-    setIsEdit(false);
-  };
-
-  const onSubmitCustomField = async () => {
+  const onSubmitCustomField = useCallback(async () => {
     const { isValid, data } = await formState.submit();
 
     if (isValid) {
@@ -142,102 +138,39 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
         value,
       });
     }
+  }, [customField, customFieldConfiguration.key, formState, onSubmit]);
 
-    setIsEdit(false);
-  };
-
-  const title = customFieldConfiguration.label;
+  const hasPendingChange = formState.value !== effectiveInitialValue;
   const isTextFieldValid =
     formState.isValid ||
     (formState.value === customFieldConfiguration.defaultValue && !initialValue);
-  const isCustomFieldValueDefined = !isEmpty(customField?.value);
 
   return (
-    <>
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="none"
-        justifyContent="spaceBetween"
-        responsive={false}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiText>
-            <h4>{title}</h4>
-          </EuiText>
-        </EuiFlexItem>
-        {isLoading && (
-          <EuiLoadingSpinner
-            data-test-subj={`case-text-custom-field-loading-${customFieldConfiguration.key}`}
-          />
-        )}
-        {!isLoading && canUpdate && (
-          <EuiFlexItem grow={false}>
-            <EuiToolTip content={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)} disableScreenReaderOutput>
-              <EuiButtonIcon
-                data-test-subj={`case-text-custom-field-edit-button-${customFieldConfiguration.key}`}
-                aria-label={EDIT_CUSTOM_FIELDS_ARIA_LABEL(title)}
-                iconType={'pencil'}
-                onClick={onEdit}
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
-      <EuiHorizontalRule margin="xs" />
-      <EuiFlexGroup
-        gutterSize="m"
-        data-test-subj={`case-text-custom-field-${customFieldConfiguration.key}`}
-        direction="column"
-      >
-        {!isCustomFieldValueDefined && !isEdit && (
-          <p data-test-subj="no-custom-field-value">{NO_CUSTOM_FIELD_SET}</p>
-        )}
-        {!isEdit && isCustomFieldValueDefined && (
-          <EuiFlexItem>
-            <View customField={customField} />
-          </EuiFlexItem>
-        )}
-        {isEdit && canUpdate && (
-          <EuiFlexGroup gutterSize="m" direction="column">
-            <EuiFlexItem>
-              <FormWrapperComponent
-                initialValue={initialValue}
-                isLoading={isLoading}
-                onChange={setFormState}
-                customFieldConfiguration={customFieldConfiguration}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    color="primary"
-                    data-test-subj={`case-text-custom-field-submit-button-${customFieldConfiguration.key}`}
-                    fill
-                    iconType="save"
-                    onClick={onSubmitCustomField}
-                    size="s"
-                    disabled={!isTextFieldValid || isLoading}
-                  >
-                    {SAVE}
-                  </EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty
-                    data-test-subj={`case-text-custom-field-cancel-button-${customFieldConfiguration.key}`}
-                    iconType="cross"
-                    onClick={onCancel}
-                    size="s"
-                  >
-                    {CANCEL}
-                  </EuiButtonEmpty>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        )}
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup
+      gutterSize="m"
+      data-test-subj={`case-text-custom-field-${customFieldConfiguration.key}`}
+      direction="column"
+    >
+      <EuiFlexItem>
+        <FormWrapperComponent
+          key={formResetKey}
+          initialValue={initialValue}
+          isLoading={isLoading}
+          canUpdate={canUpdate}
+          onChange={setFormState}
+          customFieldConfiguration={customFieldConfiguration}
+        />
+      </EuiFlexItem>
+      {hasPendingChange && canUpdate && !isLoading && (
+        <InlineFieldActions
+          name={customFieldConfiguration.key}
+          onConfirm={onSubmitCustomField}
+          onCancel={onCancel}
+          isLoading={isLoading}
+          isDisabled={!isTextFieldValid}
+        />
+      )}
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.test.tsx
@@ -121,3 +121,32 @@ describe('Edit ', () => {
     });
   });
 });
+
+describe('Edit inline variant', () => {
+  const onSubmit = jest.fn();
+  const customField = customFieldsMock[1] as CaseCustomFieldToggle;
+  const customFieldConfiguration = customFieldsConfigurationMock[1];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with form-row label (no h4 header rule layout)', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          editVariant="inline"
+          customField={customField}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    expect(screen.getByText(customFieldConfiguration.label)).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeChecked();
+    expect(screen.queryByRole('heading', { level: 4 })).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.tsx
@@ -139,10 +139,10 @@ const EditComponent: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
   ...props
 }) => {
   if (editVariant === 'inline') {
-    return <InlineEdit {...props} editVariant={editVariant} />;
+    return <InlineEdit {...props} />;
   }
 
-  return <ClassicEdit {...props} editVariant={editVariant} />;
+  return <ClassicEdit {...props} />;
 };
 
 EditComponent.displayName = 'Edit';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.tsx
@@ -9,12 +9,79 @@ import React from 'react';
 import { Form, UseField, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 
 import { ToggleField } from '@kbn/es-ui-shared-plugin/static/forms/components';
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiText } from '@elastic/eui';
 import type { CaseCustomFieldToggle } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CustomFieldType } from '../types';
 
-const EditComponent: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
+const ClassicEdit: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
+  customField,
+  customFieldConfiguration,
+  onSubmit,
+  isLoading,
+  canUpdate,
+}) => {
+  const initialValue = Boolean(customField?.value);
+  const title = customFieldConfiguration.label;
+
+  const { form } = useForm<{ value: boolean }>({
+    defaultValue: { value: initialValue },
+  });
+
+  const onSubmitCustomField = async () => {
+    const { isValid, data } = await form.submit();
+
+    if (isValid) {
+      onSubmit({
+        ...customField,
+        key: customField?.key ?? customFieldConfiguration.key,
+        type: CustomFieldTypes.TOGGLE,
+        value: data.value,
+      });
+    }
+  };
+
+  return (
+    <>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="none"
+        justifyContent="spaceBetween"
+        responsive={false}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiText>
+            <h4>{title}</h4>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiHorizontalRule margin="xs" />
+      <EuiFlexGroup
+        gutterSize="m"
+        data-test-subj={`case-toggle-custom-field-${customFieldConfiguration.key}`}
+        direction="column"
+      >
+        <Form form={form}>
+          <UseField
+            path="value"
+            component={ToggleField}
+            onChange={onSubmitCustomField}
+            componentProps={{
+              euiFieldProps: {
+                disabled: isLoading || !canUpdate,
+                'data-test-subj': `case-toggle-custom-field-form-field-${customFieldConfiguration.key}`,
+              },
+            }}
+          />
+        </Form>
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+ClassicEdit.displayName = 'ClassicEdit';
+
+const InlineEdit: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
   customField,
   customFieldConfiguration,
   onSubmit,
@@ -63,6 +130,19 @@ const EditComponent: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
       </Form>
     </EuiFlexGroup>
   );
+};
+
+InlineEdit.displayName = 'InlineEdit';
+
+const EditComponent: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
+  editVariant = 'classic',
+  ...props
+}) => {
+  if (editVariant === 'inline') {
+    return <InlineEdit {...props} editVariant={editVariant} />;
+  }
+
+  return <ClassicEdit {...props} editVariant={editVariant} />;
 };
 
 EditComponent.displayName = 'Edit';

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/toggle/edit.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Form, UseField, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 
 import { ToggleField } from '@kbn/es-ui-shared-plugin/static/forms/components';
-import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiText } from '@elastic/eui';
+import { EuiFlexGroup } from '@elastic/eui';
 import type { CaseCustomFieldToggle } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CustomFieldType } from '../types';
@@ -42,40 +42,26 @@ const EditComponent: CustomFieldType<CaseCustomFieldToggle>['Edit'] = ({
   };
 
   return (
-    <>
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="none"
-        justifyContent="spaceBetween"
-        responsive={false}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiText>
-            <h4>{title}</h4>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiHorizontalRule margin="xs" />
-      <EuiFlexGroup
-        gutterSize="m"
-        data-test-subj={`case-toggle-custom-field-${customFieldConfiguration.key}`}
-        direction="column"
-      >
-        <Form form={form}>
-          <UseField
-            path="value"
-            component={ToggleField}
-            onChange={onSubmitCustomField}
-            componentProps={{
-              euiFieldProps: {
-                disabled: isLoading || !canUpdate,
-                'data-test-subj': `case-toggle-custom-field-form-field-${customFieldConfiguration.key}`,
-              },
-            }}
-          />
-        </Form>
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup
+      gutterSize="m"
+      data-test-subj={`case-toggle-custom-field-${customFieldConfiguration.key}`}
+      direction="column"
+    >
+      <Form form={form}>
+        <UseField
+          path="value"
+          component={ToggleField}
+          label={title}
+          onChange={onSubmitCustomField}
+          componentProps={{
+            euiFieldProps: {
+              disabled: isLoading || !canUpdate,
+              'data-test-subj': `case-toggle-custom-field-form-field-${customFieldConfiguration.key}`,
+            },
+          }}
+        />
+      </Form>
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/custom_fields/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/custom_fields/types.ts
@@ -26,6 +26,11 @@ export interface CustomFieldType<T extends CaseUICustomField> {
     onSubmit: (customField: T) => void;
     isLoading: boolean;
     canUpdate: boolean;
+    /**
+     * `classic` — pencil + view mode (legacy case view).
+     * `inline` — always-visible input with confirm/cancel (redesign case view).
+     */
+    editVariant?: 'classic' | 'inline';
   }>;
   Create: React.FC<{
     customFieldConfiguration: CasesConfigurationUICustomField;

--- a/x-pack/platform/plugins/shared/cases/public/components/templates/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates/index.tsx
@@ -27,6 +27,16 @@ interface Props {
   onAddTemplate: () => void;
   onEditTemplate: (key: string) => void;
   onDeleteTemplate: (key: string) => void;
+  /**
+   * Hides the described-form-group title/description. Used when the parent
+   * (e.g. redesign SettingsSection) already provides section headings.
+   */
+  hideTitle?: boolean;
+  /**
+   * Renders the list without the surrounding subdued panel, as line-separated
+   * rows. Only used by the cases redesign settings page.
+   */
+  useLineSeparators?: boolean;
 }
 
 const TemplatesComponent: React.FC<Props> = ({
@@ -36,6 +46,8 @@ const TemplatesComponent: React.FC<Props> = ({
   onAddTemplate,
   onEditTemplate,
   onDeleteTemplate,
+  hideTitle = false,
+  useLineSeparators = false,
 }) => {
   const [error, setError] = useState<boolean>(false);
 
@@ -65,7 +77,62 @@ const TemplatesComponent: React.FC<Props> = ({
     [setError, onDeleteTemplate]
   );
 
-  return (
+  const listAndFooter = (
+    <>
+      {templates.length ? (
+        <TemplatesList
+          templates={templates}
+          onEditTemplate={handleEditTemplate}
+          onDeleteTemplate={handleDeleteTemplate}
+          useLineSeparators={useLineSeparators}
+        />
+      ) : null}
+      <EuiSpacer size="s" />
+      {!templates.length ? (
+        <EuiFlexGroup justifyContent="center">
+          <EuiFlexItem grow={false} data-test-subj="empty-templates">
+            {i18n.NO_TEMPLATES}
+            <EuiSpacer size="m" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : null}
+      <EuiFlexGroup justifyContent="center">
+        <EuiFlexItem grow={false}>
+          {templates.length < MAX_TEMPLATES_LENGTH ? (
+            <EuiButtonEmpty
+              isLoading={isLoading}
+              isDisabled={disabled || error}
+              size="s"
+              onClick={handleAddTemplate}
+              iconType="plusCircle"
+              data-test-subj="add-template"
+            >
+              {i18n.ADD_TEMPLATE}
+            </EuiButtonEmpty>
+          ) : (
+            <EuiFlexGroup justifyContent="center">
+              <EuiFlexItem grow={false}>
+                <EuiText>{i18n.MAX_TEMPLATE_LIMIT(MAX_TEMPLATES_LENGTH)}</EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+          <EuiSpacer size="s" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+
+  const templatesContent = useLineSeparators ? (
+    listAndFooter
+  ) : (
+    <EuiPanel paddingSize="s" color="subdued" hasBorder={false} hasShadow={false}>
+      {listAndFooter}
+    </EuiPanel>
+  );
+
+  const content = hideTitle ? (
+    templatesContent
+  ) : (
     <EuiDescribedFormGroup
       fullWidth
       title={
@@ -76,54 +143,13 @@ const TemplatesComponent: React.FC<Props> = ({
         </EuiFlexGroup>
       }
       description={<p>{i18n.TEMPLATE_DESCRIPTION}</p>}
-      data-test-subj="templates-form-group"
       css={{ alignItems: 'flex-start' }}
     >
-      <EuiPanel paddingSize="s" color="subdued" hasBorder={false} hasShadow={false}>
-        {templates.length ? (
-          <>
-            <TemplatesList
-              templates={templates}
-              onEditTemplate={handleEditTemplate}
-              onDeleteTemplate={handleDeleteTemplate}
-            />
-          </>
-        ) : null}
-        <EuiSpacer size="s" />
-        {!templates.length ? (
-          <EuiFlexGroup justifyContent="center">
-            <EuiFlexItem grow={false} data-test-subj="empty-templates">
-              {i18n.NO_TEMPLATES}
-              <EuiSpacer size="m" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        ) : null}
-        <EuiFlexGroup justifyContent="center">
-          <EuiFlexItem grow={false}>
-            {templates.length < MAX_TEMPLATES_LENGTH ? (
-              <EuiButtonEmpty
-                isLoading={isLoading}
-                isDisabled={disabled || error}
-                size="s"
-                onClick={handleAddTemplate}
-                iconType="plusCircle"
-                data-test-subj="add-template"
-              >
-                {i18n.ADD_TEMPLATE}
-              </EuiButtonEmpty>
-            ) : (
-              <EuiFlexGroup justifyContent="center">
-                <EuiFlexItem grow={false}>
-                  <EuiText>{i18n.MAX_TEMPLATE_LIMIT(MAX_TEMPLATES_LENGTH)}</EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            )}
-            <EuiSpacer size="s" />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
+      {templatesContent}
     </EuiDescribedFormGroup>
   );
+
+  return <div data-test-subj="templates-form-group">{content}</div>;
 };
 
 TemplatesComponent.displayName = 'Templates';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates/index.tsx
@@ -37,6 +37,10 @@ interface Props {
    * rows. Only used by the cases redesign settings page.
    */
   useLineSeparators?: boolean;
+  /** Overrides the default empty-state copy. Pass `null` to hide it. */
+  emptyStateMessage?: string | null;
+  /** Overrides the add-button label. */
+  addButtonLabel?: string;
 }
 
 const TemplatesComponent: React.FC<Props> = ({
@@ -48,6 +52,8 @@ const TemplatesComponent: React.FC<Props> = ({
   onDeleteTemplate,
   hideTitle = false,
   useLineSeparators = false,
+  emptyStateMessage,
+  addButtonLabel,
 }) => {
   const [error, setError] = useState<boolean>(false);
 
@@ -88,10 +94,10 @@ const TemplatesComponent: React.FC<Props> = ({
         />
       ) : null}
       <EuiSpacer size="s" />
-      {!templates.length ? (
+      {!templates.length && emptyStateMessage !== null ? (
         <EuiFlexGroup justifyContent="center">
           <EuiFlexItem grow={false} data-test-subj="empty-templates">
-            {i18n.NO_TEMPLATES}
+            {emptyStateMessage ?? i18n.NO_TEMPLATES}
             <EuiSpacer size="m" />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -107,7 +113,7 @@ const TemplatesComponent: React.FC<Props> = ({
               iconType="plusCircle"
               data-test-subj="add-template"
             >
-              {i18n.ADD_TEMPLATE}
+              {addButtonLabel ?? i18n.ADD_TEMPLATE}
             </EuiButtonEmpty>
           ) : (
             <EuiFlexGroup justifyContent="center">

--- a/x-pack/platform/plugins/shared/cases/public/components/templates/templates_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates/templates_list.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiBadge,
   EuiBadgeGroup,
@@ -23,16 +23,30 @@ import { TruncatedText } from '../truncated_text';
 import type { TemplateConfiguration, TemplatesConfiguration } from '../../../common/types/domain';
 import { DeleteConfirmationModal } from '../configure_cases/delete_confirmation_modal';
 import * as i18n from './translations';
+
 export interface Props {
   templates: TemplatesConfiguration;
   onDeleteTemplate: (key: string) => void;
   onEditTemplate: (key: string) => void;
+  /**
+   * Renders the list as line-separated rows instead of individual panels.
+   * Only used by the cases redesign settings page.
+   */
+  useLineSeparators?: boolean;
 }
 
 const TemplatesListComponent: React.FC<Props> = (props) => {
-  const { templates, onEditTemplate, onDeleteTemplate } = props;
+  const { templates, onEditTemplate, onDeleteTemplate, useLineSeparators = false } = props;
   const { euiTheme } = useEuiTheme();
   const [itemToBeDeleted, setItemToBeDeleted] = useState<TemplateConfiguration | null>(null);
+
+  const redesignRowCss = useMemo(
+    () => css`
+      padding: ${euiTheme.size.s} 0;
+      border-bottom: ${euiTheme.border.thin};
+    `,
+    [euiTheme]
+  );
 
   const onConfirm = useCallback(() => {
     if (itemToBeDeleted) {
@@ -48,7 +62,94 @@ const TemplatesListComponent: React.FC<Props> = (props) => {
 
   const showModal = Boolean(itemToBeDeleted);
 
-  return templates.length ? (
+  const actionButtons = (template: TemplateConfiguration) => (
+    <>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={`${template.key}-template-edit`} disableScreenReaderOutput>
+          <EuiButtonIcon
+            data-test-subj={`${template.key}-template-edit`}
+            aria-label={`${template.key}-template-edit`}
+            iconType="pencil"
+            color="primary"
+            onClick={() => onEditTemplate(template.key)}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={`${template.key}-template-delete`} disableScreenReaderOutput>
+          <EuiButtonIcon
+            data-test-subj={`${template.key}-template-delete`}
+            aria-label={`${template.key}-template-delete`}
+            iconType="minusCircle"
+            color="danger"
+            onClick={() => setItemToBeDeleted(template)}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </>
+  );
+
+  const templateMeta = (template: TemplateConfiguration) => (
+    <EuiFlexGroup alignItems="center" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <EuiText size="s">
+          <h4>
+            <TruncatedText text={template.name} />
+          </h4>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiBadgeGroup gutterSize="s">
+        {template.tags?.length
+          ? template.tags.map((tag, index) => (
+              <EuiBadge
+                css={css`
+                  max-width: 100px;
+                `}
+                key={`${template.key}-tag-${index}`}
+                data-test-subj={`${template.key}-tag-${index}`}
+                color={euiTheme.colors.body}
+              >
+                {tag}
+              </EuiBadge>
+            ))
+          : null}
+      </EuiBadgeGroup>
+    </EuiFlexGroup>
+  );
+
+  const redesignList = (
+    <EuiFlexGroup
+      justifyContent="flexStart"
+      direction="column"
+      gutterSize="none"
+      data-test-subj="templates-list"
+    >
+      <EuiFlexItem>
+        {templates.map((template) => (
+          <div key={template.key} css={redesignRowCss} data-test-subj={`template-${template.key}`}>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={true}>{templateMeta(template)}</EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                  {actionButtons(template)}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        ))}
+      </EuiFlexItem>
+      {showModal && itemToBeDeleted ? (
+        <DeleteConfirmationModal
+          title={i18n.DELETE_TITLE(itemToBeDeleted.name)}
+          message={i18n.DELETE_MESSAGE(itemToBeDeleted.name)}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      ) : null}
+    </EuiFlexGroup>
+  );
+
+  const legacyList = (
     <>
       <EuiSpacer size="s" />
       <EuiFlexGroup justifyContent="flexStart" data-test-subj="templates-list">
@@ -61,63 +162,10 @@ const TemplatesListComponent: React.FC<Props> = (props) => {
                 hasShadow={false}
               >
                 <EuiFlexGroup alignItems="center" gutterSize="s">
-                  <EuiFlexItem grow={true}>
-                    <EuiFlexGroup alignItems="center" gutterSize="s">
-                      <EuiFlexItem grow={false}>
-                        <EuiText size="s">
-                          <h4>
-                            <TruncatedText text={template.name} />
-                          </h4>
-                        </EuiText>
-                      </EuiFlexItem>
-                      <EuiBadgeGroup gutterSize="s">
-                        {template.tags?.length
-                          ? template.tags.map((tag, index) => (
-                              <EuiBadge
-                                css={css`
-                                  max-width: 100px;
-                                `}
-                                key={`${template.key}-tag-${index}`}
-                                data-test-subj={`${template.key}-tag-${index}`}
-                                color={euiTheme.colors.body}
-                              >
-                                {tag}
-                              </EuiBadge>
-                            ))
-                          : null}
-                      </EuiBadgeGroup>
-                    </EuiFlexGroup>
-                  </EuiFlexItem>
+                  <EuiFlexItem grow={true}>{templateMeta(template)}</EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
-                      <EuiFlexItem grow={false}>
-                        <EuiToolTip
-                          content={`${template.key}-template-edit`}
-                          disableScreenReaderOutput
-                        >
-                          <EuiButtonIcon
-                            data-test-subj={`${template.key}-template-edit`}
-                            aria-label={`${template.key}-template-edit`}
-                            iconType="pencil"
-                            color="primary"
-                            onClick={() => onEditTemplate(template.key)}
-                          />
-                        </EuiToolTip>
-                      </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <EuiToolTip
-                          content={`${template.key}-template-delete`}
-                          disableScreenReaderOutput
-                        >
-                          <EuiButtonIcon
-                            data-test-subj={`${template.key}-template-delete`}
-                            aria-label={`${template.key}-template-delete`}
-                            iconType="minusCircle"
-                            color="danger"
-                            onClick={() => setItemToBeDeleted(template)}
-                          />
-                        </EuiToolTip>
-                      </EuiFlexItem>
+                      {actionButtons(template)}
                     </EuiFlexGroup>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -136,7 +184,9 @@ const TemplatesListComponent: React.FC<Props> = (props) => {
         ) : null}
       </EuiFlexGroup>
     </>
-  ) : null;
+  );
+
+  return templates.length ? (useLineSeparators ? redesignList : legacyList) : null;
 };
 
 TemplatesListComponent.displayName = 'TemplatesList';

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -1114,23 +1114,33 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a custom field correctly', async () => {
-        const inputField = await testSubjects.find(
-          `case-text-custom-field-form-field-${customFields[0].key}`
-        );
-        expect(await inputField.getAttribute('value')).equal('this is a text field value');
+        const textField = await testSubjects.find(`case-text-custom-field-${customFields[0].key}`);
+        expect(await textField.getVisibleText()).equal('this is a text field value');
 
         const toggle = await testSubjects.find(
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await toggle.getAttribute('aria-checked')).equal('true');
 
+        await testSubjects.click(`case-text-custom-field-edit-button-${customFields[0].key}`);
+
+        await retry.waitFor('custom field edit form to exist', async () => {
+          return await testSubjects.exists(
+            `case-text-custom-field-form-field-${customFields[0].key}`
+          );
+        });
+
+        const inputField = await testSubjects.find(
+          `case-text-custom-field-form-field-${customFields[0].key}`
+        );
+
         await inputField.type(' edited!!');
 
-        await testSubjects.click(`template-field-confirm-${customFields[0].key}`);
+        await testSubjects.click(`case-text-custom-field-submit-button-${customFields[0].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await inputField.getAttribute('value')).equal('this is a text field value edited!!');
+        expect(await textField.getVisibleText()).equal('this is a text field value edited!!');
 
         await toggle.click();
 
@@ -1147,18 +1157,30 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a number custom field correctly', async () => {
+        const numberField = await testSubjects.find(
+          `case-number-custom-field-${customFields[2].key}`
+        );
+        expect(await numberField.getVisibleText()).equal('1234');
+
+        await testSubjects.click(`case-number-custom-field-edit-button-${customFields[2].key}`);
+
+        await retry.waitFor('custom field edit form to exist', async () => {
+          return await testSubjects.exists(
+            `case-number-custom-field-form-field-${customFields[2].key}`
+          );
+        });
+
         const inputField = await testSubjects.find(
           `case-number-custom-field-form-field-${customFields[2].key}`
         );
-        expect(await inputField.getAttribute('value')).equal('1234');
 
         await inputField.type('12345');
 
-        await testSubjects.click(`template-field-confirm-${customFields[2].key}`);
+        await testSubjects.click(`case-number-custom-field-submit-button-${customFields[2].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await inputField.getAttribute('value')).equal('123412345');
+        expect(await numberField.getVisibleText()).equal('123412345');
       });
     });
   });

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -1114,33 +1114,23 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a custom field correctly', async () => {
-        const textField = await testSubjects.find(`case-text-custom-field-${customFields[0].key}`);
-        expect(await textField.getVisibleText()).equal('this is a text field value');
+        const inputField = await testSubjects.find(
+          `case-text-custom-field-form-field-${customFields[0].key}`
+        );
+        expect(await inputField.getAttribute('value')).equal('this is a text field value');
 
         const toggle = await testSubjects.find(
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await toggle.getAttribute('aria-checked')).equal('true');
 
-        await testSubjects.click(`case-text-custom-field-edit-button-${customFields[0].key}`);
-
-        await retry.waitFor('custom field edit form to exist', async () => {
-          return await testSubjects.exists(
-            `case-text-custom-field-form-field-${customFields[0].key}`
-          );
-        });
-
-        const inputField = await testSubjects.find(
-          `case-text-custom-field-form-field-${customFields[0].key}`
-        );
-
         await inputField.type(' edited!!');
 
-        await testSubjects.click(`case-text-custom-field-submit-button-${customFields[0].key}`);
+        await testSubjects.click(`template-field-confirm-${customFields[0].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await textField.getVisibleText()).equal('this is a text field value edited!!');
+        expect(await inputField.getAttribute('value')).equal('this is a text field value edited!!');
 
         await toggle.click();
 
@@ -1157,30 +1147,18 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a number custom field correctly', async () => {
-        const numberField = await testSubjects.find(
-          `case-number-custom-field-${customFields[2].key}`
-        );
-        expect(await numberField.getVisibleText()).equal('1234');
-
-        await testSubjects.click(`case-number-custom-field-edit-button-${customFields[2].key}`);
-
-        await retry.waitFor('custom field edit form to exist', async () => {
-          return await testSubjects.exists(
-            `case-number-custom-field-form-field-${customFields[2].key}`
-          );
-        });
-
         const inputField = await testSubjects.find(
           `case-number-custom-field-form-field-${customFields[2].key}`
         );
+        expect(await inputField.getAttribute('value')).equal('1234');
 
         await inputField.type('12345');
 
-        await testSubjects.click(`case-number-custom-field-submit-button-${customFields[2].key}`);
+        await testSubjects.click(`template-field-confirm-${customFields[2].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await numberField.getVisibleText()).equal('123412345');
+        expect(await inputField.getAttribute('value')).equal('123412345');
       });
     });
   });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
@@ -505,19 +505,29 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a custom field correctly', async () => {
-        const inputField = await testSubjects.find(
-          `case-text-custom-field-form-field-${customFields[0].key}`
-        );
-        expect(await inputField.getAttribute('value')).equal('this is a text field value');
+        const textField = await testSubjects.find(`case-text-custom-field-${customFields[0].key}`);
+        expect(await textField.getVisibleText()).equal('this is a text field value');
 
         const toggle = await testSubjects.find(
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await toggle.getAttribute('aria-checked')).equal('true');
 
+        await testSubjects.click(`case-text-custom-field-edit-button-${customFields[0].key}`);
+
+        await retry.waitFor('custom field edit form to exist', async () => {
+          return await testSubjects.exists(
+            `case-text-custom-field-form-field-${customFields[0].key}`
+          );
+        });
+
+        const inputField = await testSubjects.find(
+          `case-text-custom-field-form-field-${customFields[0].key}`
+        );
+
         await inputField.type(' edited!!');
 
-        await testSubjects.click(`template-field-confirm-${customFields[0].key}`);
+        await testSubjects.click(`case-text-custom-field-submit-button-${customFields[0].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
@@ -525,7 +535,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await inputField.getAttribute('value')).equal('this is a text field value edited!!');
+        expect(await textField.getVisibleText()).equal('this is a text field value edited!!');
 
         expect(await toggle.getAttribute('aria-checked')).equal('false');
 

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
@@ -505,29 +505,19 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a custom field correctly', async () => {
-        const textField = await testSubjects.find(`case-text-custom-field-${customFields[0].key}`);
-        expect(await textField.getVisibleText()).equal('this is a text field value');
+        const inputField = await testSubjects.find(
+          `case-text-custom-field-form-field-${customFields[0].key}`
+        );
+        expect(await inputField.getAttribute('value')).equal('this is a text field value');
 
         const toggle = await testSubjects.find(
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await toggle.getAttribute('aria-checked')).equal('true');
 
-        await testSubjects.click(`case-text-custom-field-edit-button-${customFields[0].key}`);
-
-        await retry.waitFor('custom field edit form to exist', async () => {
-          return await testSubjects.exists(
-            `case-text-custom-field-form-field-${customFields[0].key}`
-          );
-        });
-
-        const inputField = await testSubjects.find(
-          `case-text-custom-field-form-field-${customFields[0].key}`
-        );
-
         await inputField.type(' edited!!');
 
-        await testSubjects.click(`case-text-custom-field-submit-button-${customFields[0].key}`);
+        await testSubjects.click(`template-field-confirm-${customFields[0].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
@@ -535,7 +525,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await textField.getVisibleText()).equal('this is a text field value edited!!');
+        expect(await inputField.getAttribute('value')).equal('this is a text field value edited!!');
 
         expect(await toggle.getAttribute('aria-checked')).equal('false');
 

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
@@ -503,29 +503,19 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a custom field correctly', async () => {
-        const textField = await testSubjects.find(`case-text-custom-field-${customFields[0].key}`);
-        expect(await textField.getVisibleText()).equal('this is a text field value');
+        const inputField = await testSubjects.find(
+          `case-text-custom-field-form-field-${customFields[0].key}`
+        );
+        expect(await inputField.getAttribute('value')).equal('this is a text field value');
 
         const toggle = await testSubjects.find(
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await toggle.getAttribute('aria-checked')).equal('true');
 
-        await testSubjects.click(`case-text-custom-field-edit-button-${customFields[0].key}`);
-
-        await retry.waitFor('custom field edit form to exist', async () => {
-          return await testSubjects.exists(
-            `case-text-custom-field-form-field-${customFields[0].key}`
-          );
-        });
-
-        const inputField = await testSubjects.find(
-          `case-text-custom-field-form-field-${customFields[0].key}`
-        );
-
         await inputField.type(' edited!!');
 
-        await testSubjects.click(`case-text-custom-field-submit-button-${customFields[0].key}`);
+        await testSubjects.click(`template-field-confirm-${customFields[0].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
@@ -535,7 +525,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await textField.getVisibleText()).equal('this is a text field value edited!!');
+        expect(await inputField.getAttribute('value')).equal('this is a text field value edited!!');
 
         expect(await toggle.getAttribute('aria-checked')).equal('false');
 

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
@@ -503,19 +503,29 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('updates a custom field correctly', async () => {
-        const inputField = await testSubjects.find(
-          `case-text-custom-field-form-field-${customFields[0].key}`
-        );
-        expect(await inputField.getAttribute('value')).equal('this is a text field value');
+        const textField = await testSubjects.find(`case-text-custom-field-${customFields[0].key}`);
+        expect(await textField.getVisibleText()).equal('this is a text field value');
 
         const toggle = await testSubjects.find(
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await toggle.getAttribute('aria-checked')).equal('true');
 
+        await testSubjects.click(`case-text-custom-field-edit-button-${customFields[0].key}`);
+
+        await retry.waitFor('custom field edit form to exist', async () => {
+          return await testSubjects.exists(
+            `case-text-custom-field-form-field-${customFields[0].key}`
+          );
+        });
+
+        const inputField = await testSubjects.find(
+          `case-text-custom-field-form-field-${customFields[0].key}`
+        );
+
         await inputField.type(' edited!!');
 
-        await testSubjects.click(`template-field-confirm-${customFields[0].key}`);
+        await testSubjects.click(`case-text-custom-field-submit-button-${customFields[0].key}`);
 
         await header.waitUntilLoadingHasFinished();
 
@@ -525,7 +535,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await header.waitUntilLoadingHasFinished();
 
-        expect(await inputField.getAttribute('value')).equal('this is a text field value edited!!');
+        expect(await textField.getVisibleText()).equal('this is a text field value edited!!');
 
         expect(await toggle.getAttribute('aria-checked')).equal('false');
 


### PR DESCRIPTION
## What & Why
Polishes Cases redesign custom-field editing (inline confirm/cancel, form labels, Optional) and create-case spacing, and adds a one-time All Cases search toast when templates are enabled. Legacy case view keeps the classic pencil/view custom-field UI and Extended fields headings so existing workflows stay unchanged.

Also gates **pre-migration (legacy) custom fields and templates** behind a local-storage switch (default OFF) on redesigned Settings, Create Case, and redesigned Case Details when templates v2 is enabled—so migrated Field Library / Templates v2 remain the primary path while old definitions stay discoverable for troubleshooting.

## How to Test
1. **Legacy case view** (redesign off): open a case with text/number/toggle custom fields — pencil edit, Save/Cancel, and Extended fields heading behave as before.
2. **Redesign case view**: same fields show always-visible inputs; confirm/cancel appear on change; optional fields show Optional; no Extended fields heading under the Fields accordion.
3. **Create case**: with legacy custom fields + template/global fields, confirm spacing between sections; without legacy custom fields, no flush stacking under Description.
4. **Redesign All Cases** with templates enabled: submit a non-empty search once and confirm the hidden-fields info toast; remount to see it again.
5. **Redesign Settings** (templates v2 on): see deprecation section + switch (default off). Turn on → lists, Deprecated badges, Add/Edit/Delete flyouts work; Add after Edit opens a blank Add flyout.
6. **Create case** (templates v2 on, switch off): legacy custom fields hidden; submit does **not** include stale legacy `customFields`. Switch on → Deprecated badge + callout (mentions expected duplication) + divider.
7. **Redesign Case Details** (templates v2 on, switch on): Custom fields accordion (closed by default) with Deprecated badge and duplication disclaimer.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/main/src/dev/ci_setup/README.md) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

---
Replaces #279272, which was accidentally opened with its head branch on `elastic/kibana` instead of my fork.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->