### PR TITLE
[8.19] [Fleet] Fix escape_string YAML corruption regression (#279391)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -243,6 +243,29 @@ text_var: {{escape_string text_var}}
       });
     });
 
+    it('should preserve double quotes inside escape_string values without corrupting surrounding YAML', () => {
+      // Regression: https://github.com/elastic/kibana/issues/279388
+      // escape_string wraps single-line values in YAML single quotes: 'user"name'
+      // The newline-collapse regex was incorrectly treating the `"` inside the
+      // single-quoted scalar as a double-quote delimiter, matching across lines
+      // and collapsing subsequent YAML keys onto one line.
+      const template = `
+username: {{escape_string username}}
+password: {{escape_string password}}
+interval: 24h
+`;
+      const vars = {
+        username: { type: 'text', value: 'user"name' },
+        password: { type: 'password', value: 'p@ss"word' },
+      };
+      const output = compileTemplate(vars, getMockedMetaVariable(), template);
+      expect(output).toEqual({
+        username: 'user"name',
+        password: 'p@ss"word',
+        interval: '24h',
+      });
+    });
+
     it('should respect new lines and literal escapes', () => {
       const vars = {
         text_var: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -258,7 +258,7 @@ interval: 24h
         username: { type: 'text', value: 'user"name' },
         password: { type: 'password', value: 'p@ss"word' },
       };
-      const output = compileTemplate(vars, getMockedMetaVariable(), template);
+      const output = compileTemplate(vars, template);
       expect(output).toEqual({
         username: 'user"name',
         password: 'p@ss"word',

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -27,14 +27,17 @@ export function compileTemplate(variables: PackagePolicyConfigRecord, templateSt
     throw new PackageInvalidArchiveError(`Error while compiling agent template: ${err.message}`);
   }
 
-  // Must run before replaceRootLevelYamlVariables: stringify output may contain
-  // unquoted `"` chars (e.g. regexp patterns) that cause this regex to match
-  // across lines and corrupt the YAML structure.
-  compiledTemplate = compiledTemplate.replace(/"(?:[^"\\]|\\.)*"/gs, (match) =>
-    match.includes('\n')
+  // Must run before replaceRootLevelYamlVariables: yaml.stringify output may contain
+  // double-quoted scalars with literal newlines that the yaml parser rejects.
+  // The alternation skips YAML single-quoted scalars first (including any `"` they
+  // contain) so that a `"` inside e.g. `'user"name'` is never treated as a
+  // double-quote delimiter.
+  compiledTemplate = compiledTemplate.replace(/'(?:[^']|'')*'|"(?:[^"\\]|\\.)*"/gs, (match) => {
+    if (match[0] === "'") return match; // single-quoted scalar — no escaping needed
+    return match.includes('\n')
       ? match.replace(/\n+/g, (newlines) => '\\n'.repeat(newlines.length - 1))
-      : match
-  );
+      : match;
+  });
 
   compiledTemplate = replaceRootLevelYamlVariables(yamlValues, compiledTemplate);
 


### PR DESCRIPTION
## Summary

Fixes TypeScript errors in the backport of #279391 to 8.19.

On 8.19, `compileTemplate` takes 2 arguments `(variables, templateStr)`.
The backported test was written for main's 3-argument form `(variables, metaVariable, templateStr)` and referenced `getMockedMetaVariable()` which does not exist on 8.19.

Fix: drop the `metaVariable` argument and remove the undefined `getMockedMetaVariable()` call.

Replaces #279534 (kibanamachine backport that failed TypeScript check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)