### PR TITLE
[9.5] [a11y] Add tableCaption to EuiBasicTable and EuiInMemoryTable components (#278132)

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_category_flyout.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_category_flyout.tsx
@@ -124,7 +124,14 @@ export function KnowledgeBaseCategoryFlyout({
         {hasDescription ? (
           hasDescription
         ) : (
-          <EuiBasicTable<KnowledgeBaseEntry> columns={columns} items={category.entries ?? []} />
+          <EuiBasicTable<KnowledgeBaseEntry>
+            tableCaption={i18n.translate(
+              'xpack.observabilityAiAssistantManagement.knowledgeBaseCategoryFlyout.tableCaption',
+              { defaultMessage: 'Knowledge base category entries' }
+            )}
+            columns={columns}
+            items={category.entries ?? []}
+          />
         )}
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/edit/tabs/plugins_tab.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/edit/tabs/plugins_tab.tsx
@@ -233,6 +233,9 @@ const PluginsSelection: React.FC<PluginsSelectionProps> = ({
       </EuiFlexGroup>
 
       <EuiInMemoryTable
+        tableCaption={i18n.translate('xpack.agentBuilder.plugins.tableCaption', {
+          defaultMessage: 'Plugins',
+        })}
         columns={columns}
         items={filteredPlugins}
         itemId="id"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/list/agents_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/list/agents_list.tsx
@@ -255,6 +255,9 @@ export const AgentsList: React.FC = () => {
   return (
     <>
       <EuiInMemoryTable
+        tableCaption={i18n.translate('xpack.agentBuilder.agents.tableCaption', {
+          defaultMessage: 'Agents',
+        })}
         data-test-subj="agentBuilderAgentsListTable"
         rowProps={(row) => ({ 'data-test-subj': `agentBuilderAgentsListRow-${row.id}` })}
         items={agents}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/index_search/index_search_pattern.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/index_search/index_search_pattern.tsx
@@ -146,6 +146,9 @@ export const IndexSearchPattern: React.FC = () => {
       <EuiSpacer size="s" />
 
       <EuiBasicTable
+        tableCaption={i18n.translate('xpack.agentBuilder.tools.indexPattern.tableCaption', {
+          defaultMessage: 'Index patterns',
+        })}
         items={pageOfItems}
         columns={columns}
         loading={hasQuery ? isLoading : false}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_tab_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_tab_content.tsx
@@ -254,6 +254,9 @@ export const PoliciesTabContent = ({ onPolicyClick, onRuleClick, activeRuleId }:
       )}
       <TruncatedCallout data={data} searchParam={searchParam} />
       <EuiBasicTable<PolicyExecutionHistoryItem>
+        tableCaption={i18n.translate('xpack.alertingV2.executionHistory.tableCaption', {
+          defaultMessage: 'Execution history policies',
+        })}
         items={items}
         columns={columns}
         loading={isFetching}

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/table.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/table.tsx
@@ -91,6 +91,7 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
   ) : (
     <>
       <EuiBasicTable
+        tableCaption={i18n.TABLE_CAPTION}
         className={classnames({ isSelectorView })}
         columns={columns}
         rowHeader={rowHeader}

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
@@ -338,3 +338,7 @@ export const CLOSE_CASE_MODAL_REASON_OTHER = i18n.translate(
     defaultMessage: 'Other',
   }
 );
+
+export const TABLE_CAPTION = i18n.translate('xpack.cases.caseTable.tableCaption', {
+  defaultMessage: 'Cases',
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/pages/all_field_definitions_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/pages/all_field_definitions_page.tsx
@@ -246,6 +246,7 @@ export const AllFieldDefinitionsPage: React.FC<AllFieldDefinitionsPageProps> = (
         ) : (
           <EuiBasicTable
             items={fieldDefinitions}
+            tableCaption={i18n.FIELD_DEFINITIONS_TABLE_CAPTION}
             rowHeader="name"
             columns={columns}
             data-test-subj="fieldDefinitionsTable"

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/translations.ts
@@ -205,3 +205,10 @@ export const GLOBAL_FIELD_YES = i18n.translate('xpack.cases.fieldLibrary.globalF
 export const GLOBAL_FIELD_NO = i18n.translate('xpack.cases.fieldLibrary.globalFieldNo', {
   defaultMessage: 'No',
 });
+
+export const FIELD_DEFINITIONS_TABLE_CAPTION = i18n.translate(
+  'xpack.cases.fieldLibrary.tableCaption',
+  {
+    defaultMessage: 'Field definitions',
+  }
+);

--- a/x-pack/platform/plugins/shared/cases/public/components/similar_cases/table.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/similar_cases/table.tsx
@@ -51,6 +51,7 @@ export const SimilarCasesTable: FunctionComponent<SimilarCasesTableProps> = ({
   ) : (
     <>
       <EuiBasicTable
+        tableCaption={i18n.TABLE_CAPTION}
         onChange={onChange}
         pagination={pagination}
         columns={columns}

--- a/x-pack/platform/plugins/shared/cases/public/components/similar_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/similar_cases/translations.ts
@@ -26,3 +26,7 @@ export const NO_CASES_BODY = i18n.translate('xpack.cases.similarCaseTable.noCase
 export const SIMILARITY_REASON = i18n.translate('xpack.cases.similarCaseTable.similarities.title', {
   defaultMessage: 'Similar observable values',
 });
+
+export const TABLE_CAPTION = i18n.translate('xpack.cases.similarCaseTable.tableCaption', {
+  defaultMessage: 'Similar cases',
+});

--- a/x-pack/platform/plugins/shared/dataset_quality/common/translations.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/common/translations.ts
@@ -904,3 +904,17 @@ export const createConvertProcessor = i18n.translate(
     defaultMessage: 'Create a convert processor',
   }
 );
+
+export const qualityIssuesTableCaption = i18n.translate(
+  'xpack.datasetQuality.details.qualityIssuesTableCaption',
+  {
+    defaultMessage: 'Quality issues',
+  }
+);
+
+export const failedDocsInfoTableCaption = i18n.translate(
+  'xpack.datasetQuality.details.failedDocsInfoTableCaption',
+  {
+    defaultMessage: 'Failed documents information',
+  }
+);

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/quality_issues/table.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/quality_issues/table.tsx
@@ -10,6 +10,7 @@ import { ES_FIELD_TYPES, KBN_FIELD_TYPES } from '@kbn/field-types';
 import React from 'react';
 import {
   overviewDegradedFieldsTableLoadingText,
+  qualityIssuesTableCaption,
   qualityIssuesTableNoData,
 } from '../../../../../common/translations';
 import { useQualityIssues } from '../../../../hooks';
@@ -40,6 +41,7 @@ export const QualityIssuesTable = () => {
 
   return (
     <EuiBasicTable
+      tableCaption={qualityIssuesTableCaption}
       tableLayout="fixed"
       columns={columns}
       items={renderedItems ?? []}

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/filed_info.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/filed_info.tsx
@@ -21,6 +21,7 @@ import React from 'react';
 import {
   failedDocsErrorsColumnName,
   failedDocsErrorsColumnNameTooltip,
+  failedDocsInfoTableCaption,
   overviewDegradedFieldsTableLoadingText,
 } from '../../../../../common/translations';
 import { useQualityIssues } from '../../../../hooks';
@@ -77,6 +78,7 @@ export const FailedFieldInfo = () => {
           </EuiText>
           <EuiHorizontalRule margin="xs" />
           <EuiBasicTable
+            tableCaption={failedDocsInfoTableCaption}
             tableLayout="fixed"
             responsiveBreakpoint={true}
             columns={failedDocsErrorsColumns}

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_list/table.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_list/table.tsx
@@ -255,9 +255,6 @@ export const ComponentTable: FunctionComponent<Props> = ({
 
   const tableProps: EuiInMemoryTableProps<ComponentTemplateListItem> = {
     tableLayout: 'auto',
-    tableCaption: i18n.translate('xpack.idxMgmt.componentTemplatesList.table.tableCaption', {
-      defaultMessage: 'Component templates list',
-    }),
     itemId: 'name',
     'data-test-subj': 'componentTemplatesTable',
     sorting,
@@ -430,5 +427,12 @@ export const ComponentTable: FunctionComponent<Props> = ({
     items: filteredComponentTemplates,
   };
 
-  return <EuiInMemoryTable {...tableProps} />;
+  return (
+    <EuiInMemoryTable
+      {...tableProps}
+      tableCaption={i18n.translate('xpack.idxMgmt.componentTemplatesList.table.tableCaption', {
+        defaultMessage: 'Component templates list',
+      })}
+    />
+  );
 };

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/manage_processors/geoip_list.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/manage_processors/geoip_list.tsx
@@ -66,9 +66,6 @@ export const GeoipList: React.FunctionComponent = () => {
   );
   const tableProps: EuiInMemoryTableProps<GeoipDatabase> = {
     'data-test-subj': 'geoipDatabaseList',
-    tableCaption: i18n.translate('xpack.ingestPipelines.manageProcessors.geoip.list.tableCaption', {
-      defaultMessage: 'List of geoIP databases',
-    }),
     rowProps: () => ({
       'data-test-subj': 'geoipDatabaseListRow',
     }),
@@ -190,7 +187,16 @@ export const GeoipList: React.FunctionComponent = () => {
         </EuiFlexGroup>
 
         <EuiSpacer size="l" />
-        <EuiInMemoryTable css={styles.table} {...tableProps} />
+        <EuiInMemoryTable
+          css={styles.table}
+          tableCaption={i18n.translate(
+            'xpack.ingestPipelines.manageProcessors.geoip.list.tableCaption',
+            {
+              defaultMessage: 'List of geoIP databases',
+            }
+          )}
+          {...tableProps}
+        />
       </>
     );
   }

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/models/text_expansion/text_expansion_output.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/models/text_expansion/text_expansion_output.tsx
@@ -159,6 +159,10 @@ export const DocumentResultWithTokens: FC<{
             </EuiCallOut>
             <EuiSpacer size="s" />
             <EuiInMemoryTable
+              tableCaption={i18n.translate(
+                'xpack.ml.trainedModels.testModelsFlyout.textExpansion.tableCaption',
+                { defaultMessage: 'Text expansion results' }
+              )}
               items={tokens}
               columns={[
                 {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/schema_changes_review_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/schema_changes_review_modal.tsx
@@ -478,7 +478,14 @@ export function SchemaChangesReviewModal({
             <EuiSpacer size="m" />
           </>
         )}
-        <EuiBasicTable items={changes} columns={fieldColumns} />
+        <EuiBasicTable
+          tableCaption={i18n.translate(
+            'xpack.streams.schemaEditor.confirmChangesModal.tableCaption',
+            { defaultMessage: 'Schema changes' }
+          )}
+          items={changes}
+          columns={fieldColumns}
+        />
       </EuiModalBody>
       <EuiModalFooter>
         <EuiButtonEmpty

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/component_template_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/component_template_panel.tsx
@@ -126,6 +126,9 @@ export function ComponentTemplatePanel({
     >
       {componentTemplates && (
         <EuiInMemoryTable
+          tableCaption={i18n.translate('xpack.streams.componentTemplatePanel.tableCaption', {
+            defaultMessage: 'Component templates',
+          })}
           items={componentTemplates}
           columns={columns}
           tableLayout={'auto'}

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/changes/change_list.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/changes/change_list.tsx
@@ -235,7 +235,14 @@ export function ChangeList({ title, items }: ChangeListProps) {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiBasicTable items={items} columns={columns} tableLayout="auto" />
+        <EuiBasicTable
+          tableCaption={i18n.translate('xpack.observabilityAiAssistant.changesList.tableCaption', {
+            defaultMessage: 'Changes',
+          })}
+          items={items}
+          columns={columns}
+          tableLayout="auto"
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/rca/rca_entity_log_pattern_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/rca/rca_entity_log_pattern_table/index.tsx
@@ -208,6 +208,10 @@ export function RootCauseAnalysisEntityLogPatternTable({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiBasicTable
+        tableCaption={i18n.translate(
+          'xpack.observabilityAiAssistant.rca.logPatternTable.tableCaption',
+          { defaultMessage: 'Log patterns' }
+        )}
         tableLayout="auto"
         columns={columns}
         items={visibleItems}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/errors/error_groups_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/errors/error_groups_list.tsx
@@ -342,6 +342,9 @@ const ExpandedGroupRow = ({
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiInMemoryTable
+            tableCaption={i18n.translate('xpack.synthetics.errorGroups.tableCaption', {
+              defaultMessage: 'Error groups',
+            })}
             items={group.items}
             columns={columns}
             compressed

--- a/x-pack/solutions/security/plugins/cloud_defend/public/components/policies_table/index.tsx
+++ b/x-pack/solutions/security/plugins/cloud_defend/public/components/policies_table/index.tsx
@@ -141,6 +141,9 @@ export const PoliciesTable = ({
 
   return (
     <EuiBasicTable
+      tableCaption={i18n.translate('xpack.cloudDefend.policies.policiesTable.tableCaption', {
+        defaultMessage: 'Cloud defend policies',
+      })}
       data-test-subj={rest['data-test-subj']}
       items={policies}
       columns={POLICIES_TABLE_COLUMNS}

--- a/x-pack/solutions/security/plugins/kubernetes_security/public/components/container_name_widget/index.tsx
+++ b/x-pack/solutions/security/plugins/kubernetes_security/public/components/container_name_widget/index.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from 'react';
 import React, { useMemo, useState, useRef, useCallback } from 'react';
 import type { EuiTableSortingType, EuiBasicTableColumn } from '@elastic/eui';
 import { EuiBasicTable, EuiProgress } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useStyles } from './styles';
 import { ContainerNameRow } from './container_name_row';
 import type { IndexPattern, GlobalFilter } from '../../types';
@@ -260,6 +261,9 @@ export const ContainerNameWidget = ({
         />
       )}
       <EuiBasicTable
+        tableCaption={i18n.translate('xpack.kubernetesSecurity.containerNameWidget.tableCaption', {
+          defaultMessage: 'Container names',
+        })}
         aria-label={CONTAINER_NAME_SESSION_ARIA_LABEL}
         items={containerNameArray}
         columns={columns}

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/risk_summary_mini.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/risk_summary_mini.tsx
@@ -103,6 +103,10 @@ const ContributionsTable: React.FC<{
 
   return (
     <EuiBasicTable
+      tableCaption={i18n.translate(
+        'xpack.securitySolution.agentBuilder.entityAttachment.risk.tableCaption',
+        { defaultMessage: 'Risk score contributions' }
+      )}
       data-test-subj={testSubj}
       responsiveBreakpoint={false}
       columns={columnsArray}

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
@@ -462,7 +462,7 @@ export const EntityTable: React.FC<EntityTableProps> = ({ entities }) => {
       ))}
       <div css={tableScrollStyles}>
         <EuiBasicTable
-          aria-label={i18n.translate(
+          tableCaption={i18n.translate(
             'xpack.securitySolution.agentBuilder.entityAttachment.table.caption',
             { defaultMessage: 'Entities referenced in this message' }
           )}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/jobs_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/jobs_table.tsx
@@ -157,6 +157,7 @@ export const JobsTableComponent = ({
   return (
     <EuiBasicTable
       data-test-subj="jobs-table"
+      tableCaption={i18n.JOBS_TABLE_CAPTION}
       columns={getJobsTableColumns(isLoading, onJobStateChange)}
       items={getPaginatedItems(
         jobs.map((j) => ({ ...j, isCompatible: mlNodesAvailable ? j.isCompatible : false })),

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/translations.ts
@@ -41,3 +41,10 @@ export const CREATE_CUSTOM_JOB = i18n.translate(
     defaultMessage: 'Create custom job',
   }
 );
+
+export const JOBS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.caption',
+  {
+    defaultMessage: 'ML jobs',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
@@ -1686,3 +1686,10 @@ export const RULE_SETTINGS_TITLE = i18n.translate(
     defaultMessage: 'Settings',
   }
 );
+
+export const UPGRADE_PREBUILT_RULES_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.upgradePrebuiltRulesTableCaption',
+  {
+    defaultMessage: 'Prebuilt rules available for upgrade',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/gap_auto_fill_logs/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/gap_auto_fill_logs/index.tsx
@@ -339,6 +339,7 @@ export const GapAutoFillLogsFlyout = ({ isOpen, onClose }: GapAutoFillLogsFlyout
               loading={isLogsLoading}
               items={logsData?.data ?? []}
               itemId="id"
+              tableCaption={i18n.GAP_AUTO_FILL_LOGS_TABLE_CAPTION}
               columns={columns as EuiBasicTableColumn<SchedulerLog>[]}
               pagination={{
                 pageIndex,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/gap_auto_fill_logs/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/gap_auto_fill_logs/translations.ts
@@ -217,3 +217,10 @@ export const GAP_AUTO_FILL_STATUS_NO_GAPS_TOOLTIP = i18n.translate(
     defaultMessage: "Gaps in rule executions don't currently exist.",
   }
 );
+
+export const GAP_AUTO_FILL_LOGS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.gapAutoFillLogs.tableCaption',
+  {
+    defaultMessage: 'Gap auto fill logs',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rule_backfills_info/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rule_backfills_info/index.tsx
@@ -207,6 +207,7 @@ export const RuleBackfillsInfo = React.memo<{ ruleId: string }>(({ ruleId }) => 
 
       <EuiBasicTable
         data-test-subj="rule-backfills-table"
+        tableCaption={i18n.RULE_BACKFILLS_TABLE_CAPTION}
         items={backfills}
         columns={columns}
         pagination={pagination}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/last_response_summary_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/last_response_summary_chart.tsx
@@ -177,6 +177,7 @@ export const LastResponseSummaryChart: React.FC<LastResponseSummaryChartProps> =
             items={tableData}
             columns={columns}
             tableLayout="auto"
+            tableCaption={i18n.LAST_RESPONSE_SUMMARY_TABLE_CAPTION}
             data-test-subj="last-response-summary-table"
           />
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/rule_gap_summary_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/rule_gap_summary_chart.tsx
@@ -228,6 +228,7 @@ export const RuleGapSummaryChart: React.FC<RuleGapSummaryChartProps> = ({ enable
             items={tableData}
             columns={columns}
             tableLayout="auto"
+            tableCaption={i18n.RULE_GAP_SUMMARY_TABLE_CAPTION}
             data-test-subj="rule-gap-summary-table"
           />
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/translations.tsx
@@ -184,3 +184,17 @@ export const ERROR_RULE_GAP_SUMMARY = i18n.translate(
     defaultMessage: 'Failed to load gap summary. Please try again later.',
   }
 );
+
+export const LAST_RESPONSE_SUMMARY_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.ruleGapsOverviewPanel.lastResponseSummaryTableCaption',
+  {
+    defaultMessage: 'Last response summary',
+  }
+);
+
+export const RULE_GAP_SUMMARY_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.ruleGapsOverviewPanel.ruleGapSummaryTableCaption',
+  {
+    defaultMessage: 'Rule gap summary',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/translations.ts
@@ -328,3 +328,10 @@ export const GAP_DETECTION_SCOPE_INCLUDE_DISABLED_LABEL = i18n.translate(
     defaultMessage: 'Include gaps created when a rule was disabled.',
   }
 );
+
+export const RULE_BACKFILLS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleGaps.backfillsTableCaption',
+  {
+    defaultMessage: 'Rule backfills',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_tables.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_tables.tsx
@@ -394,6 +394,7 @@ export const RulesTables = React.memo<RulesTableProps>(({ selectedTab }) => {
           <EuiBasicTable
             itemId="id"
             items={rules}
+            tableCaption={i18n.RULES_TABLE_CAPTION}
             noItemsMessage={NO_ITEMS_MESSAGE}
             onChange={tableOnChangeCallback}
             pagination={paginationMemo}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -122,6 +122,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
 
               <EuiBasicTable
                 loading={isFetching}
+                tableCaption={i18n.UPGRADE_PREBUILT_RULES_TABLE_CAPTION}
                 items={ruleUpgradeStates}
                 pagination={{
                   totalItemCount: pagination.total,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/value_lists_management_flyout/flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/value_lists_management_flyout/flyout.tsx
@@ -238,6 +238,7 @@ export const ValueListsFlyoutComponent: React.FC<ValueListsFlyoutProps> = ({
           </EuiText>
           <EuiBasicTable
             data-test-subj="value-lists-table"
+            tableCaption={i18n.VALUE_LISTS_TABLE_CAPTION}
             columns={columns}
             items={tableItems}
             loading={lists.loading}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/value_lists_management_flyout/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/value_lists_management_flyout/translations.ts
@@ -179,6 +179,13 @@ export const REFERENCE_MODAL_CONFIRM_BUTTON = i18n.translate(
   }
 );
 
+export const VALUE_LISTS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.lists.valueListsTableCaption',
+  {
+    defaultMessage: 'Value lists',
+  }
+);
+
 export const referenceErrorMessage = (referenceCount: number) =>
   i18n.translate('xpack.securitySolution.lists.referenceModalDescription', {
     defaultMessage:

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring_ui/components/health_overview/top_messages_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring_ui/components/health_overview/top_messages_section.tsx
@@ -34,7 +34,12 @@ export const TopMessagesSection = memo(function TopMessagesSection({
       <EuiFlexItem>
         <SectionPanel title={i18n.TOP_ERRORS_TITLE}>
           {topErrors.length > 0 ? (
-            <EuiBasicTable items={topErrors} columns={TOP_MSG_COLUMNS} compressed />
+            <EuiBasicTable
+              tableCaption={i18n.TOP_ERRORS_TABLE_CAPTION}
+              items={topErrors}
+              columns={TOP_MSG_COLUMNS}
+              compressed
+            />
           ) : (
             <EuiText size="s" color="subdued">
               {i18n.NO_ERRORS_RECORDED}
@@ -45,7 +50,12 @@ export const TopMessagesSection = memo(function TopMessagesSection({
       <EuiFlexItem>
         <SectionPanel title={i18n.TOP_WARNINGS_TITLE}>
           {topWarnings.length > 0 ? (
-            <EuiBasicTable items={topWarnings} columns={TOP_MSG_COLUMNS} compressed />
+            <EuiBasicTable
+              tableCaption={i18n.TOP_WARNINGS_TABLE_CAPTION}
+              items={topWarnings}
+              columns={TOP_MSG_COLUMNS}
+              compressed
+            />
           ) : (
             <EuiText size="s" color="subdued">
               {i18n.NO_WARNINGS_RECORDED}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring_ui/components/health_overview/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring_ui/components/health_overview/translations.ts
@@ -186,6 +186,16 @@ export const NO_WARNINGS_RECORDED = i18n.translate(
   { defaultMessage: 'No warnings recorded.' }
 );
 
+export const TOP_ERRORS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleMonitoring.healthOverview.topErrorsTableCaption',
+  { defaultMessage: 'Top error messages' }
+);
+
+export const TOP_WARNINGS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleMonitoring.healthOverview.topWarningsTableCaption',
+  { defaultMessage: 'Top warning messages' }
+);
+
 // ---------------------------------------------------------------------------
 // Historical Trends
 // ---------------------------------------------------------------------------

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.tsx
@@ -41,6 +41,7 @@ import {
   LAST_SEEN_COLUMN,
   RISK_SCORE_COLUMN,
   ACTIONS_COLUMN,
+  ADD_ENTITIES_TABLE_CAPTION,
 } from './translations';
 import {
   ADD_ENTITIES_SECTION_TEST_ID,
@@ -247,6 +248,7 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
         )}
         <EuiBasicTable
           data-test-subj={ADD_ENTITIES_TABLE_TEST_ID}
+          tableCaption={ADD_ENTITIES_TABLE_CAPTION}
           items={records}
           columns={columns}
           loading={isLoading}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
@@ -39,6 +39,8 @@ import {
   CANNOT_REMOVE_TARGET_TOOLTIP,
   RESOLUTION_EMPTY_STATE,
   RESOLUTION_FETCH_ERROR,
+  RESOLUTION_GROUP_TABLE_CAPTION,
+  RESOLUTION_GROUP_DETAILS_TABLE_CAPTION,
 } from './translations';
 import {
   RESOLUTION_GROUP_TABLE_TEST_ID,
@@ -242,6 +244,7 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
 
     return (
       <EuiBasicTable
+        tableCaption={RESOLUTION_GROUP_TABLE_CAPTION}
         data-test-subj={RESOLUTION_EMPTY_STATE_TEST_ID}
         items={[]}
         columns={emptyColumns}
@@ -253,6 +256,7 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
 
   return (
     <EuiBasicTable
+      tableCaption={RESOLUTION_GROUP_DETAILS_TABLE_CAPTION}
       data-test-subj={RESOLUTION_GROUP_TABLE_TEST_ID}
       items={items}
       columns={columns}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/translations.ts
@@ -164,3 +164,20 @@ export const ENTITY_HAS_ALIASES_ERROR = i18n.translate(
       'This entity already belongs to another resolution group. Unlink it from its current group before adding it here.',
   }
 );
+
+export const RESOLUTION_GROUP_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.entityResolution.resolutionGroupTableCaption',
+  { defaultMessage: 'Entity resolution group' }
+);
+
+export const RESOLUTION_GROUP_DETAILS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.entityResolution.resolutionGroupDetailsTableCaption',
+  { defaultMessage: 'Resolution group details' }
+);
+
+export const ADD_ENTITIES_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.entityResolution.addEntitiesTableCaption',
+  {
+    defaultMessage: 'Entities to add',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/table_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/tabs/table_tab.tsx
@@ -108,6 +108,10 @@ export const TableTab = memo(({ hit, renderCellActions }: TableTabProps) => {
 
   return (
     <EuiInMemoryTable
+      tableCaption={i18n.translate(
+        'xpack.securitySolution.attackDetailsFlyout.table.tableCaption',
+        { defaultMessage: 'Attack details' }
+      )}
       items={items}
       itemId="field"
       columns={columns}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/field_table_columns/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/field_table_columns/index.test.tsx
@@ -54,7 +54,11 @@ describe('useFieldTableColumns', () => {
     });
 
     const { container, getByTestId } = render(
-      <EuiInMemoryTable items={[fieldItem]} columns={columns} />,
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
       {
         wrapper: TestProviders,
       }
@@ -74,7 +78,11 @@ describe('useFieldTableColumns', () => {
     });
 
     const { container, queryByTestId } = render(
-      <EuiInMemoryTable items={[fieldItem]} columns={columns} />,
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
       {
         wrapper: TestProviders,
       }
@@ -94,7 +102,11 @@ describe('useFieldTableColumns', () => {
     });
 
     const { container, queryByTestId } = render(
-      <EuiInMemoryTable items={[{ ...fieldItem, isRuntime: false }]} columns={columns} />,
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[{ ...fieldItem, isRuntime: false }]}
+        columns={columns}
+      />,
       {
         wrapper: TestProviders,
       }
@@ -113,9 +125,16 @@ describe('useFieldTableColumns', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     getByTestId('actionEditRuntimeField').click();
     expect(mockOnHide).toHaveBeenCalledTimes(1);
@@ -131,9 +150,16 @@ describe('useFieldTableColumns', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     getByTestId('actionEditRuntimeField').click();
     expect(mockOpenFieldEditor).toHaveBeenCalledTimes(1);
@@ -148,9 +174,16 @@ describe('useFieldTableColumns', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     getByTestId('actionDeleteRuntimeField').click();
     expect(mockOpenDeleteFieldModal).toHaveBeenCalledTimes(1);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -153,9 +153,16 @@ describe('useFieldBrowserOptions', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     getByTestId('actionEditRuntimeField').click();
     expect(mockOnHide).toHaveBeenCalledTimes(1);
@@ -211,9 +218,16 @@ describe('useFieldBrowserOptions', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     getByTestId('actionEditRuntimeField').click();
     expect(onSave).toBeDefined();
@@ -248,9 +262,16 @@ describe('useFieldBrowserOptions', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     getByTestId('actionDeleteRuntimeField').click();
     expect(onDelete).toBeDefined();
@@ -304,9 +325,16 @@ describe('useFieldBrowserOptions', () => {
       onHide: mockOnHide,
     });
 
-    const { getByTestId } = render(<EuiInMemoryTable items={[fieldItem]} columns={columns} />, {
-      wrapper: TestProviders,
-    });
+    const { getByTestId } = render(
+      <EuiInMemoryTable
+        tableCaption="Fields browser table"
+        items={[fieldItem]}
+        columns={columns}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     expect(editorActionsRef?.current).toBeNull();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/value_list/components/list_item_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/value_list/components/list_item_table.tsx
@@ -21,6 +21,7 @@ import {
   DELETE_LIST_ITEM,
   DELETE_LIST_ITEM_DESCRIPTION,
   NOT_FOUND_ITEMS,
+  LIST_ITEMS_TABLE_CAPTION,
 } from '../translations';
 
 export const ListItemTable = ({
@@ -75,6 +76,7 @@ export const ListItemTable = ({
   return (
     <EuiBasicTable
       data-test-subj="value-list-items-modal-table"
+      tableCaption={LIST_ITEMS_TABLE_CAPTION}
       items={items}
       columns={columns}
       pagination={pagination}

--- a/x-pack/solutions/security/plugins/security_solution/public/value_list/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/value_list/translations.ts
@@ -163,3 +163,10 @@ export const getInfoTotalItems = (listType: string) =>
 export const NOT_FOUND_ITEMS = i18n.translate('xpack.securitySolution.listItems.notFoundItems', {
   defaultMessage: '0 list items match your search criteria.',
 });
+
+export const LIST_ITEMS_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.listItems.tableCaption',
+  {
+    defaultMessage: 'List items',
+  }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[a11y] Add tableCaption to EuiBasicTable and EuiInMemoryTable components (#278132)](https://github.com/elastic/kibana/pull/278132)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-07-21T10:40:38Z","message":"[a11y] Add tableCaption to EuiBasicTable and EuiInMemoryTable components (#278132)\n\n## Summary\n\nFixes `@elastic/eui/require-table-caption` accessibility violations\nacross 39 component files. Every `EuiBasicTable` and `EuiInMemoryTable`\nnow has a `tableCaption` prop, which renders a visually hidden\n`<caption>` element inside the `<table>` for screen readers.\n\n## Changes\n\n- **39 component files** — added `tableCaption` prop with\n`i18n.translate()` inline or via a translations constant\n- **13 translations files** — added new table caption export constants\nfollowing the existing i18n pattern in each file\n- **2 test files** — added plain string `tableCaption` (no i18n needed\nin tests)\n- **`geoip_list.tsx` and `component_template_list/table.tsx`** — moved\n`tableCaption` from a spread object (`{...tableProps}`) to a direct JSX\nprop so the ESLint rule can statically detect it\n- **`entity_table.tsx`** — replaced `aria-label` with `tableCaption`\n(the ESLint rule requires `tableCaption` specifically; `aria-label` does\nnot satisfy it)\n\n## Test plan\n\n- [ ] ESLint passes with no `@elastic/eui/require-table-caption` errors\non all modified files\n- [ ] All existing Jest tests for modified components continue to pass\n- [ ] No new TypeScript type errors introduced\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"d11b6509841dc011d7e65e9417c906e27c005ec8","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","ci:project-deploy-observability","backport:version","a11y:agent-pr","v9.5.0","v9.6.0"],"title":"[a11y] Add tableCaption to EuiBasicTable and EuiInMemoryTable components","number":278132,"url":"https://github.com/elastic/kibana/pull/278132","mergeCommit":{"message":"[a11y] Add tableCaption to EuiBasicTable and EuiInMemoryTable components (#278132)\n\n## Summary\n\nFixes `@elastic/eui/require-table-caption` accessibility violations\nacross 39 component files. Every `EuiBasicTable` and `EuiInMemoryTable`\nnow has a `tableCaption` prop, which renders a visually hidden\n`<caption>` element inside the `<table>` for screen readers.\n\n## Changes\n\n- **39 component files** — added `tableCaption` prop with\n`i18n.translate()` inline or via a translations constant\n- **13 translations files** — added new table caption export constants\nfollowing the existing i18n pattern in each file\n- **2 test files** — added plain string `tableCaption` (no i18n needed\nin tests)\n- **`geoip_list.tsx` and `component_template_list/table.tsx`** — moved\n`tableCaption` from a spread object (`{...tableProps}`) to a direct JSX\nprop so the ESLint rule can statically detect it\n- **`entity_table.tsx`** — replaced `aria-label` with `tableCaption`\n(the ESLint rule requires `tableCaption` specifically; `aria-label` does\nnot satisfy it)\n\n## Test plan\n\n- [ ] ESLint passes with no `@elastic/eui/require-table-caption` errors\non all modified files\n- [ ] All existing Jest tests for modified components continue to pass\n- [ ] No new TypeScript type errors introduced\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"d11b6509841dc011d7e65e9417c906e27c005ec8"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278132","number":278132,"mergeCommit":{"message":"[a11y] Add tableCaption to EuiBasicTable and EuiInMemoryTable components (#278132)\n\n## Summary\n\nFixes `@elastic/eui/require-table-caption` accessibility violations\nacross 39 component files. Every `EuiBasicTable` and `EuiInMemoryTable`\nnow has a `tableCaption` prop, which renders a visually hidden\n`<caption>` element inside the `<table>` for screen readers.\n\n## Changes\n\n- **39 component files** — added `tableCaption` prop with\n`i18n.translate()` inline or via a translations constant\n- **13 translations files** — added new table caption export constants\nfollowing the existing i18n pattern in each file\n- **2 test files** — added plain string `tableCaption` (no i18n needed\nin tests)\n- **`geoip_list.tsx` and `component_template_list/table.tsx`** — moved\n`tableCaption` from a spread object (`{...tableProps}`) to a direct JSX\nprop so the ESLint rule can statically detect it\n- **`entity_table.tsx`** — replaced `aria-label` with `tableCaption`\n(the ESLint rule requires `tableCaption` specifically; `aria-label` does\nnot satisfy it)\n\n## Test plan\n\n- [ ] ESLint passes with no `@elastic/eui/require-table-caption` errors\non all modified files\n- [ ] All existing Jest tests for modified components continue to pass\n- [ ] No new TypeScript type errors introduced\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"d11b6509841dc011d7e65e9417c906e27c005ec8"}}]}] BACKPORT-->