### PR TITLE
[Security Solution][exploratory-tester] Add explicit agent goal and anti-goal to SKILL.md

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md
@@ -15,6 +15,9 @@ Explore a Kibana Security Solution feature area through a real browser, collect 
 
 **Execute phases 0 → 1 → 2 → 3 in strict order. Read each phase file before executing it.**
 
+**Your goal:** Surface genuine issues that would affect real users.
+**Your anti-goal:** Do not produce findings to fill a report — if you explored thoroughly and found nothing, that is a valid and useful result. Precision over volume: one confirmed Level 1 bug is worth more than ten uncertain Level 2 observations.
+
 ## Quick Reference
 
 | Phase | Exit condition |
@@ -71,6 +74,7 @@ Pre-session errors that make findings low-value before exploration even starts:
 | "I don't know how this feature works" | Check specs → official docs → UI → test files for user flows. |
 | "This error is expected" | Document it. User decides — then add to `knowledge/<area-slug>.md`. |
 | "I called the API and it works" | UI and API hit different code paths. Browser reproduction required. |
+| "I didn't find anything — I should flag this observation just in case" | If you completed the checklist and nothing confirmed, report it as clean. That is signal, not failure. |
 ## Phases
 
 Execute in order — read each file before starting it:

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md
@@ -16,7 +16,7 @@ Explore a Kibana Security Solution feature area through a real browser, collect 
 **Execute phases 0 → 1 → 2 → 3 in strict order. Read each phase file before executing it.**
 
 **Your goal:** Surface genuine issues that would affect real users.
-**Your anti-goal:** Do not produce findings to fill a report — if you explored thoroughly and found nothing, that is a valid and useful result. Precision over volume: one confirmed Level 1 bug is worth more than ten uncertain Level 2 observations.
+**Your anti-goal:** Do not produce findings to fill a report — if you explored thoroughly and found nothing, that is a valid and useful result. Precision over volume: one confirmed Level 1 bug is worth more than ten uncertain Level 2 flags.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

Closes elastic/security-team#18305

The `exploratory-tester` skill is entirely procedural — phases, checklists, finding formats — but never states what the agent is actually trying to achieve. This is a silent failure mode: when the agent hits a situation the instructions didn't anticipate (ambiguous UI state, time running out mid-checklist), it falls back on whatever it infers the goal to be. For a skill called "tester," the default inference is **produce findings**, which inflates noise. An agent that explored thoroughly and found nothing feels like it failed, so it starts classifying cosmetic observations as Level 2s.

This PR adds two anchors to `SKILL.md`:

1. **Goal / anti-goal block** — two lines that give the agent an explicit tiebreaker for every unscripted judgment call. Instead of asking "what would a tester do?" (→ produces findings), it asks "does this serve the goal?" (→ surfaces real user-facing issues). The anti-goal makes the precision-over-volume expectation explicit: a clean session is a valid, useful result, not a failure.

2. **New Red Flags row** — "I didn't find anything — I should flag this observation just in case" → "If you completed the checklist and nothing confirmed, report it as clean. That is signal, not failure." This directly addresses the padding behaviour at the point where the agent is most likely to rationalise inflating the report.

### Why the goal block is placed where it is

The goal / anti-goal block sits immediately after the `**Execute phases 0 → 1 → 2 → 3 in strict order**` line and before `## Quick Reference`. This is the last thing the agent reads before it starts scanning the procedural phase table — making the goal the final framing thought before execution begins.

Two alternative placements were considered:

- **After the one-line skill description (line 14)** — would group the goal with the skill's identity ("what this is"), which is conceptually clean but one step removed from the procedure it needs to govern.
- **After the "Execute phases" line (chosen)** — positions the goal as the bridge into execution: "here's the phase order → here's the mission that governs all of it → now here's the phase table." The goal is adjacent to the procedure it steers, making it a stronger execution anchor.

Since the entire `SKILL.md` stays in the agent's context through all phases, placement doesn't affect whether the goal is seen — it affects how it is framed. The chosen position frames the goal as a rule to consult while working rather than a definition of the skill.

## Changes

- `x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md` — 4 lines added, no other files changed.

## Test plan

- [ ] `SKILL.md` contains the goal + anti-goal block between the "Execute phases" line and `## Quick Reference`
- [ ] The Red Flags table contains the "didn't find anything" row
- [ ] A session that completes all checklist steps with no confirmed findings produces a clean report (not padded with Level 3 observations) and the agent does not describe this as a failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)