### PR TITLE
[Security Solution] Differentiate ELSER cold-start from not-deployed in migration init

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_ready_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_ready_panel.test.tsx
@@ -27,7 +27,7 @@ const mockMigrationStateWithError: RuleMigrationStats = {
   status: SiemMigrationTaskStatus.READY,
   last_execution: {
     error:
-      'Failed to populate ELSER indices. Make sure the ELSER model is deployed and running at Machine Learning > Trained Models. Error: Exception when running inference id [.elser-2-elasticsearch] on field [elser_embedding]',
+      'Migration initialization failed. Error: ELSER is still starting up. Please wait a moment and retry the migration.',
   },
   id: 'c44d2c7d-0de1-4231-8b82-0dcfd67a9fe3',
   name: 'Migration 1',
@@ -145,7 +145,7 @@ describe('MigrationReadyPanel', () => {
         'Migration of 6 rules failed. Please correct the below error and try again.'
       );
       expect(screen.getByTestId('ruleMigrationLastError')).toHaveTextContent(
-        'Failed to populate ELSER indices. Make sure the ELSER model is deployed and running at Machine Learning > Trained Models. Error: Exception when running inference id [.elser-2-elasticsearch] on field [elser_embedding]'
+        'Migration initialization failed. Error: ELSER is still starting up. Please wait a moment and retry the migration.'
       );
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/data/elser_populate_error.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/data/elser_populate_error.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Error thrown from a data-client `populate()` when an Elasticsearch bulk response
+ * reports item-level errors. It preserves the Elasticsearch `type` and HTTP
+ * `statusCode` from the first item error so callers can classify on the stable
+ * `type` rather than the human-readable reason string, which is not version-stable.
+ */
+export class ElserPopulateError extends Error {
+  constructor(message: string, public readonly type?: string, public readonly statusCode?: number) {
+    super(message);
+    this.name = 'ElserPopulateError';
+    // Required so `instanceof` works when targeting ES5/ES2015 (see TS handbook).
+    Object.setPrototypeOf(this, ElserPopulateError.prototype);
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_integrations_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_integrations_client.ts
@@ -13,6 +13,7 @@ import {
 } from '@kbn/agent-builder-genai-utils/tools/utils/token_count';
 import type { RuleMigrationIntegration } from '../types';
 import { SiemMigrationsDataBaseClient } from '../../common/data/siem_migrations_data_base_client';
+import { ElserPopulateError } from '../../common/data/elser_populate_error';
 
 const INTEGRATION_WEIGHTS = [
   // These integrations should be boosted because in many cases they are used as fallback.
@@ -183,9 +184,11 @@ export class RuleMigrationsDataIntegrationsClient extends SiemMigrationsDataBase
         )
         .then((response) => {
           if (response.errors) {
-            // use the first error to throw
-            const reason = response.items.find((item) => item.update?.error)?.update?.error?.reason;
-            throw new Error(reason ?? 'Unknown error');
+            // use the first error to throw, preserving the ES error type for classification.
+            // Bulk item errors carry `type` + `reason` but no HTTP status; classification
+            // keys on the stable `type`.
+            const itemError = response.items.find((item) => item.update?.error)?.update?.error;
+            throw new ElserPopulateError(itemError?.reason ?? 'Unknown error', itemError?.type);
           }
         })
         .catch((error) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_prebuilt_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_prebuilt_rules_client.ts
@@ -10,6 +10,7 @@ import { createPrebuiltRuleAssetsClient } from '../../../detection_engine/prebui
 import { createPrebuiltRuleObjectsClient } from '../../../detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client';
 import { fetchRuleVersionsTriad } from '../../../detection_engine/prebuilt_rules/logic/rule_versions/fetch_rule_versions_triad';
 import { SiemMigrationsDataBaseClient } from '../../common/data/siem_migrations_data_base_client';
+import { ElserPopulateError } from '../../common/data/elser_populate_error';
 import type { RuleMigrationPrebuiltRule } from '../types';
 
 export type { RuleVersions };
@@ -75,9 +76,11 @@ export class RuleMigrationsDataPrebuiltRulesClient extends SiemMigrationsDataBas
         )
         .then((response) => {
           if (response.errors) {
-            // use the first error to throw
-            const reason = response.items.find((item) => item.update?.error)?.update?.error?.reason;
-            throw new Error(reason ?? 'Unknown error');
+            // use the first error to throw, preserving the ES error type for classification.
+            // Bulk item errors carry `type` + `reason` but no HTTP status; classification
+            // keys on the stable `type`.
+            const itemError = response.items.find((item) => item.update?.error)?.update?.error;
+            throw new ElserPopulateError(itemError?.reason ?? 'Unknown error', itemError?.type);
           }
         })
         .catch((error) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/get_elser_error_message.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/get_elser_error_message.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { ElserPopulateError } from '../../../common/data/elser_populate_error';
+import {
+  ELSER_COLD_START_MESSAGE,
+  ELSER_NOT_DEPLOYED_MESSAGE,
+  ELSER_NO_ML_CAPACITY_MESSAGE,
+  getElserErrorMessage,
+} from './get_elser_error_message';
+
+type ResponseErrorMeta = ConstructorParameters<typeof EsErrors.ResponseError>[0];
+
+const responseError = (type: string, statusCode: number): EsErrors.ResponseError =>
+  new EsErrors.ResponseError({
+    statusCode,
+    body: { error: { type, reason: 'reason' } },
+    warnings: null,
+  } as unknown as ResponseErrorMeta);
+
+describe('getElserErrorMessage', () => {
+  describe('when ELSER is deployed but still starting up (cold start)', () => {
+    it('returns the cold-start message from a preserved bulk item error type', () => {
+      const error = new ElserPopulateError(
+        'Timed out after [10s] waiting for trained model deployment [.elser-2-elasticsearch] to start',
+        'model_deployment_timeout_exception'
+      );
+      expect(getElserErrorMessage(error)).toBe(ELSER_COLD_START_MESSAGE);
+    });
+
+    it('returns the cold-start message from a transport error with status 408', () => {
+      expect(getElserErrorMessage(responseError('some_other_type', 408))).toBe(
+        ELSER_COLD_START_MESSAGE
+      );
+    });
+  });
+
+  describe('when the ELSER model is not deployed', () => {
+    it('returns the not-deployed message from a preserved bulk item error type', () => {
+      const error = new ElserPopulateError(
+        'Inference endpoint not found [.elser-2-elasticsearch]',
+        'resource_not_found_exception'
+      );
+      expect(getElserErrorMessage(error)).toBe(ELSER_NOT_DEPLOYED_MESSAGE);
+    });
+
+    it('returns the not-deployed message from a transport error with status 404', () => {
+      expect(getElserErrorMessage(responseError('some_other_type', 404))).toBe(
+        ELSER_NOT_DEPLOYED_MESSAGE
+      );
+    });
+  });
+
+  describe('when there is no machine learning capacity to start ELSER', () => {
+    it('returns the no-capacity message', () => {
+      const error = new ElserPopulateError(
+        'Could not start deployment because no suitable nodes were found',
+        'status_exception'
+      );
+      expect(getElserErrorMessage(error)).toBe(ELSER_NO_ML_CAPACITY_MESSAGE);
+    });
+  });
+
+  describe('when the error is unrelated to ELSER', () => {
+    it('returns undefined for a plain error', () => {
+      expect(getElserErrorMessage(new Error('boom'))).toBeUndefined();
+    });
+
+    it('returns undefined for an ELSER error with an unrecognized type', () => {
+      const error = new ElserPopulateError('some unexpected reason', 'unexpected_exception');
+      expect(getElserErrorMessage(error)).toBeUndefined();
+    });
+
+    it('returns undefined for a non-object error', () => {
+      expect(getElserErrorMessage('a string error')).toBeUndefined();
+      expect(getElserErrorMessage(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/get_elser_error_message.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/get_elser_error_message.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * User-facing messages surfaced through `last_execution.error` when populating
+ * the ELSER-backed indices fails during migration initialization.
+ */
+export const ELSER_COLD_START_MESSAGE =
+  'ELSER is still starting up. Please wait a moment and retry the migration.';
+
+export const ELSER_NOT_DEPLOYED_MESSAGE =
+  'The ELSER model is not deployed. Please deploy and start ELSER at Machine Learning > Trained Models, then retry the migration.';
+
+export const ELSER_NO_ML_CAPACITY_MESSAGE =
+  'ELSER could not be started because there is no available machine learning capacity. Please ensure an ML node with sufficient capacity is available, then retry the migration.';
+
+/**
+ * Extracts an Elasticsearch error `type` from an error thrown while populating the
+ * ELSER indices. The error may arrive either as:
+ *  - an `ElserPopulateError` preserved by the data client (`type` set directly), or
+ *  - a raw `@elastic/elasticsearch` `ResponseError` (`meta.body.error.type`).
+ */
+const getEsErrorType = (error: unknown): string | undefined => {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+  const candidate = error as {
+    type?: unknown;
+    meta?: { body?: { error?: { type?: unknown } } };
+  };
+  const directType = candidate.type;
+  if (typeof directType === 'string') {
+    return directType;
+  }
+  const bodyType = candidate.meta?.body?.error?.type;
+  return typeof bodyType === 'string' ? bodyType : undefined;
+};
+
+const getEsStatusCode = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+  const { statusCode } = error as { statusCode?: unknown };
+  return typeof statusCode === 'number' ? statusCode : undefined;
+};
+
+/**
+ * Classifies an error thrown while populating the ELSER indices and returns the
+ * corresponding user-facing message, or `undefined` when the error is not a
+ * recognized ELSER condition (the caller should rethrow the original error).
+ *
+ * Classification keys on the stable Elasticsearch `error.type` (with HTTP status as
+ * a secondary signal) rather than the human-readable reason string, which is not
+ * version-stable.
+ *
+ * - `model_deployment_timeout_exception` / 408: ELSER is deployed but still scaling
+ *   up from zero allocations (cold start) — transient, the user should retry.
+ * - `resource_not_found_exception` / 404: the ELSER model/endpoint is genuinely
+ *   absent — the user must deploy it.
+ * - `status_exception` (no suitable/ML nodes): there is no ML capacity to start ELSER.
+ */
+export const getElserErrorMessage = (error: unknown): string | undefined => {
+  const type = getEsErrorType(error);
+  const statusCode = getEsStatusCode(error);
+
+  if (type === 'model_deployment_timeout_exception' || statusCode === 408) {
+    return ELSER_COLD_START_MESSAGE;
+  }
+
+  if (type === 'resource_not_found_exception' || statusCode === 404) {
+    return ELSER_NOT_DEPLOYED_MESSAGE;
+  }
+
+  if (type === 'status_exception') {
+    return ELSER_NO_ML_CAPACITY_MESSAGE;
+  }
+
+  return undefined;
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_migrations_retriever.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_migrations_retriever.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElserPopulateError } from '../../../common/data/elser_populate_error';
+import { RuleMigrationsRetriever } from './rule_migrations_retriever';
+import type { RuleMigrationsRetrieverDeps } from './rule_migrations_retriever';
+import { IntegrationRetriever } from './integration_retriever';
+import { PrebuiltRulesRetriever } from './prebuilt_rules_retriever';
+import { RuleResourceRetriever } from './rule_resource_retriever';
+import { ELSER_COLD_START_MESSAGE, ELSER_NOT_DEPLOYED_MESSAGE } from './get_elser_error_message';
+
+jest.mock('./integration_retriever');
+jest.mock('./prebuilt_rules_retriever');
+jest.mock('./rule_resource_retriever');
+
+const MockIntegrationRetriever = IntegrationRetriever as jest.MockedClass<
+  typeof IntegrationRetriever
+>;
+const MockPrebuiltRulesRetriever = PrebuiltRulesRetriever as jest.MockedClass<
+  typeof PrebuiltRulesRetriever
+>;
+const MockRuleResourceRetriever = RuleResourceRetriever as jest.MockedClass<
+  typeof RuleResourceRetriever
+>;
+
+describe('RuleMigrationsRetriever initialize()', () => {
+  let integrationsPopulateIndex: jest.Mock;
+  let prebuiltRulesPopulateIndex: jest.Mock;
+
+  const buildRetriever = () =>
+    new RuleMigrationsRetriever('migration-1', {
+      data: { resources: {} },
+    } as unknown as RuleMigrationsRetrieverDeps);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // The retriever dedupes populate across instances via a static promise; reset it so
+    // each test starts from a clean state and is not affected by test ordering.
+    (
+      RuleMigrationsRetriever as unknown as { populatePromise: Promise<void> | null }
+    ).populatePromise = null;
+
+    integrationsPopulateIndex = jest.fn().mockResolvedValue(undefined);
+    prebuiltRulesPopulateIndex = jest.fn().mockResolvedValue(undefined);
+
+    MockIntegrationRetriever.mockImplementation(
+      () => ({ populateIndex: integrationsPopulateIndex } as unknown as IntegrationRetriever)
+    );
+    MockPrebuiltRulesRetriever.mockImplementation(
+      () => ({ populateIndex: prebuiltRulesPopulateIndex } as unknown as PrebuiltRulesRetriever)
+    );
+    MockRuleResourceRetriever.mockImplementation(
+      () =>
+        ({ initialize: jest.fn().mockResolvedValue(undefined) } as unknown as RuleResourceRetriever)
+    );
+  });
+
+  it('rethrows an unrelated error without masking it', async () => {
+    prebuiltRulesPopulateIndex.mockRejectedValue(new Error('boom'));
+
+    await expect(buildRetriever().initialize()).rejects.toThrow('boom');
+  });
+
+  it('surfaces the deploy guidance when the ELSER model is not deployed', async () => {
+    prebuiltRulesPopulateIndex.mockRejectedValue(
+      new ElserPopulateError(
+        'Inference endpoint not found [.elser-2-elasticsearch]',
+        'resource_not_found_exception'
+      )
+    );
+
+    await expect(buildRetriever().initialize()).rejects.toThrow(ELSER_NOT_DEPLOYED_MESSAGE);
+  });
+
+  it('surfaces the retry guidance when ELSER is still starting up', async () => {
+    prebuiltRulesPopulateIndex.mockRejectedValue(
+      new ElserPopulateError(
+        'Timed out after [10s] waiting for trained model deployment [.elser-2-elasticsearch] to start',
+        'model_deployment_timeout_exception'
+      )
+    );
+
+    await expect(buildRetriever().initialize()).rejects.toThrow(ELSER_COLD_START_MESSAGE);
+  });
+
+  it('shares a single populate outcome across concurrent migrations', async () => {
+    prebuiltRulesPopulateIndex.mockRejectedValue(
+      new ElserPopulateError(
+        'Timed out after [10s] waiting for trained model deployment [.elser-2-elasticsearch] to start',
+        'model_deployment_timeout_exception'
+      )
+    );
+
+    const first = buildRetriever();
+    const second = buildRetriever();
+    const results = await Promise.allSettled([first.initialize(), second.initialize()]);
+
+    // Both concurrent callers observe the same shared outcome...
+    expect(results[0].status).toBe('rejected');
+    expect(results[1].status).toBe('rejected');
+    // ...and the underlying populate runs only once for the shared promise.
+    expect(prebuiltRulesPopulateIndex).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_migrations_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_migrations_retriever.ts
@@ -12,6 +12,7 @@ import type { RuleMigrationsDataClient } from '../../data/rule_migrations_data_c
 import { IntegrationRetriever } from './integration_retriever';
 import { PrebuiltRulesRetriever } from './prebuilt_rules_retriever';
 import { RuleResourceRetriever } from './rule_resource_retriever';
+import { getElserErrorMessage } from './get_elser_error_message';
 
 export interface RuleMigrationsRetrieverDeps {
   data: RuleMigrationsDataClient;
@@ -44,20 +45,29 @@ export class RuleMigrationsRetriever {
   }
 
   private async populateElserIndices() {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
         Promise.all([this.prebuiltRules.populateIndex(), this.integrations.populateIndex()]),
         new Promise((_, reject) => {
-          setTimeout(
+          timeoutId = setTimeout(
             () => reject(new Error(`Timeout (${POPULATE_ELSER_INDICES_TIMEOUT_MIN}m)`)),
             POPULATE_ELSER_INDICES_TIMEOUT_MIN * 60 * 1000
           );
         }),
       ]);
     } catch (err) {
-      throw new Error(
-        `Failed to populate ELSER indices. Make sure the ELSER model is deployed and running at Machine Learning > Trained Models. ${err}`
-      );
+      const elserMessage = getElserErrorMessage(err);
+      if (elserMessage) {
+        throw new Error(elserMessage);
+      }
+      throw err;
+    } finally {
+      // Clear the timeout timer so it does not keep the event loop alive once the
+      // populate has settled (either resolved or rejected).
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

During SIEM rule-migration initialization, populating the ELSER-backed indices could fail for several distinct reasons, but the code masked **every** failure with the same message: *"Failed to populate ELSER indices. Make sure the ELSER model is deployed…"*. The most common real cause is an ELSER **cold start** — the model deployment scaling up from zero allocations — which is transient and resolves on retry, yet users were told to deploy an already-deployed model.

This PR classifies the failure by the stable Elasticsearch `error.type` and surfaces the correct message per case:
- **cold-start** (`model_deployment_timeout_exception` / 408) → "ELSER is still starting up. Please wait a moment and retry the migration."
- **not-deployed** (`resource_not_found_exception` / 404) → keeps the deploy-ELSER guidance
- **no ML capacity** (`status_exception`) → dedicated message
- **anything else** → rethrown unmasked (no longer swallowed)

To make classification robust, the data-client bulk error sites now preserve the ES error type via a small `ElserPopulateError`, so classification keys on the version-stable `error.type` rather than a translatable reason string.

### Evidence: which exception maps to what

**Cold-start ⇒ HTTP 408 (`model_deployment_timeout_exception`)** — ELSER runs with adaptive allocations that scale to zero when idle; the first inference after idle must wait for the deployment to start. When that wait exceeds the timeout, Elasticsearch returns a 408:
- **Source:** [`ModelDeploymentTimeoutException.java` L13-L15](https://github.com/elastic/elasticsearch/blob/1b58d21e1cd1518891a9ffef6eaf116253bbb370/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/ModelDeploymentTimeoutException.java#L13-L15) — `extends ElasticsearchStatusException` with `RestStatus.REQUEST_TIMEOUT`.
- **PR that introduced it:** [elastic/elasticsearch#128218](https://github.com/elastic/elasticsearch/pull/128218) — "Improve exception for trained model deployment scale up timeout".
- **Official docs:** [Start a trained model deployment API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-trained-model-deployment) (deployment start + `timeout` semantics).

**Not-deployed ⇒ HTTP 404 (`resource_not_found_exception`)** — endpoint/model genuinely absent (`Inference endpoint not found […]` / `Could not find trained model […]`):
- **Official docs:** [Get an inference endpoint API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-get).

**Kibana throw sites** that previously discarded the ES `type` (now preserved via `ElserPopulateError`):
[`rule_migrations_data_prebuilt_rules_client.ts` L76-L86](https://github.com/elastic/kibana/blob/8378759e9c6a629a38c821345a86eb164531931b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_prebuilt_rules_client.ts#L76-L86) · [`rule_migrations_data_integrations_client.ts` L184-L194](https://github.com/elastic/kibana/blob/8378759e9c6a629a38c821345a86eb164531931b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_integrations_client.ts#L184-L194).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any text added follows EUI writing guidelines and includes i18n support — N/A: these are backend error strings that follow the existing (non-i18n) convention of the sibling ELSER error string
- [ ] Flaky Test Runner — N/A (unit tests only)
- [x] The PR description includes the appropriate Release Notes section and `release_note:*` label
- [ ] Review the backport guidelines and apply applicable `backport:*` labels

### Identify risks

- **Behavior change (low):** unknown/unrelated errors are now rethrown raw instead of being wrapped in the ELSER message. Intended — it stops misattributing unrelated failures as an ELSER problem. The user-facing string in `last_execution.error` changes for these cases; a FE fixture was updated to match.
- **Classification drift (low):** classification keys on the stable ES `error.type` (with HTTP status as a fallback), verified against Elasticsearch source and production error captures. Brittle reason-string matching was deliberately avoided.
- No data loss, no saved-object/schema changes, no HTTP API changes, no performance impact.

### Release note

> Migration initialization now distinguishes an ELSER cold-start (still starting up — retry) from a genuinely undeployed ELSER model, instead of always showing "deploy ELSER".

**Suggested label:** `release_note:fix`
