### PR TITLE
[Entity Analytics][UI] Fix position of close tooltip

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
@@ -147,9 +147,12 @@ const TopNComponent: React.FC<Props> = ({
         )}
       </div>
 
-      <EuiToolTip content={i18n.CLOSE} disableScreenReaderOutput>
+      <EuiToolTip
+        content={i18n.CLOSE}
+        disableScreenReaderOutput
+        anchorProps={{ css: styles.closeButton }}
+      >
         <EuiButtonIcon
-          css={styles.closeButton}
           aria-label={i18n.CLOSE}
           data-test-subj="close"
           iconType="cross"


### PR DESCRIPTION
## Summary

Fixes position of close button tooltip.
Closes https://github.com/elastic/kibana/issues/278720

<img width="3024" height="1680" alt="image" src="https://github.com/user-attachments/assets/765fa9ee-6c77-4b2b-9c91-161f6fae365b" />




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->