### PR TITLE
Update skills to support mitre v19

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/find_rules.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/find_rules.spec.ts
@@ -373,7 +373,7 @@ evaluate.describe(
                 },
                 output: {
                   expected:
-                    'Found 2 detection rules covering tactic TA0005 (Defense Evasion). ' +
+                    'Found 2 detection rules covering tactic TA0005 (Stealth). ' +
                     '"Process Injection T1055" is a critical severity eql rule with risk score 95 and is enabled. ' +
                     '"Process Hollowing Detection" is a high severity query rule with risk score 70 and is enabled. ' +
                     'The find_rules tool was called with mitreTactic set to "TA0005".',

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/find_rules_fixtures.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/find_rules_fixtures.ts
@@ -156,13 +156,7 @@ export const SEEDED_RULES: SeededRule[] = [
   {
     name: 'Process Injection T1055',
     description: 'Detects process injection via SetWindowsHookEx',
-    tags: [
-      'MITRE',
-      'Domain: Endpoint',
-      'OS: Windows',
-      'Tactic: Defense Evasion',
-      'Technique: T1055',
-    ],
+    tags: ['MITRE', 'Domain: Endpoint', 'OS: Windows', 'Tactic: Stealth', 'Technique: T1055'],
     type: 'eql',
     enabled: true,
     severity: 'critical',
@@ -170,7 +164,7 @@ export const SEEDED_RULES: SeededRule[] = [
     indexPattern: ENDPOINT_INDEX,
     threat: {
       tacticId: 'TA0005',
-      tacticName: 'Defense Evasion',
+      tacticName: 'Stealth',
       techniqueId: 'T1055',
       techniqueName: 'Process Injection',
     },
@@ -228,7 +222,7 @@ export const SEEDED_RULES: SeededRule[] = [
     },
   },
   {
-    // Intentionally has NO "Tactic: Defense Evasion" tag — only structured threat data.
+    // Intentionally has NO "Tactic: Stealth" tag — only structured threat data.
     name: 'Process Hollowing Detection',
     description: 'Detects process hollowing attempts without tactic tag',
     tags: ['MITRE', 'Domain: Endpoint', 'OS: Windows'],
@@ -239,7 +233,7 @@ export const SEEDED_RULES: SeededRule[] = [
     indexPattern: ENDPOINT_INDEX,
     threat: {
       tacticId: 'TA0005',
-      tacticName: 'Defense Evasion',
+      tacticName: 'Stealth',
       techniqueId: 'T1055',
       techniqueName: 'Process Injection',
     },

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/recommend_prebuilt_rules.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/recommend_prebuilt_rules.spec.ts
@@ -62,11 +62,11 @@ const evaluate = base.extend<{ evaluateDataset: EvaluateDataset }, {}>({
 });
 
 // Tactic under test. The ID is stable across MITRE and rule-package versions, so
-// we assert on it rather than rule names/counts. Defense Evasion (TA0005) is one
-// of the largest tactics in the bundled catalog, so a tactic query reliably
-// returns many installable rules.
+// we assert on it rather than rule names/counts. Stealth (TA0005, renamed from
+// Defense Evasion in ATT&CK v19) is one of the largest tactics in the bundled
+// catalog, so a tactic query reliably returns many installable rules.
 const TACTIC_ID = 'TA0005';
-const TACTIC_NAME = 'Defense Evasion';
+const TACTIC_NAME = 'Stealth';
 
 const FIND_PREBUILT_RULES_TOOL_ID = 'security.find_prebuilt_rules';
 const GET_CATALOG_OVERVIEW_TOOL_ID = 'security.get_installable_catalog_overview';
@@ -165,7 +165,7 @@ const tagsFromFilter = (step: ToolCallStep): string[] => {
     : [];
 };
 
-// The 14 canonical MITRE ATT&CK Enterprise tactics the skill routes to (its prompt table).
+// The 15 canonical MITRE ATT&CK Enterprise tactics the skill routes to (its prompt table).
 // Unlike tags, tactics are NOT discovered from a tool — they are a fixed set — so the grounding
 // source of truth is this constant, and the schema accepts any string, so this guard is real.
 const CANONICAL_TACTICS: ReadonlyArray<{ id: string; name: string }> = [
@@ -173,7 +173,7 @@ const CANONICAL_TACTICS: ReadonlyArray<{ id: string; name: string }> = [
   { id: 'TA0002', name: 'Execution' },
   { id: 'TA0003', name: 'Persistence' },
   { id: 'TA0004', name: 'Privilege Escalation' },
-  { id: 'TA0005', name: 'Defense Evasion' },
+  { id: 'TA0005', name: 'Stealth' },
   { id: 'TA0006', name: 'Credential Access' },
   { id: 'TA0007', name: 'Discovery' },
   { id: 'TA0008', name: 'Lateral Movement' },
@@ -183,6 +183,7 @@ const CANONICAL_TACTICS: ReadonlyArray<{ id: string; name: string }> = [
   { id: 'TA0040', name: 'Impact' },
   { id: 'TA0042', name: 'Resource Development' },
   { id: 'TA0043', name: 'Reconnaissance' },
+  { id: 'TA0112', name: 'Defense Impairment' },
 ];
 
 const CANONICAL_TACTIC_IDS = new Set(CANONICAL_TACTICS.map((tactic) => tactic.id));

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -306,7 +306,7 @@ Common mappings:
 - TA0002 Execution
 - TA0003 Persistence
 - TA0004 Privilege Escalation
-- TA0005 Defense Evasion
+- TA0005 Stealth
 - TA0006 Credential Access
 - TA0007 Discovery
 - TA0008 Lateral Movement
@@ -314,6 +314,7 @@ Common mappings:
 - TA0010 Exfiltration
 - TA0011 Command and Control
 - TA0040 Impact
+- TA0112 Defense Impairment
 
 ### Schedule (interval and from)
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_rules/find_rules_skill.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_rules/find_rules_skill.test.ts
@@ -168,6 +168,7 @@ describe('findRulesSkill', () => {
       'TA0040',
       'TA0042',
       'TA0043',
+      'TA0112',
     ]) {
       expect(skill.content).toContain(tactic);
     }
@@ -176,7 +177,7 @@ describe('findRulesSkill', () => {
       'Execution',
       'Persistence',
       'Privilege Escalation',
-      'Defense Evasion',
+      'Stealth',
       'Credential Access',
       'Discovery',
       'Lateral Movement',
@@ -186,6 +187,7 @@ describe('findRulesSkill', () => {
       'Impact',
       'Resource Development',
       'Reconnaissance',
+      'Defense Impairment',
     ]) {
       expect(skill.content).toContain(name);
     }

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_rules/find_rules_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_rules/find_rules_skill.ts
@@ -100,7 +100,7 @@ Canonical MITRE tactics (Enterprise ATT&CK):
 | TA0002 | Execution |
 | TA0003 | Persistence |
 | TA0004 | Privilege Escalation |
-| TA0005 | Defense Evasion |
+| TA0005 | Stealth |
 | TA0006 | Credential Access |
 | TA0007 | Discovery |
 | TA0008 | Lateral Movement |
@@ -110,10 +110,12 @@ Canonical MITRE tactics (Enterprise ATT&CK):
 | TA0040 | Impact |
 | TA0042 | Resource Development |
 | TA0043 | Reconnaissance |
+| TA0112 | Defense Impairment |
 
 Examples:
 - "rules for T1059" -> \`{ mitreTechnique: "T1059" }\`
-- "rules for Defense Evasion" -> \`{ mitreTactic: "TA0005" }\`
+- "rules for Stealth" -> \`{ mitreTactic: "TA0005" }\`
+- "rules for Defense Impairment" -> \`{ mitreTactic: "TA0112" }\`
 - "rules for TA0006" -> \`{ mitreTactic: "TA0006" }\`
 - "rules for phishing" (technique-flavored, no exact name) -> \`{ searchTerm: "phishing" }\`
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/get_installed_rules_mitre_coverage_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/get_installed_rules_mitre_coverage_tool.test.ts
@@ -150,7 +150,7 @@ describe('buildMitreCoverageFromRules', () => {
     const result = buildMitreCoverageFromRules(
       rules(
         rule([
-          mitre('TA0005', 'Defense Evasion', [
+          mitre('TA0005', 'Stealth', [
             tech('T1055', 'Process Injection', [
               sub('T1055.001', 'Dynamic-link Library Injection'),
               sub('T1055.002', 'Portable Executable Injection'),

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/get_installed_rules_mitre_coverage_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/get_installed_rules_mitre_coverage_tool.ts
@@ -125,7 +125,7 @@ export const createGetInstalledRulesMitreCoverageTool = ({
     'Includes total rule count, count with MITRE mappings, and per-tactic and per-technique ' +
     'rule counts. ' +
     'Only returns tactics and techniques with count > 0 — absence means zero coverage. ' +
-    'The canonical 14-tactic list is in the skill prompt; use it to identify missing tactics. ' +
+    'The canonical 15-tactic list is in the skill prompt; use it to identify missing tactics. ' +
     'Session-cached — do not call again in the same conversation.',
   schema: getInstalledRulesMitreCoverageSchema,
   handler: async (_input, { request }) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/recommend_prebuilt_rules_skill.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/recommend_prebuilt_rules_skill.test.ts
@@ -63,7 +63,7 @@ describe('createRecommendPrebuiltRulesSkill', () => {
     expect(skill.content).toContain(GET_INSTALLED_RULES_MITRE_COVERAGE_INLINE_TOOL_ID);
   });
 
-  it('content includes the canonical 14 MITRE tactics', () => {
+  it('content includes the canonical 15 MITRE tactics', () => {
     const { getStartServices, logger, ml } = createDeps();
     const skill = createRecommendPrebuiltRulesSkill({ getStartServices, logger, ml });
     const tacticIds = [
@@ -81,6 +81,7 @@ describe('createRecommendPrebuiltRulesSkill', () => {
       'TA0040',
       'TA0042',
       'TA0043',
+      'TA0112',
     ];
     tacticIds.forEach((id) => expect(skill.content).toContain(id));
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/recommend_prebuilt_rules_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/recommend_prebuilt_rules/recommend_prebuilt_rules_skill.ts
@@ -68,8 +68,8 @@ The goal is to surface rules that are **worth installing here.** Four factors ma
 
 1. **Data availability gates the set.** Lead with rules whose related integrations the user already has; surface high-value rules that need missing integrations separately, not interleaved (see Integration Coverage). This decides what is recommendable, not the order within it. (Factor: *user has the data*.)
 2. **Threat impact sets the rank.** Within recommendable rules, prefer the ones that matter most, weighing three things together:
-   - **Tactic criticality** — read from each rule's triage \`threat\` (its \`tactic\` entries; a multi-tactic rule takes its highest-ranked tactic). v18 order, highest first:
-     - **Critical:** Credential Access, Lateral Movement, Privilege Escalation, Defense Evasion
+   - **Tactic criticality** — read from each rule's triage \`threat\` (its \`tactic\` entries; a multi-tactic rule takes its highest-ranked tactic). v19 order, highest first:
+     - **Critical:** Credential Access, Lateral Movement, Privilege Escalation, Stealth, Defense Impairment
      - **High:** Command and Control, Execution, Exfiltration, Impact
      - **Medium:** Persistence, Initial Access, Collection
      - **Lower:** Discovery, Resource Development, Reconnaissance
@@ -128,7 +128,7 @@ Every tag value, rule name, \`rule_id\`, count, total, and MITRE tactic/techniqu
 
 **Coverage intent** ("which MITRE tactics am I missing?"):
 1. Call \`security.get_installed_rules_mitre_coverage\`. Frame the answer with \`total_with_mitre_mapping\` out of \`total_installed_rules\` (e.g. "of your 320 installed rules, 290 carry MITRE mappings") so the user knows how much of their estate the coverage reflects.
-2. Diff its \`tactics\` against the canonical 14 below — any tactic not present has zero installed coverage.
+2. Diff its \`tactics\` against the canonical 15 below — any tactic not present has zero installed coverage.
 3. Use the per-\`technique\` counts to judge depth **within** a covered tactic: a high tactic count can still be lopsided (many rules on a few techniques, none on others). The result lists only techniques with coverage, so a technique you'd expect from your own ATT&CK knowledge but don't see has zero installed coverage — call those out as thin spots even when the parent tactic looks covered.
 4. To recommend rules that fill the gaps, call \`security.find_prebuilt_rules\` with \`mitreTactic: ["<TA-ID-1>", "<TA-ID-2>", ...]\` for the missing tactics in one call (or one call per tactic when you want balanced coverage of each). For a thin technique inside an otherwise-covered tactic, target it directly with \`mitreTechnique: ["<T-ID>"]\`.
 
@@ -181,7 +181,7 @@ Priority:
 | TA0002 | Execution |
 | TA0003 | Persistence |
 | TA0004 | Privilege Escalation |
-| TA0005 | Defense Evasion |
+| TA0005 | Stealth |
 | TA0006 | Credential Access |
 | TA0007 | Discovery |
 | TA0008 | Lateral Movement |
@@ -191,6 +191,7 @@ Priority:
 | TA0040 | Impact |
 | TA0042 | Resource Development |
 | TA0043 | Reconnaissance |
+| TA0112 | Defense Impairment |
 
 ## Integration Coverage
 
@@ -219,7 +220,7 @@ Do **not** re-call \`security.get_user_data_inventory\`, \`security.get_installa
 - For **install recommendations**, justify each recommended rule in a few words (why it fits the user's data or coverage gap), and group "related integration installed" vs "needs another integration" — at most 5 rules per group.
 - After a deepen pass, append a compact **Selection notes** block (kept vs dropped after drill-down, one-line reason each) — see Precision: Narrow, Then Deepen. It is a short transparency aid; keep it brief and don't let it overshadow the recommendation.
 - For pure **count** questions, answer from \`total\` with \`perPage: 1\`; no table needed.
-- For **coverage** questions, list covered tactics and explicitly call out the missing ones from the canonical 14.
+- For **coverage** questions, list covered tactics and explicitly call out the missing ones from the canonical 15.
 - Offer a follow-up refinement ("want me to narrow to critical only, or to your endpoint data?").
 
 ## Worked Examples
@@ -234,7 +235,7 @@ Each maps a user request to the tool call(s). These are patterns for you, not sc
 - "Do you have a rule that mentions mimikatz?" -> \`security.find_prebuilt_rules { filter: { keywords: "mimikatz" } }\` (searches description too).
 - "Show me critical ES|QL rules to install" -> \`security.find_prebuilt_rules { filter: { severity: ["critical"], ruleType: ["esql"] } }\`.
 - "How many LLM rules can I install?" -> \`security.get_installable_catalog_overview\` (read the \`Domain: LLM\` tag count); confirm with \`security.find_prebuilt_rules { filter: { tags: ["Domain: LLM"] }, perPage: 1 }\` and answer from \`total\`.
-- "Which MITRE tactics am I missing?" -> \`security.get_installed_rules_mitre_coverage\`, then diff against the canonical 14.
+- "Which MITRE tactics am I missing?" -> \`security.get_installed_rules_mitre_coverage\`, then diff against the canonical 15.
 - "Recommend rules to fill those gaps" -> \`security.find_prebuilt_rules { filter: { mitreTactic: ["<TA-ID-1>", "<TA-ID-2>", ...] } }\` for the missing tactics in one call (or one call per tactic if you want balanced coverage of each), prioritizing rules whose related integrations are already installed.
 
 ## No Actions


### PR DESCRIPTION
## Summary

Some tactics were renamed in mitre v19 and from 9.5 rule will use v19. So we update our skill to support this version

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->