### PR TITLE
[Entity Analytics] Only showing timeline action when timeline is available on anomaly table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_table_row_actions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_table_row_actions.test.ts
@@ -8,15 +8,15 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { FilterStateStore } from '@kbn/es-query';
 import { useKibana } from '../../../common/lib/kibana';
-import { useUserPrivileges } from '../../../common/components/user_privileges';
+import { useShowTimeline } from '../../../common/utils/timeline/use_show_timeline';
 import { useInvestigateInTimeline } from '../../../common/hooks/timeline/use_investigate_in_timeline';
 import { useAnomalySingleMetricViewerUrl } from './use_anomaly_single_metric_viewer_url';
 import { useAnomalyTableRowActions } from './use_anomaly_table_row_actions';
 import type { TableRow } from '../../components/anomalies/table/types';
 
 jest.mock('../../../common/lib/kibana', () => ({ useKibana: jest.fn() }));
-jest.mock('../../../common/components/user_privileges', () => ({
-  useUserPrivileges: jest.fn(),
+jest.mock('../../../common/utils/timeline/use_show_timeline', () => ({
+  useShowTimeline: jest.fn(),
 }));
 jest.mock('../../../common/hooks/timeline/use_investigate_in_timeline', () => ({
   useInvestigateInTimeline: jest.fn(),
@@ -26,7 +26,7 @@ jest.mock('./use_anomaly_single_metric_viewer_url', () => ({
 }));
 
 const mockUseKibana = useKibana as jest.Mock;
-const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
+const mockUseShowTimeline = useShowTimeline as jest.Mock;
 const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.Mock;
 const mockUseAnomalySingleMetricViewerUrl = useAnomalySingleMetricViewerUrl as jest.Mock;
 
@@ -123,7 +123,7 @@ beforeEach(() => {
     },
   });
 
-  mockUseUserPrivileges.mockReturnValue({ timelinePrivileges: { read: true } });
+  mockUseShowTimeline.mockReturnValue([true]);
   mockUseInvestigateInTimeline.mockReturnValue({
     investigateInTimeline: mockInvestigateInTimeline,
   });
@@ -148,8 +148,8 @@ describe('useAnomalyTableRowActions', () => {
       expect(keys).toEqual(['add-to-timeline', 'view-in-discover', 'view-in-single-metric-viewer']);
     });
 
-    it('excludes add-to-timeline when canReadTimeline is false', () => {
-      mockUseUserPrivileges.mockReturnValue({ timelinePrivileges: { read: false } });
+    it('excludes add-to-timeline when timeline is not available', () => {
+      mockUseShowTimeline.mockReturnValue([false]);
       const { result } = renderActions();
       const keys = result.current.actions.map((a) => a.key);
       expect(keys).not.toContain('add-to-timeline');

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_table_row_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_table_row_actions.ts
@@ -10,7 +10,7 @@ import type { IconType } from '@elastic/eui';
 import { FilterStateStore, escapeQuotes, type Filter } from '@kbn/es-query';
 import type { SerializableRecord } from '@kbn/utility-types';
 import { useInvestigateInTimeline } from '../../../common/hooks/timeline/use_investigate_in_timeline';
-import { useUserPrivileges } from '../../../common/components/user_privileges';
+import { useShowTimeline } from '../../../common/utils/timeline/use_show_timeline';
 import { useKibana } from '../../../common/lib/kibana';
 import type { TableRow } from '../../components/anomalies/table/types';
 import {
@@ -113,9 +113,7 @@ export const useAnomalyTableRowActions = ({
 }: UseAnomalyTableRowActionsArgs): AnomalyTableRowActionsResult => {
   const { services } = useKibana();
   const { ml, share, data } = services;
-  const {
-    timelinePrivileges: { read: canReadTimeline },
-  } = useUserPrivileges();
+  const [canReadTimeline] = useShowTimeline();
   const { investigateInTimeline } = useInvestigateInTimeline();
 
   const cachedRecordRef = useRef<CachedRecord | null>(null);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/278708

## Summary

The investigation timeline is not available on the Manage Entity Analytics page so clicking the `Add to Timeline` action from the anomaly table action dropdown would not do anything. This PR fixes this by checking if the timeline is available and not adding that as a possible action if the timeline is not available in the current context. The `useShowTimeline` combines the check for timeline availability with user permissions so users without Timeline permission will continue to not see the option in the table dropdown.

https://github.com/user-attachments/assets/242df3e5-703e-4660-8105-27b41921e5a2



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->