### PR TITLE
[Security Solution][Cypress] Fix flaky alert_reason_preview test (#260562)

### DIFF
--- a/src/platform/packages/shared/kbn-cypress-test-helper/src/services/alerting_services.ts
+++ b/src/platform/packages/shared/kbn-cypress-test-helper/src/services/alerting_services.ts
@@ -47,14 +47,6 @@ const waitForAlerts = () => {
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
-  // Do NOT add a `globalLoadingIndicator` ([data-test-subj="globalLoadingIndicator"]) assertion
-  // here. That chrome-level spinner reflects *any* in-flight HTTP request app-wide (telemetry,
-  // capabilities, session pings, etc.), not just the alerts search. `waitForAlertsToPopulate()`
-  // calls `refreshPage()` in a retry loop, which triggers enough incidental app-wide requests to
-  // keep that spinner mounted almost continuously under CI load, causing spurious 150s timeouts.
-  // The Security Solution copy of this helper (cypress/tasks/alerts.ts) hit this exact issue and
-  // removed the equivalent check in https://github.com/elastic/kibana/pull/274408 — see
-  // https://github.com/elastic/kibana/issues/260562 for a fully worked example failure.
 };
 
 export const waitForAlertsToPopulate = (alertCountThreshold = 1) => {

--- a/src/platform/packages/shared/kbn-cypress-test-helper/src/services/alerting_services.ts
+++ b/src/platform/packages/shared/kbn-cypress-test-helper/src/services/alerting_services.ts
@@ -12,7 +12,6 @@ import 'cypress-network-idle';
 const REFRESH_BUTTON = `[data-test-subj="kbnQueryBar"] [data-test-subj="querySubmitButton"]`;
 const DATAGRID_CHANGES_IN_PROGRESS = '[data-test-subj="body-data-grid"] .euiProgress';
 const EVENT_CONTAINER_TABLE_LOADING = '[data-test-subj="internalAlertsPageLoading"]';
-const LOADING_INDICATOR = '[data-test-subj="globalLoadingIndicator"]';
 const EMPTY_ALERT_TABLE = '[data-test-subj="alertsTableEmptyState"]';
 const ALERTS_TABLE_COUNT = `[data-test-subj="toolbar-alerts-count"]`;
 const DETECTION_PAGE_FILTER_GROUP_WRAPPER = '.filter-group__wrapper';
@@ -47,8 +46,15 @@ const waitForAlerts = () => {
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
-  cy.get(LOADING_INDICATOR).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
+  // Do NOT add a `globalLoadingIndicator` ([data-test-subj="globalLoadingIndicator"]) assertion
+  // here. That chrome-level spinner reflects *any* in-flight HTTP request app-wide (telemetry,
+  // capabilities, session pings, etc.), not just the alerts search. `waitForAlertsToPopulate()`
+  // calls `refreshPage()` in a retry loop, which triggers enough incidental app-wide requests to
+  // keep that spinner mounted almost continuously under CI load, causing spurious 150s timeouts.
+  // The Security Solution copy of this helper (cypress/tasks/alerts.ts) hit this exact issue and
+  // removed the equivalent check in https://github.com/elastic/kibana/pull/274408 — see
+  // https://github.com/elastic/kibana/issues/260562 for a fully worked example failure.
 };
 
 export const waitForAlertsToPopulate = (alertCountThreshold = 1) => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -468,13 +468,6 @@ export const waitForAlerts = () => {
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
-  // Do NOT add a `globalLoadingIndicator` ([data-test-subj="globalLoadingIndicator"]) assertion
-  // here. That chrome-level spinner reflects *any* in-flight HTTP request app-wide (telemetry,
-  // capabilities, session pings, etc.), not just the alerts search. `waitForAlertsToPopulate()`
-  // calls `refreshPage()` in a retry loop, which triggers enough incidental app-wide requests to
-  // keep that spinner mounted almost continuously under CI load, causing spurious 150s timeouts
-  // (see https://github.com/elastic/kibana/issues/260562 and #274408, which removed this exact
-  // check for the same reason).
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -468,6 +468,13 @@ export const waitForAlerts = () => {
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
+  // Do NOT add a `globalLoadingIndicator` ([data-test-subj="globalLoadingIndicator"]) assertion
+  // here. That chrome-level spinner reflects *any* in-flight HTTP request app-wide (telemetry,
+  // capabilities, session pings, etc.), not just the alerts search. `waitForAlertsToPopulate()`
+  // calls `refreshPage()` in a retry loop, which triggers enough incidental app-wide requests to
+  // keep that spinner mounted almost continuously under CI load, causing spurious 150s timeouts
+  // (see https://github.com/elastic/kibana/issues/260562 and #274408, which removed this exact
+  // check for the same reason).
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {


### PR DESCRIPTION
Fixes #260562

## Summary

**Problem:** `alert_reason_preview.cy.ts`'s `beforeEach` timed out after 150s waiting for a `span.euiLoadingSpinner` to disappear — Kibana's chrome-level `globalLoadingIndicator`, which fires for any in-flight HTTP request app-wide, not alerts-table readiness.

**Root cause:** this exact assertion was already removed from Security Solution's `waitForAlerts()` by [#274408](https://github.com/elastic/kibana/pull/274408) (merged 2026-06-23), which fixed 6 other issues with the identical stack-trace shape. Cross-checking all 5 sibling issues in this epic (#260562, #262632, #258812, #258943, #264641) — none has a recorded failure *after* that fix landed, meaning all five are stale duplicates of an already-fixed bug.

**What I actually fixed:**
1. Added a regression-guard comment above `waitForAlerts()` explaining why the `globalLoadingIndicator` check must never come back.
2. Found the *exact same* bug still live and unfixed in a separate, drifted copy of this helper (`kbn-cypress-test-helper`, used by Osquery's Cypress suite) — applied the identical fix there.

**Risk:** Very low — the Security Solution change is comment-only; the `kbn-cypress-test-helper` change is a one-line deletion mirroring a fix that's been stable in CI for over a month.

## Repro & Verification

- Confirmed via `git show` on the parent of #274408's fix commit that the removed line matches the reported stack trace exactly, and cross-referenced all 5 sibling issues' failure timestamps against the fix landing date (table of evidence in original investigation).
- Attempted a live repro against this already-fixed branch; got a different, unrelated failure (query bar never rendering) caused by extreme host contention — ~10 other agents running full Kibana/ES stacks concurrently, CPU pinned near 100%, load average 27-32. Documented candidly as an environment artifact, not a real repro of either the old or a new bug.
- Verified with `typecheck` and `prettier --check` on both modified files (both clean).
- Given the strength of this evidence, recommend closing #260562 and its four siblings once this (and the companion PRs) merge.

Made with [Cursor](https://cursor.com)
