### PR TITLE
[8.19] [ML] Fix ML saved objects API privileges (#276936)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/server/routes/saved_objects.ts
+++ b/x-pack/platform/plugins/shared/ml/server/routes/saved_objects.ts
@@ -34,7 +34,15 @@ export function savedObjectsRoutes(
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: ['ml:canGetJobs', 'ml:canGetTrainedModels'],
+          requiredPrivileges: [
+            {
+              anyRequired: [
+                'ml:canGetJobs',
+                'ml:canGetDataFrameAnalytics',
+                'ml:canGetTrainedModels',
+              ],
+            },
+          ],
         },
       },
       summary: 'Get job and trained model saved object status',
@@ -68,9 +76,13 @@ export function savedObjectsRoutes(
       security: {
         authz: {
           requiredPrivileges: [
-            'ml:canCreateJob',
-            'ml:canCreateDataFrameAnalytics',
-            'ml:canCreateTrainedModels',
+            {
+              anyRequired: [
+                'ml:canCreateJob',
+                'ml:canCreateDataFrameAnalytics',
+                'ml:canCreateTrainedModels',
+              ],
+            },
           ],
         },
       },
@@ -113,9 +125,13 @@ export function savedObjectsRoutes(
       security: {
         authz: {
           requiredPrivileges: [
-            'ml:canCreateJob',
-            'ml:canCreateDataFrameAnalytics',
-            'ml:canCreateTrainedModels',
+            {
+              anyRequired: [
+                'ml:canCreateJob',
+                'ml:canCreateDataFrameAnalytics',
+                'ml:canCreateTrainedModels',
+              ],
+            },
           ],
         },
       },
@@ -156,9 +172,13 @@ export function savedObjectsRoutes(
       security: {
         authz: {
           requiredPrivileges: [
-            'ml:canGetJobs',
-            'ml:canGetDataFrameAnalytics',
-            'ml:canGetTrainedModels',
+            {
+              anyRequired: [
+                'ml:canGetJobs',
+                'ml:canGetDataFrameAnalytics',
+                'ml:canGetTrainedModels',
+              ],
+            },
           ],
         },
       },
@@ -197,7 +217,11 @@ export function savedObjectsRoutes(
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: ['ml:canCreateJob', 'ml:canCreateDataFrameAnalytics'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['ml:canCreateJob', 'ml:canCreateDataFrameAnalytics'],
+            },
+          ],
         },
       },
       summary: 'Update what spaces jobs are assigned to',
@@ -278,7 +302,15 @@ export function savedObjectsRoutes(
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: ['ml:canCreateJob', 'ml:canCreateDataFrameAnalytics'],
+          requiredPrivileges: [
+            {
+              anyRequired: [
+                'ml:canCreateJob',
+                'ml:canCreateDataFrameAnalytics',
+                'ml:canCreateTrainedModels',
+              ],
+            },
+          ],
         },
       },
       summary: 'Remove jobs or trained models from the current space',
@@ -344,7 +376,11 @@ export function savedObjectsRoutes(
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: ['ml:canGetJobs', 'ml:canGetDataFrameAnalytics'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['ml:canGetJobs', 'ml:canGetDataFrameAnalytics'],
+            },
+          ],
         },
       },
       summary: 'Get all jobs and their spaces',
