### PR TITLE
[Agent Builder][Vega] Restore hardened server-side validation

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/jest.integration.config.js
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/jest.integration.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_integration_node',
+  rootDir: '../../../../../..',
+  roots: [
+    '<rootDir>/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server',
+  ],
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/moon.yml
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/moon.yml
@@ -26,6 +26,7 @@ dependsOn:
   - '@kbn/logging'
   - '@kbn/palettes'
   - '@kbn/zod'
+  - '@kbn/setup-node-env'
 tags:
   - shared-server
   - package
@@ -36,6 +37,8 @@ tags:
 fileGroups:
   src:
     - '**/*.ts'
+    - '**/*.cjs'
+    - jest.integration.config.js
     - '!target/**/*'
   jest-config:
     - jest.config.js

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/tsconfig.json
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "target/types",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "**/*.cjs", "jest.integration.config.js"],
   "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/agent-builder-common",
@@ -15,6 +15,7 @@
     "@kbn/lens-embeddable-utils",
     "@kbn/logging",
     "@kbn/palettes",
-    "@kbn/zod"
+    "@kbn/zod",
+    "@kbn/setup-node-env"
   ]
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/actions.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/actions.ts
@@ -27,7 +27,7 @@ export interface AuthorSpecAction {
   error?: string;
 }
 
