### PR TITLE
[Synthetics] Harden private location monitor recreation after cleanup

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
+import type { NewPackagePolicyWithId } from '@kbn/fleet-plugin/server/services/package_policy';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { PackagePolicyService } from './package_policy_service';
+import type { SyntheticsServerSetup } from '../../types';
+
+const makeServer = (bulkCreateMock: jest.Mock) => {
+  const soClient = {} as SavedObjectsClientContract;
+  const logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+  const server = {
+    coreStart: {
+      savedObjects: {
+        getUnsafeInternalClient: () => ({ asScopedToNamespace: () => soClient }),
+      },
+      elasticsearch: { client: { asInternalUser: {} } },
+    },
+    fleet: { packagePolicyService: { bulkCreate: bulkCreateMock } },
+    logger,
+  } as unknown as SyntheticsServerSetup;
+  return { server, logger };
+};
+
+const policy = (id: string) =>
+  ({ id, name: id, policy_ids: ['ap-1'] } as unknown as NewPackagePolicyWithId);
+
+describe('PackagePolicyService.bulkCreate retry of failed creates', () => {
+  test('returns early without calling fleet when there are no policies', async () => {
+    const bulkCreateMock = jest.fn();
+    const { server } = makeServer(bulkCreateMock);
+
+    const res = await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [],
+      spaceId: DEFAULT_SPACE_ID,
+    });
+
+    expect(res).toEqual({ created: [], failed: [] });
+    expect(bulkCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('retries only the failed policies and merges the created results (retryFailed)', async () => {
+    const bulkCreateMock = jest
+      .fn()
+      // first attempt: p-2 fails
+      .mockResolvedValueOnce({
+        created: [policy('p-1'), policy('p-3')],
+        failed: [{ packagePolicy: policy('p-2'), error: new Error('boom') }],
+      })
+      // retry attempt: only p-2 is retried and now succeeds
+      .mockResolvedValueOnce({ created: [policy('p-2')], failed: [] });
+
+    const { server } = makeServer(bulkCreateMock);
+
+    const res = await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy('p-1'), policy('p-2'), policy('p-3')],
+      spaceId: DEFAULT_SPACE_ID,
+      retryFailed: true,
+    });
+
+    expect(bulkCreateMock).toHaveBeenCalledTimes(2);
+    // retry received ONLY the failed policy, not the whole batch
+    const retriedPolicies = bulkCreateMock.mock.calls[1][2];
+    expect(retriedPolicies.map((p: NewPackagePolicyWithId) => p.id)).toEqual(['p-2']);
+
+    expect(res.failed).toEqual([]);
+    expect(res.created.map((p: NewPackagePolicyWithId) => p.id).sort()).toEqual([
+      'p-1',
+      'p-2',
+      'p-3',
+    ]);
+  });
+
+  test('stops after the max attempts and returns the still-failing policies (retryFailed)', async () => {
+    const failure = { packagePolicy: policy('p-2'), error: new Error('boom') };
+    const bulkCreateMock = jest
+      .fn()
+      .mockResolvedValue({ created: [], failed: [failure] }); // always fails
+
+    const { server } = makeServer(bulkCreateMock);
+
+    const res = await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy('p-2')],
+      spaceId: DEFAULT_SPACE_ID,
+      retryFailed: true,
+    });
+
+    // 1 initial attempt + 2 retries
+    expect(bulkCreateMock).toHaveBeenCalledTimes(3);
+    expect(res.failed).toHaveLength(1);
+    expect((res.failed[0].packagePolicy as NewPackagePolicyWithId).id).toBe('p-2');
+  });
+
+  test('does NOT retry failures when retryFailed is not set (non-sync callers)', async () => {
+    const failure = { packagePolicy: policy('p-2'), error: new Error('boom') };
+    const bulkCreateMock = jest.fn().mockResolvedValue({ created: [], failed: [failure] });
+
+    const { server } = makeServer(bulkCreateMock);
+
+    const res = await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy('p-2')],
+      spaceId: DEFAULT_SPACE_ID,
+    });
+
+    expect(bulkCreateMock).toHaveBeenCalledTimes(1);
+    expect(res.failed).toHaveLength(1);
+  });
+
+  test('does not retry when the first attempt fully succeeds', async () => {
+    const bulkCreateMock = jest
+      .fn()
+      .mockResolvedValueOnce({ created: [policy('p-1')], failed: [] });
+
+    const { server } = makeServer(bulkCreateMock);
+
+    await new PackagePolicyService(server).bulkCreate({
+      newPolicies: [policy('p-1')],
+      spaceId: DEFAULT_SPACE_ID,
+      retryFailed: true,
+    });
+
+    expect(bulkCreateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.ts
@@ -13,6 +13,8 @@ import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { uniqBy } from 'lodash';
 import type { SyntheticsServerSetup } from '../../types';
 
+const MAX_BULK_CREATE_RETRIES = 2;
+
 export class PackagePolicyService {
   private readonly server: SyntheticsServerSetup;
 
@@ -86,14 +88,46 @@ export class PackagePolicyService {
   async bulkCreate({
     newPolicies,
     spaceId,
+    retryFailed = false,
   }: {
     newPolicies: NewPackagePolicyWithId[];
     spaceId: string;
+    // Opt-in retry of only the failed creations, used by the sync task recreation path so a
+    // transient failure for one monitor doesn't leave it without a package policy (stuck pending).
+    retryFailed?: boolean;
   }) {
     if (newPolicies.length === 0) {
       return { created: [], failed: [] };
     }
 
+    let { created, failed } = await this.bulkCreateOnce({ newPolicies, spaceId });
+
+    // Retry only the policies that failed, so a transient failure for one monitor doesn't force
+    // re-creating the policies that already succeeded.
+    let attempt = 0;
+    while (retryFailed && failed.length > 0 && attempt < MAX_BULK_CREATE_RETRIES) {
+      attempt++;
+      const retryPolicies = failed.map((f) => f.packagePolicy as NewPackagePolicyWithId);
+      this.server.logger.debug(
+        `[PackagePolicyService] Retrying ${retryPolicies.length} failed package policy creation(s) (attempt ${
+          attempt + 1
+        }/${MAX_BULK_CREATE_RETRIES + 1})`
+      );
+      const res = await this.bulkCreateOnce({ newPolicies: retryPolicies, spaceId });
+      created = created.concat(res.created);
+      failed = res.failed;
+    }
+
+    return { created, failed };
+  }
+
+  private async bulkCreateOnce({
+    newPolicies,
+    spaceId,
+  }: {
+    newPolicies: NewPackagePolicyWithId[];
+    spaceId: string;
+  }) {
     const promises = (
       await this.getDefaultAndSpacePackagePolicies({
         policies: newPolicies,

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -384,7 +384,8 @@ export class SyntheticsPrivateLocation {
     configs: Array<{ config: HeartbeatConfig; globalParams: Record<string, string> }>,
     allPrivateLocations: SyntheticsPrivateLocations,
     spaceId: string,
-    maintenanceWindows: MaintenanceWindow[]
+    maintenanceWindows: MaintenanceWindow[],
+    { retryFailedCreates = false }: { retryFailedCreates?: boolean } = {}
   ) {
     if (configs.length === 0) {
       return {
@@ -467,6 +468,7 @@ export class SyntheticsPrivateLocation {
     const createResponse = await this.packagePolicyService.bulkCreate({
       newPolicies: policiesToCreate,
       spaceId,
+      retryFailed: retryFailedCreates,
     });
 
     if (createResponse.failed.length > 0) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/clean_up_duplicate_policies.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/clean_up_duplicate_policies.test.ts
@@ -5,10 +5,21 @@
  * 2.0.
  */
 
-import { deleteDuplicatePackagePolicies } from './clean_up_duplicate_policies';
+import {
+  cleanUpDuplicatedPackagePolicies,
+  deleteDuplicatePackagePolicies,
+} from './clean_up_duplicate_policies';
 import type { SyntheticsServerSetup } from '../types';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SyncTaskState } from './sync_private_locations_monitors_task';
+
+jest.mock('../synthetics_service/private_location/synthetics_private_location', () => ({
+  // Mirror the 9.4+ scheme: `${configId}-${locationId}` (no spaceId suffix).
+  SyntheticsPrivateLocation: jest.fn().mockImplementation(() => ({
+    getPolicyId: (config: { id: string }, locId: string) => `${config.id}-${locId}`,
+  })),
+}));
 
 describe('deleteDuplicatePackagePolicies', () => {
   const makeServerSetup = (deleteMock: jest.Mock) => {
@@ -108,6 +119,100 @@ describe('deleteDuplicatePackagePolicies', () => {
       spaceIds: ['*'],
     });
     expect(deleteMock).toHaveBeenNthCalledWith(3, soClient, esClient, thirdBatch, {
+      force: true,
+      ignoreMissing: true,
+      spaceIds: ['*'],
+    });
+  });
+});
+
+describe('cleanUpDuplicatedPackagePolicies latch behavior', () => {
+  const makeContext = ({
+    monitorLocationIds,
+    existingPolicyIds,
+  }: {
+    monitorLocationIds: string[];
+    existingPolicyIds: string[];
+  }) => {
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+    const logger = { info: jest.fn(), debug: jest.fn(), error: jest.fn() };
+
+    const monitor = {
+      attributes: {
+        id: 'mon-1',
+        origin: 'ui',
+        locations: monitorLocationIds.map((id) => ({ id, isServiceManaged: false })),
+      },
+    };
+    const finder = {
+      async *find() {
+        yield { saved_objects: [monitor] };
+      },
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const serverSetup = {
+      pluginsStart: {
+        fleet: {
+          packagePolicyService: {
+            async *fetchAllItemIds() {
+              yield existingPolicyIds;
+            },
+            delete: deleteMock,
+          },
+        },
+      },
+      coreStart: { elasticsearch: { client: { asInternalUser: {} } } },
+      logger,
+    } as unknown as SyntheticsServerSetup;
+
+    const soClient = {
+      createPointInTimeFinder: () => finder,
+    } as unknown as SavedObjectsClientContract;
+
+    const taskState: SyncTaskState = {
+      lastStartedAt: new Date().toISOString(),
+      hasAlreadyDoneCleanup: false,
+      maxCleanUpRetries: 3,
+    };
+
+    return { serverSetup, soClient, taskState, deleteMock };
+  };
+
+  test('latches hasAlreadyDoneCleanup when already converged (nothing to delete, none missing)', async () => {
+    const { serverSetup, soClient, taskState, deleteMock } = makeContext({
+      monitorLocationIds: ['loc-1'],
+      existingPolicyIds: ['mon-1-loc-1'], // matches expected new-format id
+    });
+
+    const { performCleanupSync } = await cleanUpDuplicatedPackagePolicies(
+      serverSetup,
+      soClient,
+      taskState
+    );
+
+    expect(performCleanupSync).toBe(false);
+    expect(taskState.hasAlreadyDoneCleanup).toBe(true);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  test('does NOT latch when a follow-up recreation is still required (legacy deleted, new missing)', async () => {
+    const { serverSetup, soClient, taskState, deleteMock } = makeContext({
+      monitorLocationIds: ['loc-1'],
+      existingPolicyIds: ['mon-1-loc-1-default'], // legacy (spaceId-suffixed) id only
+    });
+
+    const { performCleanupSync } = await cleanUpDuplicatedPackagePolicies(
+      serverSetup,
+      soClient,
+      taskState
+    );
+
+    // Legacy policy is deleted, but the expected new-format policy is missing, so the migration is
+    // not complete — the flag must stay false so the next run retries recreation.
+    expect(performCleanupSync).toBe(true);
+    expect(taskState.hasAlreadyDoneCleanup).toBe(false);
+    expect(deleteMock).toHaveBeenCalledWith(soClient, expect.anything(), ['mon-1-loc-1-default'], {
       force: true,
       ignoreMissing: true,
       spaceIds: ['*'],

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/clean_up_duplicate_policies.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/clean_up_duplicate_policies.ts
@@ -109,7 +109,15 @@ export async function cleanUpDuplicatedPackagePolicies(
         serverSetup
       );
     }
-    taskState.hasAlreadyDoneCleanup = true;
+    // Only treat the one-time migration as done once the deployment already matches the expected
+    // state (nothing to delete and no expected policy missing). When a follow-up sync is still
+    // required we leave the flag unset so the next run re-verifies and retries recreation — the
+    // recreation (`deployEditMonitors`) can partially fail without throwing, so latching here would
+    // otherwise strand private location monitors without a package policy (stuck "pending") with no
+    // auto-recovery.
+    if (!performCleanupSync) {
+      taskState.hasAlreadyDoneCleanup = true;
+    }
     taskState.maxCleanUpRetries = 3;
     return { performCleanupSync };
   } catch (e) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -267,7 +267,8 @@ export class DeployPrivateLocationMonitors {
           privateConfigs,
           allPrivateLocations,
           spaceId,
-          maintenanceWindows
+          maintenanceWindows,
+          { retryFailedCreates: true }
         );
 
         if (result?.failedCreates && result.failedCreates.length > 0) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -423,7 +423,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         expect.any(Array),
         mockAllPrivateLocations,
         'space1',
-        []
+        [],
+        { retryFailedCreates: true }
       );
     });
 


### PR DESCRIPTION
## Summary

Hardens the private location monitor sync/cleanup path so a failed or partial package-policy recreation no longer leaves monitors stuck **pending** with no recovery.

### Background / root cause

The one-time private location cleanup (`cleanUpDuplicatedPackagePolicies`) deletes legacy-format package policies and then relies on a follow-up sync to recreate them in the new (space-agnostic) id format. Two issues combined to strand monitors:

1. `hasAlreadyDoneCleanup` was latched to `true` **immediately after the delete**, before confirming the new-format policies were actually recreated. Once latched, the cleanup never runs again.
2. The recreation path (`deployEditMonitors` → `editMonitors` → `bulkCreate`) **swallows partial failures** — `failedCreates` is logged, not thrown. So a failed/partial recreate is invisible to the caller.

Together, if recreation failed after the delete, the affected monitors had no package policy and no way to auto-recover (recovery required manually editing each monitor).

### Changes

- **Latch on convergence** (`clean_up_duplicate_policies.ts`): `hasAlreadyDoneCleanup` is now set only once the deployment already matches the expected state (nothing to delete **and** no expected policy missing). While a follow-up sync is still required the flag stays unset, so the sync task re-verifies and retries recreation each run (~5 min) until it converges. Healthy deployments still latch on the first run.
- **Retry only the failed creations** (`package_policy_service.ts`): `bulkCreate` gained an opt-in `retryFailed` flag that retries **only** the package policies Fleet reported as failed (up to 2 extra attempts), leaving already-created ones untouched. It is threaded through `editMonitors({ retryFailedCreates })` and enabled **only on the sync-task path** (`deployEditMonitors`). UI create/edit paths are unchanged (a live request surfaces its own errors).

### Recovery model

1. **In-run, targeted:** only the specific failed policy creations are retried during a sync.
2. **Cross-run, self-healing:** anything still missing is detected and recreated on the next task run, since cleanup no longer latches until converged.

## Testing

- New unit tests for `PackagePolicyService.bulkCreate` (retries only failed, merges created, stops after max attempts, and does **not** retry for non-sync callers).
- New unit tests for `cleanUpDuplicatedPackagePolicies` latch behavior (latches when converged; does **not** latch when recreation is still required).
- Existing `synthetics_private_location`, `sync_private_locations_monitors_task`, and `synthetics_monitor_client` suites updated and green.

## Risk

Low. Behavior change is scoped to the private location sync/cleanup task; UI monitor CRUD paths keep their existing behavior.
