### PR TITLE
[8.19] [Security Solution][DEX] Skip response actions during rule preview (#278393)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isEmpty, partition } from 'lodash';
+import { isEmpty, noop, partition } from 'lodash';
 import agent from 'elastic-apm-node';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
@@ -116,6 +116,8 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
   }) =>
   (type) => {
     const { alertIgnoreFields: ignoreFields, alertMergeStrategy: mergeStrategy } = config;
+    // Rule preview must stay non-operational, similar to regular actions
+    const responseActionsService = isPreview ? noop : scheduleNotificationResponseActionsService;
     const persistenceRuleType = createPersistenceRuleTypeWrapper({
       ruleDataClient,
       logger,
@@ -493,7 +495,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                     ignoreFieldsRegexes,
                     eventsTelemetry,
                     licensing,
-                    scheduleNotificationResponseActionsService,
+                    scheduleNotificationResponseActionsService: responseActionsService,
                   },
                 });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -58,7 +58,7 @@ describe('Custom Query Alerts', () => {
 
   const eventsTelemetry = createMockTelemetryEventsSender(true);
 
-  const securityRuleTypeWrapper = createSecurityRuleTypeWrapper({
+  const wrapperOptions = {
     actions,
     docLinks,
     lists,
@@ -73,7 +73,9 @@ describe('Custom Query Alerts', () => {
     eventsTelemetry,
     licensing,
     scheduleNotificationResponseActionsService: () => null,
-  });
+  };
+
+  const securityRuleTypeWrapper = createSecurityRuleTypeWrapper(wrapperOptions);
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -201,5 +203,46 @@ describe('Custom Query Alerts', () => {
           "The rule's max alerts per run setting (10000) is greater than the Kibana alerting limit (1000). The rule will only write a maximum of 1000 alerts per rule run.",
       })
     );
+  });
+
+  describe('response actions', () => {
+    const buildWrapper = (isPreview: boolean, scheduleService: jest.Mock) =>
+      createSecurityRuleTypeWrapper({
+        ...wrapperOptions,
+        isPreview,
+        scheduleNotificationResponseActionsService: scheduleService,
+      });
+
+    const runRule = async ({ isPreview }: { isPreview: boolean }) => {
+      const scheduleService = jest.fn();
+      const queryAlertType = buildWrapper(
+        isPreview,
+        scheduleService
+      )(createQueryAlertType({ id: QUERY_RULE_TYPE_ID, name: 'Custom Query Rule' }));
+      alerting.registerType(queryAlertType);
+
+      services.scopedClusterClient.asCurrentUser.search.mockResolvedValue({
+        hits: {
+          hits: [sampleDocNoSortId()],
+          total: { relation: 'eq', value: 1 },
+        },
+        took: 0,
+        timed_out: false,
+        _shards: { failed: 0, skipped: 0, successful: 1, total: 1 },
+      });
+
+      await executor({ params: getQueryRuleParams() });
+      return scheduleService;
+    };
+
+    it('dispatches response actions on a normal rule run', async () => {
+      const scheduleService = await runRule({ isPreview: false });
+      expect(scheduleService).toHaveBeenCalled();
+    });
+
+    it('never dispatches response actions during preview', async () => {
+      const scheduleService = await runRule({ isPreview: true });
+      expect(scheduleService).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [[Security Solution][DEX] Skip response actions during rule preview (#278393)](https://github.com/elastic/kibana/pull/278393)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":278393,"url":"https://github.com/elastic/kibana/pull/278393","title":"[Security Solution][DEX] Skip response actions during rule preview"},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"sourceCommit":{"sha":"fa852f1e49be89dd9759ee1e03aae1933acae086"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)