### PR TITLE
[Security Solution][Cypress] Fix flaky attach_alert_to_case test (#262632)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases/attach_alert_to_case.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases/attach_alert_to_case.cy.ts
@@ -17,7 +17,6 @@ import { visit } from '../../../tasks/navigation';
 
 import { ALERTS_URL } from '../../../urls/navigation';
 import { ATTACH_ALERT_TO_CASE_BUTTON, TIMELINE_CONTEXT_MENU_BTN } from '../../../screens/alerts';
-import { LOADING_INDICATOR } from '../../../screens/security_header';
 import { deleteAlertsAndRules } from '../../../tasks/api_calls/common';
 
 const loadDetectionsPage = (role: SecurityRoleName) => {
@@ -55,7 +54,6 @@ describe('Alerts timeline', () => {
   context('Privileges: can crud', { tags: ['@ess', '@serverless'] }, () => {
     beforeEach(() => {
       loadDetectionsPage(ROLES.platform_engineer);
-      cy.get(LOADING_INDICATOR).should('not.exist');
     });
 
     it('should allow a user with crud privileges to attach alerts to cases', () => {


### PR DESCRIPTION
Fixes #262632

## Summary

**Problem:** `attach_alert_to_case.cy.ts`'s `beforeEach` intermittently timed out after 150s waiting for a `span.euiLoadingSpinner` to disappear. That spinner is Kibana's chrome-level `globalLoadingIndicator`, which fires for *any* in-flight HTTP request app-wide — not alerts-table readiness specifically.

**Solution:** This exact assertion was already removed from the shared `waitForAlerts()` helper by [#274408](https://github.com/elastic/kibana/pull/274408). This spec file had a **leftover copy of the same check** hardcoded in its own `beforeEach` (`cy.get(LOADING_INDICATOR).should('not.exist')`). Removed it — the surrounding `waitForAlertsToPopulate()` call already verifies the alerts table is settled without depending on the unrelated chrome spinner.

**Risk:** None — test-only deletion of a redundant, already-proven-safe-to-remove assertion.

## Repro & Verification

The exact reported failure is no longer producible on `main` (already fixed by #274408 for the shared path); this PR closes the one remaining copy of the same anti-pattern still living directly in this spec file.

- Confirmed via `git show` that #274408 removed the equivalent check from the shared helper, and that the DOM signature (`euiLoadingSpinner...-l`) matches Kibana's `globalLoadingIndicator` 1:1.
- Local `yarn cypress:ess` runs were inconclusive due to heavy resource contention from other agents' parallel Kibana/ES stacks on this shared dev machine (Docker's ES transport port is hardcoded and can't run more than one instance at a time). One run did reproduce a `beforeEach` timeout in the same retry-loop path, though on a different selector due to the ES container being overloaded — consistent with the same fragility class.
- Verified with `eslint` (clean) and by manually tracing `waitForAlertsToPopulate()` to confirm no test intent is lost.
- Recommend a [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner) pass before merge for a clean-environment signal.

Made with [Cursor](https://cursor.com)
