### PR TITLE
[9.3] [APM] Fix team ownership: add -team suffix to @elastic/obs-signals-traces (#279292)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -447,10 +447,10 @@ src/platform/packages/shared/kbn-alerts-ui-shared @elastic/response-ops
 src/platform/packages/shared/kbn-ambient-storybook-types @elastic/kibana-operations
 src/platform/packages/shared/kbn-ambient-ui-types @elastic/kibana-operations
 src/platform/packages/shared/kbn-analytics @elastic/kibana-core
-src/platform/packages/shared/kbn-apm-data-view @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-utils @elastic/obs-signals-traces
+src/platform/packages/shared/kbn-apm-data-view @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-utils @elastic/obs-signals-traces-team
 src/platform/packages/shared/kbn-avc-banner @elastic/security-defend-workflows
 src/platform/packages/shared/kbn-axe-config @elastic/appex-qa
 src/platform/packages/shared/kbn-babel-register @elastic/kibana-operations
@@ -609,8 +609,8 @@ src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
-src/platform/packages/shared/kbn-synthtrace @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team @elastic/nightshift-context-and-research-team
-src/platform/packages/shared/kbn-synthtrace-client @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-synthtrace @elastic/obs-signals-traces-team @elastic/streams-ui @elastic/obs-exploration-team @elastic/nightshift-context-and-research-team
+src/platform/packages/shared/kbn-synthtrace-client @elastic/obs-signals-traces-team @elastic/streams-ui @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-telemetry @elastic/kibana-core @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-telemetry-config @elastic/kibana-core
 src/platform/packages/shared/kbn-test @elastic/kibana-operations @elastic/appex-qa
@@ -629,7 +629,7 @@ src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 src/platform/packages/shared/kbn-tracing-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-triggers-actions-ui-types @elastic/response-ops
 src/platform/packages/shared/kbn-try-in-console @elastic/search-kibana
-src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-signals-traces-team
 src/platform/packages/shared/kbn-ui-actions-browser @elastic/appex-sharedux
 src/platform/packages/shared/kbn-ui-theme @elastic/kibana-operations
 src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
@@ -945,7 +945,7 @@ x-pack/platform/packages/shared/kbn-ai-assistant @elastic/search-kibana @elastic
 x-pack/platform/packages/shared/kbn-ai-tools @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-ai-tools-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
-x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-signals-traces
+x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-signals-traces-team
 x-pack/platform/packages/shared/kbn-classic-stream-flyout @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-content-packs-schema @elastic/streams-ui
 x-pack/platform/packages/shared/kbn-data-forge @elastic/actionable-obs-team
@@ -957,7 +957,7 @@ x-pack/platform/packages/shared/kbn-entities-schema @elastic/obs-entities
 x-pack/platform/packages/shared/kbn-es-snapshot-loader @elastic/nightshift-context-and-research-team
 x-pack/platform/packages/shared/kbn-evals @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-evals-suite-streams @elastic/streams-ui @elastic/obs-sig-events-team
-x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-signals-traces-team @elastic/obs-exploration-team
 x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
 x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/streams-ui
@@ -967,7 +967,7 @@ x-pack/platform/packages/shared/kbn-inference-prompt-utils @elastic/appex-ai-inf
 x-pack/platform/packages/shared/kbn-inference-tracing @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-tracing-config @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-ink @elastic/streams-program-team
-x-pack/platform/packages/shared/kbn-key-value-metadata-table @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/kbn-key-value-metadata-table @elastic/obs-signals-traces-team @elastic/obs-exploration-team
 x-pack/platform/packages/shared/kbn-kibana-api-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-langchain @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver @elastic/security-generative-ai
@@ -1050,7 +1050,7 @@ x-pack/platform/plugins/shared/ai_infra/llm_tasks @elastic/appex-ai-infra
 x-pack/platform/plugins/shared/ai_infra/product_doc_base @elastic/appex-ai-infra
 x-pack/platform/plugins/shared/aiops @elastic/ml-ui
 x-pack/platform/plugins/shared/alerting @elastic/response-ops
-x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-signals-traces
+x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-signals-traces-team
 x-pack/platform/plugins/shared/automatic_import @elastic/integration-experience
 x-pack/platform/plugins/shared/automatic_import_v2 @elastic/integration-experience
 x-pack/platform/plugins/shared/cases @elastic/kibana-cases
@@ -1161,9 +1161,9 @@ x-pack/solutions/observability/packages/synthetics-test-data @elastic/actionable
 x-pack/solutions/observability/packages/utils-browser @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-common @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-server @elastic/observability-ui
-x-pack/solutions/observability/plugins/apm @elastic/obs-signals-traces
-x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-signals-traces
-x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-signals-traces
+x-pack/solutions/observability/plugins/apm @elastic/obs-signals-traces-team
+x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-signals-traces-team
+x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-signals-traces-team
 x-pack/solutions/observability/plugins/exploratory_view @elastic/actionable-obs-team
 x-pack/solutions/observability/plugins/infra @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/metrics_data_access @elastic/obs-presentation-team
@@ -1526,11 +1526,11 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## This should allow the infra team to work without dependencies on the @elastic/obs-exploration-team, which will maintain ownership of the Logs UI code only.
 
 ## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-signals-traces-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/infra/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.serverless.config.ts @elastic/obs-presentation-team
@@ -1656,12 +1656,12 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/serverless/api_integration/services/default_fleet_setup.ts @elastic/fleet
 
 # APM
-/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-signals-traces
+/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-signals-traces-team
 /src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-signals-traces-team
 #CC# /src/plugins/apm_oss/ @elastic/apm-ui
 #CC# /x-pack/plugins/observability_solution/observability/ @elastic/apm-ui
 

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -62,7 +62,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-knowledge-team',
     'elastic/streams-ui',
     'elastic/obs-presentation-team',
-    'elastic/obs-signals-traces',
+    'elastic/obs-signals-traces-team',
     'elastic/observability-ui',
     'elastic/obs-ux-management-team',
     'elastic/observability-design',

--- a/src/platform/packages/shared/kbn-apm-data-view/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-data-view/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-data-view",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-data-view/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-data-view/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-data-view'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-data-view'
   description: Moon project for @kbn/apm-data-view
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-data-view
 tags:
   - shared-common

--- a/src/platform/packages/shared/kbn-apm-types-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-types-shared/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-types-shared",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-types-shared/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-types-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-types-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-types-shared'
   description: Moon project for @kbn/apm-types-shared
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-types-shared
 dependsOn: []
 tags:

--- a/src/platform/packages/shared/kbn-apm-ui-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/apm-ui-shared",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-ui-shared/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-ui-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-ui-shared'
   description: Moon project for @kbn/apm-ui-shared
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-ui-shared
 dependsOn:
   - '@kbn/i18n'

--- a/src/platform/packages/shared/kbn-apm-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-utils/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-utils",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-utils'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-utils'
   description: Moon project for @kbn/apm-utils
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-utils
 tags:
   - shared-common

--- a/src/platform/packages/shared/kbn-synthtrace-client/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-synthtrace-client/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/synthtrace-client",
   "owner": [
-    "@elastic/obs-presentation-team",
+    "@elastic/obs-signals-traces-team",
     "@elastic/streams-ui",
     "@elastic/obs-exploration-team"
   ],

--- a/src/platform/packages/shared/kbn-synthtrace-client/moon.yml
+++ b/src/platform/packages/shared/kbn-synthtrace-client/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/synthtrace-client'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/synthtrace-client'
   description: Moon project for @kbn/synthtrace-client
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-synthtrace-client
 dependsOn:
   - '@kbn/datemath'

--- a/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-synthtrace/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-server",
   "id": "@kbn/synthtrace",
   "owner": [
-    "@elastic/obs-presentation-team",
+    "@elastic/obs-signals-traces-team",
     "@elastic/streams-ui",
     "@elastic/obs-exploration-team",
     "@elastic/nightshift-context-and-research-team"

--- a/src/platform/packages/shared/kbn-synthtrace/moon.yml
+++ b/src/platform/packages/shared/kbn-synthtrace/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/synthtrace'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/synthtrace'
   description: Moon project for @kbn/synthtrace
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-synthtrace
 dependsOn:
   - '@kbn/datemath'

--- a/src/platform/packages/shared/kbn-typed-react-router-config/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/kibana.jsonc
@@ -3,7 +3,7 @@
   "id": "@kbn/typed-react-router-config",
   "owner": [
     "@elastic/obs-knowledge-team",
-    "@elastic/obs-presentation-team"
+    "@elastic/obs-signals-traces-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/packages/shared/kbn-apm-types/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-apm-types/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-types",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-apm-types/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-apm-types/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-types'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-types'
   description: Moon project for @kbn/apm-types
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-apm-types
 dependsOn:
   - '@kbn/elastic-agent-utils'

--- a/x-pack/platform/packages/shared/kbn-event-stacktrace/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-event-stacktrace/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/event-stacktrace",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces-team", "@elastic/obs-exploration-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-event-stacktrace/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-event-stacktrace/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/event-stacktrace'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/event-stacktrace'
   description: Moon project for @kbn/event-stacktrace
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-event-stacktrace
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/key-value-metadata-table",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces-team", "@elastic/obs-exploration-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/key-value-metadata-table'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/key-value-metadata-table'
   description: Moon project for @kbn/key-value-metadata-table
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-key-value-metadata-table
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/platform/plugins/shared/apm_sources_access/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/apm_sources_access/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-sources-access-plugin",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/apm_sources_access/moon.yml
+++ b/x-pack/platform/plugins/shared/apm_sources_access/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-sources-access-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-sources-access-plugin'
   description: Moon project for @kbn/apm-sources-access-plugin
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/plugins/shared/apm_sources_access
 dependsOn:
   - '@kbn/config-schema'

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/apm-ftr-e2e",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-ftr-e2e'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-ftr-e2e'
   description: Moon project for @kbn/apm-ftr-e2e
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/solutions/observability/plugins/apm/ftr_e2e
 dependsOn:
   - '@kbn/test'

--- a/x-pack/solutions/observability/plugins/apm/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-plugin",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "observability",
   "visibility": "private",
   "description": "The user interface for Elastic APM",

--- a/x-pack/solutions/observability/plugins/apm/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-plugin'
   description: Moon project for @kbn/apm-plugin
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/solutions/observability/plugins/apm
 dependsOn:
   - '@kbn/core'

--- a/x-pack/solutions/observability/plugins/apm_data_access/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm_data_access/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-data-access-plugin",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/apm_data_access/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm_data_access/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-data-access-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-data-access-plugin'
   description: Moon project for @kbn/apm-data-access-plugin
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/solutions/observability/plugins/apm_data_access
 dependsOn:
   - '@kbn/config-schema'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[APM] Fix team ownership: add -team suffix to @elastic/obs-signals-traces (#279292)](https://github.com/elastic/kibana/pull/279292)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

---

#### Conflict resolution notes

Follow-up fix to the ownership migration (base backport #279149). `apm_shared` doesn't exist on this branch and was dropped. The divergent APM paths carried in the base backport (`apm/ftr_e2e`, `test/functional/apps/apm/`, `test/apm_cypress/`) also received the `-team` suffix for consistency. The unrelated `kbn-investigation-output` owner (which differs between this branch and `main`) was left untouched.
