### PR TITLE
[Workflows] Fix bare "0" for zero step execution duration

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.test.tsx
@@ -93,6 +93,13 @@ describe('StepExecutionTreeItemLabel', () => {
     expect(screen.queryByText(/\ds/)).not.toBeInTheDocument();
   });
 
+  it('does not render execution duration when executionTimeMs is 0', () => {
+    renderWithIntl({ ...defaultProps, executionTimeMs: 0 });
+    // Avoid the React {0 && …} trap: must not render a bare "0" text node
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+    expect(screen.queryByText('0ms')).not.toBeInTheDocument();
+  });
+
   it('renders without a status', () => {
     renderWithIntl({ ...defaultProps, status: undefined });
     expect(screen.getByTestId('workflowStepName')).toHaveTextContent('my_step');

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
@@ -85,13 +85,18 @@ export function StepExecutionTreeItemLabel({
           <TokenUsageBadge usage={usage} compact data-test-subj="workflowStepTreeTokenUsage" />
         </EuiFlexItem>
       )}
-      {executionTimeMs && status !== ExecutionStatus.WAITING_FOR_INPUT && !isTriggerPseudoStep && (
-        <EuiFlexItem grow={false} css={[styles.duration, isDangerous && styles.durationDangerous]}>
-          <EuiText size="xs" color="subdued">
-            {formatDuration(executionTimeMs)}
-          </EuiText>
-        </EuiFlexItem>
-      )}
+      {executionTimeMs > 0 &&
+        status !== ExecutionStatus.WAITING_FOR_INPUT &&
+        !isTriggerPseudoStep && (
+          <EuiFlexItem
+            grow={false}
+            css={[styles.duration, isDangerous && styles.durationDangerous]}
+          >
+            <EuiText size="xs" color="subdued">
+              {formatDuration(executionTimeMs)}
+            </EuiText>
+          </EuiFlexItem>
+        )}
     </EuiFlexGroup>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes unstyled `0` next to workflow step names when `executionTimeMs` is `0`
- Root cause: `{0 && <Duration />}` evaluates to `0`, which React renders as text
- Change condition to `executionTimeMs > 0` so null/zero stay hidden (original intent) without the React trap

Before:
<img width="693" height="416" alt="image" src="https://github.com/user-attachments/assets/df0b8f28-9acf-47cb-a35f-abf71013785c" />

After:
<img width="687" height="377" alt="image" src="https://github.com/user-attachments/assets/32850f73-a758-482a-b5dc-4429ebc71355" />

Fixes https://github.com/elastic/security-team/issues/17874

Made with [Cursor](https://cursor.com)