### PR TITLE
Upgrade websocket-driver to 0.7.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -35972,9 +35972,9 @@ webpack@5, webpack@5.96.1, webpack@^5:
     webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
## Summary

Relocks `websocket-driver` from 0.7.4 to 0.7.5 to pick up upstream fixes. Lockfile-only change; the existing semver ranges (`^0.7.4` / `>=0.5.1`) already allow it, so no `package.json` changes are needed.

Validated with `yarn kbn bootstrap`.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->