### PR TITLE
[Entity Analytics] Enable historical risk scoring feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -314,7 +314,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the risk score history API endpoint for Entity Analytics.
    */
-  riskScoreHistoryEnabled: false,
+  riskScoreHistoryEnabled: true,
 
   /**
    * Enables UI treatments surfacing rules whose MITRE ATT&CK mappings drift


### PR DESCRIPTION

## Summary

Enabling the historical risk scoring flag


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->