### PR TITLE
[Infra] Add maxLenght to schema strings (CodeQl unbounded-string)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts
@@ -74,7 +74,7 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
       path: '/api/metrics/source/{sourceId}',
       validate: {
         params: schema.object({
-          sourceId: schema.string(),
+          sourceId: schema.string({ maxLength: 256 }),
         }),
       },
     },
@@ -121,7 +121,7 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
       path: '/api/metrics/source/{sourceId}',
       validate: {
         params: schema.object({
-          sourceId: schema.string(),
+          sourceId: schema.string({ maxLength: 256 }),
         }),
         body: createRouteValidationFunction(partialMetricsSourceConfigurationReqPayloadRT),
       },
@@ -185,7 +185,7 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
       path: '/api/metrics/source/{sourceId}/hasData',
       validate: {
         params: schema.object({
-          sourceId: schema.string(),
+          sourceId: schema.string({ maxLength: 256 }),
         }),
       },
     },

--- a/x-pack/solutions/observability/plugins/infra/server/routes/profiling/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/profiling/index.ts
@@ -58,7 +58,7 @@ export function initProfilingRoutes({ framework, getStartServices, logger }: Inf
       path: '/api/infra/profiling/flamegraph',
       validate: {
         query: schema.object({
-          kuery: schema.string(),
+          kuery: schema.string({ maxLength: 2048 }),
           from: schema.number(),
           to: schema.number(),
         }),
@@ -93,7 +93,7 @@ export function initProfilingRoutes({ framework, getStartServices, logger }: Inf
       path: '/api/infra/profiling/functions',
       validate: {
         query: schema.object({
-          kuery: schema.string(),
+          kuery: schema.string({ maxLength: 2048 }),
           from: schema.number(),
           to: schema.number(),
           startIndex: schema.number(),

--- a/x-pack/solutions/observability/plugins/infra/server/saved_objects/custom_dashboards/custom_dashboards_saved_object.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/saved_objects/custom_dashboards/custom_dashboards_saved_object.ts
@@ -45,9 +45,9 @@ export const infraCustomDashboardsSavedObjectType: SavedObjectsType = {
       changes: [],
       schemas: {
         create: schema.object({
-          dashboardIdList: schema.arrayOf(schema.string()),
-          assetType: schema.string(),
-          kuery: schema.maybe(schema.string()),
+          dashboardIdList: schema.arrayOf(schema.string({ maxLength: 256 })),
+          assetType: schema.string({ maxLength: 64 }),
+          kuery: schema.maybe(schema.string({ maxLength: 2048 })),
         }),
       },
     },
@@ -71,8 +71,8 @@ export const infraCustomDashboardsSavedObjectType: SavedObjectsType = {
       ],
       schemas: {
         create: schema.object({
-          dashboardSavedObjectId: schema.string(),
-          assetType: schema.string(),
+          dashboardSavedObjectId: schema.string({ maxLength: 256 }),
+          assetType: schema.string({ maxLength: 64 }),
           dashboardFilterAssetIdEnabled: schema.boolean(),
         }),
       },

--- a/x-pack/solutions/observability/plugins/infra/server/saved_objects/custom_dashboards/custom_dashboards_saved_object.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/saved_objects/custom_dashboards/custom_dashboards_saved_object.ts
@@ -45,7 +45,9 @@ export const infraCustomDashboardsSavedObjectType: SavedObjectsType = {
       changes: [],
       schemas: {
         create: schema.object({
-          dashboardIdList: schema.arrayOf(schema.string({ maxLength: 256 })),
+          dashboardIdList: schema.arrayOf(schema.string({ maxLength: 256 }), {
+            maxSize: 100,
+          }),
           assetType: schema.string({ maxLength: 64 }),
           kuery: schema.maybe(schema.string({ maxLength: 2048 })),
         }),


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana-team/issues/3664

Adds `maxLength` to `schema.string()` calls flagged by CodeQL `js/kibana/unbounded-string-in-schema` (high/DoS) in Infra metrics source routes, Infra profiling routes, and the Infra custom dashboards saved-object schemas.

Only `maxLength` is added (no `minLength`/regex), so existing legitimate values keep validating.

| Field | maxLength | Rationale |
| ----- | --------- | --------- |
| `sourceId` (metrics source route params) | 256 | Short source configuration IDs (typically `default`) |
| `kuery` (profiling flamegraph/functions query) | 2048 | Matches Profiling `MAX_KUERY_LENGTH` and similar SLO/APM KQL bounds |
| `dashboardSavedObjectId` / `dashboardIdList[]` | 256 | Saved object IDs |
| `assetType` | 64 | Inventory item type enum values |
| `kuery` (custom dashboards SO modelVersion 1) | 2048 | KQL / filter string |

### Files

- `x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts`
- `x-pack/solutions/observability/plugins/infra/server/routes/profiling/index.ts`
- `x-pack/solutions/observability/plugins/infra/server/saved_objects/custom_dashboards/custom_dashboards_saved_object.ts`

