### PR TITLE
[Infra] Bound ip_to_host schema strings with maxLength (CodeQL)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/routes/ip_to_hostname.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/ip_to_hostname.ts
@@ -18,8 +18,8 @@ interface HostDoc {
 }
 
 const ipToHostSchema = schema.object({
-  ip: schema.string(),
-  index_pattern: schema.string(),
+  ip: schema.string({ maxLength: 64 }),
+  index_pattern: schema.string({ maxLength: 1000 }),
 });
 
 export const initIpToHostName = ({ framework }: InfraBackendLibs) => {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana-team/issues/3673

Adds `maxLength` to unbounded `schema.string()` fields in the Infra `ip_to_host` route body schema (CodeQL `js/kibana/unbounded-string-in-schema`).

Only `maxLength` is added (no `minLength`/regex), so existing legitimate values keep validating.

| Field | maxLength | Rationale |
| ----- | --------- | --------- |
| `ip` | 64 | Covers IPv4 and IPv6 (incl. mapped forms) with headroom |
| `index_pattern` | 1000 | Aligns with index_management / APM index-pattern prior art |

### Files

- `x-pack/solutions/observability/plugins/infra/server/routes/ip_to_hostname.ts`
