### PR TITLE
[9.5] [Security Solution][Endpoint] Show "Creating action" message in Response Console while action is being created (#276523)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_execution_output.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_execution_output.test.tsx
@@ -11,6 +11,7 @@ import type { AppContextTestRender } from '../../../../common/mock/endpoint';
 import { getConsoleTestSetup } from '../mocks';
 import { act } from '@testing-library/react';
 import type { CommandExecutionComponentProps } from '../types';
+import type { CommandExecutionState } from './console_state/types';
 
 describe('When using CommandExecutionOutput component', () => {
   let render: (
@@ -18,6 +19,7 @@ describe('When using CommandExecutionOutput component', () => {
   ) => Promise<ReturnType<AppContextTestRender['render']>>;
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let setCmd1ToComplete: () => void;
+  let setCmd1Status: (status: CommandExecutionState['status']) => void;
 
   beforeEach(() => {
     const { renderConsole, commands, enterCommand } = getConsoleTestSetup();
@@ -31,6 +33,7 @@ describe('When using CommandExecutionOutput component', () => {
     (cmd1.RenderComponent as jest.Mock).mockImplementation(
       (props: CommandExecutionComponentProps) => {
         setCmd1ToComplete = () => props.setStatus('success');
+        setCmd1Status = (status) => props.setStatus(status);
 
         return <div>{'output'}</div>;
       }
@@ -71,5 +74,44 @@ describe('When using CommandExecutionOutput component', () => {
     });
 
     expect(renderResult.queryByTestId('test-longRunningCommandHint')).toBeNull();
+  });
+
+  it('should not show the busy indicator or long running hint while status is `creating`', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    await render();
+
+    act(() => {
+      setCmd1Status('creating');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(16 * 1000);
+    });
+
+    expect(renderResult.container.querySelector('.busy-indicator')).toBeNull();
+    expect(renderResult.queryByTestId('test-longRunningCommandHint')).toBeNull();
+  });
+
+  it('should only start the long running hint timer once status becomes `pending`', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    await render();
+
+    // While `creating`, the hint should not appear even after the long-running threshold elapses
+    act(() => {
+      setCmd1Status('creating');
+    });
+    act(() => {
+      jest.advanceTimersByTime(16 * 1000);
+    });
+    expect(renderResult.queryByTestId('test-longRunningCommandHint')).toBeNull();
+
+    // Once the command transitions to `pending`, the timer starts fresh and the hint appears after 15s
+    act(() => {
+      setCmd1Status('pending');
+    });
+    act(() => {
+      jest.advanceTimersByTime(16 * 1000);
+    });
+    expect(renderResult.getByTestId('test-longRunningCommandHint')).not.toBeNull();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_execution_output.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_execution_output.tsx
@@ -32,9 +32,14 @@ export const CommandExecutionOutput = memo<CommandExecutionOutputProps>(
     const dispatch = useConsoleStateDispatch();
     const RenderComponent = command.commandDefinition.RenderComponent;
     const [isLongRunningCommand, setIsLongRunningCommand] = useState(false);
+    const [pendingStartedAt, setPendingStartedAt] = useState<string | undefined>(undefined);
 
-    const isRunning = useMemo(() => {
+    const isPending = useMemo(() => {
       return state.status === 'pending';
+    }, [state.status]);
+
+    const isCreating = useMemo(() => {
+      return state.status === 'creating';
     }, [state.status]);
 
     /** Updates the Command's status */
@@ -65,12 +70,22 @@ export const CommandExecutionOutput = memo<CommandExecutionOutputProps>(
       [dispatch, id]
     );
 
+    // When the command status goes into `pending`, set the `pendingStartedAt` so that we can track when
+    // the command becomes a "long running command" and show a hint.
+    useEffect(() => {
+      if (isPending && !pendingStartedAt) {
+        setPendingStartedAt(new Date().toISOString());
+      } else if (!isPending) {
+        setPendingStartedAt(undefined);
+      }
+    }, [isPending, pendingStartedAt]);
+
     // keep track if this becomes a long running command
     useEffect(() => {
       let timeoutId: ReturnType<typeof setTimeout>;
 
-      if (isRunning && !isLongRunningCommand) {
-        const elapsedSeconds = moment().diff(moment(enteredAt), 'seconds');
+      if (isPending && pendingStartedAt && !isCreating && !isLongRunningCommand) {
+        const elapsedSeconds = moment().diff(moment(pendingStartedAt), 'seconds');
 
         if (elapsedSeconds >= 15) {
           setIsLongRunningCommand(true);
@@ -87,7 +102,7 @@ export const CommandExecutionOutput = memo<CommandExecutionOutputProps>(
           clearTimeout(timeoutId);
         }
       };
-    }, [enteredAt, isLongRunningCommand, isRunning]);
+    }, [pendingStartedAt, isCreating, isLongRunningCommand, isPending]);
 
     return (
       <CommandOutputContainer>
@@ -108,9 +123,9 @@ export const CommandExecutionOutput = memo<CommandExecutionOutputProps>(
             ResultComponent={CommandExecutionResult}
           />
 
-          {isRunning && <EuiLoadingChart className="busy-indicator" />}
+          {isPending && <EuiLoadingChart className="busy-indicator" />}
 
-          {isRunning && isLongRunningCommand && (
+          {isPending && isLongRunningCommand && (
             <>
               <EuiSpacer size="s" />
               <LongRunningCommandHint />

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/console_state/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/console_state/types.ts
@@ -133,7 +133,14 @@ export interface CommandHistoryItem {
 }
 
 export interface CommandExecutionState {
-  status: 'pending' | 'success' | 'error';
+  /**
+   * The overall status of the Command execution.
+   * - creating: The command request is being created
+   * - pending: The command request has been created and is still being executed.
+   * - success: The command was executed successfully.
+   * - error: The command execution failed.
+   */
+  status: 'creating' | 'pending' | 'success' | 'error';
   store: Record<string, unknown>;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/kill_process_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/kill_process_action.test.tsx
@@ -470,7 +470,7 @@ describe('When using the kill-process action from response actions console', () 
         'kill-process --processName="notepad" --comment="some comment"'
       );
 
-      expect(renderResult.getByTestId('killProcess-pending'));
+      expect(renderResult.getByTestId('killProcess-creating'));
 
       await waitFor(() => {
         expect(apiMocks.responseProvider.killProcess).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.test.tsx
@@ -141,6 +141,50 @@ describe('When using `useConsoleActionSubmitter()` hook', () => {
     expect(renderArgs.store?.actionApiState?.request.actionId).toBe(undefined);
   });
 
+  it('should set status to `creating` and show the creating message while the action request is being created', async () => {
+    render();
+
+    await waitFor(() => {
+      expect(renderArgs.setStatus).toHaveBeenCalledWith('creating');
+    });
+
+    expect(renderResult.getByTestId('test-creating')).not.toBeNull();
+    expect(getOutputTextContent()).toEqual(
+      'Creating action (do not close the console until this step is completed)...'
+    );
+  });
+
+  it('should transition status from `creating` to `pending` once the action request has been created', async () => {
+    render();
+
+    await waitFor(() => {
+      expect(renderArgs.setStatus).toHaveBeenCalledWith('creating');
+    });
+
+    releaseSuccessActionRequestApiResponse();
+
+    await waitFor(() => {
+      expect(renderArgs.setStatus).toHaveBeenCalledWith('pending');
+    });
+  });
+
+  it('should set status to `error` if creating the action request fails', async () => {
+    render();
+    const error = new Error('oh oh. request failed');
+
+    await waitFor(() => {
+      expect(renderArgs.setStatus).toHaveBeenCalledWith('creating');
+    });
+
+    act(() => {
+      releaseFailedActionRequestApiResponse(error);
+    });
+
+    await waitFor(() => {
+      expect(renderArgs.setStatus).toHaveBeenCalledWith('error');
+    });
+  });
+
   it('should store the action id when action request api is successful', async () => {
     render();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.tsx
@@ -121,6 +121,7 @@ export const useConsoleActionSubmitter = <
   const isMounted = useIsMounted();
   const getTestId = useTestIdGenerator(dataTestSubj);
   const isPending = status === 'pending';
+  const isCreating = status === 'creating';
 
   const currentActionState = useMemo<
     Immutable<
@@ -169,6 +170,8 @@ export const useConsoleActionSubmitter = <
         sent: true,
       };
 
+      setStatus('creating');
+
       // The object defined above (`updatedRequestState`) is saved to the command state right away.
       // the creation of the Action request (below) will mutate this object to store the Action ID
       // once the API response is received. We do this to ensure that the action is not created more
@@ -180,9 +183,17 @@ export const useConsoleActionSubmitter = <
         .mutateAsync(actionRequestBody)
         .then((response) => {
           updatedRequestState.actionId = response.data.id;
+
+          if (isMounted()) {
+            setStatus('pending');
+          }
         })
         .catch((err) => {
           updatedRequestState.error = err;
+
+          if (isMounted()) {
+            setStatus('error');
+          }
         })
         .finally(() => {
           // If the component is mounted, then set the store with the updated data (causes a rerender)
@@ -215,16 +226,26 @@ export const useConsoleActionSubmitter = <
     actionRequestSent,
     currentActionState,
     isMounted,
+    setStatus,
     setStore,
   ]);
+
+  // If we have an Action ID, but the overall status is `creating`, then set the status to pending.
+  // This status inconsistency can happen if the user closes the console while the action request is
+  // still being created
+  useEffect(() => {
+    if (actionId && isCreating) {
+      setStatus('pending');
+    }
+  }, [actionId, isCreating, setStatus]);
 
   // If an error was returned while attempting to create the action request,
   // then set command status to error
   useEffect(() => {
-    if (actionRequestError && isPending) {
+    if (actionRequestError && (isPending || isCreating)) {
       setStatus('error');
     }
-  }, [actionRequestError, isPending, setStatus]);
+  }, [actionRequestError, isPending, isCreating, setStatus]);
 
   // If an error was return by the Action Details API, then store it and set the status to error
   useEffect(() => {
@@ -263,6 +284,19 @@ export const useConsoleActionSubmitter = <
 
   // Calculate the action's UI result based on the different API responses
   const result = useMemo(() => {
+    // If we don't yet have an Action ID and no API error, then show message indicating that
+    // action request is still being created
+    if (isCreating) {
+      return (
+        <ResultComponent showAs="pending" data-test-subj={getTestId('creating')}>
+          <FormattedMessage
+            id="xpack.securitySolution.endpointResponder.creatingActionMessage"
+            defaultMessage="Creating action (do not close the console until this step is completed)..."
+          />
+        </ResultComponent>
+      );
+    }
+
     if (isPending) {
       return (
         <ResultComponent showAs="pending" data-test-subj={getTestId('pending')}>
@@ -321,6 +355,7 @@ export const useConsoleActionSubmitter = <
     return <></>;
   }, [
     isPending,
+    isCreating,
     actionRequestError,
     actionDetailsError,
     actionDetails,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution][Endpoint] Show "Creating action" message in Response Console while action is being created (#276523)](https://github.com/elastic/kibana/pull/276523)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-20T21:23:48Z","message":"[Security Solution][Endpoint] Show \"Creating action\" message in Response Console while action is being created (#276523)\n\n## Summary\n\nAdds a new intermediate `creating` status to the Response Console\ncommand execution lifecycle so that users get immediate feedback while a\nresponse action request is being created (i.e. before the create-action\nAPI call returns and the action ID is known).\n\nPreviously the console jumped straight into the `pending` (long‑running)\nstate. Now, while the action request is being created, the console\nshows:\n\n> Creating action (do not close the console until this step is\ncompleted)...\n\nOnce the action is created (API responds with the action ID), the status\ntransitions to `pending`, and the \"long running command\" hint timer now\nstarts from when the command actually enters `pending` (rather than when\nit was entered), so the hint is no longer shown prematurely while the\naction is still being created.\n\n\n\n### Changes\n- **`console_state/types.ts`** – Add `creating` to\n`CommandExecutionState['status']` and document each status value.\n- **`command_execution_output.tsx`** – Distinguish `pending` vs\n`creating`; track `pendingStartedAt` and base the long‑running‑command\nhint timer off that timestamp, so the hint only counts elapsed time once\nthe command is actually `pending` (not `creating`).\n- **`use_console_action_submitter.tsx`** – Set status to `creating` when\nsubmitting, transition to `pending` on success (with action ID) or\n`error` on failure; render the \"Creating action...\" message while in\n`creating`.","sha":"3efe2510c7f65d92f0f8cc384cfa8489dbaa5ed9","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Defend Workflows","backport:version","v9.5.0","v9.6.0"],"title":"[Security Solution][Endpoint] Show \"Creating action\" message in Response Console while action is being created","number":276523,"url":"https://github.com/elastic/kibana/pull/276523","mergeCommit":{"message":"[Security Solution][Endpoint] Show \"Creating action\" message in Response Console while action is being created (#276523)\n\n## Summary\n\nAdds a new intermediate `creating` status to the Response Console\ncommand execution lifecycle so that users get immediate feedback while a\nresponse action request is being created (i.e. before the create-action\nAPI call returns and the action ID is known).\n\nPreviously the console jumped straight into the `pending` (long‑running)\nstate. Now, while the action request is being created, the console\nshows:\n\n> Creating action (do not close the console until this step is\ncompleted)...\n\nOnce the action is created (API responds with the action ID), the status\ntransitions to `pending`, and the \"long running command\" hint timer now\nstarts from when the command actually enters `pending` (rather than when\nit was entered), so the hint is no longer shown prematurely while the\naction is still being created.\n\n\n\n### Changes\n- **`console_state/types.ts`** – Add `creating` to\n`CommandExecutionState['status']` and document each status value.\n- **`command_execution_output.tsx`** – Distinguish `pending` vs\n`creating`; track `pendingStartedAt` and base the long‑running‑command\nhint timer off that timestamp, so the hint only counts elapsed time once\nthe command is actually `pending` (not `creating`).\n- **`use_console_action_submitter.tsx`** – Set status to `creating` when\nsubmitting, transition to `pending` on success (with action ID) or\n`error` on failure; render the \"Creating action...\" message while in\n`creating`.","sha":"3efe2510c7f65d92f0f8cc384cfa8489dbaa5ed9"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276523","number":276523,"mergeCommit":{"message":"[Security Solution][Endpoint] Show \"Creating action\" message in Response Console while action is being created (#276523)\n\n## Summary\n\nAdds a new intermediate `creating` status to the Response Console\ncommand execution lifecycle so that users get immediate feedback while a\nresponse action request is being created (i.e. before the create-action\nAPI call returns and the action ID is known).\n\nPreviously the console jumped straight into the `pending` (long‑running)\nstate. Now, while the action request is being created, the console\nshows:\n\n> Creating action (do not close the console until this step is\ncompleted)...\n\nOnce the action is created (API responds with the action ID), the status\ntransitions to `pending`, and the \"long running command\" hint timer now\nstarts from when the command actually enters `pending` (rather than when\nit was entered), so the hint is no longer shown prematurely while the\naction is still being created.\n\n\n\n### Changes\n- **`console_state/types.ts`** – Add `creating` to\n`CommandExecutionState['status']` and document each status value.\n- **`command_execution_output.tsx`** – Distinguish `pending` vs\n`creating`; track `pendingStartedAt` and base the long‑running‑command\nhint timer off that timestamp, so the hint only counts elapsed time once\nthe command is actually `pending` (not `creating`).\n- **`use_console_action_submitter.tsx`** – Set status to `creating` when\nsubmitting, transition to `pending` on success (with action ID) or\n`error` on failure; render the \"Creating action...\" message while in\n`creating`.","sha":"3efe2510c7f65d92f0f8cc384cfa8489dbaa5ed9"}}]}] BACKPORT-->