### PR TITLE
[Fleet] Categorize EPR response errors

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/error.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/error.ts
@@ -7,11 +7,25 @@
 
 export type FleetErrorType = 'verification_failed' | 'package_assets_verification_failed';
 
+/**
+ * Categories for Elastic Package Registry (EPR) connection failures, derived from
+ * the underlying Node system error code (e.g. `ENOTFOUND` -> `dns`).
+ */
+export type RegistryConnectionErrorType = 'timeout' | 'dns' | 'connection' | 'unknown';
+
+/**
+ * Categories for all EPR errors: connection-level failures plus `http` for 4xx/5xx
+ * responses returned by the registry.
+ */
+export type RegistryErrorType = RegistryConnectionErrorType | 'http';
+
 export interface FleetErrorResponse {
   message: string;
   statusCode: number;
   attributes?: {
-    type?: FleetErrorType;
+    type?: FleetErrorType | RegistryErrorType;
+    /** Underlying failure reason, e.g. a Node error code (`ETIMEDOUT`) or an HTTP status code. */
+    reason?: string;
     missing_assets?: Array<{ id: string; type: string }>;
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/server/errors/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/errors/handlers.test.ts
@@ -14,6 +14,8 @@ import { appContextService } from '../services';
 import {
   FleetError,
   RegistryError,
+  RegistryConnectionError,
+  RegistryResponseError,
   PackageNotFoundError,
   PackageUnsupportedMediaTypeError,
   defaultFleetErrorHandler,
@@ -50,6 +52,33 @@ describe('defaultFleetErrorHandler', () => {
       // logging
       expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
       expect(mockContract.logger?.error).toHaveBeenCalledWith(error.message);
+    });
+
+    it('502: RegistryConnectionError surfaces categorized attributes', async () => {
+      const error = new RegistryConnectionError('cannot connect', {
+        type: 'dns',
+        reason: 'ENOTFOUND',
+      });
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultFleetErrorHandler({ error, response });
+
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 502,
+        body: { message: error.message, attributes: { type: 'dns', reason: 'ENOTFOUND' } },
+      });
+    });
+
+    it('500: RegistryResponseError surfaces http attributes', async () => {
+      const error = new RegistryResponseError('bad response', 500);
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultFleetErrorHandler({ error, response });
+
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 500,
+        body: { message: error.message, attributes: { type: 'http', reason: '500' } },
+      });
     });
 
     it('415: PackageUnsupportedMediaType', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/errors/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/errors/index.ts
@@ -10,6 +10,8 @@ import type { ElasticsearchErrorDetails } from '@kbn/es-errors';
 
 import { isObjectLike } from 'lodash';
 
+import type { RegistryConnectionErrorType } from '../../common/types';
+
 import { FleetError } from '../../common/errors';
 
 import { isESClientError } from './utils';
@@ -49,10 +51,23 @@ export class FleetErrorWithStatusCode<TMeta = unknown> extends FleetError<TMeta>
 }
 
 export class RegistryError extends FleetError {}
-export class RegistryConnectionError extends RegistryError {}
+export class RegistryConnectionError extends RegistryError {
+  constructor(
+    message?: string,
+    attributes?: { type: RegistryConnectionErrorType; reason?: string }
+  ) {
+    super(message);
+    if (attributes) {
+      this.attributes = attributes;
+    }
+  }
+}
 export class RegistryResponseError extends RegistryError {
   constructor(message?: string, public readonly status?: number) {
     super(message);
+    if (status) {
+      this.attributes = { type: 'http', reason: String(status) };
+    }
   }
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/requests.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/requests.test.ts
@@ -13,7 +13,7 @@ import type { Logger } from '@kbn/core/server';
 import { RegistryError, RegistryConnectionError, RegistryResponseError } from '../../../errors';
 import { appContextService } from '../../app_context';
 
-import { fetchUrl, getResponse } from './requests';
+import { categorizeRegistryConnectionError, fetchUrl, getResponse } from './requests';
 jest.mock('node-fetch');
 jest.mock('../../app_context');
 
@@ -71,6 +71,35 @@ describe('Registry requests', () => {
           'User-Agent': 'Kibana/8.0.0 node-fetch',
         },
       });
