### PR TITLE
[9.5] [Entity Analytics] Updating anomalies swimlane tooltip info and styling (#278265)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/anomaly_summary/anomaly_summary.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/anomaly_summary/anomaly_summary.gen.ts
@@ -180,6 +180,10 @@ export const AnomalyOverviewEntry = lazySchema(() =>
      * MITRE ATT&CK tactic names for all jobs that fired in this bucket
      */
     threatTactics: z.array(z.string().max(150)).max(100),
+    /**
+     * Number of anomaly records per MITRE ATT&CK tactic within this time bucket; a job's doc_count is attributed to each tactic it is configured for
+     */
+    tacticCounts: z.object({}).catchall(z.number().int()).optional(),
   })
 );
 export type AnomalyOverviewEntry = z.infer<typeof AnomalyOverviewEntry>;

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/anomaly_summary/anomaly_summary.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/anomaly_summary/anomaly_summary.schema.yaml
@@ -420,6 +420,11 @@ components:
             type: string
             maxLength: 150
           description: MITRE ATT&CK tactic names for all jobs that fired in this bucket
+        tacticCounts:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Number of anomaly records per MITRE ATT&CK tactic within this time bucket; a job's doc_count is attributed to each tactic it is configured for
 
     AnomalyOverviewHit:
       type: object

