### PR TITLE
[version bump] Automate serverless test disabling and schedule updates on minor bump

### DIFF
--- a/.buildkite/scripts/steps/version_bump/update_pipeline_resource_definitions.sh
+++ b/.buildkite/scripts/steps/version_bump/update_pipeline_resource_definitions.sh
@@ -13,12 +13,59 @@ FILES=(
   ".buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml"
   ".buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml"
   ".buildkite/pipeline-resource-definitions/kibana-on-merge.yml"
+  ".buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml"
 )
 
 for file in "${FILES[@]}"; do
   echo "Updating branch_configuration in $file"
   sed -i "s/branch_configuration: main/branch_configuration: main ${BRANCH}/" "$file"
 done
+
+echo "Adding ${BRANCH} daily schedule to kibana-es-snapshots.yml"
+es_snapshots=".buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml"
+if grep -q "branch: '${BRANCH}'" "$es_snapshots"; then
+  echo "Schedule for ${BRANCH} already exists in kibana-es-snapshots.yml, skipping"
+else
+  awk -v branch="$BRANCH" '
+    !done && /^          branch: main$/ {
+      print
+      print "        Daily build (" branch "):"
+      print "          cronline: 0 22 * * * America/New_York"
+      print "          message: Daily build"
+      print "          branch: \047" branch "\047"
+      done = 1
+      next
+    }
+    { print }
+  ' "$es_snapshots" > "${es_snapshots}.tmp" && mv "${es_snapshots}.tmp" "$es_snapshots"
+  if ! grep -q "branch: '${BRANCH}'" "$es_snapshots"; then
+    echo "ERROR: Failed to insert ${BRANCH} schedule into kibana-es-snapshots.yml — 'branch: main' pattern not found" >&2
+    exit 1
+  fi
+fi
+
+echo "Adding ${BRANCH} daily schedule to kibana-scout-update-metadata.yml"
+scout_metadata=".buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml"
+if grep -q "branch: '${BRANCH}'" "$scout_metadata"; then
+  echo "Schedule for ${BRANCH} already exists in kibana-scout-update-metadata.yml, skipping"
+else
+  awk -v branch="$BRANCH" '
+    !done && /^          branch: main$/ {
+      print
+      print "        Daily (" branch "):"
+      print "          cronline: 0 0 * * * America/New_York"
+      print "          message: Daily Scout metadata update"
+      print "          branch: \047" branch "\047"
+      done = 1
+      next
+    }
+    { print }
+  ' "$scout_metadata" > "${scout_metadata}.tmp" && mv "${scout_metadata}.tmp" "$scout_metadata"
+  if ! grep -q "branch: '${BRANCH}'" "$scout_metadata"; then
+    echo "ERROR: Failed to insert ${BRANCH} schedule into kibana-scout-update-metadata.yml — 'branch: main' pattern not found" >&2
+    exit 1
+  fi
+fi
 
 echo --- Committing pipeline resource definition changes
 

--- a/.buildkite/scripts/steps/version_bump/update_release_branch.sh
+++ b/.buildkite/scripts/steps/version_bump/update_release_branch.sh
@@ -19,9 +19,48 @@ jq --arg branch "$BRANCH" '.branch = $branch' package.json > package.json.tmp &&
 # Prevent backport assignments
 printf '\n# See https://github.com/elastic/kibana/pull/199404\n# Prevent backport assignments\n* @kibanamachine' >> .github/CODEOWNERS
 
+echo "Disabling serverless jest integration config on release branch"
+jq '. + ["src/core/server/integration_tests/saved_objects/serverless/migrations/jest.integration.config.js"] | unique' \
+  .buildkite/disabled_jest_configs.json > .buildkite/disabled_jest_configs.json.tmp \
+  && mv .buildkite/disabled_jest_configs.json.tmp .buildkite/disabled_jest_configs.json
+
+echo "Moving serverless FTR manifest enabled configs to disabled on release branch"
+for manifest in .buildkite/ftr-manifests/*serverless*_configs.yml; do
+  awk '
+    /^defaultQueue:/ { dq = $0; next }
+    /^enabled:$/ { found_enabled = 1; next }
+    { print }
+    END {
+      if (found_enabled) { printf "\n"; if (dq) print dq; print "enabled:" }
+      else if (dq) print dq
+    }
+  ' "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest"
+done
+
+echo "Skipping serverless core integration tests on release branch"
+SERVERLESS_TESTS=(
+  "src/core/server/integration_tests/elasticsearch/capabilities_serverless.test.ts"
+  "src/core/server/integration_tests/elasticsearch/project_routing_serverless_cps.test.ts"
+  "src/core/server/integration_tests/elasticsearch/project_routing_serverless_non_cps.test.ts"
+)
+for test_file in "${SERVERLESS_TESTS[@]}"; do
+  if grep -q "^describe\.skip(" "$test_file"; then
+    echo "INFO: $test_file already patched, skipping"
+    continue
+  fi
+  if ! grep -q "^describe(" "$test_file"; then
+    echo "ERROR: Expected top-level describe() not found in $test_file" >&2
+    exit 1
+  fi
+  sed -i "0,/^describe(/s/^describe(/\/\/ Serverless tests are only supported on main\ndescribe.skip(/" "$test_file"
+done
+
 head_branch="bump-versions-$(date +%F_%H-%M-%S)-release-branch"
 git checkout -b "$head_branch"
-git add package.json .github/CODEOWNERS
+git add package.json .github/CODEOWNERS \
+  .buildkite/disabled_jest_configs.json \
+  .buildkite/ftr-manifests/*serverless*_configs.yml \
+  "${SERVERLESS_TESTS[@]}"
 git commit -m "[release branch setup] Set branch to ${BRANCH}"
 
 git push origin "$head_branch"


### PR DESCRIPTION
## Summary

When a new minor release branch is cut, two manual follow-up PRs were needed that the minor-bump automation missed:
- [#277557](https://github.com/elastic/kibana/pull/277557) — disable serverless tests on the new release branch
- [#277288](https://github.com/elastic/kibana/pull/277288) — add the new branch to ES snapshot and Scout metadata schedules

This wires both into the existing minor-bump steps so they never need to be done manually again.

### `update_pipeline_resource_definitions.sh` (step 2 — runs on main)

- Adds `kibana-scout-update-metadata.yml` to the `FILES` array so it receives the `branch_configuration` update
- Inserts a per-branch daily schedule entry into `kibana-es-snapshots.yml` (after the existing `main` schedule)
- Inserts a per-branch daily schedule entry into `kibana-scout-update-metadata.yml` (after the existing `main` schedule)
- Both insertions are idempotent (skipped if the branch entry already exists) and fail loudly if the anchor pattern is not found

### `update_release_branch.sh` (step 4 — runs on the new release branch)

- Appends the serverless saved-objects migrations Jest integration config to `.buildkite/disabled_jest_configs.json`
- Transforms all `.buildkite/ftr-manifests/*serverless*_configs.yml` files: moves all currently-enabled configs under `disabled:` and leaves `enabled:` empty at the bottom of the file
- Adds `describe.skip` (with comment) to three serverless core integration tests; fails loudly if the expected top-level `describe(` is not found