### PR TITLE
feat(agent-builder): platform support for endpoint response actions

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
@@ -153,6 +153,23 @@ export type OtherResult<T extends Object = Record<string, unknown>> = ToolResult
   T
 >;
 
+/**
+ * Shape-level marker for `ToolResultType.other` results produced by the
+ * endpoint response actions skill (isolate/unisolate/scan/running-processes/
+ * list-endpoints/get-endpoint-status). `ToolResultType.other` is used by
+ * dozens of unrelated skills across solutions, so a global change to how
+ * `other` results render would be far too broad (see anti-overengineering
+ * gate). Instead, response-action tools stamp `kind: 'response_action_result'`
+ * on their `data` payload so a follow-up UI renderer can identify and
+ * render them inline without affecting any other skill's `other` results.
+ */
+export interface ResponseActionResultData {
+  kind: 'response_action_result';
+  [key: string]: unknown;
+}
+
+export type ResponseActionResult = ToolResultMixin<ToolResultType.other, ResponseActionResultData>;
+
 // error
 
 export interface ErrorResultData {
@@ -206,4 +223,13 @@ export const isFileReferenceResult = (result: ToolResult): result is FileReferen
 
 export const isVisualizationResult = (result: ToolResult): result is VisualizationResult => {
   return result.type === ToolResultType.visualization;
+};
+
+export const isResponseActionResult = (result: ToolResult): result is ResponseActionResult => {
+  return (
+    result.type === ToolResultType.other &&
+    typeof result.data === 'object' &&
+    result.data !== null &&
+    (result.data as Record<string, unknown>).kind === 'response_action_result'
+  );
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -173,9 +173,6 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'significant-events-onboarding',
   'streams-gap-detection',
 
-  // Platform – Context Engine
-  'ki-automation-generation',
-
   // Platform – Workflows
   'workflow-authoring',
 
@@ -194,6 +191,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'pci-compliance',
   'investigate-rule',
   'siem-readiness',
+  'endpoint-response-actions',
   'attack-discovery-alert-retrieval-builder',
   'attack-discovery-generator',
   'attack-discovery-workflow-troubleshooting',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { ConversationRoundStatus, type ConversationRound } from '@kbn/agent-builder-common';
+import { AgentPromptType } from '@kbn/agent-builder-common/agents';
 import { RoundLayout } from './round_layout';
 import { RoundResponse } from './round_response/round_response';
 import { useConversationStream } from '../../../hooks/use_conversation_stream';
@@ -25,7 +26,7 @@ jest.mock('./round_error/round_error', () => ({
 }));
 
 jest.mock('./round_prompt', () => ({
-  ConfirmationPrompt: () => null,
+  ConfirmationPrompt: jest.fn(() => null),
 }));
 
 jest.mock('./round_attachment_references', () => ({
@@ -40,6 +41,7 @@ const useConversationStreamMock = useConversationStream as jest.MockedFunction<
   typeof useConversationStream
 >;
 const roundResponseMock = RoundResponse as jest.MockedFunction<typeof RoundResponse>;
+const { ConfirmationPrompt: ConfirmationPromptMock } = jest.requireMock('./round_prompt');
 
 const createRound = (version: number): ConversationRound =>
   ({
@@ -148,5 +150,65 @@ describe('RoundLayout', () => {
     expect(roundResponseMock.mock.calls[1][0].attachmentRefs).toEqual([
       { attachment_id: 'attachment-1', version: 2 },
     ]);
+  });
+
+  it('keeps HITL confirmation buttons enabled as soon as the round reaches awaitingPrompt, even while the stream is still closing', () => {
+    const awaitingPromptRound: ConversationRound = {
+      id: 'round-2',
+      status: ConversationRoundStatus.awaitingPrompt,
+      input: { message: 'run scan' },
+      response: { message: 'Run malware scan?' },
+      steps: [],
+      pending_prompts: [
+        {
+          id: 'prompt-1',
+          type: AgentPromptType.confirmation,
+          title: 'Run malware scan?',
+          message: 'Scan /tmp for malware?',
+          confirm_text: 'Run scan',
+          cancel_text: 'Deny',
+        },
+      ],
+      started_at: '2026-01-01T00:00:00.000Z',
+      time_to_first_token: 1,
+      time_to_last_token: 1,
+      model_usage: {
+        connector_id: 'connector-1',
+        llm_calls: 1,
+        input_tokens: 1,
+        output_tokens: 1,
+      },
+    } as unknown as ConversationRound;
+
+    useConversationStreamMock.mockReturnValue({
+      sendMessage: jest.fn(),
+      isResponseLoading: false,
+      isStreaming: true,
+      pendingMessage: undefined,
+      error: null,
+      errorSteps: [],
+      retry: jest.fn(),
+      canCancel: false,
+      cancel: jest.fn(),
+      removeError: jest.fn(),
+      resumeRound: jest.fn(),
+      isResuming: false,
+      regenerate: jest.fn(),
+      isRegenerating: false,
+    } as ReturnType<typeof useConversationStream>);
+
+    render(
+      <RoundLayout
+        allRounds={[awaitingPromptRound]}
+        conversationId="conversation-1"
+        isCurrentRound={true}
+        rawRound={awaitingPromptRound}
+        roundIndex={0}
+        scrollContainerHeight={100}
+      />
+    );
+
+    const lastCall = ConfirmationPromptMock.mock.calls.at(-1)[0];
+    expect(lastCall.isDisabled).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -107,13 +107,16 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
 
   const {
     isResponseLoading,
-    isStreaming,
     error,
     retry: retrySendMessage,
     resumeRound,
     isResuming,
   } = useConversationStream();
-  const isHitlDisabled = isStreaming && !isResuming;
+  // Once the round reaches awaitingPrompt the response is effectively paused and the user
+  // should be able to answer the HITL prompt immediately. Locking only during response loading
+  // (round still in progress / resume in flight) prevents clicks while the assistant is actively
+  // generating, without the 1–2 s delay caused by the trailing stream close.
+  const isHitlDisabled = isResponseLoading && !isResuming;
 
   const isLoadingCurrentRound = isResponseLoading && isCurrentRound;
   const isErrorCurrentRound = Boolean(error) && isCurrentRound;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/streaming_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/streaming_context.tsx
@@ -48,15 +48,31 @@ export const StreamingProvider = ({ children }: { children: React.ReactNode }) =
   const [activeStreams, setActiveStreams] = useState<Map<string, ActiveStream>>(() => new Map());
   const [byConversationId, setByConversationId] = useState<Record<string, StreamRecord>>({});
 
-  const setActiveStream = useCallback((conversationId: string, value: ActiveStream) => {
-    setActiveStreams((prev) => new Map(prev).set(conversationId, value));
-  }, []);
+  const setActiveStream = useCallback(
+    (conversationId: string, value: Pick<ActiveStream, 'type'>) => {
+      setActiveStreams((prev) => {
+        const existing = prev.get(conversationId);
+        const next = new Map(prev);
+        next.set(conversationId, {
+          type: value.type,
+          count: (existing?.count ?? 0) + 1,
+        });
+        return next;
+      });
+    },
+    []
+  );
 
   const clearActiveStream = useCallback((conversationId: string) => {
     setActiveStreams((prev) => {
-      if (!prev.has(conversationId)) return prev;
+      const existing = prev.get(conversationId);
+      if (!existing) return prev;
       const next = new Map(prev);
-      next.delete(conversationId);
+      if (existing.count <= 1) {
+        next.delete(conversationId);
+      } else {
+        next.set(conversationId, { ...existing, count: existing.count - 1 });
+      }
       return next;
     });
   }, []);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/types.ts
@@ -11,6 +11,8 @@ export type StreamType = 'send' | 'regenerate' | 'resume';
 
 export interface ActiveStream {
   type: StreamType;
+  /** Number of in-flight mutations for this conversation. Ref-counted so a send and a resume can overlap. */
+  count: number;
 }
 
 export interface StreamRecord {


### PR DESCRIPTION
## Summary

Platform-level changes extracted from #272111 to keep workchat-eng-owned Agent Builder files separate from the security_solution-owned endpoint response actions skill.

### Changes

| File | Change |
|---|---|
| `agent-builder-common/tools/tool_result.ts` | `ResponseActionResultData` type + `isResponseActionResult` guard so a follow-up UI renderer can identify response-action results without affecting other skills' `other` results |
| `agent-builder-server/allow_lists.ts` | Register `endpoint-response-actions` as a builtin skill |
| `round_layout.tsx` | Fix HITL confirmation buttons staying disabled during the 1-2s stream-close window after `awaitingPrompt` |
| `round_layout.test.tsx` | Test for the HITL timing fix |
| `streaming_context.tsx` | Ref-counted `ActiveStream` so overlapping send+resume mutations don't prematurely clear the active stream |
| `streaming/types.ts` | Add `count` field to `ActiveStream` |

### Why separate from #272111

#272111 ships the endpoint response actions skill entirely within `security_solution/`. These 6 files are in Agent Builder platform paths owned by `@elastic/workchat-eng`. Splitting them avoids coupling the security team review with platform review.

The skill itself is unaffected by this PR — it works with or without these platform changes. Tool results render via **View JSON** until the follow-up `response_action_result` UI renderer merges.

## Checklist
- [x] Typecheck clean
- [x] ESLint clean
- [x] Unit tests pass
- [x] Feature flag: `endpointResponseActionsSkill` defaults to `false`