@@ -407,9 +443,13 @@ export function savedObjectsRoutes(
       security: {
         authz: {
           requiredPrivileges: [
-            'ml:canGetJobs',
-            'ml:canGetDataFrameAnalytics',
-            'ml:canGetTrainedModels',
+            {
+              anyRequired: [
+                'ml:canGetJobs',
+                'ml:canGetDataFrameAnalytics',
+                'ml:canGetTrainedModels',
+              ],
+            },
           ],
         },
       },
@@ -458,9 +498,13 @@ export function savedObjectsRoutes(
       security: {
         authz: {
           requiredPrivileges: [
-            'ml:canGetJobs',
-            'ml:canGetDataFrameAnalytics',
-            'ml:canGetTrainedModels',
+            {
+              anyRequired: [
+                'ml:canGetJobs',
+                'ml:canGetDataFrameAnalytics',
+                'ml:canGetTrainedModels',
+              ],
+            },
           ],
         },
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix ML saved objects API privileges (#276936)](https://github.com/elastic/kibana/pull/276936)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"James Gowdy","email":"jgowdy@elastic.co"},"sourceCommit":{"committedDate":"2026-07-21T08:06:08Z","message":"[ML] Fix ML saved objects API privileges (#276936)\n\nUpdates the `requiredPrivileges` for multiple saved object apis to\nensure any of the relevant AD, DFA or trained models capabilities are\npresent.\nPreviously a user would be required to have all three. This could cause\na problem if a feature has been disabled causing one of the capabilities\nto be false.\n\nFrom a security point of view, it's not possible to grant a user a\nmixture of these three capabilities, e.g. write permission for AD and\nDFA jobs but only read for trained models.\n\nAlso fixes an issue where the\n`saved_objects/remove_item_from_current_space` api was missing the\ncapability `canCreateTrainedModels`\n\n---------\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"6c9a9d79f2ccd4906dbce9af1b1c29847f185bf9","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","v9.5.0","v9.4.4","v9.6.0","v8.19.19","v9.3.8","v9.4.5"],"title":"[ML] Fix ML saved objects API privileges","number":276936,"url":"https://github.com/elastic/kibana/pull/276936","mergeCommit":{"message":"[ML] Fix ML saved objects API privileges (#276936)\n\nUpdates the `requiredPrivileges` for multiple saved object apis to\nensure any of the relevant AD, DFA or trained models capabilities are\npresent.\nPreviously a user would be required to have all three. This could cause\na problem if a feature has been disabled causing one of the capabilities\nto be false.\n\nFrom a security point of view, it's not possible to grant a user a\nmixture of these three capabilities, e.g. write permission for AD and\nDFA jobs but only read for trained models.\n\nAlso fixes an issue where the\n`saved_objects/remove_item_from_current_space` api was missing the\ncapability `canCreateTrainedModels`\n\n---------\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"6c9a9d79f2ccd4906dbce9af1b1c29847f185bf9"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279721","number":279721,"state":"MERGED","mergeCommit":{"sha":"d32053eb60ed623beff20095bf2dee7005a159c3","message":"[9.5] [ML] Fix ML saved objects API privileges (#276936) (#279721)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[ML] Fix ML saved objects API privileges\n(#276936)](https://github.com/elastic/kibana/pull/276936)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: James Gowdy <jgowdy@elastic.co>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279720","number":279720,"state":"MERGED","mergeCommit":{"sha":"68601cbd339eedfaab789972d1889185e25419e1","message":"[9.4] [ML] Fix ML saved objects API privileges (#276936) (#279720)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[ML] Fix ML saved objects API privileges\n(#276936)](https://github.com/elastic/kibana/pull/276936)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: James Gowdy <jgowdy@elastic.co>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276936","number":276936,"mergeCommit":{"message":"[ML] Fix ML saved objects API privileges (#276936)\n\nUpdates the `requiredPrivileges` for multiple saved object apis to\nensure any of the relevant AD, DFA or trained models capabilities are\npresent.\nPreviously a user would be required to have all three. This could cause\na problem if a feature has been disabled causing one of the capabilities\nto be false.\n\nFrom a security point of view, it's not possible to grant a user a\nmixture of these three capabilities, e.g. write permission for AD and\nDFA jobs but only read for trained models.\n\nAlso fixes an issue where the\n`saved_objects/remove_item_from_current_space` api was missing the\ncapability `canCreateTrainedModels`\n\n---------\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"6c9a9d79f2ccd4906dbce9af1b1c29847f185bf9"}},{"branch":"8.19","label":"v8.19.19","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279719","number":279719,"state":"MERGED","mergeCommit":{"sha":"b6cd0ad9a837638a7920f1f8c5e52dcac6f0ab66","message":"[9.3] [ML] Fix ML saved objects API privileges (#276936) (#279719)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[ML] Fix ML saved objects API privileges\n(#276936)](https://github.com/elastic/kibana/pull/276936)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: James Gowdy <jgowdy@elastic.co>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"}}]}] BACKPORT-->