### PR TITLE
[ML] Fixing apply annotation to series checkbox

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/annotations/annotation_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/annotations/annotation_flyout/index.tsx
@@ -93,6 +93,7 @@ export class AnnotationFlyoutUI extends Component<CommonProps & Props> {
     this.annotationSub = annotationUpdatesService.update$().subscribe((v) => {
       this.setState({
         annotationState: v,
+        applyAnnotationToSeries: v?.detector_index !== undefined,
       });
     });
   }

--- a/x-pack/platform/plugins/shared/ml/public/application/components/annotations/annotation_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/annotations/annotation_flyout/index.tsx
@@ -93,7 +93,7 @@ export class AnnotationFlyoutUI extends Component<CommonProps & Props> {
     this.annotationSub = annotationUpdatesService.update$().subscribe((v) => {
       this.setState({
         annotationState: v,
-        applyAnnotationToSeries: v?.detector_index !== undefined,
+        applyAnnotationToSeries: v?._id === undefined ? true : v?.detector_index !== undefined,
       });
     });
   }


### PR DESCRIPTION
Fixing issue where the `Apply annotation to this series` checkbox is not correctly deselected when editing an existing annotation.

<img width="801" height="668" alt="image" src="https://github.com/user-attachments/assets/5ad3248b-7869-4e4f-a90e-722043c0adb2" />


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->