### PR TITLE
[Entity Store] Fix too_long_http_line_exception in resolve closed indices

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
@@ -161,7 +161,7 @@ describe('resolveClosedIndexAdjustments', () => {
     expect(resolveIndex).toHaveBeenCalledTimes(1);
   });
 
-  it('second resolveIndex call uses the concrete backing index names', async () => {
+  it('batches backing index names into a single resolveIndex call when small enough to fit', async () => {
     const resolveIndex = jest
       .fn()
       .mockResolvedValueOnce({
@@ -185,6 +185,110 @@ describe('resolveClosedIndexAdjustments', () => {
         name: ['.ds-logs-foo-000001', '.ds-logs-foo-000002'],
       })
     );
+  });
+
+  it('splits backing index names across multiple batches when URL length would be exceeded', async () => {
+    // 300 names × ~21 bytes each exceeds 3500 bytes per batch, guaranteeing multiple batches
+    const allBackingIndices = Array.from(
+      { length: 300 },
+      (_, i) => `.ds-logs-batch-${String(i).padStart(6, '0')}`
+    );
+
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          {
+            name: 'logs-batch',
+            backing_indices: allBackingIndices,
+            timestamp_field: '@timestamp',
+          },
+        ],
+      })
+      .mockResolvedValue(emptyResolve);
+
+    await resolveClosedIndexAdjustments(makeEsClient(resolveIndex), ['logs-batch'], logger);
+
+    // More than 2 calls means batching occurred (call 1 = pattern resolve, calls 2+ = batches)
+    expect(resolveIndex.mock.calls.length).toBeGreaterThan(2);
+
+    // Every backing index name must appear in exactly one batch call
+    const batchCalls = resolveIndex.mock.calls.slice(1);
+    const allNamesFromBatches = batchCalls.flatMap((args) => (args[0] as { name: string[] }).name);
+    expect(allNamesFromBatches).toEqual(allBackingIndices);
+  });
+
+  it('merges closed backing index results across all batches', async () => {
+    const allBackingIndices = Array.from(
+      { length: 300 },
+      (_, i) => `.ds-logs-merge-${String(i).padStart(6, '0')}`
+    );
+    // Mark the first and last index as closed so they are guaranteed to be in different batches
+    const closedSet = new Set([allBackingIndices[0], allBackingIndices[allBackingIndices.length - 1]]);
+
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          {
+            name: 'logs-merge',
+            backing_indices: allBackingIndices,
+            timestamp_field: '@timestamp',
+          },
+        ],
+      })
+      .mockImplementation(({ name }: { name: string[] }) =>
+        Promise.resolve({
+          indices: name.map((n) => ({
+            name: n,
+            attributes: [closedSet.has(n) ? 'closed' : 'open'],
+          })),
+          aliases: [],
+          data_streams: [],
+        })
+      );
+
+    const result = await resolveClosedIndexAdjustments(
+      makeEsClient(resolveIndex),
+      ['logs-merge'],
+      logger
+    );
+
+    expect(result.negations).toContain('-logs-merge');
+    expect(result.openBackingIndices).toHaveLength(allBackingIndices.length - closedSet.size);
+    for (const closed of closedSet) {
+      expect(result.openBackingIndices).not.toContain(closed);
+    }
+  });
+
+  it('returns empty result and logs a warning if a batch resolveIndex call fails', async () => {
+    const backingIndices = ['.ds-logs-foo-000001', '.ds-logs-foo-000002'];
+    const resolveIndex = jest
+      .fn()
+      .mockResolvedValueOnce({
+        indices: [],
+        aliases: [],
+        data_streams: [
+          { name: 'logs-foo', backing_indices: backingIndices, timestamp_field: '@timestamp' },
+        ],
+      })
+      .mockRejectedValue(new Error('batch resolve failed'));
+
+    const result = await resolveClosedIndexAdjustments(
+      makeEsClient(resolveIndex),
+      ['logs-foo'],
+      logger
+    );
+
+    expect(result).toEqual({ openBackingIndices: [], negations: [] });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to resolve closed indices')
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('batch resolve failed'));
   });
 
   it('calls resolveIndex with correct expand_wildcards and ignore options', async () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.test.ts
@@ -226,7 +226,10 @@ describe('resolveClosedIndexAdjustments', () => {
       (_, i) => `.ds-logs-merge-${String(i).padStart(6, '0')}`
     );
     // Mark the first and last index as closed so they are guaranteed to be in different batches
-    const closedSet = new Set([allBackingIndices[0], allBackingIndices[allBackingIndices.length - 1]]);
+    const closedSet = new Set([
+      allBackingIndices[0],
+      allBackingIndices[allBackingIndices.length - 1],
+    ]);
 
     const resolveIndex = jest
       .fn()

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolve_closed_indices.ts
@@ -39,6 +39,32 @@ export interface ClosedIndexAdjustments {
 
 const toArray = (v: string | string[]): string[] => ([] as string[]).concat(v);
 
+// The ES client joins name arrays with commas then calls encodeURIComponent, so each comma
+// becomes %2C (3 bytes). Elasticsearch's Netty HTTP server rejects request lines > 4096 bytes,
+// so we cap each batch well below that limit.
+const MAX_URL_NAMES_BYTES = 3_500;
+
+const chunkByUrlLength = (names: string[]): string[][] => {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+
+  for (const name of names) {
+    const cost = name.length + (current.length > 0 ? 3 : 0); // 3 bytes for %2C separator
+    if (current.length > 0 && currentBytes + cost > MAX_URL_NAMES_BYTES) {
+      chunks.push(current);
+      current = [name];
+      currentBytes = name.length;
+    } else {
+      current.push(name);
+      currentBytes += cost;
+    }
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+};
+
 const resolveArgs = (name: string[]) => ({
   name,
   expand_wildcards: ['open', 'closed', 'hidden'] as Array<'open' | 'closed' | 'hidden'>,
@@ -69,12 +95,21 @@ export const resolveClosedIndexAdjustments = async (
 
     const backingIndexNames = resolved.data_streams.flatMap((ds) => toArray(ds.backing_indices));
     if (backingIndexNames.length > 0) {
-      // Second call with concrete backing index names — the first call returns them as plain
-      // strings with no open/closed attributes; we need this call to learn their status.
-      const backingResolved = await esClient.indices.resolveIndex(resolveArgs(backingIndexNames));
+      // The first resolveIndex call returns backing index names without open/closed attributes,
+      // so a second round is needed to learn their status. Batching avoids a
+      // too_long_http_line_exception when many backing indices would push the URL past the
+      // Elasticsearch Netty limit of 4096 bytes.
+      const batchResults = await Promise.all(
+        chunkByUrlLength(backingIndexNames).map((chunk) =>
+          esClient.indices.resolveIndex(resolveArgs(chunk))
+        )
+      );
 
       const closedBackingNames = new Set(
-        backingResolved.indices.filter((i) => i.attributes?.includes('closed')).map((i) => i.name)
+        batchResults
+          .flatMap((r) => r.indices)
+          .filter((i) => i.attributes?.includes('closed'))
+          .map((i) => i.name)
       );
 
       for (const ds of resolved.data_streams) {


### PR DESCRIPTION
## Summary

Closes elastic/security-team#18279

In environments with many data streams and a large number of rollover generations, the closed-index pre-flight check throws a `too_long_http_line_exception`. The root cause is that the second `resolveIndex` call — needed to learn the open/closed status of each backing index — passes all concrete backing index names as a comma-joined URL path segment. Elasticsearch's Netty HTTP server rejects request lines larger than 4096 bytes, and a high backing-index count easily exceeds that limit.

The fix batches the backing index names into URL-safe chunks (capped at 3 500 bytes of name content to stay well below the Netty limit), runs all batch requests concurrently via `Promise.all`, and merges the results before determining which data streams contain closed indices. Environments with few rollovers are unaffected — their names fit in a single batch and the behaviour is identical to before.

## Test plan
- [ ] Unit tests updated and passing (`resolve_closed_indices.test.ts`)
- [ ] Reproduce locally: create a data stream under `logs-*`, force ~120+ rollovers, confirm the error no longer occurs when the entity store runs its closed-index resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->