### PR TITLE
[9.3] [Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint (#278125)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.test.ts
@@ -116,6 +116,57 @@ describe('Perform Rule Upgrade Route Schemas', () => {
         );
       });
 
+      // Regression test for https://github.com/elastic/kibana/issues/232614:
+      // resolving a `required_fields` conflict must not require the computed
+      // `ecs` property on input (it is derived on the server).
+      it('accepts a resolved required_fields value without the computed `ecs` property', () => {
+        const input = {
+          required_fields: {
+            pick_version: 'RESOLVED',
+            resolved_value: [
+              { name: '@timestamp', type: 'date' },
+              { name: 'user.name', type: 'keyword' },
+            ],
+          },
+        };
+        const result = RuleFieldsToUpgrade.safeParse(input);
+        expectParseSuccess(result);
+        expect(result.data).toEqual(input);
+      });
+
+      // The pre-fix workaround sent `ecs` hardcoded; that must keep working.
+      // `ecs` is not part of the input schema, so it is stripped on parse.
+      it('strips a provided `ecs` property from a resolved required_fields value', () => {
+        const input = {
+          required_fields: {
+            pick_version: 'RESOLVED',
+            resolved_value: [{ name: '@timestamp', type: 'date', ecs: false }],
+          },
+        };
+        const result = RuleFieldsToUpgrade.safeParse(input);
+        expectParseSuccess(result);
+        expect(result.data).toEqual({
+          required_fields: {
+            pick_version: 'RESOLVED',
+            resolved_value: [{ name: '@timestamp', type: 'date' }],
+          },
+        });
+      });
+
+      it('invalidates a resolved required_fields value missing required properties', () => {
+        const input = {
+          required_fields: {
+            pick_version: 'RESOLVED',
+            resolved_value: [{ name: '@timestamp' }],
+          },
+        };
+        const result = RuleFieldsToUpgrade.safeParse(input);
+        expectParseError(result);
+        expect(stringifyZodError(result.error)).toMatchInlineSnapshot(
+          `"required_fields.resolved_value.0.type: Invalid input: expected string, received undefined"`
+        );
+      });
+
       it('invalidates unknown fields', () => {
         const input = {
           unknown_field: {

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.test.ts
@@ -163,7 +163,7 @@ describe('Perform Rule Upgrade Route Schemas', () => {
         const result = RuleFieldsToUpgrade.safeParse(input);
         expectParseError(result);
         expect(stringifyZodError(result.error)).toMatchInlineSnapshot(
-          `"required_fields.resolved_value.0.type: Invalid input: expected string, received undefined"`
+          `"required_fields.resolved_value.0.type: Required"`
         );
       });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.ts
@@ -9,7 +9,7 @@ import { z } from '@kbn/zod';
 import { mapValues } from 'lodash';
 import { RuleResponse } from '../../model/rule_schema/rule_schemas.gen';
 import { AggregatedPrebuiltRuleError, DiffableAllFields, ThreeWayDiffConflict } from '../model';
-import { RuleSignatureId, RuleVersion } from '../../model';
+import { RequiredFieldInput, RuleSignatureId, RuleVersion } from '../../model';
 import { PrebuiltRulesFilter } from '../common/prebuilt_rules_filter';
 
 export type Mode = z.infer<typeof Mode>;
@@ -66,9 +66,20 @@ export const DiffableFieldsToOmit = NON_UPGRADEABLE_DIFFABLE_FIELDS.reduce((acc,
  * Specific fields are omitted because they are not upgradeable, and
  * handled under the hood by endpoint logic.
  * See: https://github.com/elastic/kibana/issues/186544
+ *
+ * These field schemas are used exclusively to validate a field's
+ * `resolved_value` on input (i.e. `pick_version: 'RESOLVED'`), so they describe
+ * the input shape, not the response shape. `required_fields` is overridden to
+ * `RequiredFieldInput` (name + type) because its `ecs` boolean is computed by
+ * the server (`addEcsToRequiredFields`) and only present in responses. Reusing
+ * the response schema (`RequiredField`, where `ecs` is mandatory) made resolving
+ * a `required_fields` conflict impossible.
+ * See: https://github.com/elastic/kibana/issues/232614
  */
 export type DiffableUpgradableFields = z.infer<typeof DiffableUpgradableFields>;
-export const DiffableUpgradableFields = DiffableAllFields.omit(DiffableFieldsToOmit);
+export const DiffableUpgradableFields = DiffableAllFields.omit(DiffableFieldsToOmit).extend({
+  required_fields: z.array(RequiredFieldInput),
+});
 
 export type FieldUpgradeSpecifier<T> = z.infer<
   ReturnType<typeof fieldUpgradeSpecifier<z.ZodType<T>>>

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.ts
@@ -62,19 +62,13 @@ export const DiffableFieldsToOmit = NON_UPGRADEABLE_DIFFABLE_FIELDS.reduce((acc,
 }, {} as NON_UPGRADEABLE_DIFFABLE_FIELDS_TO_OMIT_TYPE);
 
 /**
- * Fields upgradable by the /upgrade/_perform endpoint.
- * Specific fields are omitted because they are not upgradeable, and
- * handled under the hood by endpoint logic.
+ * Fields upgradable by the /upgrade/_perform endpoint. Non-upgradeable fields
+ * are omitted because they are handled under the hood by endpoint logic.
  * See: https://github.com/elastic/kibana/issues/186544
  *
- * These field schemas are used exclusively to validate a field's
- * `resolved_value` on input (i.e. `pick_version: 'RESOLVED'`), so they describe
- * the input shape, not the response shape. `required_fields` is overridden to
- * `RequiredFieldInput` (name + type) because its `ecs` boolean is computed by
- * the server (`addEcsToRequiredFields`) and only present in responses. Reusing
- * the response schema (`RequiredField`, where `ecs` is mandatory) made resolving
- * a `required_fields` conflict impossible.
- * See: https://github.com/elastic/kibana/issues/232614
+ * These schemas validate each field's `resolved_value` on input, so
+ * `required_fields` uses `RequiredFieldInput` (no `ecs`): `ecs` is computed by
+ * the server and only present in responses.
  */
 export type DiffableUpgradableFields = z.infer<typeof DiffableUpgradableFields>;
 export const DiffableUpgradableFields = DiffableAllFields.omit(DiffableFieldsToOmit).extend({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint (#278125)](https://github.com/elastic/kibana/pull/278125)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Edgar Santos","email":"edgar.santos@elastic.co"},"sourceCommit":{"committedDate":"2026-07-17T15:48:50Z","message":"[Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint (#278125)","sha":"f73f17344d8b15d509918534e03b35872f0f8500","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","backport:version","v9.5.0","v9.2.9","Team:Detection Engineering","v9.4.4","v9.6.0","v9.3.8"],"title":"[Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint","number":278125,"url":"https://github.com/elastic/kibana/pull/278125","mergeCommit":{"message":"[Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint (#278125)","sha":"f73f17344d8b15d509918534e03b35872f0f8500"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279286","number":279286,"state":"OPEN"},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279285","number":279285,"state":"MERGED","mergeCommit":{"sha":"519d53c627e22a9fe35bc7b1c7b048dcc6b31df8","message":"[9.4] [Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint (#278125) (#279285)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Detection Engineering] Fix input schema in prebuilt rule upgrade\nendpoint (#278125)](https://github.com/elastic/kibana/pull/278125)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Edgar Santos <edgar.santos@elastic.co>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278125","number":278125,"mergeCommit":{"message":"[Detection Engineering] Fix input schema in prebuilt rule upgrade endpoint (#278125)","sha":"f73f17344d8b15d509918534e03b35872f0f8500"}},{"branch":"9.3","label":"v9.3.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->