### PR TITLE
Set maxLength for getComponentData

### DIFF
--- a/src/platform/plugins/private/inspect_component/server/routes/component_data/get_component_data.ts
+++ b/src/platform/plugins/private/inspect_component/server/routes/component_data/get_component_data.ts
@@ -22,6 +22,8 @@ import { getComponentCodeowners } from '../../lib/codeowners/get_component_codeo
 export const getComponentDataBodySchema = schema.object({
   path: schema.string({
     minLength: 1,
+    // Linux PATH_MAX equivalent
+    maxLength: 4096,
   }),
 });
 


### PR DESCRIPTION
## Summary

This PR caps `getComponentData` validation to `4096` which is the largest allowed file path length on Linux.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4","9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->