### PR TITLE
[8.19] [Alerting] Scope bulk untrack queries to the active space (#279159)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -6,7 +6,7 @@
  */
 import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
-import { ALERT_RULE_UUID, ALERT_UUID } from '@kbn/rule-data-utils';
+import { ALERT_RULE_UUID, ALERT_UUID, SPACE_IDS } from '@kbn/rule-data-utils';
 import { setAlertsToUntracked } from './set_alerts_to_untracked';
 
 let clusterClient: ElasticsearchClientMock;
@@ -468,6 +468,11 @@ describe('setAlertsToUntracked()', () => {
               ],
               filter: [
                 {
+                  terms: {
+                    [SPACE_IDS]: ['default'],
+                  },
+                },
+                {
                   bool: {
                     must: {
                       term: {
@@ -498,6 +503,11 @@ describe('setAlertsToUntracked()', () => {
                 },
               ],
               filter: [
+                {
+                  terms: {
+                    [SPACE_IDS]: ['default'],
+                  },
+                },
                 {
                   bool: {
                     must: {
@@ -607,6 +617,11 @@ describe('setAlertsToUntracked()', () => {
               ],
               filter: [
                 {
+                  terms: {
+                    [SPACE_IDS]: ['default'],
+                  },
+                },
+                {
                   bool: {
                     must: {
                       term: {
@@ -624,5 +639,151 @@ describe('setAlertsToUntracked()', () => {
 
     expect(clusterClient.search).not.toHaveBeenCalledWith();
     expect(result).toEqual([]);
+  });
+
+  describe('space isolation (direct UUID path)', () => {
+    test('should include space filter in updateByQuery when spaceId is provided', async () => {
+      await setAlertsToUntracked({
+        logger,
+        esClient: clusterClient,
+        indices: ['test-index'],
+        alertUuids: ['test-alert-uuid'],
+        spaceId: 'space1',
+      });
+
+      expect(clusterClient.updateByQuery).toHaveBeenCalledTimes(1);
+      expect(clusterClient.updateByQuery.mock.lastCall![0].body?.query).toMatchObject({
+        bool: {
+          must: expect.any(Array),
+          filter: [
+            {
+              terms: {
+                [SPACE_IDS]: ['space1'],
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    test('should include space filter in authorization search when spaceId is provided', async () => {
+      clusterClient.search.mockResponseOnce({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { hits: [] },
+        aggregations: {
+          ruleTypeIds: {
+            buckets: [{ key: 'some-rule', consumers: { buckets: [{ key: 'o11y' }] } }],
+          },
+        },
+      });
+
+      await setAlertsToUntracked({
+        logger,
+        esClient: clusterClient,
+        indices: ['test-index'],
+        alertUuids: ['test-alert-uuid'],
+        spaceId: 'space1',
+        ensureAuthorized: ensureAuthorizedMock,
+      });
+
+      // First search is for authorization aggregation
+      expect(clusterClient.search.mock.calls[0][0]).toMatchObject({
+        body: {
+          query: {
+            bool: {
+              must: expect.any(Array),
+              filter: [
+                {
+                  terms: {
+                    [SPACE_IDS]: ['space1'],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    test('should not include space filter when spaceId is absent', async () => {
+      await setAlertsToUntracked({
+        logger,
+        esClient: clusterClient,
+        indices: ['test-index'],
+        alertUuids: ['test-alert-uuid'],
+      });
+
+      const query = clusterClient.updateByQuery.mock.lastCall![0].body?.query;
+      expect(query).toMatchObject({ bool: { must: expect.any(Array) } });
+      expect(query).not.toHaveProperty('bool.filter');
+    });
+
+    test('should include space filter in post-update search when spaceId is provided', async () => {
+      clusterClient.updateByQuery.mockResponseOnce({ total: 1, updated: 1 });
+
+      await setAlertsToUntracked({
+        logger,
+        esClient: clusterClient,
+        indices: ['test-index'],
+        alertUuids: ['test-alert-uuid'],
+        spaceId: 'space1',
+      });
+
+      // The search after update should also carry the space filter
+      expect(clusterClient.search.mock.lastCall![0]).toMatchObject({
+        body: {
+          query: {
+            bool: {
+              must: expect.any(Array),
+              filter: [
+                {
+                  terms: {
+                    [SPACE_IDS]: ['space1'],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    test('should NOT include the all-spaces wildcard in the space filter', async () => {
+      // Untracking must never match globally visible ('*') alerts (e.g. internally managed
+      // Streams "Significant Events" alerts). Only the caller's own space is allowed.
+      await setAlertsToUntracked({
+        logger,
+        esClient: clusterClient,
+        indices: ['test-index'],
+        alertUuids: ['test-alert-uuid'],
+        spaceId: 'space1',
+      });
+
+      const query = clusterClient.updateByQuery.mock.lastCall![0].body?.query;
+      expect(query).toMatchObject({
+        bool: {
+          filter: [
+            {
+              terms: {
+                [SPACE_IDS]: ['space1'],
+              },
+            },
+          ],
+        },
+      });
+      expect(query).not.toMatchObject({
+        bool: {
+          filter: [
+            {
+              terms: {
+                [SPACE_IDS]: expect.arrayContaining(['*']),
+              },
+            },
+          ],
+        },
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -653,7 +653,8 @@ describe('setAlertsToUntracked()', () => {
 
       expect(clusterClient.updateByQuery).toHaveBeenCalledTimes(1);
       expect(
-        (clusterClient.updateByQuery.mock.lastCall![0] as { body?: { query?: unknown } }).body?.query
+        (clusterClient.updateByQuery.mock.lastCall![0] as { body?: { query?: unknown } }).body
+          ?.query
       ).toMatchObject({
         bool: {
           must: expect.any(Array),

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -652,7 +652,9 @@ describe('setAlertsToUntracked()', () => {
       });
 
       expect(clusterClient.updateByQuery).toHaveBeenCalledTimes(1);
-      expect(clusterClient.updateByQuery.mock.lastCall![0].body?.query).toMatchObject({
+      expect(
+        (clusterClient.updateByQuery.mock.lastCall![0] as { body?: { query?: unknown } }).body?.query
+      ).toMatchObject({
         bool: {
           must: expect.any(Array),
           filter: [
@@ -715,7 +717,9 @@ describe('setAlertsToUntracked()', () => {
         alertUuids: ['test-alert-uuid'],
       });
 
-      const query = clusterClient.updateByQuery.mock.lastCall![0].body?.query;
+      const query = (
+        clusterClient.updateByQuery.mock.lastCall![0] as { body?: { query?: unknown } }
+      ).body?.query;
       expect(query).toMatchObject({ bool: { must: expect.any(Array) } });
       expect(query).not.toHaveProperty('bool.filter');
     });
@@ -761,7 +765,9 @@ describe('setAlertsToUntracked()', () => {
         spaceId: 'space1',
       });
 
-      const query = clusterClient.updateByQuery.mock.lastCall![0].body?.query;
+      const query = (
+        clusterClient.updateByQuery.mock.lastCall![0] as { body?: { query?: unknown } }
+      ).body?.query;
       expect(query).toMatchObject({
         bool: {
           filter: [

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.ts
@@ -19,6 +19,7 @@ import {
   ALERT_STATUS_UNTRACKED,
   ALERT_TIME_RANGE,
   ALERT_UUID,
+  SPACE_IDS,
 } from '@kbn/rule-data-utils';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { RulesClientContext } from '../../rules_client';
@@ -61,6 +62,8 @@ const getUntrackQuery = (
   params: SetAlertsToUntrackedParamsWithDep,
   alertStatus: AlertStatus
 ): QueryDslQueryContainer => {
+  const { spaceId } = params;
+
   const statusTerms: Array<{ term: Record<string, { value: string }> }> = [
     {
       term: {
@@ -69,12 +72,26 @@ const getUntrackQuery = (
     },
   ];
 
+  // Restrict untracking to alerts that belong to the active space only.
+  //
+  // Note we intentionally do NOT include the all-spaces wildcard ('*') here, unlike the
+  // read-side `getSpacesFilter` in rule_registry. Reading globally visible alerts across
+  // spaces is legitimate, but mutating them is not: the only rule types that write '*'
+  // alerts are internally managed (e.g. Streams "Significant Events"), whose alerts are
+  // point-in-time occurrence records that back an internal feature and are never meant to
+  // be untracked by users. Matching '*' here would let a caller in one space mutate a
+  // document shared by every space. Please keep this divergence from the read path.
+  //
+  // When spaceId is absent (internal cleanup calls), no space filter is applied.
+  const spaceFilter = spaceId ? { terms: { [SPACE_IDS]: [spaceId] } } : undefined;
+
   if (params.isUsingQuery) {
     const { query } = params;
+    const filterClauses = [...(spaceFilter ? [spaceFilter] : []), ...(query ?? [])];
     return {
       bool: {
         must: statusTerms,
-        ...(query ? { filter: query } : {}),
+        ...(filterClauses.length > 0 ? { filter: filterClauses } : {}),
       },
     };
   } else {
@@ -110,6 +127,7 @@ const getUntrackQuery = (
             },
           },
         ],
+        ...(spaceFilter ? { filter: [spaceFilter] } : {}),
       },
     };
   }

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_untrack_space_isolation.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_untrack_space_isolation.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Regression test for space isolation in bulk untrack.
+ *
+ * Scenario: a user with `stackAlerts: ['all']` only in space1 calls
+ * `POST /s/space1/internal/alerting/alerts/_bulk_untrack` supplying a
+ * client-side index and alert UUID that belong to space2. The foreign alert
+ * must remain active regardless of what the override-path call returns.
+ *
+ * The hard assertion is the alert-document state, not the override-path
+ * status code, so the test decouples from the fix shape.
+ */
+
+import expect from '@kbn/expect';
+import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import { ALERT_STATUS, ALERT_UUID, SPACE_IDS } from '@kbn/rule-data-utils';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../common/lib';
+
+const STACK_ALERTS_INDEX = '.alerts-stack.alerts-default';
+
+// Low-privilege user: stackAlerts:['all'] in space1 only, no privileges in space2.
+const SPACE1_ONLY_USER = 'stack_alerts_only';
+const SPACE1_ONLY_PASS = 'stack_alerts_only-password';
+
+export default function bulkUntrackSpaceIsolationTests({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const retry = getService('retry');
+  const es = getService('es');
+  const esTestIndexTool = new ESTestIndexTool(es, retry);
+
+  describe('bulk untrack space isolation', () => {
+    const objectRemover = new ObjectRemover(supertest);
+
+    before(async () => {
+      await esTestIndexTool.destroy();
+      await esTestIndexTool.setup();
+    });
+
+    afterEach(async () => {
+      await objectRemover.removeAll();
+      await es.deleteByQuery({
+        index: STACK_ALERTS_INDEX,
+        query: { match_all: {} },
+        conflicts: 'proceed',
+        ignore_unavailable: true,
+        refresh: true,
+      });
+    });
+
+    after(async () => {
+      await esTestIndexTool.destroy();
+    });
+
+    it('alert in another space must remain active when untrack is called from own space', async () => {
+      // Index a document with a current timestamp so the rule fires on its
+      // first execution.
+      await es.index({
+        index: ES_TEST_INDEX_NAME,
+        document: { date: new Date().toISOString() },
+        refresh: true,
+      });
+
+      // Create the rule in space2 as admin.
+      const { body: space2Rule } = await supertest
+        .post(`${getUrlPrefix('space2')}/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          name: 'bulk-untrack-space-isolation',
+          consumer: 'stackAlerts',
+          enabled: true,
+          rule_type_id: '.es-query',
+          schedule: { interval: '1d' },
+          actions: [],
+          notify_when: 'onActiveAlert',
+          params: {
+            size: 100,
+            timeWindowSize: 60,
+            timeWindowUnit: 'm',
+            thresholdComparator: '>',
+            threshold: [0],
+            searchType: 'esQuery',
+            timeField: 'date',
+            esQuery: '{"query":{"match_all":{}}}',
+            index: [ES_TEST_INDEX_NAME],
+            excludeHitsFromPreviousRun: false,
+          },
+        })
+        .expect(200);
+
+      objectRemover.add('space2', space2Rule.id, 'rule', 'alerting');
+
+      // Wait for the rule to execute and produce an active alert.
+      await retry.try(async () => {
+        return await getEventLog({
+          getService,
+          spaceId: 'space2',
+          type: 'alert',
+          id: space2Rule.id,
+          provider: 'alerting',
+          actions: new Map([['active-instance', { gte: 1 }]]),
+        });
+      });
+
+      // Capture the alert UUID. By the time the event log confirms execution the
+      // document is already written, so this should resolve immediately.
+      let space2AlertUuid!: string;
+      await retry.try(async () => {
+        const result = await es.search({
+          index: STACK_ALERTS_INDEX,
+          query: { term: { 'kibana.alert.rule.uuid': space2Rule.id } },
+          ignore_unavailable: true,
+        });
+        const hits = result.hits.hits;
+        if (hits.length === 0) {
+          throw new Error('Alert doc not yet visible in stack alerts index');
+        }
+        const source = hits[0]._source as Record<string, unknown>;
+        if (source[ALERT_STATUS] !== 'active') {
+          throw new Error(`Expected active alert, got status: ${source[ALERT_STATUS]}`);
+        }
+        space2AlertUuid = source[ALERT_UUID] as string;
+      });
+
+      // Step 1 - direct call: user without space2 access calls the space2 route.
+      // Must return 403. This also validates the test setup: if the role were
+      // misconfigured with space2 access, this would fail and tell us the
+      // premises of the test are wrong.
+      const directResponse = await supertestWithoutAuth
+        .post(`${getUrlPrefix('space2')}/internal/alerting/alerts/_bulk_untrack`)
+        .set('kbn-xsrf', 'foo')
+        .auth(SPACE1_ONLY_USER, SPACE1_ONLY_PASS)
+        .send({
+          indices: [STACK_ALERTS_INDEX],
+          alert_uuids: [space2AlertUuid],
+        });
+
+      expect(directResponse.statusCode).to.eql(403);
+
+      // Step 2 - own-space call with foreign alert UUID: user calls the space1
+      // route supplying a client-side index and the space2 alert UUID. We do not
+      // assert the status code here because the fix shape is not yet determined
+      // (may be 204 no-op, 403, or 400).
+      await supertestWithoutAuth
+        .post(`${getUrlPrefix('space1')}/internal/alerting/alerts/_bulk_untrack`)
+        .set('kbn-xsrf', 'foo')
+        .auth(SPACE1_ONLY_USER, SPACE1_ONLY_PASS)
+        .send({
+          indices: [STACK_ALERTS_INDEX],
+          alert_uuids: [space2AlertUuid],
+        });
+
+      // Step 3 - space isolation invariant: the space2 alert must still be
+      // active and still belong to space2 regardless of what step 2 returned.
+      // This assertion FAILS on vulnerable code (alert becomes untracked) and
+      // PASSES once the fix lands.
+      const { hits } = (
+        await es.search({
+          index: STACK_ALERTS_INDEX,
+          query: { term: { 'kibana.alert.rule.uuid': space2Rule.id } },
+          ignore_unavailable: true,
+        })
+      ).hits;
+
+      expect(hits.length).to.be.greaterThan(0);
+
+      const space2AlertDoc = hits.find(
+        (h) => (h._source as Record<string, unknown>)[ALERT_UUID] === space2AlertUuid
+      );
+      expect(space2AlertDoc).not.to.be(undefined);
+
+      const source = space2AlertDoc!._source as Record<string, unknown>;
+
+      expect(source[SPACE_IDS]).to.eql(['space2']);
+      expect(source[ALERT_STATUS]).to.eql('active');
+    });
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/index.ts
@@ -34,6 +34,7 @@ export default function alertingTests({ loadTestFile, getService }: FtrProviderC
       loadTestFile(require.resolve('./rule_types_internal'));
       loadTestFile(require.resolve('./retain_api_key'));
       loadTestFile(require.resolve('./bulk_untrack'));
+      loadTestFile(require.resolve('./bulk_untrack_space_isolation'));
       loadTestFile(require.resolve('./bulk_untrack_by_query'));
       loadTestFile(require.resolve('./gap'));
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Alerting] Scope bulk untrack queries to the active space (#279159)](https://github.com/elastic/kibana/pull/279159)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-21T09:44:40Z","message":"[Alerting] Scope bulk untrack queries to the active space (#279159)\n\n### Summary\n\nCloses https://github.com/elastic/response-ops-team/issues/645\n\nBulk untrack builds its Elasticsearch query without a space filter. On\nshared alert indices that are not space-aware (for example\n`.alerts-stack.alerts-default`), the query could therefore match alert\ndocuments that belong to a different space than the request.\n\nThe rules-client layer already passes `context.spaceId`, but\n`getUntrackQuery` did not use it. This change uses that value to\nconstrain the authorization lookup, the update, and the post-update\nlookup to alerts belonging to the request's own space only\n(`[spaceId]`).\n\nUnlike the read-side `getSpacesFilter` in Rule Registry, we\nintentionally do **not** match globally visible (`'*'`) alerts. Reading\nglobal alerts across spaces is legitimate, but mutating them is not: the\nonly rule types that write `'*'` alerts are internally managed (e.g.\nStreams \"Significant Events\"), whose alerts are point-in-time occurrence\nrecords that back an internal feature and are never meant to be\nuntracked by users. Matching `'*'` here would let a caller in one space\nuntrack a document shared by every space.\n\n### What changed\n\n- Updated `set_alerts_to_untracked.ts` so untrack queries are scoped to\n`[spaceId]` only, while preserving existing behavior for internal calls\nthat do not supply a space ID.\n- Extended unit tests to verify the space filter is applied to the\nauthorization search, the update, and the post-update search, that the\nwildcard is never included, and coverage for the no-space-ID path.\n- Added an integration regression test that creates an active alert in\nspace 2 and verifies a space 1 user's untrack request does not modify\nit, even when passing the shared index and the alert UUID.","sha":"66e700b35c5c69ddc06d526f50e4ed5ec7072c9e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:all-open","v9.6.0"],"title":"[Alerting] Scope bulk untrack queries to the active space","number":279159,"url":"https://github.com/elastic/kibana/pull/279159","mergeCommit":{"message":"[Alerting] Scope bulk untrack queries to the active space (#279159)\n\n### Summary\n\nCloses https://github.com/elastic/response-ops-team/issues/645\n\nBulk untrack builds its Elasticsearch query without a space filter. On\nshared alert indices that are not space-aware (for example\n`.alerts-stack.alerts-default`), the query could therefore match alert\ndocuments that belong to a different space than the request.\n\nThe rules-client layer already passes `context.spaceId`, but\n`getUntrackQuery` did not use it. This change uses that value to\nconstrain the authorization lookup, the update, and the post-update\nlookup to alerts belonging to the request's own space only\n(`[spaceId]`).\n\nUnlike the read-side `getSpacesFilter` in Rule Registry, we\nintentionally do **not** match globally visible (`'*'`) alerts. Reading\nglobal alerts across spaces is legitimate, but mutating them is not: the\nonly rule types that write `'*'` alerts are internally managed (e.g.\nStreams \"Significant Events\"), whose alerts are point-in-time occurrence\nrecords that back an internal feature and are never meant to be\nuntracked by users. Matching `'*'` here would let a caller in one space\nuntrack a document shared by every space.\n\n### What changed\n\n- Updated `set_alerts_to_untracked.ts` so untrack queries are scoped to\n`[spaceId]` only, while preserving existing behavior for internal calls\nthat do not supply a space ID.\n- Extended unit tests to verify the space filter is applied to the\nauthorization search, the update, and the post-update search, that the\nwildcard is never included, and coverage for the no-space-ID path.\n- Added an integration regression test that creates an active alert in\nspace 2 and verifies a space 1 user's untrack request does not modify\nit, even when passing the shared index and the alert UUID.","sha":"66e700b35c5c69ddc06d526f50e4ed5ec7072c9e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279159","number":279159,"mergeCommit":{"message":"[Alerting] Scope bulk untrack queries to the active space (#279159)\n\n### Summary\n\nCloses https://github.com/elastic/response-ops-team/issues/645\n\nBulk untrack builds its Elasticsearch query without a space filter. On\nshared alert indices that are not space-aware (for example\n`.alerts-stack.alerts-default`), the query could therefore match alert\ndocuments that belong to a different space than the request.\n\nThe rules-client layer already passes `context.spaceId`, but\n`getUntrackQuery` did not use it. This change uses that value to\nconstrain the authorization lookup, the update, and the post-update\nlookup to alerts belonging to the request's own space only\n(`[spaceId]`).\n\nUnlike the read-side `getSpacesFilter` in Rule Registry, we\nintentionally do **not** match globally visible (`'*'`) alerts. Reading\nglobal alerts across spaces is legitimate, but mutating them is not: the\nonly rule types that write `'*'` alerts are internally managed (e.g.\nStreams \"Significant Events\"), whose alerts are point-in-time occurrence\nrecords that back an internal feature and are never meant to be\nuntracked by users. Matching `'*'` here would let a caller in one space\nuntrack a document shared by every space.\n\n### What changed\n\n- Updated `set_alerts_to_untracked.ts` so untrack queries are scoped to\n`[spaceId]` only, while preserving existing behavior for internal calls\nthat do not supply a space ID.\n- Extended unit tests to verify the space filter is applied to the\nauthorization search, the update, and the post-update search, that the\nwildcard is never included, and coverage for the no-space-ID path.\n- Added an integration regression test that creates an active alert in\nspace 2 and verifies a space 1 user's untrack request does not modify\nit, even when passing the shared index and the alert UUID.","sha":"66e700b35c5c69ddc06d526f50e4ed5ec7072c9e"}},{"url":"https://github.com/elastic/kibana/pull/279742","number":279742,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/279743","number":279743,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/279744","number":279744,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->