### PR TITLE
[9.4] [Security Solution][Cases] Count internal API requests using core's built-in function (#279173)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/moon.yml
+++ b/x-pack/platform/plugins/shared/cases/moon.yml
@@ -114,6 +114,7 @@ dependsOn:
   - '@kbn/css-utils'
   - '@kbn/shared-ux-column-presets'
   - '@kbn/core-ui-settings-browser'
+  - '@kbn/core-http-common'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/register_routes.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/register_routes.test.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { httpServerMock, httpServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
-
+import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
 import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/server/mocks';
 
 import type { CasesRequestHandlerContext, CasesRouter } from '../../types';
@@ -86,24 +86,26 @@ describe('registerRoutes', () => {
       method: keyof Pick<CasesRouter, 'get' | 'post'>;
       path: string;
       context?: CasesRequestHandlerContext;
-      headers?: Record<string, unknown>;
+      headers?: Record<string, string>;
     }) => {
+      const registeredRoute = router[method] as jest.Mock;
       const [, registeredRouteHandler] =
-        // @ts-ignore
-        router[method].mock.calls.find((call) => {
+        registeredRoute.mock.calls.find((call) => {
           return call[0].path === path;
         }) ?? [];
 
       if (!registeredRouteHandler) return;
 
-      const result = await registeredRouteHandler(
-        context,
-        // @ts-ignore we don't need to pass a real request object here
-        { headers },
-        { customError, badRequest }
-      );
+      const fakeRequest = httpServerMock.createKibanaRequest({
+        headers,
+        path,
+        method,
+      });
 
-      return result;
+      return registeredRouteHandler(context, fakeRequest, {
+        customError,
+        badRequest,
+      });
     };
 
     return {
@@ -129,7 +131,7 @@ describe('registerRoutes', () => {
     });
   };
 
-  const initAndSimulateDeprecationEndpoint = async (headers?: Record<string, unknown>) => {
+  const initAndSimulateDeprecationEndpoint = async (headers?: Record<string, string>) => {
     const { simulateRequest } = initApi([
       ...routes,
       createCasesRoute({
@@ -224,7 +226,7 @@ describe('registerRoutes', () => {
       await simulateRequest({
         method: 'get',
         path: '/foo/{case_id}',
-        headers: { 'kbn-version': '8.2.0', referer: 'https://example.com' },
+        headers: { 'kbn-version': '8.2.0', [X_ELASTIC_INTERNAL_ORIGIN_REQUEST]: 'Kibana' },
       });
       expect(telemetryUsageCounter.incrementCounter).toHaveBeenCalledWith({
         counterName: 'GET /foo/{case_id}',
@@ -283,7 +285,7 @@ describe('registerRoutes', () => {
     it('does NOT log the deprecation message if it is a kibana request', async () => {
       await initAndSimulateDeprecationEndpoint({
         'kbn-version': '8.2.0',
-        referer: 'https://example.com',
+        [X_ELASTIC_INTERNAL_ORIGIN_REQUEST]: 'Kibana',
       });
 
       expect(logger.warn).not.toHaveBeenCalled();
@@ -292,9 +294,7 @@ describe('registerRoutes', () => {
     it('adds the warning header', async () => {
       response.ok.mockReturnValue({ status: 200, options: {} });
       const res = await initAndSimulateDeprecationEndpoint();
-      // @ts-expect-error upgrade typescript v5.4.5
       const warningHeader = res.options.headers.warning;
-      // @ts-expect-error upgrade typescript v5.4.5
       const warningValue = extractWarningValueFromWarningHeader(warningHeader);
       expect(warningValue).toBe('Deprecated endpoint');
     });

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/register_routes.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/register_routes.ts
@@ -6,16 +6,10 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { Headers, RouteRegistrar, RouteSecurity } from '@kbn/core/server';
+import type { RouteRegistrar, RouteSecurity } from '@kbn/core/server';
 import type { CasesRequestHandlerContext } from '../../types';
 import type { RegisterRoutesDeps } from './types';
-import {
-  escapeHatch,
-  getIsKibanaRequest,
-  getWarningHeader,
-  logDeprecatedEndpoint,
-  wrapError,
-} from './utils';
+import { escapeHatch, getWarningHeader, logDeprecatedEndpoint, wrapError } from './utils';
 
 const getEndpoint = (method: string, path: string): string => `${method.toUpperCase()} ${path}`;
 
@@ -47,20 +41,20 @@ const increaseTelemetryCounters = ({
 
 const logAndIncreaseDeprecationTelemetryCounters = ({
   logger,
-  headers,
   method,
   path,
+  isKibanaRequest,
   telemetryUsageCounter,
 }: {
   logger: RegisterRoutesDeps['logger'];
-  headers: Headers;
   method: string;
   path: string;
+  isKibanaRequest: boolean;
   telemetryUsageCounter?: Exclude<RegisterRoutesDeps['telemetryUsageCounter'], undefined>;
 }) => {
   const endpoint = getEndpoint(method, path);
 
-  logDeprecatedEndpoint(logger, headers, `The endpoint ${endpoint} is deprecated.`);
+  logDeprecatedEndpoint(logger, isKibanaRequest, `The endpoint ${endpoint} is deprecated.`);
 
   if (telemetryUsageCounter) {
     telemetryUsageCounter.incrementCounter({
@@ -89,7 +83,7 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
       },
       async (context, request, response) => {
         let responseHeaders = {};
-        const isKibanaRequest = getIsKibanaRequest(request.headers);
+        const isKibanaRequest = request.isInternalApiRequest;
 
         if (!context.cases) {
           return response.badRequest({ body: 'RouteHandlerContext is not registered for cases' });
@@ -102,7 +96,7 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
               logger,
               path,
               method,
-              headers: request.headers,
+              isKibanaRequest,
             });
 
             responseHeaders = {

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/utils.test.ts
@@ -59,19 +59,18 @@ describe('Utils', () => {
 
   describe('logDeprecatedEndpoint', () => {
     const logger = loggingSystemMock.createLogger();
-    const kibanaHeader = { 'kbn-version': '8.1.0', referer: 'test' };
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
     it('does NOT log when the request is from the kibana client', () => {
-      logDeprecatedEndpoint(logger, kibanaHeader, 'test');
+      logDeprecatedEndpoint(logger, true, 'test');
       expect(logger.warn).not.toHaveBeenCalledWith('test');
     });
 
     it('does log when the request is NOT from the kibana client', () => {
-      logDeprecatedEndpoint(logger, {}, 'test');
+      logDeprecatedEndpoint(logger, false, 'test');
       expect(logger.warn).toHaveBeenCalledWith('test');
     });
   });

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts
@@ -8,7 +8,7 @@
 import type { Boom } from '@hapi/boom';
 import { boomify, isBoom } from '@hapi/boom';
 import { schema } from '@kbn/config-schema';
-import type { CustomHttpResponseOptions, ResponseError, Headers, Logger } from '@kbn/core/server';
+import type { CustomHttpResponseOptions, ResponseError, Logger } from '@kbn/core/server';
 import type { CaseError, HTTPError } from '../../common/error';
 import { isCaseError, isHTTPError } from '../../common/error';
 
@@ -49,19 +49,8 @@ export const getWarningHeader = (
   warning: `299 Kibana-${kibanaVersion} "${msg}"`,
 });
 
-/**
- * Taken from
- * https://github.com/elastic/kibana/blob/ec30f2aeeb10fb64b507935e558832d3ef5abfaa/x-pack/plugins/spaces/server/usage_stats/usage_stats_client.ts#L113-L118
- */
-
-export const getIsKibanaRequest = (headers?: Headers): boolean => {
-  // The presence of these two request headers gives us a good indication that this is a first-party request from the Kibana client.
-  // We can't be 100% certain, but this is a reasonable attempt.
-  return !!(headers && headers['kbn-version'] && headers.referer);
-};
-
-export const logDeprecatedEndpoint = (logger: Logger, headers: Headers, msg: string) => {
-  if (!getIsKibanaRequest(headers)) {
+export const logDeprecatedEndpoint = (logger: Logger, isKibanaRequest: Boolean, msg: string) => {
+  if (!isKibanaRequest) {
     logger.warn(msg);
   }
 };

--- a/x-pack/platform/plugins/shared/cases/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cases/tsconfig.json
@@ -110,6 +110,7 @@
     "@kbn/css-utils",
     "@kbn/shared-ux-column-presets",
     "@kbn/core-ui-settings-browser",
+    "@kbn/core-http-common",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution][Cases] Count internal API requests using core's built-in function (#279173)](https://github.com/elastic/kibana/pull/279173)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Valentina Radtke","email":"valentina.glagoleva@elastic.co"},"sourceCommit":{"committedDate":"2026-07-20T11:20:55Z","message":"[Security Solution][Cases] Count internal API requests using core's built-in function (#279173)\n\n## Summary\n\nPart of https://github.com/elastic/security-team/issues/18030\n\nReplace cases own `getIsKibanaRequest(headers)` implementation, which\nwas guessing Kibana request based on `kbn-version` + `referer` headers,\nwith core's [`built-in\nrequest.isInternalApiRequest`](https://github.com/elastic/kibana/blob/main/src/core/packages/http/router-server-internal/src/request.ts#L205).\n\nThe new check:\n- true if the `x-elastic-internal-origin` header is present (any value)\nor the` elasticInternalOrigin` query param is set\n  - forced false if `elasticInternalOrigin=false`\n\n## Issue Background\n\n\n[getIsKibanaRequest()](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts#L57)\nclassifies a request as first-party (\"internal\") only if both\n`kbn-version` and `referer` headers are present:\n```\n  // x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts\n  return !!(headers && headers['kbn-version'] && headers.referer);\n```\nBut **referer is a browser-managed header that Kibana does not contro**l\n- proxies and referrer policies routinely strip it. When that happens,\ngenuine Kibana UI traffic is counted as external (`kibanaRequest.no`),\nskewing the internal/external telemetry.\n\n=> `kibanaRequest.yes` / `kibanaRequest.no` counters are unreliable for\nany customer behind a referer-stripping proxy.\n\n## Testing\n\nSteps to reproduce the behavior:\n  1. Baseline - normal browser (expect `kibanaRequest.yes`)\n  - Create/edit a case in the UI.\n  - Wait ~5s, then in Dev Tools → Console:\n  ```\n  GET .kibana_usage_counters/_search\n  { \"query\": { \"bool\": { \"filter\": [\n    { \"term\": { \"usage-counter.domainId\": \"cases\" } },\n    { \"prefix\": { \"usage-counter.counterType\": \"kibanaRequest\" } }\n  ]}}}\n  ```\n  - `kibanaRequest.yes` increments.\n  2. Reproduce the bug — strip referer\n  - Firefox: `about:config` → `network.http.sendRefererHeader` = 0.\n  - Create/edit a case again, re-run the counter query.\n- Before fix: `kibanaRequest.no` increments (wrong - this is real UI\ntraffic).\n  - After fix: `kibanaRequest.yes` increments.\n\n3. External sanity check (expect kibanaRequest.no both before and after)\n- Send `POST /api/cases`, with no referer/kbn-version via curl / Postman\n/ Bruno.\n- `kibaneaRequest.no` increments - genuine external calls stay\nclassified as external.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"34d3c4f70dab0567ce67f5e649dc2307c2d13826","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:Cases","v9.5.0","v9.6.0","v9.4.5"],"title":"[Security Solution][Cases] Count internal API requests using core's built-in function","number":279173,"url":"https://github.com/elastic/kibana/pull/279173","mergeCommit":{"message":"[Security Solution][Cases] Count internal API requests using core's built-in function (#279173)\n\n## Summary\n\nPart of https://github.com/elastic/security-team/issues/18030\n\nReplace cases own `getIsKibanaRequest(headers)` implementation, which\nwas guessing Kibana request based on `kbn-version` + `referer` headers,\nwith core's [`built-in\nrequest.isInternalApiRequest`](https://github.com/elastic/kibana/blob/main/src/core/packages/http/router-server-internal/src/request.ts#L205).\n\nThe new check:\n- true if the `x-elastic-internal-origin` header is present (any value)\nor the` elasticInternalOrigin` query param is set\n  - forced false if `elasticInternalOrigin=false`\n\n## Issue Background\n\n\n[getIsKibanaRequest()](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts#L57)\nclassifies a request as first-party (\"internal\") only if both\n`kbn-version` and `referer` headers are present:\n```\n  // x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts\n  return !!(headers && headers['kbn-version'] && headers.referer);\n```\nBut **referer is a browser-managed header that Kibana does not contro**l\n- proxies and referrer policies routinely strip it. When that happens,\ngenuine Kibana UI traffic is counted as external (`kibanaRequest.no`),\nskewing the internal/external telemetry.\n\n=> `kibanaRequest.yes` / `kibanaRequest.no` counters are unreliable for\nany customer behind a referer-stripping proxy.\n\n## Testing\n\nSteps to reproduce the behavior:\n  1. Baseline - normal browser (expect `kibanaRequest.yes`)\n  - Create/edit a case in the UI.\n  - Wait ~5s, then in Dev Tools → Console:\n  ```\n  GET .kibana_usage_counters/_search\n  { \"query\": { \"bool\": { \"filter\": [\n    { \"term\": { \"usage-counter.domainId\": \"cases\" } },\n    { \"prefix\": { \"usage-counter.counterType\": \"kibanaRequest\" } }\n  ]}}}\n  ```\n  - `kibanaRequest.yes` increments.\n  2. Reproduce the bug — strip referer\n  - Firefox: `about:config` → `network.http.sendRefererHeader` = 0.\n  - Create/edit a case again, re-run the counter query.\n- Before fix: `kibanaRequest.no` increments (wrong - this is real UI\ntraffic).\n  - After fix: `kibanaRequest.yes` increments.\n\n3. External sanity check (expect kibanaRequest.no both before and after)\n- Send `POST /api/cases`, with no referer/kbn-version via curl / Postman\n/ Bruno.\n- `kibaneaRequest.no` increments - genuine external calls stay\nclassified as external.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"34d3c4f70dab0567ce67f5e649dc2307c2d13826"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279476","number":279476,"state":"MERGED","mergeCommit":{"sha":"74597438274d08b7e5f6de88fceda891b4a7ef0a","message":"[9.5] [Security Solution][Cases] Count internal API requests using core's built-in function (#279173) (#279476)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Security Solution][Cases] Count internal API requests using core's\nbuilt-in function\n(#279173)](https://github.com/elastic/kibana/pull/279173)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Valentina Radtke <valentina.glagoleva@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279173","number":279173,"mergeCommit":{"message":"[Security Solution][Cases] Count internal API requests using core's built-in function (#279173)\n\n## Summary\n\nPart of https://github.com/elastic/security-team/issues/18030\n\nReplace cases own `getIsKibanaRequest(headers)` implementation, which\nwas guessing Kibana request based on `kbn-version` + `referer` headers,\nwith core's [`built-in\nrequest.isInternalApiRequest`](https://github.com/elastic/kibana/blob/main/src/core/packages/http/router-server-internal/src/request.ts#L205).\n\nThe new check:\n- true if the `x-elastic-internal-origin` header is present (any value)\nor the` elasticInternalOrigin` query param is set\n  - forced false if `elasticInternalOrigin=false`\n\n## Issue Background\n\n\n[getIsKibanaRequest()](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts#L57)\nclassifies a request as first-party (\"internal\") only if both\n`kbn-version` and `referer` headers are present:\n```\n  // x-pack/platform/plugins/shared/cases/server/routes/api/utils.ts\n  return !!(headers && headers['kbn-version'] && headers.referer);\n```\nBut **referer is a browser-managed header that Kibana does not contro**l\n- proxies and referrer policies routinely strip it. When that happens,\ngenuine Kibana UI traffic is counted as external (`kibanaRequest.no`),\nskewing the internal/external telemetry.\n\n=> `kibanaRequest.yes` / `kibanaRequest.no` counters are unreliable for\nany customer behind a referer-stripping proxy.\n\n## Testing\n\nSteps to reproduce the behavior:\n  1. Baseline - normal browser (expect `kibanaRequest.yes`)\n  - Create/edit a case in the UI.\n  - Wait ~5s, then in Dev Tools → Console:\n  ```\n  GET .kibana_usage_counters/_search\n  { \"query\": { \"bool\": { \"filter\": [\n    { \"term\": { \"usage-counter.domainId\": \"cases\" } },\n    { \"prefix\": { \"usage-counter.counterType\": \"kibanaRequest\" } }\n  ]}}}\n  ```\n  - `kibanaRequest.yes` increments.\n  2. Reproduce the bug — strip referer\n  - Firefox: `about:config` → `network.http.sendRefererHeader` = 0.\n  - Create/edit a case again, re-run the counter query.\n- Before fix: `kibanaRequest.no` increments (wrong - this is real UI\ntraffic).\n  - After fix: `kibanaRequest.yes` increments.\n\n3. External sanity check (expect kibanaRequest.no both before and after)\n- Send `POST /api/cases`, with no referer/kbn-version via curl / Postman\n/ Bruno.\n- `kibaneaRequest.no` increments - genuine external calls stay\nclassified as external.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"34d3c4f70dab0567ce67f5e649dc2307c2d13826"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->