### PR TITLE
fix(exploratory-tester): use full repo path in invocation example

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md
@@ -31,7 +31,7 @@ Explore a Kibana Security Solution feature area through a real browser, collect 
 **The entire invocation block below is optional.** If `Area` or `Flows` is missing, the agent runs a short guided intake.
 
 ```
-Read and follow exploratory-tester/SKILL.md [in parallel mode] [for issue/PR #N]
+Read and follow x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md [in parallel mode] [for issue/PR #N]
 Area: <feature area>
 Flows:
   - <flow name>
@@ -46,6 +46,8 @@ Session-dir: .exploratory-session/entity-analytics-20260714-093022  # optional �
 Environment: profile <name>  # optional — or just: Environment: <name> if the profile file exists
 Session-config: <path>       # optional — read all inputs from a YAML file instead of this block
 ```
+
+Claude Code users who set up the symlink from Prerequisites (`ln -s "$(pwd)/x-pack/…/exploratory-tester" ~/.claude/skills/exploratory-tester`) can use the short form `exploratory-tester/SKILL.md` instead. Cursor and other IDEs use the full path above.
 
 Guided intake: if `Area`/`Flows` missing, the agent asks interactively with defaults (`phases/0-setup.md`). Environment profiles: `Environment: profile <name>` loads a saved profile; the agent offers to save a new profile after validating a user-provided environment (`phases/0-setup.md`). Session-config: `Session-config: <path>` reads all inputs from YAML; copy `templates/session.example.yaml` as a template.
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/0-setup.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/phases/0-setup.md
@@ -13,11 +13,12 @@ Before starting, verify these are in place:
   ```json
   { "mcpServers": { "playwright": { "command": "npx", "args": ["@playwright/mcp@latest"] } } }
   ```
-- **Skill symlink** (from repo root, then restart your IDE):
+- **Skill symlink** _(optional — Claude Code short-form convenience only; skip if using Cursor, JetBrains, or VS Code)_:
   ```bash
   SKILL=x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester
   ln -s "$(pwd)/$SKILL" ~/.claude/skills/exploratory-tester
   ```
+  Enables the short invocation form `exploratory-tester/SKILL.md` in Claude Code. Not required — the full repo path works everywhere without this step.
 - **Scout** (agent-managed environments only) — `node scripts/scout.js` available. Run `yarn kbn bootstrap` if not.
 
 ---


### PR DESCRIPTION
## Summary

The invocation example used `exploratory-tester/SKILL.md`, which only works after a symlink is created under `~/.claude/skills/` — a prerequisite many users skip. Cursor, JetBrains, and other IDEs have no symlink mechanism at all.

- Switch the canonical invocation path to the full repo-relative path so it works everywhere without any setup
- Add one-line note that Claude Code users who set up the symlink can use the short form as a convenience

## Test plan

- [x] Full path works in Claude Code without the symlink
- [x] Full path works as a Cursor `@`-mention (`@x-pack/solutions/security/plugins/security_solution/.agents/skills/exploratory-tester/SKILL.md`)
- [x] Short form still documented for Claude Code symlink users

🤖 Generated with [Claude Code](https://claude.com/claude-code)