### PR TITLE
[8.19] [APM] Fix team ownership: add -team suffix to @elastic/obs-signals-traces (#279292)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,17 +48,17 @@ src/platform/packages/private/analytics/utils/analytics_collection_utils @elasti
 src/platform/test/analytics/plugins/analytics_ftr_helpers @elastic/kibana-core
 src/platform/test/analytics/plugins/analytics_plugin_a @elastic/kibana-core
 src/platform/packages/private/kbn-apm-config-loader @elastic/kibana-core @vigneshshanmugam
-x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-data-view @elastic/obs-signals-traces
-x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-signals-traces
-x-pack/solutions/observability/plugins/apm @elastic/obs-signals-traces
-x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-synthtrace @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-apm-synthtrace-client @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team
-x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-signals-traces
-src/platform/packages/shared/kbn-apm-utils @elastic/obs-signals-traces
+x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-data-view @elastic/obs-signals-traces-team
+x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-signals-traces-team
+x-pack/solutions/observability/plugins/apm @elastic/obs-signals-traces-team
+x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-synthtrace @elastic/obs-signals-traces-team @elastic/streams-ui @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-apm-synthtrace-client @elastic/obs-signals-traces-team @elastic/streams-ui @elastic/obs-exploration-team
+x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-signals-traces-team
+src/platform/packages/shared/kbn-apm-utils @elastic/obs-signals-traces-team
 src/platform/test/plugin_functional/plugins/app_link_test @elastic/kibana-core
 x-pack/platform/test/usage_collection/plugins/application_usage_test @elastic/kibana-core
 x-pack/platform/test/security_api_integration/plugins/audit_log @elastic/kibana-security
@@ -479,7 +479,7 @@ src/platform/plugins/private/event_annotation_listing @elastic/kibana-visualizat
 src/platform/plugins/private/event_annotation @elastic/kibana-visualizations
 x-pack/platform/test/plugin_api_integration/plugins/event_log @elastic/response-ops
 x-pack/platform/plugins/shared/event_log @elastic/response-ops
-x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-signals-traces-team @elastic/obs-exploration-team
 x-pack/solutions/security/packages/expandable-flyout @elastic/security-threat-hunting-investigations
 src/platform/packages/shared/kbn-expect @elastic/kibana-operations @elastic/appex-qa
 x-pack/examples/exploratory_view_example @elastic/obs-presentation-team
@@ -592,7 +592,7 @@ src/platform/test/plugin_functional/plugins/kbn_sample_panel_action @elastic/app
 src/platform/test/plugin_functional/plugins/kbn_top_nav @elastic/kibana-core
 src/platform/test/plugin_functional/plugins/kbn_tp_custom_visualizations @elastic/kibana-visualizations
 src/platform/test/interpreter_functional/plugins/kbn_tp_run_pipeline @elastic/kibana-core
-x-pack/platform/packages/shared/kbn-key-value-metadata-table @elastic/obs-presentation-team @elastic/streams-ui
+x-pack/platform/packages/shared/kbn-key-value-metadata-table @elastic/obs-signals-traces-team @elastic/streams-ui
 x-pack/platform/packages/shared/kbn-kibana-api-cli @elastic/appex-ai-infra
 x-pack/platform/test/functional_cors/plugins/kibana_cors_test @elastic/kibana-security
 packages/kbn-kibana-manifest-schema @elastic/kibana-operations
@@ -1063,7 +1063,7 @@ src/platform/packages/shared/kbn-try-in-console @elastic/search-kibana
 packages/kbn-ts-projects @elastic/kibana-operations
 packages/kbn-ts-type-check-cli @elastic/kibana-operations
 packages/kbn-tsconfig/base @elastic/kibana-operations
-src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-signals-traces-team
 src/platform/packages/shared/kbn-ui-actions-browser @elastic/appex-sharedux
 x-pack/examples/ui_actions_enhanced_examples @elastic/appex-sharedux
 src/platform/plugins/shared/ui_actions_enhanced @elastic/appex-sharedux
@@ -1354,11 +1354,11 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## This should allow the infra team to work without dependencies on the @elastic/obs-exploration-team, which will maintain ownership of the Logs UI code only.
 
 ## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-signals-traces-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/infra/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.serverless.config.ts @elastic/obs-presentation-team
@@ -1481,12 +1481,12 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 
 # APM
 /x-pack/platform/test/api_integration/services/apm_synthtrace_kibana_client.ts @elastic/obs-presentation-team @elastic/streams-ui @elastic/obs-exploration-team
-/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-signals-traces
+/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-signals-traces-team
 /src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-signals-traces
-/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-signals-traces
+/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-signals-traces-team
+/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-signals-traces-team
 #CC# /src/plugins/apm_oss/ @elastic/apm-ui
 #CC# /x-pack/plugins/observability_solution/observability/ @elastic/apm-ui
 

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -52,7 +52,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-entities',
     'elastic/obs-knowledge-team',
     'elastic/obs-presentation-team',
-    'elastic/obs-signals-traces',
+    'elastic/obs-signals-traces-team',
     'elastic/streams-ui',
     'elastic/obs-ux-management-team',
     'elastic/observability-design',

--- a/src/platform/packages/shared/kbn-apm-data-view/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-data-view/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-data-view",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-data-view/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-data-view/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-data-view'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-data-view'
   description: Moon project for @kbn/apm-data-view
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-data-view
 tags:
   - shared-common

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/apm-synthtrace-client",
   "owner": [
-    "@elastic/obs-presentation-team",
+    "@elastic/obs-signals-traces-team",
     "@elastic/streams-ui",
     "@elastic/obs-exploration-team"
   ],

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-synthtrace-client'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-synthtrace-client'
   description: Moon project for @kbn/apm-synthtrace-client
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-synthtrace-client
 dependsOn:
   - '@kbn/datemath'

--- a/src/platform/packages/shared/kbn-apm-synthtrace/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-server",
   "id": "@kbn/apm-synthtrace",
   "owner": [
-    "@elastic/obs-presentation-team",
+    "@elastic/obs-signals-traces-team",
     "@elastic/streams-ui",
     "@elastic/obs-exploration-team"
   ],

--- a/src/platform/packages/shared/kbn-apm-synthtrace/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-synthtrace'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-synthtrace'
   description: Moon project for @kbn/apm-synthtrace
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-synthtrace
 dependsOn:
   - '@kbn/datemath'

--- a/src/platform/packages/shared/kbn-apm-types-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-types-shared/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-types-shared",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-types-shared/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-types-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-types-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-types-shared'
   description: Moon project for @kbn/apm-types-shared
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-types-shared
 dependsOn: []
 tags:

--- a/src/platform/packages/shared/kbn-apm-ui-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/apm-ui-shared",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-ui-shared/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-ui-shared'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-ui-shared'
   description: Moon project for @kbn/apm-ui-shared
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-ui-shared
 dependsOn:
   - '@kbn/i18n'

--- a/src/platform/packages/shared/kbn-apm-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-utils/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-utils",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-apm-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-apm-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-utils'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-utils'
   description: Moon project for @kbn/apm-utils
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: src/platform/packages/shared/kbn-apm-utils
 tags:
   - shared-common

--- a/src/platform/packages/shared/kbn-typed-react-router-config/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/typed-react-router-config",
-  "owner": ["@elastic/obs-knowledge-team", "@elastic/obs-presentation-team"],
+  "owner": ["@elastic/obs-knowledge-team", "@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-apm-types/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-apm-types/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-types",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-apm-types/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-apm-types/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-types'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-types'
   description: Moon project for @kbn/apm-types
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-apm-types
 dependsOn:
   - '@kbn/elastic-agent-utils'

--- a/x-pack/platform/packages/shared/kbn-event-stacktrace/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-event-stacktrace/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/event-stacktrace",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-exploration-team"],
+  "owner": ["@elastic/obs-signals-traces-team", "@elastic/obs-exploration-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-event-stacktrace/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-event-stacktrace/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/event-stacktrace'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/event-stacktrace'
   description: Moon project for @kbn/event-stacktrace
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-event-stacktrace
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/key-value-metadata-table",
-  "owner": ["@elastic/obs-presentation-team", "@elastic/obs-onboarding-team"],
+  "owner": ["@elastic/obs-signals-traces-team", "@elastic/obs-onboarding-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/key-value-metadata-table'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/key-value-metadata-table'
   description: Moon project for @kbn/key-value-metadata-table
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/packages/shared/kbn-key-value-metadata-table
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/platform/plugins/shared/apm_sources_access/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/apm_sources_access/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-sources-access-plugin",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/apm_sources_access/moon.yml
+++ b/x-pack/platform/plugins/shared/apm_sources_access/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-sources-access-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-sources-access-plugin'
   description: Moon project for @kbn/apm-sources-access-plugin
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/platform/plugins/shared/apm_sources_access
 dependsOn:
   - '@kbn/config-schema'

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/apm-ftr-e2e",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-ftr-e2e'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-ftr-e2e'
   description: Moon project for @kbn/apm-ftr-e2e
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/solutions/observability/plugins/apm/ftr_e2e
 dependsOn:
   - '@kbn/test'

--- a/x-pack/solutions/observability/plugins/apm/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-plugin",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "observability",
   "visibility": "private",
   "description": "The user interface for Elastic APM",

--- a/x-pack/solutions/observability/plugins/apm/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-plugin'
   description: Moon project for @kbn/apm-plugin
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/solutions/observability/plugins/apm
 dependsOn:
   - '@kbn/core'

--- a/x-pack/solutions/observability/plugins/apm_data_access/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm_data_access/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-data-access-plugin",
-  "owner": ["@elastic/obs-signals-traces"],
+  "owner": ["@elastic/obs-signals-traces-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/apm_data_access/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm_data_access/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/apm-data-access-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-signals-traces'
+  defaultOwner: '@elastic/obs-signals-traces-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/apm-data-access-plugin'
   description: Moon project for @kbn/apm-data-access-plugin
   channel: ''
-  owner: '@elastic/obs-signals-traces'
+  owner: '@elastic/obs-signals-traces-team'
   sourceRoot: x-pack/solutions/observability/plugins/apm_data_access
 dependsOn:
   - '@kbn/config-schema'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [[APM] Fix team ownership: add -team suffix to @elastic/obs-signals-traces (#279292)](https://github.com/elastic/kibana/pull/279292)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

---

#### Conflict resolution notes

Follow-up fix to the ownership migration (base backport #279151). This branch predates the `teams.jsonc` registry, so the `code_owner_areas.ts` area map entry received the `-team` suffix instead. Packages that don't exist here (`apm_shared`, `kbn-apm-api-shared`, `kbn-apm-common`, `kbn-apm-embeddable-common`) were dropped. The synthtrace packages use the `kbn-apm-synthtrace` / `kbn-apm-synthtrace-client` names on this branch and were migrated accordingly. Per-branch co-owners that differ from `main` were preserved (`kbn-typed-react-router-config` keeps `obs-knowledge-team`; `kbn-key-value-metadata-table` keeps `obs-onboarding-team` in kibana.jsonc / `streams-ui` in CODEOWNERS — a pre-existing inconsistency on 8.19, left untouched). The divergent APM paths (`apm/ftr_e2e`, `test/functional/apps/apm/`, `test/apm_cypress/`) also received the suffix for consistency.
