### PR TITLE
[Observability] Fix CodeQL unbounded-string and insecure-randomness alerts

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-observability-schema/related_dashboards/rest_specs/get_related_dashboards/v1.ts
+++ b/x-pack/solutions/observability/packages/kbn-observability-schema/related_dashboards/rest_specs/get_related_dashboards/v1.ts
@@ -10,7 +10,7 @@ import { linkedDashboardSchema, suggestedDashboardSchema } from '../../schema/re
 
 export const getRelatedDashboardsParamsSchema = z.object({
   query: z.object({
-    alertId: z.string(),
+    alertId: z.string().max(256),
   }),
 });
 

--- a/x-pack/solutions/observability/plugins/infra/test/scenarios/infra_k8s_pods.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scenarios/infra_k8s_pods.ts
@@ -10,7 +10,7 @@
  */
 
 import type { InfraDocument } from '@kbn/synthtrace-client';
-import { infra, generateShortId } from '@kbn/synthtrace-client';
+import { infra } from '@kbn/synthtrace-client';
 
 import type { Scenario } from '@kbn/synthtrace';
 import { withClient, getNumberOpt } from '@kbn/synthtrace';
@@ -24,7 +24,9 @@ const scenario: Scenario<InfraDocument> = async (runOptions) => {
       const PODS = Array(numPods)
         .fill(0)
         .map((_, idx) => {
-          const uid = generateShortId();
+          // Deterministic pod UIDs for synthtrace fixtures — not security-sensitive
+          // (avoids CodeQL js/insecure-randomness on generateShortId / Math.random).
+          const uid = `pod-${idx}`;
           return infra.pod(uid, `node-${idx}`);
         });
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana-team/issues/3685

Addresses CodeQL security scanning findings in Observability:

1. **Unbounded string** (`js/kibana/unbounded-string-in-schema`): add `.max(256)` to `alertId` in the related dashboards request query schema.
2. **Insecure randomness** (`js/insecure-randomness`): replace `generateShortId()` with deterministic `pod-${idx}` UIDs in the Infra K8s pods synthtrace scenario. These IDs are fixture labels only, not security-sensitive values.

| Location | Change | Bound / rationale |
| -------- | ------ | ----------------- |
| `alertId` (related dashboards query) | `z.string().max(256)` | Alert identifiers (typically UUID-length) |
| Infra K8s pods synthtrace scenario | `` `pod-${idx}` `` | Deterministic test fixture IDs; avoids weak PRNG for non-secret values |

### Files

- `x-pack/solutions/observability/packages/kbn-observability-schema/related_dashboards/rest_specs/get_related_dashboards/v1.ts`
- `x-pack/solutions/observability/plugins/infra/test/scenarios/infra_k8s_pods.ts`