--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/anomalies/derive_bucket_interval.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/anomalies/derive_bucket_interval.ts
@@ -5,20 +5,22 @@
  * 2.0.
  */
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 
 interface BucketInterval {
   value: number;
   unit: 'h' | 'd';
+  ms: number;
 }
 
 export const deriveBucketInterval = (fromMs: number, toMs: number): BucketInterval => {
   const spanMs = Math.max(0, toMs - fromMs);
   if (spanMs <= 2 * DAY_MS) {
-    return { value: 1, unit: 'h' };
+    return { value: 1, unit: 'h', ms: HOUR_MS };
   }
-  if (spanMs <= 30 * DAY_MS) {
-    return { value: 1, unit: 'd' };
+  if (spanMs <= 45 * DAY_MS) {
+    return { value: 1, unit: 'd', ms: DAY_MS };
   }
-  return { value: 7, unit: 'd' };
+  return { value: 7, unit: 'd', ms: 7 * DAY_MS };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_overview.ts
@@ -44,6 +44,12 @@ export const useAnomalyOverview = ({
   return useQuery(
     [...ANOMALY_OVERVIEW_QUERY_KEY, entityType, entityId, from, to, threatTactics, scoreRanges],
     ({ signal }) => fetchAnomalyOverview({ entityType, entityId, body, signal }),
-    { enabled: enabled && !!entityId, keepPreviousData: true, refetchOnWindowFocus: false }
+    {
+      enabled: enabled && !!entityId,
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
+      retry: (failureCount, error) =>
+        failureCount < 3 && (error as { response?: { status?: number } })?.response?.status !== 400,
+    }
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_summary.ts
@@ -40,6 +40,12 @@ export const useAnomalySummary = ({
   return useQuery(
     [...ANOMALY_SUMMARY_QUERY_KEY, entityType, entityId, resolvedBody],
     ({ signal }) => fetchAnomalySummary({ entityType, entityId, body: resolvedBody, signal }),
-    { enabled: enabled && !!entityId, keepPreviousData: true, refetchOnWindowFocus: false }
+    {
+      enabled: enabled && !!entityId,
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
+      retry: (failureCount, error) =>
+        failureCount < 3 && (error as { response?: { status?: number } })?.response?.status !== 400,
+    }
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_swimlane.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_swimlane.tsx
@@ -8,13 +8,17 @@
 import {
   Chart,
   Heatmap,
+  type HeatmapCellDatum,
   type HeatmapStyle,
   type Predicate,
   type RecursivePartial,
   ScaleType,
   Settings,
+  Tooltip,
+  TooltipContainer,
+  type CustomTooltip,
 } from '@elastic/charts';
-import { EuiFlexItem } from '@elastic/eui';
+import { EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { useElasticChartsTheme } from '@kbn/charts-theme';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
@@ -22,12 +26,14 @@ import { deriveBucketInterval } from '../../../../common/entity_analytics/anomal
 import { getAnomalyChartStyling } from '../recent_anomalies/anomaly_chart_styling';
 import type { AnomalyBand } from '../recent_anomalies/anomaly_bands';
 import {
+  ENTITY_ANOMALIES_SWIMLANE_ANOMALY_COUNT,
   ENTITY_ANOMALIES_SWIMLANE_MAX_SCORE,
   ENTITY_ANOMALIES_SWIMLANE_X_AXIS_LABEL,
 } from './translations';
 
 const SWIMLANE_X_ACCESSOR_KEY = '@timestamp';
 const SWIMLANE_Y_ACCESSOR_KEY = 'record_score';
+const SWIMLANE_COUNT_ACCESSOR_KEY = 'count';
 
 const heatmapComponentStyle: RecursivePartial<HeatmapStyle> = {
   brushTool: {
@@ -61,6 +67,16 @@ const dateLabelFormatter = new Intl.DateTimeFormat(i18n.getLocale(), {
   year: 'numeric',
 });
 
+const dateTimeLabelFormatter = new Intl.DateTimeFormat(i18n.getLocale(), {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: 'UTC',
+});
+
 /** Formats x-axis ticks as "May 25, 2026". */
 const formatDateTick = (value: string | number): string => {
   const ms = typeof value === 'number' ? value : Number(value);
@@ -69,6 +85,92 @@ const formatDateTick = (value: string | number): string => {
   }
   return dateLabelFormatter.format(new Date(ms));
 };
+
+function getSeverityColor(score: number, bands: AnomalyBand[]): string | undefined {
+  return bands.find((band) => score >= band.start && score < band.end)?.color;
+}
+
+function createSwimlaneTooltip(
+  bucketIntervalMs: number,
+  records: Array<Record<string, unknown>>,
+  yAxisLabel: string,
+  anomalyBands: AnomalyBand[]
+): CustomTooltip<HeatmapCellDatum> {
+  const SwimlaneTooltip: CustomTooltip<HeatmapCellDatum> = ({ values }) => {
+    const { euiTheme } = useEuiTheme();
+    const datum = values[0]?.datum;
+    if (!datum) return null;
+
+    const bucketStart = datum.x as number;
+    const bucketEnd = bucketStart + bucketIntervalMs;
+    const yValue = datum.y as string;
+    const maxScore = datum.value;
+    const count = (records[datum.originalIndex]?.[SWIMLANE_COUNT_ACCESSOR_KEY] as number) ?? 0;
+    const severityColor = getSeverityColor(maxScore, anomalyBands);
+
+    const timeRange = `${dateTimeLabelFormatter.format(
+      bucketStart
+    )} – ${dateTimeLabelFormatter.format(bucketEnd)}`;
+
+    const rows = [
+      { label: yAxisLabel, value: yValue },
+      { label: ENTITY_ANOMALIES_SWIMLANE_ANOMALY_COUNT, value: String(count) },
+      {
+        label: ENTITY_ANOMALIES_SWIMLANE_MAX_SCORE,
+        value: maxScore.toFixed(2),
+        swatch: severityColor,
+      },
+    ];
+
+    return (
+      <TooltipContainer>
+        <div style={{ minWidth: 240 }}>
+          <div
+            style={{
+              fontWeight: euiTheme.font.weight.bold,
+              padding: `${euiTheme.size.s} ${euiTheme.size.m}`,
+              borderBottom: euiTheme.border.thin,
+            }}
+          >
+            {timeRange}
+          </div>
+          <div style={{ padding: `${euiTheme.size.xxs} 0` }}>
+            {rows.map(({ label, value, swatch }) => (
+              <div
+                key={label}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: euiTheme.size.l,
+                  padding: `1px ${euiTheme.size.m}`,
+                  position: 'relative',
+                }}
+              >
+                {swatch && (
+                  <span
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: 6,
+                      borderRadius: 1,
+                      backgroundColor: swatch,
+                    }}
+                  />
+                )}
+                <span>{label}</span>
+                <span>{value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </TooltipContainer>
+    );
+  };
+
+  return SwimlaneTooltip;
+}
 
 interface AnomaliesSwimlaneProps {
   anomalyBands: AnomalyBand[];
@@ -96,6 +198,11 @@ export const AnomaliesSwimlane: React.FC<AnomaliesSwimlaneProps> = ({
   const xDomain = useMemo(() => ({ min: from, max: to }), [from, to]);
   const bucketInterval = useMemo(() => deriveBucketInterval(from, to), [from, to]);
 
+  const swimlaneTooltip = useMemo(
+    () => createSwimlaneTooltip(bucketInterval.ms, records, yAxisLabel, anomalyBands),
+    [bucketInterval.ms, records, yAxisLabel, anomalyBands]
+  );
+
   const chartBands = useMemo(
     () => anomalyBands.map(({ start, end, color }) => ({ start, end, color })),
     [anomalyBands]
@@ -111,6 +218,7 @@ export const AnomaliesSwimlane: React.FC<AnomaliesSwimlaneProps> = ({
       }}
     >
       <Chart>
+        <Tooltip customTooltip={swimlaneTooltip} />
         <Settings
           baseTheme={baseTheme}
           locale={i18n.getLocale()}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_tab.test.tsx
@@ -234,12 +234,12 @@ describe('AnomaliesTab', () => {
       );
     });
 
-    it('does not re-include a deselected middle range when critical remains selected', () => {
+    it('allows non-contiguous score selection', () => {
       // Regression test for https://github.com/elastic/kibana/issues/277648: collapsing the
       // selection into a single min/max span silently re-included the deselected Major range
       // whenever critical (which has no upper bound) stayed selected.
       render(<AnomaliesTab {...defaultProps} />, { wrapper: Wrapper });
-      // Select Warning, Minor, and Critical, but deselect Major [50,75).
+      // Select Warning, Minor, and Critical, but not Major [50,75).
       act(() => {
         onSeverityChange!([WARNING, MINOR, CRITICAL] as unknown as SeverityOption[]);
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_tab.tsx
@@ -100,18 +100,25 @@ export const AnomaliesTab: React.FC<AnomaliesTabProps> = ({ entityId, entityType
   );
   const [recentTimeRanges, setRecentTimeRanges] = useState<TimeRangeBoundsOption[]>([]);
 
-  const handleDatePickerChange = useCallback((args: DateRangePickerOnChangeProps) => {
-    if (args.isInvalid) return;
-    setStart(args.start);
-    setEnd(args.end);
-    setDatePickerValue(args.value);
-    setRecentTimeRanges((prev) => {
-      const key = `${args.start}|${args.end}`;
-      const deduped = prev.filter((r) => `${r.start}|${r.end}` !== key);
-      return [{ start: args.start, end: args.end }, ...deduped].slice(0, 10);
-    });
-    setTablePageIndex(0);
-  }, []);
+  const handleDatePickerChange = useCallback(
+    (args: DateRangePickerOnChangeProps) => {
+      if (args.isInvalid) return;
+      setStart(args.start);
+      setEnd(args.end);
+      setDatePickerValue(args.value);
+      setRecentTimeRanges((prev) => {
+        const key = `${args.start}|${args.end}`;
+        const deduped = prev.filter((r) => `${r.start}|${r.end}` !== key);
+        return [{ start: args.start, end: args.end }, ...deduped].slice(0, 10);
+      });
+      setTablePageIndex(0);
+      if (args.start !== start || args.end !== end) {
+        setIsOverviewFilterPending(true);
+        setIsSummaryFilterPending(true);
+      }
+    },
+    [start, end]
+  );
 
   const timeRangeMs = useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_tab_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/anomalies_tab_timeline.tsx
@@ -38,8 +38,21 @@ const tacticNames = [...mitreTactics]
 
 const TACTIC_ACCESSOR = 'mitre_tactic';
 
+interface SwimlaneRecord {
+  '@timestamp': number;
+  record_score: number;
+  count: number;
+}
+
+interface AnomalyTimeBucketEntry {
+  timestamp: string;
+  maxScore: number;
+  threatTactics?: string[];
+  tacticCounts?: Record<string, number>;
+}
+
 interface AnomalyTabTimelineProps {
-  anomalies: Array<{ timestamp: string; maxScore: number; threatTactics?: string[] }>;
+  anomalies: AnomalyTimeBucketEntry[];
   selectedTactic?: string | null;
   timeRangeMs: { from: number; to: number };
   isEmpty?: boolean;
@@ -71,10 +84,14 @@ export const AnomalyTabTimelineSection: React.FC<AnomalyTabTimelineProps> = ({
   );
 
   const records = useMemo(() => {
-    const byTactic = new Map<string, Array<{ '@timestamp': number; record_score: number }>>();
+    const byTactic = new Map<string, SwimlaneRecord[]>();
     for (const a of anomalies) {
       for (const tactic of a.threatTactics ?? []) {
-        const entry = { '@timestamp': new Date(a.timestamp).getTime(), record_score: a.maxScore };
+        const entry = {
+          '@timestamp': new Date(a.timestamp).getTime(),
+          record_score: a.maxScore,
+          count: a.tacticCounts?.[tactic] ?? 0,
+        };
         const existing = byTactic.get(tactic);
         if (existing) {
           existing.push(entry);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/translations.ts
@@ -59,6 +59,11 @@ export const ENTITY_ANOMALIES_SWIMLANE_MAX_SCORE = i18n.translate(
   { defaultMessage: 'Max anomaly score' }
 );
 
+export const ENTITY_ANOMALIES_SWIMLANE_ANOMALY_COUNT = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.entityAnomalies.overview.swimlane.anomalyCount',
+  { defaultMessage: 'Anomaly count' }
+);
+
 export const ENTITY_ANOMALIES_SWIMLANE_X_AXIS_LABEL = i18n.translate(
   'xpack.securitySolution.entityAnalytics.entityAnomalies.overview.swimlane.xAxis',
   { defaultMessage: 'Date' }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/anomaly_summary/get_anomaly_overview.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/anomaly_summary/get_anomaly_overview.test.ts
@@ -233,6 +233,22 @@ describe('getEntityAnomalyOverview', () => {
       });
     });
 
+    it('computes per-tactic counts within each time bucket', async () => {
+      const result = await getEntityAnomalyOverview(baseParams);
+
+      // bucket1: JOB_A (doc_count 2) → Execution+Discovery=2 each; JOB_B (doc_count 1) → Persistence=1
+      expect(result.anomalyByTimeBucket[0].tacticCounts).toEqual({
+        Execution: 2,
+        Discovery: 2,
+        Persistence: 1,
+      });
+      // bucket2: JOB_A only (doc_count 2) → Execution+Discovery=2 each
+      expect(result.anomalyByTimeBucket[1].tacticCounts).toEqual({
+        Execution: 2,
+        Discovery: 2,
+      });
+    });
+
     it('returns the total anomaly count from hits.total', async () => {
       const result = await getEntityAnomalyOverview(baseParams);
 
@@ -503,7 +519,7 @@ describe('getEntityAnomalyOverview', () => {
       await getEntityAnomalyOverview({
         ...baseParams,
         fromMs: FROM_MS,
-        toMs: FROM_MS + 31 * DAY_MS,
+        toMs: FROM_MS + 46 * DAY_MS,
       });
       expect(getFixedInterval()).toBe('7d');
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/anomaly_summary/get_anomaly_overview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/anomaly_summary/get_anomaly_overview.ts
@@ -195,12 +195,20 @@ export const getEntityAnomalyOverview = async ({
   const anomalyByTimeBucket: AnomalyOverviewEntry[] = (aggs?.by_time?.buckets ?? [])
     .filter((b) => b.doc_count > 0 && b.max_score.value !== null)
     .map((b) => {
-      const bucketJobIds = b.jobs.buckets.map((j) => j.key);
+      const jobsBucket = b?.jobs?.buckets ?? [];
+      const bucketJobIds = jobsBucket.map((j) => j.key);
       const tactics = [...new Set(bucketJobIds.flatMap((id) => tacticsByJob.get(id) ?? []))];
+      const tacticCounts = jobsBucket.reduce<Record<string, number>>((acc, { key, doc_count }) => {
+        for (const tactic of tacticsByJob.get(key) ?? []) {
+          acc[tactic] = (acc[tactic] ?? 0) + doc_count;
+        }
+        return acc;
+      }, {});
       return {
         timestamp: new Date(b.key).toISOString(),
         maxScore: b.max_score.value as number,
         threatTactics: tactics,
+        tacticCounts,
       };
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/anomaly_summary/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/anomaly_summary/route.ts
@@ -29,10 +29,10 @@ import { getEntityAnomalies } from './get_anomaly_details';
 import { DEFAULT_OVERVIEW_LOOKBACK_MS, getEntityAnomalyOverview } from './get_anomaly_overview';
 import { _formatPrivileges, hasReadWritePermissions } from '../utils/check_and_format_privileges';
 
-const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
-
 const getStartOfDayOneYearAgo = (): number => {
-  const d = new Date(Date.now() - ONE_YEAR_MS);
+  const d = new Date();
+  d.setUTCFullYear(d.getUTCFullYear() - 1);
+  d.setUTCDate(d.getUTCDate() - 1); // one extra day tolerance for timezone offsets
   d.setUTCHours(0, 0, 0, 0);
   return d.getTime();
 };

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_security_entity_ml_anomaly_summary/api/tests/entity_analytics/ml_anomaly_summary/ml_anomaly_summary.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_security_entity_ml_anomaly_summary/api/tests/entity_analytics/ml_anomaly_summary/ml_anomaly_summary.spec.ts
@@ -612,6 +612,10 @@ apiTest.describe(
           expect(typeof entry.maxScore).toBe('number');
           expect(entry.maxScore).toBeGreaterThan(0);
           expect(Array.isArray(entry.threatTactics)).toBe(true);
+          expect(typeof entry.tacticCounts).toBe('object');
+          for (const c of Object.values(entry.tacticCounts ?? {})) {
+            expect(c).toBeGreaterThan(0);
+          }
         }
 
         // auth_high_count_logon_events_ea contributes 'Credential Access' and 'Initial Access'
@@ -639,6 +643,9 @@ apiTest.describe(
         expect(body.anomalyByTimeBucket.length).toBeGreaterThanOrEqual(1);
         const highestBucketMax = Math.max(...body.anomalyByTimeBucket.map((a) => a.maxScore));
         expect(highestBucketMax).toBeGreaterThanOrEqual(31);
+        // Both records share the same timestamp so they land in one bucket; tacticCounts reflects both.
+        const bucket = body.anomalyByTimeBucket[0];
+        expect(bucket.tacticCounts?.['Credential Access']).toBe(2);
       }
     );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Analytics] Updating anomalies swimlane tooltip info and styling (#278265)](https://github.com/elastic/kibana/pull/278265)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2026-07-16T16:54:25Z","message":"[Entity Analytics] Updating anomalies swimlane tooltip info and styling (#278265)\n\nFixes https://github.com/elastic/kibana/issues/278023\nFixes https://github.com/elastic/kibana/issues/278009\n\n## Summary\n\nA few items addressed in this PR:\n\n1. Updates the anomalies swimlane tooltip to explicitly include the\nbucket time range and also include the count of anomalies within the\nbucket (along with max score and MITRE tactic)\n\n<img width=\"450\" height=\"176\" alt=\"Screenshot 2026-07-15 at 8 48 59 AM\"\nsrc=\"https://github.com/user-attachments/assets/b492a2a1-6b68-4c17-9e4c-4434144ee76d\"\n/>\n\n2. Fixes issue with derived bucket interval so that 30 days resolves to\n1 day buckets.\n3. Showing loading indicator when date range is changed (missed from\nhttps://github.com/elastic/kibana/pull/277811)\n4. Fixing max time range check - added padding to account for different\ntime zones.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6b5785bdec33f7b4cb16ca96f2f87756d6213bb3","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Entity Analytics","backport:version","v9.5.0","reviewer:scout","v9.6.0"],"title":"[Entity Analytics] Updating anomalies swimlane tooltip info and styling","number":278265,"url":"https://github.com/elastic/kibana/pull/278265","mergeCommit":{"message":"[Entity Analytics] Updating anomalies swimlane tooltip info and styling (#278265)\n\nFixes https://github.com/elastic/kibana/issues/278023\nFixes https://github.com/elastic/kibana/issues/278009\n\n## Summary\n\nA few items addressed in this PR:\n\n1. Updates the anomalies swimlane tooltip to explicitly include the\nbucket time range and also include the count of anomalies within the\nbucket (along with max score and MITRE tactic)\n\n<img width=\"450\" height=\"176\" alt=\"Screenshot 2026-07-15 at 8 48 59 AM\"\nsrc=\"https://github.com/user-attachments/assets/b492a2a1-6b68-4c17-9e4c-4434144ee76d\"\n/>\n\n2. Fixes issue with derived bucket interval so that 30 days resolves to\n1 day buckets.\n3. Showing loading indicator when date range is changed (missed from\nhttps://github.com/elastic/kibana/pull/277811)\n4. Fixing max time range check - added padding to account for different\ntime zones.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6b5785bdec33f7b4cb16ca96f2f87756d6213bb3"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278265","number":278265,"mergeCommit":{"message":"[Entity Analytics] Updating anomalies swimlane tooltip info and styling (#278265)\n\nFixes https://github.com/elastic/kibana/issues/278023\nFixes https://github.com/elastic/kibana/issues/278009\n\n## Summary\n\nA few items addressed in this PR:\n\n1. Updates the anomalies swimlane tooltip to explicitly include the\nbucket time range and also include the count of anomalies within the\nbucket (along with max score and MITRE tactic)\n\n<img width=\"450\" height=\"176\" alt=\"Screenshot 2026-07-15 at 8 48 59 AM\"\nsrc=\"https://github.com/user-attachments/assets/b492a2a1-6b68-4c17-9e4c-4434144ee76d\"\n/>\n\n2. Fixes issue with derived bucket interval so that 30 days resolves to\n1 day buckets.\n3. Showing loading indicator when date range is changed (missed from\nhttps://github.com/elastic/kibana/pull/277811)\n4. Fixing max time range check - added padding to account for different\ntime zones.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6b5785bdec33f7b4cb16ca96f2f87756d6213bb3"}}]}] BACKPORT-->