+    });
+  });
+
+  describe('categorizeRegistryConnectionError', () => {
+    it.each([
+      ['ETIMEDOUT', 'timeout'],
+      ['ESOCKETTIMEDOUT', 'timeout'],
+      ['ECONNABORTED', 'timeout'],
+      ['ENOTFOUND', 'dns'],
+      ['EAI_AGAIN', 'dns'],
+      ['ECONNREFUSED', 'connection'],
+      ['ECONNRESET', 'connection'],
+      ['EHOSTUNREACH', 'connection'],
+      ['ENETUNREACH', 'connection'],
+      ['EPIPE', 'connection'],
+      ['EPROTO', 'connection'],
+      ['ESOMETHING', 'unknown'],
+    ])('maps code %s to type "%s"', (code, type) => {
+      const error = new FetchError('message', 'system', { code });
+      expect(categorizeRegistryConnectionError(error)).toEqual({ type, reason: code });
+    });
+
+    it('returns type "unknown" with no reason when there is no code', () => {
+      const error = new FetchError('message', 'system');
+      expect(categorizeRegistryConnectionError(error)).toEqual({ type: 'unknown' });
+    });
+
+    it('returns type "unknown" with no reason for a non-fetch error', () => {
+      expect(categorizeRegistryConnectionError(new Error('boom'))).toEqual({ type: 'unknown' });
     });
   });
 
@@ -148,6 +177,42 @@ describe('Registry requests', () => {
       });
     });
 
