### PR TITLE
[Security Solution][Cypress] Fix flaky alert_details_left_panel_entities_tab test (#264641)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -467,6 +467,17 @@ export const waitForAlerts = () => {
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
+  // Do NOT add a `cy.get(LOADING_INDICATOR).should('not.exist')` check here (`globalLoadingIndicator`,
+  // the chrome-level `EuiLoadingSpinner` driven by `http.getLoadingCount$()`). It reflects ALL in-flight
+  // HTTP requests app-wide (telemetry, capabilities, session pings, etc.), not just the alerts search.
+  // `waitForAlertsToPopulate()` calls `refreshPage()` in a retry loop, which piles up unrelated network
+  // requests and can keep that spinner mounted indefinitely, exhausting the 150s Cypress retry window
+  // long before those unrelated chrome requests settle. This exact assertion caused a wave of "before
+  // each" hook timeouts across many specs sharing this helper, all with the same symptom: "Expected
+  // <span.euiLoadingSpinner...> not to exist in the DOM, but it was continuously found." — see #274408
+  // (removal fix) and #264641, #272791, #274536, #274543, #274544, #274608, #274616 (tracked failures).
+  // The checks above (page filters, refresh button, datagrid, table loading) plus the network-idle wait
+  // below already guarantee the alerts table itself is fully settled.
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };
 


### PR DESCRIPTION
Fixes #264641

## Summary

**Problem:** `alert_details_left_panel_entities_tab.cy.ts`'s `beforeEach` timed out after 150s waiting for a `span.euiLoadingSpinner` to disappear — Kibana's chrome-level `globalLoadingIndicator`, which fires for any in-flight HTTP request app-wide, not alerts-table readiness.

**Root cause:** this exact assertion was already removed from the shared `waitForAlerts()` helper by [#274408](https://github.com/elastic/kibana/pull/274408), which fixed the identical stack-trace signature for six sibling issues. #264641 has the same signature but predates that fix and was never cross-linked, so it stayed open despite the bug already being resolved on `main`.

**Fix:** since there's no remaining code bug at this path, added a regression-guard comment directly in `waitForAlerts()` explaining why the `globalLoadingIndicator` check must never be reintroduced, cross-referencing this issue and the sibling issues #274408 already fixed.

**Note (not fixed here, flagging for a follow-up):** found `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')` in the same function is likely a no-op (a jQuery collection is never `=== true`). Left untouched here since `waitForAlerts()` is called from 60+ specs and tightening it could surface unrelated flakiness elsewhere — better as its own isolated PR.

## Repro & Verification

- The literal reported failure can't be reproduced on `main` (already fixed by #274408) — confirmed by inspecting the pre-fix commit and matching the DOM class (`euiLoadingSpinner-l`) to Kibana's `globalLoadingIndicator` component 1:1.
- Ran the current (already-fixed) spec twice locally; neither reproduced the original spinner timeout. One run hit an unrelated environment-load symptom (query bar not rendering, Task Manager reporting itself degraded) — this machine was concurrently running several other agents' full Kibana/ES/Cypress stacks, so attributed to local resource contention, not a product or test bug.
- Verified with `prettier --check` (comment-only change, no behavioral risk).
- Recommend a [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner) pass for a clean-environment signal before merge.

**Release note:** No user-facing changes — test helper documentation only. Suggested label: `release_note:skip`.

Made with [Cursor](https://cursor.com)
