### PR TITLE
[8.19] [Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match) (#271639)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.test.ts
@@ -6,9 +6,11 @@
  */
 
 import expect from '@kbn/expect';
+import { fromKueryExpression } from '@kbn/es-query';
 import type { DataProvider } from '../../../../common/types/timeline';
 import { buildGlobalQuery, convertToBuildEsQuery } from '.';
 import { mockDataViewSpec } from '../../mock';
+import { mockBrowserFields } from '../../containers/source/mock';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 describe('convertToBuildEsQuery', () => {
@@ -382,6 +384,60 @@ describe('buildGlobalQuery', () => {
 
     const query = buildGlobalQuery(providers, {});
 
-    expect(query).to.equal('host.name : (p1 OR p2)');
+    expect(query).to.equal('host.name : ("p1" OR "p2")');
+  });
+
+  it('should quote array values that contain reserved KQL characters', () => {
+    const url =
+      'https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png';
+    const providers = [
+      {
+        and: [],
+        enabled: true,
+        id: 'timeline-url-includes',
+        name: url,
+        excluded: false,
+        kqlQuery: '',
+        queryMatch: {
+          field: 'url.full',
+          value: [url],
+          operator: 'includes',
+          displayField: 'url.full',
+          displayValue: url,
+        },
+      } as DataProvider,
+    ];
+
+    const query = buildGlobalQuery(providers, {});
+
+    expect(query).to.equal(`url.full : ("${url}")`);
+    expect(() => fromKueryExpression(query)).not.to.throwError();
+  });
+
+  it('should quote nested field values that contain reserved KQL characters', () => {
+    const url =
+      'https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png';
+    const providers = [
+      {
+        and: [],
+        enabled: true,
+        id: 'timeline-nested-url',
+        name: url,
+        excluded: false,
+        kqlQuery: '',
+        queryMatch: {
+          field: 'nestedField.firstAttributes',
+          value: url,
+          operator: ':',
+          displayField: 'nestedField.firstAttributes',
+          displayValue: url,
+        },
+      } as DataProvider,
+    ];
+
+    const query = buildGlobalQuery(providers, mockBrowserFields);
+
+    expect(query).to.equal(`nestedField: { firstAttributes: "${url}" }`);
+    expect(() => fromKueryExpression(query)).not.to.throwError();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts
@@ -95,6 +95,19 @@ export const checkIfFieldTypeIsDate = (field: string, browserFields: BrowserFiel
   return false;
 };
 
+const formatNestedFieldValue = (
+  value: PrimitiveOrArrayOfPrimitives,
+  browserField: { type?: string }
+): string => {
+  if (browserField.type === 'date') {
+    return `"${value}"`;
+  }
+  if (Array.isArray(value)) {
+    return `(${value.map((item) => prepareKQLParam(item)).join(' OR ')})`;
+  }
+  return prepareKQLParam(value);
+};
+
 export const convertNestedFieldToQuery = (
   field: string,
   value: PrimitiveOrArrayOfPrimitives,
@@ -104,7 +117,7 @@ export const convertNestedFieldToQuery = (
   const browserField = get(pathBrowserField, browserFields);
   const nestedPath = browserField.subType.nested.path;
   const key = field.replace(`${nestedPath}.`, '');
-  return `${nestedPath}: { ${key}: ${browserField.type === 'date' ? `"${value}"` : value} }`;
+  return `${nestedPath}: { ${key}: ${formatNestedFieldValue(value, browserField)} }`;
 };
 
 export const convertNestedFieldToExistQuery = (field: string, browserFields: BrowserFields) => {
@@ -141,7 +154,9 @@ const buildQueryMatch = (
         ? convertDateFieldToQuery(dataProvider.queryMatch.field, dataProvider.queryMatch.value)
         : `${dataProvider.queryMatch.field} : ${
             Array.isArray(dataProvider.queryMatch.value)
-              ? `(${dataProvider.queryMatch.value.join(' OR ')})`
+              ? `(${dataProvider.queryMatch.value
+                  .map((item) => prepareKQLParam(item))
+                  .join(' OR ')})`
               : prepareKQLParam(dataProvider.queryMatch.value)
           }`
       : checkIfFieldTypeIsNested(dataProvider.queryMatch.field, browserFields)

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.test.ts
@@ -161,7 +161,43 @@ describe('helpers', () => {
           mockTimelineDetails,
           TimelineTypeEnum.default
         );
-        expect(replacement).toEqual('host.name: apache');
+        expect(replacement).toEqual('host.name: "apache"');
+      });
+
+      test('it should replace a quoted placeholder that contains spaces without double-quoting', () => {
+        const replacement = replaceTemplateFieldFromQuery(
+          'host.name: "place holder"',
+          mockTimelineDetails,
+          TimelineTypeEnum.default
+        );
+        expect(replacement).toEqual('host.name: "apache"');
+      });
+
+      test('it should replace a quoted placeholder without spaces without double-quoting', () => {
+        const replacement = replaceTemplateFieldFromQuery(
+          'host.name: "placeholdertext"',
+          mockTimelineDetails,
+          TimelineTypeEnum.default
+        );
+        expect(replacement).toEqual('host.name: "apache"');
+      });
+
+      test('it should quote substituted template values that contain reserved KQL characters', () => {
+        const url =
+          'https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png';
+        const replacement = replaceTemplateFieldFromQuery(
+          'host.name: placeholdertext',
+          [
+            {
+              field: 'host.name',
+              values: [url],
+              originalValue: url,
+              isObjectArray: false,
+            },
+          ],
+          TimelineTypeEnum.default
+        );
+        expect(replacement).toEqual(`host.name: "${url}"`);
       });
 
       test('it should replace a template field with an ECS value that is not an array', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.ts
@@ -10,6 +10,7 @@ import { isEmpty } from 'lodash/fp';
 import type { Filter, KueryNode } from '@kbn/es-query';
 import { FilterStateStore, fromKueryExpression } from '@kbn/es-query';
 
+import { prepareKQLStringParam } from '../../../../common/utils/kql';
 import type { TimelineEventsDetailsItem } from '../../../../common/search_strategy';
 import {
   DataProviderTypeEnum,
@@ -125,7 +126,13 @@ export const replaceTemplateFieldFromQuery = (
       return valueToChange.reduce((newQuery, vtc) => {
         const newValue = getStringArray(vtc.field, eventData);
         if (newValue.length) {
-          return newQuery.replace(vtc.valueToChange, newValue[0]);
+          const quotedPlaceholder = `"${vtc.valueToChange}"`;
+          const replacement = prepareKQLStringParam(newValue[0]);
+
+          if (newQuery.includes(quotedPlaceholder)) {
+            return newQuery.replace(quotedPlaceholder, replacement);
+          }
+          return newQuery.replace(vtc.valueToChange, replacement);
         } else {
           return newQuery;
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/helpers.test.tsx
@@ -362,7 +362,7 @@ describe('isStringOrNumberArray', () => {
           field: 'nestedField.secondAttributes',
           value: 'text',
         })
-      ).toBe(`nestedField: { secondAttributes${IS_OPERATOR} text }`);
+      ).toBe(`nestedField: { secondAttributes${IS_OPERATOR} \"text\" }`);
     });
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match) (#271639)](https://github.com/elastic/kibana/pull/271639)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Agustina Nahir Ruidiaz","email":"61565784+agusruidiazgd@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-17T08:08:15Z","message":"[Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match) (#271639)\n\n## Summary\n\nCloses: https://github.com/elastic/kibana/issues/271448 \n\nFixes Timeline KQL generation so field values containing reserved Kuery\ncharacters (notably : in URLs) are properly quoted/escaped.\nAddresses SDH\n[elastic/sdh-security-team#1681](https://github.com/elastic/sdh-security-team/issues/1681)\nwhere Investigate in Timeline fails for Indicator Match alerts with\nKQLSyntaxError.\n\n### What changed\n\n- Nested KQL builder now quotes/escapes non-date values in\n`convertNestedFieldToQuery`:\n\n`x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts`\n- Includes operator arrays now quote each element instead of raw `join('\nOR ')`:\n\n`x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts`\n- Timeline template substitution now wraps substituted values with\n`prepareKQLStringParam(...)` so template-driven Timeline queries remain\nvalid:\n\n`x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.ts`\n\n\n### Identify risks\n\n- Change is limited to KQL serialization for Timeline queries; no\nserver-side behavior changes.\n- Template substitutions now produce quoted values (e.g. host.name:\n\"apache\"), which is valid KQL and prevents reserved-character parse\nerrors.\n\n**Before:**\n<img width=\"1582\" height=\"781\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/04654c6f-a8a8-4975-8d01-791d83de5bb8\"\n/>\n\n**After fix:**\n\n\nhttps://github.com/user-attachments/assets/7343b251-af68-450e-8da4-91440c1b4a1c\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"53c5e6d62f068804a6222a1145d4c2e02f449963","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","Team: SecuritySolution","ci:cloud-deploy","backport:version","v9.5.0","v8.19.16","v9.4.2","v9.6.0"],"title":"[Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match)","number":271639,"url":"https://github.com/elastic/kibana/pull/271639","mergeCommit":{"message":"[Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match) (#271639)\n\n## Summary\n\nCloses: https://github.com/elastic/kibana/issues/271448 \n\nFixes Timeline KQL generation so field values containing reserved Kuery\ncharacters (notably : in URLs) are properly quoted/escaped.\nAddresses SDH\n[elastic/sdh-security-team#1681](https://github.com/elastic/sdh-security-team/issues/1681)\nwhere Investigate in Timeline fails for Indicator Match alerts with\nKQLSyntaxError.\n\n### What changed\n\n- Nested KQL builder now quotes/escapes non-date values in\n`convertNestedFieldToQuery`:\n\n`x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts`\n- Includes operator arrays now quote each element instead of raw `join('\nOR ')`:\n\n`x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts`\n- Timeline template substitution now wraps substituted values with\n`prepareKQLStringParam(...)` so template-driven Timeline queries remain\nvalid:\n\n`x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.ts`\n\n\n### Identify risks\n\n- Change is limited to KQL serialization for Timeline queries; no\nserver-side behavior changes.\n- Template substitutions now produce quoted values (e.g. host.name:\n\"apache\"), which is valid KQL and prevents reserved-character parse\nerrors.\n\n**Before:**\n<img width=\"1582\" height=\"781\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/04654c6f-a8a8-4975-8d01-791d83de5bb8\"\n/>\n\n**After fix:**\n\n\nhttps://github.com/user-attachments/assets/7343b251-af68-450e-8da4-91440c1b4a1c\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"53c5e6d62f068804a6222a1145d4c2e02f449963"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279112","number":279112,"state":"MERGED","mergeCommit":{"sha":"5419d559f8baeb067087959bd701a1f42d57ae35","message":"[9.5] [Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match) (#271639) (#279112)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Security Solution][Timeline] Quote KQL values to prevent syntax\nerrors for URLs (Indicator Match)\n(#271639)](https://github.com/elastic/kibana/pull/271639)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Agustina Nahir Ruidiaz <61565784+agusruidiazgd@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.16","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271639","number":271639,"mergeCommit":{"message":"[Security Solution][Timeline] Quote KQL values to prevent syntax errors for URLs (Indicator Match) (#271639)\n\n## Summary\n\nCloses: https://github.com/elastic/kibana/issues/271448 \n\nFixes Timeline KQL generation so field values containing reserved Kuery\ncharacters (notably : in URLs) are properly quoted/escaped.\nAddresses SDH\n[elastic/sdh-security-team#1681](https://github.com/elastic/sdh-security-team/issues/1681)\nwhere Investigate in Timeline fails for Indicator Match alerts with\nKQLSyntaxError.\n\n### What changed\n\n- Nested KQL builder now quotes/escapes non-date values in\n`convertNestedFieldToQuery`:\n\n`x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts`\n- Includes operator arrays now quote each element instead of raw `join('\nOR ')`:\n\n`x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts`\n- Timeline template substitution now wraps substituted values with\n`prepareKQLStringParam(...)` so template-driven Timeline queries remain\nvalid:\n\n`x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/helpers.ts`\n\n\n### Identify risks\n\n- Change is limited to KQL serialization for Timeline queries; no\nserver-side behavior changes.\n- Template substitutions now produce quoted values (e.g. host.name:\n\"apache\"), which is valid KQL and prevents reserved-character parse\nerrors.\n\n**Before:**\n<img width=\"1582\" height=\"781\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/04654c6f-a8a8-4975-8d01-791d83de5bb8\"\n/>\n\n**After fix:**\n\n\nhttps://github.com/user-attachments/assets/7343b251-af68-450e-8da4-91440c1b4a1c\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"53c5e6d62f068804a6222a1145d4c2e02f449963"}}]}] BACKPORT-->