### PR TITLE
[CI] Disable promotion pipelines issue reporting

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'
-        REPORT_FAILED_TESTS_TO_GITHUB: 'true'
+        REPORT_FAILED_TESTS_TO_GITHUB: 'false'
       allow_rebuilds: false
       branch_configuration: main
       default_branch: main

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -23,7 +23,7 @@ spec:
         ES_SERVERLESS_IMAGE: docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:latest
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'
-        REPORT_FAILED_TESTS_TO_GITHUB: 'true'
+        REPORT_FAILED_TESTS_TO_GITHUB: 'false'
       allow_rebuilds: true
       branch_configuration: main
       default_branch: main

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -149,7 +149,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'
-        REPORT_FAILED_TESTS_TO_GITHUB: 'true'
+        REPORT_FAILED_TESTS_TO_GITHUB: 'false'
         SCOUT_REPORTER_ENABLED: 'true'
       allow_rebuilds: true
       branch_configuration: main 9.5 9.4 9.3 8.19


### PR DESCRIPTION
## Summary
recently big fallouts are causing mass issue management duty for devs

for now, we are disabling the github issues, but the slack notifications should stay there.