### PR TITLE
feat(exploratory-tester): add token usage to session report

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/3-report.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/3-report.md
@@ -18,6 +18,17 @@ Then write `$SESSION_DIR/report.md` using the template:
 x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/templates/report-format.md
 ```
 
+### Populate Timing & Cost
+
+**Per-flow rows:** read the `<!-- flow: <name> | started: <ISO> | ended: <ISO> | duration: <Xm Ys> -->` header from each `findings-flow-<N>.md`. Use those values directly for `Started`, `Duration`, and `Status`. Compute `Over?` by comparing `duration` against `config.json → flows[N].timeout_minutes`. The `Total session` row duration = report-written time − `session_started_at` from `config.json`.
+
+**Token usage:** run the token script and capture its output:
+```bash
+python3 x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
+```
+- If the script exits 0 and prints a line (e.g. `input=… output=… cache_create=… cache_read=… total=…`), write it into the token-usage line.
+- If the script exits non-zero or prints nothing, write `**Token usage:** not available` — this is expected on non-Claude-Code harnesses (Cursor, Codex, etc.) or when the transcript is unavailable.
+
 ---
 
 ## Step 3b — Filter known noise

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/3-report.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/3-report.md
@@ -26,7 +26,7 @@ x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-t
 ```bash
 python3 x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
 ```
-- If the script exits 0 and prints a line (e.g. `input=… output=… cache_create=… cache_read=… total=…`), write it into the token-usage line.
+- If the script exits 0 and prints a line (e.g. `input=… output=… cache_create=… cache_read=… total=…`), reformat it into the token-usage line — replace `_` with `-` and `key=N` with `key N`, separated by `·`. Example: `input=270 output=156097` → `input 270 · output 156097 …`.
 - If the script exits non-zero or prints nothing, write `**Token usage:** not available` — this is expected on non-Claude-Code harnesses (Cursor, Codex, etc.) or when the transcript is unavailable.
 
 ---

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/3-report.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/3-report.md
@@ -20,13 +20,13 @@ x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-t
 
 ### Populate Timing & Cost
 
-**Per-flow rows:** read the `<!-- flow: <name> | started: <ISO> | ended: <ISO> | duration: <Xm Ys> -->` header from each `findings-flow-<N>.md`. Use those values directly for `Started`, `Duration`, and `Status`. Compute `Over?` by comparing `duration` against `config.json → flows[N].timeout_minutes`. The `Total session` row duration = report-written time − `session_started_at` from `config.json`.
+**Per-flow rows:** read the `<!-- flow: <name> | started: <ISO> | ended: <ISO> | duration: <Xm Ys> -->` header from each `findings-flow-<N>.md`. Use `started` and `duration` directly for `Started` and `Duration`. Derive `Status` from these sources — no findings file for the flow → `not started`; flow is in `config.json → skipped_setup` or `deferred_flows` → the reason recorded there; findings file contains `session lost` markers → `session lost`; otherwise → `completed`. Compute `Over?` by comparing `duration` against `config.json → flows[N].timeout_minutes`. The `Total session` row duration = report-written time − `session_started_at` from `config.json`.
 
 **Token usage:** run the token script and capture its output:
 ```bash
 python3 x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
 ```
-- If the script exits 0 and prints a line (e.g. `input=… output=… cache_create=… cache_read=… total=…`), reformat it into the token-usage line — replace `_` with `-` and `key=N` with `key N`, separated by `·`. Example: `input=270 output=156097` → `input 270 · output 156097 …`.
+- If the script exits 0 and prints a line (e.g. `input=… output=… cache_create=… cache_read=… total=…`), reformat it into the token-usage line — replace `_` with `-` and `key=N` with `key N`, separated by `·`, and wrap the final `total N` in `**…**`. Example: `input=270 output=156097 … total=11512028` → `input 270 · output 156097 · … · **total 11512028**`.
 - If the script exits non-zero or prints nothing, write `**Token usage:** not available` — this is expected on non-Claude-Code harnesses (Cursor, Codex, etc.) or when the transcript is unavailable.
 
 ---

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Reads the Claude Code session transcript and prints token usage totals.
+
+Output (on success):
+    input=N output=N cache_create=N cache_read=N total=N
+
+Exit 0: transcript found and parsed; totals printed to stdout.
+Exit 1: transcript not found or unreadable (not Claude Code, wrong harness, etc.)
+        — prints nothing; caller should write "not available".
+
+Transcript location:
+    ~/.claude/projects/<cwd-slug>/<session-id>.jsonl
+    where <cwd-slug> = current working directory with '/' replaced by '-'
+    and <session-id> = $CLAUDE_CODE_SESSION_ID environment variable.
+
+Usage:
+    python3 scripts/session-token-usage.py [TRANSCRIPT_PATH]
+
+If TRANSCRIPT_PATH is given it overrides the auto-resolved location.
+Run this at the end of Phase 3 (Step 3a) while building the Timing & Cost section.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def resolve_transcript(explicit_path=None):
+    """Return the path to the JSONL transcript, or None if not found."""
+    if explicit_path:
+        p = Path(explicit_path)
+        return p if p.is_file() else None
+
+    session_id = os.environ.get('CLAUDE_CODE_SESSION_ID', '').strip()
+    if not session_id:
+        return None
+
+    # cwd slug: replace '/' with '-' (leading '/' becomes leading '-')
+    cwd_slug = os.getcwd().replace('/', '-')
+    transcript = Path.home() / '.claude' / 'projects' / cwd_slug / f'{session_id}.jsonl'
+    if transcript.is_file():
+        return transcript
+
+    # Fallback: newest *.jsonl in the projects/<cwd-slug> directory
+    project_dir = Path.home() / '.claude' / 'projects' / cwd_slug
+    if project_dir.is_dir():
+        candidates = sorted(project_dir.glob('*.jsonl'), key=lambda p: p.stat().st_mtime)
+        if candidates:
+            return candidates[-1]
+
+    return None
+
+
+def sum_tokens(transcript_path):
+    """
+    Sum token fields across all lines in the JSONL transcript.
+
+    Each line may be a JSON object with a top-level 'usage' key (older format)
+    or a 'message' key whose value has a 'usage' sub-key (newer format).
+    Unrecognised or unparseable lines are silently skipped.
+    """
+    totals = {
+        'input_tokens': 0,
+        'output_tokens': 0,
+        'cache_creation_input_tokens': 0,
+        'cache_read_input_tokens': 0,
+    }
+
+    with open(transcript_path, encoding='utf-8') as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            # Try 'message.usage' first (Claude Code ≥ 2025 format)
+            usage = None
+            msg = obj.get('message')
+            if isinstance(msg, dict):
+                usage = msg.get('usage')
+            # Fall back to top-level 'usage'
+            if not isinstance(usage, dict):
+                usage = obj.get('usage')
+            if not isinstance(usage, dict):
+                continue
+
+            for key in totals:
+                v = usage.get(key, 0)
+                if isinstance(v, (int, float)):
+                    totals[key] += int(v)
+
+    return totals
+
+
+def main():
+    explicit_path = sys.argv[1] if len(sys.argv) > 1 else None
+    transcript = resolve_transcript(explicit_path)
+
+    if transcript is None:
+        # Not Claude Code or transcript missing — caller writes "not available"
+        sys.exit(1)
+
+    try:
+        t = sum_tokens(transcript)
+    except OSError:
+        sys.exit(1)
+
+    total = sum(t.values())
+    print(
+        f"input={t['input_tokens']} "
+        f"output={t['output_tokens']} "
+        f"cache_create={t['cache_creation_input_tokens']} "
+        f"cache_read={t['cache_read_input_tokens']} "
+        f"total={total}"
+    )
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
@@ -43,13 +43,8 @@ def resolve_transcript(explicit_path=None):
     if transcript.is_file():
         return transcript
 
-    # Fallback: newest *.jsonl in the projects/<cwd-slug> directory
-    project_dir = Path.home() / '.claude' / 'projects' / cwd_slug
-    if project_dir.is_dir():
-        candidates = sorted(project_dir.glob('*.jsonl'), key=lambda p: p.stat().st_mtime)
-        if candidates:
-            return candidates[-1]
-
+    # Session ID was set but the specific file wasn't found — don't guess with a
+    # different session's transcript; return None so the caller writes "not available".
     return None
 
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/scripts/session-token-usage.py
@@ -5,9 +5,10 @@ Reads the Claude Code session transcript and prints token usage totals.
 Output (on success):
     input=N output=N cache_create=N cache_read=N total=N
 
-Exit 0: transcript found and parsed; totals printed to stdout.
-Exit 1: transcript not found or unreadable (not Claude Code, wrong harness, etc.)
-        — prints nothing; caller should write "not available".
+Exit 0: transcript found, parsed, and contains at least one usage block; totals printed to stdout.
+Exit 1: transcript not found, unreadable, or contains no usage blocks (not Claude Code,
+        wrong harness, unrecognised format, or session ended before any exchange) —
+        prints nothing; caller should write "not available".
 
 Transcript location:
     ~/.claude/projects/<cwd-slug>/<session-id>.jsonl
@@ -62,6 +63,7 @@ def sum_tokens(transcript_path):
         'cache_creation_input_tokens': 0,
         'cache_read_input_tokens': 0,
     }
+    usage_blocks = 0
 
     with open(transcript_path, encoding='utf-8') as fh:
         for raw in fh:
@@ -84,12 +86,13 @@ def sum_tokens(transcript_path):
             if not isinstance(usage, dict):
                 continue
 
+            usage_blocks += 1
             for key in totals:
                 v = usage.get(key, 0)
                 if isinstance(v, (int, float)):
                     totals[key] += int(v)
 
-    return totals
+    return totals, usage_blocks
 
 
 def main():
@@ -101,8 +104,14 @@ def main():
         sys.exit(1)
 
     try:
-        t = sum_tokens(transcript)
+        t, usage_blocks = sum_tokens(transcript)
     except OSError:
+        sys.exit(1)
+
+    if usage_blocks == 0:
+        # Transcript exists but contains no usage blocks — format unrecognised or
+        # session ended before any exchange was recorded. Treat as unreadable so
+        # the caller writes "not available" rather than a misleading "total 0".
         sys.exit(1)
 
     total = sum(t.values())

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/templates/report-format.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/templates/report-format.md
@@ -19,14 +19,6 @@ Write `$SESSION_DIR/report.md` using this template:
 **Session duration:** <total elapsed — compute: now minus session_started_at>
 **Session cap:** <session_timeout_minutes from config.json> min
 
-## Summary
-- Level 1 (confirmed bugs): N
-- Level 2 (suspicious — your review needed): N
-- Level 3 (observations): N
-- Known / suppressed: N
-- **Flows completed:** N of N
-- **Flows not fully completed:** N — list each with its status
-
 ## Timing & Cost
 
 Compute per-flow duration from the `<!-- flow: ... | started: <ISO> | ended: <ISO> -->` header in each findings file. Compute total session duration as `report_written_at − session_started_at`.
@@ -48,6 +40,17 @@ Compute per-flow duration from the `<!-- flow: ... | started: <ISO> | ended: <IS
 - **Over?** for individual flows: ⚠️ if `Duration > Budget`
 - **Over?** for total session: ⚠️ if `Session duration > session_timeout_minutes`
 - Flows cut short by the session cap are a signal to either raise `Session-timeout:` or reduce the number / scope of flows
