### PR TITLE
chore(eslint): enforce `@elastic/eui/require-table-caption` rule at the error level

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -476,8 +476,9 @@ module.exports = {
     '@elastic/eui/badge-accessibility-rules': 'error',
     '@elastic/eui/consistent-is-invalid-props': 'error',
     '@elastic/eui/tooltip-no-interactive-content': 'error',
+    '@elastic/eui/require-table-caption': 'error',
   },
-
+ss
   overrides: [
     {
       files: [

--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -478,7 +478,7 @@ module.exports = {
     '@elastic/eui/tooltip-no-interactive-content': 'error',
     '@elastic/eui/require-table-caption': 'error',
   },
-ss
+
   overrides: [
     {
       files: [


### PR DESCRIPTION
## Summary

This PR enforces `@elastic/eui/require-table-caption` rule  at the `error` level in the shared `@kbn/eslint-config` configuration:

- **`@elastic/eui/require-table-caption`** — Ensure `EuiInMemoryTable`, `EuiBasicTable` have a `tableCaption` property for accessibility.


### Changes

- `packages/kbn-eslint-config/.eslintrc.js`