### PR TITLE
[Security Solution][Cypress] Fix flaky changed_banner test (#258812)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -465,7 +465,11 @@ export const showTopNAlertProperty = (propertySelector: string, rowIndex: number
 export const waitForAlerts = () => {
   waitForPageFilters();
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
-  cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
+  // `.should('not.be.true')` on a jQuery collection is always true (a jQuery object is
+  // never strictly `=== true`), so this used to be a silent no-op regardless of whether
+  // the data grid was mid-refresh. Assert on absence of the element instead so Cypress
+  // actually retries until the in-progress indicator is gone.
+  cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.exist');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };


### PR DESCRIPTION
Fixes #258812

## Summary

**Problem:** `changed_banner.cy.ts`'s `beforeEach` timed out after 150s inside the shared `waitForAlerts()` helper, waiting for a stray `span.euiLoadingSpinner` to disappear.

**Root cause (reported symptom):** that spinner is Kibana's chrome-level `globalLoadingIndicator`, which reacts to *any* in-flight HTTP request app-wide. The exact assertion causing this was already removed from `waitForAlerts()` upstream by [#274408](https://github.com/elastic/kibana/pull/274408) (this issue's last recorded failure predates that fix).

**A second, still-live bug found while auditing the same helper:** `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')` is a silent no-op — a jQuery collection is never `=== true`, so this assertion passes instantly regardless of whether the data grid is actually still refreshing. This weakens the "table is settled" guarantee `waitForAlerts()` is supposed to provide for every caller.

**Fix:** Changed it to `.should('not.exist')`, matching the identical pattern used one line below for `EVENT_CONTAINER_TABLE_LOADING`, so Cypress now actually retries until the grid's in-progress indicator is gone.

**Scope:** This is a one-line fix in a shared helper (`cypress/tasks/alerts.ts`) used by 60+ specs, not just this one.

## Repro & Verification

- The original spinner symptom is not reproducible on `main` (fixed by #274408). The `DATAGRID_CHANGES_IN_PROGRESS` bug has no observable before/after behavior difference in a single run (it's a static/logical no-op every time) — confirmed by reading the assertion and reasoning about jQuery truthiness, and by tracing the selector to its render site (`EuiProgress` bar in the alerts table component).
- ~15 attempts to get a clean local `yarn cypress:ess` run (before and after the fix) were blocked by heavy resource contention on this shared machine (Docker ES port conflicts, then Kibana/Task Manager degradation under load) — documented candidly rather than claiming a repro that wasn't achieved.
- The change itself is a minimal `.should()` matcher swap with no new imports/types — low risk.
- Recommend a [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner) pass before merge.

Made with [Cursor](https://cursor.com)
