### PR TITLE
[9.5] [One Workflow] Remove agentBuilder:experimentalFeatures gate from AI workflow authoring UI (#278343)

### DIFF
--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -103,7 +103,6 @@ dependsOn:
   - '@kbn/core-user-profile-server'
   - '@kbn/core-user-profile-server-mocks'
   - '@kbn/logging'
-  - '@kbn/management-settings-ids'
   - '@kbn/agent-context-layer-plugin'
   - '@kbn/std'
   - '@kbn/use-observable'

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -8,7 +8,6 @@
  */
 
 import { act, renderHook } from '@testing-library/react';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import { useAgentBuilderIntegration } from './use_agent_builder_integration';
 import { useKibana } from '../../../../hooks/use_kibana';
@@ -28,11 +27,6 @@ const mockTelemetry = {
 jest.mock('../../../../hooks/use_telemetry', () => ({
   useTelemetry: () => mockTelemetry,
 }));
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  ...jest.requireActual('@kbn/kibana-react-plugin/public'),
-  useUiSetting: jest.fn(),
-}));
-const useUiSettingMock = useUiSetting as jest.MockedFunction<typeof useUiSetting>;
 jest.mock('uuid', () => ({ v4: () => 'mock-uuid-1234' }));
 jest.mock('../../../../features/ai_integration', () => ({
   AttachmentBridge: jest.fn().mockImplementation(() => ({
@@ -147,7 +141,6 @@ describe('useAgentBuilderIntegration', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockModel = createMockModel(INITIAL_YAML);
-    useUiSettingMock.mockReturnValue(true);
     mockConsumeSidebarRestoreFor.mockReturnValue(false);
   });
 
@@ -582,22 +575,6 @@ describe('useAgentBuilderIntegration', () => {
 
       expect(mockTelemetry.reportWorkflowAiChatOpened).toHaveBeenCalledTimes(1);
     });
-
-    it('does not auto-open when experimental features are disabled', () => {
-      const agentBuilder = createMockAgentBuilder();
-      setupKibanaMock(agentBuilder);
-      useUiSettingMock.mockReturnValue(false);
-      const editor = createMockEditor(mockModel);
-
-      renderHook(() =>
-        useAgentBuilderIntegration({
-          editorRef: { current: editor },
-          isEditorMounted: true,
-        })
-      );
-
-      expect(agentBuilder.openChat).not.toHaveBeenCalled();
-    });
   });
 
   describe('cleanup closes the chat sidebar', () => {
@@ -901,10 +878,9 @@ describe('useAgentBuilderIntegration', () => {
   });
 
   describe('isAgentBuilderAvailable', () => {
-    it('returns true when agentBuilder is available and experimental features enabled', () => {
+    it('returns true when agentBuilder is available', () => {
       const agentBuilder = createMockAgentBuilder();
       setupKibanaMock(agentBuilder);
-      useUiSettingMock.mockReturnValue(true);
       const editor = createMockEditor(mockModel);
 
       const { result } = renderHook(() =>
@@ -919,22 +895,6 @@ describe('useAgentBuilderIntegration', () => {
 
     it('returns false when agentBuilder is not available', () => {
       setupKibanaMock(undefined);
-      const editor = createMockEditor(mockModel);
-
-      const { result } = renderHook(() =>
-        useAgentBuilderIntegration({
-          editorRef: { current: editor },
-          isEditorMounted: true,
-        })
-      );
-
-      expect(result.current.isAgentBuilderAvailable).toBe(false);
-    });
-
-    it('returns false when experimental features are disabled', () => {
-      const agentBuilder = createMockAgentBuilder();
-      setupKibanaMock(agentBuilder);
-      useUiSettingMock.mockReturnValue(false);
       const editor = createMockEditor(mockModel);
 
       const { result } = renderHook(() =>

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -13,8 +13,6 @@ import { v4 } from 'uuid';
 import { isConversationIdSetEvent } from '@kbn/agent-builder-common/chat/events';
 import type { monaco } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
-import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import { setAiAssisted } from '../../../../entities/workflows/store/workflow_detail/slice';
 import {
@@ -69,9 +67,6 @@ export const useAgentBuilderIntegration = ({
 }: UseAgentBuilderIntegrationParams): UseAgentBuilderIntegrationReturn => {
   const { workflowsManagement } = useKibana().services;
   const agentBuilder = workflowsManagement?.agentBuilder;
-  const isExperimentalEnabled = useUiSetting<boolean>(
-    AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID
-  );
   const telemetry = useTelemetry();
   const dispatch = useDispatch();
   const proposalManagerRef = useRef<ProposalManager | null>(null);
@@ -92,7 +87,7 @@ export const useAgentBuilderIntegration = ({
 
   useEffect(() => {
     const editor = editorRef.current;
-    if (!isEditorMounted || !editor || !agentBuilder || !isExperimentalEnabled) {
+    if (!isEditorMounted || !editor || !agentBuilder) {
       return;
     }
 
@@ -294,20 +289,11 @@ export const useAgentBuilderIntegration = ({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (window as any).__wfTestBridge;
     };
-  }, [
-    isEditorMounted,
-    editorRef,
-    agentBuilder,
-    isExperimentalEnabled,
-    attachmentId,
-    workflowId,
-    telemetry,
-    dispatch,
-  ]);
+  }, [isEditorMounted, editorRef, agentBuilder, attachmentId, workflowId, telemetry, dispatch]);
 
   const openAgentChat = useCallback(
     (options?: OpenAgentChatOptions) => {
-      if (!agentBuilder || !isExperimentalEnabled) {
+      if (!agentBuilder) {
         return;
       }
 
@@ -343,33 +329,30 @@ export const useAgentBuilderIntegration = ({
         chatOpenedReportedRef.current = true;
       }
     },
-    [
-      agentBuilder,
-      isExperimentalEnabled,
-      editorRef,
-      attachmentId,
-      workflowId,
-      workflowName,
-      validationErrors,
-      telemetry,
-    ]
+    [agentBuilder, editorRef, attachmentId, workflowId, workflowName, validationErrors, telemetry]
   );
 
   // Auto-open only on /workflows/create, or on a saved workflow whose sidebar
   // the save thunk requested we restore. Never on an existing workflow the
   // user navigated to directly. Guarded per-mount so a manual close stays.
   useEffect(() => {
-    if (!isEditorMounted || !agentBuilder || !isExperimentalEnabled) return;
-    if (hasAutoOpenedRef.current) return;
+    if (!isEditorMounted || !agentBuilder) {
+      return;
+    }
+    if (hasAutoOpenedRef.current) {
+      return;
+    }
 
     const shouldRestoreForSavedWorkflow =
       workflowId != null && consumeSidebarRestoreFor(workflowId);
 
-    if (workflowId != null && !shouldRestoreForSavedWorkflow) return;
+    if (workflowId != null && !shouldRestoreForSavedWorkflow) {
+      return;
+    }
 
     hasAutoOpenedRef.current = true;
     openAgentChat({ isAutoOpen: true });
-  }, [isEditorMounted, agentBuilder, isExperimentalEnabled, workflowId, openAgentChat]);
+  }, [isEditorMounted, agentBuilder, workflowId, openAgentChat]);
 
   // Close the sidebar on unmount (leaving the workflow scope). Empty deps so
   // it does not fire on prop changes. `application.navigateToApp` remounts
@@ -385,7 +368,7 @@ export const useAgentBuilderIntegration = ({
 
   return {
     openAgentChat,
-    isAgentBuilderAvailable: agentBuilder != null && isExperimentalEnabled,
+    isAgentBuilderAvailable: agentBuilder != null,
     proposalManager: proposalManagerRef.current,
   };
 };

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor/proposed_changes.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor/proposed_changes.spec.ts
@@ -82,12 +82,6 @@ const ALL_STEPS_MODIFIED = INITIAL_YAML.replace(
   .replace('message: "Hello from step three"', 'message: "Modified three"');
 
 test.describe('Proposed changes accept and reject', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ scoutSpace }) => {
-    await scoutSpace.uiSettings.set({
-      'agentBuilder:experimentalFeatures': true,
-    });
-  });
-
   test.beforeEach(async ({ browserAuth, pageObjects }) => {
     await browserAuth.loginAsPrivilegedUser();
     await pageObjects.workflowEditor.gotoNewWorkflow();
@@ -96,7 +90,6 @@ test.describe('Proposed changes accept and reject', { tag: [...tags.stateful.cla
   });
 
   test.afterAll(async ({ scoutSpace, apiServices }) => {
-    await scoutSpace.uiSettings.unset('agentBuilder:experimentalFeatures');
     await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
   });
 

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -101,7 +101,6 @@
     "@kbn/core-user-profile-server",
     "@kbn/core-user-profile-server-mocks",
     "@kbn/logging",
-    "@kbn/management-settings-ids",
     "@kbn/agent-context-layer-plugin",
     "@kbn/std",
     "@kbn/use-observable",

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/moon.yml
@@ -29,7 +29,6 @@ dependsOn:
   - '@kbn/zod'
   - '@kbn/agent-builder-genai-utils'
   - '@kbn/agent-builder-tools-base'
-  - '@kbn/management-settings-ids'
   - '@kbn/core-lifecycle-browser-mocks'
   - '@kbn/workflows-ui'
   - '@kbn/code-editor'

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/plugin.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/plugin.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { registerWorkflowAttachmentRenderers } from './attachment_types';
+import { AgentBuilderWorkflowsPlugin } from './plugin';
+import type { PluginSetupDependencies, PluginStartDependencies } from './types';
+
+jest.mock('./attachment_types', () => ({
+  registerWorkflowAttachmentRenderers: jest.fn(),
+}));
+
+const registerWorkflowAttachmentRenderersMock =
+  registerWorkflowAttachmentRenderers as jest.MockedFunction<
+    typeof registerWorkflowAttachmentRenderers
+  >;
+
+const flushPromises = () => new Promise(process.nextTick);
+
+describe('AgentBuilderWorkflowsPlugin', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setupPlugin = () => {
+    const coreSetup = coreMock.createSetup();
+    const coreStart = coreMock.createStart();
+
+    const attachments = { addAttachmentType: jest.fn() };
+    const telemetry = { reportWorkflowCreated: jest.fn() };
+    const queryClient = { getQueryData: jest.fn() };
+
+    const depsStart = {
+      agentBuilder: { attachments },
+      workflowsManagement: {
+        getTelemetry: jest.fn().mockResolvedValue(telemetry),
+        getQueryClient: jest.fn().mockResolvedValue(queryClient),
+      },
+    } as unknown as PluginStartDependencies;
+
+    coreSetup.getStartServices.mockResolvedValue([coreStart, depsStart, {}]);
+
+    const plugin = new AgentBuilderWorkflowsPlugin();
+    plugin.setup(coreSetup, {} as PluginSetupDependencies);
+
+    return { coreSetup, coreStart, attachments, telemetry, queryClient };
+  };
+
+  it('registers workflow attachment renderers on setup', async () => {
+    const { coreStart, attachments, telemetry, queryClient } = setupPlugin();
+
+    await flushPromises();
+
+    expect(registerWorkflowAttachmentRenderersMock).toHaveBeenCalledTimes(1);
+    expect(registerWorkflowAttachmentRenderersMock).toHaveBeenCalledWith(attachments, {
+      core: coreStart,
+      telemetry,
+      queryClient,
+    });
+  });
+
+  it('does not gate renderer registration behind any ui setting', async () => {
+    // Regression guard: registration used to wait for the
+    // `agentBuilder:experimentalFeatures` advanced setting to become true,
+    // leaving workflow attachments unrendered on default deployments.
+    const { coreSetup } = setupPlugin();
+
+    await flushPromises();
+
+    expect(coreSetup.uiSettings.get$).not.toHaveBeenCalled();
+    expect(registerWorkflowAttachmentRenderersMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/plugin.tsx
@@ -6,8 +6,6 @@
  */
 
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
-import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
-import { first } from 'rxjs';
 import type {
   AgentBuilderWorkflowsPluginSetup,
   AgentBuilderWorkflowsPluginStart,
@@ -28,23 +26,21 @@ export class AgentBuilderWorkflowsPlugin
     coreSetup: CoreSetup<PluginStartDependencies, AgentBuilderWorkflowsPluginStart>,
     setupDeps: PluginSetupDependencies
   ): AgentBuilderWorkflowsPluginSetup {
-    coreSetup.uiSettings
-      .get$<boolean>(AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID)
-      .pipe(first((enabled) => enabled))
-      .subscribe(async () => {
-        const [[coreStart, depsStart], { registerWorkflowAttachmentRenderers }] = await Promise.all(
-          [coreSetup.getStartServices(), import('./attachment_types')]
-        );
-        const [telemetry, queryClient] = await Promise.all([
-          depsStart.workflowsManagement.getTelemetry(),
-          depsStart.workflowsManagement.getQueryClient(),
-        ]);
-        registerWorkflowAttachmentRenderers(depsStart.agentBuilder.attachments, {
-          core: coreStart,
-          telemetry,
-          queryClient,
-        });
+    void (async () => {
+      const [[coreStart, depsStart], { registerWorkflowAttachmentRenderers }] = await Promise.all([
+        coreSetup.getStartServices(),
+        import('./attachment_types'),
+      ]);
+      const [telemetry, queryClient] = await Promise.all([
+        depsStart.workflowsManagement.getTelemetry(),
+        depsStart.workflowsManagement.getQueryClient(),
+      ]);
+      registerWorkflowAttachmentRenderers(depsStart.agentBuilder.attachments, {
+        core: coreStart,
+        telemetry,
+        queryClient,
       });
+    })();
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/tsconfig.json
@@ -18,7 +18,6 @@
     "@kbn/zod",
     "@kbn/agent-builder-genai-utils",
     "@kbn/agent-builder-tools-base",
-    "@kbn/management-settings-ids",
     "@kbn/core-lifecycle-browser-mocks",
     "@kbn/workflows-ui",
     "@kbn/code-editor",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[One Workflow] Remove agentBuilder:experimentalFeatures gate from AI workflow authoring UI (#278343)](https://github.com/elastic/kibana/pull/278343)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":278343,"url":"https://github.com/elastic/kibana/pull/278343","title":"[One Workflow] Remove agentBuilder:experimentalFeatures gate from AI workflow authoring UI"},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"sourceCommit":{"sha":"017644b92e406ad4728ae04b1a34e00b534b2614"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)