### PR TITLE
[Security Solution][Flyout] add url synchronisation to all flyouts of the new flyout system in Security Solution. Also add share button to alert and attack flyouts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/index.test.tsx
@@ -80,6 +80,16 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+// HomePage wires up flyoutV2 URL restoration/interop, whose restore logic (including its
+// `useEsDocSearch` calls) is covered by dedicated unit tests in `flyout_v2/shared/url_state`.
+// Mocked here as no-ops so this suite doesn't need a `UnifiedDocViewerServices` registration.
+jest.mock('../../flyout_v2/shared/url_state/use_flyout_v2_restore', () => ({
+  useFlyoutV2RestoreFromUrl: jest.fn(),
+}));
+jest.mock('../../flyout_v2/shared/url_state/use_expandable_flyout_url_interop', () => ({
+  useLegacyFlyoutUrlInterop: jest.fn(),
+}));
+
 const mockQueryTimelineById = jest.fn();
 jest.mock('../../timelines/components/open_timeline/helpers', () => {
   const original = jest.requireActual('../../timelines/components/open_timeline/helpers');

--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
@@ -27,6 +27,13 @@ import { TopValuesPopover } from '../components/top_values_popover/top_values_po
 import { useInitDataViewManager } from '../../data_view_manager/hooks/use_init_data_view_manager';
 import { useRestoreDataViewManagerStateFromURL } from '../../data_view_manager/hooks/use_sync_url_state';
 import { useBrowserFields } from '../../data_view_manager/hooks/use_browser_fields';
+import { useFlyoutV2RestoreFromUrl } from '../../flyout_v2/shared/url_state/use_flyout_v2_restore';
+import {
+  FLYOUT_V2_URL_PARAM,
+  FLYOUT_V2_TIMELINE_URL_PARAM,
+} from '../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { useLegacyFlyoutUrlInterop } from '../../flyout_v2/shared/url_state/use_expandable_flyout_url_interop';
+import { URL_PARAM_KEY } from '../../common/hooks/constants';
 
 interface HomePageProps {
   children: React.ReactNode;
@@ -39,6 +46,11 @@ const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
   useRestoreDataViewManagerStateFromURL(useInitDataViewManager(), getScopeFromPath(pathname));
 
   useUrlState();
+  // Interop must run before the restore hook so the legacy param is consumed first.
+  useLegacyFlyoutUrlInterop(URL_PARAM_KEY.flyout, FLYOUT_V2_URL_PARAM);
+  useLegacyFlyoutUrlInterop(URL_PARAM_KEY.timelineFlyout, FLYOUT_V2_TIMELINE_URL_PARAM);
+  useFlyoutV2RestoreFromUrl(FLYOUT_V2_URL_PARAM);
+  useFlyoutV2RestoreFromUrl(FLYOUT_V2_TIMELINE_URL_PARAM);
   useUpdateBrowserTitle();
   useUpdateExecutionContext();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
@@ -12,8 +12,11 @@ import { AlertDetailsRedirect } from './alert_details_redirect';
 import { TestProviders } from '../../../common/mock';
 import { ALERT_DETAILS_REDIRECT_PATH, ALERTS_PATH } from '../../../../common/constants';
 import { mockHistory } from '../../../common/utils/route/mocks';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { encodeFlyoutV2UrlParam } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
 
 jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
 
 const testAlertId = 'test-alert-id';
 jest.mock('react-router-dom', () => ({
@@ -27,7 +30,13 @@ const testIndex = '.someTestIndex';
 const testTimestamp = '2023-04-20T12:00:00.000Z';
 const mockPathname = `${ALERT_DETAILS_REDIRECT_PATH}/${testAlertId}`;
 
+const mockUseIsNewFlyoutEnabled = useIsNewFlyoutEnabled as jest.Mock;
+
 describe('AlertDetailsRedirect', () => {
+  beforeEach(() => {
+    mockUseIsNewFlyoutEnabled.mockReturnValue(false);
+  });
+
   afterEach(() => {
     mockHistory.replace.mockClear();
   });
@@ -145,6 +154,102 @@ describe('AlertDetailsRedirect', () => {
         search: `?${expectedSearchParam.toString()}`,
         state: undefined,
       });
+    });
+  });
+
+  describe('with new flyout enabled', () => {
+    beforeEach(() => {
+      mockUseIsNewFlyoutEnabled.mockReturnValue(true);
+    });
+
+    it('emits flyoutV2 param (not legacy flyout) with index and timestamp set', () => {
+      const testSearch = `?index=${testIndex}&timestamp=${testTimestamp}`;
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: testSearch,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <AlertDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      const expectedFlyoutV2 = encodeFlyoutV2UrlParam([
+        { kind: 'document', documentId: testAlertId, indexName: testIndex },
+      ]);
+      const expectedSearch = new URLSearchParams({
+        query: "(language:kuery,query:'_id: test-alert-id')",
+        timerange:
+          "(global:(linkTo:!(timeline),timerange:(from:'2023-04-20T12:00:00.000Z',kind:absolute,to:'2023-04-20T12:05:00.000Z')),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))",
+        pageFilters:
+          '!((display_settings:(hide_action_bar:!f),exclude:!f,exists_selected:!f,field_name:kibana.alert.workflow_status,selected_options:!(),title:Status))',
+        flyoutV2: expectedFlyoutV2,
+      });
+
+      expect(historyMock.replace).toHaveBeenCalledWith({
+        hash: '',
+        pathname: ALERTS_PATH,
+        search: `?${expectedSearch.toString()}`,
+        state: undefined,
+      });
+    });
+
+    it('does not emit legacy flyout param', () => {
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: `?index=${testIndex}&timestamp=${testTimestamp}`,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <AlertDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      const [[callArg]] = (historyMock.replace as jest.Mock).mock.calls;
+      expect(callArg.search).not.toContain('flyout=');
+      expect(callArg.search).toContain('flyoutV2=');
+    });
+
+    it('preserves existing flyoutV2 param from the URL', () => {
+      const existingFlyoutV2 = encodeFlyoutV2UrlParam([
+        { kind: 'document', documentId: 'existing-id', indexName: '.existing-index' },
+      ]);
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: `?index=${testIndex}&timestamp=${testTimestamp}&flyoutV2=${encodeURIComponent(
+            existingFlyoutV2
+          )}`,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <AlertDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      const [[callArg]] = (historyMock.replace as jest.Mock).mock.calls;
+      const search = new URLSearchParams(callArg.search);
+      expect(search.get('flyoutV2')).toBe(existingFlyoutV2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
@@ -15,9 +15,11 @@ import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
 import { ALERTS_PATH, DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
 import { inputsSelectors } from '../../../common/store';
 import { formatPageFilterSearchParam } from '../../../../common/utils/format_page_filter_search_param';
-import { resolveFlyoutParams } from './utils';
+import { FLYOUT_V2_URL_PARAM } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { resolveFlyoutParams, resolveFlyoutV2Params } from './utils';
 
 export const AlertDetailsRedirect = () => {
   const { alertId } = useParams<{ alertId: string }>();
@@ -66,13 +68,21 @@ export const AlertDetailsRedirect = () => {
 
   const pageFiltersQuery = encode(formatPageFilterSearchParam([statusPageFilter]));
 
+  const isNewFlyoutEnabled = useIsNewFlyoutEnabled();
+
   const currentFlyoutParams = searchParams.get(URL_PARAM_KEY.flyout);
+  const currentFlyoutV2Params = searchParams.get(FLYOUT_V2_URL_PARAM);
+
+  const flyoutParamKey = isNewFlyoutEnabled ? FLYOUT_V2_URL_PARAM : URL_PARAM_KEY.flyout;
+  const flyoutParamValue = isNewFlyoutEnabled
+    ? resolveFlyoutV2Params({ index, alertId }, currentFlyoutV2Params)
+    : resolveFlyoutParams({ index, alertId }, currentFlyoutParams);
 
   const urlParams = new URLSearchParams({
     [URL_PARAM_KEY.appQuery]: kqlAppQuery,
     [URL_PARAM_KEY.timerange]: timerange,
     [URL_PARAM_KEY.pageFilter]: pageFiltersQuery,
-    [URL_PARAM_KEY.flyout]: resolveFlyoutParams({ index, alertId }, currentFlyoutParams),
+    [flyoutParamKey]: flyoutParamValue,
   });
 
   const url = `${ALERTS_PATH}?${urlParams.toString()}`;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/utils.test.ts
@@ -7,7 +7,8 @@
 
 import { encode } from '@kbn/rison';
 import { DocumentDetailsRightPanelKey } from '../../../flyout/document_details/shared/constants/panel_keys';
-import { resolveFlyoutParams } from './utils';
+import { encodeFlyoutV2UrlParam } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { resolveFlyoutParams, resolveFlyoutV2Params } from './utils';
 
 describe('resolveFlyoutParams', () => {
   it('preserves existing flyout query string', () => {
@@ -25,5 +26,19 @@ describe('resolveFlyoutParams', () => {
       preview: [],
     });
     expect(resolveFlyoutParams({ index: '.idx', alertId: 'a1' }, null)).toBe(expected);
+  });
+});
+
+describe('resolveFlyoutV2Params', () => {
+  it('preserves existing flyoutV2 query string', () => {
+    const existing = '!((kind:document,documentId:a1,indexName:.idx))';
+    expect(resolveFlyoutV2Params({ index: '.idx', alertId: 'a1' }, existing)).toBe(existing);
+  });
+
+  it('encodes a document descriptor when no current params', () => {
+    const expected = encodeFlyoutV2UrlParam([
+      { kind: 'document', documentId: 'a1', indexName: '.idx' },
+    ]);
+    expect(resolveFlyoutV2Params({ index: '.idx', alertId: 'a1' }, null)).toBe(expected);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/utils.ts
@@ -10,6 +10,7 @@ import {
   expandableFlyoutStateRightPanelOnly,
   resolveFlyoutUrlParam,
 } from '../../../flyout/shared/utils/expandable_flyout_url_state';
+import { encodeFlyoutV2UrlParam } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
 
 export interface ResolveFlyoutParamsConfig {
   index: string;
@@ -37,3 +38,18 @@ export const resolveFlyoutParams = (
       },
     })
   );
+
+/**
+ * Resolves the flyoutV2 URL parameter for the new flyout system.
+ * If the URL already carries a flyoutV2 param (e.g. from a prior share link), preserves it.
+ * Otherwise encodes a document descriptor for the given alert.
+ */
+export const resolveFlyoutV2Params = (
+  { index, alertId }: ResolveFlyoutParamsConfig,
+  currentParamsString: string | null
+): string => {
+  if (currentParamsString) {
+    return currentParamsString;
+  }
+  return encodeFlyoutV2UrlParam([{ kind: 'document', documentId: alertId, indexName: index }]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attack_details_redirect.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attack_details_redirect.test.tsx
@@ -16,10 +16,13 @@ import {
   DEFAULT_ALERTS_INDEX,
 } from '../../../../common/constants';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
 import { mockHistory } from '../../../common/utils/route/mocks';
+import { encodeFlyoutV2UrlParam } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
 import { resolveAttackFlyoutParams } from './utils';
 
 jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
 
 const testAttackId = 'test-attack-id';
 const mockRouteParams: { attackId?: string } = { attackId: testAttackId };
@@ -33,9 +36,12 @@ const testIndex = '.someTestIndex';
 const testTimestamp = '2023-04-20T12:00:00.000Z';
 const mockPathname = `${ATTACK_DETAILS_REDIRECT_PATH}/${testAttackId}`;
 
+const mockUseIsNewFlyoutEnabled = useIsNewFlyoutEnabled as jest.Mock;
+
 describe('AttackDetailsRedirect', () => {
   beforeEach(() => {
     mockRouteParams.attackId = testAttackId;
+    mockUseIsNewFlyoutEnabled.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -148,6 +154,100 @@ describe('AttackDetailsRedirect', () => {
         search: '',
         state: undefined,
       });
+    });
+  });
+
+  describe('with new flyout enabled', () => {
+    beforeEach(() => {
+      mockUseIsNewFlyoutEnabled.mockReturnValue(true);
+    });
+
+    it('emits flyoutV2 param (not legacy flyout) with an attack descriptor', () => {
+      const testSearch = `?index=${testIndex}&timestamp=${testTimestamp}`;
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: testSearch,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <AttackDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      const expectedFlyoutV2 = encodeFlyoutV2UrlParam([
+        { kind: 'attack', attackId: testAttackId, indexName: testIndex },
+      ]);
+      const expectedSearch = new URLSearchParams({
+        query: "(language:kuery,query:'_id: test-attack-id')",
+        timerange:
+          "(global:(linkTo:!(timeline),timerange:(from:'2023-04-20T12:00:00.000Z',kind:absolute,to:'2023-04-20T12:05:00.000Z')),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))",
+        flyoutV2: expectedFlyoutV2,
+      });
+
+      expect(historyMock.replace).toHaveBeenCalledWith({
+        hash: '',
+        pathname: ATTACKS_PATH,
+        search: `?${expectedSearch.toString()}`,
+        state: undefined,
+      });
+    });
+
+    it('does not emit legacy flyout param', () => {
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: `?index=${testIndex}&timestamp=${testTimestamp}`,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <AttackDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      const [[callArg]] = (historyMock.replace as jest.Mock).mock.calls;
+      expect(callArg.search).not.toContain('flyout=');
+      expect(callArg.search).toContain('flyoutV2=');
+    });
+
+    it('preserves existing flyoutV2 param from the URL', () => {
+      const existingFlyoutV2 = encodeFlyoutV2UrlParam([
+        { kind: 'attack', attackId: 'existing-id', indexName: '.existing-index' },
+      ]);
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: `?index=${testIndex}&timestamp=${testTimestamp}&flyoutV2=${encodeURIComponent(
+            existingFlyoutV2
+          )}`,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <AttackDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      const [[callArg]] = (historyMock.replace as jest.Mock).mock.calls;
+      const search = new URLSearchParams(callArg.search);
+      expect(search.get('flyoutV2')).toBe(existingFlyoutV2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attack_details_redirect.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/attack_details_redirect.tsx
@@ -13,14 +13,17 @@ import moment from 'moment';
 import { encode } from '@kbn/rison';
 import { ATTACKS_PATH, DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
 import { inputsSelectors } from '../../../common/store';
-import { resolveAttackFlyoutParams } from './utils';
+import { FLYOUT_V2_URL_PARAM } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { resolveAttackFlyoutParams, resolveAttackFlyoutV2Params } from './utils';
 
 export const AttackDetailsRedirect = () => {
   const { attackId } = useParams<{ attackId: string }>();
   const { search } = useLocation();
   const getInputSelector = useMemo(() => inputsSelectors.inputsSelector(), []);
   const inputState = useSelector(getInputSelector);
+  const isNewFlyoutEnabled = useIsNewFlyoutEnabled();
 
   if (!attackId) {
     return <Redirect to={ATTACKS_PATH} />;
@@ -57,11 +60,17 @@ export const AttackDetailsRedirect = () => {
   const kqlAppQuery = encode({ language: 'kuery', query: `_id: ${attackId}` });
 
   const currentFlyoutParams = searchParams.get(URL_PARAM_KEY.flyout);
+  const currentFlyoutV2Params = searchParams.get(FLYOUT_V2_URL_PARAM);
+
+  const flyoutParamKey = isNewFlyoutEnabled ? FLYOUT_V2_URL_PARAM : URL_PARAM_KEY.flyout;
+  const flyoutParamValue = isNewFlyoutEnabled
+    ? resolveAttackFlyoutV2Params({ index, attackId }, currentFlyoutV2Params)
+    : resolveAttackFlyoutParams({ index, attackId }, currentFlyoutParams);
 
   const urlParams = new URLSearchParams({
     [URL_PARAM_KEY.appQuery]: kqlAppQuery,
     [URL_PARAM_KEY.timerange]: timerange,
-    [URL_PARAM_KEY.flyout]: resolveAttackFlyoutParams({ index, attackId }, currentFlyoutParams),
+    [flyoutParamKey]: flyoutParamValue,
   });
 
   const url = `${ATTACKS_PATH}?${urlParams.toString()}`;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/utils.test.ts
@@ -7,7 +7,8 @@
 
 import { encode } from '@kbn/rison';
 import { AttackDetailsRightPanelKey } from '../../../flyout/attack_details/constants/panel_keys';
-import { resolveAttackFlyoutParams } from './utils';
+import { encodeFlyoutV2UrlParam } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
+import { resolveAttackFlyoutParams, resolveAttackFlyoutV2Params } from './utils';
 
 describe('resolveAttackFlyoutParams', () => {
   it('preserves existing flyout query string', () => {
@@ -25,5 +26,19 @@ describe('resolveAttackFlyoutParams', () => {
       preview: [],
     });
     expect(resolveAttackFlyoutParams({ index: '.idx', attackId: 'a1' }, null)).toBe(expected);
+  });
+});
+
+describe('resolveAttackFlyoutV2Params', () => {
+  it('preserves existing flyoutV2 query string', () => {
+    const existing = '!((kind:attack,attackId:a1,indexName:.idx))';
+    expect(resolveAttackFlyoutV2Params({ index: '.idx', attackId: 'a1' }, existing)).toBe(existing);
+  });
+
+  it('encodes an attack descriptor when no current params', () => {
+    const expected = encodeFlyoutV2UrlParam([
+      { kind: 'attack', attackId: 'a1', indexName: '.idx' },
+    ]);
+    expect(resolveAttackFlyoutV2Params({ index: '.idx', attackId: 'a1' }, null)).toBe(expected);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/attacks/utils.ts
@@ -10,6 +10,7 @@ import {
   expandableFlyoutStateRightPanelOnly,
   resolveFlyoutUrlParam,
 } from '../../../flyout/shared/utils/expandable_flyout_url_state';
+import { encodeFlyoutV2UrlParam } from '../../../flyout_v2/shared/url_state/flyout_v2_url_param';
 
 export interface ResolveAttackFlyoutParamsConfig {
   index: string;
@@ -34,3 +35,18 @@ export const resolveAttackFlyoutParams = (
       },
     })
   );
+
+/**
+ * Resolves the flyoutV2 URL parameter for the new flyout system.
+ * If the URL already carries a flyoutV2 param (e.g. from a prior share link), preserves it.
+ * Otherwise encodes an attack descriptor for the given attack.
+ */
+export const resolveAttackFlyoutV2Params = (
+  { index, attackId }: ResolveAttackFlyoutParamsConfig,
+  currentParamsString: string | null
+): string => {
+  if (currentParamsString) {
+    return currentParamsString;
+  }
+  return encodeFlyoutV2UrlParam([{ kind: 'attack', attackId, indexName: index }]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/constants/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/constants/test_ids.ts
@@ -25,6 +25,8 @@ export const HEADER_ASSIGNEES_ADD_BUTTON_TEST_ID =
   `${ATTACK_FLYOUT_V2_PREFIX}-header-assignees-add-button` as const;
 export const HEADER_SUMMARY_PANEL_TEST_ID =
   `${ATTACK_FLYOUT_V2_PREFIX}-header-summary-panel` as const;
+export const HEADER_SHARE_BUTTON_TEST_ID =
+  `${ATTACK_FLYOUT_V2_PREFIX}-header-share-button` as const;
 export const INSIGHTS_CORRELATIONS_TEST_ID =
   `${ATTACK_FLYOUT_V2_PREFIX}-overview-insights-correlations` as const;
 export const INSIGHTS_ENTITIES_TEST_ID =

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/header.test.tsx
@@ -10,7 +10,8 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { Header } from './header';
-import { HEADER_SUMMARY_PANEL_TEST_ID } from './constants/test_ids';
+import { HEADER_SHARE_BUTTON_TEST_ID, HEADER_SUMMARY_PANEL_TEST_ID } from './constants/test_ids';
+import { useGetAttackFlyoutLink } from '../../../flyout/attack_details/hooks/use_get_attack_flyout_link';
 
 jest.mock('./components/header_title', () => ({
   HeaderTitle: ({ hit }: { hit: DataTableRecord }) => (
@@ -55,6 +56,20 @@ jest.mock('../../shared/components/notes', () => ({
   ),
 }));
 
+jest.mock('../../shared/components/share_url_icon_button', () => ({
+  ShareUrlIconButton: ({
+    url,
+    dataTestSubj,
+  }: {
+    url: string | null | undefined;
+    dataTestSubj: string;
+  }) => (url ? <button type="button" data-test-subj={dataTestSubj} /> : null),
+}));
+
+jest.mock('../../../flyout/attack_details/hooks/use_get_attack_flyout_link', () => ({
+  useGetAttackFlyoutLink: jest.fn(),
+}));
+
 const createMockHit = (overrides: Partial<DataTableRecord> = {}): DataTableRecord =>
   ({
     id: 'test-attack-id',
@@ -67,10 +82,16 @@ const createMockHit = (overrides: Partial<DataTableRecord> = {}): DataTableRecor
     ...overrides,
   } as DataTableRecord);
 
+const mockUseGetAttackFlyoutLink = useGetAttackFlyoutLink as jest.Mock;
+
 describe('<Header />', () => {
   const mockHit = createMockHit();
   const onAttackUpdated = jest.fn();
   const onShowNotes = jest.fn();
+
+  beforeEach(() => {
+    mockUseGetAttackFlyoutLink.mockReturnValue(null);
+  });
 
   const renderHeader = (props?: Partial<Parameters<typeof Header>[0]>) =>
     render(
@@ -95,10 +116,28 @@ describe('<Header />', () => {
     expect(getByTestId(HEADER_SUMMARY_PANEL_TEST_ID)).toBeInTheDocument();
   });
 
-  it('does not render a share action button (matches document flyout v2)', () => {
+  it('renders the share button when a link is available', () => {
+    mockUseGetAttackFlyoutLink.mockReturnValue('https://example.com/attacks/redirect/test-id');
+    const { getByTestId } = renderHeader();
+
+    expect(getByTestId(HEADER_SHARE_BUTTON_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('does not render the share button when link is null (e.g. missing timestamp)', () => {
+    mockUseGetAttackFlyoutLink.mockReturnValue(null);
     const { queryByTestId } = renderHeader();
 
-    expect(queryByTestId('attack-flyout-v2-header-share-button')).not.toBeInTheDocument();
+    expect(queryByTestId(HEADER_SHARE_BUTTON_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('requests the attack (not alert) redirect link, using attackId/indexName/timestamp from the hit', () => {
+    renderHeader();
+
+    expect(mockUseGetAttackFlyoutLink).toHaveBeenCalledWith({
+      attackId: 'test-attack-id',
+      indexName: '',
+      timestamp: '2023-01-01T00:00:00.000Z',
+    });
   });
 
   it('passes hit to all sub-components', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/main/header.tsx
@@ -8,6 +8,8 @@
 import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { flyoutHeaderBlockStyles } from '../../shared/components/flyout_header_block';
 import { Notes } from '../../shared/components/notes';
@@ -15,7 +17,25 @@ import { HeaderTitle } from './components/header_title';
 import { Status } from './components/status';
 import { AlertsCount } from './components/alerts_count';
 import { Assignees } from './components/assignees';
-import { HEADER_SUMMARY_PANEL_TEST_ID } from './constants/test_ids';
+import { HEADER_SHARE_BUTTON_TEST_ID, HEADER_SUMMARY_PANEL_TEST_ID } from './constants/test_ids';
+import { ShareUrlIconButton } from '../../shared/components/share_url_icon_button';
+import { useGetAttackFlyoutLink } from '../../../flyout/attack_details/hooks/use_get_attack_flyout_link';
+
+const SHARE_ATTACK_LABEL = i18n.translate(
+  'xpack.securitySolution.flyoutV2.attack.header.shareAttackLabel',
+  {
+    defaultMessage: 'Share attack',
+  }
+);
+
+// Positioned relative to the flyout itself (the nearest positioned ancestor), matching where EUI
+// places its own close button (`right: euiTheme.size.s` / `top: euiTheme.size.s`). The larger
+// inline-end offset makes room for the close button so the two sit side by side.
+const shareButtonStyles = css`
+  position: absolute;
+  inset-inline-end: 36px;
+  inset-block-start: 8px;
+`;
 
 export interface HeaderProps {
   /**
@@ -42,8 +62,22 @@ export interface HeaderProps {
 export const Header: FC<HeaderProps> = memo(({ hit, onAttackUpdated, onShowNotes }) => {
   const documentId = useMemo(() => hit.raw._id ?? '', [hit]);
 
+  const attackDetailsLink = useGetAttackFlyoutLink({
+    attackId: hit.raw._id ?? '',
+    indexName: hit.raw._index ?? '',
+    timestamp: hit.flattened?.['@timestamp'] ? String(hit.flattened['@timestamp']) : undefined,
+  });
+
   return (
     <>
+      <div css={shareButtonStyles}>
+        <ShareUrlIconButton
+          url={attackDetailsLink}
+          tooltip={SHARE_ATTACK_LABEL}
+          ariaLabel={SHARE_ATTACK_LABEL}
+          dataTestSubj={HEADER_SHARE_BUTTON_TEST_ID}
+        />
+      </div>
       <HeaderTitle hit={hit} />
       <EuiSpacer size="m" />
       <EuiFlexGroup
@@ -64,7 +98,7 @@ export const Header: FC<HeaderProps> = memo(({ hit, onAttackUpdated, onShowNotes
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem css={flyoutHeaderBlockStyles}>
-          <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
+          <EuiFlexGroup direction="row" gutterSize="s" responsive={false} alignItems="center">
             <EuiFlexItem>
               <Assignees hit={hit} onAttackUpdated={onAttackUpdated} />
             </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.test.tsx
@@ -21,6 +21,7 @@ import {
   FLYOUT_TOOL,
   FLYOUT_SESSION_KIND,
 } from '../../common/lib/telemetry';
+import { FLYOUT_DESCRIPTOR_KIND } from '../shared/url_state/flyout_v2_url_param';
 
 jest.mock('react-redux-v7', () => ({
   ...jest.requireActual('react-redux-v7'),
@@ -40,14 +41,28 @@ jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   defaultToolsFlyoutProperties: { size: 'm' },
 }));
 
+const mockWriteOnOpen = jest.fn();
+const mockBuildOnClose = jest.fn(() => jest.fn());
+jest.mock('../shared/url_state/flyout_v2_url_writer', () => ({
+  useFlyoutV2UrlWriter: jest.fn(() => ({
+    writeOnOpen: mockWriteOnOpen,
+    buildOnClose: mockBuildOnClose,
+  })),
+}));
+
 const mockOpenSystemFlyout = jest.fn();
 const mockReportEvent = jest.fn();
-const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+const hit = {
+  id: '1',
+  raw: { _id: 'attack-id', _index: 'attack-index' },
+  flattened: {},
+} as unknown as DataTableRecord;
 
 describe('useAttackFlyoutApi', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOpenSystemFlyout.mockReturnValue({ onClose: Promise.resolve(), close: jest.fn() });
+    mockBuildOnClose.mockReturnValue(jest.fn());
     (useKibana as jest.Mock).mockReturnValue({
       services: {
         overlays: { openSystemFlyout: mockOpenSystemFlyout },
@@ -92,6 +107,18 @@ describe('useAttackFlyoutApi', () => {
     });
   });
 
+  it('openAttackFlyout writes an attack descriptor to the URL', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackFlyout({ attackId: 'attack-1', indexName: '.alerts-security' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.attack,
+      attackId: 'attack-1',
+      indexName: '.alerts-security',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
   it('openAttackFlyoutAsChild opens a system flyout that inherits the current session', () => {
     const { result } = renderHook(() => useAttackFlyoutApi());
     result.current.openAttackFlyoutAsChild({ attackId: 'attack-1', indexName: '.alerts-security' });
@@ -112,6 +139,18 @@ describe('useAttackFlyoutApi', () => {
       session: FLYOUT_SESSION_KIND.INHERIT,
       origin: undefined,
     });
+  });
+
+  it('openAttackFlyoutAsChild writes an attack descriptor in inherit mode', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackFlyoutAsChild({ attackId: 'attack-1', indexName: '.alerts-security' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith(
+      { kind: FLYOUT_DESCRIPTOR_KIND.attack, attackId: 'attack-1', indexName: '.alerts-security' },
+      'inherit'
+    );
+    // buildOnClose is called with null (no prior URL state in this test environment)
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
   });
 
   it('openAttackCorrelations opens the correlations tool flyout with the tools properties and propagates inherit context to its content', () => {
@@ -136,6 +175,20 @@ describe('useAttackFlyoutApi', () => {
     });
   });
 
+  it('openAttackCorrelations writes an attackCorrelations descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackCorrelations({ hit, alertIds: ['alert-1', 'alert-2'] });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.attackCorrelations,
+      attackId: 'attack-id',
+      indexName: 'attack-index',
+      alertIds: ['alert-1', 'alert-2'],
+    });
+    // A tool is a session:'start' root; closing it clears the param (no parent to revert to).
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
   it('openAttackEntities opens the entities tool flyout with the tools properties and propagates inherit context to its content', () => {
     const { result } = renderHook(() => useAttackFlyoutApi());
     result.current.openAttackEntities({ hit, alertIds: ['alert-1'] });
@@ -156,6 +209,20 @@ describe('useAttackFlyoutApi', () => {
       session: 'inherit',
       historyKey: documentFlyoutHistoryKey,
     });
+  });
+
+  it('openAttackEntities writes an attackEntities descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useAttackFlyoutApi());
+    result.current.openAttackEntities({ hit, alertIds: ['alert-1', 'alert-2'] });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.attackEntities,
+      attackId: 'attack-id',
+      indexName: 'attack-index',
+      alertIds: ['alert-1', 'alert-2'],
+    });
+    // A tool is a session:'start' root; closing it clears the param (no parent to revert to).
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
   });
 
   it('uses the doc-viewer history key when outside the security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -179,14 +179,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         }
       );
     },
-    [
-      open,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      sessionMode,
-      writeOnOpen,
-      buildOnClose,
-    ]
+    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode, writeOnOpen, buildOnClose]
   );
 
   const openAttackFlyoutAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/attack/use_attack_flyout_api.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { lazy, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { noop } from 'lodash/fp';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
@@ -31,6 +32,21 @@ import {
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import { getAttackTitleValue } from './utils/get_attack_title';
 import { useFlyoutSessionContext } from '../session_context';
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import {
+  FLYOUT_DESCRIPTOR_KIND,
+  decodeFlyoutV2UrlParam,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
+
+/**
+ * Extracts the minimal identifying fields from an attack DataTableRecord for use in URL descriptors.
+ */
+const attackIdsFromHit = (hit: DataTableRecord): { attackId: string; indexName: string } => ({
+  attackId: (hit.raw._id as string) ?? '',
+  indexName: (hit.raw._index as string) ?? '',
+});
 
 // Lazy-loaded so consumers of this hook don't statically pull the attack flyout graph into their
 // bundle; the chunk only loads when the flyout (or one of its tools) is actually opened.
@@ -103,8 +119,8 @@ export interface AttackFlyoutApi {
 /**
  * Developer-facing API to open the new (EUI-based) attack flyout and its tool flyouts, in the same
  * mindset as `useExpandableFlyoutApi`, `useDocumentFlyoutApi`, etc. It encapsulates the provider
- * wiring (`flyoutProviders` + `overlays.openSystemFlyout`) and the per-flyout properties so call
- * sites don't repeat them.
+ * wiring (`flyoutProviders` + `overlays.openSystemFlyout`, via `useOpenFlyout`) and the per-flyout
+ * properties so call sites don't repeat them. `useOpenFlyout` also reports open/close telemetry.
  *
  * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
  * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
@@ -113,9 +129,22 @@ export interface AttackFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useAttackFlyoutApi = (): AttackFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const open = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
+
+  // Reads the first descriptor from the current URL stack without bumping the generation.
+  // Used by openAttackFlyoutAsChild to determine the parent descriptor (close fallback)
+  // before appending the child descriptor with writeOnOpen('inherit').
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
 
   const openAttackFlyout = useCallback(
     ({
@@ -126,6 +155,8 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
       renderCellActions = cellActionRenderer,
       origin,
     }: OpenAttackFlyoutParams) => {
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.attack, attackId, indexName });
+      const onClose = buildOnClose(null);
       open(
         <AttackFlyoutWrapper
           attackId={attackId}
@@ -138,6 +169,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           historyKey,
           session: sessionMode,
           title: formatFlyoutTitle(ATTACK_TITLE, attackTitle),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
@@ -147,7 +179,14 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         }
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode]
+    [
+      open,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      sessionMode,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openAttackFlyoutAsChild = useCallback(
@@ -159,6 +198,9 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
       renderCellActions = cellActionRenderer,
       origin,
     }: OpenAttackFlyoutParams) => {
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.attack, attackId, indexName }, 'inherit');
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <AttackFlyoutWrapper
           attackId={attackId}
@@ -171,6 +213,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.INHERIT,
           title: buildFlyoutNavTitle(formatFlyoutTitle(ATTACK_TITLE, attackTitle)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
@@ -181,11 +224,28 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey]
+    [
+      open,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      readFirstDescriptor,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openAttackCorrelations = useCallback(
     ({ hit, alertIds, onShowAlert, origin }: OpenAttackCorrelationsParams) => {
+      const { attackId, indexName } = attackIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.attackCorrelations,
+        attackId,
+        indexName,
+        alertIds,
+      });
+      // A tool flyout opens with session:'start' (a root, not a child of the attack): the attack is
+      // not persisted alongside it, so closing the tool clears the param.
+      const onClose = buildOnClose(null);
       open(
         <CorrelationsDetails hit={hit} alertIds={alertIds} onShowAlert={onShowAlert} />,
         {
@@ -193,6 +253,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(ATTACK_CORRELATIONS_TITLE, getAttackTitleValue(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -204,11 +265,21 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openAttackEntities = useCallback(
     ({ hit, alertIds, origin }: OpenAttackEntitiesParams) => {
+      const { attackId, indexName } = attackIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.attackEntities,
+        attackId,
+        indexName,
+        alertIds,
+      });
+      // A tool flyout opens with session:'start' (a root, not a child of the attack): the attack is
+      // not persisted alongside it, so closing the tool clears the param.
+      const onClose = buildOnClose(null);
       open(
         <EntitiesDetails hit={hit} alertIds={alertIds} />,
         {
@@ -216,6 +287,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(ATTACK_ENTITIES_TITLE, getAttackTitleValue(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -227,7 +299,7 @@ export const useAttackFlyoutApi = (): AttackFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
@@ -119,14 +119,7 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => ref.close(), onClose: ref.onClose };
     },
-    [
-      open,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      sessionMode,
-      writeOnOpen,
-      buildOnClose,
-    ]
+    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode, writeOnOpen, buildOnClose]
   );
 
   const openMisconfigurationFindingAsChild = useCallback(
@@ -195,14 +188,7 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => ref.close(), onClose: ref.onClose };
     },
-    [
-      open,
-      defaultDocumentFlyoutProperties,
-      historyKey,
-      sessionMode,
-      writeOnOpen,
-      buildOnClose,
-    ]
+    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode, writeOnOpen, buildOnClose]
   );
 
   const openVulnerabilityFindingAsChild = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/csp/use_csp_flyout_api.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { lazy, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import type { OpenFindingInSystemFlyoutHandle } from '@kbn/cloud-security-posture-plugin/public';
 import type { FlyoutOrigin } from '../../common/lib/telemetry';
 import { FLYOUT_SESSION_KIND, FLYOUT_SURFACE, FLYOUT_TYPE } from '../../common/lib/telemetry';
@@ -15,6 +16,13 @@ import { useFlyoutSessionContext } from '../session_context';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import type { MisconfigurationProps } from './misconfiguration/main';
 import type { VulnerabilityProps } from './vulnerability/main';
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import {
+  FLYOUT_DESCRIPTOR_KIND,
+  decodeFlyoutV2UrlParam,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the CSP finding flyout graph into
 // their bundle; the chunk only loads when a finding is actually opened.
@@ -78,15 +86,31 @@ export interface CspFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useCspFlyoutApi = (): CspFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const open = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
+
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
 
   const openMisconfigurationFinding = useCallback(
     (params: MisconfigurationProps): OpenFindingInSystemFlyoutHandle => {
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.cspMisconfiguration,
+        resourceId: params.resourceId,
+        ruleId: params.ruleId,
+      });
+      const onClose = buildOnClose(null);
       const ref = open(
         <Misconfiguration {...params} />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode },
+        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode, onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.MISCONFIGURATION,
@@ -95,7 +119,14 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => ref.close(), onClose: ref.onClose };
     },
-    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode]
+    [
+      open,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      sessionMode,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openMisconfigurationFindingAsChild = useCallback(
@@ -103,6 +134,16 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       params: MisconfigurationProps,
       options?: OpenCspFindingAsChildOptions
     ): OpenFindingInSystemFlyoutHandle => {
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.cspMisconfiguration,
+          resourceId: params.resourceId,
+          ruleId: params.ruleId,
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       const ref = open(
         <Misconfiguration {...params} />,
         {
@@ -110,6 +151,7 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.INHERIT,
           title: options?.title ? buildFlyoutNavTitle(options.title) : undefined,
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
@@ -121,14 +163,30 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => ref.close(), onClose: ref.onClose };
     },
-    [open, defaultDocumentFlyoutProperties, historyKey]
+    [
+      open,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      readFirstDescriptor,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openVulnerabilityFinding = useCallback(
     (params: VulnerabilityProps): OpenFindingInSystemFlyoutHandle => {
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.cspVulnerability,
+        vulnerabilityId: params.vulnerabilityId,
+        resourceId: params.resourceId,
+        packageName: params.packageName,
+        packageVersion: params.packageVersion,
+        eventId: params.eventId,
+      });
+      const onClose = buildOnClose(null);
       const ref = open(
         <Vulnerability {...params} />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode },
+        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode, onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.VULNERABILITY,
@@ -137,7 +195,14 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => ref.close(), onClose: ref.onClose };
     },
-    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode]
+    [
+      open,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      sessionMode,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openVulnerabilityFindingAsChild = useCallback(
@@ -145,6 +210,19 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       params: VulnerabilityProps,
       options?: OpenCspFindingAsChildOptions
     ): OpenFindingInSystemFlyoutHandle => {
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.cspVulnerability,
+          vulnerabilityId: params.vulnerabilityId,
+          resourceId: params.resourceId,
+          packageName: params.packageName,
+          packageVersion: params.packageVersion,
+          eventId: params.eventId,
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       const ref = open(
         <Vulnerability {...params} />,
         {
@@ -152,6 +230,7 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.INHERIT,
           title: options?.title ? buildFlyoutNavTitle(options.title) : undefined,
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
@@ -163,7 +242,14 @@ export const useCspFlyoutApi = (): CspFlyoutApi => {
       );
       return { close: () => ref.close(), onClose: ref.onClose };
     },
-    [open, defaultDocumentFlyoutProperties, historyKey]
+    [
+      open,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      readFirstDescriptor,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insights_section.tsx
@@ -11,7 +11,6 @@ import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useFlyoutApi } from '../../../use_flyout_api';
 import { type CellActionRenderer } from '../../../shared/components/cell_actions';
 import { EventKind } from '../constants/event_kinds';
-import { getColumns } from '../../tools/prevalence/utils/get_columns';
 import { useRuleWithFallback } from '../../../../detection_engine/rule_management/logic/use_rule_with_fallback';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 import { PREFIX } from '../../../../flyout/shared/test_ids';
@@ -21,9 +20,6 @@ import { ThreatIntelligenceOverview } from './threat_intelligence_overview';
 import { CorrelationsOverview } from './correlations_overview';
 import { PrevalenceOverview } from './prevalence_overview';
 import { EntitiesOverview } from './entities_overview';
-import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
-import type { OpenFlyoutLinkProps } from '../../../shared/components/open_flyout_link';
-import { OpenFlyoutLink } from '../../../shared/components/open_flyout_link';
 import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
 import { INSIGHTS_SECTION_TITLE } from '../../../shared/constants/flyout_titles';
 
@@ -52,7 +48,6 @@ export interface InsightsSectionProps {
  */
 export const InsightsSection = memo(
   ({ hit, renderCellActions, onAlertUpdated }: InsightsSectionProps) => {
-    const isInSecurityApp = useIsInSecurityApp();
     const {
       openDocumentFlyoutFromIndexAsChild,
       openDocumentEntities,
@@ -126,27 +121,15 @@ export const InsightsSection = memo(
       [openDocumentCorrelations, hit, onShowAlert, onShowAttack]
     );
 
-    const renderFlyoutLink = useCallback(
-      (props: OpenFlyoutLinkProps) => <OpenFlyoutLink {...props} />,
-      []
-    );
-
     const onShowPrevalenceDetails = useCallback(() => {
       openDocumentPrevalence({
         hit,
         investigationFields,
         scopeId: '',
-        columns: getColumns(renderCellActions, isInSecurityApp, '', renderFlyoutLink),
+        renderCellActions,
         origin: FLYOUT_ORIGIN.INSIGHTS_PREVALENCE,
       });
-    }, [
-      openDocumentPrevalence,
-      renderCellActions,
-      hit,
-      investigationFields,
-      isInSecurityApp,
-      renderFlyoutLink,
-    ]);
+    }, [openDocumentPrevalence, renderCellActions, hit, investigationFields]);
 
     return (
       <ExpandableSection

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/header.test.tsx
@@ -10,15 +10,25 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { Header } from './header';
-import { ALERT_SUMMARY_PANEL_TEST_ID } from '../../shared/components/test_ids';
+import {
+  ALERT_SUMMARY_PANEL_TEST_ID,
+  DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID,
+} from '../../shared/components/test_ids';
+import { useGetFlyoutLink } from '../../../flyout/document_details/right/hooks/use_get_flyout_link';
 
 jest.mock('../../../common/lib/kibana', () => ({
   useKibana: () => ({
     services: {
       application: {
-        getUrlForApp: jest.fn().mockReturnValue('https://example.com/rule/test-rule-id'),
+        getUrlForApp: jest.fn().mockReturnValue('/app/security/alerts/redirect/test-id'),
       },
     },
+  }),
+}));
+
+jest.mock('../../../common/lib/kibana/hooks', () => ({
+  useAppUrl: () => ({
+    getAppUrl: jest.fn(({ path }: { path: string }) => path),
   }),
 }));
 
@@ -72,6 +82,20 @@ jest.mock('./components/assignees', () => ({
   ),
 }));
 
+jest.mock('../../shared/components/share_url_icon_button', () => ({
+  ShareUrlIconButton: ({
+    url,
+    dataTestSubj,
+  }: {
+    url: string | null | undefined;
+    dataTestSubj: string;
+  }) => (url ? <button type="button" data-test-subj={dataTestSubj} /> : null),
+}));
+
+jest.mock('../../../flyout/document_details/right/hooks/use_get_flyout_link', () => ({
+  useGetFlyoutLink: jest.fn(),
+}));
+
 jest.mock('../../../common/components/formatted_date', () => ({
   PreferenceFormattedDate: ({ value }: { value: Date }) => (
     <div data-test-subj="mockPreferenceFormattedDate">{value.toISOString()}</div>
@@ -121,7 +145,12 @@ const renderHeader = (props: RenderHeaderProps) =>
     </IntlProvider>
   );
 
+const mockUseGetFlyoutLink = useGetFlyoutLink as jest.Mock;
+
 describe('<DocumentHeader />', () => {
+  beforeEach(() => {
+    mockUseGetFlyoutLink.mockReturnValue(null);
+  });
   it('should pass the hit to the severity component', () => {
     const { getByTestId } = renderHeader({ hit: alertHit });
 
@@ -202,5 +231,26 @@ describe('<DocumentHeader />', () => {
     const { queryByTestId } = renderHeader({ hit: eventHit });
 
     expect(queryByTestId(ALERT_SUMMARY_PANEL_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should render the share button for alerts when a link is available', () => {
+    mockUseGetFlyoutLink.mockReturnValue('https://example.com/alerts/redirect/test-id');
+    const { getByTestId } = renderHeader({ hit: alertHit });
+
+    expect(getByTestId(DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should not render the share button for alerts when link is null (e.g. preview index)', () => {
+    mockUseGetFlyoutLink.mockReturnValue(null);
+    const { queryByTestId } = renderHeader({ hit: alertHit });
+
+    expect(queryByTestId(DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should not render the share button for non-alert events', () => {
+    mockUseGetFlyoutLink.mockReturnValue('https://example.com/alerts/redirect/test-id');
+    const { queryByTestId } = renderHeader({ hit: eventHit });
+
+    expect(queryByTestId(DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/header.tsx
@@ -8,6 +8,8 @@
 import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
@@ -20,10 +22,31 @@ import { Notes } from '../../shared/components/notes';
 import { DocumentSeverity } from './components/severity';
 import { Timestamp } from '../../shared/components/timestamp';
 import { RiskScore } from './components/risk_score';
-import { ALERT_SUMMARY_PANEL_TEST_ID } from '../../shared/components/test_ids';
+import {
+  ALERT_SUMMARY_PANEL_TEST_ID,
+  DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID,
+} from '../../shared/components/test_ids';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { noopCellActionRenderer } from '../../shared/components/cell_actions';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
+import { ShareUrlIconButton } from '../../shared/components/share_url_icon_button';
+import { useGetFlyoutLink } from '../../../flyout/document_details/right/hooks/use_get_flyout_link';
+
+const SHARE_ALERT_LABEL = i18n.translate(
+  'xpack.securitySolution.flyoutV2.document.header.shareAlertLabel',
+  {
+    defaultMessage: 'Share alert',
+  }
+);
+
+// Positioned relative to the flyout itself (the nearest positioned ancestor), matching where EUI
+// places its own close button (`right: euiTheme.size.s` / `top: euiTheme.size.s`). The larger
+// inline-end offset makes room for the close button so the two sit side by side.
+const shareButtonStyles = css`
+  position: absolute;
+  inset-inline-end: 36px;
+  inset-block-start: 8px;
+`;
 
 export interface HeaderProps {
   /**
@@ -57,8 +80,22 @@ export const Header: FC<HeaderProps> = memo(
       [hit]
     );
 
+    const alertDetailsLink = useGetFlyoutLink({
+      eventId: hit.raw._id ?? '',
+      indexName: hit.raw._index ?? '',
+      timestamp: String(hit.flattened?.['@timestamp'] ?? ''),
+    });
+
     return (
       <>
+        <div css={shareButtonStyles}>
+          <ShareUrlIconButton
+            url={isAlert ? alertDetailsLink : null}
+            tooltip={SHARE_ALERT_LABEL}
+            ariaLabel={SHARE_ALERT_LABEL}
+            dataTestSubj={DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID}
+          />
+        </div>
         <DocumentSeverity hit={hit}>
           <EuiSpacer size="s" />
         </DocumentSeverity>
@@ -93,7 +130,7 @@ export const Header: FC<HeaderProps> = memo(
                 </EuiFlexGroup>
               </EuiFlexItem>
               <EuiFlexItem css={flyoutHeaderBlockStyles}>
-                <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
+                <EuiFlexGroup direction="row" gutterSize="s" responsive={false} alignItems="center">
                   <EuiFlexItem>
                     <Assignees hit={hit} onAlertUpdated={onAlertUpdated} />
                   </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.test.tsx
@@ -41,14 +41,28 @@ jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   defaultToolsFlyoutProperties: { size: 'm' },
 }));
 
+const mockWriteOnOpen = jest.fn();
+const mockBuildOnClose = jest.fn(() => jest.fn());
+jest.mock('../shared/url_state/flyout_v2_url_writer', () => ({
+  useFlyoutV2UrlWriter: jest.fn(() => ({
+    writeOnOpen: mockWriteOnOpen,
+    buildOnClose: mockBuildOnClose,
+  })),
+}));
+
 const mockOpenSystemFlyout = jest.fn();
 const mockReportEvent = jest.fn();
-const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+const hit = {
+  id: '1',
+  raw: { _id: 'doc-id', _index: 'doc-index' },
+  flattened: {},
+} as unknown as DataTableRecord;
 
 describe('useDocumentFlyoutApi', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOpenSystemFlyout.mockReturnValue({ onClose: Promise.resolve(), close: jest.fn() });
+    mockBuildOnClose.mockReturnValue(jest.fn());
     (useKibana as jest.Mock).mockReturnValue({
       services: {
         overlays: { openSystemFlyout: mockOpenSystemFlyout },
@@ -215,7 +229,6 @@ describe('useDocumentFlyoutApi', () => {
       hit,
       investigationFields: [],
       scopeId: '',
-      columns: [],
     });
 
     expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
@@ -234,11 +247,7 @@ describe('useDocumentFlyoutApi', () => {
     ['openDocumentThreatIntelligence', 'threat_intelligence', () => ({ hit })],
     ['openDocumentInvestigationGuide', 'investigation_guide', () => ({ hit })],
     ['openDocumentGraph', 'graph', () => ({ hit })],
-    [
-      'openDocumentPrevalence',
-      'prevalence',
-      () => ({ hit, investigationFields: [], scopeId: '', columns: [] }),
-    ],
+    ['openDocumentPrevalence', 'prevalence', () => ({ hit, investigationFields: [], scopeId: '' })],
   ] as const)('%s opens a tools flyout as a new session', (method, tool, buildParams) => {
     const { result } = renderHook(() => useDocumentFlyoutApi());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -282,7 +291,7 @@ describe('useDocumentFlyoutApi', () => {
       'openDocumentPrevalence',
       'prevalence',
       'insights_prevalence',
-      () => ({ hit, investigationFields: [], scopeId: '', columns: [] }),
+      () => ({ hit, investigationFields: [], scopeId: '' }),
     ],
   ] as const)('%s forwards the given origin', (method, tool, origin, buildParams) => {
     const { result } = renderHook(() => useDocumentFlyoutApi());
@@ -301,5 +310,125 @@ describe('useDocumentFlyoutApi', () => {
     result.current.openAnalyzer({ hit });
 
     expect(getProperties().historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+
+  describe('URL descriptor capture', () => {
+    it('openDocumentFlyoutFromIndex writes a document descriptor with null fallback', () => {
+      const { result } = renderHook(() => useDocumentFlyoutApi());
+      result.current.openDocumentFlyoutFromIndex({ documentId: 'doc-id', indexName: 'doc-index' });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith({
+        kind: 'document',
+        documentId: 'doc-id',
+        indexName: 'doc-index',
+      });
+      expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+      expect(getProperties().onClose).toBeDefined();
+    });
+
+    it('openDocumentFlyoutFromIndex uses empty string for undefined indexName', () => {
+      const { result } = renderHook(() => useDocumentFlyoutApi());
+      result.current.openDocumentFlyoutFromIndex({ documentId: 'doc-id', indexName: undefined });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'document', indexName: '' })
+      );
+    });
+
+    it('openDocumentFlyoutFromPattern writes a documentFromPattern descriptor with null fallback', () => {
+      const { result } = renderHook(() => useDocumentFlyoutApi());
+      result.current.openDocumentFlyoutFromPattern({ documentId: 'doc-id', indexName: 'logs-*' });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith({
+        kind: 'documentFromPattern',
+        documentId: 'doc-id',
+        indexName: 'logs-*',
+      });
+      expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+    });
+
+    it('openDocumentFlyoutFromIndexAsChild writes in inherit mode and uses parent as fallback', () => {
+      const { result } = renderHook(() => useDocumentFlyoutApi());
+      result.current.openDocumentFlyoutFromIndexAsChild({
+        documentId: 'doc-id',
+        indexName: 'doc-index',
+      });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(
+        { kind: 'document', documentId: 'doc-id', indexName: 'doc-index' },
+        'inherit'
+      );
+      // buildOnClose is called with the parent descriptor (null when URL has no prior state)
+      expect(mockBuildOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['openAnalyzer', 'analyzer', () => ({ hit })],
+      ['openSessionView', 'sessionView', () => ({ hit })],
+      ['openDocumentEntities', 'documentEntities', () => ({ hit })],
+      ['openDocumentResponse', 'documentResponse', () => ({ hit })],
+      ['openDocumentThreatIntelligence', 'documentThreatIntelligence', () => ({ hit })],
+      ['openDocumentInvestigationGuide', 'documentInvestigationGuide', () => ({ hit })],
+      ['openDocumentGraph', 'documentGraph', () => ({ hit })],
+    ] as const)(
+      '%s writes its descriptor and clears the param on close (session:start root)',
+      (method, expectedKind, buildParams) => {
+        const { result } = renderHook(() => useDocumentFlyoutApi());
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result.current[method] as (params: any) => void)(buildParams());
+
+        expect(mockWriteOnOpen).toHaveBeenCalledWith(
+          expect.objectContaining({
+            kind: expectedKind,
+            documentId: 'doc-id',
+            indexName: 'doc-index',
+          })
+        );
+        // A tool is a session:'start' root; closing it clears the param (no parent to revert to).
+        expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+        expect(getProperties().onClose).toBeDefined();
+      }
+    );
+
+    it('openDocumentCorrelations writes its descriptor and clears the param on close', () => {
+      const { result } = renderHook(() => useDocumentFlyoutApi());
+      result.current.openDocumentCorrelations({
+        hit,
+        scopeId: 'scope-1',
+        isRulePreview: false,
+        onShowAlert: jest.fn(),
+      });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'documentCorrelations',
+          documentId: 'doc-id',
+          indexName: 'doc-index',
+          scopeId: 'scope-1',
+          isRulePreview: false,
+        })
+      );
+      expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+    });
+
+    it('openDocumentPrevalence writes its descriptor (without columns, built internally) and clears the param on close', () => {
+      const { result } = renderHook(() => useDocumentFlyoutApi());
+      result.current.openDocumentPrevalence({
+        hit,
+        investigationFields: ['host.name'],
+        scopeId: 'scope-1',
+      });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'documentPrevalence',
+          documentId: 'doc-id',
+          indexName: 'doc-index',
+          scopeId: 'scope-1',
+          investigationFields: ['host.name'],
+        })
+      );
+      expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/use_document_flyout_api.tsx
@@ -5,11 +5,10 @@
  * 2.0.
  */
 
-import type { ReactNode } from 'react';
 import React, { lazy, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { noop } from 'lodash/fp';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import type { PrevalenceDetailsProps } from './tools/prevalence';
 import type { FlyoutOrigin } from '../../common/lib/telemetry';
 import {
   FLYOUT_SESSION_KIND,
@@ -17,8 +16,12 @@ import {
   FLYOUT_TOOL,
   FLYOUT_TYPE,
 } from '../../common/lib/telemetry';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { cellActionRenderer } from '../shared/components/cell_actions';
+import type { OpenFlyoutLinkProps } from '../shared/components/open_flyout_link';
+import { OpenFlyoutLink } from '../shared/components/open_flyout_link';
+import { getColumns } from './tools/prevalence/utils/get_columns';
 import {
   defaultToolsFlyoutProperties,
   useDefaultDocumentFlyoutProperties,
@@ -39,6 +42,22 @@ import {
 } from '../shared/constants/flyout_titles';
 import { getAlertHistoryTitle, getDocumentTitle } from './main/utils/get_header_title';
 import { useFlyoutSessionContext } from '../session_context';
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
+import {
+  decodeFlyoutV2UrlParam,
+  FLYOUT_DESCRIPTOR_KIND,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+
+/**
+ * Extracts the minimal identifying fields from a DataTableRecord for use in URL descriptors.
+ * Both `_id` and `_index` are always present on Elasticsearch hits.
+ */
+const documentIdsFromHit = (hit: DataTableRecord): { documentId: string; indexName: string } => ({
+  documentId: (hit.raw._id as string) ?? '',
+  indexName: (hit.raw._index as string) ?? '',
+});
 
 // Tools are lazy-loaded so consumers of this hook don't statically pull the whole document-flyout
 // tool graph into their bundle; the chunk only loads when a flyout is actually opened.
@@ -164,14 +183,23 @@ export interface OpenDocumentInvestigationGuideParams {
   origin?: FlyoutOrigin;
 }
 
-/**
- * Parameters for the prevalence tool. Mirrors the tool's own props (the caller builds `columns`),
- * plus the UI trigger that opened it.
- */
-export type OpenDocumentPrevalenceParams = PrevalenceDetailsProps & {
+export interface OpenDocumentPrevalenceParams {
+  /** Alert/event document to show prevalence for. */
+  hit: DataTableRecord;
+  /** List of investigation fields retrieved from the rule. */
+  investigationFields: string[];
+  /** Scope id, used for cell actions. */
+  scopeId: string;
+  /**
+   * Optional cell-action renderer override; defaults to the standard Security cell actions.
+   * The table `columns` themselves are built internally (not by the caller) so that this open
+   * method — and therefore the restore-from-URL path, which has no table-rendering context of
+   * its own — can be called with only serializable data.
+   */
+  renderCellActions?: CellActionRenderer;
   /** Which UI trigger opened the prevalence tool, when known. */
   origin?: FlyoutOrigin;
-};
+}
 
 export interface OpenDocumentGraphParams {
   /** The document to render the graph for. */
@@ -233,9 +261,30 @@ export interface DocumentFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const open = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
+  const isInSecurityApp = useIsInSecurityApp();
+
+  // Stable wrapper so prevalence's `columns` (built internally, see `openDocumentPrevalence`)
+  // don't depend on a fresh inline component identity every render.
+  const renderFlyoutLink = useCallback(
+    (props: OpenFlyoutLinkProps) => <OpenFlyoutLink {...props} />,
+    []
+  );
+
+  // Reads the first descriptor from the current URL stack without bumping the generation.
+  // Used by openDocumentFlyoutFromIndexAsChild to determine the parent descriptor (close fallback)
+  // before appending the child descriptor with writeOnOpen('inherit').
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
 
   // Builds the document flyout content (resolved from a concrete `_index`), shared by both the main
   // and child open methods. Only the `session` differs between them, so it is kept private here and
@@ -246,7 +295,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       indexName,
       renderCellActions = cellActionRenderer,
       onAlertUpdated = noop,
-    }: OpenDocumentFlyoutParams): ReactNode => (
+    }: OpenDocumentFlyoutParams) => (
       <DocumentFlyoutWrapper
         documentId={documentId}
         indexName={indexName}
@@ -259,6 +308,12 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
 
   const openDocumentFlyoutFromIndex = useCallback(
     (params: OpenDocumentFlyoutParams) => {
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.document,
+        documentId: params.documentId,
+        indexName: params.indexName ?? '',
+      });
+      const onClose = buildOnClose(null);
       open(
         buildFromIndexContent(params),
         {
@@ -266,6 +321,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: sessionMode,
           title: params.title,
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
@@ -275,11 +331,31 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         }
       );
     },
-    [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey, sessionMode]
+    [
+      open,
+      buildFromIndexContent,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      sessionMode,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openDocumentFlyoutFromIndexAsChild = useCallback(
     (params: OpenDocumentFlyoutParams) => {
+      // Read the parent descriptor from the URL before appending the child so we know what to
+      // restore to when the child closes (e.g. the analyzer that opened this document as a child).
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.document,
+          documentId: params.documentId,
+          indexName: params.indexName ?? '',
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         buildFromIndexContent(params),
         {
@@ -287,6 +363,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.INHERIT,
           title: buildFlyoutNavTitle(params.title ?? getAlertHistoryTitle()),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
@@ -297,7 +374,15 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, buildFromIndexContent, defaultDocumentFlyoutProperties, historyKey]
+    [
+      open,
+      buildFromIndexContent,
+      defaultDocumentFlyoutProperties,
+      historyKey,
+      readFirstDescriptor,
+      writeOnOpen,
+      buildOnClose,
+    ]
   );
 
   const openDocumentFlyoutFromPattern = useCallback(
@@ -308,6 +393,12 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       onAlertUpdated = noop,
       origin,
     }: OpenDocumentFlyoutParams) => {
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.documentFromPattern,
+        documentId,
+        indexName: indexName ?? '',
+      });
+      const onClose = buildOnClose(null);
       open(
         <DocumentFlyoutWrapperFromPattern
           documentId={documentId}
@@ -315,7 +406,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           renderCellActions={renderCellActions}
           onAlertUpdated={onAlertUpdated}
         />,
-        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode },
+        { ...defaultDocumentFlyoutProperties, historyKey, session: sessionMode, onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.DOCUMENT,
@@ -324,7 +415,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         }
       );
     },
-    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode]
+    [open, defaultDocumentFlyoutProperties, historyKey, sessionMode, writeOnOpen, buildOnClose]
   );
 
   const openAnalyzer = useCallback(
@@ -334,6 +425,12 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       onAlertUpdated = noop,
       origin,
     }: OpenAnalyzerParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.analyzer, documentId, indexName });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <AnalyzerGraph
           hit={hit}
@@ -345,6 +442,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(ANALYZER_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -356,7 +454,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openSessionView = useCallback(
@@ -368,6 +466,18 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       onAlertUpdated = noop,
       origin,
     }: OpenSessionViewParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.sessionView,
+        documentId,
+        indexName,
+        jumpToCursor,
+        jumpToEntityId,
+      });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <SessionView
           hit={hit}
@@ -381,6 +491,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(SESSION_VIEW_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -392,11 +503,22 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentEntities = useCallback(
     ({ hit, scopeId, origin }: OpenDocumentEntitiesParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.documentEntities,
+        documentId,
+        indexName,
+        scopeId,
+      });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <EntityDetails hit={hit} scopeId={scopeId} />,
         {
@@ -404,6 +526,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(ENTITIES_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -415,7 +538,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentCorrelations = useCallback(
@@ -427,6 +550,18 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       onShowAttack,
       origin,
     }: OpenDocumentCorrelationsParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.documentCorrelations,
+        documentId,
+        indexName,
+        scopeId,
+        isRulePreview,
+      });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <CorrelationsDetails
           hit={hit}
@@ -440,6 +575,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(CORRELATIONS_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -451,11 +587,17 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentResponse = useCallback(
     ({ hit, origin }: OpenDocumentResponseParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.documentResponse, documentId, indexName });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <ResponseDetails hit={hit} />,
         {
@@ -463,6 +605,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(RESPONSE_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -474,11 +617,21 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentThreatIntelligence = useCallback(
     ({ hit, origin }: OpenDocumentThreatIntelligenceParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.documentThreatIntelligence,
+        documentId,
+        indexName,
+      });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <ThreatIntelligenceDetails hit={hit} />,
         {
@@ -486,6 +639,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(THREAT_INTELLIGENCE_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -497,11 +651,38 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentPrevalence = useCallback(
-    ({ hit, investigationFields, scopeId, columns, origin }: OpenDocumentPrevalenceParams) => {
+    ({
+      hit,
+      investigationFields,
+      scopeId,
+      renderCellActions: renderCellActionsOverride = cellActionRenderer,
+      origin,
+    }: OpenDocumentPrevalenceParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.documentPrevalence,
+        documentId,
+        indexName,
+        scopeId,
+        investigationFields,
+      });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
+      // `columns` is built here (rather than accepted from the caller) so this method only needs
+      // serializable data — that lets the restore-from-URL path reopen the tool directly instead
+      // of falling back to the document main flyout.
+      const columns = getColumns(
+        renderCellActionsOverride,
+        isInSecurityApp,
+        scopeId,
+        renderFlyoutLink
+      );
       open(
         <PrevalenceDetails
           hit={hit}
@@ -514,6 +695,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(PREVALENCE_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -525,11 +707,21 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose, isInSecurityApp, renderFlyoutLink]
   );
 
   const openDocumentInvestigationGuide = useCallback(
     ({ hit, origin }: OpenDocumentInvestigationGuideParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.documentInvestigationGuide,
+        documentId,
+        indexName,
+      });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <InvestigationGuide hit={hit} />,
         {
@@ -537,6 +729,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(INVESTIGATION_GUIDE_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -548,7 +741,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   const openDocumentGraph = useCallback(
@@ -558,6 +751,12 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
       onAlertUpdated = noop,
       origin,
     }: OpenDocumentGraphParams) => {
+      const { documentId, indexName } = documentIdsFromHit(hit);
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.documentGraph, documentId, indexName });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <GraphDetails
           hit={hit}
@@ -569,6 +768,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(GRAPH_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -580,7 +780,7 @@ export const useDocumentFlyoutApi = (): DocumentFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.test.tsx
@@ -14,6 +14,7 @@ import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { documentFlyoutHistoryKey } from '../shared/constants/flyout_history';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
+import { FLYOUT_DESCRIPTOR_KIND } from '../shared/url_state/flyout_v2_url_param';
 
 jest.mock('../shared/utils/build_flyout_nav_title', () => ({
   buildFlyoutNavTitle: jest.fn((title: string) => `NAV:${title}`),
@@ -37,13 +38,25 @@ jest.mock('../shared/hooks/use_default_flyout_properties', () => ({
   defaultToolsFlyoutProperties: { size: 'm' },
 }));
 
+const mockWriteOnOpen = jest.fn();
+const mockBuildOnClose = jest.fn(() => jest.fn());
+jest.mock('../shared/url_state/flyout_v2_url_writer', () => ({
+  useFlyoutV2UrlWriter: jest.fn(() => ({
+    writeOnOpen: mockWriteOnOpen,
+    buildOnClose: mockBuildOnClose,
+  })),
+}));
+
 const mockOpenSystemFlyout = jest.fn();
 const mockReportEvent = jest.fn();
+
+const managedUser = { _id: 'managed-user-id', _index: 'managed-user-index' };
 
 describe('useEntityFlyoutApi', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOpenSystemFlyout.mockReturnValue({ onClose: Promise.resolve(), close: jest.fn() });
+    mockBuildOnClose.mockReturnValue(jest.fn());
     (useKibana as jest.Mock).mockReturnValue({
       services: {
         overlays: { openSystemFlyout: mockOpenSystemFlyout },
@@ -78,6 +91,19 @@ describe('useEntityFlyoutApi', () => {
     expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('My Custom Host');
   });
 
+  it('openHostFlyout writes a host descriptor to the URL', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openHostFlyout({ hostName: 'host-1', entityId: 'entity-1', scopeId: 'scope-1' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.host,
+      hostName: 'host-1',
+      entityId: 'entity-1',
+      scopeId: 'scope-1',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
   it('openHostFlyoutAsChild opens a system flyout that inherits the current session', () => {
     const { result } = renderHook(() => useEntityFlyoutApi());
     result.current.openHostFlyoutAsChild({ hostName: 'host-1' });
@@ -101,6 +127,23 @@ describe('useEntityFlyoutApi', () => {
     expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('NAV:Host: host-1');
   });
 
+  it('openHostFlyoutAsChild writes a host descriptor in inherit mode', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openHostFlyoutAsChild({ hostName: 'host-1', entityId: 'entity-1' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith(
+      {
+        kind: FLYOUT_DESCRIPTOR_KIND.host,
+        hostName: 'host-1',
+        entityId: 'entity-1',
+        scopeId: undefined,
+      },
+      'inherit'
+    );
+    // readFirstDescriptor returns null (history has no location in tests)
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
   it('openUserFlyout opens a system flyout as a new session with the document properties', () => {
     const { result } = renderHook(() => useEntityFlyoutApi());
     result.current.openUserFlyout({ userName: 'user-1' });
@@ -118,6 +161,19 @@ describe('useEntityFlyoutApi', () => {
     expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('User: user-1');
   });
 
+  it('openUserFlyout writes a user descriptor to the URL', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openUserFlyout({ userName: 'user-1', entityId: 'entity-2' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.user,
+      userName: 'user-1',
+      entityId: 'entity-2',
+      scopeId: undefined,
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
   it('openUserFlyoutAsChild opens a system flyout that inherits the current session', () => {
     const { result } = renderHook(() => useEntityFlyoutApi());
     result.current.openUserFlyoutAsChild({ userName: 'user-1' });
@@ -131,6 +187,32 @@ describe('useEntityFlyoutApi', () => {
 
     expect(buildFlyoutNavTitle).toHaveBeenCalledWith('User: user-1');
     expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('NAV:User: user-1');
+  });
+
+  it('openServiceFlyout writes a service descriptor to the URL', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openServiceFlyout({ serviceName: 'svc-1', entityId: 'entity-3' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.service,
+      serviceName: 'svc-1',
+      entityId: 'entity-3',
+      scopeId: undefined,
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openGenericEntityFlyout writes a genericEntity descriptor to the URL', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openGenericEntityFlyout({ entityId: 'generic-1', scopeId: 'scope-1' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.genericEntity,
+      scopeId: 'scope-1',
+      entityId: 'generic-1',
+      entityDocId: undefined,
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
   });
 
   it('openEntityDetailsAsChild opens the matching entity flyout that inherits the current session', () => {
@@ -174,6 +256,30 @@ describe('useEntityFlyoutApi', () => {
   });
 
   it.each([
+    ['host', FLYOUT_DESCRIPTOR_KIND.host],
+    ['user', FLYOUT_DESCRIPTOR_KIND.user],
+    ['service', FLYOUT_DESCRIPTOR_KIND.service],
+    ['unknown', FLYOUT_DESCRIPTOR_KIND.genericEntity],
+  ] as const)(
+    'openEntityDetailsAsChild writes a %s descriptor in inherit mode',
+    (engineType, expectedKind) => {
+      const { result } = renderHook(() => useEntityFlyoutApi());
+      result.current.openEntityDetailsAsChild({
+        engineType,
+        entityId: 'entity-1',
+        entityName: 'name-1',
+        scopeId: 'scope-1',
+      });
+
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: expectedKind }),
+        'inherit'
+      );
+      expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+    }
+  );
+
+  it.each([
     'openEntityRiskInputs',
     'openEntityAnomalyInsights',
     'openEntityAlertsInsights',
@@ -197,7 +303,7 @@ describe('useEntityFlyoutApi', () => {
       entityId: 'entity-1',
       scopeId: '',
       document: {},
-      managedUser: {},
+      managedUser,
     });
 
     expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
@@ -229,6 +335,133 @@ describe('useEntityFlyoutApi', () => {
     result.current.openEntityRiskInputs({ entityType: EntityType.host, entityName: 'my-host' });
 
     expect(mockOpenSystemFlyout.mock.calls[0][1].title).toBe('Risk score: my-host');
+  });
+
+  it('openEntityRiskInputs writes an entityRiskInputs descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityRiskInputs({
+      entityType: EntityType.host,
+      entityName: 'my-host',
+      entityId: 'e-1',
+    });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityRiskInputs,
+      entityType: 'host',
+      entityName: 'my-host',
+      entityId: 'e-1',
+    });
+    // A tool is a session:'start' root; closing it clears the param (no parent to revert to).
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityAnomalyInsights writes an entityAnomalyInsights descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityAnomalyInsights({
+      entityType: EntityType.user,
+      value: 'user-1',
+      entityId: 'e-2',
+    });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityAnomalyInsights,
+      entityType: 'user',
+      value: 'user-1',
+      entityId: 'e-2',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityAlertsInsights writes null fallback for generic entity (no scopeId available)', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityAlertsInsights({
+      entityType: EntityType.generic,
+      value: 'generic-entity-id',
+      entityId: 'e-3',
+    });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityAlertsInsights,
+      entityType: 'generic',
+      value: 'generic-entity-id',
+      entityId: 'e-3',
+    });
+    // Generic entity lacks scopeId in tool params, so fallback is null
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityGraphView writes an entityGraphView descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityGraphView({
+      entityId: 'entity-1',
+      scopeId: 'scope-1',
+      entityName: 'entity-name',
+      onShowEntity: jest.fn(),
+    });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityGraphView,
+      entityId: 'entity-1',
+      scopeId: 'scope-1',
+      entityName: 'entity-name',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityResolution writes an entityResolution descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityResolution({
+      entityId: 'entity-1',
+      entityType: EntityType.service,
+      entityName: 'svc-1',
+      scopeId: 'scope-1',
+    });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityResolution,
+      entityId: 'entity-1',
+      entityType: 'service',
+      entityName: 'svc-1',
+      scopeId: 'scope-1',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityEntraInsights writes an entityEntraInsights descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityEntraInsights({ managedUser, value: 'user@example.com' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityEntraInsights,
+      managedUserId: 'managed-user-id',
+      managedUserIndex: 'managed-user-index',
+      value: 'user@example.com',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityOktaInsights writes an entityOktaInsights descriptor and clears the param on close', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityOktaInsights({ managedUser, value: 'user@example.com' });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.entityOktaInsights,
+      managedUserId: 'managed-user-id',
+      managedUserIndex: 'managed-user-index',
+      value: 'user@example.com',
+    });
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+  });
+
+  it('openEntityFieldsTable does not write a descriptor (intentionally not wired for URL sync)', () => {
+    const { result } = renderHook(() => useEntityFlyoutApi());
+    result.current.openEntityFieldsTable({
+      document: { 'host.name': 'host-1' },
+      entityName: 'host-1',
+    });
+
+    expect(mockWriteOnOpen).not.toHaveBeenCalled();
+    expect(mockBuildOnClose).not.toHaveBeenCalled();
   });
 
   it('uses the doc-viewer history key when outside the security app', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -7,7 +7,7 @@
 
 import type { ReactNode } from 'react';
 import React, { lazy, useCallback, useMemo } from 'react';
-import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import { useHistory } from 'react-router-dom';
 import type { FlyoutOrigin, FlyoutType } from '../../common/lib/telemetry';
 import {
   FLYOUT_SESSION_KIND,
@@ -53,6 +53,13 @@ import type { AnomalyInsightsProps } from './shared/tools/anomaly_insights';
 import type { FieldsTableToolProps } from './shared/tools/fields_table';
 import type { ResolutionProps } from './shared/tools/resolution';
 import type { GraphViewProps } from './shared/tools/graph_view'; // Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import {
+  FLYOUT_DESCRIPTOR_KIND,
+  decodeFlyoutV2UrlParam,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
 // bundle; each chunk only loads when the corresponding flyout is actually opened.
@@ -199,14 +206,27 @@ export interface EntityFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useEntityFlyoutApi = (): EntityFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const open = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
+
+  // Reads the first descriptor from the current URL stack without bumping the generation.
+  // Used by ...AsChild openers and openEntityDetailsAsChild to get the parent descriptor
+  // (close fallback) before appending the child descriptor with writeOnOpen('inherit').
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
 
   // The entity flyouts differ only in their base properties (document vs tools size) and session;
   // both are kept private here so callers never reason about them — they pick the method they want.
   const mainProperties = useCallback(
-    (session = sessionMode, title?: string): OverlaySystemFlyoutOpenOptions => ({
+    (session = sessionMode, title?: string) => ({
       ...defaultDocumentFlyoutProperties,
       historyKey,
       session,
@@ -216,7 +236,7 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   );
 
   const toolProperties = useCallback(
-    (title?: string): OverlaySystemFlyoutOpenOptions => ({
+    (title?: string) => ({
       ...defaultToolsFlyoutProperties,
       historyKey,
       session: FLYOUT_SESSION_KIND.START,
@@ -229,21 +249,43 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   const openHostFlyout = useCallback(
     ({ title, origin, ...props }: OpenHostFlyoutParams) => {
       const flyoutTitle = title ?? formatFlyoutTitle(HOST_TITLE, props.hostName);
-      open(<Host {...props} />, mainProperties(undefined, flyoutTitle), {
-        surface: FLYOUT_SURFACE.FLYOUT,
-        flyoutType: FLYOUT_TYPE.HOST,
-        session: sessionMode,
-        origin,
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.host,
+        hostName: props.hostName,
+        entityId: props.entityId,
+        scopeId: props.scopeId,
       });
+      const onClose = buildOnClose(null);
+      open(
+        <Host {...props} />,
+        { ...mainProperties(undefined, flyoutTitle), onClose },
+        {
+          surface: FLYOUT_SURFACE.FLYOUT,
+          flyoutType: FLYOUT_TYPE.HOST,
+          session: sessionMode,
+          origin,
+        }
+      );
     },
-    [open, mainProperties, sessionMode]
+    [open, mainProperties, sessionMode, writeOnOpen, buildOnClose]
   );
   const openHostFlyoutAsChild = useCallback(
     ({ title, origin, ...props }: OpenHostFlyoutParams) => {
       const childTitle = title ?? formatFlyoutTitle(HOST_TITLE, props.hostName);
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.host,
+          hostName: props.hostName,
+          entityId: props.entityId,
+          scopeId: props.scopeId,
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <Host {...props} />,
-        mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.HOST,
@@ -253,26 +295,48 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, mainProperties]
+    [open, mainProperties, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
   const openUserFlyout = useCallback(
     ({ title, origin, ...props }: OpenUserFlyoutParams) => {
       const flyoutTitle = title ?? formatFlyoutTitle(USER_TITLE, props.userName);
-      open(<User {...props} />, mainProperties(undefined, flyoutTitle), {
-        surface: FLYOUT_SURFACE.FLYOUT,
-        flyoutType: FLYOUT_TYPE.USER,
-        session: sessionMode,
-        origin,
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.user,
+        userName: props.userName,
+        entityId: props.entityId,
+        scopeId: props.scopeId,
       });
+      const onClose = buildOnClose(null);
+      open(
+        <User {...props} />,
+        { ...mainProperties(undefined, flyoutTitle), onClose },
+        {
+          surface: FLYOUT_SURFACE.FLYOUT,
+          flyoutType: FLYOUT_TYPE.USER,
+          session: sessionMode,
+          origin,
+        }
+      );
     },
-    [open, mainProperties, sessionMode]
+    [open, mainProperties, sessionMode, writeOnOpen, buildOnClose]
   );
   const openUserFlyoutAsChild = useCallback(
     ({ title, origin, ...props }: OpenUserFlyoutParams) => {
       const childTitle = title ?? formatFlyoutTitle(USER_TITLE, props.userName);
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.user,
+          userName: props.userName,
+          entityId: props.entityId,
+          scopeId: props.scopeId,
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <User {...props} />,
-        mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.USER,
@@ -282,26 +346,48 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, mainProperties]
+    [open, mainProperties, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
   const openServiceFlyout = useCallback(
     ({ title, origin, ...props }: OpenServiceFlyoutParams) => {
       const flyoutTitle = title ?? formatFlyoutTitle(SERVICE_TITLE, props.serviceName);
-      open(<Service {...props} />, mainProperties(undefined, flyoutTitle), {
-        surface: FLYOUT_SURFACE.FLYOUT,
-        flyoutType: FLYOUT_TYPE.SERVICE,
-        session: sessionMode,
-        origin,
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.service,
+        serviceName: props.serviceName,
+        entityId: props.entityId,
+        scopeId: props.scopeId,
       });
+      const onClose = buildOnClose(null);
+      open(
+        <Service {...props} />,
+        { ...mainProperties(undefined, flyoutTitle), onClose },
+        {
+          surface: FLYOUT_SURFACE.FLYOUT,
+          flyoutType: FLYOUT_TYPE.SERVICE,
+          session: sessionMode,
+          origin,
+        }
+      );
     },
-    [open, mainProperties, sessionMode]
+    [open, mainProperties, sessionMode, writeOnOpen, buildOnClose]
   );
   const openServiceFlyoutAsChild = useCallback(
     ({ title, origin, ...props }: OpenServiceFlyoutParams) => {
       const childTitle = title ?? formatFlyoutTitle(SERVICE_TITLE, props.serviceName);
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.service,
+          serviceName: props.serviceName,
+          entityId: props.entityId,
+          scopeId: props.scopeId,
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <Service {...props} />,
-        mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.SERVICE,
@@ -311,26 +397,53 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, mainProperties]
+    [open, mainProperties, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
   const openGenericEntityFlyout = useCallback(
     ({ title, origin, ...props }: OpenGenericEntityFlyoutParams) => {
       const flyoutTitle = title ?? GENERIC_ENTITY_TITLE;
-      open(<GenericEntity {...props} />, mainProperties(undefined, flyoutTitle), {
-        surface: FLYOUT_SURFACE.FLYOUT,
-        flyoutType: FLYOUT_TYPE.GENERIC,
-        session: sessionMode,
-        origin,
+      // GenericEntityProps is a union type; extract entityId/entityDocId safely.
+      const entityId = (props as { entityId?: string }).entityId;
+      const entityDocId = (props as { entityDocId?: string }).entityDocId;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.genericEntity,
+        scopeId: props.scopeId,
+        entityId,
+        entityDocId,
       });
+      const onClose = buildOnClose(null);
+      open(
+        <GenericEntity {...props} />,
+        { ...mainProperties(undefined, flyoutTitle), onClose },
+        {
+          surface: FLYOUT_SURFACE.FLYOUT,
+          flyoutType: FLYOUT_TYPE.GENERIC,
+          session: sessionMode,
+          origin,
+        }
+      );
     },
-    [open, mainProperties, sessionMode]
+    [open, mainProperties, sessionMode, writeOnOpen, buildOnClose]
   );
   const openGenericEntityFlyoutAsChild = useCallback(
     ({ title, origin, ...props }: OpenGenericEntityFlyoutParams) => {
       const childTitle = title ?? GENERIC_ENTITY_TITLE;
+      const entityId = (props as { entityId?: string }).entityId;
+      const entityDocId = (props as { entityDocId?: string }).entityDocId;
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.genericEntity,
+          scopeId: props.scopeId,
+          entityId,
+          entityDocId,
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <GenericEntity {...props} />,
-        mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.GENERIC,
@@ -340,31 +453,43 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, mainProperties]
+    [open, mainProperties, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
 
   const openEntityDetailsAsChild = useCallback(
     ({ engineType, entityId, entityName, scopeId, title, origin }: OpenEntityDetailsParams) => {
       let children: ReactNode;
+      let descriptor: FlyoutDescriptor;
       switch (engineType) {
         case 'host':
           children = <Host hostName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />;
+          descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.host, hostName: entityName ?? '', entityId };
           break;
         case 'user':
           children = <User userName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />;
+          descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.user, userName: entityName ?? '', entityId };
           break;
         case 'service':
           children = (
             <Service serviceName={entityName ?? ''} entityId={entityId} scopeId={scopeId} />
           );
+          descriptor = {
+            kind: FLYOUT_DESCRIPTOR_KIND.service,
+            serviceName: entityName ?? '',
+            entityId,
+          };
           break;
         default:
           children = <GenericEntity entityId={entityId} scopeId={scopeId} />;
+          descriptor = { kind: FLYOUT_DESCRIPTOR_KIND.genericEntity, entityId, scopeId };
       }
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(descriptor, 'inherit');
+      const onClose = buildOnClose(parentDescriptor);
       const childTitle = title ?? entityName ?? entityId;
       open(
         children,
-        mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType:
@@ -377,95 +502,151 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, mainProperties]
+    [open, mainProperties, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
 
   // Entity tool flyouts.
   const openEntityRiskInputs = useCallback(
-    ({ title, origin, ...props }: OpenEntityRiskInputsParams) =>
+    ({ title, origin, ...props }: OpenEntityRiskInputsParams) => {
+      const { entityType, entityName, entityId } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityRiskInputs,
+        entityType: entityType as string,
+        entityName,
+        entityId,
+      });
+      // Entity tools open session:'start' (roots): the entity main is not persisted alongside the
+      // tool, so closing the tool clears the param rather than reverting to the entity.
+      const onClose = buildOnClose(null);
       open(
         <RiskInputs {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(RISK_INPUTS_TITLE, props.entityName)),
+        { ...toolProperties(title ?? formatFlyoutTitle(RISK_INPUTS_TITLE, entityName)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.RISK_INPUTS,
-          flyoutType: props.entityType,
+          flyoutType: entityType,
           session: FLYOUT_SESSION_KIND.START,
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityAnomalyInsights = useCallback(
-    ({ title, origin, ...props }: OpenEntityAnomalyInsightsParams) =>
+    ({ title, origin, ...props }: OpenEntityAnomalyInsightsParams) => {
+      const { entityType, value, entityId } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityAnomalyInsights,
+        entityType: entityType as string,
+        value,
+        entityId,
+      });
+      const onClose = buildOnClose(null);
       open(
         <AnomalyInsights {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(ANOMALY_INSIGHTS_TITLE, props.value)),
+        { ...toolProperties(title ?? formatFlyoutTitle(ANOMALY_INSIGHTS_TITLE, value)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.ANOMALY_INSIGHTS,
-          flyoutType: props.entityType,
+          flyoutType: entityType,
           session: FLYOUT_SESSION_KIND.START,
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityAlertsInsights = useCallback(
-    ({ title, origin, ...props }: OpenEntityAlertsInsightsParams) =>
+    ({ title, origin, ...props }: OpenEntityAlertsInsightsParams) => {
+      const { entityType, value, entityId } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityAlertsInsights,
+        entityType: entityType as string,
+        value,
+        entityId,
+      });
+      const onClose = buildOnClose(null);
       open(
         <AlertsInsights {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(ALERTS_INSIGHTS_TITLE, props.value)),
+        { ...toolProperties(title ?? formatFlyoutTitle(ALERTS_INSIGHTS_TITLE, value)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.ALERTS_INSIGHTS,
-          flyoutType: props.entityType,
+          flyoutType: entityType,
           session: FLYOUT_SESSION_KIND.START,
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityMisconfigurationInsights = useCallback(
-    ({ title, origin, ...props }: OpenEntityMisconfigurationInsightsParams) =>
+    ({ title, origin, ...props }: OpenEntityMisconfigurationInsightsParams) => {
+      const { entityType, value, entityId } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityMisconfigurationInsights,
+        entityType: entityType as string,
+        value,
+        entityId,
+      });
+      const onClose = buildOnClose(null);
       open(
         <MisconfigurationInsights {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(MISCONFIGURATION_INSIGHTS_TITLE, props.value)),
+        {
+          ...toolProperties(title ?? formatFlyoutTitle(MISCONFIGURATION_INSIGHTS_TITLE, value)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.MISCONFIGURATION_INSIGHTS,
-          flyoutType: props.entityType,
+          flyoutType: entityType,
           session: FLYOUT_SESSION_KIND.START,
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityVulnerabilityInsights = useCallback(
-    ({ title, origin, ...props }: OpenEntityVulnerabilityInsightsParams) =>
+    ({ title, origin, ...props }: OpenEntityVulnerabilityInsightsParams) => {
+      const { value, entityId, entityType } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityVulnerabilityInsights,
+        value,
+        entityId,
+        entityType: entityType as string | undefined,
+      });
+      const onClose = buildOnClose(null);
       open(
         <VulnerabilityInsights {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(VULNERABILITY_INSIGHTS_TITLE, props.value)),
+        {
+          ...toolProperties(title ?? formatFlyoutTitle(VULNERABILITY_INSIGHTS_TITLE, value)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.VULNERABILITY_INSIGHTS,
-          flyoutType: props.entityType ?? FLYOUT_TYPE.HOST,
+          flyoutType: entityType ?? FLYOUT_TYPE.HOST,
           session: FLYOUT_SESSION_KIND.START,
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityGraphView = useCallback(
-    ({ title, origin, flyoutType, ...props }: OpenEntityGraphViewParams) =>
+    ({ title, origin, flyoutType, ...props }: OpenEntityGraphViewParams) => {
+      const { entityId, scopeId, entityName } = props;
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.entityGraphView, entityId, scopeId, entityName });
+      const onClose = buildOnClose(null);
       open(
         <GraphView {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(ENTITY_GRAPH_VIEW_TITLE, props.entityName)),
+        { ...toolProperties(title ?? formatFlyoutTitle(ENTITY_GRAPH_VIEW_TITLE, entityName)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.GRAPH_VIEW,
@@ -474,30 +655,49 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityResolution = useCallback(
-    ({ title, origin, ...props }: OpenEntityResolutionParams) =>
+    ({ title, origin, ...props }: OpenEntityResolutionParams) => {
+      const { entityId, entityType, entityName, scopeId } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityResolution,
+        entityId,
+        entityType: entityType as string,
+        entityName,
+        scopeId,
+      });
+      const onClose = buildOnClose(null);
       open(
         <Resolution {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(RESOLUTION_TITLE, props.entityName)),
+        { ...toolProperties(title ?? formatFlyoutTitle(RESOLUTION_TITLE, entityName)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.RESOLUTION,
-          flyoutType: props.entityType,
+          flyoutType: entityType,
           session: FLYOUT_SESSION_KIND.START,
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityEntraInsights = useCallback(
-    ({ title, origin, ...props }: OpenEntityEntraInsightsParams) =>
+    ({ title, origin, ...props }: OpenEntityEntraInsightsParams) => {
+      const { managedUser, value } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityEntraInsights,
+        managedUserId: managedUser._id,
+        managedUserIndex: managedUser._index,
+        value,
+      });
+      const onClose = buildOnClose(null);
       open(
         <EntraInsights {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(ENTRA_INSIGHTS_TITLE, props.value)),
+        { ...toolProperties(title ?? formatFlyoutTitle(ENTRA_INSIGHTS_TITLE, value)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.ENTRA_INSIGHTS,
@@ -506,14 +706,23 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityOktaInsights = useCallback(
-    ({ title, origin, ...props }: OpenEntityOktaInsightsParams) =>
+    ({ title, origin, ...props }: OpenEntityOktaInsightsParams) => {
+      const { managedUser, value } = props;
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityOktaInsights,
+        managedUserId: managedUser._id,
+        managedUserIndex: managedUser._index,
+        value,
+      });
+      const onClose = buildOnClose(null);
       open(
         <OktaInsights {...props} />,
-        toolProperties(title ?? formatFlyoutTitle(OKTA_INSIGHTS_TITLE, props.value)),
+        { ...toolProperties(title ?? formatFlyoutTitle(OKTA_INSIGHTS_TITLE, value)), onClose },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.OKTA_INSIGHTS,
@@ -522,11 +731,15 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
           origin,
         },
         FLYOUT_SESSION_KIND.INHERIT
-      ),
-    [open, toolProperties]
+      );
+    },
+    [open, toolProperties, writeOnOpen, buildOnClose]
   );
   const openEntityFieldsTable = useCallback(
     ({ title, origin, ...props }: OpenEntityFieldsTableParams) =>
+      // openEntityFieldsTable is intentionally not wired for URL sync: its `document` prop is a
+      // full flattened entity record (Record<string, unknown>) that is not cheaply URL-serializable.
+      // On refresh the parent entity main flyout restores instead (see flyout_v2_url_param.ts).
       open(
         <FieldsTableTool {...props} />,
         toolProperties(title ?? formatFlyoutTitle(FIELDS_TABLE_TITLE, props.entityName)),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -285,7 +285,10 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       const onClose = buildOnClose(parentDescriptor);
       open(
         <Host {...props} />,
-        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
+        {
+          ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.HOST,
@@ -336,7 +339,10 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       const onClose = buildOnClose(parentDescriptor);
       open(
         <User {...props} />,
-        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
+        {
+          ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.USER,
@@ -387,7 +393,10 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       const onClose = buildOnClose(parentDescriptor);
       open(
         <Service {...props} />,
-        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
+        {
+          ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.SERVICE,
@@ -443,7 +452,10 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       const onClose = buildOnClose(parentDescriptor);
       open(
         <GenericEntity {...props} />,
-        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
+        {
+          ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType: FLYOUT_TYPE.GENERIC,
@@ -489,7 +501,10 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       const childTitle = title ?? entityName ?? entityId;
       open(
         children,
-        { ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)), onClose },
+        {
+          ...mainProperties(FLYOUT_SESSION_KIND.INHERIT, buildFlyoutNavTitle(childTitle)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.FLYOUT,
           flyoutType:
@@ -646,7 +661,10 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
       const onClose = buildOnClose(null);
       open(
         <GraphView {...props} />,
-        { ...toolProperties(title ?? formatFlyoutTitle(ENTITY_GRAPH_VIEW_TITLE, entityName)), onClose },
+        {
+          ...toolProperties(title ?? formatFlyoutTitle(ENTITY_GRAPH_VIEW_TITLE, entityName)),
+          onClose,
+        },
         {
           surface: FLYOUT_SURFACE.TOOL,
           tool: FLYOUT_TOOL.GRAPH_VIEW,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/use_entity_flyout_api.tsx
@@ -21,21 +21,21 @@ import {
 } from '../shared/hooks/use_default_flyout_properties';
 import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import {
+  ALERTS_INSIGHTS_TITLE,
+  ANOMALY_INSIGHTS_TITLE,
+  ENTITY_GRAPH_VIEW_TITLE,
+  ENTRA_INSIGHTS_TITLE,
+  FIELDS_TABLE_TITLE,
   formatFlyoutTitle,
   GENERIC_ENTITY_TITLE,
   HOST_TITLE,
+  MISCONFIGURATION_INSIGHTS_TITLE,
+  OKTA_INSIGHTS_TITLE,
+  RESOLUTION_TITLE,
+  RISK_INPUTS_TITLE,
   SERVICE_TITLE,
   USER_TITLE,
-  RISK_INPUTS_TITLE,
-  ANOMALY_INSIGHTS_TITLE,
-  ALERTS_INSIGHTS_TITLE,
-  MISCONFIGURATION_INSIGHTS_TITLE,
   VULNERABILITY_INSIGHTS_TITLE,
-  ENTITY_GRAPH_VIEW_TITLE,
-  RESOLUTION_TITLE,
-  ENTRA_INSIGHTS_TITLE,
-  OKTA_INSIGHTS_TITLE,
-  FIELDS_TABLE_TITLE,
 } from '../shared/constants/flyout_titles';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import { useFlyoutSessionContext } from '../session_context';
@@ -54,12 +54,12 @@ import type { FieldsTableToolProps } from './shared/tools/fields_table';
 import type { ResolutionProps } from './shared/tools/resolution';
 import type { GraphViewProps } from './shared/tools/graph_view'; // Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
 import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 import {
-  FLYOUT_DESCRIPTOR_KIND,
   decodeFlyoutV2UrlParam,
+  FLYOUT_DESCRIPTOR_KIND,
   urlParamKeyForHistoryKey,
 } from '../shared/url_state/flyout_v2_url_param';
-import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the entity flyout graph into their
 // bundle; each chunk only loads when the corresponding flyout is actually opened.
@@ -657,7 +657,13 @@ export const useEntityFlyoutApi = (): EntityFlyoutApi => {
   const openEntityGraphView = useCallback(
     ({ title, origin, flyoutType, ...props }: OpenEntityGraphViewParams) => {
       const { entityId, scopeId, entityName } = props;
-      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.entityGraphView, entityId, scopeId, entityName });
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.entityGraphView,
+        entityId,
+        scopeId,
+        entityName,
+        entityType: flyoutType as string | undefined,
+      });
       const onClose = buildOnClose(null);
       open(
         <GraphView {...props} />,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.test.tsx
@@ -6,6 +6,8 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import { useHistory } from 'react-router-dom';
+import { decode } from '@kbn/rison';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import type { Indicator } from '../../../common/threat_intelligence/types/indicator';
 import { useIocFlyoutApi } from './use_ioc_flyout_api';
@@ -29,6 +31,8 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: jest.fn(() => ({})),
 }));
+
+const useHistoryMock = useHistory as jest.Mock;
 jest.mock('../../common/lib/kibana');
 jest.mock('../../common/hooks/is_in_security_app');
 jest.mock('../shared/components/flyout_provider', () => ({
@@ -49,6 +53,7 @@ const indicator = {
 describe('useIocFlyoutApi', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useHistoryMock.mockReturnValue({});
     mockOpenSystemFlyout.mockReturnValue({ onClose: Promise.resolve(), close: jest.fn() });
     (useKibana as jest.Mock).mockReturnValue({
       services: {
@@ -118,5 +123,29 @@ describe('useIocFlyoutApi', () => {
     result.current.openIocFlyout({ indicator });
 
     expect(mockOpenSystemFlyout.mock.calls[0][1].historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+
+  it("persists the indicator's `_index` in the flyoutV2 URL descriptor so it can be restored", () => {
+    const replace = jest.fn();
+    useHistoryMock.mockReturnValue({ location: { search: '' }, replace });
+    const indicatorWithIndex = {
+      _id: 'ioc-1',
+      _index: 'logs-ti_abusech_malware-latest',
+      fields: { 'threat.indicator.type': ['url'] },
+    } as unknown as Indicator;
+
+    const { result } = renderHook(() => useIocFlyoutApi());
+    result.current.openIocFlyout({ indicator: indicatorWithIndex });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    const { search } = replace.mock.calls[0][0];
+    const encoded = new URLSearchParams(search).get('flyoutV2');
+    expect(decode(encoded as string)).toEqual([
+      {
+        kind: 'ioc',
+        indicatorId: 'ioc-1',
+        indicatorIndex: 'logs-ti_abusech_malware-latest',
+      },
+    ]);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
@@ -36,6 +36,19 @@ import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 // bundle; the chunk only loads when the flyout is actually opened.
 const IOCDetails = lazy(() => import('./main').then((m) => ({ default: m.IOCDetails })));
 
+/**
+ * The `indicator` is an ES search hit, so at runtime it carries `_index` even though the
+ * `Indicator` type only declares `_id`/`fields`. Persisting it in the URL descriptor lets the
+ * restore hook re-fetch the indicator on refresh: it filters by `_index` against the default
+ * security data view, which matches threat-intel indices (`logs-ti_*`) via its `logs-*` pattern.
+ * Falls back to '' when unavailable (e.g. a case attachment without the source hit), in which case
+ * the restore is gracefully skipped.
+ */
+const getIndicatorIndex = (indicator: Indicator): string => {
+  const rawIndex = (indicator as { _index?: unknown })._index;
+  return typeof rawIndex === 'string' ? rawIndex : '';
+};
+
 export interface OpenIocFlyoutParams {
   /** The indicator to render in the flyout. Its `_id`/`fields` are used to build the flyout's record. */
   indicator: Indicator;
@@ -135,12 +148,10 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
 
   const openIocFlyout = useCallback(
     (params: OpenIocFlyoutParams) => {
-      // indicatorIndex is not available on the Indicator type; '' causes the restore hook to search
-      // across the default index pattern. Best-effort: if not found, the restore is gracefully skipped.
       writeOnOpen({
         kind: FLYOUT_DESCRIPTOR_KIND.ioc,
         indicatorId: params.indicator._id as string,
-        indicatorIndex: '',
+        indicatorIndex: getIndicatorIndex(params.indicator),
       });
       const onClose = buildOnClose(null);
       open(buildContent(params), sessionMode, getTitle(params), onClose, params.origin);
@@ -155,7 +166,7 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
         {
           kind: FLYOUT_DESCRIPTOR_KIND.ioc,
           indicatorId: params.indicator._id as string,
-          indicatorIndex: '',
+          indicatorIndex: getIndicatorIndex(params.indicator),
         },
         'inherit'
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/ioc/use_ioc_flyout_api.tsx
@@ -7,6 +7,7 @@
 
 import type { ReactNode } from 'react';
 import React, { lazy, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import {
@@ -23,6 +24,13 @@ import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import { formatFlyoutTitle, IOC_TITLE } from '../shared/constants/flyout_titles';
 import { useFlyoutSessionContext } from '../session_context';
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import {
+  FLYOUT_DESCRIPTOR_KIND,
+  decodeFlyoutV2UrlParam,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the IOC flyout graph into their
 // bundle; the chunk only loads when the flyout is actually opened.
@@ -63,18 +71,26 @@ export interface IocFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useIocFlyoutApi = (): IocFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const openFlyout = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
 
-  // `session` is the only thing that differs between a main and a child flyout. It is kept private
-  // here so callers never have to reason about it: they pick `openIocFlyout` (main) or
-  // `openIocFlyoutAsChild` (child) and this helper maps that to the right session.
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
+
   const open = useCallback(
     (
       children: ReactNode,
       session: FlyoutSessionKind,
       title: OverlaySystemFlyoutOpenOptions['title'],
+      onClose: (() => void) | undefined,
       origin?: FlyoutOrigin
     ) => {
       const properties: OverlaySystemFlyoutOpenOptions = {
@@ -82,6 +98,7 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
         historyKey,
         session,
         title,
+        onClose,
       };
       openFlyout(
         children,
@@ -117,20 +134,41 @@ export const useIocFlyoutApi = (): IocFlyoutApi => {
   );
 
   const openIocFlyout = useCallback(
-    (params: OpenIocFlyoutParams) =>
-      open(buildContent(params), sessionMode, getTitle(params), params.origin),
-    [open, buildContent, sessionMode, getTitle]
+    (params: OpenIocFlyoutParams) => {
+      // indicatorIndex is not available on the Indicator type; '' causes the restore hook to search
+      // across the default index pattern. Best-effort: if not found, the restore is gracefully skipped.
+      writeOnOpen({
+        kind: FLYOUT_DESCRIPTOR_KIND.ioc,
+        indicatorId: params.indicator._id as string,
+        indicatorIndex: '',
+      });
+      const onClose = buildOnClose(null);
+      open(buildContent(params), sessionMode, getTitle(params), onClose, params.origin);
+    },
+    [open, buildContent, sessionMode, getTitle, writeOnOpen, buildOnClose]
   );
 
   const openIocFlyoutAsChild = useCallback(
-    (params: OpenIocFlyoutParams) =>
+    (params: OpenIocFlyoutParams) => {
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        {
+          kind: FLYOUT_DESCRIPTOR_KIND.ioc,
+          indicatorId: params.indicator._id as string,
+          indicatorIndex: '',
+        },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         buildContent(params),
         FLYOUT_SESSION_KIND.INHERIT,
         buildFlyoutNavTitle(getTitle(params)),
+        onClose,
         params.origin
-      ),
-    [open, buildContent, getTitle]
+      );
+    },
+    [open, buildContent, getTitle, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/network/use_network_flyout_api.tsx
@@ -7,6 +7,7 @@
 
 import type { ReactNode } from 'react';
 import React, { lazy, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { FlowTargetSourceDest } from '../../../common/search_strategy/security_solution/network';
 import type { FlyoutOrigin, FlyoutSessionKind } from '../../common/lib/telemetry';
@@ -16,6 +17,13 @@ import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import { formatFlyoutTitle, NETWORK_TITLE } from '../shared/constants/flyout_titles';
 import { useFlyoutSessionContext } from '../session_context';
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import {
+  FLYOUT_DESCRIPTOR_KIND,
+  decodeFlyoutV2UrlParam,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the network flyout graph into their
 // bundle; the chunk only loads when the flyout is actually opened.
@@ -57,18 +65,26 @@ export interface NetworkFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const openFlyout = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
 
-  // `session` is the only thing that differs between a main and a child flyout. It is kept private
-  // here so callers never have to reason about it: they pick `openNetworkFlyout` (main) or
-  // `openNetworkFlyoutAsChild` (child) and this helper maps that to the right session.
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
+
   const open = useCallback(
     (
       children: ReactNode,
       session: FlyoutSessionKind,
       title: OverlaySystemFlyoutOpenOptions['title'],
+      onClose: (() => void) | undefined,
       origin?: FlyoutOrigin
     ) => {
       const properties: OverlaySystemFlyoutOpenOptions = {
@@ -76,6 +92,7 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
         historyKey,
         session,
         title,
+        onClose,
       };
       openFlyout(
         children,
@@ -89,26 +106,36 @@ export const useNetworkFlyoutApi = (): NetworkFlyoutApi => {
 
   const openNetworkFlyout = useCallback(
     ({ ip, flowTarget, origin }: OpenNetworkFlyoutParams) => {
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.network, ip, flowTarget: flowTarget as string });
+      const onClose = buildOnClose(null);
       open(
         <Network ip={ip} flowTarget={flowTarget} />,
         sessionMode,
         formatFlyoutTitle(NETWORK_TITLE, ip),
+        onClose,
         origin
       );
     },
-    [open, sessionMode]
+    [open, sessionMode, writeOnOpen, buildOnClose]
   );
 
   const openNetworkFlyoutAsChild = useCallback(
     ({ ip, flowTarget, origin }: OpenNetworkFlyoutParams) => {
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen(
+        { kind: FLYOUT_DESCRIPTOR_KIND.network, ip, flowTarget: flowTarget as string },
+        'inherit'
+      );
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <Network ip={ip} flowTarget={flowTarget} />,
         FLYOUT_SESSION_KIND.INHERIT,
         buildFlyoutNavTitle(formatFlyoutTitle(NETWORK_TITLE, ip)),
+        onClose,
         origin
       );
     },
-    [open]
+    [open, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/rule/use_rule_flyout_api.tsx
@@ -7,6 +7,7 @@
 
 import type { ReactNode } from 'react';
 import React, { lazy, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import type { FlyoutOrigin, FlyoutSessionKind } from '../../common/lib/telemetry';
 import { FLYOUT_SESSION_KIND, FLYOUT_SURFACE, FLYOUT_TYPE } from '../../common/lib/telemetry';
@@ -15,6 +16,13 @@ import { useOpenFlyout } from '../shared/hooks/use_open_flyout';
 import { buildFlyoutNavTitle } from '../shared/utils/build_flyout_nav_title';
 import { RULE_TITLE } from '../shared/constants/flyout_titles';
 import { useFlyoutSessionContext } from '../session_context';
+import { useFlyoutV2UrlWriter } from '../shared/url_state/flyout_v2_url_writer';
+import {
+  FLYOUT_DESCRIPTOR_KIND,
+  decodeFlyoutV2UrlParam,
+  urlParamKeyForHistoryKey,
+} from '../shared/url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../shared/url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the rule flyout graph into their
 // bundle; the chunk only loads when the flyout is actually opened.
@@ -59,18 +67,26 @@ export interface RuleFlyoutApi {
  * Must be used within the Security Solution app shell (Redux store + router + Kibana services).
  */
 export const useRuleFlyoutApi = (): RuleFlyoutApi => {
+  const history = useHistory();
   const { session: sessionMode, historyKey } = useFlyoutSessionContext();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const openFlyout = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
 
-  // `session` is the only thing that differs between a main and a child flyout. It is kept private
-  // here so callers never have to reason about it: they pick `openRuleFlyout` (main) or
-  // `openRuleFlyoutAsChild` (child) and this helper maps that to the right session.
+  const readFirstDescriptor = useCallback((): FlyoutDescriptor | null => {
+    if (!history?.location) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    const stack = decodeFlyoutV2UrlParam(raw);
+    return stack?.[0] ?? null;
+  }, [history, urlParamKey]);
+
   const open = useCallback(
     (
       children: ReactNode,
       session: FlyoutSessionKind,
       title: OverlaySystemFlyoutOpenOptions['title'],
+      onClose: (() => void) | undefined,
       origin?: FlyoutOrigin
     ) => {
       const properties: OverlaySystemFlyoutOpenOptions = {
@@ -78,6 +94,7 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
         historyKey,
         session,
         title,
+        onClose,
       };
       openFlyout(
         children,
@@ -91,21 +108,27 @@ export const useRuleFlyoutApi = (): RuleFlyoutApi => {
 
   const openRuleFlyout = useCallback(
     ({ ruleId, title, origin }: OpenRuleFlyoutParams) => {
-      open(<RuleDetails ruleId={ruleId} />, sessionMode, title ?? RULE_TITLE, origin);
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.rule, ruleId });
+      const onClose = buildOnClose(null);
+      open(<RuleDetails ruleId={ruleId} />, sessionMode, title ?? RULE_TITLE, onClose, origin);
     },
-    [open, sessionMode]
+    [open, sessionMode, writeOnOpen, buildOnClose]
   );
 
   const openRuleFlyoutAsChild = useCallback(
     ({ ruleId, title, origin }: OpenRuleFlyoutParams) => {
+      const parentDescriptor = readFirstDescriptor();
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.rule, ruleId }, 'inherit');
+      const onClose = buildOnClose(parentDescriptor);
       open(
         <RuleDetails ruleId={ruleId} />,
         FLYOUT_SESSION_KIND.INHERIT,
         buildFlyoutNavTitle(title ?? RULE_TITLE),
+        onClose,
         origin
       );
     },
-    [open]
+    [open, readFirstDescriptor, writeOnOpen, buildOnClose]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
@@ -17,6 +17,8 @@ import { of } from 'rxjs';
 import type { StartServices } from '../../../types';
 import { SECURITY_FEATURE_ID } from '../../../../common/constants';
 import { useConsoleManager } from '../../../management/components/console/components/console_manager';
+import { setAbsoluteRangeDatePicker } from '../../../common/store/inputs/actions';
+import { InputsModelId } from '../../../common/store/inputs/constants';
 import { flyoutProviders } from './flyout_provider';
 
 jest.mock('../../../common/components/user_privileges/user_privileges_context', () => ({
@@ -171,5 +173,40 @@ describe('flyoutProviders', () => {
     );
 
     expect(screen.getByTestId('console-manager-probe')).toHaveTextContent('function');
+  });
+
+  describe('TimeRangeSync', () => {
+    const absoluteRangeAction = setAbsoluteRangeDatePicker({
+      id: InputsModelId.global,
+      from: '2024-01-01',
+      to: '2024-01-02',
+    });
+
+    afterEach(() => {
+      window.history.pushState({}, '', '/');
+    });
+
+    it('does NOT seed the global time range when on a Security app path', () => {
+      window.history.pushState({}, '', '/app/security/alerts');
+      const store = createStore(() => ({}));
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      render(flyoutProviders({ services, store, children: <div /> }));
+
+      const seeded = dispatchSpy.mock.calls.some(
+        ([action]) => (action as { type?: string })?.type === absoluteRangeAction.type
+      );
+      expect(seeded).toBe(false);
+    });
+
+    it('seeds the global time range from the timefilter when NOT on a Security app path', () => {
+      window.history.pushState({}, '', '/app/discover');
+      const store = createStore(() => ({}));
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      render(flyoutProviders({ services, store, children: <div /> }));
+
+      expect(dispatchSpy).toHaveBeenCalledWith(absoluteRangeAction);
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
@@ -31,13 +31,27 @@ import { InputsModelId } from '../../../common/store/inputs/constants';
 import { ConsoleManager } from '../../../management/components/console/components/console_manager';
 
 /**
- * Syncs Kibana's global time filter to the Security Solution Redux store on mount.
+ * Seeds the Security Solution Redux `global` time range from Kibana's global time filter on mount.
+ *
+ * This is only needed when the flyout is rendered OUTSIDE the Security app (e.g. in Discover), where
+ * the Security Redux `global` input is not otherwise populated. Inside the Security app that Redux
+ * input is already the source of truth for the page's time range — and may hold a *relative* range
+ * such as "Today". Seeding it from the timefilter there calls `getAbsoluteTime()` and would overwrite
+ * the relative range with fixed timestamps on every flyout open (which then syncs to the URL), so we
+ * skip it in the Security app.
+ *
+ * The guard is a SYNCHRONOUS `window.location.pathname` check, not an app-id observable
+ * (`useIsInSecurityApp`): this effect runs once on mount, and an observable-based hook yields
+ * `undefined` on the first render, so the destructive seed would run before the guard resolved.
+ * The flyout renders in a separate React root (EUI flyout-manager portal), which makes that
+ * first-render race reliably lose. The pathname is correct synchronously on mount regardless.
  */
 const TimeRangeSync: FC<{ children: ReactNode }> = ({ children }) => {
   const { services } = useKibana();
   const store = useStore();
 
   useEffect(() => {
+    if (window.location.pathname.includes('/app/security')) return;
     const tf = services.data.query.timefilter.timefilter;
     const { from, to } = tf.getAbsoluteTime();
     store.dispatch(setAbsoluteRangeDatePicker({ id: InputsModelId.global, from, to }));

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.test.tsx
@@ -10,9 +10,10 @@ import { render } from '@testing-library/react';
 import { TestProviders } from '../../../common/mock';
 import { OpenFlyoutLink } from './open_flyout_link';
 import { OPEN_FLYOUT_LINK_TEST_ID } from './test_ids';
-import { buildFlyoutContent } from '../utils/build_flyout_content';
+import { buildFlyoutContent, buildFlyoutDescriptorFromField } from '../utils/build_flyout_content';
 import { buildFlyoutNavTitle } from '../utils/build_flyout_nav_title';
 import { FlyoutSessionContextProvider } from '../../session_context';
+import { FLYOUT_DESCRIPTOR_KIND } from '../url_state/flyout_v2_url_param';
 
 jest.mock('../utils/build_flyout_content');
 jest.mock('../utils/build_flyout_nav_title', () => ({
@@ -23,6 +24,15 @@ jest.mock('./flyout_provider', () => ({
 }));
 jest.mock('../hooks/use_default_flyout_properties', () => ({
   useDefaultDocumentFlyoutProperties: () => ({ outsideClickCloses: true }),
+}));
+
+const mockWriteOnOpen = jest.fn();
+const mockBuildOnClose = jest.fn(() => jest.fn());
+jest.mock('../url_state/flyout_v2_url_writer', () => ({
+  useFlyoutV2UrlWriter: jest.fn(() => ({
+    writeOnOpen: mockWriteOnOpen,
+    buildOnClose: mockBuildOnClose,
+  })),
 }));
 
 const mockOpenSystemFlyout = jest.fn();
@@ -44,6 +54,7 @@ jest.mock('../../../common/lib/kibana', () => {
 });
 
 const buildFlyoutContentMock = buildFlyoutContent as jest.Mock;
+const buildFlyoutDescriptorFromFieldMock = buildFlyoutDescriptorFromField as jest.Mock;
 const buildFlyoutNavTitleMock = buildFlyoutNavTitle as jest.Mock;
 
 const renderOpenFlyoutLink = (props: Partial<React.ComponentProps<typeof OpenFlyoutLink>> = {}) =>
@@ -59,11 +70,19 @@ describe('<OpenFlyoutLink />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOpenSystemFlyout.mockReturnValue({ onClose: Promise.resolve(), close: jest.fn() });
+    mockBuildOnClose.mockReturnValue(jest.fn());
   });
 
   describe('when the field is supported', () => {
+    const mockDescriptor = {
+      kind: FLYOUT_DESCRIPTOR_KIND.network,
+      ip: '10.0.0.1',
+      flowTarget: 'source',
+    };
+
     beforeEach(() => {
       buildFlyoutContentMock.mockReturnValue(<div data-test-subj="mockFlyoutContent" />);
+      buildFlyoutDescriptorFromFieldMock.mockReturnValue(mockDescriptor);
     });
 
     it('should render a link with the value as text when no children are provided', () => {
@@ -164,11 +183,40 @@ describe('<OpenFlyoutLink />', () => {
       expect(buildFlyoutNavTitleMock).toHaveBeenCalled();
       expect(mockOpenSystemFlyout.mock.calls[0][1].title).toMatch(/^NAV:/);
     });
+
+    it('calls writeOnOpen with the descriptor on click', () => {
+      const { getByTestId } = renderOpenFlyoutLink();
+
+      getByTestId(OPEN_FLYOUT_LINK_TEST_ID).click();
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(mockDescriptor, 'start');
+    });
+
+    it('calls writeOnOpen with mode "inherit" when session is "inherit"', () => {
+      const { getByTestId } = render(
+        <TestProviders>
+          <FlyoutSessionContextProvider value={{ session: 'inherit' }}>
+            <OpenFlyoutLink field="source.ip" value="10.0.0.1" />
+          </FlyoutSessionContextProvider>
+        </TestProviders>
+      );
+
+      getByTestId(OPEN_FLYOUT_LINK_TEST_ID).click();
+      expect(mockWriteOnOpen).toHaveBeenCalledWith(mockDescriptor, 'inherit');
+    });
+
+    it('passes an onClose callback to openSystemFlyout when descriptor is present', () => {
+      const { getByTestId } = renderOpenFlyoutLink();
+
+      getByTestId(OPEN_FLYOUT_LINK_TEST_ID).click();
+      expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+      expect(mockOpenSystemFlyout.mock.calls[0][1].onClose).toBeDefined();
+    });
   });
 
   describe('when the field is not supported', () => {
     beforeEach(() => {
       buildFlyoutContentMock.mockReturnValue(null);
+      buildFlyoutDescriptorFromFieldMock.mockReturnValue(null);
     });
 
     it('should render children as fallback', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/open_flyout_link.tsx
@@ -7,6 +7,7 @@
 
 import type { FC, ReactNode } from 'react';
 import React, { useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { EuiLink } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useDefaultDocumentFlyoutProperties } from '../hooks/use_default_flyout_properties';
@@ -16,10 +17,13 @@ import {
   buildFlyoutContent,
   getFlyoutTypeForField,
   buildFlyoutTitleFromField,
+  buildFlyoutDescriptorFromField,
 } from '../utils/build_flyout_content';
 import { buildFlyoutNavTitle } from '../utils/build_flyout_nav_title';
 import { useFlyoutSessionContext } from '../../session_context';
 import { FLYOUT_ORIGIN, FLYOUT_SESSION_KIND, FLYOUT_SURFACE } from '../../../common/lib/telemetry';
+import { useFlyoutV2UrlWriter } from '../url_state/flyout_v2_url_writer';
+import { urlParamKeyForHistoryKey, decodeFlyoutV2UrlParam } from '../url_state/flyout_v2_url_param';
 
 export interface OpenFlyoutLinkProps {
   /**
@@ -79,20 +83,42 @@ export const OpenFlyoutLink: FC<OpenFlyoutLinkProps> = ({
   'data-test-subj': dataTestSubj = OPEN_FLYOUT_LINK_TEST_ID,
 }) => {
   const open = useOpenFlyout();
+  const history = useHistory();
   const defaultDocumentFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const { historyKey, session: sessionMode } = useFlyoutSessionContext();
 
   const flyoutContent = useMemo(() => buildFlyoutContent(field, value, hit), [field, value, hit]);
   const flyoutType = useMemo(() => getFlyoutTypeForField(field), [field]);
+  const flyoutDescriptor = useMemo(
+    () => buildFlyoutDescriptorFromField(field, value),
+    [field, value]
+  );
   const titleValue = displayValue ?? value;
   const flyoutTitle = useMemo(
     () => buildFlyoutTitleFromField(field, titleValue) ?? titleValue,
     [field, titleValue]
   );
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
 
   const onClick = useCallback(() => {
     if (flyoutContent) {
       const resolvedSession = asParent ? FLYOUT_SESSION_KIND.START : sessionMode;
+      const mode = resolvedSession === FLYOUT_SESSION_KIND.INHERIT ? 'inherit' : 'start';
+      let onClose: (() => void) | undefined;
+      if (flyoutDescriptor) {
+        // For a child ('inherit') open, closing it must revert to the parent (the session-start
+        // root), NOT clear the whole flyoutV2 param — otherwise the still-open parent tool flyout is
+        // lost on refresh. Read the current root before writeOnOpen mutates the stack.
+        const parentDescriptor =
+          mode === 'inherit'
+            ? decodeFlyoutV2UrlParam(
+                new URLSearchParams(history?.location?.search ?? '').get(urlParamKey)
+              )?.[0] ?? null
+            : null;
+        writeOnOpen(flyoutDescriptor, mode);
+        onClose = buildOnClose(parentDescriptor);
+      }
       open(
         flyoutContent,
         {
@@ -104,6 +130,7 @@ export const OpenFlyoutLink: FC<OpenFlyoutLinkProps> = ({
             resolvedSession === FLYOUT_SESSION_KIND.INHERIT
               ? buildFlyoutNavTitle(flyoutTitle)
               : flyoutTitle,
+          ...(onClose && { onClose }),
         },
         flyoutType
           ? {
@@ -121,8 +148,13 @@ export const OpenFlyoutLink: FC<OpenFlyoutLinkProps> = ({
     open,
     flyoutContent,
     flyoutType,
-    asParent,
+    flyoutDescriptor,
+    history,
     historyKey,
+    urlParamKey,
+    writeOnOpen,
+    buildOnClose,
+    asParent,
     flyoutTitle,
     sessionMode,
   ]);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/share_url_icon_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/share_url_icon_button.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ShareUrlIconButton } from './share_url_icon_button';
+
+jest.mock('@elastic/eui', () => ({
+  ...jest.requireActual('@elastic/eui'),
+  EuiCopy: jest.fn(({ children: functionAsChild }) => functionAsChild(jest.fn())),
+}));
+
+describe('ShareUrlIconButton', () => {
+  it('renders nothing when url is null', () => {
+    const { container } = render(
+      <ShareUrlIconButton url={null} tooltip="Share" ariaLabel="Share" dataTestSubj="share-btn" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when url is undefined', () => {
+    const { container } = render(
+      <ShareUrlIconButton
+        url={undefined}
+        tooltip="Share"
+        ariaLabel="Share"
+        dataTestSubj="share-btn"
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a button when url is set', () => {
+    const { getByRole } = render(
+      <ShareUrlIconButton
+        url="https://example.com/alert"
+        tooltip="Share alert"
+        ariaLabel="Share alert"
+        dataTestSubj="share-btn"
+      />
+    );
+    expect(getByRole('button', { name: 'Share alert' })).toBeInTheDocument();
+  });
+
+  it('applies the provided data-test-subj', () => {
+    const { getByTestId } = render(
+      <ShareUrlIconButton
+        url="https://example.com/alert"
+        tooltip="Share"
+        ariaLabel="Share"
+        dataTestSubj="my-share-btn"
+      />
+    );
+    expect(getByTestId('my-share-btn')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/share_url_icon_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/share_url_icon_button.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+import React, { memo } from 'react';
+import { EuiButtonIcon, EuiCopy, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+
+export interface ShareUrlIconButtonProps {
+  /**
+   * Absolute URL to copy; when null/undefined, nothing is rendered.
+   */
+  url: string | null | undefined;
+  /**
+   * Tooltip content.
+   */
+  tooltip: ReactNode;
+  /**
+   * Accessible label for the icon button.
+   */
+  ariaLabel: string;
+  /**
+   * data-test-subj for the button.
+   */
+  dataTestSubj: string;
+}
+
+/**
+ * Share icon that copies a URL to the clipboard (EuiCopy + EuiButtonIcon).
+ * Renders nothing when `url` is falsy.
+ */
+export const ShareUrlIconButton = memo(
+  ({ url, tooltip, ariaLabel, dataTestSubj }: ShareUrlIconButtonProps) => {
+    if (!url) {
+      return null;
+    }
+
+    return (
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={tooltip}>
+          <EuiCopy textToCopy={url}>
+            {(copy) => (
+              <EuiButtonIcon
+                iconType="share"
+                color="text"
+                aria-label={ariaLabel}
+                data-test-subj={dataTestSubj}
+                onClick={copy}
+              />
+            )}
+          </EuiCopy>
+        </EuiToolTip>
+      </EuiFlexItem>
+    );
+  }
+);
+
+ShareUrlIconButton.displayName = 'ShareUrlIconButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/test_ids.ts
@@ -49,3 +49,5 @@ export const GRAPH_PREVIEW_TEST_ID = `${PREFIX}GraphPreview` as const;
 export const GRAPH_PREVIEW_LOADING_TEST_ID = `${GRAPH_PREVIEW_TEST_ID}Loading` as const;
 export const GRAPH_PREVIEW_TECHNICAL_PREVIEW_TEST_ID =
   `${GRAPH_PREVIEW_TEST_ID}TechnicalPreview` as const;
+
+export const DOCUMENT_FLYOUT_HEADER_SHARE_BUTTON_TEST_ID = `${PREFIX}HeaderShareButton` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.test.tsx
@@ -8,35 +8,11 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { useDocumentFlyoutTitle } from './use_document_flyout_title';
-import { useKibana } from '../../../common/lib/kibana';
-import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
-import { documentFlyoutHistoryKey } from '../constants/flyout_history';
-import {
-  FlyoutV2EventTypes,
-  FLYOUT_ORIGIN,
-  FLYOUT_SURFACE,
-  FLYOUT_TYPE,
-  FLYOUT_SESSION_KIND,
-} from '../../../common/lib/telemetry';
+import { useFlyoutApi } from '../../use_flyout_api';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
 
-jest.mock('react-redux-v7', () => ({
-  ...jest.requireActual('react-redux-v7'),
-  useStore: () => ({ getState: jest.fn(), dispatch: jest.fn(), subscribe: jest.fn() }),
-}));
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({}),
-}));
-jest.mock('../../../common/lib/kibana');
-jest.mock('../../../common/hooks/is_in_security_app');
-jest.mock('../components/flyout_provider', () => ({
-  flyoutProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-jest.mock('../../document/main', () => ({
-  DocumentFlyout: () => <div data-test-subj="documentFlyoutMock" />,
-}));
+jest.mock('../../use_flyout_api');
 jest.mock('../../document/main/components/severity', () => ({
   DocumentSeverity: () => <div data-test-subj="documentSeverityMock" />,
 }));
@@ -64,21 +40,11 @@ const eventHit = createHit({
 });
 
 describe('useDocumentFlyoutTitle', () => {
-  const mockUseKibana = jest.mocked(useKibana);
-  const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
-  const openSystemFlyout = jest.fn();
-  const reportEvent = jest.fn();
+  const openDocumentFlyoutFromIndexAsChild = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    openSystemFlyout.mockReturnValue({ onClose: Promise.resolve(), close: jest.fn() });
-    mockUseIsInSecurityApp.mockReturnValue(true);
-    mockUseKibana.mockReturnValue({
-      services: {
-        overlays: { openSystemFlyout },
-        telemetry: { reportEvent },
-      },
-    } as unknown as ReturnType<typeof useKibana>);
+    (useFlyoutApi as jest.Mock).mockReturnValue({ openDocumentFlyoutFromIndexAsChild });
   });
 
   it('derives label and warning icon for alerts', () => {
@@ -95,44 +61,19 @@ describe('useDocumentFlyoutTitle', () => {
     expect(result.current.iconType).toBe('analyzeEvent');
   });
 
-  it('opens the document flyout with documentFlyoutHistoryKey and session inherit when in the Security app', () => {
+  it('opens the source document as a child flyout via openDocumentFlyoutFromIndexAsChild (so it is URL-persisted and reports telemetry)', () => {
     const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: alertHit }));
 
     act(() => {
       result.current.onTitleClick();
     });
 
-    expect(openSystemFlyout).toHaveBeenCalledTimes(1);
-    expect(openSystemFlyout).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledTimes(1);
+    expect(openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledWith(
       expect.objectContaining({
-        historyKey: documentFlyoutHistoryKey,
-        session: 'inherit',
-      })
-    );
-    expect(reportEvent).toHaveBeenCalledWith(FlyoutV2EventTypes.FlyoutOpened, {
-      surface: FLYOUT_SURFACE.FLYOUT,
-      flyoutType: FLYOUT_TYPE.DOCUMENT,
-      tool: undefined,
-      session: FLYOUT_SESSION_KIND.INHERIT,
-      origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
-    });
-  });
-
-  it('uses DOC_VIEWER_FLYOUT_HISTORY_KEY when not in the Security app', () => {
-    mockUseIsInSecurityApp.mockReturnValue(false);
-
-    const { result } = renderHook(() => useDocumentFlyoutTitle({ hit: eventHit }));
-
-    act(() => {
-      result.current.onTitleClick();
-    });
-
-    expect(openSystemFlyout).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        historyKey: DOC_VIEWER_FLYOUT_HISTORY_KEY,
-        session: 'inherit',
+        documentId: '1',
+        indexName: 'test',
+        origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -77,13 +77,7 @@ export const useDocumentFlyoutTitle = ({
       title: sessionTitle,
       origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
     });
-  }, [
-    openDocumentFlyoutFromIndexAsChild,
-    hit,
-    renderCellActions,
-    onAlertUpdated,
-    sessionTitle,
-  ]);
+  }, [openDocumentFlyoutFromIndexAsChild, hit, renderCellActions, onAlertUpdated, sessionTitle]);
 
   const badge = <DocumentSeverity hit={hit} />;
   const timestamp = <Timestamp hit={hit} size="xs" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_document_flyout_title.tsx
@@ -9,31 +9,18 @@ import React, { useCallback, useMemo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux-v7';
 import { noop } from 'lodash/fp';
 import { EventKind } from '../../document/main/constants/event_kinds';
 import {
   getDocumentHistoryTitle,
   getDocumentTitle,
 } from '../../document/main/utils/get_header_title';
-import { useKibana } from '../../../common/lib/kibana';
 import type { CellActionRenderer } from '../components/cell_actions';
 import { noopCellActionRenderer } from '../components/cell_actions';
-import { flyoutProviders } from '../components/flyout_provider';
-import { DocumentFlyout } from '../../document/main';
-import { useDefaultDocumentFlyoutProperties } from './use_default_flyout_properties';
-import { useFlyoutTelemetry } from './use_flyout_telemetry';
-import {
-  FLYOUT_ORIGIN,
-  FLYOUT_SESSION_KIND,
-  FLYOUT_SURFACE,
-  FLYOUT_TYPE,
-} from '../../../common/lib/telemetry';
-import { buildFlyoutNavTitle } from '../utils/build_flyout_nav_title';
+import { FLYOUT_ORIGIN } from '../../../common/lib/telemetry';
 import { DocumentSeverity } from '../../document/main/components/severity';
 import { Timestamp } from '../components/timestamp';
-import { FlyoutSessionContextProvider, useFlyoutSessionContext } from '../../session_context';
+import { useFlyoutApi } from '../../use_flyout_api';
 
 export interface UseDocumentFlyoutTitleOptions {
   /** The source document to derive display values from. */
@@ -65,12 +52,7 @@ export const useDocumentFlyoutTitle = ({
   renderCellActions = noopCellActionRenderer,
   onAlertUpdated = noop,
 }: UseDocumentFlyoutTitleOptions): DocumentFlyoutTitleResult => {
-  const { services } = useKibana();
-  const store = useStore();
-  const history = useHistory();
-  const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-  const { historyKey } = useFlyoutSessionContext();
-  const { reportOpened, reportClosed } = useFlyoutTelemetry();
+  const { openDocumentFlyoutFromIndexAsChild } = useFlyoutApi();
 
   const isAlert = useMemo(
     () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -81,53 +63,26 @@ export const useDocumentFlyoutTitle = ({
   const sessionTitle = useMemo(() => getDocumentHistoryTitle(hit), [hit]);
   const iconType = isAlert ? 'warning' : 'analyzeEvent';
 
+  // Open the source document as a child flyout. Route through the shared
+  // `openDocumentFlyoutFromIndexAsChild` API rather than calling `overlays.openSystemFlyout`
+  // directly, so the child descriptor is written to the flyoutV2 URL param (via the API's
+  // internal writeOnOpen('inherit')). Opening it directly here bypassed the URL writer, so the
+  // child was not restored on refresh — only the parent tool flyout reopened.
   const onTitleClick = useCallback(() => {
-    const ref = services.overlays?.openSystemFlyout(
-      flyoutProviders({
-        services,
-        store,
-        history,
-        children: (
-          <FlyoutSessionContextProvider
-            value={{ session: FLYOUT_SESSION_KIND.INHERIT, historyKey }}
-          >
-            <DocumentFlyout
-              hit={hit}
-              renderCellActions={renderCellActions}
-              onAlertUpdated={onAlertUpdated}
-            />
-          </FlyoutSessionContextProvider>
-        ),
-      }),
-      {
-        ...defaultFlyoutProperties,
-        historyKey,
-        session: FLYOUT_SESSION_KIND.INHERIT,
-        title: buildFlyoutNavTitle(sessionTitle),
-      }
-    );
-    if (!ref) return;
-    const meta = {
-      surface: FLYOUT_SURFACE.FLYOUT,
-      flyoutType: FLYOUT_TYPE.DOCUMENT,
-      session: FLYOUT_SESSION_KIND.INHERIT,
+    openDocumentFlyoutFromIndexAsChild({
+      documentId: hit.raw._id ?? '',
+      indexName: (hit.raw._index as string) ?? '',
+      renderCellActions,
+      onAlertUpdated,
+      title: sessionTitle,
       origin: FLYOUT_ORIGIN.TOOL_HEADER_TITLE,
-    };
-    const openedAt = Date.now();
-    reportOpened(meta);
-    ref.onClose.then(() => reportClosed(meta, Date.now() - openedAt)).catch(noop);
+    });
   }, [
-    defaultFlyoutProperties,
-    history,
-    historyKey,
+    openDocumentFlyoutFromIndexAsChild,
     hit,
-    onAlertUpdated,
     renderCellActions,
-    reportClosed,
-    reportOpened,
-    services,
+    onAlertUpdated,
     sessionTitle,
-    store,
   ]);
 
   const badge = <DocumentSeverity hit={hit} />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.test.tsx
@@ -13,6 +13,7 @@ import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { flyoutProviders } from '../components/flyout_provider';
 import { documentFlyoutHistoryKey } from '../constants/flyout_history';
+import { FLYOUT_DESCRIPTOR_KIND } from '../url_state/flyout_v2_url_param';
 
 jest.mock('react-redux-v7', () => ({
   ...jest.requireActual('react-redux-v7'),
@@ -31,8 +32,21 @@ jest.mock('../hooks/use_default_flyout_properties', () => ({
   defaultToolsFlyoutProperties: { size: 'm' },
 }));
 
+const mockWriteOnOpen = jest.fn();
+const mockBuildOnClose = jest.fn(() => jest.fn());
+jest.mock('../url_state/flyout_v2_url_writer', () => ({
+  useFlyoutV2UrlWriter: jest.fn(() => ({
+    writeOnOpen: mockWriteOnOpen,
+    buildOnClose: mockBuildOnClose,
+  })),
+}));
+
 const mockOpenSystemFlyout = jest.fn();
-const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+const hit = {
+  id: '1',
+  raw: { _id: 'doc-id', _index: 'doc-index' },
+  flattened: {},
+} as unknown as DataTableRecord;
 
 describe('useSharedToolsFlyoutApi', () => {
   beforeEach(() => {
@@ -78,5 +92,26 @@ describe('useSharedToolsFlyoutApi', () => {
     result.current.openNotes({ hit });
 
     expect(getProperties().historyKey).toBe(DOC_VIEWER_FLYOUT_HISTORY_KEY);
+  });
+
+  it('openNotes writes a notes descriptor with document ids from the hit', () => {
+    const { result } = renderHook(() => useSharedToolsFlyoutApi());
+    result.current.openNotes({ hit });
+
+    expect(mockWriteOnOpen).toHaveBeenCalledWith({
+      kind: FLYOUT_DESCRIPTOR_KIND.notes,
+      documentId: 'doc-id',
+      indexName: 'doc-index',
+    });
+  });
+
+  it('openNotes clears the param on close (tool is a session:start root)', () => {
+    mockBuildOnClose.mockReturnValue(jest.fn());
+    const { result } = renderHook(() => useSharedToolsFlyoutApi());
+    result.current.openNotes({ hit });
+
+    // A tool is a session:'start' root; closing it clears the param (no parent to revert to).
+    expect(mockBuildOnClose).toHaveBeenCalledWith(null);
+    expect(getProperties().onClose).toBeDefined();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/use_shared_tools_flyout_api.tsx
@@ -14,6 +14,8 @@ import { useOpenFlyout } from '../hooks/use_open_flyout';
 import { formatFlyoutTitle, NOTES_TITLE } from '../constants/flyout_titles';
 import { getDocumentTitle } from '../../document/main/utils/get_header_title';
 import { useFlyoutSessionContext } from '../../session_context';
+import { useFlyoutV2UrlWriter } from '../url_state/flyout_v2_url_writer';
+import { FLYOUT_DESCRIPTOR_KIND, urlParamKeyForHistoryKey } from '../url_state/flyout_v2_url_param';
 
 // Lazy-loaded so consumers of this hook don't statically pull the shared tool graph into their
 // bundle; the chunk only loads when the tool is actually opened.
@@ -35,8 +37,9 @@ export interface SharedToolsFlyoutApi {
  * Developer-facing API to open the new (EUI-based) shared tool flyouts — tools that are not owned by
  * a single flyout type and are reused across several of them (e.g. the notes flyout, opened from both
  * the document and attack flyouts). Same mindset as `useDocumentFlyoutApi`, `useEntityFlyoutApi`, etc.:
- * it encapsulates the provider wiring (`flyoutProviders` + `overlays.openSystemFlyout`) and the tool
- * flyout properties so call sites don't repeat them.
+ * it encapsulates the provider wiring (`flyoutProviders` + `overlays.openSystemFlyout`, via
+ * `useOpenFlyout`) and the tool flyout properties so call sites don't repeat them. `useOpenFlyout`
+ * also reports open/close telemetry.
  *
  * This API only ever opens the NEW flyout. It does not know about the legacy expandable flyout:
  * callers remain responsible for gating on `useIsNewFlyoutEnabled()` and falling back to the
@@ -47,9 +50,18 @@ export interface SharedToolsFlyoutApi {
 export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
   const { historyKey } = useFlyoutSessionContext();
   const open = useOpenFlyout();
+  const urlParamKey = urlParamKeyForHistoryKey(historyKey);
+  const { writeOnOpen, buildOnClose } = useFlyoutV2UrlWriter(urlParamKey, historyKey);
 
   const openNotes = useCallback(
     ({ hit, origin }: OpenNotesParams) => {
+      const documentId = hit.raw._id as string;
+      const indexName = hit.raw._index as string;
+      writeOnOpen({ kind: FLYOUT_DESCRIPTOR_KIND.notes, documentId, indexName });
+      // A tool flyout opens with session:'start' — it is a root, not a child of the document, and
+      // the document is not persisted alongside it. Closing the tool therefore clears the param
+      // (reverting to the document would resurrect a flyout that was never part of the saved state).
+      const onClose = buildOnClose(null);
       open(
         <NotesDetails hit={hit} />,
         {
@@ -57,6 +69,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
           historyKey,
           session: FLYOUT_SESSION_KIND.START,
           title: formatFlyoutTitle(NOTES_TITLE, getDocumentTitle(hit)),
+          onClose,
         },
         {
           surface: FLYOUT_SURFACE.TOOL,
@@ -67,7 +80,7 @@ export const useSharedToolsFlyoutApi = (): SharedToolsFlyoutApi => {
         FLYOUT_SESSION_KIND.INHERIT
       );
     },
-    [open, historyKey]
+    [open, historyKey, writeOnOpen, buildOnClose]
   );
 
   return useMemo(() => ({ openNotes }), [openNotes]);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.test.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { encode } from '@kbn/rison';
+import {
+  decodeFlyoutV2UrlParam,
+  encodeFlyoutV2UrlParam,
+  FLYOUT_V2_URL_PARAM,
+  FLYOUT_V2_TIMELINE_URL_PARAM,
+  urlParamKeyForHistoryKey,
+  type FlyoutV2UrlParamValue,
+} from './flyout_v2_url_param';
+import { documentFlyoutHistoryKey, timelineFlyoutHistoryKey } from '../constants/flyout_history';
+
+describe('flyoutV2 URL param', () => {
+  describe('constants', () => {
+    it('exports the correct param name', () => {
+      expect(FLYOUT_V2_URL_PARAM).toBe('flyoutV2');
+    });
+
+    it('exports the correct timeline param name', () => {
+      expect(FLYOUT_V2_TIMELINE_URL_PARAM).toBe('flyoutV2Timeline');
+    });
+  });
+
+  describe('urlParamKeyForHistoryKey', () => {
+    it('returns the Timeline param key for timelineFlyoutHistoryKey', () => {
+      expect(urlParamKeyForHistoryKey(timelineFlyoutHistoryKey)).toBe(FLYOUT_V2_TIMELINE_URL_PARAM);
+    });
+
+    it('returns the page param key for documentFlyoutHistoryKey', () => {
+      expect(urlParamKeyForHistoryKey(documentFlyoutHistoryKey)).toBe(FLYOUT_V2_URL_PARAM);
+    });
+
+    it('returns the page param key for any other symbol', () => {
+      expect(urlParamKeyForHistoryKey(Symbol('other'))).toBe(FLYOUT_V2_URL_PARAM);
+    });
+  });
+
+  describe('encodeFlyoutV2UrlParam', () => {
+    it('encodes a single document descriptor', () => {
+      const value: FlyoutV2UrlParamValue = [
+        { kind: 'document', documentId: 'abc', indexName: 'logs-*' },
+      ];
+      const encoded = encodeFlyoutV2UrlParam(value);
+      expect(typeof encoded).toBe('string');
+      expect(encoded.length).toBeGreaterThan(0);
+    });
+
+    it('encodes a two-entry chain (tool + child)', () => {
+      const value: FlyoutV2UrlParamValue = [
+        { kind: 'analyzer', documentId: 'abc', indexName: 'logs-*' },
+        { kind: 'document', documentId: 'abc', indexName: 'logs-*' },
+      ];
+      const encoded = encodeFlyoutV2UrlParam(value);
+      expect(typeof encoded).toBe('string');
+    });
+  });
+
+  describe('decodeFlyoutV2UrlParam', () => {
+    it('returns null for null input', () => {
+      expect(decodeFlyoutV2UrlParam(null)).toBeNull();
+    });
+
+    it('returns null for undefined input', () => {
+      expect(decodeFlyoutV2UrlParam(undefined)).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(decodeFlyoutV2UrlParam('')).toBeNull();
+    });
+
+    it('returns null for malformed rison', () => {
+      expect(decodeFlyoutV2UrlParam('not-rison-!!!')).toBeNull();
+    });
+
+    it('returns null for a rison object (not array)', () => {
+      const raw = encode({ kind: 'document', documentId: 'abc', indexName: 'logs-*' });
+      expect(decodeFlyoutV2UrlParam(raw)).toBeNull();
+    });
+
+    it('returns null for an empty array', () => {
+      const raw = encode([]);
+      expect(decodeFlyoutV2UrlParam(raw)).toBeNull();
+    });
+
+    it('returns null when an entry has an unknown kind', () => {
+      const raw = encode([{ kind: 'unknownKind', documentId: 'abc' }]);
+      expect(decodeFlyoutV2UrlParam(raw)).toBeNull();
+    });
+
+    it('returns null when an entry is null', () => {
+      const raw = encode([null]);
+      expect(decodeFlyoutV2UrlParam(raw)).toBeNull();
+    });
+
+    it('returns null when an entry is a primitive (not an object)', () => {
+      const raw = encode(['hello']);
+      expect(decodeFlyoutV2UrlParam(raw)).toBeNull();
+    });
+
+    it('returns null when an entry is a nested array', () => {
+      const raw = encode([[{ kind: 'document' }]]);
+      expect(decodeFlyoutV2UrlParam(raw)).toBeNull();
+    });
+
+    it('never throws on any input', () => {
+      const inputs = [null, undefined, '', 'garbage', '!@#$', '()', '!()'];
+      for (const input of inputs) {
+        expect(() => decodeFlyoutV2UrlParam(input)).not.toThrow();
+      }
+    });
+  });
+
+  describe('round-trip: single descriptor', () => {
+    it.each([
+      ['document', { kind: 'document' as const, documentId: 'doc1', indexName: 'logs-*' }],
+      [
+        'documentFromPattern',
+        {
+          kind: 'documentFromPattern' as const,
+          documentId: 'doc1',
+          indexName: 'logs-*,.siem-signals-*',
+        },
+      ],
+      ['analyzer', { kind: 'analyzer' as const, documentId: 'doc1', indexName: 'idx' }],
+      [
+        'sessionView',
+        {
+          kind: 'sessionView' as const,
+          documentId: 'd',
+          indexName: 'i',
+          jumpToCursor: 'c',
+          jumpToEntityId: 'e',
+        },
+      ],
+      [
+        'documentEntities',
+        { kind: 'documentEntities' as const, documentId: 'd', indexName: 'i', scopeId: 's' },
+      ],
+      [
+        'documentCorrelations',
+        {
+          kind: 'documentCorrelations' as const,
+          documentId: 'd',
+          indexName: 'i',
+          scopeId: 's',
+          isRulePreview: false,
+        },
+      ],
+      [
+        'documentPrevalence',
+        {
+          kind: 'documentPrevalence' as const,
+          documentId: 'd',
+          indexName: 'i',
+          scopeId: 's',
+          investigationFields: ['host.name'],
+        },
+      ],
+      ['documentResponse', { kind: 'documentResponse' as const, documentId: 'd', indexName: 'i' }],
+      [
+        'documentThreatIntelligence',
+        { kind: 'documentThreatIntelligence' as const, documentId: 'd', indexName: 'i' },
+      ],
+      [
+        'documentInvestigationGuide',
+        { kind: 'documentInvestigationGuide' as const, documentId: 'd', indexName: 'i' },
+      ],
+      ['documentGraph', { kind: 'documentGraph' as const, documentId: 'd', indexName: 'i' }],
+      ['notes', { kind: 'notes' as const, documentId: 'd', indexName: 'i' }],
+      ['attack', { kind: 'attack' as const, attackId: 'a1', indexName: '.alerts-*' }],
+      [
+        'attackCorrelations',
+        {
+          kind: 'attackCorrelations' as const,
+          attackId: 'a1',
+          indexName: '.alerts-*',
+          alertIds: ['id1', 'id2'],
+        },
+      ],
+      [
+        'attackEntities',
+        {
+          kind: 'attackEntities' as const,
+          attackId: 'a1',
+          indexName: '.alerts-*',
+          alertIds: ['id1'],
+        },
+      ],
+      ['host', { kind: 'host' as const, hostName: 'my-host', entityId: 'eid', scopeId: 's' }],
+      ['user', { kind: 'user' as const, userName: 'alice', entityId: 'eid' }],
+      ['service', { kind: 'service' as const, serviceName: 'api', entityId: 'eid', scopeId: 's' }],
+      [
+        'genericEntity',
+        { kind: 'genericEntity' as const, scopeId: 's', entityId: 'eid', entityDocId: 'docid' },
+      ],
+      [
+        'entityRiskInputs',
+        {
+          kind: 'entityRiskInputs' as const,
+          entityType: 'host',
+          entityName: 'my-host',
+          entityId: 'eid',
+        },
+      ],
+      [
+        'entityAnomalyInsights',
+        {
+          kind: 'entityAnomalyInsights' as const,
+          entityType: 'user',
+          value: 'alice',
+          entityId: 'eid',
+        },
+      ],
+      [
+        'entityAlertsInsights',
+        { kind: 'entityAlertsInsights' as const, entityType: 'host', value: 'h', entityId: 'eid' },
+      ],
+      [
+        'entityMisconfigurationInsights',
+        { kind: 'entityMisconfigurationInsights' as const, entityType: 'host', value: 'h' },
+      ],
+      [
+        'entityVulnerabilityInsights',
+        { kind: 'entityVulnerabilityInsights' as const, value: 'h', entityType: 'host' },
+      ],
+      [
+        'entityGraphView',
+        { kind: 'entityGraphView' as const, entityId: 'eid', scopeId: 's', entityName: 'n' },
+      ],
+      [
+        'entityResolution',
+        {
+          kind: 'entityResolution' as const,
+          entityId: 'eid',
+          entityType: 'host',
+          entityName: 'n',
+          scopeId: 's',
+        },
+      ],
+      [
+        'entityEntraInsights',
+        {
+          kind: 'entityEntraInsights' as const,
+          managedUserId: 'mid',
+          managedUserIndex: 'idx',
+          value: 'alice',
+        },
+      ],
+      [
+        'entityOktaInsights',
+        {
+          kind: 'entityOktaInsights' as const,
+          managedUserId: 'mid',
+          managedUserIndex: 'idx',
+          value: 'alice',
+        },
+      ],
+      ['network', { kind: 'network' as const, ip: '1.2.3.4', flowTarget: 'source' }],
+      ['rule', { kind: 'rule' as const, ruleId: 'r1' }],
+      ['ioc', { kind: 'ioc' as const, indicatorId: 'iid', indicatorIndex: 'ti-*' }],
+      [
+        'cspMisconfiguration',
+        { kind: 'cspMisconfiguration' as const, resourceId: 'res1', ruleId: 'csp-rule-1' },
+      ],
+      [
+        'cspVulnerability',
+        {
+          kind: 'cspVulnerability' as const,
+          vulnerabilityId: 'CVE-2021-44228',
+          resourceId: 'res2',
+          packageName: 'log4j',
+          packageVersion: '2.14.1',
+          eventId: 'ev1',
+        },
+      ],
+    ])('round-trips a %s descriptor', (_name, descriptor) => {
+      const value: FlyoutV2UrlParamValue = [descriptor];
+      const encoded = encodeFlyoutV2UrlParam(value);
+      const decoded = decodeFlyoutV2UrlParam(encoded);
+      expect(decoded).toEqual(value);
+    });
+  });
+
+  describe('round-trip: two-entry chain', () => {
+    it('round-trips [tool, child] — analyzer + document', () => {
+      const value: FlyoutV2UrlParamValue = [
+        { kind: 'analyzer', documentId: 'doc1', indexName: 'logs-*' },
+        { kind: 'document', documentId: 'doc1', indexName: 'logs-*' },
+      ];
+      const encoded = encodeFlyoutV2UrlParam(value);
+      const decoded = decodeFlyoutV2UrlParam(encoded);
+      expect(decoded).toEqual(value);
+    });
+
+    it('round-trips [attack tool, attack child]', () => {
+      const value: FlyoutV2UrlParamValue = [
+        { kind: 'attackCorrelations', attackId: 'a1', indexName: '.alerts-*', alertIds: ['x'] },
+        { kind: 'attack', attackId: 'a1', indexName: '.alerts-*' },
+      ];
+      const encoded = encodeFlyoutV2UrlParam(value);
+      const decoded = decodeFlyoutV2UrlParam(encoded);
+      expect(decoded).toEqual(value);
+    });
+
+    it('preserves array order (first entry is the tool, second is the child)', () => {
+      const tool = { kind: 'sessionView' as const, documentId: 'd', indexName: 'i' };
+      const child = { kind: 'document' as const, documentId: 'd', indexName: 'i' };
+      const value: FlyoutV2UrlParamValue = [tool, child];
+      const decoded = decodeFlyoutV2UrlParam(encodeFlyoutV2UrlParam(value));
+      expect(decoded![0].kind).toBe('sessionView');
+      expect(decoded![1].kind).toBe('document');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
@@ -1,0 +1,438 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { decode, encode } from '@kbn/rison';
+import { timelineFlyoutHistoryKey } from '../constants/flyout_history';
+
+/**
+ * URL parameter that carries the currently-open flyout chain for the page (non-Timeline) context.
+ * The value is a rison-encoded ordered array of up to 2 {@link FlyoutDescriptor} entries.
+ *
+ * Separate from the legacy `flyout` param (expandable-flyout) and the pre-existing
+ * `attackFlyoutV2` param (auto-open on the Attacks page). Do NOT unify with those.
+ */
+export const FLYOUT_V2_URL_PARAM = 'flyoutV2' as const;
+
+/**
+ * URL parameter for the Timeline flyout context (second instantiation of the sync layer).
+ * Same shape as {@link FLYOUT_V2_URL_PARAM}; keyed separately so page and Timeline restore
+ * independently.
+ */
+export const FLYOUT_V2_TIMELINE_URL_PARAM = 'flyoutV2Timeline' as const;
+
+/**
+ * Maps a runtime `historyKey` (from `useFlyoutSessionContext`) to the appropriate URL param key.
+ * Timeline-context flyouts write to `flyoutV2Timeline`; all others write to `flyoutV2`.
+ */
+export const urlParamKeyForHistoryKey = (
+  historyKey: symbol
+): typeof FLYOUT_V2_URL_PARAM | typeof FLYOUT_V2_TIMELINE_URL_PARAM =>
+  historyKey === timelineFlyoutHistoryKey ? FLYOUT_V2_TIMELINE_URL_PARAM : FLYOUT_V2_URL_PARAM;
+
+// ---------------------------------------------------------------------------
+// Kind constants
+// ---------------------------------------------------------------------------
+
+export const FLYOUT_DESCRIPTOR_KIND = {
+  // Document main flyouts
+  document: 'document',
+  documentFromPattern: 'documentFromPattern',
+  // Document tools
+  analyzer: 'analyzer',
+  sessionView: 'sessionView',
+  documentEntities: 'documentEntities',
+  documentCorrelations: 'documentCorrelations',
+  documentPrevalence: 'documentPrevalence',
+  documentResponse: 'documentResponse',
+  documentThreatIntelligence: 'documentThreatIntelligence',
+  documentInvestigationGuide: 'documentInvestigationGuide',
+  documentGraph: 'documentGraph',
+  notes: 'notes',
+  // Attack main flyout + tools
+  attack: 'attack',
+  attackCorrelations: 'attackCorrelations',
+  attackEntities: 'attackEntities',
+  // Entity main flyouts
+  host: 'host',
+  user: 'user',
+  service: 'service',
+  genericEntity: 'genericEntity',
+  // Entity tools
+  entityRiskInputs: 'entityRiskInputs',
+  entityAnomalyInsights: 'entityAnomalyInsights',
+  entityAlertsInsights: 'entityAlertsInsights',
+  entityMisconfigurationInsights: 'entityMisconfigurationInsights',
+  entityVulnerabilityInsights: 'entityVulnerabilityInsights',
+  entityGraphView: 'entityGraphView',
+  entityResolution: 'entityResolution',
+  entityEntraInsights: 'entityEntraInsights',
+  entityOktaInsights: 'entityOktaInsights',
+  // NOTE: 'entityFieldsTable' is intentionally omitted — its `document: Record<string, unknown>`
+  // prop is a full flattened entity document that is not cheaply URL-serializable. Restorers
+  // for this kind would open the parent entity main flyout instead.
+  // Network / Rule / IOC / CSP
+  network: 'network',
+  rule: 'rule',
+  ioc: 'ioc',
+  cspMisconfiguration: 'cspMisconfiguration',
+  cspVulnerability: 'cspVulnerability',
+} as const;
+
+export type FlyoutDescriptorKind =
+  (typeof FLYOUT_DESCRIPTOR_KIND)[keyof typeof FLYOUT_DESCRIPTOR_KIND];
+
+// ---------------------------------------------------------------------------
+// Per-kind descriptor params
+// ---------------------------------------------------------------------------
+
+// --- Document ---
+
+export interface DocumentDescriptor {
+  kind: 'document';
+  documentId: string;
+  indexName: string;
+}
+
+export interface DocumentFromPatternDescriptor {
+  kind: 'documentFromPattern';
+  documentId: string;
+  /** Index pattern (possibly comma-separated or wildcard) that resolves the document. */
+  indexName: string;
+}
+
+// --- Document tools ---
+// All document tools identify the source document by {documentId, indexName} extracted
+// from hit.raw._id / hit.raw._index at capture time.
+
+export interface AnalyzerDescriptor {
+  kind: 'analyzer';
+  documentId: string;
+  indexName: string;
+}
+
+export interface SessionViewDescriptor {
+  kind: 'sessionView';
+  documentId: string;
+  indexName: string;
+  jumpToCursor?: string;
+  jumpToEntityId?: string;
+}
+
+export interface DocumentEntitiesDescriptor {
+  kind: 'documentEntities';
+  documentId: string;
+  indexName: string;
+  scopeId?: string;
+}
+
+export interface DocumentCorrelationsDescriptor {
+  kind: 'documentCorrelations';
+  documentId: string;
+  indexName: string;
+  scopeId: string;
+  isRulePreview: boolean;
+}
+
+export interface DocumentPrevalenceDescriptor {
+  kind: 'documentPrevalence';
+  documentId: string;
+  indexName: string;
+  scopeId: string;
+  investigationFields: string[];
+}
+
+export interface DocumentResponseDescriptor {
+  kind: 'documentResponse';
+  documentId: string;
+  indexName: string;
+}
+
+export interface DocumentThreatIntelligenceDescriptor {
+  kind: 'documentThreatIntelligence';
+  documentId: string;
+  indexName: string;
+}
+
+export interface DocumentInvestigationGuideDescriptor {
+  kind: 'documentInvestigationGuide';
+  documentId: string;
+  indexName: string;
+}
+
+export interface DocumentGraphDescriptor {
+  kind: 'documentGraph';
+  documentId: string;
+  indexName: string;
+}
+
+export interface NotesDescriptor {
+  kind: 'notes';
+  documentId: string;
+  indexName: string;
+}
+
+// --- Attack ---
+
+export interface AttackDescriptor {
+  kind: 'attack';
+  attackId: string;
+  indexName: string;
+}
+
+export interface AttackCorrelationsDescriptor {
+  kind: 'attackCorrelations';
+  attackId: string;
+  indexName: string;
+  alertIds: string[];
+}
+
+export interface AttackEntitiesDescriptor {
+  kind: 'attackEntities';
+  attackId: string;
+  indexName: string;
+  alertIds: string[];
+}
+
+// --- Entity main flyouts ---
+
+export interface HostDescriptor {
+  kind: 'host';
+  hostName: string;
+  entityId?: string;
+  scopeId?: string;
+}
+
+export interface UserDescriptor {
+  kind: 'user';
+  userName: string;
+  entityId?: string;
+  scopeId?: string;
+}
+
+export interface ServiceDescriptor {
+  kind: 'service';
+  serviceName: string;
+  entityId?: string;
+  scopeId?: string;
+}
+
+export interface GenericEntityDescriptor {
+  kind: 'genericEntity';
+  scopeId: string;
+  /** Canonical Entity Store v2 id (`entity.id`). Either entityDocId or entityId must be set. */
+  entityId?: string;
+  /** Raw document `_id` of the asset-inventory record. */
+  entityDocId?: string;
+}
+
+// --- Entity tools ---
+// EntityType enum values are stored as plain strings.
+// Restorers must cast back: `entityType as EntityType`.
+
+export interface EntityRiskInputsDescriptor {
+  kind: 'entityRiskInputs';
+  /** EntityType stored as plain string. Cast back to EntityType on restore. */
+  entityType: string;
+  entityName: string;
+  entityId?: string;
+}
+
+export interface EntityAnomalyInsightsDescriptor {
+  kind: 'entityAnomalyInsights';
+  /** EntityType stored as plain string. Cast back to EntityType on restore. */
+  entityType: string;
+  value: string;
+  entityId?: string;
+}
+
+export interface EntityAlertsInsightsDescriptor {
+  kind: 'entityAlertsInsights';
+  /** EntityType stored as plain string. Cast back to EntityType on restore. */
+  entityType: string;
+  value: string;
+  entityId?: string;
+}
+
+export interface EntityMisconfigurationInsightsDescriptor {
+  kind: 'entityMisconfigurationInsights';
+  /** EntityType stored as plain string. Cast back to EntityType on restore. */
+  entityType: string;
+  value: string;
+  entityId?: string;
+}
+
+export interface EntityVulnerabilityInsightsDescriptor {
+  kind: 'entityVulnerabilityInsights';
+  value: string;
+  entityId?: string;
+  /** EntityType stored as plain string. Cast back to EntityType on restore. */
+  entityType?: string;
+}
+
+export interface EntityGraphViewDescriptor {
+  kind: 'entityGraphView';
+  entityId: string;
+  scopeId: string;
+  entityName: string;
+}
+
+export interface EntityResolutionDescriptor {
+  kind: 'entityResolution';
+  entityId: string;
+  /** EntityType stored as plain string. Cast back to EntityType on restore. */
+  entityType: string;
+  entityName: string;
+  scopeId: string;
+}
+
+/**
+ * Stores the identifying parts of the ManagedUserHit (`_id` / `_index`) for Entra Insights.
+ * The restorer rebuilds the ManagedUserHit from these two fields.
+ */
+export interface EntityEntraInsightsDescriptor {
+  kind: 'entityEntraInsights';
+  managedUserId: string;
+  managedUserIndex: string;
+  value: string;
+}
+
+/**
+ * Stores the identifying parts of the ManagedUserHit (`_id` / `_index`) for Okta Insights.
+ * The restorer rebuilds the ManagedUserHit from these two fields.
+ */
+export interface EntityOktaInsightsDescriptor {
+  kind: 'entityOktaInsights';
+  managedUserId: string;
+  managedUserIndex: string;
+  value: string;
+}
+
+// --- Network / Rule / IOC / CSP ---
+
+/**
+ * FlowTargetSourceDest enum values are stored as plain strings.
+ * Restorers must cast back: `flowTarget as FlowTargetSourceDest`.
+ */
+export interface NetworkDescriptor {
+  kind: 'network';
+  ip: string;
+  flowTarget: string;
+}
+
+export interface RuleDescriptor {
+  kind: 'rule';
+  ruleId: string;
+}
+
+/**
+ * IOC descriptor stores the indicator's `_id` and `_index` so the restorer can re-fetch it.
+ */
+export interface IocDescriptor {
+  kind: 'ioc';
+  indicatorId: string;
+  indicatorIndex: string;
+}
+
+export interface CspMisconfigurationDescriptor {
+  kind: 'cspMisconfiguration';
+  resourceId: string;
+  ruleId: string;
+}
+
+export interface CspVulnerabilityDescriptor {
+  kind: 'cspVulnerability';
+  vulnerabilityId?: string | string[];
+  resourceId?: string;
+  packageName?: string | string[];
+  packageVersion?: string | string[];
+  eventId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union
+// ---------------------------------------------------------------------------
+
+export type FlyoutDescriptor =
+  | DocumentDescriptor
+  | DocumentFromPatternDescriptor
+  | AnalyzerDescriptor
+  | SessionViewDescriptor
+  | DocumentEntitiesDescriptor
+  | DocumentCorrelationsDescriptor
+  | DocumentPrevalenceDescriptor
+  | DocumentResponseDescriptor
+  | DocumentThreatIntelligenceDescriptor
+  | DocumentInvestigationGuideDescriptor
+  | DocumentGraphDescriptor
+  | NotesDescriptor
+  | AttackDescriptor
+  | AttackCorrelationsDescriptor
+  | AttackEntitiesDescriptor
+  | HostDescriptor
+  | UserDescriptor
+  | ServiceDescriptor
+  | GenericEntityDescriptor
+  | EntityRiskInputsDescriptor
+  | EntityAnomalyInsightsDescriptor
+  | EntityAlertsInsightsDescriptor
+  | EntityMisconfigurationInsightsDescriptor
+  | EntityVulnerabilityInsightsDescriptor
+  | EntityGraphViewDescriptor
+  | EntityResolutionDescriptor
+  | EntityEntraInsightsDescriptor
+  | EntityOktaInsightsDescriptor
+  | NetworkDescriptor
+  | RuleDescriptor
+  | IocDescriptor
+  | CspMisconfigurationDescriptor
+  | CspVulnerabilityDescriptor;
+
+/** Ordered array of up to 2 descriptors representing the current open flyout chain. */
+export type FlyoutV2UrlParamValue = FlyoutDescriptor[];
+
+// ---------------------------------------------------------------------------
+// Kind guard (validates the `kind` field is one we know)
+// ---------------------------------------------------------------------------
+
+const KNOWN_KINDS = new Set<string>(Object.values(FLYOUT_DESCRIPTOR_KIND));
+
+const isKnownKind = (kind: unknown): kind is FlyoutDescriptorKind =>
+  typeof kind === 'string' && KNOWN_KINDS.has(kind);
+
+// ---------------------------------------------------------------------------
+// Encode / decode
+// ---------------------------------------------------------------------------
+
+export const encodeFlyoutV2UrlParam = (value: FlyoutV2UrlParamValue): string => encode(value);
+
+/**
+ * Decodes the value of the flyoutV2 URL parameter.
+ * Returns null when the value is missing, malformed, not an array, or contains an entry
+ * with an unknown `kind`. Never throws.
+ *
+ * Mirrors the null-on-malformed pattern of `decodeAttackFlyoutV2UrlParam`.
+ */
+export const decodeFlyoutV2UrlParam = (
+  raw: string | null | undefined
+): FlyoutV2UrlParamValue | null => {
+  if (!raw) return null;
+
+  try {
+    const decoded = decode(raw);
+
+    if (!Array.isArray(decoded) || decoded.length === 0) return null;
+
+    for (const entry of decoded) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
+      if (!isKnownKind((entry as Record<string, unknown>).kind)) return null;
+    }
+
+    return decoded as unknown as FlyoutV2UrlParamValue;
+  } catch {
+    return null;
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_param.ts
@@ -278,6 +278,12 @@ export interface EntityGraphViewDescriptor {
   entityId: string;
   scopeId: string;
   entityName: string;
+  /**
+   * EntityType of the originating entity, stored as a plain string. Used on restore to rebuild the
+   * header's "show entity" action so the entity name/icon reappear after a refresh. Optional for
+   * backward compatibility with URLs encoded before this field existed.
+   */
+  entityType?: string;
 }
 
 export interface EntityResolutionDescriptor {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_writer.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_writer.test.ts
@@ -1,0 +1,327 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from '@kbn/shared-ux-router';
+import { useFlyoutV2UrlWriter } from './flyout_v2_url_writer';
+import { FLYOUT_V2_URL_PARAM } from './flyout_v2_url_param';
+import { documentFlyoutHistoryKey } from '../constants/flyout_history';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const renderWriter = (
+  history = createMemoryHistory(),
+  urlParamKey: string = FLYOUT_V2_URL_PARAM
+) => {
+  const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+    React.createElement(Router, { history }, children as React.ReactElement);
+  const { result } = renderHook(() => useFlyoutV2UrlWriter(urlParamKey, documentFlyoutHistoryKey), {
+    wrapper,
+  });
+  return { result, history };
+};
+
+const getParam = (history: ReturnType<typeof createMemoryHistory>, key = FLYOUT_V2_URL_PARAM) =>
+  new URLSearchParams(history.location.search).get(key);
+
+const docDescriptor = (id: string) =>
+  ({ kind: 'document' as const, documentId: id, indexName: 'idx' } as const);
+
+const analyzerDescriptor = (id: string) =>
+  ({ kind: 'analyzer' as const, documentId: id, indexName: 'idx' } as const);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useFlyoutV2UrlWriter', () => {
+  describe('writeOnOpen — start mode (default)', () => {
+    it('writes the descriptor to the URL', () => {
+      const { result, history } = renderWriter();
+
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'));
+      });
+
+      expect(getParam(history)).not.toBeNull();
+      expect(history.location.search).toContain('doc-1');
+    });
+
+    it('replaces any existing URL array with [descriptor]', () => {
+      const { result, history } = renderWriter();
+
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'));
+      });
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('doc-2'));
+      });
+
+      // URL should contain only the second descriptor
+      expect(history.location.search).not.toContain('doc-1');
+      expect(history.location.search).toContain('doc-2');
+      expect(history.location.search).toContain('analyzer');
+    });
+
+    it('uses history.replace (not push): does not grow history.length', () => {
+      const { result, history } = renderWriter();
+      const initialLength = history.length;
+
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'));
+      });
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-2'));
+      });
+
+      expect(history.length).toBe(initialLength);
+    });
+  });
+
+  describe('writeOnOpen — inherit mode', () => {
+    it('appends the descriptor to the existing URL array', () => {
+      const { result, history } = renderWriter();
+
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('doc-1'));
+      });
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'), 'inherit');
+      });
+
+      const raw = getParam(history);
+      expect(raw).not.toBeNull();
+      // Both kinds should appear in the rison-encoded array
+      expect(history.location.search).toContain('analyzer');
+      expect(history.location.search).toContain('document');
+    });
+
+    it('replaces the child (keeps the root) when inherit is called again — [root, newChild]', () => {
+      const { result, history } = renderWriter();
+
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('tool-doc')); // root (tool), session start
+      });
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('child-1'), 'inherit'); // first child
+      });
+      act(() => {
+        // A child opened from within the first child (e.g. tool -> document -> host) REPLACES the
+        // previous child. The root is kept and the array stays capped at 2 — critically, it is the
+        // NEWEST child that is kept, not dropped.
+        result.current.writeOnOpen(docDescriptor('child-2'), 'inherit');
+      });
+
+      expect(getParam(history)).not.toBeNull();
+      expect(history.location.search).toContain('tool-doc'); // root (analyzer) kept
+      expect(history.location.search).toContain('child-2'); // newest child present
+      expect(history.location.search).not.toContain('child-1'); // previous child replaced
+    });
+  });
+
+  describe('buildOnClose — generation-guarded close', () => {
+    it('clears the URL param when the fallback is null (top-level close)', () => {
+      const { result, history } = renderWriter();
+
+      let onClose!: () => void;
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'));
+        onClose = result.current.buildOnClose(null);
+      });
+
+      act(() => {
+        onClose();
+      });
+
+      expect(getParam(history)).toBeNull();
+    });
+
+    it('reverts to [fallback] when the flyout that opened it closes normally', () => {
+      const { result, history } = renderWriter();
+
+      let onClose!: () => void;
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('doc-1'));
+        onClose = result.current.buildOnClose(docDescriptor('doc-1'));
+      });
+
+      act(() => {
+        onClose();
+      });
+
+      expect(history.location.search).toContain('doc-1');
+      expect(history.location.search).not.toContain('analyzer');
+    });
+
+    it('does NOT revert when a newer writeOnOpen superseded the current one (cascade-eviction)', () => {
+      const { result, history } = renderWriter();
+
+      let toolOnClose!: () => void;
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('doc-1'));
+        toolOnClose = result.current.buildOnClose(docDescriptor('doc-1'));
+      });
+
+      // A newer flyout opens after the tool (e.g. clicking a node opens a child document)
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-2'));
+      });
+
+      // EUI cascades the tool's close as a side effect of the child opening
+      act(() => {
+        toolOnClose();
+      });
+
+      // The child's descriptor must still be in the URL — the tool's stale onClose is a no-op
+      expect(history.location.search).toContain('doc-2');
+      expect(history.location.search).not.toContain('analyzer');
+    });
+
+    it('does revert when it is the most-recent write and nothing newer has superseded it', () => {
+      const { result, history } = renderWriter();
+
+      let mainOnClose!: () => void;
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'));
+        mainOnClose = result.current.buildOnClose(null);
+      });
+
+      act(() => {
+        mainOnClose();
+      });
+
+      expect(getParam(history)).toBeNull();
+    });
+
+    it('most-recent-write wins: the last buildOnClose is the one that can revert', () => {
+      const { result, history } = renderWriter();
+
+      let firstOnClose!: () => void;
+      let secondOnClose!: () => void;
+
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-1'));
+        firstOnClose = result.current.buildOnClose(null);
+      });
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-2'));
+        secondOnClose = result.current.buildOnClose(docDescriptor('doc-1'));
+      });
+
+      // First onClose is now stale — should not revert
+      act(() => {
+        firstOnClose();
+      });
+      expect(history.location.search).toContain('doc-2');
+
+      // Second onClose is current — should revert to doc-1
+      act(() => {
+        secondOnClose();
+      });
+      expect(history.location.search).toContain('doc-1');
+    });
+
+    it('clears the param when a root and its child both close together (full-session close)', () => {
+      // Regression test: root (tool, session:'start') opens, then a child opens on top of it
+      // (session:'inherit'). Closing the WHOLE session (root + child dismissed together, e.g. the
+      // tools flyout is closed which also closes its child) must clear the param entirely — not
+      // leave the child's revert-to-root fallback as a stale final state.
+      const { result, history } = renderWriter();
+
+      let rootOnClose!: () => void;
+      let childOnClose!: () => void;
+
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('tool-doc')); // root (tool), session start
+        rootOnClose = result.current.buildOnClose(null);
+      });
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('child-1'), 'inherit'); // child
+        childOnClose = result.current.buildOnClose(analyzerDescriptor('tool-doc'));
+      });
+
+      // EUI fires the CHILD's cascade onClose first (reverts to [root] as an intermediate step)...
+      act(() => {
+        childOnClose();
+      });
+      expect(history.location.search).toContain('tool-doc');
+
+      // ...then the ROOT's own onClose fires (the final close of the whole session) and must be
+      // allowed to clear the param, even though its generation is older than the child's.
+      act(() => {
+        rootOnClose();
+      });
+      expect(getParam(history)).toBeNull();
+    });
+
+    it('does not let a stale eviction through just because a sibling happens to still be open', () => {
+      // Guards against a naive "count reaches 0" only implementation: the evicted tool's onClose
+      // must stay suppressed while the flyout that replaced it (doc-2) is still open.
+      const { result, history } = renderWriter();
+
+      let toolOnClose!: () => void;
+      act(() => {
+        result.current.writeOnOpen(analyzerDescriptor('doc-1'));
+        toolOnClose = result.current.buildOnClose(docDescriptor('doc-1'));
+      });
+      act(() => {
+        result.current.writeOnOpen(docDescriptor('doc-2')); // new root, evicts the tool
+      });
+
+      act(() => {
+        toolOnClose(); // cascade-eviction side effect of doc-2 opening
+      });
+
+      expect(history.location.search).toContain('doc-2');
+      expect(history.location.search).not.toContain('analyzer');
+    });
+  });
+
+  describe('generation isolation across urlParamKey contexts', () => {
+    it('a write on a different urlParamKey does NOT invalidate the current context onClose', () => {
+      const historyA = createMemoryHistory();
+      const { result: resultA } = renderWriter(historyA, FLYOUT_V2_URL_PARAM);
+      const { result: resultB } = renderWriter(historyA, 'flyoutV2Timeline');
+
+      let onCloseA!: () => void;
+      act(() => {
+        resultA.current.writeOnOpen(docDescriptor('doc-A'));
+        onCloseA = resultA.current.buildOnClose(null);
+      });
+
+      // Write on a different param key (timeline context)
+      act(() => {
+        resultB.current.writeOnOpen(docDescriptor('doc-B'));
+      });
+
+      // onCloseA should still fire (its context was not superseded)
+      act(() => {
+        onCloseA();
+      });
+
+      expect(getParam(historyA, FLYOUT_V2_URL_PARAM)).toBeNull();
+    });
+  });
+
+  describe('no-op when history is not usable', () => {
+    it('writeOnOpen is a no-op when history has no location', () => {
+      // Pass no Router wrapper — useHistory returns a minimal mock that lacks location
+      // The hook degrades gracefully without throwing
+      expect(() => {
+        const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+          children as React.ReactElement;
+        renderHook(() => useFlyoutV2UrlWriter(FLYOUT_V2_URL_PARAM, documentFlyoutHistoryKey), {
+          wrapper,
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_writer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/flyout_v2_url_writer.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
+import { encode } from '@kbn/rison';
+import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
+import type { FlyoutDescriptor, FlyoutV2UrlParamValue } from './flyout_v2_url_param';
+import { decodeFlyoutV2UrlParam } from './flyout_v2_url_param';
+
+// ---------------------------------------------------------------------------
+// Generation tracking (cascade-close guard)
+// ---------------------------------------------------------------------------
+
+/**
+ * Monotonic counter bumped by every `writeOnOpen` call. Module-scoped (not a useRef) so that
+ * `buildOnClose` can compare at call time vs. at invocation time — detecting whether any newer
+ * open superseded the current one after `buildOnClose` was created.
+ *
+ * Keyed by `urlParamKey` to isolate the page-flyout context (flyoutV2) from the Timeline-flyout
+ * context (flyoutV2Timeline). A new open in context A does NOT invalidate a pending close in
+ * context B.
+ *
+ * This is the "cascade-close" guard: EUI fires `onClose` on a genuine close AND on a
+ * cascade-eviction (a deeper flyout evicting the current slot occupant). Naive pop-on-close
+ * corrupts the stack; the generation check lets the returned `onClose` ignore evictions.
+ */
+const writeGenerations: Record<string, number> = {};
+
+/**
+ * Stack of write-generations currently believed to be "open" for a given `urlParamKey`, mirroring
+ * the shape of the URL array: index 0 is the root (session:'start'), index 1 is the child
+ * (session:'inherit'). Capped at 2 entries, same as the URL itself.
+ *
+ * The generation guard alone is not sufficient: when a root flyout with an open child is closed
+ * as a whole (e.g. the tools flyout AND its child both dismissed together), EUI fires the CHILD's
+ * onClose first (cascade), then the ROOT's own onClose second — but the root's write generation
+ * is older than the child's, so the plain "am I the most recent write" check would wrongly treat
+ * the root's onClose as a stale eviction and swallow it, leaving the child's `[root]` revert-write
+ * as the final (wrong) URL state instead of the root's own `null` (fully cleared) write.
+ *
+ * This stack lets `buildOnClose` ask the more precise question: "is anything with a newer
+ * generation than mine STILL open?" A 'start' write resets the stack to `[gen]` (discarding stale
+ * entries, mirroring how it discards the stale URL chain too), which also self-heals any entry
+ * that never got popped (e.g. a flyout unmounted through a path that skipped `onClose`).
+ */
+const openGenerationStacks: Record<string, number[]> = {};
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface FlyoutUrlWriter {
+  /**
+   * Call when a flyout opens. Records the descriptor in the URL param.
+   *
+   * `mode = 'start'` (default): replaces the URL array with `[descriptor]`.
+   *   Use for session:'start' opens — any existing chain is cleared.
+   * `mode = 'inherit'`: appends `descriptor` to the current URL array (capped at 2).
+   *   Use for session:'inherit' / `...AsChild` opens so the restore array contains
+   *   both the parent (index 0) and the child (index 1).
+   */
+  writeOnOpen: (descriptor: FlyoutDescriptor, mode?: 'start' | 'inherit') => void;
+  /**
+   * Call right after `writeOnOpen` to build the `onClose` callback for `openSystemFlyout`.
+   *
+   * The returned callback writes `[fallback]` (or clears the param if `fallback` is `null`)
+   * unless something with a newer generation is still open — that would mean this close is a
+   * cascade-eviction side effect, and writing would clobber the newer descriptor. When the newer
+   * open has ALSO since closed (e.g. a root closing together with its already-cascaded child),
+   * the write goes through even though this generation is no longer the most recent one.
+   */
+  buildOnClose: (fallback: FlyoutDescriptor | null) => () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared write-side helper for keeping the `flyoutV2` (or `flyoutV2Timeline`) URL param in sync
+ * with whichever flyout chain is currently open.
+ *
+ * Parameterized by `(urlParamKey, historyKey)` so the page-flyout context and the
+ * Timeline-flyout context are two independent instantiations of the same mechanism.
+ *
+ * Creates `createKbnUrlStateStorage` (following the legacy expandable-flyout pattern) and
+ * exposes it for use by the restore hook (T-003). Writes use `history.replace` (never `push`)
+ * to avoid creating extra Back/Forward stops.
+ *
+ * Degrades to a no-op when `history` lacks `location`/`replace` (many unit tests pass a
+ * minimal history object).
+ */
+export const useFlyoutV2UrlWriter = (
+  urlParamKey: string,
+  // historyKey is not used internally for URL writes but is part of the contract: callers
+  // instantiate one writer per context (page vs. Timeline) and pass the matching historyKey
+  // so the restore hook (T-003) can identify which EUI flyout chain to restore into.
+  _historyKey: symbol
+): FlyoutUrlWriter => {
+  const history = useHistory();
+  const hasUsableHistory = !!history?.location && typeof history.replace === 'function';
+
+  // createKbnUrlStateStorage is the Kibana-standard URL state layer used by the legacy
+  // expandable-flyout package. We create it here (a) for consistency with that pattern,
+  // (b) so the restore hook (T-003) can share the same storage instance when reading back
+  // on mount via `change$` / `get`. Write-side uses direct history.replace (synchronous)
+  // so tests can assert the URL immediately without waiting on microtask batching.
+  const urlStorage = useMemo(() => {
+    if (!hasUsableHistory) return null;
+    try {
+      return createKbnUrlStateStorage({ useHash: false, useHashQuery: false, history });
+    } catch {
+      return null;
+    }
+  }, [hasUsableHistory, history]);
+
+  // Reads the current URL stack, preferring the pending (unflushed) value in urlStorage
+  // so 'inherit' appends are consistent even when urlStorage has buffered an update.
+  const readCurrentStack = useCallback((): FlyoutV2UrlParamValue => {
+    const pending = urlStorage?.get<FlyoutV2UrlParamValue>(urlParamKey);
+    if (pending) return pending;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    return decodeFlyoutV2UrlParam(raw) ?? [];
+  }, [urlStorage, urlParamKey, history]);
+
+  // Writes directly via history.replace so the URL update is synchronous.
+  // Using history.replace (not push) means no extra Back/Forward stops are created.
+  const writeToUrl = useCallback(
+    (stack: FlyoutV2UrlParamValue | null) => {
+      if (!hasUsableHistory) return;
+      const params = new URLSearchParams(history.location.search);
+      if (stack && stack.length > 0) {
+        params.set(urlParamKey, encode(stack));
+      } else {
+        params.delete(urlParamKey);
+      }
+      const serialized = params.toString();
+      history.replace({ ...history.location, search: serialized ? `?${serialized}` : '' });
+    },
+    [hasUsableHistory, history, urlParamKey]
+  );
+
+  const writeOnOpen = useCallback(
+    (descriptor: FlyoutDescriptor, mode: 'start' | 'inherit' = 'start') => {
+      if (!hasUsableHistory) return;
+      const generation = (writeGenerations[urlParamKey] ?? 0) + 1;
+      writeGenerations[urlParamKey] = generation;
+
+      if (mode === 'inherit') {
+        // A child open keeps the session-start root (index 0) and sets the child slot to the new
+        // descriptor — REPLACING any existing child. A child opened from within another child
+        // (e.g. tool -> document -> host) must persist as [root, currentDeepestChild]; appending and
+        // slicing to 2 would instead keep the stale first two entries and drop the newest child (the
+        // one the user is actually looking at).
+        const [root] = readCurrentStack();
+        writeToUrl(root ? [root, descriptor] : [descriptor]);
+        // Keep the root's generation (index 0), replace the child's (index 1) — mirrors the URL.
+        const [rootGeneration] = openGenerationStacks[urlParamKey] ?? [];
+        openGenerationStacks[urlParamKey] = [rootGeneration ?? generation, generation];
+      } else {
+        // A 'start' open is a new top-level flyout; discard any existing chain.
+        writeToUrl([descriptor]);
+        openGenerationStacks[urlParamKey] = [generation];
+      }
+    },
+    [hasUsableHistory, urlParamKey, readCurrentStack, writeToUrl]
+  );
+
+  const buildOnClose = useCallback(
+    (fallback: FlyoutDescriptor | null): (() => void) => {
+      if (!hasUsableHistory) return () => {};
+      const ownGeneration = writeGenerations[urlParamKey] ?? 0;
+      return () => {
+        const stack = openGenerationStacks[urlParamKey] ?? [];
+        const ownIndex = stack.indexOf(ownGeneration);
+        if (ownIndex !== -1) stack.splice(ownIndex, 1);
+
+        // If something with a newer generation is STILL open, this close is a cascade-eviction
+        // side effect — do NOT overwrite the newer descriptor with this, now-stale, fallback.
+        const hasNewerStillOpen = stack.some((openGeneration) => openGeneration > ownGeneration);
+        if (hasNewerStillOpen) return;
+
+        writeToUrl(fallback ? [fallback] : null);
+      };
+    },
+    [hasUsableHistory, urlParamKey, writeToUrl]
+  );
+
+  return useMemo(() => ({ writeOnOpen, buildOnClose }), [writeOnOpen, buildOnClose]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.test.ts
@@ -1,0 +1,713 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { encode } from '@kbn/rison';
+import {
+  translateLegacyStateToDescriptors,
+  useLegacyFlyoutUrlInterop,
+} from './use_expandable_flyout_url_interop';
+import { useFlyoutApi } from '../../use_flyout_api';
+import { createFlyoutApiMock } from '../../use_flyout_api.mock';
+import { ElasticRequestState } from '@kbn/unified-doc-viewer';
+import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+import { FLYOUT_V2_URL_PARAM } from './flyout_v2_url_param';
+
+// Import the renderHook + Router helpers
+import React from 'react';
+import { createMemoryHistory } from 'history';
+import { Router } from '@kbn/shared-ux-router';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../../use_flyout_api');
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('@kbn/unified-doc-viewer-plugin/public', () => ({
+  useEsDocSearch: jest.fn(),
+}));
+jest.mock('../../../data_view_manager/hooks/use_data_view');
+
+const mockFlyoutApi = createFlyoutApiMock();
+(useFlyoutApi as jest.Mock).mockReturnValue(mockFlyoutApi);
+(useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+
+const mockDataView = { getRuntimeMappings: jest.fn(() => ({})) };
+(useDataView as jest.Mock).mockReturnValue({ dataView: mockDataView, status: 'ready' });
+
+const noHit = () =>
+  (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.NotFound, null, jest.fn()]);
+
+const withHit = (record: Record<string, unknown>) =>
+  (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Found, record, jest.fn()]);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const LEGACY_PARAM = 'flyout';
+const V2_PARAM = FLYOUT_V2_URL_PARAM;
+
+const buildLegacyUrl = (state: object) => `/?${LEGACY_PARAM}=${encode(state)}`;
+
+const renderInterop = (url: string) => {
+  const history = createMemoryHistory({ initialEntries: [url] });
+  const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+    React.createElement(Router, { history }, children as React.ReactElement);
+  const { result, rerender } = renderHook(() => useLegacyFlyoutUrlInterop(LEGACY_PARAM, V2_PARAM), {
+    wrapper,
+  });
+  return { result, history, rerender };
+};
+
+// ---------------------------------------------------------------------------
+// Unit tests: translateLegacyStateToDescriptors
+// ---------------------------------------------------------------------------
+
+describe('translateLegacyStateToDescriptors', () => {
+  describe('no-tools panel types (right+left → single main)', () => {
+    it('network: right only → single network descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'network-details', params: { ip: '1.2.3.4', flowTarget: 'source' } },
+      });
+      expect(result).toEqual([{ kind: 'network', ip: '1.2.3.4', flowTarget: 'source' }]);
+    });
+
+    it('network: right+left collapses to single network descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'network-details', params: { ip: '10.0.0.1', flowTarget: 'destination' } },
+        left: { id: 'some-network-left', params: {} },
+      });
+      expect(result).toEqual([{ kind: 'network', ip: '10.0.0.1', flowTarget: 'destination' }]);
+    });
+
+    it('rule: right only → single rule descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'rule-panel', params: { ruleId: 'rule-123' } },
+      });
+      expect(result).toEqual([{ kind: 'rule', ruleId: 'rule-123' }]);
+    });
+
+    it('CSP misconfiguration: right only → single cspMisconfiguration descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'findings-misconfiguration-panel',
+          params: { resourceId: 'res-1', ruleId: 'csp-rule-1' },
+        },
+      });
+      expect(result).toEqual([
+        { kind: 'cspMisconfiguration', resourceId: 'res-1', ruleId: 'csp-rule-1' },
+      ]);
+    });
+
+    it('CSP vulnerability: right only → single cspVulnerability descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'findings-vulnerability-panel',
+          params: { vulnerabilityId: 'CVE-1', resourceId: 'res-2' },
+        },
+      });
+      expect(result).toEqual([
+        {
+          kind: 'cspVulnerability',
+          vulnerabilityId: 'CVE-1',
+          resourceId: 'res-2',
+          packageName: undefined,
+          packageVersion: undefined,
+          eventId: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe('document flyout', () => {
+    it('right only → single document descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-1', indexName: 'logs-*', scopeId: 'alerts' },
+        },
+      });
+      expect(result).toEqual([{ kind: 'document', documentId: 'doc-1', indexName: 'logs-*' }]);
+    });
+
+    it('right+left (visualize/analyze_graph) → [analyzer, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-1', indexName: 'logs-*', scopeId: 'alerts' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'visualize', subTab: 'analyze_graph' } },
+      });
+      expect(result).toEqual([
+        { kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' },
+        { kind: 'document', documentId: 'doc-1', indexName: 'logs-*' },
+      ]);
+    });
+
+    it('right+left (visualize/session-view) → [sessionView, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-2', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'visualize', subTab: 'session-view' } },
+      });
+      expect(result).toEqual([
+        { kind: 'sessionView', documentId: 'doc-2', indexName: 'idx' },
+        { kind: 'document', documentId: 'doc-2', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (visualize/graph-visualization) → [documentGraph, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-3', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: {
+          id: 'document-details-left',
+          path: { tab: 'visualize', subTab: 'graph-visualization' },
+        },
+      });
+      expect(result).toEqual([
+        { kind: 'documentGraph', documentId: 'doc-3', indexName: 'idx' },
+        { kind: 'document', documentId: 'doc-3', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (insights/entity) → [documentEntities, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-4', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'insights', subTab: 'entity' } },
+      });
+      expect(result).toEqual([
+        { kind: 'documentEntities', documentId: 'doc-4', indexName: 'idx', scopeId: 'sc' },
+        { kind: 'document', documentId: 'doc-4', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (insights/threatIntelligence) → [documentThreatIntelligence, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-5', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: {
+          id: 'document-details-left',
+          path: { tab: 'insights', subTab: 'threatIntelligence' },
+        },
+      });
+      expect(result).toEqual([
+        { kind: 'documentThreatIntelligence', documentId: 'doc-5', indexName: 'idx' },
+        { kind: 'document', documentId: 'doc-5', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (insights/prevalence) → [documentPrevalence, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-6', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'insights', subTab: 'prevalence' } },
+      });
+      expect(result).toEqual([
+        {
+          kind: 'documentPrevalence',
+          documentId: 'doc-6',
+          indexName: 'idx',
+          scopeId: 'sc',
+          investigationFields: [],
+        },
+        { kind: 'document', documentId: 'doc-6', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (insights/correlations) → [documentCorrelations, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-7', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'insights', subTab: 'correlations' } },
+      });
+      expect(result).toEqual([
+        {
+          kind: 'documentCorrelations',
+          documentId: 'doc-7',
+          indexName: 'idx',
+          scopeId: 'sc',
+          isRulePreview: false,
+        },
+        { kind: 'document', documentId: 'doc-7', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (investigation) → [documentInvestigationGuide, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-8', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'investigation' } },
+      });
+      expect(result).toEqual([
+        { kind: 'documentInvestigationGuide', documentId: 'doc-8', indexName: 'idx' },
+        { kind: 'document', documentId: 'doc-8', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (response) → [documentResponse, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-9', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'response' } },
+      });
+      expect(result).toEqual([
+        { kind: 'documentResponse', documentId: 'doc-9', indexName: 'idx' },
+        { kind: 'document', documentId: 'doc-9', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (notes) → [notes, document]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-10', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'notes' } },
+      });
+      expect(result).toEqual([
+        { kind: 'notes', documentId: 'doc-10', indexName: 'idx' },
+        { kind: 'document', documentId: 'doc-10', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left+preview → [tool, preview-descriptor] (preview wins over right)', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-1', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'visualize', subTab: 'analyze_graph' } },
+        preview: [
+          {
+            id: 'document-details-preview',
+            params: { id: 'preview-doc', indexName: 'preview-idx' },
+          },
+        ],
+      });
+      expect(result).toEqual([
+        { kind: 'analyzer', documentId: 'doc-1', indexName: 'idx' },
+        { kind: 'document', documentId: 'preview-doc', indexName: 'preview-idx' },
+      ]);
+    });
+
+    it('right+left with unknown left tab → [document] (fallback to main)', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'document-details-right',
+          params: { id: 'doc-1', indexName: 'idx', scopeId: 'sc' },
+        },
+        left: { id: 'document-details-left', path: { tab: 'unknown-tab' } },
+      });
+      expect(result).toEqual([{ kind: 'document', documentId: 'doc-1', indexName: 'idx' }]);
+    });
+  });
+
+  describe('attack flyout', () => {
+    it('right only → single attack descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'attack-details-right', params: { attackId: 'atk-1', indexName: 'idx' } },
+      });
+      expect(result).toEqual([{ kind: 'attack', attackId: 'atk-1', indexName: 'idx' }]);
+    });
+
+    it('right+left (insights/entity) → [attackEntities, attack]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'attack-details-right', params: { attackId: 'atk-2', indexName: 'idx' } },
+        left: { id: 'attack-details-left', path: { tab: 'insights', subTab: 'entity' } },
+      });
+      expect(result).toEqual([
+        { kind: 'attackEntities', attackId: 'atk-2', indexName: 'idx', alertIds: [] },
+        { kind: 'attack', attackId: 'atk-2', indexName: 'idx' },
+      ]);
+    });
+
+    it('right+left (insights/correlation) → [attackCorrelations, attack]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'attack-details-right', params: { attackId: 'atk-3', indexName: 'idx' } },
+        left: { id: 'attack-details-left', path: { tab: 'insights', subTab: 'correlation' } },
+      });
+      expect(result).toEqual([
+        { kind: 'attackCorrelations', attackId: 'atk-3', indexName: 'idx', alertIds: [] },
+        { kind: 'attack', attackId: 'atk-3', indexName: 'idx' },
+      ]);
+    });
+  });
+
+  describe('entity flyouts', () => {
+    it('host right only → single host descriptor', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'host-panel',
+          params: { hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+        },
+      });
+      expect(result).toEqual([
+        { kind: 'host', hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+      ]);
+    });
+
+    it('host right+left (risk_inputs) → [entityRiskInputs, host]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'host-panel',
+          params: { hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+        },
+        left: { id: 'host_details', path: { tab: 'risk_inputs' } },
+      });
+      expect(result).toEqual([
+        { kind: 'entityRiskInputs', entityType: 'host', entityName: 'my-host', entityId: 'eid-1' },
+        { kind: 'host', hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+      ]);
+    });
+
+    it('host right+left (graph_view) → [entityGraphView, host]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'host-panel',
+          params: { hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+        },
+        left: { id: 'host_details', path: { tab: 'graph_view' } },
+      });
+      expect(result).toEqual([
+        { kind: 'entityGraphView', entityId: 'eid-1', scopeId: 'alerts', entityName: 'my-host' },
+        { kind: 'host', hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+      ]);
+    });
+
+    it('host right+left (csp_insights/misconfigurationTabId) → [entityMisconfigurationInsights, host]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'host-panel',
+          params: { hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+        },
+        left: {
+          id: 'host_details',
+          path: { tab: 'csp_insights', subTab: 'misconfigurationTabId' },
+        },
+      });
+      expect(result).toEqual([
+        {
+          kind: 'entityMisconfigurationInsights',
+          entityType: 'host',
+          value: 'my-host',
+          entityId: 'eid-1',
+        },
+        { kind: 'host', hostName: 'my-host', entityId: 'eid-1', scopeId: 'alerts' },
+      ]);
+    });
+
+    it('user right+left (risk_inputs) → [entityRiskInputs, user]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'user-panel', params: { userName: 'bob', entityId: 'u-1', scopeId: 'sc' } },
+        left: { id: 'user_details', path: { tab: 'risk_inputs' } },
+      });
+      expect(result).toEqual([
+        { kind: 'entityRiskInputs', entityType: 'user', entityName: 'bob', entityId: 'u-1' },
+        { kind: 'user', userName: 'bob', entityId: 'u-1', scopeId: 'sc' },
+      ]);
+    });
+
+    it('service right+left (anomalies) → [entityAnomalyInsights, service]', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'service-panel',
+          params: { serviceName: 'svc-a', entityId: 's-1', scopeId: 'sc' },
+        },
+        left: { id: 'service_details', path: { tab: 'anomalies' } },
+      });
+      expect(result).toEqual([
+        { kind: 'entityAnomalyInsights', entityType: 'service', value: 'svc-a', entityId: 's-1' },
+        { kind: 'service', serviceName: 'svc-a', entityId: 's-1', scopeId: 'sc' },
+      ]);
+    });
+
+    it('entity right+left (okta_document) → [host] (unmappable — fallback to main)', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: {
+          id: 'host-panel',
+          params: { hostName: 'my-host', entityId: 'eid-1', scopeId: 'sc' },
+        },
+        left: { id: 'host_details', path: { tab: 'okta_document' } },
+      });
+      // Okta/Entra need managed user data — fall back to main
+      expect(result).toEqual([
+        { kind: 'host', hostName: 'my-host', entityId: 'eid-1', scopeId: 'sc' },
+      ]);
+    });
+  });
+
+  describe('IOC flyout', () => {
+    it('ioc right → null (indicatorIndex missing from legacy params)', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'ioc-details-right', params: { id: 'ioc-1' } },
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('no right panel → null', () => {
+      expect(translateLegacyStateToDescriptors({ left: { id: 'anything' } })).toBeNull();
+    });
+
+    it('unknown right panel id → null', () => {
+      const result = translateLegacyStateToDescriptors({
+        right: { id: 'unknown-panel-xyz', params: {} },
+      });
+      expect(result).toBeNull();
+    });
+
+    it('right panel missing required params → null', () => {
+      expect(
+        translateLegacyStateToDescriptors({ right: { id: 'document-details-right', params: {} } })
+      ).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: useLegacyFlyoutUrlInterop hook
+// ---------------------------------------------------------------------------
+
+describe('useLegacyFlyoutUrlInterop', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFlyoutApi as jest.Mock).mockReturnValue(mockFlyoutApi);
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+    (useDataView as jest.Mock).mockReturnValue({ dataView: mockDataView, status: 'ready' });
+    noHit();
+  });
+
+  it('does nothing when new flyout is disabled', async () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(false);
+    const legacyState = {
+      right: {
+        id: 'document-details-right',
+        params: { id: 'doc-1', indexName: 'idx', scopeId: 'sc' },
+      },
+    };
+    const { history } = renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    // Legacy param should still be present
+    expect(new URLSearchParams(history.location.search).get(LEGACY_PARAM)).toBeTruthy();
+  });
+
+  it('does nothing when the v2 param is already present', async () => {
+    const legacyState = {
+      right: {
+        id: 'document-details-right',
+        params: { id: 'doc-1', indexName: 'idx', scopeId: 'sc' },
+      },
+    };
+    const legacyRison = encode(legacyState);
+    const v2Rison = encode([{ kind: 'document', documentId: 'doc-1', indexName: 'idx' }]);
+    const url = `/?${LEGACY_PARAM}=${legacyRison}&${V2_PARAM}=${v2Rison}`;
+
+    const history = createMemoryHistory({ initialEntries: [url] });
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+      React.createElement(Router, { history }, children as React.ReactElement);
+    renderHook(() => useLegacyFlyoutUrlInterop(LEGACY_PARAM, V2_PARAM), { wrapper });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('strips malformed legacy param and opens nothing', async () => {
+    const url = `/?${LEGACY_PARAM}=not-valid-rison!!!`;
+    const { history } = renderInterop(url);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Param should be stripped
+    expect(new URLSearchParams(history.location.search).get(LEGACY_PARAM)).toBeNull();
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('opens a document main flyout for right-only document legacy URL', async () => {
+    const legacyState = {
+      right: {
+        id: 'document-details-right',
+        params: { id: 'doc-1', indexName: 'logs-*', scopeId: 'sc' },
+      },
+    };
+    const { history } = renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      // Advance timers to let setTimeout(0) fire
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    // Legacy param removed
+    expect(new URLSearchParams(history.location.search).get(LEGACY_PARAM)).toBeNull();
+  });
+
+  it('opens tool + child for document right+left URL', async () => {
+    const legacyState = {
+      right: {
+        id: 'document-details-right',
+        params: { id: 'doc-1', indexName: 'idx', scopeId: 'sc' },
+      },
+      left: { id: 'document-details-left', path: { tab: 'investigation' } },
+    };
+    // documentInvestigationGuide needs a hit — provide one (useEsDocSearch returns a record)
+    withHit({ id: 'doc-1', raw: { _id: 'doc-1', _index: 'idx', fields: {} }, flattened: {} });
+
+    const { history } = renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    // Legacy param removed
+    expect(new URLSearchParams(history.location.search).get(LEGACY_PARAM)).toBeNull();
+  });
+
+  it('opens a host flyout for host right-only legacy URL', async () => {
+    const legacyState = {
+      right: {
+        id: 'host-panel',
+        params: { hostName: 'my-host', entityId: 'eid', scopeId: 'alerts' },
+      },
+    };
+    renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    expect(mockFlyoutApi.openHostFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ hostName: 'my-host' })
+    );
+  });
+
+  it('opens a rule flyout for rule right-only legacy URL', async () => {
+    const legacyState = {
+      right: { id: 'rule-panel', params: { ruleId: 'rule-42' } },
+    };
+    renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'rule-42' });
+  });
+
+  it('resolves the attack hit against the PageScope.attacks data view, not PageScope.default', async () => {
+    // The attack discovery alerts backing index is not part of the default page-scope data
+    // view's index pattern — using it there silently finds no hit and wrongly falls back to
+    // the attack main flyout. Give each scope a distinct data view instance so we can assert
+    // the attack fetch used the attacks-scoped one.
+    const mockAttacksDataView = { getRuntimeMappings: jest.fn(() => ({})) };
+    (useDataView as jest.Mock).mockImplementation((scope: PageScope) =>
+      scope === PageScope.attacks
+        ? { dataView: mockAttacksDataView, status: 'ready' }
+        : { dataView: mockDataView, status: 'ready' }
+    );
+    withHit({ id: 'atk-3', raw: { _id: 'atk-3', _index: 'idx', fields: {} }, flattened: {} });
+
+    const legacyState = {
+      right: { id: 'attack-details-right', params: { attackId: 'atk-3', indexName: 'idx' } },
+      left: { id: 'attack-details-left', path: { tab: 'insights', subTab: 'correlation' } },
+    };
+    renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    const attackFetchCall = (useEsDocSearch as jest.Mock).mock.calls.find(
+      ([params]) => params.id === 'atk-3'
+    );
+    expect(attackFetchCall?.[0].dataView).toBe(mockAttacksDataView);
+    expect(mockFlyoutApi.openAttackCorrelations).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'atk-3' }) })
+    );
+  });
+
+  it('opens nothing for IOC legacy URL (missing indicatorIndex)', async () => {
+    const legacyState = {
+      right: { id: 'ioc-details-right', params: { id: 'ioc-1' } },
+    };
+    renderInterop(buildLegacyUrl(legacyState));
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    // IOC descriptor is null → nothing opens
+    expect(mockFlyoutApi.openIocFlyout).not.toHaveBeenCalled();
+  });
+
+  it('ignores eventFlyout param (different param key)', async () => {
+    // eventFlyout is never passed as legacyParamKey — the hook is not mounted for it
+    const eventFlyoutUrl = `/?eventFlyout=${encode({
+      right: { id: 'document-details-right', params: { id: 'd', indexName: 'i', scopeId: 's' } },
+    })}`;
+    const history = createMemoryHistory({ initialEntries: [eventFlyoutUrl] });
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+      React.createElement(Router, { history }, children as React.ReactElement);
+    renderHook(() => useLegacyFlyoutUrlInterop(LEGACY_PARAM, V2_PARAM), { wrapper });
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    // Nothing opened — flyout param not present for the LEGACY_PARAM key
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('opens nothing when legacy param is absent', async () => {
+    renderInterop('/?some=other-param');
+
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_expandable_flyout_url_interop.ts
@@ -1,0 +1,686 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { decode } from '@kbn/rison';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ElasticRequestState } from '@kbn/unified-doc-viewer';
+import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+import { useFlyoutApi } from '../../use_flyout_api';
+import { openDescriptorAsStart, openDescriptorAsChild } from './use_flyout_v2_restore';
+import type { FlyoutDescriptor, FlyoutV2UrlParamValue } from './flyout_v2_url_param';
+
+// ---------------------------------------------------------------------------
+// Legacy panel ID constants (copied verbatim from the legacy flyout registry)
+// ---------------------------------------------------------------------------
+
+const DOCUMENT_DETAILS_RIGHT = 'document-details-right';
+const DOCUMENT_DETAILS_LEFT = 'document-details-left';
+const ATTACK_DETAILS_RIGHT = 'attack-details-right';
+const ATTACK_DETAILS_LEFT = 'attack-details-left';
+const HOST_PANEL = 'host-panel';
+const HOST_DETAILS = 'host_details';
+const USER_PANEL = 'user-panel';
+const USER_DETAILS = 'user_details';
+const SERVICE_PANEL = 'service-panel';
+const SERVICE_DETAILS = 'service_details';
+const GENERIC_ENTITY_PANEL = 'generic-entity-panel';
+const GENERIC_ENTITY_DETAILS = 'generic_entity_details';
+const NETWORK_PANEL = 'network-details';
+const RULE_PANEL = 'rule-panel';
+const IOC_RIGHT_PANEL = 'ioc-details-right';
+const MISCONFIGURATION_FINDINGS_PANEL = 'findings-misconfiguration-panel';
+const VULNERABILITY_FINDINGS_PANEL = 'findings-vulnerability-panel';
+
+/** Panel IDs whose right+left pair collapses to a single v2 main flyout (no tools). */
+const NO_TOOLS_PANEL_IDS = new Set([
+  NETWORK_PANEL,
+  RULE_PANEL,
+  IOC_RIGHT_PANEL,
+  MISCONFIGURATION_FINDINGS_PANEL,
+  VULNERABILITY_FINDINGS_PANEL,
+]);
+
+// ---------------------------------------------------------------------------
+// Legacy tab / subTab ID constants
+// ---------------------------------------------------------------------------
+
+// Document left tabs
+const DOC_TAB_VISUALIZE = 'visualize';
+const DOC_TAB_INSIGHTS = 'insights';
+const DOC_TAB_INVESTIGATION = 'investigation';
+const DOC_TAB_RESPONSE = 'response';
+const DOC_TAB_NOTES = 'notes';
+
+// Visualize subTabs
+const VIZ_SUBTAB_SESSION_VIEW = 'session-view';
+const VIZ_SUBTAB_GRAPH = 'graph-visualization';
+// 'analyze_graph' → analyzer (default fallback)
+
+// Insights subTabs
+const INSIGHTS_SUBTAB_THREAT_INTEL = 'threatIntelligence';
+const INSIGHTS_SUBTAB_PREVALENCE = 'prevalence';
+const INSIGHTS_SUBTAB_CORRELATIONS = 'correlations';
+
+// Attack left tabs
+const ATTACK_TAB_INSIGHTS = 'insights';
+const ATTACK_TAB_NOTES = 'notes';
+
+// Attack insights subTabs
+const ATTACK_SUBTAB_CORRELATION = 'correlation';
+
+// Entity left panel tabs (EntityDetailsLeftPanelTab enum values)
+const ENTITY_TAB_RISK_INPUTS = 'risk_inputs';
+const ENTITY_TAB_ANOMALIES = 'anomalies';
+const ENTITY_TAB_OKTA = 'okta_document';
+const ENTITY_TAB_ENTRA = 'entra_document';
+const ENTITY_TAB_CSP_INSIGHTS = 'csp_insights';
+const ENTITY_TAB_FIELDS_TABLE = 'fields_table';
+const ENTITY_TAB_GRAPH_VIEW = 'graph_view';
+const ENTITY_TAB_RESOLUTION_GROUP = 'resolution_group';
+
+// CSP insights subTabs (CspInsightLeftPanelSubTab enum values)
+const CSP_SUBTAB_VULNERABILITIES = 'vulnerabilitiesTabId';
+const CSP_SUBTAB_ALERTS = 'alertsTabId';
+
+// ---------------------------------------------------------------------------
+// Descriptor kinds that need async data fetching
+// ---------------------------------------------------------------------------
+
+const NEEDS_DOC_HIT = new Set([
+  'analyzer',
+  'sessionView',
+  'documentEntities',
+  'documentCorrelations',
+  'documentPrevalence',
+  'documentResponse',
+  'documentThreatIntelligence',
+  'documentInvestigationGuide',
+  'documentGraph',
+  'notes',
+]);
+
+const NEEDS_ATTACK_HIT = new Set(['attackCorrelations', 'attackEntities']);
+
+// ---------------------------------------------------------------------------
+// Legacy rison shape
+// ---------------------------------------------------------------------------
+
+interface LegacyPanel {
+  id: string;
+  params?: Record<string, unknown>;
+  path?: { tab?: string; subTab?: string };
+}
+
+interface LegacyFlyoutState {
+  right?: LegacyPanel;
+  left?: LegacyPanel;
+  preview?: LegacyPanel[];
+}
+
+// ---------------------------------------------------------------------------
+// Decode legacy rison param
+// ---------------------------------------------------------------------------
+
+const decodeLegacyFlyoutParam = (raw: string | null | undefined): LegacyFlyoutState | null => {
+  if (!raw) return null;
+  try {
+    const decoded = decode(raw);
+    if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) return null;
+    return decoded as LegacyFlyoutState;
+  } catch {
+    return null;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Translation helpers
+// ---------------------------------------------------------------------------
+
+/** Translate a legacy right/preview panel to the matching v2 main flyout descriptor. */
+const rightPanelToMainDescriptor = (panel: LegacyPanel): FlyoutDescriptor | null => {
+  const { id, params = {} } = panel;
+
+  switch (id) {
+    case DOCUMENT_DETAILS_RIGHT:
+    case 'document-details-preview': {
+      const documentId = params.id as string | undefined;
+      const indexName = params.indexName as string | undefined;
+      if (!documentId || !indexName) return null;
+      return { kind: 'document', documentId, indexName };
+    }
+
+    case ATTACK_DETAILS_RIGHT:
+    case 'attack-details-preview': {
+      const attackId = params.attackId as string | undefined;
+      const indexName = params.indexName as string | undefined;
+      if (!attackId || !indexName) return null;
+      return { kind: 'attack', attackId, indexName };
+    }
+
+    case HOST_PANEL: {
+      const hostName = params.hostName as string | undefined;
+      if (!hostName) return null;
+      return {
+        kind: 'host',
+        hostName,
+        entityId: params.entityId as string | undefined,
+        scopeId: params.scopeId as string | undefined,
+      };
+    }
+
+    case USER_PANEL: {
+      const userName = params.userName as string | undefined;
+      if (!userName) return null;
+      return {
+        kind: 'user',
+        userName,
+        entityId: params.entityId as string | undefined,
+        scopeId: params.scopeId as string | undefined,
+      };
+    }
+
+    case SERVICE_PANEL: {
+      const serviceName = params.serviceName as string | undefined;
+      if (!serviceName) return null;
+      return {
+        kind: 'service',
+        serviceName,
+        entityId: params.entityId as string | undefined,
+        scopeId: params.scopeId as string | undefined,
+      };
+    }
+
+    case GENERIC_ENTITY_PANEL: {
+      const scopeId = params.scopeId as string | undefined;
+      if (!scopeId) return null;
+      return {
+        kind: 'genericEntity',
+        scopeId,
+        entityId: params.entityId as string | undefined,
+        entityDocId: params.entityDocId as string | undefined,
+      };
+    }
+
+    case NETWORK_PANEL: {
+      const ip = params.ip as string | undefined;
+      const flowTarget = params.flowTarget as string | undefined;
+      if (!ip || !flowTarget) return null;
+      return { kind: 'network', ip, flowTarget };
+    }
+
+    case RULE_PANEL: {
+      const ruleId = params.ruleId as string | undefined;
+      if (!ruleId) return null;
+      return { kind: 'rule', ruleId };
+    }
+
+    case IOC_RIGHT_PANEL: {
+      // Legacy IOC params only stored { id } without the index — cannot interop.
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[flyout-v2-interop] IOC legacy URL: indicatorIndex not stored in legacy params, cannot translate.'
+      );
+      return null;
+    }
+
+    case MISCONFIGURATION_FINDINGS_PANEL: {
+      const resourceId = params.resourceId as string | undefined;
+      const ruleId = params.ruleId as string | undefined;
+      if (!resourceId || !ruleId) return null;
+      return { kind: 'cspMisconfiguration', resourceId, ruleId };
+    }
+
+    case VULNERABILITY_FINDINGS_PANEL: {
+      return {
+        kind: 'cspVulnerability',
+        vulnerabilityId: params.vulnerabilityId as string | string[] | undefined,
+        resourceId: params.resourceId as string | undefined,
+        packageName: params.packageName as string | string[] | undefined,
+        packageVersion: params.packageVersion as string | string[] | undefined,
+        eventId: params.eventId as string | undefined,
+      };
+    }
+
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(`[flyout-v2-interop] Unknown right panel id "${id}", skipping.`);
+      return null;
+  }
+};
+
+/** Translate a legacy document-details-left panel to the matching v2 tool descriptor. */
+const docLeftToToolDescriptor = (
+  left: LegacyPanel,
+  rightParams: Record<string, unknown>
+): FlyoutDescriptor | null => {
+  const tab = left.path?.tab;
+  const subTab = left.path?.subTab;
+  const documentId = rightParams.id as string | undefined;
+  const indexName = rightParams.indexName as string | undefined;
+  const scopeId = rightParams.scopeId as string | undefined;
+
+  if (!documentId || !indexName) return null;
+
+  switch (tab) {
+    case DOC_TAB_VISUALIZE:
+      if (subTab === VIZ_SUBTAB_SESSION_VIEW) return { kind: 'sessionView', documentId, indexName };
+      if (subTab === VIZ_SUBTAB_GRAPH) return { kind: 'documentGraph', documentId, indexName };
+      // 'analyze_graph' or no subTab → analyzer
+      return { kind: 'analyzer', documentId, indexName };
+
+    case DOC_TAB_INSIGHTS:
+      if (subTab === INSIGHTS_SUBTAB_THREAT_INTEL)
+        return { kind: 'documentThreatIntelligence', documentId, indexName };
+      if (subTab === INSIGHTS_SUBTAB_PREVALENCE)
+        return {
+          kind: 'documentPrevalence',
+          documentId,
+          indexName,
+          scopeId: scopeId ?? '',
+          investigationFields: [],
+        };
+      if (subTab === INSIGHTS_SUBTAB_CORRELATIONS)
+        return {
+          kind: 'documentCorrelations',
+          documentId,
+          indexName,
+          scopeId: scopeId ?? '',
+          isRulePreview: false,
+        };
+      // 'entity' or no subTab → entities
+      return { kind: 'documentEntities', documentId, indexName, scopeId };
+
+    case DOC_TAB_INVESTIGATION:
+      return { kind: 'documentInvestigationGuide', documentId, indexName };
+
+    case DOC_TAB_RESPONSE:
+      return { kind: 'documentResponse', documentId, indexName };
+
+    case DOC_TAB_NOTES:
+      return { kind: 'notes', documentId, indexName };
+
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(`[flyout-v2-interop] Unknown document left tab "${tab}", skipping tool.`);
+      return null;
+  }
+};
+
+/** Translate a legacy attack-details-left panel to the matching v2 tool descriptor. */
+const attackLeftToToolDescriptor = (
+  left: LegacyPanel,
+  rightParams: Record<string, unknown>
+): FlyoutDescriptor | null => {
+  const tab = left.path?.tab;
+  const subTab = left.path?.subTab;
+  const attackId = rightParams.attackId as string | undefined;
+  const indexName = rightParams.indexName as string | undefined;
+
+  if (!attackId || !indexName) return null;
+
+  switch (tab) {
+    case ATTACK_TAB_INSIGHTS:
+      if (subTab === ATTACK_SUBTAB_CORRELATION)
+        return { kind: 'attackCorrelations', attackId, indexName, alertIds: [] };
+      // 'entity' or no subTab → entities
+      return { kind: 'attackEntities', attackId, indexName, alertIds: [] };
+
+    case ATTACK_TAB_NOTES:
+      // Notes for attack: best-effort — use documentId=attackId
+      return { kind: 'notes', documentId: attackId, indexName };
+
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(`[flyout-v2-interop] Unknown attack left tab "${tab}", skipping tool.`);
+      return null;
+  }
+};
+
+/** Translate a legacy entity-details-left panel to the matching v2 entity tool descriptor. */
+const entityLeftToToolDescriptor = (
+  left: LegacyPanel,
+  entityType: string,
+  entityName: string,
+  entityId: string | undefined,
+  scopeId: string | undefined
+): FlyoutDescriptor | null => {
+  const tab = left.path?.tab;
+  const subTab = left.path?.subTab;
+
+  switch (tab) {
+    case ENTITY_TAB_RISK_INPUTS:
+      return { kind: 'entityRiskInputs', entityType, entityName, entityId };
+
+    case ENTITY_TAB_ANOMALIES:
+      return { kind: 'entityAnomalyInsights', entityType, value: entityName, entityId };
+
+    case ENTITY_TAB_CSP_INSIGHTS:
+      if (subTab === CSP_SUBTAB_VULNERABILITIES)
+        return { kind: 'entityVulnerabilityInsights', value: entityName, entityId, entityType };
+      if (subTab === CSP_SUBTAB_ALERTS)
+        return { kind: 'entityAlertsInsights', entityType, value: entityName, entityId };
+      // 'misconfigurationTabId' or no subTab
+      return { kind: 'entityMisconfigurationInsights', entityType, value: entityName, entityId };
+
+    case ENTITY_TAB_GRAPH_VIEW:
+      if (!entityId || !scopeId) {
+        // eslint-disable-next-line no-console
+        console.warn('[flyout-v2-interop] entityGraphView needs entityId + scopeId, falling back.');
+        return null;
+      }
+      return { kind: 'entityGraphView', entityId, scopeId, entityName };
+
+    case ENTITY_TAB_RESOLUTION_GROUP:
+      if (!entityId || !scopeId) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[flyout-v2-interop] entityResolution needs entityId + scopeId, falling back.'
+        );
+        return null;
+      }
+      return { kind: 'entityResolution', entityId, entityType, entityName, scopeId };
+
+    case ENTITY_TAB_OKTA:
+    case ENTITY_TAB_ENTRA:
+      // managedUserId/managedUserIndex not stored in legacy params — cannot reconstruct.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[flyout-v2-interop] Entity tab "${tab}" requires managed user data not in legacy URL, falling back.`
+      );
+      return null;
+
+    case ENTITY_TAB_FIELDS_TABLE:
+      // Not restorable (document source is not URL-serializable).
+      return null;
+
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(`[flyout-v2-interop] Unknown entity left tab "${tab}", falling back.`);
+      return null;
+  }
+};
+
+/** Dispatch to the appropriate left-panel translator based on the left panel id. */
+const leftPanelToToolDescriptor = (
+  left: LegacyPanel,
+  right: LegacyPanel
+): FlyoutDescriptor | null => {
+  const rightParams = right.params ?? {};
+
+  switch (left.id) {
+    case DOCUMENT_DETAILS_LEFT:
+      return docLeftToToolDescriptor(left, rightParams);
+
+    case ATTACK_DETAILS_LEFT:
+      return attackLeftToToolDescriptor(left, rightParams);
+
+    case HOST_DETAILS:
+      return entityLeftToToolDescriptor(
+        left,
+        'host',
+        (rightParams.hostName as string) ?? '',
+        rightParams.entityId as string | undefined,
+        rightParams.scopeId as string | undefined
+      );
+
+    case USER_DETAILS:
+      return entityLeftToToolDescriptor(
+        left,
+        'user',
+        (rightParams.userName as string) ?? '',
+        rightParams.entityId as string | undefined,
+        rightParams.scopeId as string | undefined
+      );
+
+    case SERVICE_DETAILS:
+      return entityLeftToToolDescriptor(
+        left,
+        'service',
+        (rightParams.serviceName as string) ?? '',
+        rightParams.entityId as string | undefined,
+        rightParams.scopeId as string | undefined
+      );
+
+    case GENERIC_ENTITY_DETAILS:
+      return entityLeftToToolDescriptor(
+        left,
+        'generic',
+        '',
+        rightParams.entityId as string | undefined,
+        rightParams.scopeId as string | undefined
+      );
+
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(`[flyout-v2-interop] Unknown left panel id "${left.id}", skipping tool.`);
+      return null;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Main translation entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate a decoded legacy flyout state `{ right, left, preview }` into the equivalent
+ * ordered v2 descriptor array (max 2 entries).
+ *
+ * Returns null when the right panel is unknown or missing required params.
+ * Returns a single-entry array when there is no left panel or the flyout type has no tools.
+ * Returns a two-entry array [tool, child] when there is a left panel that maps to a tool.
+ */
+export const translateLegacyStateToDescriptors = (
+  state: LegacyFlyoutState
+): FlyoutV2UrlParamValue | null => {
+  const { right, left, preview } = state;
+  if (!right) return null;
+
+  const mainDescriptor = rightPanelToMainDescriptor(right);
+  if (!mainDescriptor) return null;
+
+  // No-tools types: collapse right+left to a single main flyout.
+  if (NO_TOOLS_PANEL_IDS.has(right.id)) {
+    return [mainDescriptor];
+  }
+
+  // No left panel: single main flyout.
+  if (!left) {
+    return [mainDescriptor];
+  }
+
+  // Tools types: left → tool descriptor; child = preview (if present) or right.
+  const toolDescriptor = leftPanelToToolDescriptor(left, right);
+
+  if (!toolDescriptor) {
+    // Unknown / unmappable left panel → open main flyout only.
+    return [mainDescriptor];
+  }
+
+  // Determine child descriptor.
+  // Preview wins over right as the child (it is the deepest thing the user viewed).
+  const lastPreview = preview?.at(-1);
+  const childDescriptor: FlyoutDescriptor = lastPreview
+    ? rightPanelToMainDescriptor(lastPreview) ?? mainDescriptor
+    : mainDescriptor;
+
+  return [toolDescriptor, childDescriptor];
+};
+
+// ---------------------------------------------------------------------------
+// Public hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Legacy-URL interop hook. On mount, reads the `flyout` (or `timelineFlyout`) rison URL param;
+ * if found while the new flyout is enabled, translates it to the equivalent flyoutV2 open calls,
+ * removes the legacy param, and lets the URL writer record the current state as flyoutV2.
+ *
+ * Only fires when:
+ *  - `useIsNewFlyoutEnabled()` is true
+ *  - the legacy param is present
+ *  - the v2 param is NOT already present (to avoid double-open on already-migrated URLs)
+ *
+ * Mount this hook in the Security Solution app shell (app/home/index.tsx) BEFORE
+ * `useFlyoutV2RestoreFromUrl`, so the legacy param is consumed first.
+ *
+ * The `eventFlyout` param is intentionally ignored per spec.
+ */
+export const useLegacyFlyoutUrlInterop = (legacyParamKey: string, v2ParamKey: string): void => {
+  const isNewFlyoutEnabled = useIsNewFlyoutEnabled();
+  const history = useHistory();
+  const flyoutApi = useFlyoutApi();
+  const hasOpenedRef = useRef(false);
+
+  // Decode the legacy param exactly once (synchronous useState initializer).
+  const [legacyState] = useState<LegacyFlyoutState | null>(() => {
+    if (!isNewFlyoutEnabled) return null;
+    // If v2 param already present, the URL is already migrated — do nothing.
+    const searchParams = new URLSearchParams(history.location.search);
+    if (searchParams.get(v2ParamKey)) return null;
+    const raw = searchParams.get(legacyParamKey);
+    return decodeLegacyFlyoutParam(raw);
+  });
+
+  // Track whether the raw legacy param was present but malformed.
+  const [isMalformedLegacy] = useState<boolean>(() => {
+    if (!isNewFlyoutEnabled) return false;
+    const searchParams = new URLSearchParams(history.location.search);
+    if (searchParams.get(v2ParamKey)) return false;
+    const raw = searchParams.get(legacyParamKey);
+    return raw != null && decodeLegacyFlyoutParam(raw) === null;
+  });
+
+  // Translate legacy state → v2 descriptors (synchronous).
+  const descriptors = useMemo(
+    () => (legacyState ? translateLegacyStateToDescriptors(legacyState) : null),
+    [legacyState]
+  );
+
+  // Strip malformed legacy param on mount.
+  useEffect(() => {
+    if (!isMalformedLegacy) return;
+    const params = new URLSearchParams(history.location.search);
+    params.delete(legacyParamKey);
+    const search = params.toString();
+    history.replace({ ...history.location, search: search ? `?${search}` : '' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally empty — run once on mount
+
+  // -----------------------------------------------------------------------
+  // Async data fetching (same machinery as useFlyoutV2RestoreFromUrl)
+  // -----------------------------------------------------------------------
+
+  const docFetchDescriptor = useMemo(
+    () => descriptors?.find((d) => NEEDS_DOC_HIT.has(d.kind)) ?? null,
+    [descriptors]
+  );
+
+  const attackFetchDescriptor = useMemo(
+    () => descriptors?.find((d) => NEEDS_ATTACK_HIT.has(d.kind)) ?? null,
+    [descriptors]
+  );
+
+  const { dataView, status: dataViewStatus } = useDataView(PageScope.default);
+  const dataViewReady = dataViewStatus === 'ready';
+
+  // The attack discovery alerts backing index is not part of the PageScope.default data view's
+  // index pattern, so searching for it against that data view (below) finds nothing. The live
+  // attack flyout resolves its hit against the dedicated PageScope.attacks data view (see
+  // `useAttackDetails`) — use the same one here. See the matching comment in
+  // `useFlyoutV2RestoreFromUrl` for the full story.
+  const { dataView: attackDataView, status: attackDataViewStatus } = useDataView(PageScope.attacks);
+  const attackDataViewReady = attackDataViewStatus === 'ready';
+
+  // Resolve doc/attack hits with the same single-document search the document flyout uses.
+  // NOTE: not `useTimelineEventsDetails` — see the comment in `useFlyoutV2RestoreFromUrl`; that
+  // search strategy does not resolve a concrete alerts backing index, which broke tool restoration.
+  const docEventId = (docFetchDescriptor as { documentId?: string } | null)?.documentId ?? '';
+  const docIndexName = (docFetchDescriptor as { indexName?: string } | null)?.indexName ?? '';
+  const [docRequestState, docHitRecord] = useEsDocSearch({
+    id: docEventId,
+    index: docIndexName,
+    dataView,
+    skip: !docFetchDescriptor || !dataViewReady || !docEventId || !docIndexName,
+  });
+
+  const attackEventId = (attackFetchDescriptor as { attackId?: string } | null)?.attackId ?? '';
+  const attackIndexName = (attackFetchDescriptor as { indexName?: string } | null)?.indexName ?? '';
+  const [attackRequestState, attackHitRecord] = useEsDocSearch({
+    id: attackEventId,
+    index: attackIndexName,
+    dataView: attackDataView,
+    skip: !attackFetchDescriptor || !attackDataViewReady || !attackEventId || !attackIndexName,
+  });
+
+  // -----------------------------------------------------------------------
+  // Open effect
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    if (hasOpenedRef.current || !descriptors) return;
+
+    if (docFetchDescriptor && !dataViewReady) return;
+    if (attackFetchDescriptor && !attackDataViewReady) return;
+
+    // A needed fetch is "settled" once useEsDocSearch resolves: Found WITH a record, or a terminal
+    // NotFound/Error state. (Found + null record is the transient pre-fetch state of a skipped search.)
+    const isSettled = (
+      hasDescriptor: boolean,
+      state: ElasticRequestState,
+      record: DataTableRecord | null
+    ): boolean =>
+      !hasDescriptor ||
+      (state === ElasticRequestState.Found && !!record) ||
+      state === ElasticRequestState.NotFound ||
+      state === ElasticRequestState.Error ||
+      state === ElasticRequestState.NotFoundDataView;
+
+    if (!isSettled(!!docFetchDescriptor, docRequestState, docHitRecord)) return;
+    if (!isSettled(!!attackFetchDescriptor, attackRequestState, attackHitRecord)) return;
+
+    hasOpenedRef.current = true;
+
+    const docHit: DataTableRecord | undefined = docHitRecord ?? undefined;
+    const attackHit: DataTableRecord | undefined = attackHitRecord ?? undefined;
+
+    const ctx = { docHit, attackHit };
+    const [first, second] = descriptors;
+
+    // Remove the legacy param from the URL before opening (so the URL writer,
+    // triggered by writeOnOpen inside open*, reads a clean URL when it appends flyoutV2).
+    const searchParams = new URLSearchParams(history.location.search);
+    searchParams.delete(legacyParamKey);
+    const newSearch = searchParams.toString();
+    history.replace({ ...history.location, search: newSearch ? `?${newSearch}` : '' });
+
+    // Open in the next macrotask to avoid z-index ordering races (same guard as restore hook).
+    setTimeout(() => {
+      openDescriptorAsStart(first, ctx, flyoutApi);
+      if (second) {
+        openDescriptorAsChild(second, ctx, flyoutApi);
+      }
+    }, 0);
+  }, [
+    descriptors,
+    docFetchDescriptor,
+    attackFetchDescriptor,
+    dataViewReady,
+    attackDataViewReady,
+    docRequestState,
+    docHitRecord,
+    attackRequestState,
+    attackHitRecord,
+    flyoutApi,
+    history,
+    legacyParamKey,
+  ]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
@@ -1,0 +1,889 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from '@kbn/shared-ux-router';
+import { encode } from '@kbn/rison';
+import { useFlyoutV2RestoreFromUrl } from './use_flyout_v2_restore';
+import { FLYOUT_V2_URL_PARAM, FLYOUT_V2_TIMELINE_URL_PARAM } from './flyout_v2_url_param';
+import type { FlyoutV2UrlParamValue } from './flyout_v2_url_param';
+import { useFlyoutApi } from '../../use_flyout_api';
+import { createFlyoutApiMock } from '../../use_flyout_api.mock';
+import { ElasticRequestState } from '@kbn/unified-doc-viewer';
+import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../../use_flyout_api');
+jest.mock('../../../common/hooks/use_is_new_flyout_enabled');
+jest.mock('@kbn/unified-doc-viewer-plugin/public', () => ({
+  useEsDocSearch: jest.fn(),
+}));
+jest.mock('../../../data_view_manager/hooks/use_data_view');
+
+const mockFlyoutApi = createFlyoutApiMock();
+(useFlyoutApi as jest.Mock).mockReturnValue(mockFlyoutApi);
+(useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+
+const mockDataView = {
+  getRuntimeMappings: jest.fn(() => ({})),
+  hasMatchedIndices: jest.fn(() => true),
+};
+(useDataView as jest.Mock).mockReturnValue({ dataView: mockDataView, status: 'ready' });
+
+// useEsDocSearch returns [ElasticRequestState, DataTableRecord | null, refetch].
+// Settled with no hit → terminal NotFound; resolved → Found + record; in-flight → Loading.
+const noHit = () =>
+  (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.NotFound, null, jest.fn()]);
+
+const withHit = (record: Record<string, unknown>) =>
+  (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Found, record, jest.fn()]);
+
+const loadingHit = () =>
+  (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Loading, null, jest.fn()]);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const buildUrl = (
+  descriptors: FlyoutV2UrlParamValue,
+  paramKey: typeof FLYOUT_V2_URL_PARAM | typeof FLYOUT_V2_TIMELINE_URL_PARAM = FLYOUT_V2_URL_PARAM
+) => `/?${paramKey}=${encode(descriptors)}`;
+
+const renderRestore = (url: string) => {
+  const history = createMemoryHistory({ initialEntries: [url] });
+  const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+    React.createElement(Router, { history }, children as React.ReactElement);
+  const { result, rerender } = renderHook(() => useFlyoutV2RestoreFromUrl(FLYOUT_V2_URL_PARAM), {
+    wrapper,
+  });
+  return { result, history, rerender };
+};
+
+// DataTableRecord-shaped (useEsDocSearch already returns records, not raw hits).
+const docSearchHit = {
+  id: 'doc-1',
+  raw: { _id: 'doc-1', _index: 'logs-*', fields: {} },
+  flattened: {},
+};
+const attackSearchHit = {
+  id: 'attack-1',
+  raw: { _id: 'attack-1', _index: '.alerts-*', fields: {} },
+  flattened: {},
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useFlyoutV2RestoreFromUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (useFlyoutApi as jest.Mock).mockReturnValue(mockFlyoutApi);
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(true);
+    (useDataView as jest.Mock).mockReturnValue({ dataView: mockDataView, status: 'ready' });
+    noHit();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // -----------------------------------------------------------------------
+  // Gate: new flyout disabled
+  // -----------------------------------------------------------------------
+
+  it('does not open anything when the new flyout is disabled', () => {
+    (useIsNewFlyoutEnabled as jest.Mock).mockReturnValue(false);
+    renderRestore(buildUrl([{ kind: 'document', documentId: 'doc-1', indexName: 'x' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Malformed / absent param
+  // -----------------------------------------------------------------------
+
+  it('strips a malformed param and opens nothing', () => {
+    const history = createMemoryHistory({
+      initialEntries: [`/?${FLYOUT_V2_URL_PARAM}=!!!invalid`],
+    });
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+      React.createElement(Router, { history }, children as React.ReactElement);
+    renderHook(() => useFlyoutV2RestoreFromUrl(FLYOUT_V2_URL_PARAM), { wrapper });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(new URLSearchParams(history.location.search).get(FLYOUT_V2_URL_PARAM)).toBeNull();
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the param is absent', () => {
+    renderRestore('/');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Single-main descriptors (no fetch required)
+  // -----------------------------------------------------------------------
+
+  it('opens a document flyout from a single document descriptor', () => {
+    const url = buildUrl([{ kind: 'document', documentId: 'doc-1', indexName: 'logs-*' }]);
+    renderRestore(url);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      indexName: 'logs-*',
+    });
+  });
+
+  it('opens a documentFromPattern flyout', () => {
+    renderRestore(
+      buildUrl([{ kind: 'documentFromPattern', documentId: 'doc-1', indexName: '.siem-signals-*' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentFlyoutFromPattern).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      indexName: '.siem-signals-*',
+    });
+  });
+
+  it('opens an attack flyout', () => {
+    renderRestore(buildUrl([{ kind: 'attack', attackId: 'atk-1', indexName: '.alerts-*' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAttackFlyout).toHaveBeenCalledWith({
+      attackId: 'atk-1',
+      indexName: '.alerts-*',
+    });
+  });
+
+  it('opens a host flyout', () => {
+    renderRestore(buildUrl([{ kind: 'host', hostName: 'my-host', entityId: 'eid' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openHostFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ hostName: 'my-host', entityId: 'eid' })
+    );
+  });
+
+  it('opens a user flyout', () => {
+    renderRestore(buildUrl([{ kind: 'user', userName: 'alice' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openUserFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ userName: 'alice' })
+    );
+  });
+
+  it('opens a rule flyout', () => {
+    renderRestore(buildUrl([{ kind: 'rule', ruleId: 'rule-1' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'rule-1' });
+  });
+
+  it('opens a network flyout', () => {
+    renderRestore(buildUrl([{ kind: 'network', ip: '1.2.3.4', flowTarget: 'source' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openNetworkFlyout).toHaveBeenCalledWith({
+      ip: '1.2.3.4',
+      flowTarget: 'source',
+    });
+  });
+
+  it('opens a CSP misconfiguration flyout', () => {
+    renderRestore(
+      buildUrl([{ kind: 'cspMisconfiguration', resourceId: 'res-1', ruleId: 'csp-1' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openMisconfigurationFinding).toHaveBeenCalledWith({
+      resourceId: 'res-1',
+      ruleId: 'csp-1',
+    });
+  });
+
+  it('opens a CSP vulnerability flyout', () => {
+    renderRestore(
+      buildUrl([{ kind: 'cspVulnerability', vulnerabilityId: 'CVE-1', resourceId: 'r1' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openVulnerabilityFinding).toHaveBeenCalledWith(
+      expect.objectContaining({ vulnerabilityId: 'CVE-1' })
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Entity tools (no fetch required)
+  // -----------------------------------------------------------------------
+
+  it('opens entityRiskInputs with entityType cast', () => {
+    renderRestore(
+      buildUrl([{ kind: 'entityRiskInputs', entityType: 'host', entityName: 'h', entityId: 'eid' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openEntityRiskInputs).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'host', entityName: 'h' })
+    );
+  });
+
+  it('opens entityEntraInsights by constructing ManagedUserHit from stored id/index', () => {
+    renderRestore(
+      buildUrl([
+        {
+          kind: 'entityEntraInsights',
+          managedUserId: 'mid',
+          managedUserIndex: 'idx',
+          value: 'alice',
+        },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openEntityEntraInsights).toHaveBeenCalledWith(
+      expect.objectContaining({
+        managedUser: { _id: 'mid', _index: 'idx' },
+        value: 'alice',
+      })
+    );
+  });
+
+  it('opens entityOktaInsights by constructing ManagedUserHit from stored id/index', () => {
+    renderRestore(
+      buildUrl([
+        {
+          kind: 'entityOktaInsights',
+          managedUserId: 'oid',
+          managedUserIndex: 'okta-idx',
+          value: 'bob',
+        },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openEntityOktaInsights).toHaveBeenCalledWith(
+      expect.objectContaining({
+        managedUser: { _id: 'oid', _index: 'okta-idx' },
+        value: 'bob',
+      })
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Document tools (need document hit fetch)
+  // -----------------------------------------------------------------------
+
+  it('waits for loading before opening a document tool', () => {
+    loadingHit();
+    renderRestore(buildUrl([{ kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAnalyzer).not.toHaveBeenCalled();
+  });
+
+  it('opens the analyzer once the document hit is resolved', () => {
+    withHit(docSearchHit);
+    renderRestore(buildUrl([{ kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAnalyzer).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }) })
+    );
+  });
+
+  it('falls back to the document flyout after the fetch settles with no hit', () => {
+    // The fetch runs (loading) and then settles empty — only then is the document fallback correct.
+    loadingHit();
+    const { rerender } = renderRestore(
+      buildUrl([{ kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    // Still loading — must not fall back yet.
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+
+    // Fetch settles with no hit → now the document fallback is expected.
+    noHit();
+    rerender();
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAnalyzer).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      indexName: 'logs-*',
+    });
+  });
+
+  it('does NOT fall back to the document flyout during the data-view-ready race (regression)', () => {
+    // Repro for the bug where refreshing on an open tools flyout reopened the document flyout.
+    // While the data view is not ready the fetch is skipped, so useTimelineEventsDetails reports
+    // loading=false with no hit — which previously looked (wrongly) like "fetch finished, no hit".
+    (useDataView as jest.Mock).mockReturnValue({ dataView: null, status: 'loading' });
+    noHit();
+    const { rerender } = renderRestore(
+      buildUrl([{ kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    // The fetch has not started — must NOT prematurely open the document main flyout.
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+
+    // Data view becomes ready and the fetch starts (loading, still no hit).
+    (useDataView as jest.Mock).mockReturnValue({ dataView: mockDataView, status: 'ready' });
+    loadingHit();
+    rerender();
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+
+    // Fetch resolves with the hit → the analyzer tool opens, never the document fallback.
+    withHit(docSearchHit);
+    rerender();
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAnalyzer).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }) })
+    );
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('opens the session view tool with the resolved hit', () => {
+    withHit(docSearchHit);
+    renderRestore(
+      buildUrl([
+        { kind: 'sessionView', documentId: 'doc-1', indexName: 'logs-*', jumpToCursor: 'cur' },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openSessionView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hit: expect.objectContaining({ id: 'doc-1' }),
+        jumpToCursor: 'cur',
+      })
+    );
+  });
+
+  it('opens documentEntities with the resolved hit', () => {
+    withHit(docSearchHit);
+    renderRestore(
+      buildUrl([{ kind: 'documentEntities', documentId: 'doc-1', indexName: 'i', scopeId: 's' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentEntities).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }), scopeId: 's' })
+    );
+  });
+
+  it('opens documentCorrelations with the resolved hit and a default onShowAlert callback', () => {
+    withHit(docSearchHit);
+    renderRestore(
+      buildUrl([
+        {
+          kind: 'documentCorrelations',
+          documentId: 'doc-1',
+          indexName: 'i',
+          scopeId: 's',
+          isRulePreview: false,
+        },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentCorrelations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hit: expect.objectContaining({ id: 'doc-1' }),
+        scopeId: 's',
+        isRulePreview: false,
+        onShowAlert: expect.any(Function),
+      })
+    );
+  });
+
+  it('opens documentPrevalence with the resolved hit (columns are built internally, not restored)', () => {
+    withHit(docSearchHit);
+    renderRestore(
+      buildUrl([
+        {
+          kind: 'documentPrevalence',
+          documentId: 'doc-1',
+          indexName: 'i',
+          scopeId: 's',
+          investigationFields: ['host.name'],
+        },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentPrevalence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hit: expect.objectContaining({ id: 'doc-1' }),
+        scopeId: 's',
+        investigationFields: ['host.name'],
+      })
+    );
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('falls back to document flyout for documentPrevalence when the hit cannot be resolved', () => {
+    noHit();
+    renderRestore(
+      buildUrl([
+        {
+          kind: 'documentPrevalence',
+          documentId: 'doc-1',
+          indexName: 'i',
+          scopeId: 's',
+          investigationFields: ['host.name'],
+        },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openDocumentPrevalence).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      indexName: 'i',
+    });
+  });
+
+  it('opens notes with the resolved hit', () => {
+    withHit(docSearchHit);
+    renderRestore(buildUrl([{ kind: 'notes', documentId: 'doc-1', indexName: 'i' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openNotes).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }) })
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Attack tools (need attack hit fetch)
+  // -----------------------------------------------------------------------
+
+  it('opens attackCorrelations with the resolved attack hit', () => {
+    withHit(attackSearchHit);
+    renderRestore(
+      buildUrl([
+        { kind: 'attackCorrelations', attackId: 'atk-1', indexName: '.alerts-*', alertIds: ['a1'] },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAttackCorrelations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hit: expect.objectContaining({ id: 'attack-1' }),
+        alertIds: ['a1'],
+      })
+    );
+  });
+
+  it('falls back to attack flyout after the fetch settles with no hit', () => {
+    loadingHit();
+    const { rerender } = renderRestore(
+      buildUrl([
+        { kind: 'attackCorrelations', attackId: 'atk-1', indexName: '.alerts-*', alertIds: [] },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAttackFlyout).not.toHaveBeenCalled();
+
+    noHit();
+    rerender();
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAttackCorrelations).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openAttackFlyout).toHaveBeenCalledWith({
+      attackId: 'atk-1',
+      indexName: '.alerts-*',
+    });
+  });
+
+  it('resolves the attack hit against the PageScope.attacks data view, not PageScope.default', () => {
+    // The attack discovery alerts backing index is not part of the default page-scope data
+    // view's index pattern — using it there silently finds no hit and wrongly falls back to
+    // the attack main flyout on restore. Give each scope a distinct data view instance so we
+    // can assert the attack fetch used the attacks-scoped one.
+    const mockAttacksDataView = {
+      getRuntimeMappings: jest.fn(() => ({})),
+      hasMatchedIndices: jest.fn(() => true),
+    };
+    (useDataView as jest.Mock).mockImplementation((scope: PageScope) =>
+      scope === PageScope.attacks
+        ? { dataView: mockAttacksDataView, status: 'ready' }
+        : { dataView: mockDataView, status: 'ready' }
+    );
+    withHit(attackSearchHit);
+    renderRestore(
+      buildUrl([
+        { kind: 'attackCorrelations', attackId: 'atk-1', indexName: '.alerts-*', alertIds: ['a1'] },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const attackFetchCall = (useEsDocSearch as jest.Mock).mock.calls.find(
+      ([params]) => params.id === 'atk-1'
+    );
+    expect(attackFetchCall?.[0].dataView).toBe(mockAttacksDataView);
+    expect(mockFlyoutApi.openAttackCorrelations).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'attack-1' }) })
+    );
+  });
+
+  it('waits for the attacks data view specifically, independent of the default one', () => {
+    // Only an attack descriptor is present (no doc/ioc), so restore should gate on
+    // PageScope.attacks readiness and must not hang waiting on PageScope.default.
+    (useDataView as jest.Mock).mockImplementation((scope: PageScope) =>
+      scope === PageScope.attacks
+        ? { dataView: null, status: 'loading' }
+        : { dataView: mockDataView, status: 'ready' }
+    );
+    renderRestore(
+      buildUrl([
+        { kind: 'attackCorrelations', attackId: 'atk-1', indexName: '.alerts-*', alertIds: ['a1'] },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAttackCorrelations).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openAttackFlyout).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // IOC (needs indicator fetch)
+  // -----------------------------------------------------------------------
+
+  it('opens the IOC flyout once the indicator document is fetched', () => {
+    const iocHit = {
+      id: 'ioc-1',
+      raw: { _id: 'ioc-1', _index: 'ti-*', fields: { 'threat.indicator.type': ['domain'] } },
+      flattened: {},
+    };
+    withHit(iocHit);
+    renderRestore(buildUrl([{ kind: 'ioc', indicatorId: 'ioc-1', indicatorIndex: 'ti-*' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openIocFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ indicator: expect.objectContaining({ _id: 'ioc-1' }) })
+    );
+  });
+
+  it('does not open the IOC flyout when the indicator cannot be fetched', () => {
+    noHit();
+    renderRestore(buildUrl([{ kind: 'ioc', indicatorId: 'ioc-1', indicatorIndex: 'ti-*' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openIocFlyout).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // [tool, child] two-entry chain
+  // -----------------------------------------------------------------------
+
+  it('opens [tool, child] — both entries with correct session variants', () => {
+    withHit(docSearchHit);
+    renderRestore(
+      buildUrl([
+        { kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' },
+        { kind: 'document', documentId: 'doc-1', indexName: 'logs-*' },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    // tool (position 0): openAnalyzer with the resolved hit
+    expect(mockFlyoutApi.openAnalyzer).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }) })
+    );
+    // child (position 1): openDocumentFlyoutFromIndexAsChild
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'doc-1', indexName: 'logs-*' })
+    );
+  });
+
+  it('opens [host, document] — host as start, document as AsChild', () => {
+    renderRestore(
+      buildUrl([
+        { kind: 'host', hostName: 'my-host' },
+        { kind: 'document', documentId: 'doc-1', indexName: 'i' },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openHostFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ hostName: 'my-host' })
+    );
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'doc-1' })
+    );
+  });
+
+  it('opens [cspMisconfiguration, attack] — second entry via openAttackFlyoutAsChild', () => {
+    renderRestore(
+      buildUrl([
+        { kind: 'cspMisconfiguration', resourceId: 'res-1', ruleId: 'csp-1' },
+        { kind: 'attack', attackId: 'atk-1', indexName: '.alerts-*' },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openMisconfigurationFinding).toHaveBeenCalled();
+    expect(mockFlyoutApi.openAttackFlyoutAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ attackId: 'atk-1' })
+    );
+  });
+
+  it('opens [analyzer, host] — tool restores and the entity child restores via AsChild', () => {
+    // Covers the tool -> document -> host navigation, which the writer persists as [analyzer, host]
+    // (root tool + newest/deepest child). Both must reopen.
+    withHit(docSearchHit);
+    renderRestore(
+      buildUrl([
+        { kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' },
+        { kind: 'host', hostName: 'my-host', entityId: 'eid' },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAnalyzer).toHaveBeenCalledWith(
+      expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }) })
+    );
+    expect(mockFlyoutApi.openHostFlyoutAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ hostName: 'my-host' })
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Restore at most once
+  // -----------------------------------------------------------------------
+
+  it('only restores once even if re-rendered multiple times', () => {
+    const { rerender } = renderRestore(
+      buildUrl([{ kind: 'document', documentId: 'doc-1', indexName: 'i' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    rerender();
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Wait for data view before fetching
+  // -----------------------------------------------------------------------
+
+  it('waits for the data view to be ready before opening a fetch-dependent flyout', () => {
+    (useDataView as jest.Mock).mockReturnValue({ dataView: null, status: 'loading' });
+    renderRestore(buildUrl([{ kind: 'analyzer', documentId: 'doc-1', indexName: 'i' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockFlyoutApi.openAnalyzer).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+  });
+
+  it('opens immediately (no data view wait) when no fetch is required', () => {
+    (useDataView as jest.Mock).mockReturnValue({ dataView: null, status: 'loading' });
+    renderRestore(buildUrl([{ kind: 'document', documentId: 'doc-1', indexName: 'i' }]));
+    act(() => {
+      jest.runAllTimers();
+    });
+    // Non-fetch descriptor (document) opens immediately regardless of data view status
+    expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      indexName: 'i',
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // T-012: Timeline flyout context (second URL param)
+  // -----------------------------------------------------------------------
+
+  describe('Timeline context — flyoutV2Timeline param', () => {
+    const renderTimelineRestore = (url: string) => {
+      const history = createMemoryHistory({ initialEntries: [url] });
+      const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+        React.createElement(Router, { history }, children as React.ReactElement);
+      const { result, rerender } = renderHook(
+        () => useFlyoutV2RestoreFromUrl(FLYOUT_V2_TIMELINE_URL_PARAM),
+        { wrapper }
+      );
+      return { result, history, rerender };
+    };
+
+    it('restores a single document flyout from the Timeline param', () => {
+      renderTimelineRestore(
+        buildUrl(
+          [{ kind: 'document', documentId: 'tl-doc-1', indexName: 'i' }],
+          FLYOUT_V2_TIMELINE_URL_PARAM
+        )
+      );
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(mockFlyoutApi.openDocumentFlyoutFromIndex).toHaveBeenCalledWith({
+        documentId: 'tl-doc-1',
+        indexName: 'i',
+      });
+    });
+
+    it('does NOT restore from the page flyoutV2 param when keyed to the Timeline param', () => {
+      renderTimelineRestore(
+        buildUrl(
+          [{ kind: 'document', documentId: 'page-doc', indexName: 'i' }],
+          FLYOUT_V2_URL_PARAM
+        )
+      );
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(mockFlyoutApi.openDocumentFlyoutFromIndex).not.toHaveBeenCalled();
+    });
+
+    it('restores a [tool, child] chain from the Timeline param', () => {
+      withHit(docSearchHit);
+      renderTimelineRestore(
+        buildUrl(
+          [
+            { kind: 'analyzer', documentId: 'doc-1', indexName: 'logs-*' },
+            { kind: 'document', documentId: 'doc-1', indexName: 'logs-*' },
+          ],
+          FLYOUT_V2_TIMELINE_URL_PARAM
+        )
+      );
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(mockFlyoutApi.openAnalyzer).toHaveBeenCalledWith(
+        expect.objectContaining({ hit: expect.objectContaining({ id: 'doc-1' }) })
+      );
+      expect(mockFlyoutApi.openDocumentFlyoutFromIndexAsChild).toHaveBeenCalledWith(
+        expect.objectContaining({ documentId: 'doc-1' })
+      );
+    });
+  });
+
+  describe('two-contexts-at-once', () => {
+    it('page and Timeline restore hooks can both be mounted and restore independently', () => {
+      const url = `/?${FLYOUT_V2_URL_PARAM}=${encode([
+        { kind: 'host', hostName: 'page-host' },
+      ])}&${FLYOUT_V2_TIMELINE_URL_PARAM}=${encode([
+        { kind: 'user', userName: 'timeline-alice' },
+      ])}`;
+      const history = createMemoryHistory({ initialEntries: [url] });
+      const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+        React.createElement(Router, { history }, children as React.ReactElement);
+
+      renderHook(
+        () => {
+          useFlyoutV2RestoreFromUrl(FLYOUT_V2_URL_PARAM);
+          useFlyoutV2RestoreFromUrl(FLYOUT_V2_TIMELINE_URL_PARAM);
+        },
+        { wrapper }
+      );
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(mockFlyoutApi.openHostFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({ hostName: 'page-host' })
+      );
+      expect(mockFlyoutApi.openUserFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({ userName: 'timeline-alice' })
+      );
+    });
+
+    it('a page flyout does not interfere with the Timeline restore', () => {
+      // Only the Timeline param is present; page restore should not fire anything.
+      const url = `/?${FLYOUT_V2_TIMELINE_URL_PARAM}=${encode([{ kind: 'rule', ruleId: 'r-tl' }])}`;
+      const history = createMemoryHistory({ initialEntries: [url] });
+      const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+        React.createElement(Router, { history }, children as React.ReactElement);
+
+      renderHook(
+        () => {
+          useFlyoutV2RestoreFromUrl(FLYOUT_V2_URL_PARAM);
+          useFlyoutV2RestoreFromUrl(FLYOUT_V2_TIMELINE_URL_PARAM);
+        },
+        { wrapper }
+      );
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      // Only the Timeline flyout (rule) should have been opened.
+      expect(mockFlyoutApi.openRuleFlyout).toHaveBeenCalledWith({ ruleId: 'r-tl' });
+      // openHostFlyout and other page-context openers should not have been called.
+      expect(mockFlyoutApi.openHostFlyout).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.test.tsx
@@ -263,6 +263,44 @@ describe('useFlyoutV2RestoreFromUrl', () => {
     );
   });
 
+  it('restores the tool header source context by passing an onShowEntity that reopens the host', () => {
+    renderRestore(
+      buildUrl([{ kind: 'entityRiskInputs', entityType: 'host', entityName: 'h', entityId: 'eid' }])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    const { onShowEntity } = mockFlyoutApi.openEntityRiskInputs.mock.calls[0][0];
+    expect(typeof onShowEntity).toBe('function');
+
+    // Invoking the header callback reopens the originating entity flyout as a child.
+    act(() => {
+      onShowEntity?.();
+    });
+    expect(mockFlyoutApi.openHostFlyoutAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ hostName: 'h', entityId: 'eid', title: 'h' })
+    );
+  });
+
+  it('reopens the originating user for a user-scoped tool header callback', () => {
+    renderRestore(
+      buildUrl([
+        { kind: 'entityAnomalyInsights', entityType: 'user', value: 'alice', entityId: 'uid' },
+      ])
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    const { onOpenEntity } = mockFlyoutApi.openEntityAnomalyInsights.mock.calls[0][0];
+    expect(typeof onOpenEntity).toBe('function');
+    act(() => {
+      onOpenEntity?.();
+    });
+    expect(mockFlyoutApi.openUserFlyoutAsChild).toHaveBeenCalledWith(
+      expect.objectContaining({ userName: 'alice', entityId: 'uid', title: 'alice' })
+    );
+  });
+
   it('opens entityEntraInsights by constructing ManagedUserHit from stored id/index', () => {
     renderRestore(
       buildUrl([
@@ -624,7 +662,9 @@ describe('useFlyoutV2RestoreFromUrl', () => {
       jest.runAllTimers();
     });
     expect(mockFlyoutApi.openIocFlyout).toHaveBeenCalledWith(
-      expect.objectContaining({ indicator: expect.objectContaining({ _id: 'ioc-1' }) })
+      expect.objectContaining({
+        indicator: expect.objectContaining({ _id: 'ioc-1', _index: 'ti-*' }),
+      })
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
@@ -1,0 +1,711 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ElasticRequestState } from '@kbn/unified-doc-viewer';
+import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
+import { noop } from 'lodash/fp';
+import type { Indicator } from '../../../../common/threat_intelligence/types/indicator';
+import type { EntityType } from '../../../../common/entity_analytics/types';
+import type { FlowTargetSourceDest } from '../../../../common/search_strategy/security_solution/network';
+import type { ManagedUserHit } from '../../../../common/search_strategy/security_solution/users/managed_details';
+import { useIsNewFlyoutEnabled } from '../../../common/hooks/use_is_new_flyout_enabled';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+import type { FlyoutApi } from '../../use_flyout_api';
+import { useFlyoutApi } from '../../use_flyout_api';
+import { decodeFlyoutV2UrlParam } from './flyout_v2_url_param';
+import type {
+  AnalyzerDescriptor,
+  AttackCorrelationsDescriptor,
+  AttackDescriptor,
+  AttackEntitiesDescriptor,
+  CspMisconfigurationDescriptor,
+  CspVulnerabilityDescriptor,
+  DocumentCorrelationsDescriptor,
+  DocumentDescriptor,
+  DocumentEntitiesDescriptor,
+  DocumentFromPatternDescriptor,
+  DocumentGraphDescriptor,
+  DocumentInvestigationGuideDescriptor,
+  DocumentPrevalenceDescriptor,
+  DocumentResponseDescriptor,
+  DocumentThreatIntelligenceDescriptor,
+  EntityAlertsInsightsDescriptor,
+  EntityAnomalyInsightsDescriptor,
+  EntityEntraInsightsDescriptor,
+  EntityGraphViewDescriptor,
+  EntityMisconfigurationInsightsDescriptor,
+  EntityOktaInsightsDescriptor,
+  EntityResolutionDescriptor,
+  EntityRiskInputsDescriptor,
+  EntityVulnerabilityInsightsDescriptor,
+  FlyoutDescriptor,
+  FlyoutV2UrlParamValue,
+  GenericEntityDescriptor,
+  HostDescriptor,
+  IocDescriptor,
+  NetworkDescriptor,
+  NotesDescriptor,
+  RuleDescriptor,
+  ServiceDescriptor,
+  SessionViewDescriptor,
+  UserDescriptor,
+} from './flyout_v2_url_param';
+
+// ---------------------------------------------------------------------------
+// Constants — which descriptor kinds require an async data fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Descriptor kinds that require resolving the document's DataTableRecord (via `useEsDocSearch`)
+ * before the tool flyout can be opened.
+ */
+const NEEDS_DOC_HIT = new Set<string>([
+  'analyzer',
+  'sessionView',
+  'documentEntities',
+  'documentCorrelations',
+  'documentPrevalence',
+  'documentResponse',
+  'documentThreatIntelligence',
+  'documentInvestigationGuide',
+  'documentGraph',
+  'notes',
+]);
+
+/** Descriptor kinds that require pre-fetching the attack's DataTableRecord. */
+const NEEDS_ATTACK_HIT = new Set<string>(['attackCorrelations', 'attackEntities']);
+
+// ---------------------------------------------------------------------------
+// Per-kind restorer helpers (pure functions, not hooks)
+// ---------------------------------------------------------------------------
+
+interface RestoreContext {
+  docHit?: DataTableRecord;
+  attackHit?: DataTableRecord;
+  iocIndicator?: Indicator;
+}
+
+/**
+ * Open a descriptor as the first/main flyout (session = 'start').
+ * Mutually exclusive with `openDescriptorAsChild`.
+ *
+ * Exported for reuse by `useLegacyFlyoutUrlInterop`.
+ */
+export const openDescriptorAsStart = (
+  descriptor: FlyoutDescriptor,
+  ctx: RestoreContext,
+  api: FlyoutApi
+): void => {
+  const { kind } = descriptor;
+
+  switch (kind) {
+    // --- Document main flyouts ---
+    case 'document': {
+      const { documentId, indexName } = descriptor as DocumentDescriptor;
+      api.openDocumentFlyoutFromIndex({ documentId, indexName });
+      break;
+    }
+    case 'documentFromPattern': {
+      const { documentId, indexName } = descriptor as DocumentFromPatternDescriptor;
+      api.openDocumentFlyoutFromPattern({ documentId, indexName });
+      break;
+    }
+
+    // --- Document tools (require resolved docHit) ---
+    case 'analyzer': {
+      const d = descriptor as AnalyzerDescriptor;
+      if (ctx.docHit) {
+        api.openAnalyzer({ hit: ctx.docHit });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'sessionView': {
+      const d = descriptor as SessionViewDescriptor;
+      if (ctx.docHit) {
+        api.openSessionView({
+          hit: ctx.docHit,
+          jumpToCursor: d.jumpToCursor,
+          jumpToEntityId: d.jumpToEntityId,
+        });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentEntities': {
+      const d = descriptor as DocumentEntitiesDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentEntities({ hit: ctx.docHit, scopeId: d.scopeId });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentCorrelations': {
+      const d = descriptor as DocumentCorrelationsDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentCorrelations({
+          hit: ctx.docHit,
+          scopeId: d.scopeId,
+          isRulePreview: d.isRulePreview,
+          // Provide a default onShowAlert that opens the alert as a child flyout.
+          onShowAlert: (alertId, indexName) =>
+            api.openDocumentFlyoutFromIndexAsChild({ documentId: alertId, indexName }),
+        });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentPrevalence': {
+      const d = descriptor as DocumentPrevalenceDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentPrevalence({
+          hit: ctx.docHit,
+          scopeId: d.scopeId,
+          investigationFields: d.investigationFields,
+        });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentResponse': {
+      const d = descriptor as DocumentResponseDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentResponse({ hit: ctx.docHit });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentThreatIntelligence': {
+      const d = descriptor as DocumentThreatIntelligenceDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentThreatIntelligence({ hit: ctx.docHit });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentInvestigationGuide': {
+      const d = descriptor as DocumentInvestigationGuideDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentInvestigationGuide({ hit: ctx.docHit });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'documentGraph': {
+      const d = descriptor as DocumentGraphDescriptor;
+      if (ctx.docHit) {
+        api.openDocumentGraph({ hit: ctx.docHit });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'notes': {
+      const d = descriptor as NotesDescriptor;
+      if (ctx.docHit) {
+        api.openNotes({ hit: ctx.docHit });
+      } else {
+        api.openDocumentFlyoutFromIndex({ documentId: d.documentId, indexName: d.indexName });
+      }
+      break;
+    }
+
+    // --- Attack main flyout + tools ---
+    case 'attack': {
+      const { attackId, indexName } = descriptor as AttackDescriptor;
+      api.openAttackFlyout({ attackId, indexName });
+      break;
+    }
+    case 'attackCorrelations': {
+      const d = descriptor as AttackCorrelationsDescriptor;
+      if (ctx.attackHit) {
+        api.openAttackCorrelations({ hit: ctx.attackHit, alertIds: d.alertIds });
+      } else {
+        api.openAttackFlyout({ attackId: d.attackId, indexName: d.indexName });
+      }
+      break;
+    }
+    case 'attackEntities': {
+      const d = descriptor as AttackEntitiesDescriptor;
+      if (ctx.attackHit) {
+        api.openAttackEntities({ hit: ctx.attackHit, alertIds: d.alertIds });
+      } else {
+        api.openAttackFlyout({ attackId: d.attackId, indexName: d.indexName });
+      }
+      break;
+    }
+
+    // --- Entity main flyouts ---
+    case 'host': {
+      const { hostName, entityId, scopeId } = descriptor as HostDescriptor;
+      api.openHostFlyout({ hostName, entityId, scopeId });
+      break;
+    }
+    case 'user': {
+      const { userName, entityId, scopeId } = descriptor as UserDescriptor;
+      api.openUserFlyout({ userName, entityId, scopeId });
+      break;
+    }
+    case 'service': {
+      const { serviceName, entityId, scopeId } = descriptor as ServiceDescriptor;
+      api.openServiceFlyout({ serviceName, entityId, scopeId });
+      break;
+    }
+    case 'genericEntity': {
+      const { scopeId, entityId, entityDocId } = descriptor as GenericEntityDescriptor;
+      if (!entityId && !entityDocId) break;
+      const idProps =
+        entityId && entityDocId
+          ? { entityId, entityDocId }
+          : entityId
+          ? { entityId }
+          : { entityDocId: entityDocId as string };
+      api.openGenericEntityFlyout({ scopeId, ...idProps });
+      break;
+    }
+
+    // --- Entity tools ---
+    case 'entityRiskInputs': {
+      const d = descriptor as EntityRiskInputsDescriptor;
+      api.openEntityRiskInputs({
+        entityType: d.entityType as unknown as
+          | EntityType.host
+          | EntityType.user
+          | EntityType.service,
+        entityName: d.entityName,
+        entityId: d.entityId,
+      });
+      break;
+    }
+    case 'entityAnomalyInsights': {
+      const d = descriptor as EntityAnomalyInsightsDescriptor;
+      api.openEntityAnomalyInsights({
+        entityType: d.entityType as unknown as EntityType.host | EntityType.user,
+        value: d.value,
+        entityId: d.entityId,
+      });
+      break;
+    }
+    case 'entityAlertsInsights': {
+      const d = descriptor as EntityAlertsInsightsDescriptor;
+      api.openEntityAlertsInsights({
+        entityType: d.entityType as unknown as
+          | EntityType.host
+          | EntityType.user
+          | EntityType.generic,
+        value: d.value,
+        entityId: d.entityId,
+      });
+      break;
+    }
+    case 'entityMisconfigurationInsights': {
+      const d = descriptor as EntityMisconfigurationInsightsDescriptor;
+      api.openEntityMisconfigurationInsights({
+        entityType: d.entityType as unknown as
+          | EntityType.host
+          | EntityType.user
+          | EntityType.generic,
+        value: d.value,
+        entityId: d.entityId,
+      });
+      break;
+    }
+    case 'entityVulnerabilityInsights': {
+      const d = descriptor as EntityVulnerabilityInsightsDescriptor;
+      api.openEntityVulnerabilityInsights({
+        value: d.value,
+        entityId: d.entityId,
+        entityType: d.entityType as unknown as EntityType.host | EntityType.generic | undefined,
+        onShowHost: noop,
+      });
+      break;
+    }
+    case 'entityGraphView': {
+      const d = descriptor as EntityGraphViewDescriptor;
+      api.openEntityGraphView({
+        entityId: d.entityId,
+        scopeId: d.scopeId,
+        entityName: d.entityName,
+        onShowEntity: noop,
+      });
+      break;
+    }
+    case 'entityResolution': {
+      const d = descriptor as EntityResolutionDescriptor;
+      api.openEntityResolution({
+        entityId: d.entityId,
+        entityType: d.entityType as EntityType,
+        entityName: d.entityName,
+        scopeId: d.scopeId,
+      });
+      break;
+    }
+    case 'entityEntraInsights': {
+      const d = descriptor as EntityEntraInsightsDescriptor;
+      // ManagedUserHit can be constructed directly from stored {_id, _index} — no async fetch needed.
+      // The EntraInsights component fetches the full fields lazily from within.
+      const managedUser: ManagedUserHit = {
+        _id: d.managedUserId,
+        _index: d.managedUserIndex,
+      };
+      api.openEntityEntraInsights({ managedUser, value: d.value });
+      break;
+    }
+    case 'entityOktaInsights': {
+      const d = descriptor as EntityOktaInsightsDescriptor;
+      const managedUser: ManagedUserHit = {
+        _id: d.managedUserId,
+        _index: d.managedUserIndex,
+      };
+      api.openEntityOktaInsights({ managedUser, value: d.value });
+      break;
+    }
+
+    // --- Network / Rule ---
+    case 'network': {
+      const { ip, flowTarget } = descriptor as NetworkDescriptor;
+      api.openNetworkFlyout({ ip, flowTarget: flowTarget as FlowTargetSourceDest });
+      break;
+    }
+    case 'rule': {
+      const { ruleId } = descriptor as RuleDescriptor;
+      api.openRuleFlyout({ ruleId });
+      break;
+    }
+
+    // --- IOC ---
+    case 'ioc': {
+      if (ctx.iocIndicator) {
+        api.openIocFlyout({ indicator: ctx.iocIndicator });
+      }
+      // If indicator could not be fetched: skip rather than open with empty data.
+      break;
+    }
+
+    // --- CSP ---
+    case 'cspMisconfiguration': {
+      const { resourceId, ruleId } = descriptor as CspMisconfigurationDescriptor;
+      api.openMisconfigurationFinding({ resourceId, ruleId });
+      break;
+    }
+    case 'cspVulnerability': {
+      const d = descriptor as CspVulnerabilityDescriptor;
+      api.openVulnerabilityFinding({
+        vulnerabilityId: d.vulnerabilityId,
+        resourceId: d.resourceId,
+        packageName: d.packageName,
+        packageVersion: d.packageVersion,
+        eventId: d.eventId,
+      });
+      break;
+    }
+  }
+};
+
+/**
+ * Open a descriptor as the second/child flyout (session = 'inherit').
+ * For kinds that have an explicit `...AsChild` method, that is used.
+ * For tool kinds (which are always 'start') the same method is used as for `openDescriptorAsStart`.
+ *
+ * Exported for reuse by `useLegacyFlyoutUrlInterop`.
+ */
+export const openDescriptorAsChild = (
+  descriptor: FlyoutDescriptor,
+  ctx: RestoreContext,
+  api: FlyoutApi
+): void => {
+  const { kind } = descriptor;
+
+  switch (kind) {
+    // Main flyouts that have an explicit AsChild variant
+    case 'document': {
+      const { documentId, indexName } = descriptor as DocumentDescriptor;
+      api.openDocumentFlyoutFromIndexAsChild({ documentId, indexName });
+      break;
+    }
+    case 'documentFromPattern': {
+      // No AsChild variant exists — open as main (best-effort fallback)
+      const { documentId, indexName } = descriptor as DocumentFromPatternDescriptor;
+      api.openDocumentFlyoutFromPattern({ documentId, indexName });
+      break;
+    }
+    case 'attack': {
+      const { attackId, indexName } = descriptor as AttackDescriptor;
+      api.openAttackFlyoutAsChild({ attackId, indexName });
+      break;
+    }
+    case 'host': {
+      const { hostName, entityId, scopeId } = descriptor as HostDescriptor;
+      api.openHostFlyoutAsChild({ hostName, entityId, scopeId });
+      break;
+    }
+    case 'user': {
+      const { userName, entityId, scopeId } = descriptor as UserDescriptor;
+      api.openUserFlyoutAsChild({ userName, entityId, scopeId });
+      break;
+    }
+    case 'service': {
+      const { serviceName, entityId, scopeId } = descriptor as ServiceDescriptor;
+      api.openServiceFlyoutAsChild({ serviceName, entityId, scopeId });
+      break;
+    }
+    case 'genericEntity': {
+      const { scopeId, entityId, entityDocId } = descriptor as GenericEntityDescriptor;
+      if (!entityId && !entityDocId) break;
+      const idProps =
+        entityId && entityDocId
+          ? { entityId, entityDocId }
+          : entityId
+          ? { entityId }
+          : { entityDocId: entityDocId as string };
+      api.openGenericEntityFlyoutAsChild({ scopeId, ...idProps });
+      break;
+    }
+    case 'network': {
+      const { ip, flowTarget } = descriptor as NetworkDescriptor;
+      api.openNetworkFlyoutAsChild({ ip, flowTarget: flowTarget as FlowTargetSourceDest });
+      break;
+    }
+    case 'rule': {
+      const { ruleId } = descriptor as RuleDescriptor;
+      api.openRuleFlyoutAsChild({ ruleId });
+      break;
+    }
+    case 'ioc': {
+      if (ctx.iocIndicator) {
+        api.openIocFlyoutAsChild({ indicator: ctx.iocIndicator });
+      }
+      break;
+    }
+    case 'cspMisconfiguration': {
+      const { resourceId, ruleId } = descriptor as CspMisconfigurationDescriptor;
+      api.openMisconfigurationFindingAsChild({ resourceId, ruleId });
+      break;
+    }
+    case 'cspVulnerability': {
+      const d = descriptor as CspVulnerabilityDescriptor;
+      api.openVulnerabilityFindingAsChild({
+        vulnerabilityId: d.vulnerabilityId,
+        resourceId: d.resourceId,
+        packageName: d.packageName,
+        packageVersion: d.packageVersion,
+        eventId: d.eventId,
+      });
+      break;
+    }
+
+    // Tool kinds and everything else: re-use the 'start' path (tools have no child variants).
+    default:
+      openDescriptorAsStart(descriptor, ctx, api);
+      break;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Public hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Restore-on-mount hook: on first render, reads the `flyoutV2` (or `flyoutV2Timeline`) URL param,
+ * resolves any `{id, index}` back to a DataTableRecord (for document/attack tool descriptors) or
+ * Indicator (for IOC descriptors), then replays the ordered array via `useFlyoutApi()` — first
+ * entry with session `'start'`, second entry via the `...AsChild` (`'inherit'`) form so both
+ * the tool and its child reopen.
+ *
+ * Gated on `useIsNewFlyoutEnabled()`. Runs at most once per mount.
+ *
+ * Mount this hook in the Security Solution app shell, analogous to `useUrlState()` in
+ * `app/home/index.tsx`. The `useFlyoutApi()` contract requires the Redux store, router, and
+ * Kibana services that the app shell provides.
+ */
+export const useFlyoutV2RestoreFromUrl = (urlParamKey: string): void => {
+  const isNewFlyoutEnabled = useIsNewFlyoutEnabled();
+  const history = useHistory();
+  const flyoutApi = useFlyoutApi();
+  const hasRestoredRef = useRef(false);
+
+  // Read URL param exactly once (useState initializer runs on the first render only).
+  const [descriptors] = useState<FlyoutV2UrlParamValue | null>(() => {
+    if (!isNewFlyoutEnabled) return null;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    return decodeFlyoutV2UrlParam(raw);
+  });
+
+  // Detect a malformed param (raw present but decode failed) to strip it.
+  const [isMalformed] = useState<boolean>(() => {
+    if (!isNewFlyoutEnabled) return false;
+    const raw = new URLSearchParams(history.location.search).get(urlParamKey);
+    return raw != null && decodeFlyoutV2UrlParam(raw) === null;
+  });
+
+  // Strip malformed param once on mount.
+  useEffect(() => {
+    if (!isMalformed) return;
+    const params = new URLSearchParams(history.location.search);
+    params.delete(urlParamKey);
+    const search = params.toString();
+    history.replace({ ...history.location, search: search ? `?${search}` : '' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally empty — run once on mount
+
+  // -----------------------------------------------------------------------
+  // Identify which async fetches are needed
+  // -----------------------------------------------------------------------
+
+  const docFetchDescriptor = useMemo(
+    () => descriptors?.find((d) => NEEDS_DOC_HIT.has(d.kind)) ?? null,
+    [descriptors]
+  );
+
+  const attackFetchDescriptor = useMemo(
+    () => descriptors?.find((d) => NEEDS_ATTACK_HIT.has(d.kind)) ?? null,
+    [descriptors]
+  );
+
+  const iocDescriptor = useMemo((): IocDescriptor | null => {
+    const found = descriptors?.find((d) => d.kind === 'ioc');
+    return found ? (found as IocDescriptor) : null;
+  }, [descriptors]);
+
+  // -----------------------------------------------------------------------
+  // Data fetching (hooks always called; skip controls actual execution)
+  // -----------------------------------------------------------------------
+
+  const { dataView, status: dataViewStatus } = useDataView(PageScope.default);
+  const dataViewReady = dataViewStatus === 'ready';
+
+  // The attack discovery alerts backing index (e.g.
+  // `.internal.alerts-security.attack.discovery.alerts-default-000001`) is not part of the
+  // PageScope.default data view's index pattern, so searching for it against that data view
+  // (below) finds nothing. The live attack flyout resolves its hit against the dedicated
+  // PageScope.attacks data view (see `useAttackDetails`) — use the same one here.
+  const { dataView: attackDataView, status: attackDataViewStatus } = useDataView(PageScope.attacks);
+  const attackDataViewReady = attackDataViewStatus === 'ready';
+
+  // Resolve each document / attack / indicator by id+index using the SAME single-document search
+  // (`useEsDocSearch`) that the document flyout itself uses.
+  //
+  // We deliberately do NOT use `useTimelineEventsDetails` here: that is the timeline events-details
+  // *search strategy*, intended for a broad index *pattern*, and it returns no hit for a concrete
+  // alerts backing index (e.g. `.internal.alerts-security.alerts-default-000001`) at restore time.
+  // Relying on it made a restored tool flyout (analyzer, session view, ...) fall back to the
+  // document main flyout on refresh, because `ctx.docHit` was never resolved.
+  const docEventId = (docFetchDescriptor as { documentId?: string } | null)?.documentId ?? '';
+  const docIndexName = (docFetchDescriptor as { indexName?: string } | null)?.indexName ?? '';
+  const [docRequestState, docHitRecord] = useEsDocSearch({
+    id: docEventId,
+    index: docIndexName,
+    dataView,
+    skip: !docFetchDescriptor || !dataViewReady || !docEventId || !docIndexName,
+  });
+
+  const attackEventId =
+    (attackFetchDescriptor as AttackCorrelationsDescriptor | AttackEntitiesDescriptor | null)
+      ?.attackId ?? '';
+  const attackIndexName =
+    (attackFetchDescriptor as AttackCorrelationsDescriptor | AttackEntitiesDescriptor | null)
+      ?.indexName ?? '';
+  const [attackRequestState, attackHitRecord] = useEsDocSearch({
+    id: attackEventId,
+    index: attackIndexName,
+    dataView: attackDataView,
+    skip: !attackFetchDescriptor || !attackDataViewReady || !attackEventId || !attackIndexName,
+  });
+
+  const iocEventId = iocDescriptor?.indicatorId ?? '';
+  const iocIndexName = iocDescriptor?.indicatorIndex ?? '';
+  const [iocRequestState, iocHitRecord] = useEsDocSearch({
+    id: iocEventId,
+    index: iocIndexName,
+    dataView,
+    skip: !iocDescriptor || !dataViewReady || !iocEventId || !iocIndexName,
+  });
+
+  // -----------------------------------------------------------------------
+  // Restore effect
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    if (hasRestoredRef.current || !descriptors) return;
+
+    // Wait for the relevant data view(s) to be ready before any fetch-dependent restore.
+    const needsDefaultDataView = !!docFetchDescriptor || !!iocDescriptor;
+    if (needsDefaultDataView && !dataViewReady) return;
+    if (attackFetchDescriptor && !attackDataViewReady) return;
+
+    // A needed fetch is "settled" once `useEsDocSearch` resolves: Found WITH a record, or a terminal
+    // NotFound/Error state. `Found` with a null record is the transient initial state of a skipped
+    // search, so we require a non-null record for the Found case (otherwise we would commit before
+    // the fetch actually ran and fall back to the wrong flyout).
+    const isSettled = (
+      hasDescriptor: boolean,
+      state: ElasticRequestState,
+      record: DataTableRecord | null
+    ): boolean =>
+      !hasDescriptor ||
+      (state === ElasticRequestState.Found && !!record) ||
+      state === ElasticRequestState.NotFound ||
+      state === ElasticRequestState.Error ||
+      state === ElasticRequestState.NotFoundDataView;
+
+    if (!isSettled(!!docFetchDescriptor, docRequestState, docHitRecord)) return;
+    if (!isSettled(!!attackFetchDescriptor, attackRequestState, attackHitRecord)) return;
+    if (!isSettled(!!iocDescriptor, iocRequestState, iocHitRecord)) return;
+
+    // All required fetches are done. Mark restored before setTimeout so a fast
+    // double-render cannot trigger a second open.
+    hasRestoredRef.current = true;
+
+    // Build resolved context. `useEsDocSearch` already returns `DataTableRecord`s.
+    const docHit = docHitRecord ?? undefined;
+    const attackHit = attackHitRecord ?? undefined;
+    const iocIndicator: Indicator | undefined = iocHitRecord
+      ? {
+          _id: iocHitRecord.raw._id ?? '',
+          fields: (iocHitRecord.raw.fields ?? {}) as Indicator['fields'],
+        }
+      : undefined;
+
+    const ctx: RestoreContext = { docHit, attackHit, iocIndicator };
+    const [first, second] = descriptors;
+
+    // Defer to a macrotask to avoid z-index ordering races with Timeline restore, which also
+    // fires on mount and claims its slot in the same render cycle.
+    setTimeout(() => {
+      openDescriptorAsStart(first, ctx, flyoutApi);
+      if (second) {
+        openDescriptorAsChild(second, ctx, flyoutApi);
+      }
+    }, 0);
+  }, [
+    descriptors,
+    docFetchDescriptor,
+    attackFetchDescriptor,
+    iocDescriptor,
+    dataViewReady,
+    attackDataViewReady,
+    docRequestState,
+    docHitRecord,
+    attackRequestState,
+    attackHitRecord,
+    iocRequestState,
+    iocHitRecord,
+    flyoutApi,
+  ]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/url_state/use_flyout_v2_restore.ts
@@ -20,7 +20,6 @@ import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../data_view_manager/constants';
 import type { FlyoutApi } from '../../use_flyout_api';
 import { useFlyoutApi } from '../../use_flyout_api';
-import { decodeFlyoutV2UrlParam } from './flyout_v2_url_param';
 import type {
   AnalyzerDescriptor,
   AttackCorrelationsDescriptor,
@@ -58,6 +57,7 @@ import type {
   SessionViewDescriptor,
   UserDescriptor,
 } from './flyout_v2_url_param';
+import { decodeFlyoutV2UrlParam } from './flyout_v2_url_param';
 
 // ---------------------------------------------------------------------------
 // Constants — which descriptor kinds require an async data fetch
@@ -92,6 +92,54 @@ interface RestoreContext {
   attackHit?: DataTableRecord;
   iocIndicator?: Indicator;
 }
+
+/**
+ * Builds the tool-header "show entity" callback for a restored entity tool flyout.
+ *
+ * Entity tools open with `session: 'start'`, so the entity main flyout is not persisted alongside
+ * the tool: on refresh only the tool descriptor is in the URL and there is no parent entity flyout.
+ * The shared tools header hides its source context (the entity name + icon) unless it is given a
+ * title-click handler, so without this callback a restored tool flyout would lose the host/user
+ * info in its header. Rebuilding it here restores both the header label and the
+ * click-to-open-entity behaviour the live flyout provides via its own `onShowEntity` handler.
+ */
+const buildShowEntityCallback = (
+  api: FlyoutApi,
+  {
+    entityType,
+    entityName,
+    entityId,
+    scopeId,
+  }: { entityType?: string; entityName: string; entityId?: string; scopeId?: string }
+): (() => void) => {
+  return () => {
+    switch (entityType) {
+      case 'user':
+        api.openUserFlyoutAsChild({ userName: entityName, entityId, scopeId, title: entityName });
+        break;
+      case 'service':
+        api.openServiceFlyoutAsChild({
+          serviceName: entityName,
+          entityId,
+          scopeId,
+          title: entityName,
+        });
+        break;
+      case 'host':
+        api.openHostFlyoutAsChild({ hostName: entityName, entityId, scopeId, title: entityName });
+        break;
+      default:
+        // Generic / unknown entity type: only openable when we have the canonical entity id.
+        if (entityId) {
+          api.openGenericEntityFlyoutAsChild({
+            scopeId: scopeId ?? '',
+            entityId,
+            title: entityName,
+          });
+        }
+    }
+  };
+};
 
 /**
  * Open a descriptor as the first/main flyout (session = 'start').
@@ -290,6 +338,11 @@ export const openDescriptorAsStart = (
           | EntityType.service,
         entityName: d.entityName,
         entityId: d.entityId,
+        onShowEntity: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.entityName,
+          entityId: d.entityId,
+        }),
       });
       break;
     }
@@ -299,6 +352,11 @@ export const openDescriptorAsStart = (
         entityType: d.entityType as unknown as EntityType.host | EntityType.user,
         value: d.value,
         entityId: d.entityId,
+        onOpenEntity: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.value,
+          entityId: d.entityId,
+        }),
       });
       break;
     }
@@ -311,6 +369,11 @@ export const openDescriptorAsStart = (
           | EntityType.generic,
         value: d.value,
         entityId: d.entityId,
+        onShowEntity: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.value,
+          entityId: d.entityId,
+        }),
       });
       break;
     }
@@ -323,6 +386,11 @@ export const openDescriptorAsStart = (
           | EntityType.generic,
         value: d.value,
         entityId: d.entityId,
+        onShowEntity: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.value,
+          entityId: d.entityId,
+        }),
       });
       break;
     }
@@ -332,7 +400,11 @@ export const openDescriptorAsStart = (
         value: d.value,
         entityId: d.entityId,
         entityType: d.entityType as unknown as EntityType.host | EntityType.generic | undefined,
-        onShowHost: noop,
+        onShowHost: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.value,
+          entityId: d.entityId,
+        }),
       });
       break;
     }
@@ -343,6 +415,12 @@ export const openDescriptorAsStart = (
         scopeId: d.scopeId,
         entityName: d.entityName,
         onShowEntity: noop,
+        onShowOriginatingEntity: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.entityName,
+          entityId: d.entityId,
+          scopeId: d.scopeId,
+        }),
       });
       break;
     }
@@ -353,6 +431,12 @@ export const openDescriptorAsStart = (
         entityType: d.entityType as EntityType,
         entityName: d.entityName,
         scopeId: d.scopeId,
+        onShowEntity: buildShowEntityCallback(api, {
+          entityType: d.entityType,
+          entityName: d.entityName,
+          entityId: d.entityId,
+          scopeId: d.scopeId,
+        }),
       });
       break;
     }
@@ -675,11 +759,16 @@ export const useFlyoutV2RestoreFromUrl = (urlParamKey: string): void => {
     // Build resolved context. `useEsDocSearch` already returns `DataTableRecord`s.
     const docHit = docHitRecord ?? undefined;
     const attackHit = attackHitRecord ?? undefined;
+    // Carry `_index` through on the reconstructed indicator (the `Indicator` type only declares
+    // `_id`/`fields`, but the IOC opener reads `_index` off the raw hit to re-persist the URL
+    // descriptor). Without it, re-opening on restore would rewrite the descriptor with an empty
+    // index and a second refresh would no longer restore the flyout.
     const iocIndicator: Indicator | undefined = iocHitRecord
-      ? {
+      ? ({
           _id: iocHitRecord.raw._id ?? '',
+          _index: iocHitRecord.raw._index,
           fields: (iocHitRecord.raw.fields ?? {}) as Indicator['fields'],
-        }
+        } as Indicator)
       : undefined;
 
     const ctx: RestoreContext = { docHit, attackHit, iocIndicator };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/utils/build_flyout_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/utils/build_flyout_content.test.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { buildFlyoutContent, buildFlyoutTitleFromField } from './build_flyout_content';
+import {
+  buildFlyoutContent,
+  buildFlyoutTitleFromField,
+  buildFlyoutDescriptorFromField,
+} from './build_flyout_content';
 import { FlowTargetSourceDest } from '../../../../common/search_strategy/security_solution/network';
 import {
   SIGNAL_RULE_NAME_FIELD_NAME,
   USER_NAME_FIELD_NAME,
 } from '../../../timelines/components/timeline/body/renderers/constants';
+import { FLYOUT_DESCRIPTOR_KIND } from '../url_state/flyout_v2_url_param';
 
 jest.mock('../components/table_field_name_cell', () => ({
   getEcsField: (field: string) => {
@@ -151,5 +156,48 @@ describe('buildFlyoutTitleFromField', () => {
 
   it('should return null for an unknown field', () => {
     expect(buildFlyoutTitleFromField('unknown.field', 'value')).toBeNull();
+  });
+});
+
+describe('buildFlyoutDescriptorFromField', () => {
+  it('returns a network descriptor for a source IP field', () => {
+    expect(buildFlyoutDescriptorFromField('source.ip', '10.0.0.1')).toEqual({
+      kind: FLYOUT_DESCRIPTOR_KIND.network,
+      ip: '10.0.0.1',
+      flowTarget: FlowTargetSourceDest.source,
+    });
+  });
+
+  it('returns a network descriptor with destination flowTarget for a destination IP field', () => {
+    expect(buildFlyoutDescriptorFromField('destination.ip', '192.168.1.1')).toEqual({
+      kind: FLYOUT_DESCRIPTOR_KIND.network,
+      ip: '192.168.1.1',
+      flowTarget: FlowTargetSourceDest.destination,
+    });
+  });
+
+  it('returns a rule descriptor for the signal rule name field', () => {
+    expect(buildFlyoutDescriptorFromField(SIGNAL_RULE_NAME_FIELD_NAME, 'rule-uuid')).toEqual({
+      kind: FLYOUT_DESCRIPTOR_KIND.rule,
+      ruleId: 'rule-uuid',
+    });
+  });
+
+  it('returns a host descriptor for a host.name field', () => {
+    expect(buildFlyoutDescriptorFromField('host.name', 'my-host')).toEqual({
+      kind: FLYOUT_DESCRIPTOR_KIND.host,
+      hostName: 'my-host',
+    });
+  });
+
+  it('returns a user descriptor for a user.name field', () => {
+    expect(buildFlyoutDescriptorFromField(USER_NAME_FIELD_NAME, 'my-user')).toEqual({
+      kind: FLYOUT_DESCRIPTOR_KIND.user,
+      userName: 'my-user',
+    });
+  });
+
+  it('returns null for an unsupported field', () => {
+    expect(buildFlyoutDescriptorFromField('unknown.field', 'value')).toBeNull();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/utils/build_flyout_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/utils/build_flyout_content.tsx
@@ -25,6 +25,8 @@ import {
   RULE_TITLE,
   USER_TITLE,
 } from '../constants/flyout_titles';
+import { FLYOUT_DESCRIPTOR_KIND } from '../url_state/flyout_v2_url_param';
+import type { FlyoutDescriptor } from '../url_state/flyout_v2_url_param';
 
 const Host = lazy(() => import('../../entity/host/main').then((m) => ({ default: m.Host })));
 const Network = lazy(() => import('../../network/main').then((m) => ({ default: m.Network })));
@@ -125,6 +127,41 @@ export const buildFlyoutContent = (
  */
 export const getFlyoutTypeForField = (field: string): FlyoutType | undefined =>
   getFieldDescriptor(field)?.flyoutType;
+
+/**
+ * Returns the serializable {@link FlyoutDescriptor} for the given field/value pair, or null when
+ * the field is not supported. Mirrors the field detection in {@link buildFlyoutContent} so callers
+ * can capture a URL descriptor alongside the React content they open.
+ *
+ * Supported fields: IP → network, signal rule name → rule, host.name → host, user.name → user.
+ */
+export const buildFlyoutDescriptorFromField = (
+  field: string,
+  value: string
+): FlyoutDescriptor | null => {
+  const ecsField = getEcsField(field);
+
+  if (ecsField?.type === IP_FIELD_TYPE) {
+    const flowTarget = field.includes(FlowTargetSourceDest.destination)
+      ? FlowTargetSourceDest.destination
+      : FlowTargetSourceDest.source;
+    return { kind: FLYOUT_DESCRIPTOR_KIND.network, ip: value, flowTarget: flowTarget as string };
+  }
+
+  if (field === SIGNAL_RULE_NAME_FIELD_NAME || field === LEGACY_SIGNAL_RULE_NAME_FIELD_NAME) {
+    return { kind: FLYOUT_DESCRIPTOR_KIND.rule, ruleId: value };
+  }
+
+  if (field === HOST_NAME_FIELD_NAME) {
+    return { kind: FLYOUT_DESCRIPTOR_KIND.host, hostName: value };
+  }
+
+  if (field === USER_NAME_FIELD_NAME) {
+    return { kind: FLYOUT_DESCRIPTOR_KIND.user, userName: value };
+  }
+
+  return null;
+};
 
 /**
  * Returns the flyout-history title for the given field/value pair, in the format

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/use_resolver_query_params_cleaner.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/use_resolver_query_params_cleaner.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import type { MemoryHistory } from 'history';
+import { Router } from '@kbn/shared-ux-router';
+import { useResolverQueryParamCleaner } from './use_resolver_query_params_cleaner';
+import { parameterName } from '../store/parameter_name';
+
+jest.mock('react-redux-v7', () => ({
+  ...jest.requireActual('react-redux-v7'),
+  useDispatch: () => jest.fn(),
+}));
+
+describe('useResolverQueryParamCleaner', () => {
+  const id = 'test-instance';
+  const resolverKey = parameterName(id);
+
+  const renderCleaner = (history: MemoryHistory) => {
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+      React.createElement(Router, { history }, children as React.ReactElement);
+    return renderHook(() => useResolverQueryParamCleaner(id), { wrapper });
+  };
+
+  it('removes its own resolver key on unmount and preserves other params', () => {
+    const history = createMemoryHistory({ initialEntries: [`/?${resolverKey}=foo&other=keep`] });
+    const { unmount } = renderCleaner(history);
+
+    unmount();
+
+    const params = new URLSearchParams(history.location.search);
+    expect(params.get(resolverKey)).toBeNull();
+    expect(params.get('other')).toBe('keep');
+  });
+
+  it('reads the CURRENT url at cleanup — does not resurrect a param cleared after mount', () => {
+    // Regression: the cleaner used to replay a search snapshot captured during render. If another
+    // writer (e.g. the flyout_v2 URL sync clearing its param on close) changed the url after this
+    // hook's last render, unmounting the resolver resurrected that param. It must instead read the
+    // live url and only delete its own key.
+    const history = createMemoryHistory({
+      initialEntries: [`/?${resolverKey}=foo&flyoutV2=analyzer`],
+    });
+    const { unmount } = renderCleaner(history);
+
+    // Simulate the flyout URL sync clearing flyoutV2 after this hook mounted.
+    history.replace({ search: `${resolverKey}=foo` });
+
+    unmount();
+
+    const params = new URLSearchParams(history.location.search);
+    expect(params.get(resolverKey)).toBeNull(); // own key removed
+    expect(params.get('flyoutV2')).toBeNull(); // NOT resurrected from a stale snapshot
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/use_resolver_query_params_cleaner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/use_resolver_query_params_cleaner.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { useRef, useEffect } from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux-v7';
 import { parameterName } from '../store/parameter_name';
 /**
@@ -14,14 +14,6 @@ import { parameterName } from '../store/parameter_name';
  * This works by having a React effect that just has behavior in the 'cleanup' function.
  */
 export function useResolverQueryParamCleaner(id: string) {
-  /**
-   * Keep a reference to the current search value. This is used in the cleanup function.
-   * This value of useLocation().search isn't used directly since that would change and
-   * we only want the cleanup to run on unmount or when the resolverComponentInstanceID
-   * changes.
-   */
-  const searchRef = useRef<string>();
-  searchRef.current = useLocation().search;
   const dispatch = useDispatch();
 
   const history = useHistory();
@@ -38,9 +30,13 @@ export function useResolverQueryParamCleaner(id: string) {
      */
     return () => {
       /**
-       * This effect must not be invalidated when `search` changes.
+       * Read the CURRENT url search at cleanup time — NOT a value snapshotted during render.
+       * Other code (e.g. the flyout_v2 URL sync clearing its own param when the flyout closes)
+       * may have changed the query string after this component's last render; replaying a stale
+       * snapshot here would resurrect those params. We only want to remove our own resolver key
+       * and preserve everything else that is currently in the url.
        */
-      const urlSearchParams = new URLSearchParams(searchRef.current);
+      const urlSearchParams = new URLSearchParams(history.location.search);
 
       /**
        * Remove old keys from the url

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_security_entity_ml_anomaly_summary/ui/parallel_tests/entity_analytics/entity_flyout_anomalies.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_security_entity_ml_anomaly_summary/ui/parallel_tests/entity_analytics/entity_flyout_anomalies.spec.ts
@@ -23,12 +23,18 @@ import { expect } from '@kbn/scout-security/ui';
 const ANOMALY_OVERVIEW_ROUTE = `**/internal/entity_analytics/entities/host/${HOST_FLYOUT_ENTITY_ID}/anomaly_overview`;
 const ANOMALY_SUMMARY_ROUTE = `**/internal/entity_analytics/entities/host/${HOST_FLYOUT_ENTITY_ID}/anomaly_summary`;
 const ANOMALY_PRIVILEGES_ROUTE = '**/internal/entity_analytics/anomalies/privileges';
+const ENABLE_NEW_FLYOUT_SETTING = 'securitySolution:enableNewFlyout';
 
 spaceTest.describe(
   'Entity flyout anomalies',
   { tag: [...tags.stateful.classic, ...tags.serverless.security.complete] },
   () => {
-    spaceTest.beforeAll(async ({ apiServices }) => {
+    spaceTest.beforeAll(async ({ apiServices, scoutSpace }) => {
+      // This suite drives the legacy expandable flyout via `flyout` URL params (host-panel /
+      // host_details / securitySolutionFlyoutAnomaliesTab). Disable the new flyout so those legacy
+      // panels render instead of being consumed by the flyout v2 legacy-URL interop, which drops
+      // the entity details left panel (and its anomalies tab) when translating the URL.
+      await scoutSpace.uiSettings.set({ [ENABLE_NEW_FLYOUT_SETTING]: false });
       await apiServices.entityAnalytics.installEntityStoreV2(['host']);
       await apiServices.entityAnalytics.indexEntityStoreEntry(
         HOST_FLYOUT_ENTITY_ID,
@@ -103,8 +109,9 @@ spaceTest.describe(
       });
     });
 
-    spaceTest.afterAll(async ({ apiServices }) => {
+    spaceTest.afterAll(async ({ apiServices, scoutSpace }) => {
       await apiServices.entityAnalytics.uninstallEntityStoreV2(['host']);
+      await scoutSpace.uiSettings.unset(ENABLE_NEW_FLYOUT_SETTING);
     });
 
     spaceTest(

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/alerts_flyout.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/alerts_flyout.ts
@@ -62,10 +62,13 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
       await waitForPluginInitialized({ retry, supertest, logger });
       await ebtUIHelper.setOptIn(true); // starts the recording of events from this moment
 
-      // Enable asset inventory and entity store v2 settings
+      // Enable asset inventory and entity store v2 settings.
+      // Disable the new flyout so the graph preview panel uses its legacy expandable-flyout
+      // selectors (e.g. `previewSection`), which don't exist in the new flyout system.
       await kibanaServer.uiSettings.update({
         'securitySolution:enableAssetInventory': true,
         'securitySolution:entityStoreEnableV2': true,
+        'securitySolution:enableNewFlyout': false,
       });
 
       // Initialize security-solution-default data-view (required by entity store)
@@ -87,6 +90,7 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
       await esArchiver.unload(
         'x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/logs_gcp_audit'
       );
+      await kibanaServer.uiSettings.unset('securitySolution:enableNewFlyout');
     });
 
     it('expanded flyout - filter by node', async () => {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/entity_flyout.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/entity_flyout.ts
@@ -44,6 +44,11 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
       await kibanaServer.uiSettings.update({
         'securitySolution:enableAssetInventory': true,
         'securitySolution:entityStoreEnableV2': true,
+        // This suite drives the legacy expandable flyout via `flyout` URL params (host-panel /
+        // user-panel) and asserts on legacy test subjects (`rightSection`). Disable the new flyout
+        // so those legacy panels render instead of being consumed by the flyout v2 legacy-URL
+        // interop, which translates the `flyout` param into the new (EUI) flyout.
+        'securitySolution:enableNewFlyout': false,
       });
 
       // Initialize security-solution-default data-view (required by entity store)
@@ -61,6 +66,7 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
         'securitySolution:enableAssetInventory': false,
         'securitySolution:entityStoreEnableV2': false,
       });
+      await kibanaServer.uiSettings.unset('securitySolution:enableNewFlyout');
     });
 
     describe('entity relationships', () => {


### PR DESCRIPTION
## Summary

### Context

For the last 2+ years, Security users have been using the expandable flyout to visualize their alert, event, attack, rules, network, host, user and ioc flyouts. All of these were leveraging the `kbn-expandable-flyout` package that the @elastic/security-threat-hunting team had built, that contained some logic to automatically synchronize the flyout's state to the url. This allowed page refresh to automatically reopen flyouts. It also allowed flyout sharing functionality.

The new flyout system (`flyout_v2`) doesn't persist any state in the URL. The EUI/SharedUX team does not provide (yet?) this functionality out of the box. Refreshing the page, or sharing a link, loses whatever document/attack/entity/tools flyouts were open. As we're enabling the new flyout experience by default in `9.5`, this is the last missing piece to get feature parity with the legacy expandable flyout.

### What this PR changes

The PR adds a full URL-synchronization layer for `flyout_v2`.
It also adds a share-link button to the document (for alerts only) and attack main flyouts.

> [!NOTE]
> The changes only impact Security Solution. In Discover, we do not yet have the ability to restore a flyout's state. This is OK as this functionality never existed in Discover, but it did in Security Solution where we had the legacy expandable flyout in the past.

### Main code changes

- **`shared/url_state/`** (new) is the core of the sync layer:
  - `flyout_v2_url_param.ts` defines the rison-encoded `flyoutV2` / `flyoutV2Timeline` URL params and the discriminated-union `FlyoutDescriptor` type for every flyout kind (document, attack, entity, and each of their tool flyouts).
  - `flyout_v2_url_writer.ts` writes/clears the URL param as flyouts open and close. It tracks write "generations" per open call so that closing an older flyout doesn't clobber a URL written by a newer one, while a full-session close (closing a root together with its cascaded child) still correctly clears the param.
  - `use_flyout_v2_restore.ts` reads the param on mount and re-opens the described flyout chain (up to a tool + one child), resolving the underlying ES document/data view as needed before opening.
  - `use_expandable_flyout_url_interop.ts` reads the legacy `flyout` param and converts it into a `flyoutV2` descriptor, so old shared links keep working after the new system takes over.
- **Per-flyout API wiring**: every `use_*_flyout_api.tsx` (`document`, `attack`, `entity`, `ioc`, `network`, `rule`, `csp`) now calls `writeOnOpen`/`buildOnClose` around its `open()` calls, so opening/closing any flyout or tool keeps the URL in sync.
- **Shared plumbing** (`flyout_provider.tsx`, `open_flyout_link.tsx`, `build_flyout_content.tsx`, `use_document_flyout_title.tsx`) threads through the session/history-key context the writer needs to know whether a flyout is a new root ("start") or a child of an existing one ("inherit").
- **Share button**: new `ShareUrlIconButton` (`shared/components/share_url_icon_button.tsx`) copies a direct link to the current alert/attack to the clipboard. It's rendered absolutely-positioned at the top of the document and attack main flyout headers, to the left of EUI's own close button.
- **Alerts page deep-linking**: `alert_details_redirect.tsx`/`utils.ts` and `app/home/index.tsx` wire up the new param: `useLegacyFlyoutUrlInterop` runs first to consume the legacy param, then `useFlyoutV2RestoreFromUrl` restores from `flyoutV2` (once for the page context, once for Timeline).
- `use_resolver_query_params_cleaner.ts` picked up a small fix so it stops resurrecting unrelated URL params when cleaning up.

### Desk testing

> [!NOTE]
> Page refresh should only bring the last state of the flyout. We do NOT remember the history of all flyouts opened, on purpose. This matches the logic of the legacy expandable flyout

#### Page refresh brings back the last state of the flyout

https://github.com/user-attachments/assets/c70d4f5c-7dd3-460e-9bfd-61042e976ca5

#### Opening a url previously saved with a legacy flyout will switch to the new flyout system and update the url accordingly

https://github.com/user-attachments/assets/4e0393ea-af1b-4a24-a680-bbbfa36cd970

#### Share alert and attack now works in the new system

https://github.com/user-attachments/assets/01fc7fa6-17fb-4693-8a91-49cdafc4414d

### How to test

- Open an alert flyout, open a tools flyout (e.g. Correlations), open a child flyout from within it, then refresh the page — the same chain should reopen exactly as it was.
- Repeat for an attack flyout, and for entity flyouts (host/user/service) with their tool flyouts (e.g. Prevalence with a host child).
- Close everything (including via a cascading tools-flyout close) and refresh — no flyout should reopen.
- Click the share icon on an alert or attack flyout, paste the copied link in a new tab — it should open directly to that flyout.
- Open an alert flyout via a legacy `flyout` URL param link — it should still open correctly through the new interop layer.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->