### PR TITLE
Stabilize ServiceNow OAuth form test

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/servicenow/servicenow_connectors.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/servicenow/servicenow_connectors.test.tsx
@@ -24,8 +24,7 @@ const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 const getAppInfoMock = getAppInfo as jest.Mock;
 const updateActionConnectorMock = updateActionConnector as jest.Mock;
 
-// FLAKY: https://github.com/elastic/kibana/issues/253539
-describe.skip('ServiceNowActionConnectorFields renders', () => {
+describe('ServiceNowActionConnectorFields renders', () => {
   const usesTableApiConnector = {
     id: 'test',
     actionTypeId: '.servicenow',
@@ -148,7 +147,7 @@ describe.skip('ServiceNowActionConnectorFields renders', () => {
     };
 
     render(
-      <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
+      <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit} isEdit>
         <ServiceNowConnectorFields
           readOnly={false}
           isEdit={false}
@@ -159,26 +158,18 @@ describe.skip('ServiceNowActionConnectorFields renders', () => {
 
     await userEvent.click(screen.getByTestId('use-oauth-switch'));
 
-    await userEvent.type(
-      await screen.findByRole('textbox', { name: 'Client ID' }),
-      'test-client-id'
-    );
-
-    await userEvent.type(
-      screen.getByRole('textbox', { name: 'User identifier' }),
-      'test-user-identifier'
-    );
-    await userEvent.type(
-      screen.getByRole('textbox', { name: 'JWT verifier key ID' }),
-      'test-jwt-key-id'
-    );
-
-    await userEvent.type(screen.getByLabelText('Client secret'), 'test-client-secret');
-    await userEvent.type(screen.getByLabelText('Private key'), 'test-private-key');
-    await userEvent.type(
-      screen.getByLabelText('Private key password'),
-      'test-private-key-password'
-    );
+    await userEvent.click(await screen.findByRole('textbox', { name: 'Client ID' }));
+    await userEvent.paste('test-client-id');
+    await userEvent.click(screen.getByRole('textbox', { name: 'User identifier' }));
+    await userEvent.paste('test-user-identifier');
+    await userEvent.click(screen.getByRole('textbox', { name: 'JWT verifier key ID' }));
+    await userEvent.paste('test-jwt-key-id');
+    await userEvent.click(screen.getByLabelText('Client secret'));
+    await userEvent.paste('test-client-secret');
+    await userEvent.click(screen.getByLabelText('Private key'));
+    await userEvent.paste('test-private-key');
+    await userEvent.click(screen.getByLabelText('Private key password'));
+    await userEvent.paste('test-private-key-password');
 
     await userEvent.click(await screen.findByTestId('form-test-provide-submit'));
 
@@ -367,7 +358,7 @@ describe.skip('ServiceNowActionConnectorFields renders', () => {
       updateActionConnectorMock.mockResolvedValue({ isDeprecated: false });
 
       render(
-        <ConnectorFormTestProvider connector={usesTableApiConnector}>
+        <ConnectorFormTestProvider connector={usesTableApiConnector} isEdit>
           <ServiceNowConnectorFields
             readOnly={false}
             isEdit={false}
@@ -496,7 +487,7 @@ describe.skip('ServiceNowActionConnectorFields renders', () => {
       'connector validation succeeds when connector config is valid',
       async (connector) => {
         render(
-          <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
+          <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit} isEdit>
             <ServiceNowConnectorFields
               readOnly={false}
               isEdit={false}
@@ -525,7 +516,7 @@ describe.skip('ServiceNowActionConnectorFields renders', () => {
       };
 
       render(
-        <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
+        <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit} isEdit>
           <ServiceNowConnectorFields
             readOnly={false}
             isEdit={false}


### PR DESCRIPTION
## Summary

Unskips the ServiceNow connector Jest suite and stabilizes its OAuth form submission test.

The failing test simulated every character across six fields with `userEvent.type`, despite asserting only final submitted values. It reproduced locally at Jest's 5000 ms timeout. Using paste interactions reduces the test to about 250-350 ms while preserving user interaction and form assertions.

Existing-connector scenarios now mark the shared form provider as edit mode. This preserves connector IDs and avoids create-only availability validation added while the suite was skipped.

Closes #253539

## Validation

- `yarn test:jest x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/servicenow/servicenow_connectors.test.tsx --runInBand` (25 passing)
- `node scripts/eslint x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/servicenow/servicenow_connectors.test.tsx`
- Pre-push branch checks (types, generated projects, lint, 25 Jest tests)

## Risk

Low. Test-only interaction and fixture-mode changes. Product behavior is unchanged.

## Release notes

None. Test-only change.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->