-/** Action recording the outcome of the structural check + normalization of a spec. */
+/** Action recording the outcome of structural and compile/render validation. */
 export interface ValidateSpecAction {
   type: 'validate_spec';
   success: boolean;
@@ -37,6 +37,7 @@ export interface ValidateSpecAction {
   title?: string;
   attempt: number;
   error?: string;
+  warnings?: string[];
 }
 
 export type VegaAction = GenerateEsqlAction | AuthorSpecAction | ValidateSpecAction;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -330,6 +330,45 @@ describe('createVegaGraph', () => {
       expect(state.error).toBeNull();
       expect(state.spec).not.toBeNull();
     });
+
+    it('retries when the warning review introduces an unsupported nested data source', async () => {
+      invoke
+        .mockResolvedValueOnce(asCodeBlock({ mark: 'bar' }))
+        .mockResolvedValueOnce(
+          asCodeBlock({
+            transform: [
+              {
+                lookup: 'OriginCountry',
+                from: {
+                  data: { url: { '%type%': 'esql', query: PROVIDED_ESQL } },
+                  key: 'OriginCountry',
+                },
+              },
+            ],
+            mark: 'bar',
+          })
+        )
+        .mockResolvedValueOnce(asCodeBlock({ mark: 'point' }));
+      mockedValidateVegaSpec
+        .mockResolvedValueOnce({
+          warnings: ['Infinite extent for field "count": [Infinity, -Infinity]'],
+        })
+        .mockResolvedValueOnce({
+          error:
+            'Nested or external data loading is not supported; use only the top-level ES|QL data source.',
+          warnings: [],
+        })
+        .mockResolvedValueOnce({ warnings: [] });
+
+      const state = await run({ esqlQuery: PROVIDED_ESQL });
+
+      expect(invoke).toHaveBeenCalledTimes(3);
+      expect(JSON.stringify(invoke.mock.calls[2][0])).toContain(
+        'Nested or external data loading is not supported'
+      );
+      expect(state.error).toBeNull();
+      expect(JSON.parse(state.spec!).mark).toBe('point');
+    });
   });
 
   it('rejects an authored spec with no renderable view and retries', async () => {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts
@@ -10,11 +10,16 @@ import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import { generateEsql, executeEsql } from '@kbn/agent-builder-genai-utils';
 import { VEGA_LITE_SCHEMA } from './normalize_spec';
+import { validateVegaSpec } from './vega_validator';
 import { createVegaGraph } from './graph';
 
 jest.mock('@kbn/agent-builder-genai-utils', () => ({
   generateEsql: jest.fn(),
   executeEsql: jest.fn(),
+}));
+
+jest.mock('./vega_validator', () => ({
+  validateVegaSpec: jest.fn(),
 }));
 
 jest.mock('@kbn/agent-builder-genai-utils/tools/utils/esql', () => ({
@@ -31,6 +36,7 @@ jest.mock('../shared/esql_instructions', () => ({
 
 const mockedGenerateEsql = jest.mocked(generateEsql);
 const mockedExecuteEsql = jest.mocked(executeEsql);
+const mockedValidateVegaSpec = jest.mocked(validateVegaSpec);
 
 const createMockLogger = (): Logger =>
   ({ debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() } as unknown as Logger);
@@ -75,6 +81,7 @@ describe('createVegaGraph', () => {
     mockedExecuteEsql.mockResolvedValue({ columns: [], values: [] } as Awaited<
       ReturnType<typeof executeEsql>
     >);
+    mockedValidateVegaSpec.mockResolvedValue({ warnings: [] });
   });
 
   const run = async (
@@ -251,6 +258,78 @@ describe('createVegaGraph', () => {
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(state.error).toBeNull();
     expect(JSON.parse(state.spec!).mark).toBe('line');
+  });
+
+  it('retries authoring when Vega rejects the normalized spec', async () => {
+    invoke
+      .mockResolvedValueOnce(asCodeBlock({ title: 'Broken chart', spec: { mark: 'bar' } }))
+      .mockResolvedValueOnce(asCodeBlock({ title: 'Fixed chart', spec: { mark: 'line' } }));
+    mockedValidateVegaSpec
+      .mockResolvedValueOnce({ error: 'Unknown transform op: bogus', warnings: [] })
+      .mockResolvedValueOnce({ warnings: [] });
+
+    const state = await run({ esqlQuery: PROVIDED_ESQL });
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(invoke.mock.calls[1][0])).toContain('Unknown transform op: bogus');
+    expect(state.error).toBeNull();
+    expect(state.title).toBe('Fixed chart');
+    expect(JSON.parse(state.spec!).mark).toBe('line');
+  });
+
+  describe('render warnings', () => {
+    it('hands every warning to the agent for one review pass, then finalizes its result', async () => {
+      invoke
+        .mockResolvedValueOnce(
+          asCodeBlock({
+            mark: 'line',
+            encoding: {
+              theta: { field: 'metric', type: 'nominal' },
+              radius: { field: 'value', type: 'quantitative' },
+            },
+          })
+        )
+        .mockResolvedValueOnce(
+          asCodeBlock({
+            mark: 'line',
+            encoding: {
+              x: { field: 'metric', type: 'nominal' },
+              y: { field: 'value', type: 'quantitative' },
+            },
+          })
+        );
+      mockedValidateVegaSpec
+        .mockResolvedValueOnce({
+          warnings: [
+            'theta dropped as it is incompatible with "line".',
+            'radius dropped as it is incompatible with "line".',
+          ],
+        })
+        .mockResolvedValueOnce({ warnings: [] });
+
+      const state = await run({ esqlQuery: PROVIDED_ESQL });
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(state.error).toBeNull();
+      expect(JSON.parse(state.spec!).encoding).toHaveProperty('x');
+      const secondPrompt = JSON.stringify(invoke.mock.calls[1][0]);
+      expect(secondPrompt).toContain('theta dropped as it is incompatible');
+      expect(secondPrompt).toContain('radius dropped as it is incompatible');
+      expect(secondPrompt).toContain('decide for yourself');
+    });
+
+    it('makes a single review pass and accepts the spec when the agent keeps its warnings', async () => {
+      invoke.mockResolvedValue(asCodeBlock({ mark: 'text', encoding: { x2: { value: 1 } } }));
+      mockedValidateVegaSpec.mockResolvedValue({
+        warnings: ['Infinite extent for field "count": [Infinity, -Infinity]'],
+      });
+
+      const state = await run({ esqlQuery: PROVIDED_ESQL });
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(state.error).toBeNull();
+      expect(state.spec).not.toBeNull();
+    });
   });
 
   it('rejects an authored spec with no renderable view and retries', async () => {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -16,6 +16,7 @@ import { buildTimeRangeParams } from '@kbn/agent-builder-genai-utils/tools/utils
 import { extractTextFromMessage } from '../utils/extract_text_from_message';
 import { generateVisualizationEsql } from '../shared/generate_visualization_esql';
 import { normalizeVegaSpec } from './normalize_spec';
+import { validateVegaSpec } from './vega_validator';
 import { createAuthorVegaSpecPrompt, vegaEsqlAdditionalInstructions } from './prompts';
 import { buildReferenceExamplesBlock } from './reference_examples';
 import {
@@ -106,6 +107,14 @@ const VegaStateAnnotation = Annotation.Root({
   existingEsql: Annotation<string | undefined>(),
   chartType: Annotation<SupportedChartType | undefined>(),
   // internal
+  /**
+   * Whether the model has already reviewed Vega warnings once. Further warnings
+   * are accepted so benign or unavoidable warnings cannot consume the retry budget.
+   */
+  warningsReviewed: Annotation<boolean>({
+    reducer: (_, newValue) => newValue,
+    default: () => false,
+  }),
   esqlQuery: Annotation<string>(),
   columns: Annotation<EsqlEsqlColumnInfo[] | undefined>(),
   currentAttempt: Annotation<number>({ reducer: (_, newValue) => newValue, default: () => 0 }),
@@ -125,8 +134,8 @@ type VegaState = typeof VegaStateAnnotation.State;
 /**
  * Build the LangGraph that authors a Vega-Lite spec: resolve an ES|QL query
  * (executing it for its result columns), ask the model to author a spec,
- * structurally check + normalize it, and retry authoring with error feedback
- * until it succeeds or the attempt budget is exhausted.
+ * normalize and compile/render-validate it, and retry authoring with error
+ * feedback until it succeeds or the attempt budget is exhausted.
  */
 export const createVegaGraph = async (
   modelProvider: ModelProvider,
@@ -247,7 +256,13 @@ export const createVegaGraph = async (
     const attempt = state.currentAttempt + 1;
     logger.debug(`Authoring Vega-Lite spec (attempt ${attempt}/${MAX_RETRY_ATTEMPTS})`);
 
-    // Feed back authoring and structural-check failures so the next attempt can fix them.
+    const reviewingWarnings = state.actions.some(
+      (action) =>
+        isValidateSpecAction(action) && action.success && (action.warnings?.length ?? 0) > 0
+    );
+
+    // Feed back authoring and validation failures, plus every Vega warning, so
+    // the next attempt can fix genuine issues.
     const previousContext = state.actions
       .filter((action) => isAuthorSpecAction(action) || isValidateSpecAction(action))
       .map((action) => {
@@ -259,13 +274,20 @@ export const createVegaGraph = async (
         if (!action.success) {
           return `Validation attempt ${action.attempt} failed: ${action.error}`;
         }
+        if (action.warnings && action.warnings.length > 0) {
+          return `Validation attempt ${
+            action.attempt
+          } rendered, but Vega emitted these warnings:\n${action.warnings
+            .map((warning) => `- ${warning}`)
+            .join('\n')}`;
+        }
         return undefined;
       })
       .filter(Boolean)
       .join('\n');
 
     const additionalContext = previousContext
-      ? `Previous attempts:\n${previousContext}\n\nPlease fix the errors above and return a single valid JSON object matching the response schema ("title" and "spec").`
+      ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object matching the response schema ("title" and "spec"). Fix any error above. For each warning, decide for yourself whether it signals a real authoring mistake (for example, an encoding or property Vega dropped or ignored) and fix it, or whether it is harmless or unavoidable and can be left as-is. Validation runs against empty sample data, so warnings about empty or infinite extents and disabled external data loading are expected. If a warning needs no change, keep that part of the spec unchanged.`
       : undefined;
 
     const prompt = createAuthorVegaSpecPrompt({
@@ -294,11 +316,12 @@ export const createVegaGraph = async (
     return {
       currentAttempt: attempt,
       actions: [action],
+      warningsReviewed: state.warningsReviewed || reviewingWarnings,
     };
   };
 
-  // Structurally check the authored spec (it must declare a renderable view),
-  // then normalize (harden) it into the render-ready form that is stored.
+  // Structurally check and normalize the authored spec, then compile and render
+  // it in isolation before storing it.
   const validateSpecNode = async (state: VegaState) => {
     const attempt = state.currentAttempt;
     const lastAuthor = [...state.actions].reverse().find(isAuthorSpecAction);
@@ -323,6 +346,17 @@ export const createVegaGraph = async (
         columns: state.columns,
       });
 
+      const { error: renderError, warnings } = await validateVegaSpec({
+        spec: normalized,
+        logger,
+      });
+      if (renderError) {
+        throw new Error(renderError);
+      }
+      if (warnings.length > 0) {
+        logger.debug(`Vega spec validated with warnings: ${warnings.join('; ')}`);
+      }
+
       action = {
         type: 'validate_spec',
         success: true,
@@ -330,6 +364,7 @@ export const createVegaGraph = async (
         spec: JSON.stringify(normalized, null, 2),
         title: lastAuthor.title,
         attempt,
+        warnings,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -349,7 +384,9 @@ export const createVegaGraph = async (
           isValidateSpecAction(action) && action.success && !!action.spec
       );
 
-    const chosen = rendered[0];
+    // Prefer the latest warning-free spec. If warning review did not clear all
+    // warnings, return the latest rendered spec rather than failing generation.
+    const chosen = rendered.find((action) => !action.warnings?.length) ?? rendered[0];
 
     if (chosen?.spec) {
       return { spec: chosen.spec, title: chosen.title ?? null, error: null };
@@ -390,8 +427,12 @@ export const createVegaGraph = async (
   const shouldRetryRouter = (state: VegaState): string => {
     const lastValidate = [...state.actions].reverse().find(isValidateSpecAction);
 
-    // Retry authoring when the spec failed the structural check, bounded by the budget.
-    if (lastValidate?.success) {
+    // Retry failed specs, and give successfully rendered warnings one bounded
+    // model review pass. Persistent warnings are accepted after that pass.
+    const hasWarnings = (lastValidate?.warnings?.length ?? 0) > 0;
+    const needsRepair = !lastValidate?.success || (hasWarnings && !state.warningsReviewed);
+
+    if (!needsRepair) {
       return FINALIZE_NODE;
     }
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.ts
@@ -287,7 +287,7 @@ export const createVegaGraph = async (
       .join('\n');
 
     const additionalContext = previousContext
-      ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object matching the response schema ("title" and "spec"). Fix any error above. For each warning, decide for yourself whether it signals a real authoring mistake (for example, an encoding or property Vega dropped or ignored) and fix it, or whether it is harmless or unavoidable and can be left as-is. Validation runs against empty sample data, so warnings about empty or infinite extents and disabled external data loading are expected. If a warning needs no change, keep that part of the spec unchanged.`
+      ? `Previous attempts:\n${previousContext}\n\nReturn a single valid JSON object matching the response schema ("title" and "spec"). Fix any error above. For each warning, decide for yourself whether it signals a real authoring mistake (for example, an encoding or property Vega dropped or ignored) and fix it, or whether it is harmless or unavoidable and can be left as-is. Validation runs against empty sample data, so warnings about empty or infinite extents are expected. If a warning needs no change, keep that part of the spec unchanged.`
       : undefined;
 
     const prompt = createAuthorVegaSpecPrompt({

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_distributable.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_distributable.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import Path from 'node:path';
+import * as Babel from '@babel/core';
+import {
+  requestRunner,
+  startHardenedRunner,
+  stopHardenedRunner,
+} from './vega_validator_test_utils';
+
+const SOURCE_WRAPPER_PATH = Path.resolve(__dirname, '../vega_validator_wrapper.cjs');
+const SOURCE_HOST_PATH = Path.resolve(__dirname, '../vega_validator.ts');
+const SOURCE_TASK_PATH = Path.resolve(__dirname, '../vega_validator_worker.ts');
+const TARGET_ROOT = Path.resolve(__dirname, '../../target');
+const requireForTest = createRequire(__filename);
+const { ImportLocator } = requireForTest('@kbn/import-locator') as {
+  ImportLocator: new () => {
+    get: (path: string, content: string) => Set<string>;
+  };
+};
+
+describe('Vega validator distributable', () => {
+  let buildDirectory: string;
+  let hardenedRunner: ReturnType<typeof startHardenedRunner>;
+
+  beforeAll(async () => {
+    await mkdir(TARGET_ROOT, { recursive: true });
+    buildDirectory = await mkdtemp(Path.join(TARGET_ROOT, 'vega-validator-dist-'));
+
+    const [wrapperSource, taskSource] = await Promise.all([
+      readFile(SOURCE_WRAPPER_PATH, 'utf8'),
+      readFile(SOURCE_TASK_PATH, 'utf8'),
+    ]);
+    const builtTask = Babel.transformSync(taskSource, {
+      babelrc: false,
+      configFile: false,
+      filename: SOURCE_TASK_PATH,
+      presets: [require.resolve('@kbn/babel-preset/node_preset')],
+    })?.code;
+    if (!builtTask) {
+      throw new Error('Babel failed to build the Vega validator worker task');
+    }
+
+    const builtWrapperPath = Path.join(buildDirectory, 'vega_validator_wrapper.cjs');
+    const setupNodeEnvDirectory = Path.join(
+      buildDirectory,
+      'node_modules',
+      '@kbn',
+      'setup-node-env'
+    );
+    await mkdir(setupNodeEnvDirectory, { recursive: true });
+    await Promise.all([
+      writeFile(builtWrapperPath, wrapperSource),
+      writeFile(Path.join(buildDirectory, 'vega_validator_worker.js'), builtTask),
+      // The setup package is built independently in a real distributable. This
+      // fixture keeps the smoke test focused on the validator's production
+      // layout while exercising the wrapper's production-only require path.
+      writeFile(Path.join(setupNodeEnvDirectory, 'dist.js'), 'module.exports = {};\n'),
+    ]);
+
+    hardenedRunner = startHardenedRunner({
+      workerPath: builtWrapperPath,
+      nodeEnv: 'production',
+    });
+  });
+
+  afterAll(async () => {
+    await stopHardenedRunner(hardenedRunner);
+    await rm(buildDirectory, { recursive: true, force: true });
+  });
+
+  it('loads the untransformed wrapper and transpiled task in production mode', async () => {
+    const result = await requestRunner(hardenedRunner, {
+      spec: {
+        $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+        data: { values: [] },
+        mark: 'bar',
+        encoding: { x: { field: 'status', type: 'nominal' } },
+      },
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true }));
+  });
+
+  it('exposes the wrapper and Vega packages to distributable dependency tracing', async () => {
+    const [hostSource, wrapperSource] = await Promise.all([
+      readFile(SOURCE_HOST_PATH, 'utf8'),
+      readFile(SOURCE_WRAPPER_PATH, 'utf8'),
+    ]);
+    const importLocator = new ImportLocator();
+
+    expect(importLocator.get(SOURCE_HOST_PATH, hostSource)).toContain(
+      './vega_validator_wrapper.cjs'
+    );
+    expect([...importLocator.get(SOURCE_WRAPPER_PATH, wrapperSource)]).toEqual(
+      expect.arrayContaining(['vega', 'vega-lite', 'vega-interpreter'])
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_hardened_runner.cjs
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_hardened_runner.cjs
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const { Worker } = require('node:worker_threads');
+
+const workerPath = process.env.VEGA_VALIDATOR_WORKER_PATH;
+if (!workerPath) {
+  throw new Error('VEGA_VALIDATOR_WORKER_PATH is required');
+}
+
+const worker = new Worker(workerPath);
+
+worker.on('message', (message) => process.send?.(message));
+worker.on('error', (error) => {
+  process.send?.({ ok: false, harnessError: error.message });
+});
+
+process.on('message', async (message) => {
+  if (message?.type === 'stop') {
+    await worker.terminate();
+    process.exit(0);
+  }
+
+  if (message?.type === 'probe-code-generation') {
+    const probe = new Worker(
+      `
+        const { parentPort } = require('node:worker_threads');
+        try {
+          Function('return true')();
+          parentPort.postMessage(false);
+        } catch (error) {
+          parentPort.postMessage(
+            error instanceof EvalError &&
+              error.message.includes('Code generation from strings disallowed')
+          );
+        }
+      `,
+      { eval: true }
+    );
+    const codeGenerationBlocked = await new Promise((resolve, reject) => {
+      probe.once('message', resolve);
+      probe.once('error', reject);
+    });
+    await probe.terminate();
+    process.send?.({ codeGenerationBlocked });
+    return;
+  }
+
+  worker.postMessage(message);
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_test_utils.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_test_utils.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fork, type ChildProcess } from 'node:child_process';
+
+export interface RunnerResponse {
+  ok?: boolean;
+  error?: string;
+  harnessError?: string;
+  warnings?: string[];
+  codeGenerationBlocked?: boolean;
+}
+
+const HARDENED_RUNNER_PATH = require.resolve('./vega_validator_hardened_runner.cjs');
+const REQUEST_TIMEOUT_MS = 15_000;
+const STOP_TIMEOUT_MS = 5_000;
+
+export const startHardenedRunner = ({
+  workerPath,
+  nodeEnv = process.env.NODE_ENV,
+}: {
+  workerPath: string;
+  nodeEnv?: string;
+}): ChildProcess =>
+  fork(HARDENED_RUNNER_PATH, {
+    execArgv: ['--disallow-code-generation-from-strings'],
+    env: {
+      ...process.env,
+      NODE_ENV: nodeEnv,
+      VEGA_VALIDATOR_WORKER_PATH: workerPath,
+    },
+    stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+  });
+
+export const requestRunner = <Response extends RunnerResponse>(
+  runner: ChildProcess,
+  message: object
+): Promise<Response> =>
+  new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      runner.off('error', onError);
+      runner.off('exit', onExit);
+      runner.off('message', onMessage);
+    };
+    const fail = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onError = (error: Error) => fail(error);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
+      fail(new Error(`Hardened runner exited before responding (code=${code}, signal=${signal})`));
+    const onMessage = (response: Response) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (response.harnessError) {
+        reject(new Error(response.harnessError));
+        return;
+      }
+      resolve(response);
+    };
+    const timer = setTimeout(
+      () => fail(new Error(`Hardened runner did not respond within ${REQUEST_TIMEOUT_MS}ms`)),
+      REQUEST_TIMEOUT_MS
+    );
+
+    runner.once('error', onError);
+    runner.once('exit', onExit);
+    runner.once('message', onMessage);
+    runner.send(message, (error) => {
+      if (error) {
+        fail(error);
+      }
+    });
+  });
+
+export const stopHardenedRunner = async (runner: ChildProcess): Promise<void> => {
+  if (!runner.connected || runner.exitCode !== null || runner.signalCode !== null) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const forceStop = setTimeout(() => runner.kill('SIGKILL'), STOP_TIMEOUT_MS);
+    const giveUp = setTimeout(resolve, STOP_TIMEOUT_MS + 2_000);
+    runner.once('exit', () => {
+      clearTimeout(forceStop);
+      clearTimeout(giveUp);
+      resolve();
+    });
+    runner.once('error', () => runner.kill('SIGKILL'));
+    runner.send({ type: 'stop' }, (error) => {
+      if (error) {
+        runner.kill('SIGKILL');
+      }
+    });
+  });
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_worker.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_worker.test.ts
@@ -110,7 +110,32 @@ describe('vega validator worker', () => {
     expect(result.error).toMatch(/Invalid field type/);
   });
 
-  it('does not fetch external lookup data during validation', async () => {
+  it('rejects a nested ES|QL lookup data source', async () => {
+    const result = await validate({
+      transform: [
+        {
+          lookup: 'OriginCountry',
+          from: {
+            data: {
+              url: {
+                '%type%': 'esql',
+                query: 'FROM logs-* | STATS count = COUNT() BY OriginCountry',
+              },
+            },
+            key: 'OriginCountry',
+            fields: ['OriginCountry'],
+          },
+        },
+      ],
+      mark: 'bar',
+      encoding: { x: { field: 'OriginCountry', type: 'nominal' } },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Nested or external data loading is not supported');
+  });
+
+  it('rejects nested external lookup data without fetching it', async () => {
     const server: Server = createServer((_request, response) => response.end('[]'));
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const requestedUrls: string[] = [];
@@ -136,12 +161,8 @@ describe('vega validator worker', () => {
         },
       });
 
-      expect(result.ok).toBe(true);
-      expect(result.warnings).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining('external loading disabled during validation'),
-        ])
-      );
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Nested or external data loading is not supported');
       expect(requestedUrls).toEqual([]);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_worker.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/integration_tests/vega_validator_worker.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  requestRunner,
+  startHardenedRunner,
+  stopHardenedRunner,
+  type RunnerResponse,
+} from './vega_validator_test_utils';
+
+interface WorkerResponse extends RunnerResponse {
+  ok: boolean;
+}
+
+const WORKER_PATH = require.resolve('../vega_validator_wrapper.cjs');
+
+const withEsqlData = (spec: Record<string, unknown>) => ({
+  $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+  data: { url: { '%type%': 'esql', query: 'FROM logs-*' } },
+  ...spec,
+});
+
+describe('vega validator worker', () => {
+  let hardenedRunner: ReturnType<typeof startHardenedRunner>;
+
+  beforeAll(() => {
+    hardenedRunner = startHardenedRunner({ workerPath: WORKER_PATH });
+  });
+
+  afterAll(async () => {
+    await stopHardenedRunner(hardenedRunner);
+  });
+
+  const validate = (spec: Record<string, unknown>): Promise<WorkerResponse> =>
+    requestRunner<WorkerResponse>(hardenedRunner, { spec: withEsqlData(spec) });
+
+  it('inherits the string-code-generation restriction in nested workers', async () => {
+    const result = await requestRunner(hardenedRunner, { type: 'probe-code-generation' });
+
+    expect(result.codeGenerationBlocked).toBe(true);
+  });
+
+  it('compiles and renders a valid spec when string code generation is disabled', async () => {
+    const result = await validate({
+      mark: 'bar',
+      encoding: {
+        x: { field: 'status', type: 'nominal' },
+        y: { field: 'count', type: 'quantitative' },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports incompatible polar encoding channels as warnings', async () => {
+    const result = await validate({
+      mark: { type: 'line', point: true },
+      encoding: {
+        theta: { field: 'metric', type: 'nominal' },
+        radius: { field: 'value', type: 'quantitative' },
+      },
+      projection: { type: 'polar' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        'theta dropped as it is incompatible with "line".',
+        'radius dropped as it is incompatible with "line".',
+        'theta dropped as it is incompatible with "point".',
+        'radius dropped as it is incompatible with "point".',
+      ])
+    );
+  });
+
+  it('evaluates spec expressions with the interpreter', async () => {
+    const result = await validate({
+      transform: [{ filter: 'datum.count > 0' }],
+      mark: 'point',
+      encoding: { x: { field: 'status', type: 'nominal' } },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports a render-time expression error', async () => {
+    const result = await validate({
+      transform: [{ filter: 'datum.count >' }],
+      mark: 'point',
+      encoding: { x: { field: 'status', type: 'nominal' } },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Unexpected end of input/);
+  });
+
+  it('reports a compile-time encoding error', async () => {
+    const result = await validate({
+      mark: 'bar',
+      encoding: { x: { field: 'status', type: 'not-a-real-type' } },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Invalid field type/);
+  });
+
+  it('does not fetch external lookup data during validation', async () => {
+    const server: Server = createServer((_request, response) => response.end('[]'));
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const requestedUrls: string[] = [];
+    server.on('request', (request) => requestedUrls.push(request.url ?? ''));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const result = await validate({
+        transform: [
+          {
+            lookup: 'status',
+            from: {
+              data: { url: `http://127.0.0.1:${port}/external-lookup` },
+              key: 'status',
+              fields: ['label'],
+            },
+          },
+        ],
+        mark: 'bar',
+        encoding: {
+          x: { field: 'status', type: 'nominal' },
+          y: { field: 'count', type: 'quantitative' },
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('external loading disabled during validation'),
+        ])
+      );
+      expect(requestedUrls).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.test.ts
@@ -34,6 +34,12 @@ describe('createAuthorVegaSpecPrompt', () => {
     expect(systemText('any chart')).toContain('DOTS IN FIELD NAMES');
   });
 
+  it('forbids secondary and nested data sources', () => {
+    const text = systemText('any chart');
+    expect(text).toContain('Do not add secondary or nested data sources');
+    expect(text).toContain('lookup.from.data.url');
+  });
+
   it('guides faceting: columns as a sibling and explicit per-cell sizing', () => {
     const text = systemText('small multiples of bytes by client ip');
     expect(text).toContain('FACETING / SMALL MULTIPLES');

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/prompts.ts
@@ -74,8 +74,9 @@ ${existingSpec}
 }
 DATA SOURCE RULES:
 1. Bind the data with Kibana's inline ES|QL source: a top-level "data": { "url": { "%type%": "esql", "query": <the exact query below> } }. Use the query verbatim — do not modify it; the system re-binds and validates it.
-2. The spec is built around this ES|QL query; its result columns are the only fields you may reference in encodings: ${esqlQueryJson}
-3. Reference each column by its exact name as produced by the query. If the query uses the time-picker params (?_tstart / ?_tend), add "%timefield%": "@timestamp" to the url so Kibana binds the time range.
+2. Do not add secondary or nested data sources. In particular, never use lookup.from.data.url, another ES|QL source, or an external URL; transforms must use the top-level query results.
+3. The spec is built around this ES|QL query; its result columns are the only fields you may reference in encodings: ${esqlQueryJson}
+4. Reference each column by its exact name as produced by the query. If the query uses the time-picker params (?_tstart / ?_tend), add "%timefield%": "@timestamp" to the url so Kibana binds the time range.
 
 Columns available in the data (reference these EXACT names):
 <columns>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import { validateVegaSpec } from './vega_validator';
+
+interface PostedMessage {
+  spec: Record<string, unknown>;
+}
+
+type Handler = (arg: unknown) => void;
+
+class MockWorker {
+  public readonly posted: PostedMessage[] = [];
+  public readonly terminate = jest.fn().mockResolvedValue(0);
+  private readonly handlers: Record<string, Handler[]> = {};
+
+  on(event: string, callback: Handler) {
+    (this.handlers[event] ??= []).push(callback);
+    return this;
+  }
+
+  postMessage(message: PostedMessage) {
+    this.posted.push(message);
+  }
+
+  emit(event: string, arg?: unknown) {
+    (this.handlers[event] ?? []).forEach((callback) => callback(arg));
+  }
+}
+
+const mockWorkerInstances: MockWorker[] = [];
+
+jest.mock('node:worker_threads', () => ({
+  isMainThread: true,
+  Worker: jest.fn().mockImplementation(() => {
+    const instance = new MockWorker();
+    mockWorkerInstances.push(instance);
+    return instance;
+  }),
+}));
+
+const createLogger = (): Logger =>
+  ({ debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() } as unknown as Logger);
+
+describe('validateVegaSpec', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    mockWorkerInstances.length = 0;
+    logger = createLogger();
+  });
+
+  const lastWorker = () => mockWorkerInstances[mockWorkerInstances.length - 1];
+
+  it('returns warnings reported by a successful validation', async () => {
+    const promise = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+    lastWorker().emit('message', { ok: true, warnings: ['Infinite extent for field'] });
+
+    await expect(promise).resolves.toEqual({
+      error: undefined,
+      warnings: ['Infinite extent for field'],
+    });
+  });
+
+  it('returns validation errors reported by the worker', async () => {
+    const promise = validateVegaSpec({ spec: { mark: 'bogus' }, logger });
+    lastWorker().emit('message', { ok: false, error: 'Unrecognized mark bogus' });
+
+    await expect(promise).resolves.toEqual({
+      error: 'Unrecognized mark bogus',
+      warnings: [],
+    });
+  });
+
+  it('caps worker memory and terminates it after validation', async () => {
+    const promise = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+    lastWorker().emit('message', { ok: true, warnings: [] });
+    await promise;
+
+    const { Worker } = jest.requireMock('node:worker_threads');
+    expect(Worker).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.objectContaining({ resourceLimits: { maxOldGenerationSizeMb: 128 } })
+    );
+    expect(lastWorker().terminate).toHaveBeenCalled();
+  });
+
+  it('fails open and terminates the worker when validation times out', async () => {
+    jest.useFakeTimers();
+    try {
+      const promise = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+      jest.advanceTimersByTime(10_000);
+
+      await expect(promise).resolves.toEqual({ warnings: [] });
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('timed out'));
+      expect(lastWorker().terminate).toHaveBeenCalled();
+
+      const nextPromise = validateVegaSpec({ spec: { mark: 'line' }, logger });
+      expect(mockWorkerInstances).toHaveLength(2);
+      lastWorker().emit('message', { ok: true, warnings: [] });
+      await nextPromise;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fails open when the worker reports an infrastructure failure', async () => {
+    const promise = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+    lastWorker().emit('message', { ok: false, infraError: "Cannot find module 'vega'" });
+
+    await expect(promise).resolves.toEqual({ warnings: [] });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Cannot find module 'vega'"));
+  });
+
+  it('fails open and releases capacity when the worker cannot start', async () => {
+    const { Worker } = jest.requireMock('node:worker_threads');
+    Worker.mockImplementationOnce(() => {
+      throw new Error('worker unavailable');
+    });
+
+    await expect(validateVegaSpec({ spec: { mark: 'bar' }, logger })).resolves.toEqual({
+      warnings: [],
+    });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('worker unavailable'));
+
+    const nextPromise = validateVegaSpec({ spec: { mark: 'line' }, logger });
+    lastWorker().emit('message', { ok: true, warnings: [] });
+    await nextPromise;
+  });
+
+  it('fails open when the worker crashes', async () => {
+    const promise = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+    lastWorker().emit('error', new Error('worker crashed'));
+
+    await expect(promise).resolves.toEqual({ warnings: [] });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('worker crashed'));
+  });
+
+  it('fails open when the worker exits before responding', async () => {
+    const promise = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+    lastWorker().emit('exit', 1);
+
+    await expect(promise).resolves.toEqual({ warnings: [] });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('exited before responding'));
+    expect(lastWorker().terminate).toHaveBeenCalled();
+  });
+
+  it('limits concurrent workers and fails open when capacity is exhausted', async () => {
+    const first = validateVegaSpec({ spec: { mark: 'bar' }, logger });
+    const second = validateVegaSpec({ spec: { mark: 'line' }, logger });
+
+    await expect(validateVegaSpec({ spec: { mark: 'point' }, logger })).resolves.toEqual({
+      warnings: [],
+    });
+    expect(mockWorkerInstances).toHaveLength(2);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('capacity'));
+
+    mockWorkerInstances[0].emit('message', { ok: true, warnings: [] });
+    mockWorkerInstances[1].emit('message', { ok: true, warnings: [] });
+    await Promise.all([first, second]);
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.test.ts
@@ -150,18 +150,30 @@ describe('validateVegaSpec', () => {
     expect(lastWorker().terminate).toHaveBeenCalled();
   });
 
-  it('limits concurrent workers and fails open when capacity is exhausted', async () => {
+  it('queues excess validations and runs them when capacity becomes available', async () => {
     const first = validateVegaSpec({ spec: { mark: 'bar' }, logger });
     const second = validateVegaSpec({ spec: { mark: 'line' }, logger });
-
-    await expect(validateVegaSpec({ spec: { mark: 'point' }, logger })).resolves.toEqual({
-      warnings: [],
+    const queued = validateVegaSpec({
+      spec: { transform: [{ calculate: 'undefined', as: 'broken' }], mark: 'point' },
+      logger,
     });
+
     expect(mockWorkerInstances).toHaveLength(2);
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('capacity'));
 
     mockWorkerInstances[0].emit('message', { ok: true, warnings: [] });
+    await first;
+
+    expect(mockWorkerInstances).toHaveLength(3);
+    mockWorkerInstances[2].emit('message', {
+      ok: false,
+      error: 'Unrecognized signal name: "undefined"',
+    });
+    await expect(queued).resolves.toEqual({
+      error: 'Unrecognized signal name: "undefined"',
+      warnings: [],
+    });
+
     mockWorkerInstances[1].emit('message', { ok: true, warnings: [] });
-    await Promise.all([first, second]);
+    await second;
   });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.ts
@@ -26,6 +26,26 @@ const WORKER_MAX_OLD_GEN_MB = 128;
 const MAX_CONCURRENT_VALIDATIONS = 2;
 
 let activeValidationCount = 0;
+const pendingValidationSlots: Array<() => void> = [];
+
+const acquireValidationSlot = (): Promise<void> | undefined => {
+  if (activeValidationCount < MAX_CONCURRENT_VALIDATIONS) {
+    activeValidationCount += 1;
+    return;
+  }
+
+  return new Promise<void>((resolve) => pendingValidationSlots.push(resolve));
+};
+
+const releaseValidationSlot = (): void => {
+  const next = pendingValidationSlots.shift();
+  if (next) {
+    next();
+    return;
+  }
+
+  activeValidationCount -= 1;
+};
 
 /**
  * Compile and headless-render a Vega-Lite spec in an isolated worker. Spec
@@ -39,14 +59,12 @@ export const validateVegaSpec = async ({
   spec: Record<string, unknown>;
   logger: Logger;
 }): Promise<VegaValidationResult> => {
-  if (activeValidationCount >= MAX_CONCURRENT_VALIDATIONS) {
-    logger.warn(
-      `Vega validator is at capacity (${MAX_CONCURRENT_VALIDATIONS}); skipping validation`
-    );
-    return { warnings: [] };
+  const pendingSlot = acquireValidationSlot();
+  if (pendingSlot) {
+    logger.debug(`Vega validator is at capacity (${MAX_CONCURRENT_VALIDATIONS}); waiting`);
+    await pendingSlot;
   }
 
-  activeValidationCount += 1;
   let worker: Worker | undefined;
 
   try {
@@ -128,6 +146,6 @@ export const validateVegaSpec = async ({
         );
       }
     }
-    activeValidationCount -= 1;
+    releaseValidationSlot();
   }
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Worker } from 'node:worker_threads';
+import type { Logger } from '@kbn/logging';
+import workerPath from './vega_validator_wrapper.cjs';
+
+export interface VegaValidationResult {
+  error?: string;
+  warnings: string[];
+}
+
+interface WorkerResponse {
+  ok: boolean;
+  error?: string;
+  infraError?: string;
+  warnings?: string[];
+}
+
+const VALIDATION_TIMEOUT_MS = 10_000;
+const WORKER_MAX_OLD_GEN_MB = 128;
+const MAX_CONCURRENT_VALIDATIONS = 2;
+
+let activeValidationCount = 0;
+
+/**
+ * Compile and headless-render a Vega-Lite spec in an isolated worker. Spec
+ * errors are returned to the authoring graph; infrastructure failures fail open
+ * so validation cannot block visualization generation.
+ */
+export const validateVegaSpec = async ({
+  spec,
+  logger,
+}: {
+  spec: Record<string, unknown>;
+  logger: Logger;
+}): Promise<VegaValidationResult> => {
+  if (activeValidationCount >= MAX_CONCURRENT_VALIDATIONS) {
+    logger.warn(
+      `Vega validator is at capacity (${MAX_CONCURRENT_VALIDATIONS}); skipping validation`
+    );
+    return { warnings: [] };
+  }
+
+  activeValidationCount += 1;
+  let worker: Worker | undefined;
+
+  try {
+    let activeWorker: Worker;
+    try {
+      activeWorker = new Worker(workerPath, {
+        resourceLimits: { maxOldGenerationSizeMb: WORKER_MAX_OLD_GEN_MB },
+      });
+      worker = activeWorker;
+    } catch (error) {
+      logger.warn(
+        `Could not start Vega validator worker: ${error instanceof Error ? error.message : error}`
+      );
+      return { warnings: [] };
+    }
+
+    return await new Promise<VegaValidationResult>((resolve) => {
+      let settled = false;
+      const settle = (result: VegaValidationResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      const timer = setTimeout(() => {
+        logger.warn('Vega validation timed out; skipping');
+        settle({ warnings: [] });
+      }, VALIDATION_TIMEOUT_MS);
+
+      activeWorker.on('message', (response: WorkerResponse) => {
+        if (response.infraError) {
+          logger.warn(`Vega validator could not load the Vega libraries: ${response.infraError}`);
+          settle({ warnings: [] });
+          return;
+        }
+
+        settle({
+          error: response.ok ? undefined : response.error,
+          warnings: response.warnings ?? [],
+        });
+      });
+
+      activeWorker.on('error', (error) => {
+        logger.warn(`Vega validator worker error: ${error.message}`);
+        settle({ warnings: [] });
+      });
+
+      activeWorker.on('exit', (code) => {
+        if (settled) {
+          return;
+        }
+        logger.warn(`Vega validator worker exited before responding (code ${code})`);
+        settle({ warnings: [] });
+      });
+
+      try {
+        activeWorker.postMessage({ spec });
+      } catch (error) {
+        logger.warn(
+          `Could not send Vega spec to validator worker: ${
+            error instanceof Error ? error.message : error
+          }`
+        );
+        settle({ warnings: [] });
+      }
+    });
+  } finally {
+    if (worker) {
+      try {
+        await worker.terminate();
+      } catch (error) {
+        logger.warn(
+          `Could not terminate Vega validator worker: ${
+            error instanceof Error ? error.message : error
+          }`
+        );
+      }
+    }
+    activeValidationCount -= 1;
+  }
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator_worker.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator_worker.ts
@@ -38,6 +38,8 @@ interface ValidationRequest {
 
 type LoadVegaLibs = () => Promise<VegaLibs>;
 
+const EXTERNAL_LOADING_DISABLED_REASON = 'external loading disabled during validation';
+
 const inlineData = (spec: Record<string, unknown>): Record<string, unknown> => ({
   ...spec,
   data: { values: [] },
@@ -48,7 +50,7 @@ const inlineData = (spec: Record<string, unknown>): Record<string, unknown> => (
  * URL cannot cause an SSRF request or local-file read from the Kibana server.
  */
 const createRejectingLoader = (): VegaLoader => {
-  const reject = () => Promise.reject(new Error('external loading disabled during validation'));
+  const reject = () => Promise.reject(new Error(EXTERNAL_LOADING_DISABLED_REASON));
   return { load: reject, sanitize: reject };
 };
 
@@ -95,6 +97,12 @@ const validate = async (
     await view.runAsync();
   } finally {
     view.finalize();
+  }
+
+  if (warnings.some((warning) => warning.includes(EXTERNAL_LOADING_DISABLED_REASON))) {
+    throw new Error(
+      'Nested or external data loading is not supported; use only the top-level ES|QL data source.'
+    );
   }
 
   return warnings;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator_worker.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator_worker.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parentPort } from 'node:worker_threads';
+
+type CompileFn = (spec: object, opts: { logger: unknown }) => { spec: object };
+type ParseFn = (spec: object, config: undefined, opts: { ast: boolean }) => object;
+
+interface VegaView {
+  runAsync: () => Promise<unknown>;
+  finalize: () => void;
+}
+
+interface VegaLoader {
+  load: (uri: string) => Promise<string>;
+  sanitize: (uri: string) => Promise<{ href: string }>;
+}
+
+type ViewCtor = new (
+  runtime: object,
+  opts: { renderer: 'none'; logger: unknown; loader: VegaLoader; expr: unknown }
+) => VegaView;
+
+interface VegaLibs {
+  compile: CompileFn;
+  parse: ParseFn;
+  View: ViewCtor;
+  expressionInterpreter: unknown;
+}
+
+interface ValidationRequest {
+  spec: Record<string, unknown>;
+}
+
+type LoadVegaLibs = () => Promise<VegaLibs>;
+
+const inlineData = (spec: Record<string, unknown>): Record<string, unknown> => ({
+  ...spec,
+  data: { values: [] },
+});
+
+/**
+ * Validation never needs external data. Reject every load so an LLM-authored
+ * URL cannot cause an SSRF request or local-file read from the Kibana server.
+ */
+const createRejectingLoader = (): VegaLoader => {
+  const reject = () => Promise.reject(new Error('external loading disabled during validation'));
+  return { load: reject, sanitize: reject };
+};
+
+const createCollectingLogger = (warnings: string[]) => ({
+  _level: 2,
+  level(this: { _level: number }, value?: number) {
+    if (value === undefined) {
+      return this._level;
+    }
+    this._level = value;
+    return this;
+  },
+  error(...args: unknown[]) {
+    throw new Error(args.join(' '));
+  },
+  warn(...args: unknown[]) {
+    warnings.push(args.join(' '));
+    return this;
+  },
+  info() {
+    return this;
+  },
+  debug() {
+    return this;
+  },
+});
+
+const validate = async (
+  { compile, parse, View, expressionInterpreter }: VegaLibs,
+  spec: Record<string, unknown>
+): Promise<string[]> => {
+  const warnings: string[] = [];
+  const logger = createCollectingLogger(warnings);
+  const { spec: vegaSpec } = compile(inlineData(spec), { logger });
+  const runtime = parse(vegaSpec, undefined, { ast: true });
+  const view = new View(runtime, {
+    renderer: 'none',
+    logger,
+    loader: createRejectingLoader(),
+    expr: expressionInterpreter,
+  });
+
+  try {
+    await view.runAsync();
+  } finally {
+    view.finalize();
+  }
+
+  return warnings;
+};
+
+/**
+ * Register the worker message handler. The untransformed CJS wrapper injects
+ * ESM-only Vega libraries loaded with native import(), keeping this TypeScript
+ * task free of Babel-rewritten imports and string-based code generation.
+ */
+export const startVegaValidatorWorker = (loadVegaLibs: LoadVegaLibs): void => {
+  let libs: Promise<VegaLibs> | undefined;
+  const getLibs = () => {
+    libs ??= loadVegaLibs();
+    return libs;
+  };
+
+  parentPort?.on('message', async ({ spec }: ValidationRequest) => {
+    let vegaLibs: VegaLibs;
+    try {
+      vegaLibs = await getLibs();
+    } catch (error) {
+      parentPort?.postMessage({
+        ok: false,
+        infraError: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    try {
+      const warnings = await validate(vegaLibs, spec);
+      parentPort?.postMessage({ ok: true, warnings });
+    } catch (error) {
+      parentPort?.postMessage({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator_wrapper.cjs
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator_wrapper.cjs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const { isMainThread } = require('node:worker_threads');
+
+// Requiring this module on Kibana's main thread returns the path while keeping
+// the worker-only bootstrap inert. A regular require also lets the distributable
+// dependency scanner discover the native imports below.
+module.exports = __filename;
+
+if (!isMainThread) {
+  if (process.env.NODE_ENV !== 'production') {
+    require('@kbn/setup-node-env');
+  } else {
+    require('@kbn/setup-node-env/dist');
+  }
+
+  const { startVegaValidatorWorker } = require('./vega_validator_worker');
+
+  const loadVegaLibs = async () => {
+    const [vegaLite, vega, vegaInterpreter] = await Promise.all([
+      import('vega-lite'),
+      import('vega'),
+      import('vega-interpreter'),
+    ]);
+
+    return {
+      compile: vegaLite.compile,
+      parse: vega.parse,
+      View: vega.View,
+      expressionInterpreter: vegaInterpreter.expressionInterpreter,
+    };
+  };
+
+  startVegaValidatorWorker(loadVegaLibs);
+}


### PR DESCRIPTION
## Summary

This restores the server-side Vega-Lite validator removed in #279513 while addressing the ESM-loading issue identified in #276534: the ESM-only Vega libraries are now loaded with native `import()` from an untransformed `.cjs` worker wrapper, so validation works when Node disables string code generation.

- compile and headless-render normalized specs in a per-request worker with `vega-interpreter`, a rejecting data loader, a 10-second timeout, a 128 MB old-generation limit, and a global concurrency cap
- fail open on validator infrastructure failures so visualization generation remains available
- feed Vega warnings back to the authoring model for one bounded review pass, including dropped encoding channels such as incompatible `theta`/`radius` encodings
- cover the worker under `--disallow-code-generation-from-strings` and exercise a production-like transpiled/distributable layout and dependency tracing

## Test plan

- [x] `node scripts/check.js --scope=local`
- [x] `node scripts/jest x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/graph.test.ts x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/vega/vega_validator.test.ts --runInBand`
- [x] `node scripts/jest_integration --config=x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/jest.integration.config.js`
- [x] `node scripts/type_check --project x-pack/platform/packages/shared/agent-builder/agent-builder-visualizations-server/tsconfig.json`