### PR TITLE
[CI] Skip FTR configs in pull request builds when a PR cannot affect them

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
@@ -9,7 +9,7 @@
 
 import * as Fs from 'fs';
 
-import { listChangedFiles } from '../../affected-packages';
+import { getAffectedPackages, listChangedFiles } from '../../affected-packages';
 import type { BuildkiteStep } from '../../buildkite';
 import { BuildkiteClient } from '../../buildkite';
 import { getTrackedBranch } from '../../utils';
@@ -21,6 +21,7 @@ import { loadRunOrderConfig } from './env_config';
 import { getEnabledFtrConfigs } from './ftr_manifests';
 import { discoverJestIntegrationConfigs, discoverJestUnitConfigs } from './jest_configs';
 import { getRunGroup, getRunGroups, labelJestSubgroups } from './run_groups';
+import { shouldSkipFtrTests } from './selective_ftr';
 import { isScoutTestsOnlyDiff } from './selective_scout';
 import {
   filterJestIntegrationConfigsByAffected,
@@ -43,16 +44,20 @@ export async function pickTestGroupRunOrder() {
   const ciStats = new CiStatsClient();
   const config = loadRunOrderConfig();
 
-  // Holds the merge base only when selective testing is enabled; the two
-  // `if` blocks below both use it (Scout skip check, then Jest filter).
+  // Holds the merge base only when selective testing is enabled; the blocks
+  // below use it (Scout skip check, FTR exclusion, then Jest filter).
   const selectiveTestingMergeBase = config.useSelectiveTesting ? config.prMergeBase : undefined;
 
   // Fast path: a PR whose diff is exclusively Scout test files cannot affect
   // any Jest unit/integration or FTR config — skip emitting them entirely.
   // The Scout pipeline still runs its own selective testing in parallel.
+  let selectiveChangedFiles: string[] | undefined;
   if (selectiveTestingMergeBase) {
-    const changedFiles = listChangedFiles({ mergeBase: selectiveTestingMergeBase, commit: 'HEAD' });
-    if (isScoutTestsOnlyDiff(changedFiles)) {
+    selectiveChangedFiles = listChangedFiles({
+      mergeBase: selectiveTestingMergeBase,
+      commit: 'HEAD',
+    });
+    if (isScoutTestsOnlyDiff(selectiveChangedFiles)) {
       console.log('Scout-tests-only diff detected — skipping Jest/FTR test steps');
       bk.setAnnotation(
         'selective-testing-scout-tests-only',
@@ -77,7 +82,37 @@ export async function pickTestGroupRunOrder() {
   );
   if (!ftrConfigsIncluded) ftrConfigsByQueue.clear();
 
-  if (selectiveTestingMergeBase) {
+  if (selectiveTestingMergeBase && selectiveChangedFiles) {
+    // Skip FTR when the PR only touches Scout/Jest/Cypress/lint modules or
+    // CI/docs noise. Jest selective filtering still runs below.
+    const directlyAffected = await getAffectedPackages(selectiveTestingMergeBase, {
+      strategy: 'git',
+      includeDownstream: false,
+      ignoreUncategorizedChanges: true,
+    }).catch((error) => {
+      console.error('Error getting affected packages for FTR skip check', error);
+      return null;
+    });
+
+    if (
+      directlyAffected !== null &&
+      shouldSkipFtrTests(directlyAffected, selectiveChangedFiles)
+    ) {
+      console.log(
+        `Skipping FTR configs — affected module(s) cannot impact FTR: ${
+          directlyAffected.size
+            ? [...directlyAffected].join(', ')
+            : '(uncategorized / irrelevant paths only)'
+        }`
+      );
+      bk.setAnnotation(
+        'selective-testing-ftr-excluded',
+        'info',
+        'Selective testing: FTR configs were skipped because the diff only touches modules/paths that cannot affect FTR.'
+      );
+      ftrConfigsByQueue.clear();
+    }
+
     const selectiveCtx = await resolveSelectiveTestingContext(selectiveTestingMergeBase);
     if (selectiveCtx !== null) {
       jestUnitConfigs = filterJestUnitConfigsByAffected(jestUnitConfigs, selectiveCtx);
@@ -89,6 +124,15 @@ export async function pickTestGroupRunOrder() {
   }
 
   if (!ftrConfigsByQueue.size && !jestUnitConfigs.length && !jestIntegrationConfigs.length) {
+    if (config.useSelectiveTesting) {
+      console.log('Selective testing: no Jest/FTR configs to run for this diff');
+      bk.setAnnotation(
+        'selective-testing-no-jest-ftr',
+        'info',
+        'Selective testing: no Jest unit/integration or FTR configs were scheduled for this diff.'
+      );
+      return;
+    }
     throw new Error('unable to find any unit, integration, or FTR configs');
   }
 

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
@@ -44,8 +44,6 @@ export async function pickTestGroupRunOrder() {
   const ciStats = new CiStatsClient();
   const config = loadRunOrderConfig();
 
-  // Holds the merge base only when selective testing is enabled; the blocks
-  // below use it (Scout skip check, FTR exclusion, then Jest filter).
   const selectiveTestingMergeBase = config.useSelectiveTesting ? config.prMergeBase : undefined;
 
   // Fast path: a PR whose diff is exclusively Scout test files cannot affect
@@ -83,8 +81,6 @@ export async function pickTestGroupRunOrder() {
   if (!ftrConfigsIncluded) ftrConfigsByQueue.clear();
 
   if (selectiveTestingMergeBase && selectiveChangedFiles) {
-    // Skip FTR when the PR only touches Scout/Jest/Cypress/lint modules or
-    // CI/docs noise. Jest selective filtering still runs below.
     const directlyAffected = await getAffectedPackages(selectiveTestingMergeBase, {
       strategy: 'git',
       includeDownstream: false,
@@ -99,16 +95,16 @@ export async function pickTestGroupRunOrder() {
       shouldSkipFtrTests(directlyAffected, selectiveChangedFiles)
     ) {
       console.log(
-        `Skipping FTR configs — affected module(s) cannot impact FTR: ${
+        `Skipping FTR configs — diff cannot affect FTR: ${
           directlyAffected.size
             ? [...directlyAffected].join(', ')
-            : '(uncategorized / irrelevant paths only)'
+            : '(irrelevant paths only)'
         }`
       );
       bk.setAnnotation(
         'selective-testing-ftr-excluded',
         'info',
-        'Selective testing: FTR configs were skipped because the diff only touches modules/paths that cannot affect FTR.'
+        'Selective testing: FTR configs skipped (excluded modules / irrelevant paths only).'
       );
       ftrConfigsByQueue.clear();
     }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
@@ -90,15 +90,10 @@ export async function pickTestGroupRunOrder() {
       return null;
     });
 
-    if (
-      directlyAffected !== null &&
-      shouldSkipFtrTests(directlyAffected, selectiveChangedFiles)
-    ) {
+    if (directlyAffected !== null && shouldSkipFtrTests(directlyAffected, selectiveChangedFiles)) {
       console.log(
         `Skipping FTR configs — diff cannot affect FTR: ${
-          directlyAffected.size
-            ? [...directlyAffected].join(', ')
-            : '(irrelevant paths only)'
+          directlyAffected.size ? [...directlyAffected].join(', ') : '(irrelevant paths only)'
         }`
       );
       bk.setAnnotation(

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -79,7 +79,13 @@ describe('FTR_EXCLUDED_MODULES invariants', () => {
   });
 });
 
-const SKIPPED_DIRS = new Set(['node_modules', 'target', '__snapshots__', '__mocks__', '__fixtures__']);
+const SKIPPED_DIRS = new Set([
+  'node_modules',
+  'target',
+  '__snapshots__',
+  '__mocks__',
+  '__fixtures__',
+]);
 
 function walkSourceFiles(dir: string): string[] {
   const out: string[] = [];

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FTR_EXCLUDED_MODULES, shouldSkipFtrTests } from './selective_ftr';
+
+describe('FTR_EXCLUDED_MODULES', () => {
+  const FTR_FRAMEWORK_AND_SUITES = [
+    '@kbn/test',
+    '@kbn/ftr-common-functional-services',
+    '@kbn/test-suites-src',
+    '@kbn/test-suites-xpack-platform',
+    '@kbn/journeys',
+  ];
+
+  it('does not include FTR framework or suite packages', () => {
+    for (const id of FTR_FRAMEWORK_AND_SUITES) {
+      expect(FTR_EXCLUDED_MODULES.has(id)).toBe(false);
+    }
+  });
+
+  it('includes Scout ecosystem modules', () => {
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-info')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/content-list-scout')).toBe(true);
+  });
+
+  it('includes Jest / Cypress helpers', () => {
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/cypress-test-helper')).toBe(true);
+  });
+});
+
+describe('shouldSkipFtrTests', () => {
+  it('returns false for an empty changed-files list', () => {
+    expect(shouldSkipFtrTests(new Set(['@kbn/scout']), [])).toBe(false);
+  });
+
+  it('returns true when all affected modules are excluded', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/scout', '@kbn/test-jest-helpers']), [
+        'src/platform/packages/shared/kbn-scout/src/index.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when any affected module is not excluded', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/scout', '@kbn/dashboard-plugin']), [
+        'src/platform/packages/shared/kbn-scout/src/index.ts',
+        'src/platform/plugins/shared/dashboard/public/plugin.ts',
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false when a critical path is touched even if modules are excluded', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/scout']), [
+        'src/platform/packages/shared/kbn-scout/src/index.ts',
+        'yarn.lock',
+      ])
+    ).toBe(false);
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/scout']), [
+        '.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml',
+      ])
+    ).toBe(false);
+  });
+
+  it('returns true for docs / CI / ownership-only diffs with no categorized modules', () => {
+    expect(
+      shouldSkipFtrTests(new Set(), [
+        'docs/extend/testing.md',
+        'fleet_packages.json',
+        '.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml',
+        'CODEOWNERS',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false for uncategorized diffs that are not irrelevant noise', () => {
+    expect(shouldSkipFtrTests(new Set(), ['some_random_root_script.sh'])).toBe(false);
+  });
+
+  it('returns false when FTR manifests change inside .buildkite', () => {
+    expect(
+      shouldSkipFtrTests(new Set(), [
+        '.buildkite/ftr-manifests/ftr_security_stateful_configs.yml',
+      ])
+    ).toBe(false);
+  });
+});

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -24,28 +24,16 @@ describe('FTR_EXCLUDED_MODULES', () => {
     }
   });
 
-  it('does not include packages used by FTR runtime', () => {
-    // Imported by FTR configs / ScoutFTRReporter in @kbn/test
+  it('does not include FTR runtime deps', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-info')).toBe(false);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-reporting')).toBe(false);
-    // Imported by FTR find/retry services (`delay`)
     expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(false);
   });
 
-  it('includes Playwright-only Scout helpers', () => {
+  it('includes Scout / Jest / Cypress / evals helpers', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/content-list-scout')).toBe(true);
-  });
-
-  it('includes Jest / Cypress helpers that FTR does not import', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/test-eui-helpers')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/cypress-test-helper')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/osquery-plugin-cypress')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/fleet-plugin-cypress')).toBe(true);
-  });
-
-  it('includes evals packages', () => {
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/evals-plugin')).toBe(true);
   });
 });
@@ -131,7 +119,7 @@ describe('shouldSkipFtrTests', () => {
     ).toBe(false);
   });
 
-  it('returns false for config/serverless.yml (can affect FTR feature flags)', () => {
+  it('returns false for config/serverless.yml', () => {
     expect(shouldSkipFtrTests(new Set(), ['config/serverless.yml'])).toBe(false);
   });
 });

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -7,40 +7,101 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
+import * as JSON5 from 'json5';
+import { getKibanaDir } from '../../utils';
+import { getModuleLookup } from '../../affected-packages/module_lookup';
 import { FTR_EXCLUDED_MODULES, shouldSkipFtrTests } from './selective_ftr';
 
-describe('FTR_EXCLUDED_MODULES', () => {
-  const FTR_FRAMEWORK_AND_SUITES = [
-    '@kbn/test',
-    '@kbn/ftr-common-functional-services',
-    '@kbn/test-suites-src',
-    '@kbn/test-suites-xpack-platform',
-    '@kbn/journeys',
-  ];
+/**
+ * Instead of asserting specific IDs in/out of the list (which just mirrors the
+ * list), these invariants derive correctness from the repo: every excluded
+ * module must exist, be devOnly, not look like FTR framework, and not be
+ * imported by FTR runtime packages.
+ */
+describe('FTR_EXCLUDED_MODULES invariants', () => {
+  const kibanaDir = getKibanaDir();
+  const { byId } = getModuleLookup();
 
-  it('does not include FTR framework or suite packages', () => {
-    for (const id of FTR_FRAMEWORK_AND_SUITES) {
-      expect(FTR_EXCLUDED_MODULES.has(id)).toBe(false);
+  it('every entry resolves to an existing module', () => {
+    const missing = [...FTR_EXCLUDED_MODULES].filter((id) => !byId.has(id));
+    expect(missing).toEqual([]);
+  });
+
+  it('every entry is devOnly (runtime plugins/libraries load into FTR-booted Kibana)', () => {
+    const runtimeModules: string[] = [];
+    for (const id of FTR_EXCLUDED_MODULES) {
+      const dir = byId.get(id);
+      if (!dir) continue;
+      const manifest = JSON5.parse(
+        fs.readFileSync(path.join(kibanaDir, dir, 'kibana.jsonc'), 'utf8')
+      );
+      if (!manifest.devOnly) runtimeModules.push(id);
     }
+    expect(runtimeModules).toEqual([]);
   });
 
-  it('does not include FTR runtime deps', () => {
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-info')).toBe(false);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-reporting')).toBe(false);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(false);
+  it('no entry looks like an FTR framework or suite package', () => {
+    const suspicious = [...FTR_EXCLUDED_MODULES].filter(
+      (id) =>
+        id === '@kbn/test' ||
+        id.includes('ftr') ||
+        id.includes('test-suites') ||
+        id.includes('journeys')
+    );
+    expect(suspicious).toEqual([]);
   });
 
-  it('does not include runtime plugins', () => {
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals-plugin')).toBe(false);
-  });
+  it('no entry is imported by FTR runtime packages', () => {
+    // Packages executed as part of every FTR run. An excluded module imported
+    // here (outside its tests) can change FTR behavior and must not be skipped.
+    const FTR_RUNTIME_MODULES = [
+      '@kbn/test',
+      '@kbn/ftr-common-functional-services',
+      '@kbn/ftr-common-functional-ui-services',
+    ];
 
-  it('includes Scout / Jest / Cypress / evals helpers', () => {
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/test-eui-helpers')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/cypress-test-helper')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals')).toBe(true);
+    const offenders: Record<string, string[]> = {};
+    for (const runtimeId of FTR_RUNTIME_MODULES) {
+      const dir = byId.get(runtimeId);
+      expect(dir).toBeDefined();
+      for (const file of walkSourceFiles(path.join(kibanaDir, dir!))) {
+        const content = fs.readFileSync(file, 'utf8');
+        for (const excluded of FTR_EXCLUDED_MODULES) {
+          if (content.includes(`'${excluded}'`) || content.includes(`"${excluded}"`)) {
+            (offenders[excluded] ??= []).push(path.relative(kibanaDir, file));
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual({});
   });
 });
+
+const SKIPPED_DIRS = new Set(['node_modules', 'target', '__snapshots__', '__mocks__', '__fixtures__']);
+
+function walkSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRS.has(entry.name)) out.push(...walkSourceFiles(full));
+    } else if (
+      /\.(ts|tsx|js|jsx)$/.test(entry.name) &&
+      !/\.test\.(ts|tsx|js|jsx)$/.test(entry.name)
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
 
 describe('shouldSkipFtrTests', () => {
   it('returns false for an empty changed-files list', () => {
@@ -53,24 +114,6 @@ describe('shouldSkipFtrTests', () => {
         'src/platform/packages/shared/kbn-scout/src/index.ts',
       ])
     ).toBe(true);
-  });
-
-  it('returns false when FTR runtime deps are affected', () => {
-    expect(
-      shouldSkipFtrTests(new Set(['@kbn/scout-info']), [
-        'src/platform/packages/private/kbn-scout-info/src/index.ts',
-      ])
-    ).toBe(false);
-    expect(
-      shouldSkipFtrTests(new Set(['@kbn/scout-reporting']), [
-        'src/platform/packages/private/kbn-scout-reporting/src/index.ts',
-      ])
-    ).toBe(false);
-    expect(
-      shouldSkipFtrTests(new Set(['@kbn/test-jest-helpers']), [
-        'src/platform/packages/shared/kbn-test-jest-helpers/src/index.ts',
-      ])
-    ).toBe(false);
   });
 
   it('returns false when any affected module is not excluded', () => {
@@ -117,9 +160,7 @@ describe('shouldSkipFtrTests', () => {
 
   it('returns false when FTR manifests change inside .buildkite', () => {
     expect(
-      shouldSkipFtrTests(new Set(), [
-        '.buildkite/ftr-manifests/ftr_security_stateful_configs.yml',
-      ])
+      shouldSkipFtrTests(new Set(), ['.buildkite/ftr-manifests/ftr_security_stateful_configs.yml'])
     ).toBe(false);
   });
 

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -24,10 +24,12 @@ describe('FTR_EXCLUDED_MODULES', () => {
     }
   });
 
-  it('does not include Scout packages used by FTR runtime', () => {
+  it('does not include packages used by FTR runtime', () => {
     // Imported by FTR configs / ScoutFTRReporter in @kbn/test
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-info')).toBe(false);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-reporting')).toBe(false);
+    // Imported by FTR find/retry services (`delay`)
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(false);
   });
 
   it('includes Playwright-only Scout helpers', () => {
@@ -35,8 +37,8 @@ describe('FTR_EXCLUDED_MODULES', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/content-list-scout')).toBe(true);
   });
 
-  it('includes Jest / Cypress helpers', () => {
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(true);
+  it('includes Jest / Cypress helpers that FTR does not import', () => {
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/test-eui-helpers')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/cypress-test-helper')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/osquery-plugin-cypress')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/fleet-plugin-cypress')).toBe(true);
@@ -55,16 +57,26 @@ describe('shouldSkipFtrTests', () => {
 
   it('returns true when all affected modules are excluded', () => {
     expect(
-      shouldSkipFtrTests(new Set(['@kbn/scout', '@kbn/test-jest-helpers']), [
+      shouldSkipFtrTests(new Set(['@kbn/scout', '@kbn/test-eui-helpers']), [
         'src/platform/packages/shared/kbn-scout/src/index.ts',
       ])
     ).toBe(true);
   });
 
-  it('returns false when scout-info is affected (FTR runtime dep)', () => {
+  it('returns false when FTR runtime deps are affected', () => {
     expect(
       shouldSkipFtrTests(new Set(['@kbn/scout-info']), [
         'src/platform/packages/private/kbn-scout-info/src/index.ts',
+      ])
+    ).toBe(false);
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/scout-reporting']), [
+        'src/platform/packages/private/kbn-scout-reporting/src/index.ts',
+      ])
+    ).toBe(false);
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/test-jest-helpers']), [
+        'src/platform/packages/shared/kbn-test-jest-helpers/src/index.ts',
       ])
     ).toBe(false);
   });

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -24,15 +24,27 @@ describe('FTR_EXCLUDED_MODULES', () => {
     }
   });
 
-  it('includes Scout ecosystem modules', () => {
+  it('does not include Scout packages used by FTR runtime', () => {
+    // Imported by FTR configs / ScoutFTRReporter in @kbn/test
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-info')).toBe(false);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-reporting')).toBe(false);
+  });
+
+  it('includes Playwright-only Scout helpers', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/scout-info')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/content-list-scout')).toBe(true);
   });
 
   it('includes Jest / Cypress helpers', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/cypress-test-helper')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/osquery-plugin-cypress')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/fleet-plugin-cypress')).toBe(true);
+  });
+
+  it('includes evals packages', () => {
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals-plugin')).toBe(true);
   });
 });
 
@@ -47,6 +59,14 @@ describe('shouldSkipFtrTests', () => {
         'src/platform/packages/shared/kbn-scout/src/index.ts',
       ])
     ).toBe(true);
+  });
+
+  it('returns false when scout-info is affected (FTR runtime dep)', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/scout-info']), [
+        'src/platform/packages/private/kbn-scout-info/src/index.ts',
+      ])
+    ).toBe(false);
   });
 
   it('returns false when any affected module is not excluded', () => {
@@ -83,6 +103,10 @@ describe('shouldSkipFtrTests', () => {
     ).toBe(true);
   });
 
+  it('returns true for i18nrc-only diffs', () => {
+    expect(shouldSkipFtrTests(new Set(), ['x-pack/.i18nrc.json', '.i18nrc.json'])).toBe(true);
+  });
+
   it('returns false for uncategorized diffs that are not irrelevant noise', () => {
     expect(shouldSkipFtrTests(new Set(), ['some_random_root_script.sh'])).toBe(false);
   });
@@ -93,5 +117,9 @@ describe('shouldSkipFtrTests', () => {
         '.buildkite/ftr-manifests/ftr_security_stateful_configs.yml',
       ])
     ).toBe(false);
+  });
+
+  it('returns false for config/serverless.yml (can affect FTR feature flags)', () => {
+    expect(shouldSkipFtrTests(new Set(), ['config/serverless.yml'])).toBe(false);
   });
 });

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -30,11 +30,15 @@ describe('FTR_EXCLUDED_MODULES', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/test-jest-helpers')).toBe(false);
   });
 
+  it('does not include runtime plugins', () => {
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals-plugin')).toBe(false);
+  });
+
   it('includes Scout / Jest / Cypress / evals helpers', () => {
     expect(FTR_EXCLUDED_MODULES.has('@kbn/scout')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/test-eui-helpers')).toBe(true);
     expect(FTR_EXCLUDED_MODULES.has('@kbn/cypress-test-helper')).toBe(true);
-    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals-plugin')).toBe(true);
+    expect(FTR_EXCLUDED_MODULES.has('@kbn/evals')).toBe(true);
   });
 });
 

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -10,26 +10,12 @@
 import { allChangedFilesInScope, touchedCriticalFiles } from '../../affected-packages';
 
 /**
- * Modules that can never affect FTR tests. When a PR only touches modules in
- * this set (and no FTR-critical paths), FTR configs are skipped entirely.
- *
- * Inverse of Scout's `SCOUT_EXCLUDED_MODULES`: those are FTR/Jest-infra modules
- * that should not trigger Scout; these are Scout/Jest/Cypress/lint modules that
- * should not trigger FTR.
- *
- * Do NOT add:
- * - Product plugins or shared runtime libraries consumed by the Kibana server/UI
- * - `@kbn/test`, `@kbn/test-suites-*`, `@kbn/ftr-*`, `@kbn/journeys`, or other
- *   FTR framework / suite packages
- * - Build toolchain that ships into the Kibana bundle (`@kbn/babel-*`, optimizer)
- * - `@kbn/scout-info` / `@kbn/scout-reporting` — imported by FTR configs and the
- *   FTR mocha reporter (`ScoutFTRReporter`)
- * - `@kbn/test-jest-helpers` — still imported by FTR services (e.g. `delay` in
- *   `@kbn/ftr-common-functional-ui-services` / `@kbn/ftr-common-functional-services`)
+ * Modules that cannot affect FTR. When a PR only touches these (and no critical
+ * paths), FTR is skipped. Do not add FTR runtime deps (e.g. scout-info,
+ * scout-reporting, test-jest-helpers) or product/build packages.
  */
-
 export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
-  // Scout ecosystem (Playwright-only helpers — not FTR runtime deps)
+  // Scout (Playwright)
   '@kbn/scout',
   '@kbn/scout-oblt',
   '@kbn/scout-search',
@@ -38,7 +24,7 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/scout-release-testing',
   '@kbn/content-list-scout',
 
-  // Jest-only helpers (not @kbn/test-jest-helpers — used by FTR services today)
+  // Jest
   '@kbn/test-eui-helpers',
   '@kbn/jest-serializers',
 
@@ -48,7 +34,7 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/osquery-plugin-cypress',
   '@kbn/fleet-plugin-cypress',
 
-  // Storybook / stubs / LLM eval harness
+  // Misc test-only / evals
   '@kbn/storybook',
   '@kbn/web-worker-stub',
   '@kbn/migrator-test-kit',
@@ -58,7 +44,7 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/evals-plugin',
   '@kbn/performance-testing-dataset-extractor',
 
-  // Lint / static analysis (does not affect FTR runtime)
+  // Lint
   '@kbn/eslint-config',
   '@kbn/eslint-plugin-alerting-v2',
   '@kbn/eslint-plugin-disable',
@@ -70,10 +56,7 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/check-kibana-settings-cli',
 ]);
 
-/**
- * Paths that must always keep FTR enabled when touched, even if every
- * categorized module is on the exclusion list (e.g. lockfile + scout-only).
- */
+/** Always keep FTR on when these paths change. */
 export const FTR_CRITICAL_PATHS: readonly string[] = [
   '.buildkite/ftr-manifests/**',
   '.buildkite/scripts/steps/test/ftr_configs.sh',
@@ -89,10 +72,7 @@ export const FTR_CRITICAL_PATHS: readonly string[] = [
   '.nvmrc',
 ];
 
-/**
- * When no categorized modules are affected, skip FTR only if every changed
- * file matches one of these globs (CI/docs/ownership noise).
- */
+/** Uncategorized-only diffs: skip FTR when every file matches. */
 export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   'docs/**',
   '**/docs/**',
@@ -113,7 +93,6 @@ export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   '**/.prettierrc*',
   '.mise.toml',
   '.river/**',
-  // i18n namespace registration / license / renovate noise
   '**/.i18nrc.json',
   '.i18nrc.json',
   'renovate.json',
@@ -122,7 +101,6 @@ export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   'LICENSE',
   'LICENSE.txt',
   '.backportrc.json',
-  // static assets
   '**/*.png',
   '**/*.svg',
   '**/*.gif',
@@ -131,15 +109,7 @@ export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   '**/*.webp',
 ];
 
-/**
- * Returns true when FTR configs should be omitted from the Jest/FTR
- * orchestrator for this PR.
- *
- * - Critical paths always keep FTR on.
- * - Non-empty affected modules → skip only when every module is excluded.
- * - Empty affected modules (uncategorized-only) → skip only when every
- *   changed file matches `FTR_IRRELEVANT_PATHS`.
- */
+/** True when this PR should omit FTR configs. */
 export function shouldSkipFtrTests(
   affectedModules: ReadonlySet<string>,
   changedFiles: readonly string[]

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -41,7 +41,6 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/evals',
   '@kbn/evals-extensions',
   '@kbn/evals-phoenix-executor',
-  '@kbn/evals-plugin',
   '@kbn/performance-testing-dataset-extractor',
 
   // Lint

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { allChangedFilesInScope, touchedCriticalFiles } from '../../affected-packages';
+
+/**
+ * Modules that can never affect FTR tests. When a PR only touches modules in
+ * this set (and no FTR-critical paths), FTR configs are skipped entirely.
+ *
+ * Inverse of Scout's `SCOUT_EXCLUDED_MODULES`: those are FTR/Jest-infra modules
+ * that should not trigger Scout; these are Scout/Jest/Cypress/lint modules that
+ * should not trigger FTR.
+ *
+ * Do NOT add:
+ * - Product plugins or shared runtime libraries consumed by the Kibana server/UI
+ * - `@kbn/test`, `@kbn/test-suites-*`, `@kbn/ftr-*`, `@kbn/journeys`, or other
+ *   FTR framework / suite packages
+ * - Build toolchain that ships into the Kibana bundle (`@kbn/babel-*`, optimizer)
+ */
+
+export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
+  // Scout ecosystem
+  '@kbn/scout',
+  '@kbn/scout-info',
+  '@kbn/scout-oblt',
+  '@kbn/scout-search',
+  '@kbn/scout-security',
+  '@kbn/scout-synthtrace',
+  '@kbn/scout-reporting',
+  '@kbn/scout-release-testing',
+  '@kbn/content-list-scout',
+
+  // Jest-only helpers
+  '@kbn/test-jest-helpers',
+  '@kbn/test-eui-helpers',
+
+  // Cypress
+  '@kbn/cypress-config',
+  '@kbn/cypress-test-helper',
+
+  // Storybook / stubs / LLM eval harness
+  '@kbn/storybook',
+  '@kbn/web-worker-stub',
+  '@kbn/migrator-test-kit',
+  '@kbn/evals',
+  '@kbn/evals-extensions',
+  '@kbn/evals-phoenix-executor',
+
+  // Lint / static analysis (does not affect FTR runtime)
+  '@kbn/eslint-config',
+  '@kbn/eslint-plugin-alerting-v2',
+  '@kbn/eslint-plugin-disable',
+  '@kbn/eslint-plugin-eslint',
+  '@kbn/eslint-plugin-i18n',
+  '@kbn/eslint-plugin-imports',
+  '@kbn/eslint-plugin-telemetry',
+  '@kbn/eslint-plugin-kbn-ui',
+  '@kbn/check-kibana-settings-cli',
+]);
+
+/**
+ * Paths that must always keep FTR enabled when touched, even if every
+ * categorized module is on the exclusion list (e.g. lockfile + scout-only).
+ */
+export const FTR_CRITICAL_PATHS: readonly string[] = [
+  '.buildkite/ftr-manifests/**',
+  '.buildkite/scripts/steps/test/ftr_configs.sh',
+  '.buildkite/scripts/steps/functional/**',
+  '.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/**',
+  '.buildkite/pipeline-utils/affected-packages/**',
+  'scripts/functional_tests.js',
+  'scripts/functional_tests_server.js',
+  'scripts/functional_test_runner.js',
+  'package.json',
+  'yarn.lock',
+  '.node-version',
+  '.nvmrc',
+];
+
+/**
+ * When no categorized modules are affected, skip FTR only if every changed
+ * file matches one of these globs (CI/docs/ownership noise).
+ */
+export const FTR_IRRELEVANT_PATHS: readonly string[] = [
+  'docs/**',
+  '**/docs/**',
+  'oas_docs/**',
+  '**/*.md',
+  '**/*.mdx',
+  '**/*.asciidoc',
+  'fleet_packages.json',
+  '.buildkite/**',
+  '.claude/**',
+  '.github/**',
+  '**/.github/**',
+  'CODEOWNERS',
+  '**/CODEOWNERS',
+  'OWNERS',
+  '**/OWNERS',
+  '**/.eslintrc*',
+  '**/.prettierrc*',
+  '.mise.toml',
+  '.river/**',
+];
+
+/**
+ * Returns true when FTR configs should be omitted from the Jest/FTR
+ * orchestrator for this PR.
+ *
+ * - Critical paths always keep FTR on.
+ * - Non-empty affected modules → skip only when every module is excluded.
+ * - Empty affected modules (uncategorized-only) → skip only when every
+ *   changed file matches `FTR_IRRELEVANT_PATHS`.
+ */
+export function shouldSkipFtrTests(
+  affectedModules: ReadonlySet<string>,
+  changedFiles: readonly string[]
+): boolean {
+  if (changedFiles.length === 0) {
+    return false;
+  }
+
+  if (touchedCriticalFiles([...changedFiles], [...FTR_CRITICAL_PATHS])) {
+    return false;
+  }
+
+  if (affectedModules.size > 0) {
+    for (const id of affectedModules) {
+      if (!FTR_EXCLUDED_MODULES.has(id)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return allChangedFilesInScope(changedFiles, FTR_IRRELEVANT_PATHS);
+}

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -24,6 +24,8 @@ import { allChangedFilesInScope, touchedCriticalFiles } from '../../affected-pac
  * - Build toolchain that ships into the Kibana bundle (`@kbn/babel-*`, optimizer)
  * - `@kbn/scout-info` / `@kbn/scout-reporting` — imported by FTR configs and the
  *   FTR mocha reporter (`ScoutFTRReporter`)
+ * - `@kbn/test-jest-helpers` — still imported by FTR services (e.g. `delay` in
+ *   `@kbn/ftr-common-functional-ui-services` / `@kbn/ftr-common-functional-services`)
  */
 
 export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
@@ -36,8 +38,7 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/scout-release-testing',
   '@kbn/content-list-scout',
 
-  // Jest-only helpers
-  '@kbn/test-jest-helpers',
+  // Jest-only helpers (not @kbn/test-jest-helpers — used by FTR services today)
   '@kbn/test-eui-helpers',
   '@kbn/jest-serializers',
 

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -22,27 +22,30 @@ import { allChangedFilesInScope, touchedCriticalFiles } from '../../affected-pac
  * - `@kbn/test`, `@kbn/test-suites-*`, `@kbn/ftr-*`, `@kbn/journeys`, or other
  *   FTR framework / suite packages
  * - Build toolchain that ships into the Kibana bundle (`@kbn/babel-*`, optimizer)
+ * - `@kbn/scout-info` / `@kbn/scout-reporting` — imported by FTR configs and the
+ *   FTR mocha reporter (`ScoutFTRReporter`)
  */
 
 export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
-  // Scout ecosystem
+  // Scout ecosystem (Playwright-only helpers — not FTR runtime deps)
   '@kbn/scout',
-  '@kbn/scout-info',
   '@kbn/scout-oblt',
   '@kbn/scout-search',
   '@kbn/scout-security',
   '@kbn/scout-synthtrace',
-  '@kbn/scout-reporting',
   '@kbn/scout-release-testing',
   '@kbn/content-list-scout',
 
   // Jest-only helpers
   '@kbn/test-jest-helpers',
   '@kbn/test-eui-helpers',
+  '@kbn/jest-serializers',
 
   // Cypress
   '@kbn/cypress-config',
   '@kbn/cypress-test-helper',
+  '@kbn/osquery-plugin-cypress',
+  '@kbn/fleet-plugin-cypress',
 
   // Storybook / stubs / LLM eval harness
   '@kbn/storybook',
@@ -51,6 +54,8 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/evals',
   '@kbn/evals-extensions',
   '@kbn/evals-phoenix-executor',
+  '@kbn/evals-plugin',
+  '@kbn/performance-testing-dataset-extractor',
 
   // Lint / static analysis (does not affect FTR runtime)
   '@kbn/eslint-config',
@@ -107,6 +112,22 @@ export const FTR_IRRELEVANT_PATHS: readonly string[] = [
   '**/.prettierrc*',
   '.mise.toml',
   '.river/**',
+  // i18n namespace registration / license / renovate noise
+  '**/.i18nrc.json',
+  '.i18nrc.json',
+  'renovate.json',
+  'catalog-info.yaml',
+  'NOTICE.txt',
+  'LICENSE',
+  'LICENSE.txt',
+  '.backportrc.json',
+  // static assets
+  '**/*.png',
+  '**/*.svg',
+  '**/*.gif',
+  '**/*.jpg',
+  '**/*.jpeg',
+  '**/*.webp',
 ];
 
 /**


### PR DESCRIPTION
## Summary

This PR introduces basic selective testing for FTR. PRs that only touch the following won't trigger an FTR config run:

1. **Dev-only test tooling that FTR never loads**: Scout (Playwright), Cypress, Jest helpers, eslint plugins, the evals CLI, Storybook, etc. (full list in `FTR_EXCLUDED_MODULES`)
2. **Files that can't affect tests**: docs (`docs/`, `*.md`), most of `.buildkite/`, `.github/`, CODEOWNERS, `.i18nrc.json`, licenses, images, and similar noise (full list in `FTR_IRRELEVANT_PATHS`)

> [!NOTE]
> Engineers can still run the full test suite by adding the `ci:prevent-selective-testing` label (before triggering the build).

### Safety nets

- Touching anything FTR actually depends on always runs FTR: `yarn.lock`, `package.json`, the FTR manifests and scripts, and the selective-testing logic itself (`FTR_CRITICAL_PATHS`).
- Packages that FTR imports at runtime (`@kbn/scout-info`, `@kbn/scout-reporting`, `@kbn/test-jest-helpers`) are deliberately **not** excluded. Unit tests enforce this: every excluded module must exist, be `devOnly`, and not be imported by FTR runtime packages: so a bad addition to the list fails CI instead of silently skipping tests.
- When FTR is skipped, the build gets an info annotation (`selective-testing-ftr-excluded`) explaining why.
- PR pipeline only. `kibana-on-merge` keeps running the full FTR suite as a backstop.

### Expected impact

On a sample of the last 600 commits on `main`, ~6.8% would have skipped FTR (mostly docs/CI/ownership-only changes) saving ~25–30 minutes of wall-clock each. It's important to note, however, that this selective testing mechanism will only work in `kibana-pull-request` builds, so quantifying the real impact is more challenging.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->