### PR TITLE
[Security Solution][Endpoint] Fix S1 and MS Defender response action request size limits and add passcode support to runscript

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/microsoft_defender_endpoint/microsoft_defender_endpoint.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/microsoft_defender_endpoint/microsoft_defender_endpoint.ts
@@ -515,6 +515,8 @@ export class MicrosoftDefenderEndpointConnector extends SubActionConnector<
         method: 'get',
         responseType: 'stream',
         responseSchema: DownloadActionResultsResponseSchema,
+        maxBodyLength: Infinity,
+        maxContentLength: Infinity,
       },
       connectorUsageCollector
     );

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/sentinelone.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/sentinelone.test.ts
@@ -57,6 +57,8 @@ describe('SentinelOne Connector', () => {
       expect(response).toEqual({ data: { success: true }, errors: null });
       expect(connectorInstance.requestSpy).toHaveBeenLastCalledWith({
         url: fetchFilesUrl,
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
         method: 'post',
         data: {
           data: {
@@ -102,6 +104,8 @@ describe('SentinelOne Connector', () => {
 
       expect(connectorInstance.requestSpy).toHaveBeenCalledWith({
         method: 'get',
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
         url: `${connectorInstance.constructorParams.config.url}${API_PATH}/activities`,
         params: {
           APIToken: 'token-abc',

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
@@ -385,6 +385,8 @@ export class SentinelOneConnector extends SubActionConnector<
         method: 'get',
         responseType: 'stream',
         responseSchema: SentinelOneDownloadRemoteScriptResultsResponseSchema,
+        maxBodyLength: Infinity,
+        maxContentLength: Infinity,
       },
       connectorUsageCollector
     );

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
@@ -408,6 +408,8 @@ export class SentinelOneConnector extends SubActionConnector<
           ...req.params,
           APIToken: this.secrets.token,
         },
+        maxBodyLength: Infinity,
+        maxContentLength: Infinity,
       },
       connectorUsageCollector
     );

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
@@ -1865,6 +1865,7 @@ describe('SentinelOneActionsClient class', () => {
               outputDestination: 'SentinelCloud',
               requiresApproval: false,
               scriptId: '1466645476786791838',
+              password: RESPONSE_ACTIONS_ZIP_PASSCODE.sentinel_one,
               taskDescription: expect.stringContaining(
                 'Action triggered from Elastic Security by user [foo] for action [runscript'
               ),

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
@@ -782,7 +782,10 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
   }
 
   async getFileDownload(actionId: string, agentId: string): Promise<GetFileDownloadMethodResponse> {
+    this.log.debug(`getFileDownload(): actionId=${actionId}, agentId=${agentId}`);
+
     await this.ensureValidActionId(actionId);
+
     const {
       EndpointActions: {
         data: { command },
@@ -798,6 +801,8 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
         400
       );
     }
+
+    this.log.debug(`Getting file download for action ID [${actionId}] command [${command}]`);
 
     let downloadStream: Readable | undefined;
     let fileName: string = 'download.zip';
@@ -880,6 +885,13 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
 
       throw e;
     }
+
+    downloadStream.on('error', (err) => {
+      this.log.error(
+        `Download stream error for action id [${actionId}][${command}]: ${err.message}`,
+        { error: err }
+      );
+    });
 
     return {
       stream: downloadStream,
@@ -1070,6 +1082,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
               requiresApproval: false,
               outputDestination: 'SentinelCloud',
               inputParams: reqIndexOptions.parameters?.scriptInput,
+              password: RESPONSE_ACTIONS_ZIP_PASSCODE.sentinel_one,
             },
           });
 


### PR DESCRIPTION
## Summary

This PR addresses issues with large-body HTTP requests failing against the SentinelOne and Microsoft Defender for Endpoint connectors, and adds passcode support to the SentinelOne `runscript` response action.

### Changes

- **SentinelOne connector + MS Defender connector**: Set `maxContentLength` and `maxBodyLength` on the Axios client used for S1 API requests. Without these settings, Axios defaults prevents users from being able to retrieve responses for certain response actions.

- **SentinelOne actions client** (`sentinel_one_actions_client.ts`): Added `passcode` to the `runscript` action so that response `zip` file will now require the passcode to be entered before accessing its content.



Issues reported via: #279185


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->