### PR TITLE
[Alerting V2] Change connector form flyout from small to medium

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/connector_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/connector_selector.tsx
@@ -121,6 +121,7 @@ export const ConnectorSelector = ({ connectorTypeId, value, onChange }: Connecto
             initialConnector: { actionTypeId: connectorTypeId },
             onClose: () => setIsCreateFlyoutOpen(false),
             onConnectorCreated: handleConnectorCreated,
+            size: 'm',
           })}
         </KibanaContextProvider>
       )}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
@@ -58,6 +58,7 @@ export interface CreateConnectorFlyoutProps {
   isServerless?: boolean;
   initialConnector?: Partial<Omit<ActionConnector, 'secrets'>> & { actionTypeId: string };
   icon?: IconType;
+  size?: 's' | 'm' | 'l';
 }
 
 const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
@@ -68,6 +69,7 @@ const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
   onTestConnector,
   initialConnector,
   icon,
+  size,
 }) => {
   const { docLinks } = useKibana().services;
   const [allActionTypes, setAllActionTypes] = useState<ActionTypeIndex | undefined>(undefined);
@@ -277,6 +279,7 @@ const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
           headerName: flyoutHeaderName,
         },
       })}
+      size={size}
     >
       <FlyoutHeader
         icon={icon ?? actionTypeModel?.iconClass}


### PR DESCRIPTION
## Summary

Change connector form flyout from small to medium

Before:
<img width="1712" height="952" alt="image" src="https://github.com/user-attachments/assets/833a15bf-414c-4545-9aa0-6f0196e5559a" />


After:
<img width="1705" height="961" alt="image" src="https://github.com/user-attachments/assets/c52aaaa0-3531-41f5-bb9f-a151fd1d9b48" />



## Testing
1. Enable alerting v2 in your deployment
2. Go to the rule form
3. In the "Simple action policy" section (last step of the form), click on any of the "Email" or "Slack" actions
4. Click on "+ Create new connector"
5. Verify that the connector form flyout is open and it's medium sized

