### PR TITLE
Cancel in-flight Lens searches on embeddable unmount

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
@@ -630,4 +630,45 @@ describe('Data Loader', () => {
       }
     );
   });
+
+  it('should abort in-flight searches on cleanup', async () => {
+    const abortController = new AbortController();
+    const abortSpy = jest.spyOn(abortController, 'abort');
+    const parentApi = {
+      ...createUnifiedSearchApi(),
+      searchSessionId$: new BehaviorSubject<string>(''),
+      esqlVariables$: new BehaviorSubject<ESQLControlVariable[] | undefined>([]),
+    };
+    const api: LensApi = {
+      ...getLensApiMock(),
+      parentApi,
+    };
+    const runtimeState: LensRuntimeState = { attributes: getLensAttributesMock() };
+    const getState = jest.fn(() => runtimeState);
+    const internalApi = getLensInternalApiMock({
+      attributes$: new BehaviorSubject(runtimeState.attributes),
+      expressionAbortController$: new BehaviorSubject<AbortController | undefined>(abortController),
+    });
+    const services = {
+      ...makeEmbeddableServices(new BehaviorSubject<string>(''), undefined, {
+        visOverrides: { id: 'lnsXY' },
+        dataOverrides: { id: 'formBased' },
+      }),
+      documentToExpression: jest.fn().mockResolvedValue({ ast: 'expression_string' }),
+    };
+    const { cleanup } = loadEmbeddableData(
+      faker.string.uuid(),
+      getState,
+      api,
+      parentApi,
+      internalApi,
+      services
+    );
+
+    expect(abortSpy).not.toHaveBeenCalled();
+
+    cleanup();
+
+    expect(abortSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -406,6 +406,8 @@ export function loadEmbeddableData(
 
   return {
     cleanup: () => {
+      // Cancel any in-flight searches to reduce load on the Elasticsearch cluster
+      internalApi.expressionAbortController$.getValue()?.abort();
       for (const subscription of subscriptions) {
         subscription.unsubscribe();
       }

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -406,7 +406,6 @@ export function loadEmbeddableData(
 
   return {
     cleanup: () => {
-      // Cancel any in-flight searches to reduce load on the Elasticsearch cluster
       internalApi.expressionAbortController$.getValue()?.abort();
       for (const subscription of subscriptions) {
         subscription.unsubscribe();


### PR DESCRIPTION
When a Lens embeddable unmounts (for example, when a user navigates away from a dashboard), its cleanup only unsubscribed from RxJS subscriptions. Any in-flight Elasticsearch queries kept running, adding unnecessary load to the cluster.

This adds one line to the `cleanup` function in `data_loader.ts` to abort the current expression abort controller (`internalApi.expressionAbortController$`), which signals the expressions plugin and the underlying search service to cancel pending requests.

A unit test verifies that `cleanup()` calls `.abort()` on the active abort controller.

Closes #278516