### PR TITLE
Enable the Attack Discovery 2.0: Workflows Integration feature flag

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/index.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/index.test.ts
@@ -33,6 +33,7 @@ interface ParsedStep {
   type: string;
   'create-conversation'?: boolean;
   'connector-id'?: string;
+  'max-step-size'?: string;
   'on-failure'?: unknown;
   status?: string;
   with?: Record<string, unknown>;
@@ -65,8 +66,8 @@ describe('ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW', () => {
     expect(ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW.pluginId).toBe('discoveries');
   });
 
-  it('bumps the version to 11 for the remove_alert_ids (exception-set) gate contract', () => {
-    expect(ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW.version).toBe(11);
+  it('bumps the version to 12 for max-step-size on the ai.agent gate step', () => {
+    expect(ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW.version).toBe(12);
   });
 
   it('titles the workflow "Security - Attack discovery - Skill"', () => {
@@ -107,6 +108,10 @@ describe('ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW', () => {
 
   describe('gate (ai.agent) step', () => {
     const step = getStep('ai.agent');
+
+    it('sets max-step-size to 2 MiB to avoid hitting maxResponseContentLength on large completions', () => {
+      expect(step['max-step-size']).toBe('2097152b');
+    });
 
     it('persists the conversation via create-conversation', () => {
       expect(step['create-conversation']).toBe(true);
@@ -303,6 +308,10 @@ describe('ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW', () => {
     expect(ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW.pluginId).toBe('discoveries');
   });
 
+  it('bumps the version to 3 for max-step-size on the ai.agent render_report step', () => {
+    expect(ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW.version).toBe(3);
+  });
+
   it('is discoverable from the managed registry by id', () => {
     expect(getManagedWorkflowDefinition(ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW_ID)).toBe(
       ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW
@@ -321,6 +330,10 @@ describe('ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW', () => {
 
   describe('render_report (ai.agent) step', () => {
     const step = getReportStep('ai.agent');
+
+    it('sets max-step-size to 2 MiB to avoid hitting maxResponseContentLength on large report completions', () => {
+      expect(step['max-step-size']).toBe('2097152b');
+    });
 
     it('continues the existing conversation via the conversation_id input', () => {
       expect(step.with?.conversation_id).toBe('${{ inputs.conversation_id }}');

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/index.ts
@@ -47,7 +47,7 @@ export const ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW = {
   id: ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW_ID,
   management: MANAGEMENT,
   pluginId: 'discoveries',
-  version: 11,
+  version: 12,
   yaml: SKILL_ALERT_RETRIEVAL_YAML,
 } as const satisfies ManagedWorkflowDefinition;
 
@@ -56,7 +56,7 @@ export const ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW = {
   id: ATTACK_DISCOVERY_SKILL_REPORT_WORKFLOW_ID,
   management: MANAGEMENT,
   pluginId: 'discoveries',
-  version: 2,
+  version: 3,
   yaml: SKILL_REPORT_YAML,
 } as const satisfies ManagedWorkflowDefinition;
 

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/skill_alert_retrieval.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/skill_alert_retrieval.yaml
@@ -88,6 +88,7 @@ steps:
   - name: gate
     type: ai.agent
     timeout: '10m'
+    max-step-size: '2097152b'
     create-conversation: true
     # Route the skill's model calls through the connector selected for this
     # generation (Constraint A). When the input is empty/omitted, this renders

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/skill_report.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/discoveries/skill_report.yaml
@@ -59,6 +59,7 @@ steps:
   - name: render_report
     type: ai.agent
     timeout: '10m'
+    max-step-size: '2097152b'
     # Route the skill's model calls through the connector selected for this
     # generation (Constraint A). When the input is empty/omitted, this renders
     # to undefined and the step falls back to the Agent Builder default model.

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -188,7 +188,7 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
   },
   'securitySolution:enableAttackDiscoveryWorkflows': {
     type: 'boolean',
-    _meta: { description: 'Non-default value of setting.' },
+    _meta: { description: 'Enables Attack Discovery Workflows for this space.' },
   },
   'securitySolution:enableRuleChangesHistory': {
     type: 'boolean',

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -186,6 +186,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'securitySolution:enableAttackDiscoveryWorkflows': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'securitySolution:enableRuleChangesHistory': {
     type: 'boolean',
     _meta: { description: 'Allows users to enable/disable Rule Changes History.' },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -95,6 +95,7 @@ export interface UsageStats {
   'securitySolution:defaultValueReportRate': string;
   'securitySolution:defaultValueReportTitle': string;
   'securitySolution:enableAlertsAndAttacksAlignment': boolean;
+  'securitySolution:enableAttackDiscoveryWorkflows': boolean;
   'securitySolution:enableRuleChangesHistory': boolean;
   'search:includeFrozen': boolean;
   'courier:maxConcurrentShardRequests': number;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11207,6 +11207,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:enableAttackDiscoveryWorkflows": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Enables Attack Discovery Workflows for this space."
+          }
+        },
         "securitySolution:enableRuleChangesHistory": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/generation/run_manual_orchestration/index.test.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/generation/run_manual_orchestration/index.test.ts
@@ -442,7 +442,7 @@ describe('runManualOrchestration', () => {
 
     it('throws instead of returning a silent no_alerts outcome', async () => {
       await expect(runManualOrchestration(baseParams)).rejects.toThrow(
-        /sole source.*gate added 0 alerts/i
+        /No alerts were available to analyze for the selected time range/i
       );
     });
 

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/generation/run_manual_orchestration/index.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/generation/run_manual_orchestration/index.ts
@@ -306,7 +306,7 @@ export const runManualOrchestration = async ({
       ) {
         throw new AttackDiscoveryError({
           errorCategory: ERROR_CATEGORIES.validation_error,
-          message: `Gate returned no alerts: the skill's additional retrieval was the sole source (0 deterministic candidate alerts) but the gate added 0 alerts (execution_uuid=${executionUuid}). Failing closed instead of reporting a silent no-alerts outcome.`,
+          message: `No alerts were available to analyze for the selected time range: no candidate alerts were retrieved and the skill's additional retrieval returned none (execution_uuid=${executionUuid}).`,
           workflowId: ATTACK_DISCOVERY_SKILL_ALERT_RETRIEVAL_WORKFLOW_ID,
         });
       }

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.test.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.test.ts
@@ -165,6 +165,49 @@ describe('getAnonymizedAlerts', () => {
     });
   });
 
+  it('searches with a plain ids query (no time range, no open/acknowledged status) when an ids filter is provided', async () => {
+    // The shared builder always injects a @timestamp range + open/acknowledged status
+    // clause; for an exact-id re-fetch (skill mode) we must bypass those so the
+    // gate-curated ids resolve regardless of the alert's age or workflow status.
+    (getOpenAndAcknowledgedAlertsQuery as jest.Mock).mockReturnValue({
+      index: [alertsIndexPattern],
+      size,
+      fields: [{ field: '*', include_unmapped: true }],
+      query: {
+        bool: {
+          filter: [
+            {
+              bool: {
+                should: [{ match_phrase: { 'kibana.alert.workflow_status': 'open' } }],
+                minimum_should_match: 1,
+              },
+            },
+            { range: { '@timestamp': { gte: 'now-24h', lte: 'now' } } },
+          ],
+        },
+      },
+    });
+
+    const alertIds = ['alert-id-1', 'alert-id-2'];
+
+    await getAnonymizedAlerts({
+      alertsIndexPattern,
+      esClient: mockEsClient,
+      filter: { ids: { values: alertIds } },
+      size,
+    });
+
+    const searchArg = (mockEsClient.search as unknown as jest.Mock).mock.calls[0][0];
+
+    expect(searchArg.query).toEqual({ ids: { values: alertIds } });
+    // the non-query scaffolding (index/size/fields) is preserved so anonymization still works
+    expect(searchArg.size).toBe(size);
+    expect(searchArg.fields).toEqual([{ field: '*', include_unmapped: true }]);
+    // the time and status constraints are gone
+    expect(JSON.stringify(searchArg)).not.toContain('@timestamp');
+    expect(JSON.stringify(searchArg)).not.toContain('workflow_status');
+  });
+
   it('returns the expected transformed (anonymized) raw data', async () => {
     const result = await getAnonymizedAlerts({
       alertsIndexPattern,

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.ts
@@ -52,7 +52,31 @@ export const getAnonymizedAlerts = async ({
     start,
   });
 
-  const result = await esClient.search<SearchResponse>(query);
+  // Exact-id re-fetch (skill mode): when the caller passes an `ids` filter it has
+  // already selected the precise documents to fetch (the gate-curated alerts). The
+  // shared builder unconditionally ANDs an open/acknowledged status clause and a
+  // `@timestamp` range (defaulting to now-24h) onto every query, which would drop
+  // curated alerts that are older than that window or not open/acknowledged. Override
+  // just the query clause with a plain `ids` query so those documents resolve exactly,
+  // regardless of age or status. The rest of the request (index/size/fields/_source/
+  // sort) is preserved so anonymization is unchanged. Only the id re-fetch passes an
+  // `ids` filter, so no other retrieval path is affected.
+  const rawIds =
+    filter != null && typeof filter === 'object' && 'ids' in filter
+      ? (filter as Record<string, unknown>).ids
+      : undefined;
+  const idsValues =
+    rawIds != null &&
+    typeof rawIds === 'object' &&
+    'values' in rawIds &&
+    Array.isArray((rawIds as { values?: unknown }).values)
+      ? (rawIds as { values: string[] }).values
+      : undefined;
+
+  const searchRequest =
+    idsValues != null ? { ...query, query: { ids: { values: idsValues } } } : query;
+
+  const result = await esClient.search<SearchResponse>(searchRequest);
 
   // Accumulate replacements locally so we can, for example use the same
   // replacement for a hostname when we see it in multiple alerts:

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/lib/helpers/is_workflows_enabled/index.test.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/lib/helpers/is_workflows_enabled/index.test.ts
@@ -8,14 +8,14 @@
 import { ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG, isWorkflowsEnabled } from '.';
 
 describe('isWorkflowsEnabled', () => {
-  it('queries the attackDiscoveryWorkflowsEnabled flag with a safe `false` default', async () => {
+  it('queries the attackDiscoveryWorkflowsEnabled flag with a `true` default (ON by default)', async () => {
     const getBooleanValue = jest.fn().mockResolvedValue(true);
 
     await isWorkflowsEnabled({ getBooleanValue });
 
     expect(getBooleanValue).toHaveBeenCalledWith(
       ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG,
-      false
+      true
     );
   });
 

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/lib/helpers/is_workflows_enabled/index.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/lib/helpers/is_workflows_enabled/index.ts
@@ -20,4 +20,4 @@ export const ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG =
 export const isWorkflowsEnabled = (
   featureFlags: Pick<CoreStart['featureFlags'], 'getBooleanValue'>
 ): Promise<boolean> =>
-  featureFlags.getBooleanValue(ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG, false);
+  featureFlags.getBooleanValue(ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG, true);

--- a/x-pack/solutions/security/packages/navigation/index.ts
+++ b/x-pack/solutions/security/packages/navigation/index.ts
@@ -9,10 +9,11 @@ export { useGetAppUrl, useNavigateTo, useNavigation } from './src/navigation';
 export type { GetAppUrl, NavigateTo } from './src/navigation';
 export { NavigationProvider } from './src/context';
 export {
-  SecurityPageName,
-  SecurityGroupName,
+  ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING,
+  ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
   LinkCategoryType,
   SECURITY_UI_APP_ID,
-  ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
+  SecurityGroupName,
+  SecurityPageName,
 } from './src/constants';
 export * from './src/types';

--- a/x-pack/solutions/security/packages/navigation/src/constants.ts
+++ b/x-pack/solutions/security/packages/navigation/src/constants.ts
@@ -36,6 +36,10 @@ export enum SecurityGroupName {
   alertDetections = 'securityGroup:alertDetections',
 }
 
+/** This Kibana Advanced Setting allows users to enable/disable Attack Discovery 2.0 Workflows per space */
+export const ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING =
+  'securitySolution:enableAttackDiscoveryWorkflows' as const;
+
 /** This Kibana Advanced Setting allows users to enable/disable the Alerts and Attacks Alignment feature */
 export const ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING =
   'securitySolution:enableAlertsAndAttacksAlignment' as const;

--- a/x-pack/solutions/security/plugins/discoveries/moon.yml
+++ b/x-pack/solutions/security/plugins/discoveries/moon.yml
@@ -58,6 +58,7 @@ dependsOn:
   - '@kbn/core-logging-server-mocks'
   - '@kbn/alerts-as-data-utils'
   - '@kbn/core-elasticsearch-client-server-mocks'
+  - '@kbn/core-ui-settings-server'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/discoveries/public/plugin.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/plugin.ts
@@ -51,7 +51,7 @@ export class DiscoveriesPublicPlugin
         const [coreStart] = await core.getStartServices();
         const enabled = await coreStart.featureFlags.getBooleanValue(
           ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG,
-          false
+          true
         );
         return enabled ? definition : undefined;
       };

--- a/x-pack/solutions/security/plugins/discoveries/server/agent_builder/skills/tools/run_attack_discovery_tool/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/agent_builder/skills/tools/run_attack_discovery_tool/index.test.ts
@@ -17,6 +17,7 @@ import { RUN_ATTACK_DISCOVERY_TOOL_ID, getRunAttackDiscoveryTool } from '.';
 const mockExecuteGenerationWorkflow = jest.fn();
 const mockResolveConnectorDetails = jest.fn();
 const mockGetDefaultModel = jest.fn();
+const mockIsWorkflowsEnabledForSpace = jest.fn();
 
 jest.mock('@kbn/discoveries/impl/attack_discovery/generation/execute_generation_workflow', () => ({
   executeGenerationWorkflow: (...args: unknown[]) => mockExecuteGenerationWorkflow(...args),
@@ -24,6 +25,10 @@ jest.mock('@kbn/discoveries/impl/attack_discovery/generation/execute_generation_
 
 jest.mock('../../../../workflows/helpers/resolve_connector_details', () => ({
   resolveConnectorDetails: (...args: unknown[]) => mockResolveConnectorDetails(...args),
+}));
+
+jest.mock('../../../../lib/is_workflows_enabled_for_space', () => ({
+  isWorkflowsEnabledForSpace: (...args: unknown[]) => mockIsWorkflowsEnabledForSpace(...args),
 }));
 
 const FAKE_REQUEST = httpServerMock.createKibanaRequest();
@@ -34,7 +39,12 @@ const buildToolDeps = () => ({
   getEventLogIndex: jest.fn().mockResolvedValue('event-log-*'),
   getEventLogger: jest.fn().mockResolvedValue({}),
   getStartServices: jest.fn().mockResolvedValue({
-    coreStart: {} as unknown,
+    coreStart: {
+      featureFlags: { getBooleanValue: jest.fn().mockResolvedValue(true) },
+      uiSettings: {
+        asScopedToClient: jest.fn().mockReturnValue({ get: jest.fn().mockResolvedValue(true) }),
+      },
+    } as unknown,
     pluginsStart: {
       actions: {
         getActionsClientWithRequest: jest
@@ -108,6 +118,8 @@ describe('RUN_ATTACK_DISCOVERY_TOOL_ID', () => {
 describe('getRunAttackDiscoveryTool', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockIsWorkflowsEnabledForSpace.mockResolvedValue(true);
 
     mockResolveConnectorDetails.mockResolvedValue({
       actionTypeId: '.gen-ai',
@@ -199,7 +211,12 @@ describe('getRunAttackDiscoveryTool', () => {
     const authz = { actions: { api: { get: jest.fn() } } };
     const deps = buildToolDeps();
     deps.getStartServices = jest.fn().mockResolvedValue({
-      coreStart: {} as unknown,
+      coreStart: {
+        featureFlags: { getBooleanValue: jest.fn().mockResolvedValue(true) },
+        uiSettings: {
+          asScopedToClient: jest.fn().mockReturnValue({ get: jest.fn().mockResolvedValue(true) }),
+        },
+      } as unknown,
       pluginsStart: {
         actions: {
           getActionsClientWithRequest: jest
@@ -330,5 +347,31 @@ describe('getRunAttackDiscoveryTool', () => {
     const result = await invokeHandler({});
 
     expect(result.data).not.toHaveProperty('attack_discoveries');
+  });
+
+  describe('per-space setting check', () => {
+    it('returns an error result when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const result = await invokeHandler({});
+
+      expect(result.type).toBe(ToolResultType.error);
+    });
+
+    it('does not call executeGenerationWorkflow when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      await invokeHandler({});
+
+      expect(mockExecuteGenerationWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('error message mentions the space setting when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const result = await invokeHandler({});
+
+      expect((result.data as { message: string }).message).toContain('not enabled for this space');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/discoveries/server/agent_builder/skills/tools/run_attack_discovery_tool/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/agent_builder/skills/tools/run_attack_discovery_tool/index.ts
@@ -19,6 +19,7 @@ import { z } from '@kbn/zod/v4';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getAlertsIndexForSpace } from '../../../../lib/get_alerts_index_for_space';
+import { isWorkflowsEnabledForSpace } from '../../../../lib/is_workflows_enabled_for_space';
 import type { DiscoveriesPluginStartDeps } from '../../../../types';
 import { checkManagedWorkflowIntegrity } from '../../../../managed_workflows/check_managed_workflow_integrity';
 import { resolveConnectorDetails } from '../../../../workflows/helpers/resolve_connector_details';
@@ -191,7 +192,18 @@ export const getRunAttackDiscoveryTool = ({
     } = args;
 
     try {
-      const { pluginsStart } = await getStartServices();
+      const { coreStart, pluginsStart } = await getStartServices();
+
+      if (
+        !(await isWorkflowsEnabledForSpace({
+          featureFlags: coreStart.featureFlags,
+          uiSettingsClient: coreStart.uiSettings.asScopedToClient(context.savedObjectsClient),
+        }))
+      ) {
+        return {
+          results: [buildErrorResult('Attack Discovery workflows are not enabled for this space.')],
+        };
+      }
 
       // Resolve the space the same way `executeGenerationWorkflow` does for its
       // authorization guard, so the alerts index is bounded to the caller's own

--- a/x-pack/solutions/security/plugins/discoveries/server/agent_builder/skills/workflow_troubleshooting/workflow_troubleshooting_skill.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/agent_builder/skills/workflow_troubleshooting/workflow_troubleshooting_skill.ts
@@ -125,9 +125,9 @@ problem, not a pipeline problem. Diagnose the report run separately:
 
 ## Gate Returned No Alerts (skill additional retrieval was the sole source)
 
-A failure_reason of \`Gate returned no alerts: the skill's additional retrieval was the
-sole source (0 deterministic candidate alerts) but the gate added 0 alerts … Failing
-closed\` is a **fail-closed guard**, not a silent "no matching alerts" success. It means
+A failure_reason of \`No alerts were available to analyze for the selected time range: no
+candidate alerts were retrieved and the skill's additional retrieval returned none\` is a
+**fail-closed guard**, not a silent "no matching alerts" success. It means
 the run had **no deterministic candidate alerts** — the gate's own additional retrieval
 was the ONLY source of alerts — AND the gate emitted an empty \`added_alert_ids\` (it
 either retrieved nothing or dropped everything it retrieved). Rather than report zero
@@ -625,10 +625,10 @@ changes for this category.
 
 ### validation_error
 
-**Pattern:** Error messages containing "Gate returned no alerts", "sole source", or
-"Failing closed", or a generation-phase failure whose \`failed_step\` is \`alert_retrieval\`
-with a failure_reason that names the gate. The most common case is the **gate sole-source
-zero-alerts guard**: the skill's additional retrieval was the only source of alerts (every
+**Pattern:** Error messages containing "No alerts were available to analyze" or "the
+skill's additional retrieval returned none", or a generation-phase failure whose
+\`failed_step\` is \`alert_retrieval\`. The most common case is the **gate sole source
+zero-alerts guard**: the skill's additional retrieval was the sole source of alerts (every
 deterministic retrieval toggle off, skill toggle on) and the gate emitted an empty
 \`added_alert_ids\`, so the pipeline fails closed instead of reporting a silent "no matching
 alerts" success.

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/assert_workflows_enabled/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/assert_workflows_enabled/index.test.ts
@@ -10,11 +10,19 @@ import type { RequestHandlerContext } from '@kbn/core/server';
 
 import { assertWorkflowsEnabled, ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG } from '.';
 
-const createMockContext = (featureFlagValue: boolean): RequestHandlerContext =>
+const createMockContext = (
+  featureFlagValue: boolean,
+  uiSettingValue = true
+): RequestHandlerContext =>
   ({
     core: Promise.resolve({
       featureFlags: {
         getBooleanValue: jest.fn().mockResolvedValue(featureFlagValue),
+      },
+      uiSettings: {
+        client: {
+          get: jest.fn().mockResolvedValue(uiSettingValue),
+        },
       },
     }),
   } as unknown as RequestHandlerContext);
@@ -50,14 +58,20 @@ describe('assertWorkflowsEnabled', () => {
     const context = {
       core: Promise.resolve({
         featureFlags: { getBooleanValue },
+        uiSettings: {
+          client: { get: jest.fn().mockResolvedValue(true) },
+        },
       }),
     } as unknown as RequestHandlerContext;
 
     await assertWorkflowsEnabled({ context, response });
 
+    // isWorkflowsEnabled (used internally) defaults to true (fail-open for the
+    // FF layer); fail-closed is enforced by the per-space uiSetting defaulting
+    // to false.
     expect(getBooleanValue).toHaveBeenCalledWith(
       ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG,
-      false
+      true
     );
   });
 
@@ -67,6 +81,9 @@ describe('assertWorkflowsEnabled', () => {
         featureFlags: {
           getBooleanValue: jest.fn().mockResolvedValue(null),
         },
+        uiSettings: {
+          client: { get: jest.fn().mockResolvedValue(true) },
+        },
       }),
     } as unknown as RequestHandlerContext;
 
@@ -74,5 +91,24 @@ describe('assertWorkflowsEnabled', () => {
 
     expect(result).not.toBeNull();
     expect(response.notFound).toHaveBeenCalled();
+  });
+
+  it('returns null when FF is on and per-space setting is on', async () => {
+    const context = createMockContext(true, true);
+
+    const result = await assertWorkflowsEnabled({ context, response });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns a 404 response when FF is on but per-space setting is off', async () => {
+    const context = createMockContext(true, false);
+
+    const result = await assertWorkflowsEnabled({ context, response });
+
+    expect(result).not.toBeNull();
+    expect(response.notFound).toHaveBeenCalledWith({
+      body: { message: 'Attack Discovery workflows are not enabled' },
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/assert_workflows_enabled/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/assert_workflows_enabled/index.ts
@@ -8,12 +8,15 @@
 import type { KibanaResponseFactory, RequestHandlerContext } from '@kbn/core/server';
 import { ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG } from '@kbn/discoveries/impl/lib/helpers/is_workflows_enabled';
 
+import { isWorkflowsEnabledForSpace } from '../is_workflows_enabled_for_space';
+
 export { ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG };
 
 /**
- * Checks the `attackDiscoveryWorkflowsEnabled` feature flag via the request
- * context. Returns a 404 response when the flag is OFF, or `null` when the
- * flag is ON (indicating the caller may proceed).
+ * Checks both the global `attackDiscoveryWorkflowsEnabled` feature flag AND the
+ * per-space `securitySolution:enableAttackDiscoveryWorkflows` Advanced Setting via the
+ * request context. Returns a 404 response when either is OFF, or `null` when
+ * both are ON (indicating the caller may proceed).
  */
 export const assertWorkflowsEnabled = async ({
   context,
@@ -23,11 +26,10 @@ export const assertWorkflowsEnabled = async ({
   response: KibanaResponseFactory;
 }): Promise<ReturnType<KibanaResponseFactory['notFound']> | null> => {
   const coreContext = await context.core;
-  const enabled =
-    (await coreContext?.featureFlags?.getBooleanValue(
-      ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG,
-      false
-    )) ?? false;
+  const enabled = await isWorkflowsEnabledForSpace({
+    featureFlags: coreContext.featureFlags,
+    uiSettingsClient: coreContext.uiSettings.client,
+  });
 
   if (!enabled) {
     return response.notFound({

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/is_workflows_enabled_for_space/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/is_workflows_enabled_for_space/index.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/server';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
+
+import { isWorkflowsEnabledForSpace } from '.';
+
+const FEATURE_FLAG_KEY = 'securitySolution.attackDiscoveryWorkflowsEnabled';
+const UI_SETTING_KEY = 'securitySolution:enableAttackDiscoveryWorkflows';
+
+const buildFeatureFlags = (value: boolean): CoreStart['featureFlags'] =>
+  ({
+    getBooleanValue: jest.fn().mockResolvedValue(value),
+  } as unknown as CoreStart['featureFlags']);
+
+const buildUiSettingsClient = (value: boolean): IUiSettingsClient =>
+  ({
+    get: jest.fn().mockResolvedValue(value),
+  } as unknown as IUiSettingsClient);
+
+describe('isWorkflowsEnabledForSpace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns false when FF is off and per-space setting is off', async () => {
+    const result = await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(false),
+      uiSettingsClient: buildUiSettingsClient(false),
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when FF is off and per-space setting is on', async () => {
+    const result = await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(false),
+      uiSettingsClient: buildUiSettingsClient(true),
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when FF is on and per-space setting is off', async () => {
+    const result = await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(true),
+      uiSettingsClient: buildUiSettingsClient(false),
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when FF is on and per-space setting is on', async () => {
+    const result = await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(true),
+      uiSettingsClient: buildUiSettingsClient(true),
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('does not read the uiSetting when FF is off (short-circuits)', async () => {
+    const uiSettingsClient = buildUiSettingsClient(true);
+
+    await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(false),
+      uiSettingsClient,
+    });
+
+    expect(uiSettingsClient.get).not.toHaveBeenCalled();
+  });
+
+  it('reads the correct uiSetting key', async () => {
+    const uiSettingsClient = buildUiSettingsClient(true);
+
+    await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(true),
+      uiSettingsClient,
+    });
+
+    expect(uiSettingsClient.get).toHaveBeenCalledWith(UI_SETTING_KEY);
+  });
+
+  it('reads the correct feature flag key', async () => {
+    const featureFlags = buildFeatureFlags(true);
+    const uiSettingsClient = buildUiSettingsClient(true);
+
+    await isWorkflowsEnabledForSpace({ featureFlags, uiSettingsClient });
+
+    expect(featureFlags.getBooleanValue).toHaveBeenCalledWith(FEATURE_FLAG_KEY, expect.anything());
+  });
+
+  it('returns false when uiSetting returns null', async () => {
+    const uiSettingsClient = {
+      get: jest.fn().mockResolvedValue(null),
+    } as unknown as IUiSettingsClient;
+
+    const result = await isWorkflowsEnabledForSpace({
+      featureFlags: buildFeatureFlags(true),
+      uiSettingsClient,
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/is_workflows_enabled_for_space/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/is_workflows_enabled_for_space/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
+import { isWorkflowsEnabled } from '@kbn/discoveries/impl/lib/helpers/is_workflows_enabled';
+
+// ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING is defined in @kbn/security-solution-navigation but
+// that package is not a declared dependency of the discoveries plugin. Inline the
+// constant here rather than introduce a cross-boundary import.
+const ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING = 'securitySolution:enableAttackDiscoveryWorkflows';
+
+/**
+ * Returns true only when BOTH the global feature flag
+ * (`securitySolution.attackDiscoveryWorkflowsEnabled`) AND the per-space
+ * Advanced Setting (`securitySolution:enableAttackDiscoveryWorkflows`) are enabled.
+ *
+ * Short-circuits: if the feature flag is off, the UI setting is never read.
+ */
+export const isWorkflowsEnabledForSpace = async ({
+  featureFlags,
+  uiSettingsClient,
+}: {
+  featureFlags: Pick<Parameters<typeof isWorkflowsEnabled>[0], 'getBooleanValue'>;
+  uiSettingsClient: IUiSettingsClient;
+}): Promise<boolean> => {
+  if (!(await isWorkflowsEnabled(featureFlags))) return false;
+
+  return (await uiSettingsClient.get<boolean>(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING)) ?? false;
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/schedules/workflow_executor/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/schedules/workflow_executor/index.test.ts
@@ -17,6 +17,12 @@ import { WorkflowExecutionAuthorizationError } from '@kbn/discoveries/impl/attac
 import { workflowExecutor, type WorkflowExecutorDeps } from '.';
 import { executeGenerationWorkflow } from '../../../routes/generate/helpers';
 
+const mockIsWorkflowsEnabledForSpace = jest.fn();
+
+jest.mock('../../is_workflows_enabled_for_space', () => ({
+  isWorkflowsEnabledForSpace: (...args: unknown[]) => mockIsWorkflowsEnabledForSpace(...args),
+}));
+
 const mockGenerateHash = jest.fn().mockReturnValue('mock-alert-hash');
 const mockTransformToBaseAlertDocument = jest.fn().mockReturnValue({
   'kibana.alert.url': 'https://localhost:5601/app/security/attack_discovery/mock-doc-id',
@@ -193,6 +199,8 @@ describe('workflowExecutor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockIsWorkflowsEnabledForSpace.mockResolvedValue(true);
+
     (executeGenerationWorkflow as jest.Mock).mockResolvedValue(mockSuccessOutcome);
 
     (ruleExecutorServices.alertsClient.report as jest.Mock).mockReturnValue({
@@ -259,6 +267,47 @@ describe('workflowExecutor', () => {
           validation_workflow_id: 'default',
         },
         workflowsManagementApi: mockWorkflowsManagementApi,
+      })
+    );
+  });
+
+  it('derives composite toggles from a legacy custom_only workflowConfig (backward compat)', async () => {
+    // Legacy-persisted schedules only carry the single-enum shape (no `skillEnabled`),
+    // so the executor must derive the composite toggles. `custom_only` meant
+    // "default retrieval off, custom workflows only".
+    const options = {
+      ...executorOptions,
+      params: { ...params, workflowConfig: { alertRetrievalMode: 'custom_only' } },
+    } as unknown as RuleExecutorOptions;
+
+    await workflowExecutor({ deps, options });
+
+    expect(executeGenerationWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowConfig: expect.objectContaining({
+          alert_retrieval_mode: 'custom_query',
+          default_retrieval_enabled: false,
+          skill_enabled: true,
+        }),
+      })
+    );
+  });
+
+  it('derives default_retrieval_enabled=false from legacy defaultAlertRetrievalEnabled=false', async () => {
+    const options = {
+      ...executorOptions,
+      params: { ...params, workflowConfig: { defaultAlertRetrievalEnabled: false } },
+    } as unknown as RuleExecutorOptions;
+
+    await workflowExecutor({ deps, options });
+
+    expect(executeGenerationWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowConfig: expect.objectContaining({
+          alert_retrieval_mode: 'custom_query',
+          default_retrieval_enabled: false,
+          skill_enabled: true,
+        }),
       })
     );
   });
@@ -872,6 +921,27 @@ describe('workflowExecutor', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('no discoveries to persist')
       );
+    });
+  });
+
+  describe('per-space setting check', () => {
+    it('returns { state: {} } without calling executeGenerationWorkflow when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const options = { ...executorOptions } as unknown as RuleExecutorOptions;
+
+      const result = await workflowExecutor({ deps, options });
+
+      expect(executeGenerationWorkflow).not.toHaveBeenCalled();
+      expect(result).toEqual({ state: {} });
+    });
+
+    it('does not throw when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const options = { ...executorOptions } as unknown as RuleExecutorOptions;
+
+      await expect(workflowExecutor({ deps, options })).resolves.toBeDefined();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/schedules/workflow_executor/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/schedules/workflow_executor/index.ts
@@ -40,6 +40,7 @@ import {
   executeGenerationWorkflow,
   getInferredPrebuiltStepTypes,
 } from '../../../routes/generate/helpers';
+import { isWorkflowsEnabledForSpace } from '../../is_workflows_enabled_for_space';
 import type { DiscoveriesPluginStartDeps } from '../../../types';
 import { checkManagedWorkflowIntegrity } from '../../../managed_workflows/check_managed_workflow_integrity';
 import { wrapManagementApiForScheduledExecution } from './helpers/wrap_management_api_for_scheduled_execution';
@@ -149,8 +150,20 @@ export const workflowExecutor = async ({
       ? wrapManagementApiForScheduledExecution(deps.workflowsManagementApi)
       : deps.workflowsManagementApi;
 
-  const { pluginsStart } = await deps.getStartServices();
+  const { coreStart, pluginsStart } = await deps.getStartServices();
   const { authz } = pluginsStart.security;
+
+  const spaceEnabled = await isWorkflowsEnabledForSpace({
+    featureFlags: coreStart.featureFlags,
+    uiSettingsClient: services.uiSettingsClient,
+  });
+
+  if (!spaceEnabled) {
+    tracedLogger.info(
+      `[AD] Attack Discovery workflows disabled for this space — skipping scheduled run`
+    );
+    return { state: {} };
+  }
 
   try {
     const orchestrationOutcome = await executeGenerationWorkflow({

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.test.ts
@@ -15,6 +15,12 @@ jest.mock('./constants', () => ({
   ATTACK_DISCOVERY_RUN_SOFT_DEADLINE_MS: 25,
 }));
 
+const mockIsWorkflowsEnabledForSpace = jest.fn();
+
+jest.mock('../../../lib/is_workflows_enabled_for_space', () => ({
+  isWorkflowsEnabledForSpace: (...args: unknown[]) => mockIsWorkflowsEnabledForSpace(...args),
+}));
+
 import { getRunStepDefinition } from './get_run_step_definition';
 
 const mockExecuteGenerationWorkflow = jest.fn();
@@ -195,6 +201,8 @@ describe('getRunStepDefinition', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockIsWorkflowsEnabledForSpace.mockResolvedValue(true);
 
     mockResolveConnectorDetails.mockResolvedValue({
       actionTypeId: '.gen-ai',
@@ -760,6 +768,38 @@ describe('getRunStepDefinition', () => {
         execution_uuid: 'test-execution-uuid',
         status: 'completed',
       });
+    });
+  });
+
+  describe('per-space setting check', () => {
+    it('returns an error result when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.error).toBeDefined();
+    });
+
+    it('does not call executeGenerationWorkflow when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const stepDefinition = getStepDefinition();
+
+      await stepDefinition.handler(syncMockContext as never);
+
+      expect(mockExecuteGenerationWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('error message mentions the space setting when isWorkflowsEnabledForSpace returns false', async () => {
+      mockIsWorkflowsEnabledForSpace.mockResolvedValue(false);
+
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.error?.message).toContain('not enabled for this space');
     });
   });
 

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.ts
@@ -16,6 +16,7 @@ import { getSpaceId } from '@kbn/discoveries/impl/lib/helpers/get_space_id';
 
 import { RunStepCommonDefinition } from '../../../../common/step_types/run_step';
 import { getAlertsIndexForSpace } from '../../../lib/get_alerts_index_for_space';
+import { isWorkflowsEnabledForSpace } from '../../../lib/is_workflows_enabled_for_space';
 import type { DiscoveriesPluginStartDeps } from '../../../types';
 import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
 import { resolveDefaultConnectorId } from '../../helpers/resolve_default_connector_id';
@@ -80,6 +81,19 @@ export const getRunStepDefinition = ({
         const { coreStart, pluginsStart } = await getStartServices();
         const request = context.contextManager.getFakeRequest();
 
+        const uiSettingsClient = coreStart.uiSettings.asScopedToClient(
+          coreStart.savedObjects.getScopedClient(request)
+        );
+
+        if (
+          !(await isWorkflowsEnabledForSpace({
+            featureFlags: coreStart.featureFlags,
+            uiSettingsClient,
+          }))
+        ) {
+          throw new Error('Attack Discovery workflows are not enabled for this space');
+        }
+
         // Resolve the space from the (space-scoped) fake request the same way
         // `executeGenerationWorkflow` does for its authorization guard, so the
         // alerts index is bounded to the schedule's space rather than `-default`.
@@ -96,9 +110,7 @@ export const getRunStepDefinition = ({
               inference: pluginsStart.inference,
               logger,
               request,
-              uiSettingsClient: coreStart.uiSettings.asScopedToClient(
-                coreStart.savedObjects.getScopedClient(request)
-              ),
+              uiSettingsClient,
             });
 
         context.logger.info(

--- a/x-pack/solutions/security/plugins/discoveries/tsconfig.json
+++ b/x-pack/solutions/security/plugins/discoveries/tsconfig.json
@@ -52,6 +52,7 @@
     "@kbn/discoveries-schemas",
     "@kbn/core-logging-server-mocks",
     "@kbn/alerts-as-data-utils",
-    "@kbn/core-elasticsearch-client-server-mocks"
+    "@kbn/core-elasticsearch-client-server-mocks",
+    "@kbn/core-ui-settings-server"
   ]
 }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/privileges/get_missing_privileges.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/privileges/get_missing_privileges.test.ts
@@ -10,6 +10,7 @@ import { httpServiceMock, httpServerMock } from '@kbn/core-http-server-mocks';
 import type { SecurityHasPrivilegesResponse } from '@elastic/elasticsearch/lib/api/types';
 import { WORKFLOWS_MANAGEMENT_FEATURE_ID } from '@kbn/workflows';
 
+import { ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG } from '@kbn/discoveries/impl/lib/helpers/is_workflows_enabled';
 import { getMissingIndexPrivilegesInternalRoute } from './get_missing_privileges';
 import { getMissingWorkflowsPrivileges } from './get_missing_workflows_privileges';
 import * as helpers from '../../helpers';
@@ -212,6 +213,17 @@ describe('getMissingIndexPrivilegesInternalRoute', () => {
 
     beforeEach(() => {
       mockEsClient.security.hasPrivileges.mockResolvedValue({ body: allIndexPrivilegesGranted });
+    });
+
+    it('reads the workflows feature flag with a true default', async () => {
+      (mockContext.core.featureFlags.getBooleanValue as jest.Mock).mockResolvedValue(true);
+
+      await getHandler(mockContext, mockRequest, mockResponse);
+
+      expect(mockContext.core.featureFlags.getBooleanValue).toHaveBeenCalledWith(
+        ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG,
+        true
+      );
     });
 
     it('does not evaluate workflows privileges when the workflows feature flag is OFF', async () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/privileges/get_missing_privileges.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/privileges/get_missing_privileges.ts
@@ -124,7 +124,7 @@ export const getMissingIndexPrivilegesInternalRoute = (
           // the workflows feature flag is ON (they are not required otherwise).
           const workflowsEnabled = await core.featureFlags.getBooleanValue(
             ATTACK_DISCOVERY_WORKFLOWS_ENABLED_FEATURE_FLAG,
-            false
+            true
           );
 
           const missingFeaturePrivileges = workflowsEnabled

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -14,8 +14,9 @@ import * as i18n from './translations';
 import { MITRE_ATTACK_VERSION } from './detection_engine/mitre/mitre_version';
 
 export {
-  SecurityPageName,
+  ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING,
   ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
+  SecurityPageName,
 } from '@kbn/security-solution-navigation';
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/hooks/use_has_workflows_privileges/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/hooks/use_has_workflows_privileges/index.test.tsx
@@ -16,15 +16,25 @@ const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
 
 interface MockServicesOptions {
   executeWorkflow?: boolean;
+  featureFlagEnabled?: boolean;
   isWorkflowsEnabled?: boolean;
   readWorkflow?: boolean;
+  uiSettingEnabled?: boolean;
 }
 
 const mockServices = ({
   executeWorkflow,
+  featureFlagEnabled,
   isWorkflowsEnabled = true,
   readWorkflow,
+  uiSettingEnabled,
 }: MockServicesOptions) => {
+  // Allow callers to decouple FF and uiSetting (for off-diagonal matrix cells).
+  // When featureFlagEnabled / uiSettingEnabled are not provided, fall back to
+  // the combined isWorkflowsEnabled shorthand so existing callers are unchanged.
+  const ffValue = featureFlagEnabled !== undefined ? featureFlagEnabled : isWorkflowsEnabled;
+  const settingValue = uiSettingEnabled !== undefined ? uiSettingEnabled : isWorkflowsEnabled;
+
   mockUseKibana.mockReturnValue({
     services: {
       application: {
@@ -36,7 +46,10 @@ const mockServices = ({
         },
       },
       featureFlags: {
-        getBooleanValue: jest.fn().mockResolvedValue(isWorkflowsEnabled),
+        getBooleanValue: jest.fn().mockResolvedValue(ffValue),
+      },
+      uiSettings: {
+        get: jest.fn().mockReturnValue(settingValue),
       },
     },
   } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
@@ -45,6 +58,64 @@ const mockServices = ({
 describe('useHasWorkflowsPrivileges', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('when the feature flag is ON but the per-space uiSetting is OFF', () => {
+    beforeEach(() => {
+      mockServices({
+        executeWorkflow: true,
+        featureFlagEnabled: true,
+        readWorkflow: true,
+        uiSettingEnabled: false,
+      });
+    });
+
+    it('reports hasWorkflowsRead as true (inert — uiSetting OFF gates client, not privileges)', async () => {
+      const { result } = renderHook(() => useHasWorkflowsPrivileges());
+
+      await waitFor(() => expect(result.current.hasWorkflowsRead).toBe(true));
+    });
+
+    it('reports hasWorkflowsExecute as true (inert — uiSetting OFF gates client, not privileges)', async () => {
+      const { result } = renderHook(() => useHasWorkflowsPrivileges());
+
+      await waitFor(() => expect(result.current.hasWorkflowsExecute).toBe(true));
+    });
+
+    it('reports no missing feature privileges (inert when workflows disabled by uiSetting)', async () => {
+      const { result } = renderHook(() => useHasWorkflowsPrivileges());
+
+      await waitFor(() => expect(result.current.missingPrivileges.featurePrivileges).toEqual([]));
+    });
+  });
+
+  describe('when the feature flag is OFF but the per-space uiSetting is ON', () => {
+    beforeEach(() => {
+      mockServices({
+        executeWorkflow: false,
+        featureFlagEnabled: false,
+        readWorkflow: false,
+        uiSettingEnabled: true,
+      });
+    });
+
+    it('reports hasWorkflowsRead as true (inert — FF OFF prevents workflows)', async () => {
+      const { result } = renderHook(() => useHasWorkflowsPrivileges());
+
+      await waitFor(() => expect(result.current.hasWorkflowsRead).toBe(true));
+    });
+
+    it('reports hasWorkflowsExecute as true (inert — FF OFF prevents workflows)', async () => {
+      const { result } = renderHook(() => useHasWorkflowsPrivileges());
+
+      await waitFor(() => expect(result.current.hasWorkflowsExecute).toBe(true));
+    });
+
+    it('reports no missing feature privileges (inert when FF is off)', async () => {
+      const { result } = renderHook(() => useHasWorkflowsPrivileges());
+
+      await waitFor(() => expect(result.current.missingPrivileges.featurePrivileges).toEqual([]));
+    });
   });
 
   describe('when the attackDiscoveryWorkflowsEnabled feature flag is OFF', () => {
@@ -167,7 +238,7 @@ describe('useHasWorkflowsPrivileges', () => {
     });
   });
 
-  it('reads the feature flag with the correct key and default', async () => {
+  it('reads the feature flag with the correct key and a true default (ON by default)', async () => {
     mockServices({ executeWorkflow: true, readWorkflow: true });
 
     renderHook(() => useHasWorkflowsPrivileges());
@@ -177,7 +248,7 @@ describe('useHasWorkflowsPrivileges', () => {
     await waitFor(() =>
       expect(getBooleanValue).toHaveBeenCalledWith(
         'securitySolution.attackDiscoveryWorkflowsEnabled',
-        false
+        true
       )
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/hooks/use_has_workflows_privileges/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/hooks/use_has_workflows_privileges/index.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { WORKFLOWS_MANAGEMENT_FEATURE_ID, WorkflowsManagementUiActions } from '@kbn/workflows';
 
+import { ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING } from '../../../../../common/constants';
 import type { MissingPrivileges } from '../../../../common/hooks/use_missing_privileges';
 import { useKibana } from '../../../../common/lib/kibana';
 
@@ -39,20 +40,22 @@ export interface UseHasWorkflowsPrivileges {
  * missing privileges so nothing is gated and no callout is shown.
  */
 export const useHasWorkflowsPrivileges = (): UseHasWorkflowsPrivileges => {
-  const { application, featureFlags } = useKibana().services;
+  const { application, featureFlags, uiSettings } = useKibana().services;
   const [isWorkflowsEnabled, setIsWorkflowsEnabled] = useState<boolean>(false);
 
   useEffect(() => {
     let cancelled = false;
 
     const loadFeatureFlag = async () => {
-      const enabled = await featureFlags.getBooleanValue(
+      const ffEnabled = await featureFlags.getBooleanValue(
         'securitySolution.attackDiscoveryWorkflowsEnabled',
-        false
+        true
       );
 
       if (!cancelled) {
-        setIsWorkflowsEnabled(enabled);
+        setIsWorkflowsEnabled(
+          ffEnabled && uiSettings.get(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING, false)
+        );
       }
     };
 
@@ -61,7 +64,7 @@ export const useHasWorkflowsPrivileges = (): UseHasWorkflowsPrivileges => {
     return () => {
       cancelled = true;
     };
-  }, [featureFlags]);
+  }, [featureFlags, uiSettings]);
 
   return useMemo<UseHasWorkflowsPrivileges>(() => {
     if (!isWorkflowsEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
@@ -342,10 +342,12 @@ describe('AttackDiscovery', () => {
   describe('workflows insufficient privileges callout', () => {
     afterEach(() => {
       mockUseKibanaReturnValue.services.featureFlags.getBooleanValue.mockReturnValue(false);
+      mockUseKibanaReturnValue.services.uiSettings.get.mockReturnValue(false);
     });
 
     it('renders the insufficient privileges callout when workflows are enabled but privileges are missing', async () => {
       mockUseKibanaReturnValue.services.featureFlags.getBooleanValue.mockReturnValue(true);
+      mockUseKibanaReturnValue.services.uiSettings.get.mockReturnValue(true);
 
       render(
         <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.test.tsx
@@ -60,6 +60,9 @@ describe('LoadingCallout', () => {
         featureFlags: {
           getBooleanValue: jest.fn().mockResolvedValue(false),
         },
+        uiSettings: {
+          get: jest.fn().mockReturnValue(false),
+        },
         http: {},
         telemetry: { reportEvent: jest.fn() },
       },
@@ -142,6 +145,9 @@ describe('LoadingCallout', () => {
         featureFlags: {
           getBooleanValue: jest.fn().mockResolvedValue(true),
         },
+        uiSettings: {
+          get: jest.fn().mockReturnValue(true),
+        },
         http: {},
         telemetry: { reportEvent: jest.fn() },
       },
@@ -207,6 +213,9 @@ describe('LoadingCallout', () => {
         },
         featureFlags: {
           getBooleanValue: jest.fn().mockResolvedValue(true),
+        },
+        uiSettings: {
+          get: jest.fn().mockReturnValue(true),
         },
         http: {},
         telemetry: { reportEvent: jest.fn() },
@@ -282,6 +291,9 @@ describe('LoadingCallout', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
           http: {},
         },
       } as unknown as ReturnType<typeof useKibana>);
@@ -322,6 +334,9 @@ describe('LoadingCallout', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(false),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
           http: {},
           telemetry: { reportEvent: jest.fn() },
         },
@@ -352,6 +367,9 @@ describe('LoadingCallout', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(false),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
           http: {},
           telemetry: { reportEvent: jest.fn() },
         },
@@ -375,6 +393,110 @@ describe('LoadingCallout', () => {
       expect(screen.queryByTestId('workflowExecutionDetailsFlyout')).not.toBeInTheDocument();
     });
 
+    it('does not render the Details button when the feature flag is on but the uiSetting is off (FF on, setting off → disabled)', async () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          application: {
+            capabilities: {
+              workflowsManagement: {
+                readWorkflow: true,
+              },
+            },
+          },
+          featureFlags: {
+            getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
+          http: {},
+          telemetry: { reportEvent: jest.fn() },
+        },
+      } as unknown as ReturnType<typeof useKibana>);
+
+      render(
+        <TestProviders>
+          <LoadingCallout {...defaultProps} workflowId="workflow-123" workflowRunId="run-456" />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        expect(mockUseKibana().services.featureFlags.getBooleanValue).toHaveBeenCalled();
+      });
+
+      expect(screen.queryByTestId('detailsButton')).not.toBeInTheDocument();
+    });
+
+    it('reads the feature flag with a true default (ON by default)', async () => {
+      const getBooleanValue = jest.fn().mockResolvedValue(true);
+      mockUseKibana.mockReturnValue({
+        services: {
+          application: {
+            capabilities: {
+              workflowsManagement: {
+                readWorkflow: true,
+              },
+            },
+          },
+          featureFlags: {
+            getBooleanValue,
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
+          http: {},
+          telemetry: { reportEvent: jest.fn() },
+        },
+      } as unknown as ReturnType<typeof useKibana>);
+
+      render(
+        <TestProviders>
+          <LoadingCallout {...defaultProps} workflowId="workflow-123" workflowRunId="run-456" />
+        </TestProviders>
+      );
+
+      await waitFor(() =>
+        expect(getBooleanValue).toHaveBeenCalledWith(
+          'securitySolution.attackDiscoveryWorkflowsEnabled',
+          true
+        )
+      );
+    });
+
+    it('does not render the Details button when the feature flag is off but the uiSetting is on (FF off, setting on → disabled)', async () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          application: {
+            capabilities: {
+              workflowsManagement: {
+                readWorkflow: true,
+              },
+            },
+          },
+          featureFlags: {
+            getBooleanValue: jest.fn().mockResolvedValue(false),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
+          http: {},
+          telemetry: { reportEvent: jest.fn() },
+        },
+      } as unknown as ReturnType<typeof useKibana>);
+
+      render(
+        <TestProviders>
+          <LoadingCallout {...defaultProps} workflowId="workflow-123" workflowRunId="run-456" />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        expect(mockUseKibana().services.featureFlags.getBooleanValue).toHaveBeenCalled();
+      });
+
+      expect(screen.queryByTestId('detailsButton')).not.toBeInTheDocument();
+    });
+
     it('renders the Details button when feature flag is enabled and workflow IDs are present', async () => {
       mockUseKibana.mockReturnValue({
         services: {
@@ -387,6 +509,9 @@ describe('LoadingCallout', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
           },
           http: {},
         },
@@ -417,6 +542,9 @@ describe('LoadingCallout', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
           http: {},
         },
       } as unknown as ReturnType<typeof useKibana>);
@@ -445,6 +573,9 @@ describe('LoadingCallout', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
           },
           http: {},
           telemetry: { reportEvent: jest.fn() },
@@ -481,6 +612,9 @@ describe('LoadingCallout', () => {
           },
           http: {},
           telemetry: { reportEvent: jest.fn() },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
         },
       } as unknown as ReturnType<typeof useKibana>);
     };
@@ -550,6 +684,9 @@ describe('LoadingCallout', () => {
             },
           },
           featureFlags: { getBooleanValue: jest.fn().mockResolvedValue(true) },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
           http: {},
           telemetry: { reportEvent: jest.fn() },
         },

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
@@ -29,6 +29,7 @@ import * as i18n from './translations';
 import { getIsTerminalState } from './get_is_terminal_state';
 import { useDismissAttackDiscoveryGeneration } from '../use_dismiss_attack_discovery_generations';
 import { useHasWorkflowsPrivileges } from '../hooks/use_has_workflows_privileges';
+import { ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING } from '../../../../common/constants';
 import { useKibana } from '../../../common/lib/kibana';
 import { AttackDiscoveryEventTypes } from '../../../common/lib/telemetry';
 
@@ -112,23 +113,25 @@ const LoadingCalloutComponent: React.FC<Props> = ({
 }) => {
   const { euiTheme } = useEuiTheme();
   const isDarkMode = useKibanaIsDarkMode();
-  const { featureFlags, http, telemetry } = useKibana().services;
+  const { featureFlags, http, telemetry, uiSettings } = useKibana().services;
 
   const [isWorkflowsEnabled, setIsWorkflowsEnabled] = useState<boolean>(false);
 
   const { hasWorkflowsRead } = useHasWorkflowsPrivileges();
 
-  // Load feature flag value
+  // Load feature flag value and combine with per-space uiSetting opt-in
   useEffect(() => {
     const loadFeatureFlag = async () => {
-      const enabled = await featureFlags.getBooleanValue(
+      const ffEnabled = await featureFlags.getBooleanValue(
         'securitySolution.attackDiscoveryWorkflowsEnabled',
-        false
+        true
       );
-      setIsWorkflowsEnabled(enabled);
+      setIsWorkflowsEnabled(
+        ffEnabled && uiSettings.get(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING, false)
+      );
     };
     loadFeatureFlag();
-  }, [featureFlags]);
+  }, [featureFlags, uiSettings]);
 
   const isTerminalState = useMemo(() => getIsTerminalState(status), [status]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.test.tsx
@@ -684,7 +684,7 @@ describe('useSettingsView', () => {
       );
       useIsExperimentalFeatureEnabled.mockReturnValue(true);
 
-      // Mock the feature flag to return true
+      // Mock the feature flag to return true; also enable the per-space uiSetting opt-in
       mockUseKibana.mockReturnValue({
         services: {
           data: {
@@ -700,7 +700,7 @@ describe('useSettingsView', () => {
           },
           telemetry: { reportEvent: jest.fn() },
           uiSettings: {
-            get: jest.fn(),
+            get: jest.fn().mockReturnValue(true),
           },
           unifiedSearch: {
             ui: {
@@ -1594,6 +1594,148 @@ describe('useSettingsView', () => {
         expect(onSettingsSave).toHaveBeenCalled();
         expect(screen.queryByTestId('workflowValidationErrorsCallout')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('when the feature flag is ON but the per-space uiSetting is OFF (FF on, setting off → legacy)', () => {
+    beforeEach(() => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          data: {
+            query: {
+              filterManager: mockFilterManager,
+            },
+          },
+          featureFlags: {
+            getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          lens: {
+            EmbeddableComponent: () => <div data-test-subj="mockEmbeddableComponent" />,
+          },
+          telemetry: { reportEvent: jest.fn() },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
+          unifiedSearch: {
+            ui: {
+              SearchBar: (props: { onQuerySubmit: jest.Mock }) => {
+                if (props.onQuerySubmit) {
+                  mockOnQuerySubmit.mockImplementation(props.onQuerySubmit);
+                }
+                return <div data-test-subj="alertSelectionSearchBar" />;
+              },
+            },
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+    });
+
+    it('does not render the workflow configuration panel when the feature flag is on but the uiSetting is off (FF on, setting off → workflow panel absent)', async () => {
+      const { result, rerender } = renderHook(() => useSettingsView(defaultProps), {
+        wrapper: TestProviders,
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      rerender();
+
+      render(<TestProviders>{result.current.settingsView}</TestProviders>);
+
+      expect(screen.queryByTestId('workflowConfigurationPanel')).not.toBeInTheDocument();
+    });
+
+    it('does not report alertRetrievalHasError (non-workflow path) when the feature flag is on but the uiSetting is off', async () => {
+      const { result, rerender } = renderHook(() => useSettingsView(defaultProps), {
+        wrapper: TestProviders,
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      rerender();
+
+      // alertRetrievalHasError is true only when workflows are enabled and a retrieval toggle error exists
+      expect(result.current.alertRetrievalHasError).toBe(false);
+    });
+
+    it('reads the feature flag with a true default (ON by default)', async () => {
+      renderHook(() => useSettingsView(defaultProps), { wrapper: TestProviders });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockUseKibana().services.featureFlags.getBooleanValue).toHaveBeenCalledWith(
+        'securitySolution.attackDiscoveryWorkflowsEnabled',
+        true
+      );
+    });
+  });
+
+  describe('when the feature flag is OFF but the per-space uiSetting is ON (FF off, setting on → legacy)', () => {
+    beforeEach(() => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          data: {
+            query: {
+              filterManager: mockFilterManager,
+            },
+          },
+          featureFlags: {
+            getBooleanValue: jest.fn().mockResolvedValue(false),
+          },
+          lens: {
+            EmbeddableComponent: () => <div data-test-subj="mockEmbeddableComponent" />,
+          },
+          telemetry: { reportEvent: jest.fn() },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
+          unifiedSearch: {
+            ui: {
+              SearchBar: (props: { onQuerySubmit: jest.Mock }) => {
+                if (props.onQuerySubmit) {
+                  mockOnQuerySubmit.mockImplementation(props.onQuerySubmit);
+                }
+                return <div data-test-subj="alertSelectionSearchBar" />;
+              },
+            },
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+    });
+
+    it('does not render the workflow configuration panel when the feature flag is off regardless of the uiSetting (FF off, setting on → workflow panel absent)', async () => {
+      const { result, rerender } = renderHook(() => useSettingsView(defaultProps), {
+        wrapper: TestProviders,
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      rerender();
+
+      render(<TestProviders>{result.current.settingsView}</TestProviders>);
+
+      expect(screen.queryByTestId('workflowConfigurationPanel')).not.toBeInTheDocument();
+    });
+
+    it('does not report alertRetrievalHasError (non-workflow path) when the feature flag is off', async () => {
+      const { result, rerender } = renderHook(() => useSettingsView(defaultProps), {
+        wrapper: TestProviders,
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      rerender();
+
+      expect(result.current.alertRetrievalHasError).toBe(false);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.tsx
@@ -18,6 +18,7 @@ import {
 import { css } from '@emotion/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING } from '../../../../../common/constants';
 import { DEFAULT_STACK_BY_FIELD } from '..';
 import { AlertSelection } from '../alert_selection';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -109,17 +110,19 @@ export const useSettingsView = ({
 
   const workflowConfiguration = draftWorkflowConfiguration;
 
-  // Load feature flag value
+  // Load feature flag value and combine with per-space uiSetting opt-in
   useEffect(() => {
     const loadFeatureFlag = async () => {
-      const enabled = await featureFlags.getBooleanValue(
+      const ffEnabled = await featureFlags.getBooleanValue(
         'securitySolution.attackDiscoveryWorkflowsEnabled',
-        false
+        true
       );
-      setIsWorkflowsEnabledFlag(enabled);
+      setIsWorkflowsEnabledFlag(
+        ffEnabled && uiSettings.get(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING, false)
+      );
     };
     loadFeatureFlag();
-  }, [featureFlags]);
+  }, [featureFlags, uiSettings]);
 
   const isWorkflowsEnabled = isWorkflowsEnabledOverride ?? isWorkflowsEnabledFlag;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_button/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_button/index.test.tsx
@@ -42,6 +42,9 @@ describe('CreateButton', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(false),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
         },
       });
     });
@@ -87,6 +90,9 @@ describe('CreateButton', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(false),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
           },
         },
       });
@@ -140,6 +146,9 @@ describe('CreateButton', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
           },
         },
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.test.tsx
@@ -526,6 +526,42 @@ describe.skip('EditForm', () => {
       });
     });
 
+    it('includes DEFAULT_WORKFLOW_CONFIGURATION in submit data when initialValue has no workflowConfig (C3: legacy schedule migration)', async () => {
+      // Simulate a legacy schedule (created with FF-off, no workflowConfig)
+      // opened for editing under FF-on. The form must submit DEFAULT_WORKFLOW_CONFIGURATION
+      // so that the server persists workflowConfig and the schedule migrates.
+      const onChange = jest.fn();
+
+      await act(() => {
+        render(
+          <TestProviders>
+            <EditForm
+              initialValue={{
+                ...defaultProps.initialValue,
+                connectorId: 'test-id',
+                name: 'Legacy Schedule',
+                // NOTE: no workflowConfig — this is the legacy case
+              }}
+              isWorkflowsEnabled={true}
+              onChange={onChange}
+            />
+          </TestProviders>
+        );
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled();
+      });
+
+      let result: { isValid: boolean; data: Record<string, unknown> } | undefined;
+      await act(async () => {
+        const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+        result = await lastCall.submit();
+      });
+
+      expect(result!.data.workflowConfig).toEqual(DEFAULT_WORKFLOW_CONFIGURATION);
+    });
+
     it('invokes onChange when rendered with workflow config', async () => {
       await renderWorkflowComponent();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.tsx
@@ -101,8 +101,16 @@ export const EditForm: React.FC<FormProps> = React.memo((props) => {
     [actionTypeRegistry, connectors]
   );
 
+  // Always initialize the form's workflowConfig field to a concrete value so
+  // that saving without touching any toggle still sends the correct payload.
+  // Without this, a legacy schedule (no workflowConfig) submitted via the
+  // workflows path would omit workflow_config from the API request, leaving the
+  // schedule in legacy state instead of migrating it.
   const { form } = useForm<AttackDiscoveryScheduleSchema>({
-    defaultValue: initialValue,
+    defaultValue: {
+      ...initialValue,
+      workflowConfig: initialValue.workflowConfig ?? DEFAULT_WORKFLOW_CONFIGURATION,
+    },
     options: { stripEmptyFields: false },
     schema,
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.tsx
@@ -35,6 +35,7 @@ import * as workflowI18n from '../../workflow_configuration/translations';
 import { AlertRetrievalContent } from '../../workflow_settings_view/alert_retrieval_step/alert_retrieval_content';
 import { WorkflowValidationCallouts } from '../../workflow_settings_view/components';
 import { RuleActionsField } from '../../../../../common/components/rule_actions_field';
+import { ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING } from '../../../../../../common/constants';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useConnectors } from '../../../../../common/hooks/use_connectors';
 import type { FormHook } from '../../../../../shared_imports';
@@ -74,6 +75,7 @@ export const EditForm: React.FC<FormProps> = React.memo((props) => {
     featureFlags,
     triggersActionsUi: { actionTypeRegistry },
     http,
+    uiSettings,
   } = useKibana().services;
   const { connectors, setCurrentConnector } = useConnectors({ http });
 
@@ -81,14 +83,16 @@ export const EditForm: React.FC<FormProps> = React.memo((props) => {
 
   useEffect(() => {
     const loadFeatureFlag = async () => {
-      const enabled = await featureFlags.getBooleanValue(
+      const ffEnabled = await featureFlags.getBooleanValue(
         'securitySolution.attackDiscoveryWorkflowsEnabled',
-        false
+        true
       );
-      setIsWorkflowsEnabledFlag(enabled);
+      setIsWorkflowsEnabledFlag(
+        ffEnabled && uiSettings.get(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING, false)
+      );
     };
     loadFeatureFlag();
-  }, [featureFlags]);
+  }, [featureFlags, uiSettings]);
 
   const isWorkflowsEnabled = isWorkflowsEnabledProp ?? isWorkflowsEnabledFlag;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/logic/use_schedule_api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/logic/use_schedule_api.test.ts
@@ -39,12 +39,85 @@ describe('useScheduleApi', () => {
     jest.clearAllMocks();
   });
 
+  describe('when the feature flag is ON but the per-space uiSetting is OFF', () => {
+    beforeEach(() => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+    });
+
+    it('returns isWorkflowsEnabled as false (FF on, setting off → legacy)', () => {
+      const { result } = renderHook(() => useScheduleApi());
+
+      expect(result.current.isWorkflowsEnabled).toBe(false);
+    });
+
+    it('returns public API create hook when the uiSetting is off', () => {
+      const { result } = renderHook(() => useScheduleApi());
+
+      expect(result.current.useCreateSchedule).toBe(useCreateAttackDiscoverySchedule);
+    });
+
+    it('does NOT return any workflow hooks when the uiSetting is off', () => {
+      const { result } = renderHook(() => useScheduleApi());
+
+      expect(result.current.useCreateSchedule).not.toBe(useCreateWorkflowSchedule);
+      expect(result.current.useDeleteSchedule).not.toBe(useDeleteWorkflowSchedule);
+      expect(result.current.useEnableSchedule).not.toBe(useEnableWorkflowSchedule);
+    });
+  });
+
+  describe('when the feature flag is OFF but the per-space uiSetting is ON', () => {
+    beforeEach(() => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(false),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+    });
+
+    it('returns isWorkflowsEnabled as false (FF off, setting on → legacy)', () => {
+      const { result } = renderHook(() => useScheduleApi());
+
+      expect(result.current.isWorkflowsEnabled).toBe(false);
+    });
+
+    it('returns public API create hook when the feature flag is off', () => {
+      const { result } = renderHook(() => useScheduleApi());
+
+      expect(result.current.useCreateSchedule).toBe(useCreateAttackDiscoverySchedule);
+    });
+
+    it('does NOT return any workflow hooks when the feature flag is off', () => {
+      const { result } = renderHook(() => useScheduleApi());
+
+      expect(result.current.useCreateSchedule).not.toBe(useCreateWorkflowSchedule);
+      expect(result.current.useDeleteSchedule).not.toBe(useDeleteWorkflowSchedule);
+      expect(result.current.useEnableSchedule).not.toBe(useEnableWorkflowSchedule);
+    });
+  });
+
   describe('when attackDiscoveryWorkflowsEnabled is ON', () => {
     beforeEach(() => {
       mockUseKibana.mockReturnValue({
         services: {
           featureFlags: {
             getBooleanValue: jest.fn().mockReturnValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
           },
         },
       } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
@@ -134,6 +207,9 @@ describe('useScheduleApi', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockReturnValue(false),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
         },
       } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
     });
@@ -219,14 +295,14 @@ describe('useScheduleApi', () => {
       expect(result.current.useBulkDeleteSchedules).not.toBe(useBulkDeleteWorkflowSchedules);
     });
 
-    it('reads the feature flag with the correct key and default', () => {
+    it('reads the feature flag with the correct key and a true default (ON by default)', () => {
       renderHook(() => useScheduleApi());
 
       const { getBooleanValue } = mockUseKibana().services.featureFlags;
 
       expect(getBooleanValue).toHaveBeenCalledWith(
         'securitySolution.attackDiscoveryWorkflowsEnabled',
-        false
+        true
       );
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/logic/use_schedule_api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/logic/use_schedule_api.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 
+import { ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING } from '../../../../../../common/constants';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useCreateAttackDiscoverySchedule } from './use_create_schedule';
 import { useDeleteAttackDiscoverySchedule } from './use_delete_schedule';
@@ -61,16 +62,15 @@ export interface ScheduleApi {
  * is deferred to a follow-up PR (Option C: Hybrid Scheduling Migration).
  */
 export const useScheduleApi = (): ScheduleApi => {
-  const { featureFlags } = useKibana().services;
+  const { featureFlags, uiSettings } = useKibana().services;
 
-  // Read the flag synchronously during render so the returned hook set is stable
-  // from the first render. Reading it asynchronously (useEffect + useState) would
-  // swap the returned hooks after mount when the flag is ON, violating the Rules
-  // of Hooks in consumers that call these hooks by identity.
-  const isWorkflowsEnabled = featureFlags.getBooleanValue(
-    'securitySolution.attackDiscoveryWorkflowsEnabled',
-    false
-  );
+  // Read the flag and per-space uiSetting synchronously during render so the returned hook set is
+  // stable from the first render. Reading asynchronously (useEffect + useState) would swap the
+  // returned hooks after mount when the flag is ON, violating the Rules of Hooks in consumers
+  // that call these hooks by identity.
+  const isWorkflowsEnabled =
+    featureFlags.getBooleanValue('securitySolution.attackDiscoveryWorkflowsEnabled', true) &&
+    uiSettings.get(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING, false);
 
   return useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/missing_privileges/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/missing_privileges/index.test.tsx
@@ -42,6 +42,9 @@ const mockKibana = ({
       featureFlags: {
         getBooleanValue: jest.fn().mockResolvedValue(isWorkflowsEnabled),
       },
+      uiSettings: {
+        get: jest.fn().mockReturnValue(isWorkflowsEnabled),
+      },
     },
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/schedules_table/columns/actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/schedules_table/columns/actions.test.tsx
@@ -47,6 +47,9 @@ describe('Actions Column', () => {
         featureFlags: {
           getBooleanValue: jest.fn().mockResolvedValue(false),
         },
+        uiSettings: {
+          get: jest.fn().mockReturnValue(false),
+        },
       },
     });
   });
@@ -78,6 +81,9 @@ describe('Actions Column', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(false),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
           },
         },
       });
@@ -124,6 +130,9 @@ describe('Actions Column', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
           },
         },
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/schedules_table/columns/enable.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/schedules_table/columns/enable.test.tsx
@@ -50,6 +50,9 @@ describe('Enable Column', () => {
         featureFlags: {
           getBooleanValue: jest.fn().mockResolvedValue(false),
         },
+        uiSettings: {
+          get: jest.fn().mockReturnValue(false),
+        },
       },
     });
   });
@@ -101,6 +104,9 @@ describe('Enable Column', () => {
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(false),
           },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(false),
+          },
         },
       });
     });
@@ -146,6 +152,9 @@ describe('Enable Column', () => {
           },
           featureFlags: {
             getBooleanValue: jest.fn().mockResolvedValue(true),
+          },
+          uiSettings: {
+            get: jest.fn().mockReturnValue(true),
           },
         },
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/utils/convert_form_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/utils/convert_form_data.test.ts
@@ -533,6 +533,65 @@ describe('convertFormDataToWorkflowSchedule', () => {
     });
   });
 
+  it('adds workflow_config on conversion while preserving all unrelated schedule fields (1.0 → 2.0 on mutation)', () => {
+    // Represents a legacy (1.0) schedule being edited/saved through the 2.0 workflow
+    // path: it must GAIN workflow_config without losing name/interval/actions/api_config.
+    const result = convertFormDataToWorkflowSchedule(
+      {
+        name: 'legacy schedule being converted',
+        connectorId: 'c1',
+        alertsSelectionSettings: {
+          end: 'now',
+          filters: [],
+          query: { query: 'host.name: *', language: 'kuery' },
+          size: 42,
+          start: 'now-24h',
+        },
+        interval: '30m',
+        actions: [
+          {
+            actionTypeId: '.slack',
+            group: 'default',
+            id: 'connector-123',
+            params: { message: 'hi' },
+            uuid: 'action-uuid',
+          } as RuleAction,
+        ],
+        workflowConfig: {
+          alertRetrievalMode: 'custom_query',
+          alertRetrievalWorkflowIds: [],
+          alertRetrievalWorkflowsEnabled: false,
+          defaultRetrievalEnabled: true,
+          skillEnabled: true,
+          validationWorkflowId: 'default',
+        },
+      },
+      '.alert-*',
+      {
+        actionTypeId: '.gen-ai',
+        id: 'c1',
+        name: 'c1',
+        apiProvider: 'openai',
+      } as unknown as AIConnector,
+      { get: jest.fn() } as unknown as IUiSettingsClient,
+      createStubDataView({ spec: {} })
+    );
+
+    // Unrelated fields preserved
+    expect(result.name).toBe('legacy schedule being converted');
+    expect(result.schedule).toEqual({ interval: '30m' });
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0]).toEqual(expect.objectContaining({ id: 'connector-123' }));
+    expect(result.params.api_config).toEqual(expect.objectContaining({ connector_id: 'c1' }));
+    expect(result.params.size).toBe(42);
+    expect(result.params.query).toEqual({ query: 'host.name: *', language: 'kuery' });
+
+    // AND the 2.0 discriminator is added
+    expect(result.params.workflow_config).toEqual(
+      expect.objectContaining({ default_retrieval_enabled: true, skill_enabled: true })
+    );
+  });
+
   it('does not include workflow_config when workflowConfig is undefined', () => {
     const result = convertFormDataToWorkflowSchedule(
       {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.test.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 
 import { useKibana } from '../../../common/lib/kibana';
 import { useAttackDiscovery } from '.';
+import { AttackDiscoveryEventTypes } from '../../../common/lib/telemetry';
 import { ERROR_GENERATING_ATTACK_DISCOVERIES } from '../translations';
 import { useKibana as mockUseKibana } from '../../../common/lib/kibana/__mocks__';
 import { createQueryWrapperMock } from '../../../common/__mocks__/query_wrapper';
@@ -141,6 +142,31 @@ describe('useAttackDiscovery', () => {
     );
   });
 
+  it("reports GenerationStarted telemetry with execution_mode 'legacy' on the public path", async () => {
+    (mockedUseKibana.services.http.post as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(
+      () =>
+        useAttackDiscovery({
+          connectorId: 'test-id',
+          setLoadingConnectorId,
+          size: SIZE,
+        }),
+      {
+        wrapper: queryWrapper,
+      }
+    );
+
+    await act(async () => {
+      await result.current.fetchAttackDiscoveries();
+    });
+
+    expect(mockedUseKibana.services.telemetry.reportEvent).toHaveBeenCalledWith(
+      AttackDiscoveryEventTypes.GenerationStarted,
+      expect.objectContaining({ execution_mode: 'legacy' })
+    );
+  });
+
   it('handles fetch errors correctly', async () => {
     const errorMessage = 'Fetch error';
     const error = new Error(errorMessage);
@@ -164,15 +190,121 @@ describe('useAttackDiscovery', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  describe('when the feature flag is ON but the per-space uiSetting is OFF', () => {
+    beforeEach(() => {
+      mockedUseKibana.services.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(true);
+      mockedUseKibana.services.uiSettings.get = jest.fn().mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      mockedUseKibana.services.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(false);
+      mockedUseKibana.services.uiSettings.get = jest.fn().mockReturnValue(false);
+    });
+
+    it('calls the public API route when the uiSetting is off (FF on, setting off → legacy)', async () => {
+      (mockedUseKibana.services.http.post as jest.Mock).mockResolvedValue({});
+
+      const { result } = renderHook(
+        () =>
+          useAttackDiscovery({
+            connectorId: 'test-id',
+            setLoadingConnectorId,
+            size: 20,
+          }),
+        {
+          wrapper: queryWrapper,
+        }
+      );
+
+      await act(async () => {
+        await result.current.fetchAttackDiscoveries();
+      });
+
+      expect(mockedUseKibana.services.http.post as jest.Mock).toHaveBeenCalledWith(
+        ATTACK_DISCOVERY_GENERATE,
+        expect.objectContaining({
+          version: API_VERSIONS.public.v1,
+        })
+      );
+    });
+  });
+
+  it('reads the feature flag with the correct key and a true default (ON by default)', async () => {
+    (mockedUseKibana.services.http.post as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(
+      () =>
+        useAttackDiscovery({
+          connectorId: 'test-id',
+          setLoadingConnectorId,
+          size: SIZE,
+        }),
+      {
+        wrapper: queryWrapper,
+      }
+    );
+
+    await act(async () => {
+      await result.current.fetchAttackDiscoveries();
+    });
+
+    expect(mockedUseKibana.services.featureFlags.getBooleanValue).toHaveBeenCalledWith(
+      'securitySolution.attackDiscoveryWorkflowsEnabled',
+      true
+    );
+  });
+
+  describe('when the feature flag is OFF but the per-space uiSetting is ON', () => {
+    beforeEach(() => {
+      mockedUseKibana.services.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(false);
+      mockedUseKibana.services.uiSettings.get = jest.fn().mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      mockedUseKibana.services.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(false);
+      mockedUseKibana.services.uiSettings.get = jest.fn().mockReturnValue(false);
+    });
+
+    it('calls the public API route when the FF is off (FF off, setting on → legacy)', async () => {
+      (mockedUseKibana.services.http.post as jest.Mock).mockResolvedValue({});
+
+      const { result } = renderHook(
+        () =>
+          useAttackDiscovery({
+            connectorId: 'test-id',
+            setLoadingConnectorId,
+            size: 20,
+          }),
+        {
+          wrapper: queryWrapper,
+        }
+      );
+
+      await act(async () => {
+        await result.current.fetchAttackDiscoveries();
+      });
+
+      expect(mockedUseKibana.services.http.post as jest.Mock).toHaveBeenCalledWith(
+        ATTACK_DISCOVERY_GENERATE,
+        expect.objectContaining({
+          version: API_VERSIONS.public.v1,
+        })
+      );
+    });
+  });
+
   describe('when attackDiscoveryWorkflowsEnabled feature flag is enabled', () => {
     beforeEach(() => {
       // Mock feature flags service to return true for this test suite
       mockedUseKibana.services.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(true);
+      // Also enable the per-space uiSetting opt-in
+      mockedUseKibana.services.uiSettings.get = jest.fn().mockReturnValue(true);
     });
 
     afterEach(() => {
       // Reset to default (false)
       mockedUseKibana.services.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(false);
+      mockedUseKibana.services.uiSettings.get = jest.fn().mockReturnValue(false);
     });
 
     it('calls the internal API with workflow configuration', async () => {
@@ -237,6 +369,33 @@ describe('useAttackDiscovery', () => {
         skill_enabled: true,
         validation_workflow_id: 'default',
       });
+    });
+
+    it("reports GenerationStarted telemetry with execution_mode 'workflow'", async () => {
+      (mockedUseKibana.services.http.post as jest.Mock).mockResolvedValue({
+        execution_uuid: 'test-uuid',
+      });
+
+      const { result } = renderHook(
+        () =>
+          useAttackDiscovery({
+            connectorId: 'test-id',
+            setLoadingConnectorId,
+            size: 20,
+          }),
+        {
+          wrapper: queryWrapper,
+        }
+      );
+
+      await act(async () => {
+        await result.current.fetchAttackDiscoveries();
+      });
+
+      expect(mockedUseKibana.services.telemetry.reportEvent).toHaveBeenCalledWith(
+        AttackDiscoveryEventTypes.GenerationStarted,
+        expect.objectContaining({ execution_mode: 'workflow' })
+      );
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
@@ -10,6 +10,7 @@ import { isEmpty } from 'lodash/fp';
 import { useCallback, useState } from 'react';
 import { useFetchAnonymizationFields } from '@kbn/elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields';
 
+import { ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING } from '../../../../common/constants';
 import { useKibana } from '../../../common/lib/kibana';
 import { AttackDiscoveryEventTypes } from '../../../common/lib/telemetry';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
@@ -59,6 +60,7 @@ export const useAttackDiscovery = ({
     http,
     notifications: { toasts },
     telemetry,
+    uiSettings,
   } = useKibana().services;
 
   // Get current space ID for workflow configuration
@@ -109,13 +111,14 @@ export const useAttackDiscovery = ({
         };
         setLoadingConnectorId?.(effectiveConnectorId ?? null);
 
-        // Check if workflow integration feature flag is enabled
-        const attackDiscoveryWorkflowsEnabled = await featureFlags.getBooleanValue(
-          'securitySolution.attackDiscoveryWorkflowsEnabled',
-          false
-        );
+        // Check if workflow integration feature flag is enabled AND the per-space uiSetting opt-in
+        const attackDiscoveryWorkflowsEnabled =
+          (await featureFlags.getBooleanValue(
+            'securitySolution.attackDiscoveryWorkflowsEnabled',
+            true
+          )) && uiSettings.get(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING, false);
 
-        // Call appropriate API based on feature flag
+        // Call appropriate API based on feature flag + per-space setting
         if (attackDiscoveryWorkflowsEnabled) {
           if (!alertsIndexPattern) {
             throw new Error(ALERTS_INDEX_PATTERN_ERROR);
@@ -181,6 +184,7 @@ export const useAttackDiscovery = ({
       telemetry,
       toasts,
       traceOptions,
+      uiSettings,
     ]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -328,6 +328,7 @@ export class Plugin implements ISecuritySolutionPlugin {
     });
 
     initUiSettings(core.uiSettings, experimentalFeatures, config.enableUiSettingsValidations);
+
     productFeaturesService.setup(core, plugins);
 
     events.forEach((eventConfig) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -16,7 +16,9 @@ import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { initUiSettings } from './ui_settings';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import {
+  ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING,
   ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
+  ENABLE_ASSET_INVENTORY_SETTING,
   ENABLE_NEW_FLYOUT_SETTING,
 } from '../common/constants';
 
@@ -56,6 +58,47 @@ describe('initUiSettings', () => {
         value: true,
         type: 'boolean',
       })
+    );
+  });
+
+  it('registers ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING synchronously', () => {
+    initUiSettings(mockUiSettings, mockExperimentalFeatures, false);
+
+    const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
+    expect(registeredSettings).toHaveProperty(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING);
+  });
+
+  it('registers ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING with value false (off by default)', () => {
+    initUiSettings(mockUiSettings, mockExperimentalFeatures, false);
+
+    const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
+    expect(registeredSettings[ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING].value).toBe(false);
+  });
+
+  it('registers ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING as editable (not readonly)', () => {
+    initUiSettings(mockUiSettings, mockExperimentalFeatures, false);
+
+    const registeredSettings = (mockUiSettings.register as jest.Mock).mock.calls[0][0];
+    expect(registeredSettings[ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING].readonly).toBeUndefined();
+  });
+
+  it('positions ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING immediately after ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING when alignment is enabled', () => {
+    const enabledFeatures = { ...mockExperimentalFeatures, enableAlertsAndAttacksAlignment: true };
+
+    initUiSettings(mockUiSettings, enabledFeatures, false);
+
+    const keys = Object.keys((mockUiSettings.register as jest.Mock).mock.calls[0][0]);
+    expect(keys.indexOf(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING)).toBe(
+      keys.indexOf(ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING) + 1
+    );
+  });
+
+  it('positions ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING immediately before ENABLE_ASSET_INVENTORY_SETTING when alignment is disabled', () => {
+    initUiSettings(mockUiSettings, mockExperimentalFeatures, false);
+
+    const keys = Object.keys((mockUiSettings.register as jest.Mock).mock.calls[0][0]);
+    expect(keys.indexOf(ENABLE_ASSET_INVENTORY_SETTING)).toBe(
+      keys.indexOf(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING) + 1
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -90,11 +90,15 @@ type SettingsConfig = Record<string, UiSettingsParams<unknown>>;
  * by the current management UI), so registering it here — rather than via a
  * deferred continuation — is what keeps it in the expected position.
  *
- * The toggle is always visible and defaults to `false`. Behavior is gated by the
- * global `attackDiscoveryWorkflowsEnabled` feature flag AND this per-space setting
- * (`FF && setting`) at every server and client read site (see
- * `isWorkflowsEnabledForSpace`), so when the feature flag is off this setting has
- * no effect regardless of its value.
+ * The toggle is always visible and defaults to `false`. Ideally it would be
+ * hidden when the global `attackDiscoveryWorkflowsEnabled` feature flag is off,
+ * but two platform constraints prevent that: (1) UI settings must be registered
+ * synchronously during plugin setup, and feature-flag evaluation requires
+ * `FeatureFlagsStart` (only available after setup completes); (2) the Advanced
+ * Settings page has no API to show/hide individual settings based on feature
+ * flags. The FF is only ever `false` when an administrator disables it globally;
+ * in that case the toggle is a harmless noop. Behavior is gated by `FF &&
+ * setting` at every server and client read site (see `isWorkflowsEnabledForSpace`).
  *
  * @security_note This setting is enforced server-side: `assertWorkflowsEnabled`
  * (which calls `isWorkflowsEnabledForSpace`) returns 404 on every internal AD
@@ -112,7 +116,7 @@ export const attackDiscoveryWorkflowsSetting: UiSettingsParams<boolean> = {
     'xpack.securitySolution.uiSettings.enableAttackDiscoveryWorkflows.description',
     {
       defaultMessage:
-        'Enable Attack Discovery Workflows for this space. When enabled, Attack Discovery uses orchestrated workflows for alert retrieval and analysis.',
+        'Enable Attack Discovery Workflows for this space. When enabled, Attack Discovery uses orchestrated workflows for alert retrieval and analysis. Has no effect when Attack Discovery Workflows are disabled at the deployment level.',
     }
   ),
   type: 'boolean',

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -53,6 +53,7 @@ import {
   DEFAULT_THREAT_INDEX_VALUE,
   DEFAULT_TO,
   ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
+  ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING,
   ENABLE_ASSET_INVENTORY_SETTING,
   ENABLE_CLOUD_CONNECTOR_SETTING,
   ENABLE_SIEM_READINESS_SETTING,
@@ -78,6 +79,49 @@ import type { ExperimentalFeatures } from '../common/experimental_features';
 import { LogLevelSetting } from '../common/api/detection_engine/rule_monitoring';
 
 type SettingsConfig = Record<string, UiSettingsParams<unknown>>;
+
+/**
+ * Definition for the per-space `securitySolution:enableAttackDiscoveryWorkflows`
+ * Advanced Setting.
+ *
+ * Registered synchronously as part of the `securityUiSettings` object, positioned
+ * immediately after `enableAlertsAndAttacksAlignment`. The Advanced Settings UI
+ * renders settings in server registration order (the `order` field is not honored
+ * by the current management UI), so registering it here — rather than via a
+ * deferred continuation — is what keeps it in the expected position.
+ *
+ * The toggle is always visible and defaults to `false`. Behavior is gated by the
+ * global `attackDiscoveryWorkflowsEnabled` feature flag AND this per-space setting
+ * (`FF && setting`) at every server and client read site (see
+ * `isWorkflowsEnabledForSpace`), so when the feature flag is off this setting has
+ * no effect regardless of its value.
+ *
+ * @security_note This setting is enforced server-side: `assertWorkflowsEnabled`
+ * (which calls `isWorkflowsEnabledForSpace`) returns 404 on every internal AD
+ * route when the setting is off, regardless of the caller's privilege level.
+ * The real security boundary for *who may run* Attack Discovery is role-based
+ * privileges (`securitySolution-attackDiscoveryAll` + `workflowsManagement:*`),
+ * enforced separately.  The per-space toggle controls *whether the feature is
+ * active for that space*; RBAC controls *who may use it*.
+ */
+export const attackDiscoveryWorkflowsSetting: UiSettingsParams<boolean> = {
+  name: i18n.translate('xpack.securitySolution.uiSettings.enableAttackDiscoveryWorkflows.name', {
+    defaultMessage: 'Attack Discovery Workflows',
+  }),
+  description: i18n.translate(
+    'xpack.securitySolution.uiSettings.enableAttackDiscoveryWorkflows.description',
+    {
+      defaultMessage:
+        'Enable Attack Discovery Workflows for this space. When enabled, Attack Discovery uses orchestrated workflows for alert retrieval and analysis.',
+    }
+  ),
+  type: 'boolean',
+  value: false,
+  category: [APP_ID],
+  requiresPageReload: true,
+  schema: schema.boolean(),
+  solutionViews: ['classic', 'security'],
+};
 
 /**
  * This helper is used to preserve settings order in the UI
@@ -241,6 +285,12 @@ export const initUiSettings = (
         solutionViews: ['classic', 'security'],
       },
     }),
+    // Registered here (immediately after `enableAlertsAndAttacksAlignment`, before
+    // `enableAssetInventory`) so it renders in that position: the Advanced Settings
+    // UI displays settings in server registration order, not by the `order` field.
+    // When `enableAlertsAndAttacksAlignment` is disabled its entry is absent, so this
+    // setting falls into the same slot, immediately before `enableAssetInventory`.
+    [ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING]: attackDiscoveryWorkflowsSetting,
     [ENABLE_ASSET_INVENTORY_SETTING]: {
       name: i18n.translate('xpack.securitySolution.uiSettings.enableAssetInventoryLabel', {
         defaultMessage: 'Enable Security Asset Inventory',

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -105,8 +105,12 @@ export class SecuritySolutionServerlessPlugin
     const projectSettings = [...SECURITY_PROJECT_SETTINGS];
 
     // Registered unconditionally in ESS (`security_solution/server/ui_settings.ts`), so it
-    // must be allowlisted unconditionally here too, otherwise the Attack Discovery Workflows
-    // toggle would not appear in serverless Advanced Settings.
+    // must be allowlisted unconditionally here too. Ideally this would be conditional on the
+    // `attackDiscoveryWorkflowsEnabled` feature flag, but two platform constraints prevent
+    // that: (1) feature-flag evaluation requires `FeatureFlagsStart`, which is unavailable
+    // during synchronous plugin setup; (2) the Advanced Settings page has no API to show/hide
+    // individual settings based on feature flags. The FF is only ever `false` when an
+    // administrator disables it globally; in that case the toggle is a harmless noop.
     projectSettings.push(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING);
 
     // This setting is only registered when `enableAlertsAndAttacksAlignment` is enabled

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -23,7 +23,10 @@ import {
   WORKFLOWS_UI_SETTING_ID,
   WORKFLOWS_UI_SHOW_MANAGED_WORKFLOWS_SETTING_ID,
 } from '@kbn/workflows/common/constants';
-import { ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING } from '@kbn/security-solution-navigation';
+import {
+  ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING,
+  ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING,
+} from '@kbn/security-solution-navigation';
 import { ProductTier } from '../common/product';
 import { getEnabledProductFeatures } from '../common/pli/pli_features';
 
@@ -100,6 +103,11 @@ export class SecuritySolutionServerlessPlugin
     telemetryEvents.forEach((eventConfig) => coreSetup.analytics.registerEventType(eventConfig));
 
     const projectSettings = [...SECURITY_PROJECT_SETTINGS];
+
+    // Registered unconditionally in ESS (`security_solution/server/ui_settings.ts`), so it
+    // must be allowlisted unconditionally here too, otherwise the Attack Discovery Workflows
+    // toggle would not appear in serverless Advanced Settings.
+    projectSettings.push(ENABLE_ATTACK_DISCOVERY_WORKFLOWS_SETTING);
 
     // This setting is only registered when `enableAlertsAndAttacksAlignment` is enabled
     if (this.config.experimentalFeatures.enableAlertsAndAttacksAlignment) {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/attack_discovery/privileges/trial_license_complete_tier/get/get_serverless.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/attack_discovery/privileges/trial_license_complete_tier/get/get_serverless.ts
@@ -49,7 +49,12 @@ export default ({ getService }: FtrProviderContext) => {
         const missingPrivileges = await apis.get({});
 
         expect(missingPrivileges).toEqual({
-          feature_privileges: [],
+          feature_privileges: [
+            {
+              feature_id: 'workflowsManagement',
+              privileges: ['execute'],
+            },
+          ],
           index_privileges: [
             {
               index_name: '.alerts-security.attack.discovery.alerts-default',

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/attack_discovery/privileges/utils/roles.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/attack_discovery/privileges/utils/roles.ts
@@ -20,10 +20,11 @@ export const noIndexPrivileges: Role = {
     kibana: [
       {
         feature: {
-          [SECURITY_FEATURE_ID]: ['all'],
           [ALERTS_FEATURE_ID]: ['read'],
+          [SECURITY_FEATURE_ID]: ['all'],
           securitySolutionAssistant: ['all'],
           securitySolutionAttackDiscovery: ['all'],
+          workflowsManagement: ['all'],
         },
         spaces: ['*'],
       },
@@ -45,10 +46,11 @@ export const noAdhocIndexPrivileges: Role = {
     kibana: [
       {
         feature: {
-          [SECURITY_FEATURE_ID]: ['all'],
           [ALERTS_FEATURE_ID]: ['read'],
+          [SECURITY_FEATURE_ID]: ['all'],
           securitySolutionAssistant: ['all'],
           securitySolutionAttackDiscovery: ['all'],
+          workflowsManagement: ['all'],
         },
         spaces: ['*'],
       },
@@ -70,10 +72,11 @@ export const noAttacksIndexPrivileges: Role = {
     kibana: [
       {
         feature: {
-          [SECURITY_FEATURE_ID]: ['all'],
           [ALERTS_FEATURE_ID]: ['read'],
+          [SECURITY_FEATURE_ID]: ['all'],
           securitySolutionAssistant: ['all'],
           securitySolutionAttackDiscovery: ['all'],
+          workflowsManagement: ['all'],
         },
         spaces: ['*'],
       },
@@ -95,10 +98,11 @@ export const allIndexPrivileges: Role = {
     kibana: [
       {
         feature: {
-          [SECURITY_FEATURE_ID]: ['all'],
           [ALERTS_FEATURE_ID]: ['read'],
+          [SECURITY_FEATURE_ID]: ['all'],
           securitySolutionAssistant: ['all'],
           securitySolutionAttackDiscovery: ['all'],
+          workflowsManagement: ['all'],
         },
         spaces: ['*'],
       },


### PR DESCRIPTION
## Enable the Attack Discovery 2.0: Workflows Integration feature flag

This PR enables the [Attack Discovery 2.0: Workflows Integration feature flag](https://github.com/elastic/kibana/pull/260816) by default.

When the feature flag is enabled, a new (per-space) Kibana advanced setting, `Attack Discovery Workflows` (`securitySolution:enableAttackDiscoveryWorkflows`) is avaiable in advanced settings, as illustrated by the screenshot below:

![`enableAttackDiscoveryWorkflows` advanced setting](https://github.com/user-attachments/assets/74f517be-5a77-4ff6-9947-5b3a4b9ae880)

_Above: The `Attack Discovery Workflows` (`securitySolution:enableAttackDiscoveryWorkflows`) advanced setting_

- The default value for this setting is `false`
- Users must enable this setting in each space to use Attack Discovery 2.0 Workflows in that space

### Feature flag

The default value of the `attackDiscoveryWorkflowsEnabled` is `true` after this PR is merged:

```
feature_flags.overrides:
  securitySolution.attackDiscoveryWorkflowsEnabled: true
```

It's no longer necessary to set the feature flag above to true, but it's available for operators who need to disable the feature globally.

### Advanced setting

- The new `enableAttackDiscoveryWorkflows` settings is registered synchronously in `security_solution/server/ui_settings.ts` immediately after `enableAlertsAndAttacksAlignment` so it renders directly below it — the Advanced Settings UI orders by server registration order, not the `order` field.

- It's allow listed in `security_solution_serverless` project settings so the toggle also appears in serverless.

### Fixes for issues found during desk testing

This PR contains fixes for the following issues, found during desk testing:

1) Fixed an issue where generations may fail with a `Gate workflow failed: maxContentLength size of 1048576 exceeded` error, as illustrated by the screenshot below:

![max-content-length-failure](https://github.com/user-attachments/assets/dd1d098a-4142-4e54-a2bb-1bf12801905f)

This issue was fixed by adding a `max-step-size: '2097152b'` (2 MiB) to the two AD `ai.agent` workflow steps, the always-on gate (`skill_alert_retrieval`) and the fire-and-forget report (`skill_report`), so large streamed completions no longer fail against the global `xpack.actions.maxResponseContentLength` default (1 MB).

Requires PR #275842.

2) Fixed an issue where generations may fail with a `Gate returned no alerts: the skill's additional retrieval was the sole source (0 deterministic candidate alerts) but the gate added 0 alerts (execution_uuid=<uuid>). Failing closed instead of reporting a silent no-alerts outcome.`, as illustrated by the screenshot below:

![gate_returned_no_alerts](https://github.com/user-attachments/assets/27b8c9f1-034b-4709-a469-fb6e0ba5d70c)

This issue occurred when there were no available alerts in the last 24 hours, and the Attack discovery skill widened the search beyond the default.

Fixed in the AD-2.0-only code-path in `get_anonymized_alerts` (`kbn-discoveries`): when the caller passes an `ids` filter, the search uses a plain exact-ids query (no time or status clause) so the curated documents resolve exactly. The original `getOpenAndAcknowledgedAlertsQuery` (shared by AD 1.0, the deterministic retrieval, and the assistant chat tool) is unchanged.

3) **Copy** — softened the fail-closed no-alerts message to accurate wording, and synced the `workflow_troubleshooting` skill to match.

4) Fixed an issue where editing a legacy Attack Discovery schedule (one created before the feature flag was enabled, with no `workflowConfig`) without touching any workflow toggle would silently leave the schedule on the legacy execution path instead of migrating it.

The root cause was a mismatch between `useForm`'s `defaultValue` (set to `initialValue` directly, leaving `workflowConfig: undefined` for legacy schedules) and the local toggle state (initialized to `DEFAULT_WORKFLOW_CONFIGURATION`). The toggle UI showed the correct defaults, but the hidden form field remained `undefined`. Saving without user interaction therefore omitted `workflow_config` from the API request body, and the server fell back to the existing `undefined`, keeping the schedule in legacy state.

Fixed in `edit_form.tsx` by aligning the form's `defaultValue` with the local toggle state from initialization.

_Created with [Claude Code](https://claude.com/claude-code) and Opus 4.8_

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->