### PR TITLE
[Entity Analytics] Checking entity exists before updating asset criticality in workflow step

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.test.ts
@@ -78,9 +78,10 @@ const createMockContext = (
 describe('updateAssetCriticalityStepDefinition', () => {
   const updateEntity = jest.fn();
   const listEntities = jest.fn();
-  const createCRUDClient = jest
-    .fn()
-    .mockReturnValue({ updateEntity, listEntities }) as unknown as EntityStoreStartContract['createCRUDClient'];
+  const createCRUDClient = jest.fn().mockReturnValue({
+    updateEntity,
+    listEntities,
+  }) as unknown as EntityStoreStartContract['createCRUDClient'];
   const getCreateCRUDClient = jest.fn(async () => createCRUDClient);
   const getClient = jest.fn();
   const getWorkflowsExtensionsStart = jest.fn(
@@ -117,7 +118,9 @@ describe('updateAssetCriticalityStepDefinition', () => {
     (createCRUDClient as jest.Mock).mockReturnValue({ updateEntity, listEntities });
     getCreateCRUDClient.mockImplementation(async () => createCRUDClient);
     updateEntity.mockResolvedValue(undefined);
-    listEntities.mockResolvedValue({ entities: [{ 'entity.id': 'host:my-host', 'entity.type': 'host' }] });
+    listEntities.mockResolvedValue({
+      entities: [{ 'entity.id': 'host:my-host', 'entity.type': 'host' }],
+    });
     getLicense.mockResolvedValue({ hasAtLeast: () => true });
     checkPrivilegesDynamicallyWithRequest.mockReturnValue(checkPrivileges);
     checkPrivileges.mockResolvedValue(buildCheckPrivilegesResponse(true));
@@ -297,11 +300,16 @@ describe('updateAssetCriticalityStepDefinition', () => {
         criticality_level: 'high_impact',
       });
 
-      await expect(updateAssetCriticalityStepDefinition.handler(mockContext)).rejects.toMatchObject({
-        type: 'NotFoundError',
-      });
+      await expect(updateAssetCriticalityStepDefinition.handler(mockContext)).rejects.toMatchObject(
+        {
+          type: 'NotFoundError',
+        }
+      );
       expect(listEntities).toHaveBeenCalledWith({
-        filter: [{ term: { 'entity.id': 'host:my-host' } }, { term: { 'entity.EngineMetadata.Type': 'host' } }],
+        filter: [
+          { term: { 'entity.id': 'host:my-host' } },
+          { term: { 'entity.EngineMetadata.Type': 'host' } },
+        ],
         size: 1,
       });
       expect(updateEntity).not.toHaveBeenCalled();

--- a/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.test.ts
@@ -77,9 +77,10 @@ const createMockContext = (
 
 describe('updateAssetCriticalityStepDefinition', () => {
   const updateEntity = jest.fn();
+  const listEntities = jest.fn();
   const createCRUDClient = jest
     .fn()
-    .mockReturnValue({ updateEntity }) as unknown as EntityStoreStartContract['createCRUDClient'];
+    .mockReturnValue({ updateEntity, listEntities }) as unknown as EntityStoreStartContract['createCRUDClient'];
   const getCreateCRUDClient = jest.fn(async () => createCRUDClient);
   const getClient = jest.fn();
   const getWorkflowsExtensionsStart = jest.fn(
@@ -113,9 +114,10 @@ describe('updateAssetCriticalityStepDefinition', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (createCRUDClient as jest.Mock).mockReturnValue({ updateEntity });
+    (createCRUDClient as jest.Mock).mockReturnValue({ updateEntity, listEntities });
     getCreateCRUDClient.mockImplementation(async () => createCRUDClient);
     updateEntity.mockResolvedValue(undefined);
+    listEntities.mockResolvedValue({ entities: [{ 'entity.id': 'host:my-host', 'entity.type': 'host' }] });
     getLicense.mockResolvedValue({ hasAtLeast: () => true });
     checkPrivilegesDynamicallyWithRequest.mockReturnValue(checkPrivileges);
     checkPrivileges.mockResolvedValue(buildCheckPrivilegesResponse(true));
@@ -284,6 +286,24 @@ describe('updateAssetCriticalityStepDefinition', () => {
           type: 'PermissionError',
         }
       );
+      expect(updateEntity).not.toHaveBeenCalled();
+    });
+
+    it('throws a NotFoundError ExecutionError and does not update the entity when the entity does not exist in the store', async () => {
+      listEntities.mockResolvedValueOnce({ entities: [] });
+      const mockContext = createMockContext({
+        entity_type: 'host',
+        entity_id: 'host:my-host',
+        criticality_level: 'high_impact',
+      });
+
+      await expect(updateAssetCriticalityStepDefinition.handler(mockContext)).rejects.toMatchObject({
+        type: 'NotFoundError',
+      });
+      expect(listEntities).toHaveBeenCalledWith({
+        filter: [{ term: { 'entity.id': 'host:my-host' } }, { term: { 'entity.EngineMetadata.Type': 'host' } }],
+        size: 1,
+      });
       expect(updateEntity).not.toHaveBeenCalled();
     });
   });

--- a/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.ts
@@ -74,6 +74,18 @@ export const getUpdateAssetCriticalityStepDefinition = (
             : undefined
         );
 
+        const { entities } = await crudClient.listEntities({
+          filter: [{ term: { 'entity.id': entityId } }, { term: { 'entity.EngineMetadata.Type': entityType } }],
+          size: 1,
+        });
+
+        if (entities.length === 0) {
+          throw new ExecutionError({
+            type: 'NotFoundError',
+            message: `Entity with type "${entityType}" and id "${entityId}" does not exist in the entity store.`,
+          });
+        }
+
         // `force: true` is required because `asset.criticality` is not marked
         // `allowAPIUpdate` in the Entity Store field retention definitions.
         await crudClient.updateEntity(

--- a/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/workflow/steps/update_asset_criticality.ts
@@ -75,7 +75,10 @@ export const getUpdateAssetCriticalityStepDefinition = (
         );
 
         const { entities } = await crudClient.listEntities({
-          filter: [{ term: { 'entity.id': entityId } }, { term: { 'entity.EngineMetadata.Type': entityType } }],
+          filter: [
+            { term: { 'entity.id': entityId } },
+            { term: { 'entity.EngineMetadata.Type': entityType } },
+          ],
           size: 1,
         });
 


### PR DESCRIPTION
## Summary

Adding a check that an entity exists before updating it's asset criticality, otherwise the update will incorrectly create an entity in the store.


https://github.com/user-attachments/assets/7d542002-694b-4450-b638-d45ee2fb4e7c



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->