+
+**Token usage (Claude Code session):** input <N> · output <N> · cache-create <N> · cache-read <N> · **total <N>**
+_Populate from `scripts/session-token-usage.py` output. If the script exits non-zero or prints nothing (non-Claude-Code harness, transcript unavailable), write:_ `**Token usage:** not available` _— never omit this line._
+
+## Summary
+- Level 1 (confirmed bugs): N
+- Level 2 (suspicious — your review needed): N
+- Level 3 (observations): N
+- Known / suppressed: N
+- **Flows completed:** N of N
+- **Flows not fully completed:** N — list each with its status
 
 ## Level 1 — Confirmed Bugs
 <all Level 1 findings in full finding format>

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/templates/report-format.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/templates/report-format.md
@@ -42,7 +42,7 @@ Compute per-flow duration from the `<!-- flow: ... | started: <ISO> | ended: <IS
 - Flows cut short by the session cap are a signal to either raise `Session-timeout:` or reduce the number / scope of flows
 
 **Token usage (Claude Code session):** input <N> · output <N> · cache-create <N> · cache-read <N> · **total <N>**
-_Populate from `scripts/session-token-usage.py` output. If the script exits non-zero or prints nothing (non-Claude-Code harness, transcript unavailable), write:_ `**Token usage:** not available` _— never omit this line._
+_Populate from `scripts/session-token-usage.py` output (reformat: `cache_create=N` → `cache-create N`, etc.). If the script exits non-zero or prints nothing (non-Claude-Code harness, transcript unavailable), write:_ `**Token usage:** not available` _— never omit this line. In parallel mode, sub-agent tokens are not included — orchestrator session only._
 
 ## Summary
 - Level 1 (confirmed bugs): N


### PR DESCRIPTION
## Summary

Implements [elastic/security-team#18309](https://github.com/elastic/security-team/issues/18309).

- **New script** `scripts/session-token-usage.py` — deterministic Python 3 (stdlib only); reads the Claude Code session transcript (`~/.claude/projects/<cwd-slug>/<session-id>.jsonl`) and emits `input=N output=N cache_create=N cache_read=N total=N`. Exits non-zero and prints nothing on any non-Claude-Code harness or missing transcript (graceful degradation for Cursor, Codex, etc.).
- **`templates/report-format.md`** — moved `## Timing & Cost` above `## Summary` (acceptance criterion); added token-usage line with an explicit "not available" fallback rule so the line is never omitted.
- **`phases/3-report.md`** — added a **Populate Timing & Cost** block in Step 3a: instructs the agent to derive per-flow durations from flow-file headers and invoke the token script; covers the "not available" fallback.

## Test plan

- [x] `session-token-usage.py` with `CLAUDE_CODE_SESSION_ID` set → prints four counts + total
- [x] `session-token-usage.py` with `CLAUDE_CODE_SESSION_ID` unset → no output, exits 1
- [x] `templates/report-format.md`: `## Timing & Cost` now appears before `## Summary`; token-usage line present with fallback rule
- [x] `phases/3-report.md`: Step 3a has Populate Timing & Cost block referencing flow-file headers and the script
- [x] `git diff --stat` shows exactly three paths (new script + two md files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)