### PR TITLE
Stabilize connector execute test cleanup

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts
@@ -23,8 +23,7 @@ export default function ({ getService }: FtrProviderContext) {
 
   const authorizationIndex = '.kibana-test-authorization';
 
-  // Failing: See https://github.com/elastic/kibana/issues/258921
-  describe.skip('execute', () => {
+  describe('execute', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     before(async () => {
@@ -32,10 +31,12 @@ export default function ({ getService }: FtrProviderContext) {
       await esTestIndexTool.setup();
       await es.indices.create({ index: authorizationIndex });
     });
+    afterEach(async () => {
+      await objectRemover.removeAll();
+    });
     after(async () => {
       await esTestIndexTool.destroy();
       await es.indices.delete({ index: authorizationIndex });
-      await objectRemover.removeAll();
     });
 
     for (const scenario of [...UserAtSpaceScenarios, systemActionScenario]) {


### PR DESCRIPTION
## Summary

Unskips the connector execute API integration suite and isolates connector cleanup per test.

The suite accumulated connectors from every authorization scenario, then deleted all of them concurrently in one suite-level `after` hook. The reported failures occurred only in that hook when a delete returned 404. A local baseline run also showed the delete burst saturating Kibana's event loop for 400-570 ms. Cleaning up after each test shortens connector lifetime, avoids the large concurrent delete batch, and keeps each test responsible for its own fixtures.

Closes #258921

## Validation

- `node scripts/eslint x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts`
- `node scripts/functional_tests --config x-pack/platform/test/alerting_api_integration/security_and_spaces/group12/config.ts --grep "Connectors execute"` (72 passing)
- Pre-push branch checks

## Risk

Low. Test-only lifecycle change. Assertions and product behavior are unchanged.

## Release notes

None. Test-only change.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->