### PR TITLE
[Cases][Template] Hide auto extract observables toggle in Observability and Stack

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_settings_form.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_settings_form.test.tsx
@@ -25,7 +25,11 @@ jest.mock('./template_connector_form', () => {
   };
 });
 
-const mockUseCasesFeatures = jest.fn(() => ({ isSyncAlertsEnabled: true }));
+const mockUseCasesFeatures = jest.fn(() => ({
+  isSyncAlertsEnabled: true,
+  observablesAuthorized: true,
+  isExtractObservablesEnabled: true,
+}));
 jest.mock('../../../common/use_cases_features', () => ({
   useCasesFeatures: () => mockUseCasesFeatures(),
 }));
@@ -39,7 +43,11 @@ describe('TemplateSettingsForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockConnectorFormMounts.count = 0;
-    mockUseCasesFeatures.mockReturnValue({ isSyncAlertsEnabled: true });
+    mockUseCasesFeatures.mockReturnValue({
+      isSyncAlertsEnabled: true,
+      observablesAuthorized: true,
+      isExtractObservablesEnabled: true,
+    });
   });
 
   it('reflects the current settings in the toggles and renders the connector form', () => {
@@ -121,14 +129,34 @@ describe('TemplateSettingsForm', () => {
   });
 
   it('hides the sync alerts toggle when alert syncing is disabled (e.g. Observability)', () => {
-    mockUseCasesFeatures.mockReturnValue({ isSyncAlertsEnabled: false });
+    mockUseCasesFeatures.mockReturnValue({
+      isSyncAlertsEnabled: false,
+      observablesAuthorized: true,
+      isExtractObservablesEnabled: true,
+    });
 
     render(
       <TemplateSettingsForm {...base} settings={{ syncAlerts: true, extractObservables: false }} />
     );
 
     expect(screen.queryByTestId('templateSettingsSyncAlertsSwitch')).not.toBeInTheDocument();
-    // Extract observables remains available regardless of the alert-sync feature.
     expect(screen.getByTestId('templateSettingsExtractObservablesSwitch')).toBeInTheDocument();
+  });
+
+  it('hides the extract observables toggle when the feature is unavailable (e.g. Observability/Stack)', () => {
+    mockUseCasesFeatures.mockReturnValue({
+      isSyncAlertsEnabled: true,
+      observablesAuthorized: true,
+      isExtractObservablesEnabled: false,
+    });
+
+    render(
+      <TemplateSettingsForm {...base} settings={{ syncAlerts: true, extractObservables: false }} />
+    );
+
+    expect(
+      screen.queryByTestId('templateSettingsExtractObservablesSwitch')
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('templateSettingsSyncAlertsSwitch')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_settings_form.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_settings_form.tsx
@@ -44,9 +44,11 @@ export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
   formResetKey = 0,
   compact = false,
 }) => {
-  // Alert syncing is not a feature in every solution (e.g. Observability disables it), so the toggle
-  // is hidden there — mirroring the create-case form and case settings popover.
-  const { isSyncAlertsEnabled } = useCasesFeatures();
+  // Alert syncing and observable extraction are not features in every solution (e.g. Observability
+  // disables both), so the toggles are hidden there — mirroring the create-case form and V1 templates.
+  const { isSyncAlertsEnabled, observablesAuthorized, isExtractObservablesEnabled } =
+    useCasesFeatures();
+  const canExtractObservables = observablesAuthorized && isExtractObservablesEnabled;
 
   const setSetting = useCallback(
     (key: keyof TemplateSettings, value: boolean) => {
@@ -92,14 +94,16 @@ export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
         </>
       )}
 
-      <EuiFormRow fullWidth helpText={commonI18n.EXTRACT_OBSERVABLES_HELP}>
-        <EuiSwitch
-          label={commonI18n.EXTRACT_OBSERVABLES_LABEL}
-          checked={settings?.extractObservables ?? false}
-          onChange={(e) => setSetting('extractObservables', e.target.checked)}
-          data-test-subj="templateSettingsExtractObservablesSwitch"
-        />
-      </EuiFormRow>
+      {canExtractObservables && (
+        <EuiFormRow fullWidth helpText={commonI18n.EXTRACT_OBSERVABLES_HELP}>
+          <EuiSwitch
+            label={commonI18n.EXTRACT_OBSERVABLES_LABEL}
+            checked={settings?.extractObservables ?? false}
+            onChange={(e) => setSetting('extractObservables', e.target.checked)}
+            data-test-subj="templateSettingsExtractObservablesSwitch"
+          />
+        </EuiFormRow>
+      )}
 
       <EuiHorizontalRule margin="l" />
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.test.tsx
@@ -67,6 +67,8 @@ jest.mock('../../../use_breadcrumbs', () => ({
   useCasesTemplatesBreadcrumbs: jest.fn(),
 }));
 
+const observablesEnabledFeatures = { observables: { enabled: true, autoExtract: true } };
+
 describe('CreateTemplatePage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -199,7 +201,7 @@ describe('CreateTemplatePage', () => {
 
   it('defaults a new template to sync alerts + extract observables on (Security) in the saved definition', async () => {
     render(
-      <TestProviders>
+      <TestProviders features={observablesEnabledFeatures}>
         <CreateTemplatePage />
       </TestProviders>
     );
@@ -220,16 +222,9 @@ describe('CreateTemplatePage', () => {
     expect(parsed.settings).toEqual({ syncAlerts: true, extractObservables: true });
   });
 
-  it('resets the panel config (settings/connector) draft to the defaults on successful creation', async () => {
-    const storageKey = `securitySolution.${LOCAL_STORAGE_KEYS.templatesYamlEditorCreateState}`;
-    const configKey = `${storageKey}.config`;
-    // Simulate an in-progress create that toggled both settings off; it must not leak into the next
-    // create — the draft must reset to the solution defaults.
-    localStorage.setItem(
-      configKey,
-      JSON.stringify({ settings: { syncAlerts: false, extractObservables: false } })
-    );
-
+  it('defaults extract observables off where the feature is unavailable (e.g. Observability/Stack)', async () => {
+    // Default test context uses DEFAULT_FEATURES (observables autoExtract off) and a basic license,
+    // so the toggle is hidden and the persisted default must be off.
     render(
       <TestProviders>
         <CreateTemplatePage />
@@ -244,7 +239,38 @@ describe('CreateTemplatePage', () => {
       expect(mockMutateAsync).toHaveBeenCalledTimes(1);
     });
 
-    // The config draft is reset to the create defaults (Security test context → both on), not the
+    const { definition } = (
+      mockMutateAsync.mock.calls[0][0] as { template: { definition: string } }
+    ).template;
+    const parsed = yamlParse(definition) as { settings?: Record<string, boolean> };
+    expect(parsed.settings).toEqual({ syncAlerts: true, extractObservables: false });
+  });
+
+  it('resets the panel config (settings/connector) draft to the defaults on successful creation', async () => {
+    const storageKey = `securitySolution.${LOCAL_STORAGE_KEYS.templatesYamlEditorCreateState}`;
+    const configKey = `${storageKey}.config`;
+    // Simulate an in-progress create that toggled both settings off; it must not leak into the next
+    // create — the draft must reset to the solution defaults.
+    localStorage.setItem(
+      configKey,
+      JSON.stringify({ settings: { syncAlerts: false, extractObservables: false } })
+    );
+
+    render(
+      <TestProviders features={observablesEnabledFeatures}>
+        <CreateTemplatePage />
+      </TestProviders>
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: /Configuration/ }));
+    await userEvent.type(screen.getByTestId('templateMetadataNameInput'), 'My template');
+    await userEvent.click(screen.getByTestId('saveTemplateHeaderButton'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    // The config draft is reset to the create defaults (Security context → both on), not the
     // stale in-progress `{ false, false }`.
     const storedConfig = localStorage.getItem(configKey);
     const parsedConfig = storedConfig ? JSON.parse(storedConfig) : {};

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.tsx
@@ -13,6 +13,7 @@ import { exampleTemplateDefinition } from '../../field_types/constants';
 import { TemplateFormLayout } from '../../components/template_form_layout';
 import { useCreateTemplate } from '../../hooks/use_create_template';
 import { useCasesContext } from '../../../cases_context/use_cases_context';
+import { useCasesFeatures } from '../../../../common/use_cases_features';
 import { useAvailableCasesOwners } from '../../../app/use_available_owners';
 import { getOwnerDefaultValue } from '../../../create/utils';
 import { useCasesEditTemplateNavigation } from '../../../../common/navigation';
@@ -44,15 +45,18 @@ export const CreateTemplatePage: FC<CreateTemplatePageProps> = () => {
   const availableOwners = useAvailableCasesOwners();
   const defaultOwnerValue = owner[0] ?? getOwnerDefaultValue(availableOwners);
   const { navigateToCasesEditTemplate } = useCasesEditTemplateNavigation();
+  const { isExtractObservablesEnabled } = useCasesFeatures();
 
-  // Defaults for a new template: extract observables on for every solution; sync alerts on only for
-  // Security (elsewhere the sync-alerts toggle is hidden and the value stays off).
+  // Defaults for a new template mirror toggle visibility: extract observables on only where the
+  // solution enables it, sync alerts on only for Security (the toggles are hidden otherwise).
+  // Gated on the (synchronous) feature config rather than license, since the license loads async
+  // and the panel seeds these defaults once at mount.
   const initialSettings = useMemo<TemplateSettings>(
     () => ({
       syncAlerts: defaultOwnerValue === SECURITY_SOLUTION_OWNER,
-      extractObservables: true,
+      extractObservables: isExtractObservablesEnabled,
     }),
-    [defaultOwnerValue]
+    [defaultOwnerValue, isExtractObservablesEnabled]
   );
 
   const handleCreate = useCallback(


### PR DESCRIPTION
## Summary

**Before:** Auto extract observables toggle show up in template configuration and create case unconditionally
**After:** match the check in V1 work where only Security has sync alert and auto extract observables toggle, Observability and Stack do not show either toggle

Stack
<img width="1194" height="696" alt="image" src="https://github.com/user-attachments/assets/d0eacd77-1300-43f7-9221-9083cf5e181b" />

Observability
<img width="1188" height="681" alt="image" src="https://github.com/user-attachments/assets/795428dc-26b6-4433-9c4a-2b5c52c4c585" />

Security
<img width="1203" height="638" alt="image" src="https://github.com/user-attachments/assets/7d4f9834-613f-4c23-b825-59b4864982bf" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->