### PR TITLE
Fix stuck Copy link state after short URL failures

### DIFF
--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -15,6 +15,7 @@ export interface IShareContext extends Omit<ShowShareMenuOptions, 'onClose'> {
   onClose: () => void;
   shareMenuItems: ShareConfigs[];
   isSaving?: boolean;
+  onUrlGenerationError?: (error: Error) => void;
 }
 
 const ShareContext = createContext<IShareContext | null>(null);

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
@@ -215,6 +215,49 @@ describe('LinkContent', () => {
     expect(copyButton.getAttribute('data-share-url')).toBe(shortURL);
   });
 
+  it('shows an error and allows retrying when short URL creation fails', async () => {
+    const user = userEvent.setup();
+    const error = new Error('Unable to create short URL');
+    const onUrlGenerationError = jest.fn();
+    const shortURL = 'http://localhost:5601/xyz/r/s/yellow-orange-tomato';
+    const createFromLongUrlSpy = jest.spyOn(BrowserShortUrlClient.prototype, 'createFromLongUrl');
+
+    createFromLongUrlSpy.mockReset();
+    createFromLongUrlSpy
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({
+        // @ts-expect-error we only return url property, as that's all we need for this test
+        url: shortURL,
+      });
+
+    renderComponent(
+      {
+        objectType: 'dashboard',
+        isDirty: false,
+        shareableUrl,
+        shortUrlService,
+        allowShortUrl: true,
+      },
+      { ...mockShareContext, onUrlGenerationError }
+    );
+
+    const copyButton = screen.getByTestId('copyShareUrlButton');
+
+    await user.click(copyButton);
+
+    await waitFor(() => {
+      expect(onUrlGenerationError).toHaveBeenCalledWith(error);
+      expect(copyButton).not.toBeDisabled();
+    });
+
+    await user.click(copyButton);
+
+    await waitFor(() => {
+      expect(copyButton.getAttribute('data-share-url')).toBe(shortURL);
+    });
+    expect(createFromLongUrlSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('renders a draft mode callout when dirty and triggers its save button', async () => {
     const user = userEvent.setup();
     const onSave = jest.fn();

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -53,7 +53,7 @@ export const LinkContent = ({
   shareableUrlLocatorParams,
   allowShortUrl,
 }: LinkProps) => {
-  const { onSave, isSaving } = useShareContext();
+  const { onSave, isSaving, onUrlGenerationError } = useShareContext();
   const [snapshotUrl, setSnapshotUrl] = useState<string>('');
   const [isTextCopied, setTextCopied] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -104,28 +104,39 @@ export const LinkContent = ({
   const copyUrlHelper = useCallback(async () => {
     setIsLoading(true);
 
-    if (!urlToCopy.current) {
-      urlToCopy.current = delegatedShareUrlHandler
-        ? await delegatedShareUrlHandler()
-        : allowShortUrl
-        ? await createShortUrl()
-        : snapshotUrl;
-    }
-
-    copyToClipboard(urlToCopy.current);
-    setTextCopied(() => {
-      if (copiedTextToolTipCleanupIdRef.current) {
-        clearTimeout(copiedTextToolTipCleanupIdRef.current);
+    try {
+      if (!urlToCopy.current) {
+        urlToCopy.current = delegatedShareUrlHandler
+          ? await delegatedShareUrlHandler()
+          : allowShortUrl
+          ? await createShortUrl()
+          : snapshotUrl;
       }
 
-      // set up timer to revert copied state to false after specified duration
-      copiedTextToolTipCleanupIdRef.current = setTimeout(() => setTextCopied(false), 1000);
+      copyToClipboard(urlToCopy.current);
+      setTextCopied(() => {
+        if (copiedTextToolTipCleanupIdRef.current) {
+          clearTimeout(copiedTextToolTipCleanupIdRef.current);
+        }
 
-      // set copied state to true for now
-      return true;
-    });
-    setIsLoading(false);
-  }, [snapshotUrl, delegatedShareUrlHandler, allowShortUrl, createShortUrl]);
+        // set up timer to revert copied state to false after specified duration
+        copiedTextToolTipCleanupIdRef.current = setTimeout(() => setTextCopied(false), 1000);
+
+        // set copied state to true for now
+        return true;
+      });
+    } catch (error) {
+      onUrlGenerationError?.(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    snapshotUrl,
+    delegatedShareUrlHandler,
+    allowShortUrl,
+    createShortUrl,
+    onUrlGenerationError,
+  ]);
 
   const handleTimeTypeChange = useCallback(
     (isAbsolute: boolean) => {

--- a/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
+++ b/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
@@ -64,6 +64,13 @@ export class ShareMenuManager {
             onClose,
             menuItems,
             publicAPIEnabled: !isServerless,
+            onUrlGenerationError: (error: Error) => {
+              core.notifications.toasts.addError(error, {
+                title: i18n.translate('share.link.generateUrlError', {
+                  defaultMessage: 'Unable to generate a URL',
+                }),
+              });
+            },
           },
           core.rendering
         );
@@ -309,9 +316,11 @@ export class ShareMenuManager {
       asExport,
       publicAPIEnabled,
       onSave,
+      onUrlGenerationError,
     }: ShowShareMenuOptions & {
       menuItems: ShareConfigs[];
       onClose: () => void;
+      onUrlGenerationError: (error: Error) => void;
     },
     rendering: RenderingService
   ) {
@@ -345,6 +354,7 @@ export class ShareMenuManager {
             unmount();
           },
           onSave,
+          onUrlGenerationError,
         },
       }),
       rendering


### PR DESCRIPTION
## Summary

Fixes the Share modal's stuck loading state when generating a short URL fails.

- Reset the Copy link button after a rejected URL-generation request.
- Show Kibana's standard error toast so users understand that a URL was not generated.
- Add a regression test that verifies an error is surfaced and a second click can retry successfully.

## Root cause

The async copy handler set its loading state before generating a short URL, but did not handle rejected URL-generation promises. The rejection therefore bypassed the loading-state reset and user feedback.

## Validation

- `git diff --check`
- Focused unit test added at `src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx`

The focused Jest command is `node scripts/jest src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx`. It could not run locally because Yarn dependency installation was blocked by corrupt package-cache artifacts (including a tarball integrity mismatch), despite using a clean checkout-local cache.

Closes #278722