+    describe('RegistryConnectionError categorization', () => {
+      // Use retries=0 to avoid exponential backoff; a single system error is enough to
+      // exercise the categorization path.
+      it.each([
+        ['ENOTFOUND', 'dns'],
+        ['EAI_AGAIN', 'dns'],
+        ['ETIMEDOUT', 'timeout'],
+        ['ECONNREFUSED', 'connection'],
+        ['ECONNRESET', 'connection'],
+        ['EPROTO', 'connection'],
+        ['ESOMETHING', 'unknown'],
+      ])('categorizes %s as type "%s" and surfaces it in error attributes', async (code, type) => {
+        fetchMock.mockImplementationOnce(() => {
+          throw new FetchError(`message for ${code}`, 'system', { code });
+        });
+
+        const promise = getResponse('', 0);
+        await expect(promise).rejects.toThrow(RegistryConnectionError);
+        await expect(promise).rejects.toMatchObject({
+          attributes: { type, reason: code },
+        });
+      });
+
+      it('categorizes a system error without a code as "unknown" with no reason', async () => {
+        fetchMock.mockImplementationOnce(() => {
+          throw new FetchError('no code', 'system');
+        });
+
+        const promise = getResponse('', 0);
+        await expect(promise).rejects.toThrow(RegistryConnectionError);
+        await expect(promise).rejects.toMatchObject({
+          attributes: { type: 'unknown' },
+        });
+      });
+    });
+
     describe('4xx or 5xx from Registry become RegistryResponseError', () => {
       it('404', async () => {
         fetchMock.mockImplementationOnce(() => ({
@@ -162,6 +227,9 @@ describe('Registry requests', () => {
           `'404 Not Found' error response from package registry at https://example.com`
         );
         await expect(promise).rejects.toMatchObject({ status: 404 });
+        await expect(promise).rejects.toMatchObject({
+          attributes: { type: 'http', reason: '404' },
+        });
         expect(fetchMock).toHaveBeenCalledTimes(1);
       });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/requests.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/requests.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import type { Agent as HttpsAgent } from 'https';
+import type { Agent as HttpAgent } from 'http';
+
 import fetch, { FetchError } from 'node-fetch';
 import type { RequestInit, Response } from 'node-fetch';
 import pRetry from 'p-retry';
@@ -12,12 +15,11 @@ import pRetry from 'p-retry';
 import { streamToString } from '../streams';
 import { appContextService } from '../../app_context';
 import { RegistryError, RegistryConnectionError, RegistryResponseError } from '../../../errors';
+import type { RegistryConnectionErrorType } from '../../../../common/types';
 
 import { airGappedUtils } from '../airgapped';
 
 import { getProxyAgent, getRegistryProxyUrl } from './proxy';
-import type { Agent as HttpAgent } from 'http';
-import type { Agent as HttpsAgent } from 'https';
 
 type FailedAttemptErrors = pRetry.FailedAttemptError | FetchError | Error;
 
@@ -74,7 +76,13 @@ export async function getResponse(url: string, retries: number = 5): Promise<Res
   } catch (error) {
     // isSystemError here means we didn't succeed after max retries
     if (isSystemError(error)) {
-      throw new RegistryConnectionError(`Error connecting to package registry: ${error.message}`);
+      const { type, reason } = categorizeRegistryConnectionError(error);
+      throw new RegistryConnectionError(
+        `Error connecting to package registry: ${error.message} (type: ${type}${
+          reason ? `, reason: ${reason}` : ''
+        })`,
+        { type, reason }
+      );
     }
     // don't wrap our own errors
     if (error instanceof RegistryError) {
@@ -144,6 +152,41 @@ function isFetchError(error: FailedAttemptErrors): error is FetchError {
 
 function isSystemError(error: FailedAttemptErrors): boolean {
   return isFetchError(error) && error.type === 'system';
+}
+
+// Node system error codes grouped into operator-facing categories. The Elasticsearch
+// client in Kibana applies similar categorization to its connection failures.
+const REGISTRY_ERROR_CODES_BY_TYPE: Record<
+  Exclude<RegistryConnectionErrorType, 'unknown'>,
+  readonly string[]
+> = {
+  timeout: ['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNABORTED'],
+  dns: ['ENOTFOUND', 'EAI_AGAIN'],
+  connection: ['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'EPIPE', 'EPROTO'],
+};
+
+// Maps a system `FetchError` to a failure `type` (timeout/dns/connection/unknown) and a
+// `reason` (the raw Node error code) so operators can distinguish EPR failure modes.
+// NOTE: node-fetch only emits its own `request-timeout` error when a `timeout` fetch option
+// is set (we don't set one), so socket-level timeouts arrive here as the system code
+// `ETIMEDOUT`. If a fetch `timeout` is ever introduced, `request-timeout` typed errors would
+// bypass `isSystemError` and fall through to the generic `RegistryError`, and this
+// categorization would need to account for them.
+export function categorizeRegistryConnectionError(error: FailedAttemptErrors): {
+  type: RegistryConnectionErrorType;
+  reason?: string;
+} {
+  const code = isFetchError(error) ? error.code : undefined;
+
+  if (!code) {
+    return { type: 'unknown' };
+  }
+
+  const matchedType = (
+    Object.keys(REGISTRY_ERROR_CODES_BY_TYPE) as Array<keyof typeof REGISTRY_ERROR_CODES_BY_TYPE>
+  ).find((type) => REGISTRY_ERROR_CODES_BY_TYPE[type].includes(code));
+
+  return { type: matchedType ?? 'unknown', reason: code };
 }
 
 function isRegistry5xxError(error: FailedAttemptErrors): boolean {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/274126

This PR makes an additive change so that Fleet's EPR errors now carry a categorized type (timeout/dns/connection/http/unknown) and a reason (underlying Node error code or HTTP status), surfaced in both server logs and API error responses.

### Manual testing steps

For each scenario below, point Fleet to a registry with `xpack.fleet.registryUrl: ...` in `kibana.dev.yml` then trigger an EPR fetch (open the Integrations page or `GET kbn:/api/fleet/epm/packages`) and check the API response and/or Kibana logs.

1\. Unresolvable registry (DNS), e.g. `xpack.fleet.registryUrl: "https://this-host-does-not-exist.invalid" `
Example Kibana logs:
```
[2026-07-20T16:01:58.419+02:00][ERROR][plugins.fleet] Error connecting to package registry: request to https://this-host-does-not-exist.invalid/search?kibana.version=9.6.0&spec.min=2.3&spec.max=3.6 failed, reason: getaddrinfo ENOTFOUND this-host-does-not-exist.invalid (type: dns, reason: ENOTFOUND)
```
Example response from `GET kbn:/api/fleet/epm/packages`:
```json
{
  "statusCode": 502,
  "error": "Bad Gateway",
  "message": "Error connecting to package registry: request to https://this-host-does-not-exist.invalid/search?kibana.version=9.6.0&spec.min=2.3&spec.max=3.6 failed, reason: getaddrinfo ENOTFOUND this-host-does-not-exist.invalid (type: dns, reason: ENOTFOUND)",
  "attributes": {
    "type": "dns",
    "reason": "ENOTFOUND"
  }
}
```

2\. `http` category, point to endpoint returning a 5xx (in the example below, small python script to always return 503 from http://localhost:8080)
<details>
<summary>example python script</summary>

```py
from http.server import BaseHTTPRequestHandler, HTTPServer

class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        self.send_response(503)
        self.send_header("Content-Type", "application/json")
        self.end_headers()
        self.wfile.write(b'{"error": "service unavailable"}')
    do_POST = do_GET  # same response for POST

HTTPServer(("127.0.0.1", 8080), Handler).serve_forever()
```
</details>

Example Kibana logs:
```
[2026-07-20T16:17:54.327+02:00][ERROR][plugins.fleet] Error connecting to package registry: request to https://localhost:8080/search?kibana.version=9.6.0&spec.min=2.3&spec.max=3.6 failed, reason: write EPROTO 80DD93F301000000:error:0A00010B:SSL routines:tls_validate_record_header:wrong version number:../deps/openssl/openssl/ssl/record/methods/tlsany_meth.c:78:
 (type: connection, reason: EPROTO)
```
Example response from `GET kbn:/api/fleet/epm/packages`:
```json
{
  "statusCode": 502,
  "error": "Bad Gateway",
  "message": """Error connecting to package registry: request to https://localhost:8080/search?kibana.version=9.6.0&spec.min=2.3&spec.max=3.6 failed, reason: write EPROTO 80DD93F301000000:error:0A00010B:SSL routines:tls_validate_record_header:wrong version number:../deps/openssl/openssl/ssl/record/methods/tlsany_meth.c:78:
 (type: connection, reason: EPROTO)""",
  "attributes": {
    "type": "connection",
    "reason": "EPROTO"
  }
}
```

3\. Refused connection: point to a closed local port, e.g. `xpack.fleet.registryUrl: http://127.0.0.1:9`
Example Kibana logs:
```
[2026-07-20T16:20:34.808+02:00][ERROR][plugins.fleet] Error connecting to package registry: request to http://127.0.0.1:9/search?kibana.version=9.6.0&spec.min=2.3&spec.max=3.6 failed, reason: connect ECONNREFUSED 127.0.0.1:9 (type: connection, reason: ECONNREFUSED)
```
Example response from `GET kbn:/api/fleet/epm/packages`:
```json
{
  "statusCode": 502,
  "error": "Bad Gateway",
  "message": "Error connecting to package registry: request to http://127.0.0.1:9/search?kibana.version=9.6.0&spec.min=2.3&spec.max=3.6 failed, reason: connect ECONNREFUSED 127.0.0.1:9 (type: connection, reason: ECONNREFUSED)",
  "attributes": {
    "type": "connection",
    "reason": "ECONNREFUSED"
  }
}
```

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Overall low risk:
* Backward compatibility : purely additive. `RegistryConnectionError` and `RegistryResponseError` constructors retain their existing signatures (new arguments are optional); all existing call sites continue to work without modification. `FleetErrorType` union is extended, not changed.
* Behavioral correctness: the categorization helper defaults to `{ type: 'unknown' }` for any unrecognized or missing code, so no EPR failure path can throw due to the new logic. HTTP status codes and retry behavior are untouched.
* API contract: `attributes` already existed on `FleetErrorResponse` and was already spread into 502/500 responses. Callers that don't inspect attributes are unaffected; callers that do will now receive richer data.
* Observability: the change strictly adds information (new fields + enriched message). No existing log line is removed or reformatted in a breaking way.
* Carry-forward note: if a timeout fetch option is ever added to `getFetchOptions`, the `node-fetch` request-timeout error type would bypass `isSystemError` and land in the generic `RegistryError` fallback rather than being categorized. This is documented in the code comment added to `requests.ts`.

## Release note

Adds categorization to Fleet's connection errors to Elastic Package Registry: these now carry a categorized type (timeout/dns/connection/http/unknown) and a reason (underlying Node error code or HTTP status), surfaced in both server logs and API error responses.