### PR TITLE
MCP implementation of Jira connector

### DIFF
--- a/docs/reference/connectors-kibana/jira-cloud-action-type.md
+++ b/docs/reference/connectors-kibana/jira-cloud-action-type.md
@@ -3,13 +3,13 @@ navigation_title: "Jira Cloud"
 type: reference
 description: "Use the Jira Cloud connector to search issues with JQL, retrieve issue and project details, and look up users from your Jira Cloud site."
 applies_to:
-  stack: preview 9.4
+  stack: preview 9.5
   serverless: preview
 ---
 
 # Jira Cloud connector [jira-cloud-action-type]
 
-The Jira Cloud connector communicates with the Jira Cloud REST API v3 to search issues, retrieve project and issue details, and look up users. It supports two authentication methods: Basic authentication (email and API token) and OAuth 2.0 Authorization Code flow. Both methods connect to your Atlassian site by subdomain.
+The Jira Cloud connector connects to the official [Atlassian remote MCP server](https://developer.atlassian.com/cloud/jira/platform/mcp/) to search issues, retrieve project and issue details, and look up users. It uses OAuth 2.0 Authorization Code flow (Atlassian OAuth) for authentication.
 
 ## Create connectors in {{kib}} [define-jira-cloud-ui]
 
@@ -19,23 +19,8 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 
 Jira Cloud connectors have the following configuration properties:
 
-Subdomain
-:   Your Atlassian subdomain (for example, `your-domain` for `https://your-domain.atlassian.net`).
-
 Authentication type
-:   The method used to authenticate with Jira Cloud. Choose one of the following:
-    - **Basic**: Uses an email address and API token. Refer to [Get API credentials](#jira-cloud-api-credentials).
-    - **OAuth 2.0 Authorization Code**: Uses an OAuth app for delegated, per-user access. Refer to [Set up OAuth authentication](#jira-cloud-oauth-setup).
-
-#### Basic authentication fields
-
-Email
-:   The email address associated with your Atlassian account.
-
-API token
-:   A Jira API token for authentication. Refer to [Get API credentials](#jira-cloud-api-credentials) for instructions.
-
-#### OAuth 2.0 authentication fields
+:   OAuth 2.0 Authorization Code flow. Refer to [Set up OAuth authentication](#jira-cloud-oauth-setup) for setup instructions.
 
 Client ID
 :   The client ID from your Atlassian OAuth 2.0 app.
@@ -43,14 +28,13 @@ Client ID
 Client secret
 :   The client secret from your Atlassian OAuth 2.0 app.
 
-Cloud ID
-:   Your Jira Cloud site's unique identifier, required for OAuth. To find your Cloud ID, visit `https://<your-subdomain>.atlassian.net/_edge/tenant_info` and use the `cloudId` value from the JSON response.
-
 ## Test connectors [jira-cloud-action-configuration]
 
 You can test connectors when you create or edit the connector in {{kib}}.
 
-The Jira Cloud connector has the following actions:
+## Actions [jira-cloud-actions]
+
+The Jira Cloud connector provides the following actions:
 
 Search issues with JQL
 :   Search or filter Jira issues using JQL (Jira Query Language).
@@ -58,52 +42,38 @@ Search issues with JQL
     - `maxResults` (optional): Maximum number of issues to return.
     - `nextPageToken` (optional): Pagination token from a previous response.
 
-Get resource
-:   Retrieve full details of a single Jira issue or project by ID or key.
-    - `resourceType` (required): The type of resource to retrieve. Valid values: `issue`, `project`.
-    - `id` (required): The issue key (for example, `PROJ-123`) or project ID.
+Get issue
+:   Fetch full details of a single Jira issue by its key or ID (for example, `PROJ-123`). Returns all issue fields including summary, description, status, priority, assignee, comments, and metadata.
 
 Get projects
-:   List or search Jira projects.
+:   List or search Jira projects accessible to the authenticated user.
     - `query` (optional): Search term to filter projects by name or key.
     - `maxResults` (optional): Maximum number of projects to return.
-    - `startAt` (optional): Index of the first result for pagination.
+    - `startAt` (optional): Zero-based index for pagination.
+
+Get project
+:   Fetch full details of a single Jira project by its key or numeric ID. Returns project name, description, issue types, and project lead.
 
 Search users
-:   Search for Jira users by name, username, or email.
-    - `query` (optional): A search string matching display name, email, or username.
-    - `username` (optional): Filter by exact username.
-    - `accountId` (optional): Filter by exact account ID.
-    - `startAt` (optional): Index of the first result for pagination.
-    - `maxResults` (optional): Maximum number of users to return.
-    - `property` (optional): A user property key to filter by.
+:   Search for Jira users by display name, email, username, or account ID. Returns matching users with their account IDs. Use this to find account IDs for JQL `assignee` filters.
 
 ## Connector networking configuration [jira-cloud-connector-networking-configuration]
 
 Use the [Action configuration settings](/reference/configuration-reference/alerting-settings.md#action-settings) to customize connector networking, such as proxies, certificates, or TLS settings. You can set configurations that apply to all your connectors or use `xpack.actions.customHostSettings` to set per-host configurations.
 
-## Get API credentials [jira-cloud-api-credentials]
-
-To use the Jira Cloud connector with Basic authentication, you need a Jira API token:
-
-1. Log in to your [Atlassian account](https://id.atlassian.com/).
-2. Go to **Security** > **API tokens** (or open [API token management](https://id.atlassian.com/manage-profile/security/api-tokens) directly).
-3. Select **Create API token**.
-4. Enter a label (for example, `Kibana connector`) and select **Create**.
-5. Copy the token and store it securely. Enter this value as the **API token** when configuring the connector in {{kib}}. The email address associated with your Atlassian account is used as the username for Basic authentication.
-
 ## Set up OAuth authentication [jira-cloud-oauth-setup]
 
-To use the Jira Cloud connector with OAuth 2.0, you must create an OAuth app in the Atlassian Developer Console and configure it to work with {{kib}}.
+To use the Jira Cloud connector, you must create an OAuth 2.0 app in the Atlassian Developer Console and configure it for the Atlassian MCP server.
 
 ### Create an OAuth 2.0 app in Atlassian
 
 1. Go to the [Atlassian Developer Console](https://developer.atlassian.com/console/myapps/) and sign in with your Atlassian account.
 2. Select **Create** and choose **OAuth 2.0 integration**.
-3. Enter a name for the app (for example, `Kibana connector`) and agree to the developer terms, then select **Create**.
+3. Enter a name for the app (for example, `Kibana Jira Cloud connector`) and agree to the developer terms, then select **Create**.
 4. In the app settings, go to **Authorization** and select **Add** next to **OAuth 2.0 (3LO)**.
-5. Set the **Callback URL** to your {{kib}} OAuth callback URL. The format is: `https://<your-kibana-url>/api/actions/connector/_oauth_callback`
-6. Select **Save changes**.
+5. When prompted for **Access type**, select **Resource-level**. This restricts the OAuth token to the specific Jira site the user selects during authorization.
+6. Set the **Callback URL** to your {{kib}} OAuth callback URL. The format is: `https://<your-kibana-url>/api/actions/connector/_oauth_callback`
+7. Select **Save changes**.
 
 ### Configure permissions
 
@@ -117,10 +87,5 @@ To use the Jira Cloud connector with OAuth 2.0, you must create an OAuth app in 
 
 1. In the app settings, go to **Settings**.
 2. Copy the **Client ID** and **Secret** values. Enter these when configuring the connector in {{kib}}.
-
-### Find your Cloud ID
-
-1. Navigate to `https://<your-subdomain>.atlassian.net/_edge/tenant_info` in your browser (replace `<your-subdomain>` with your Atlassian subdomain).
-2. Copy the `cloudId` value from the JSON response. Enter this when configuring the connector in {{kib}}.
 
 For more information on Atlassian OAuth 2.0 apps, refer to [Atlassian's OAuth 2.0 (3LO) documentation](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/).

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.test.ts
@@ -8,297 +8,173 @@
  */
 
 import type { ActionContext } from '../../../connector_spec';
+import { getConnectorSpec } from '../../../..';
 import { JiraConnector } from './jira';
 
-describe('JiraConnector', () => {
-  const mockClient = {
-    get: jest.fn(),
-    post: jest.fn(),
-  };
+const mockCallTool = jest.fn();
+const mockListTools = jest.fn();
 
+jest.mock('../../../lib/mcp/with_mcp_client', () => ({
+  withMcpClient: jest.fn(async (_ctx: unknown, fn: (mcp: unknown) => Promise<unknown>) => {
+    return fn({ callTool: mockCallTool, listTools: mockListTools });
+  }),
+}));
+
+describe('JiraConnector', () => {
   const mockContext = {
-    client: mockClient,
+    client: {},
     log: { debug: jest.fn() },
-    config: { subdomain: 'mycompany' },
+    config: { serverUrl: 'https://mcp.atlassian.com/v1/sse' },
   } as unknown as ActionContext;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCallTool.mockResolvedValue({
+      content: [{ type: 'text', text: '{}' }],
+    });
+    mockListTools.mockResolvedValue({
+      tools: [{ name: 'get_issue' }, { name: 'search_issues_using_jql' }],
+    });
   });
 
   describe('auth', () => {
-    it('supports basic auth', () => {
-      const types = (JiraConnector.auth?.types as Array<string | { type: string }>).map((t) =>
-        typeof t === 'string' ? t : t.type
-      );
-      expect(types).toContain('basic');
+    it('supports only oauth_authorization_code', () => {
+      expect(JiraConnector.auth?.types).toHaveLength(1);
+      expect(JiraConnector.auth?.types[0]).toMatchObject({ type: 'oauth_authorization_code' });
     });
 
-    it('supports oauth_authorization_code with correct Atlassian defaults', () => {
-      const oauthType = (
-        JiraConnector.auth?.types as Array<
-          string | { type: string; defaults?: Record<string, unknown> }
-        >
-      ).find((t) => typeof t === 'object' && t.type === 'oauth_authorization_code');
-      expect(oauthType).toBeDefined();
-      expect(oauthType).toMatchObject({
-        type: 'oauth_authorization_code',
+    it('uses Atlassian OAuth endpoints', () => {
+      expect(JiraConnector.auth?.types[0]).toMatchObject({
         defaults: {
           authorizationUrl: 'https://auth.atlassian.com/authorize',
           tokenUrl: 'https://auth.atlassian.com/oauth/token',
-          scope: 'read:jira-work read:jira-user offline_access',
         },
       });
     });
   });
 
-  describe('buildBaseUrl', () => {
-    it.each([
-      ['config is undefined', undefined],
-      ['subdomain is missing', {}],
-    ])('should throw a clear error when %s', async (_, config) => {
-      const ctx = { ...mockContext, config } as unknown as ActionContext;
-      await expect(
-        JiraConnector.actions.searchIssuesWithJql.handler(ctx, { jql: 'project = X' })
-      ).rejects.toThrow('Jira Cloud subdomain is required');
+  describe('schema', () => {
+    it('has a serverUrl field defaulting to the Atlassian MCP server', () => {
+      if (!JiraConnector.schema) throw new Error('schema not defined');
+      const parsed = JiraConnector.schema.parse({});
+      expect((parsed as { serverUrl?: string }).serverUrl).toBe('https://mcp.atlassian.com/v1/sse');
     });
+  });
+
+  it('is discoverable via getConnectorSpec', () => {
+    const spec = getConnectorSpec('.jira-cloud');
+    expect(spec).toBe(JiraConnector);
   });
 
   describe('searchIssuesWithJql action', () => {
-    it('should search issues with JQL and return response data', async () => {
-      const mockResponse = {
-        data: {
-          issues: [
-            {
-              id: '10001',
-              key: 'MYPROJ-1',
-              fields: { summary: 'Fix login bug', status: { name: 'In Progress' } },
-            },
-          ],
-          total: 1,
-        },
-      };
-      mockClient.post.mockResolvedValue(mockResponse);
-
-      const result = await JiraConnector.actions.searchIssuesWithJql.handler(mockContext, {
-        jql: 'project = MYPROJ',
-      });
-
-      expect(mockClient.post).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/search/jql',
-        { jql: 'project = MYPROJ' }
-      );
-      expect(result).toEqual(mockResponse.data);
+    it('is exposed as a tool', () => {
+      expect(JiraConnector.actions.searchIssuesWithJql.isTool).toBe(true);
     });
 
-    it('should build base URL from config subdomain', async () => {
-      const mockResponse = { data: { issues: [], total: 0 } };
-      mockClient.post.mockResolvedValue(mockResponse);
-
-      const contextWithSubdomain = {
-        ...mockContext,
-        config: { subdomain: 'acme' },
-      } as unknown as ActionContext;
-
-      await JiraConnector.actions.searchIssuesWithJql.handler(contextWithSubdomain, {
-        jql: 'assignee = currentUser()',
-      });
-
-      expect(mockClient.post).toHaveBeenCalledWith(
-        'https://acme.atlassian.net/rest/api/3/search/jql',
-        { jql: 'assignee = currentUser()' }
-      );
-    });
-
-    it('should include optional maxResults and nextPageToken in the request', async () => {
-      const mockResponse = { data: { issues: [], total: 0 } };
-      mockClient.post.mockResolvedValue(mockResponse);
-
+    it('calls search_issues_using_jql with jql, max_results, and next_page_token', async () => {
       await JiraConnector.actions.searchIssuesWithJql.handler(mockContext, {
-        jql: 'status = Done',
-        maxResults: 50,
-        nextPageToken: 'page-token-abc',
+        jql: 'project = PROJ AND status = "In Progress"',
+        maxResults: 10,
+        nextPageToken: 'tok123',
       });
 
-      expect(mockClient.post).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/search/jql',
-        {
-          jql: 'status = Done',
-          maxResults: 50,
-          nextPageToken: 'page-token-abc',
-        }
-      );
-    });
-
-    it('should use api.atlassian.com base URL when using OAuth with cloud ID', async () => {
-      const oauthContext = {
-        ...mockContext,
-        config: {
-          subdomain: 'mycompany',
-          cloudId: '11223344-a1b2-3c33-d444-ef1234567890',
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'search_issues_using_jql',
+        arguments: {
+          jql: 'project = PROJ AND status = "In Progress"',
+          max_results: 10,
+          next_page_token: 'tok123',
         },
-        secrets: { authType: 'oauth_authorization_code' },
-      } as unknown as ActionContext;
-
-      const mockResponse = { data: { issues: [], total: 0 } };
-      mockClient.post.mockResolvedValue(mockResponse);
-
-      await JiraConnector.actions.searchIssuesWithJql.handler(oauthContext, { jql: 'project = X' });
-
-      expect(mockClient.get).not.toHaveBeenCalled();
-      expect(mockClient.post).toHaveBeenCalledWith(
-        'https://api.atlassian.com/ex/jira/11223344-a1b2-3c33-d444-ef1234567890/rest/api/3/search/jql',
-        { jql: 'project = X' }
-      );
-    });
-
-    it('should throw when OAuth is used without cloud ID', async () => {
-      const oauthContext = {
-        ...mockContext,
-        secrets: { authType: 'oauth_authorization_code' },
-      } as unknown as ActionContext;
-
-      await expect(
-        JiraConnector.actions.searchIssuesWithJql.handler(oauthContext, { jql: 'project = X' })
-      ).rejects.toThrow(
-        'Jira Cloud ID is required in connector configuration when using OAuth authentication.'
-      );
+      });
     });
   });
 
   describe('getIssue action', () => {
-    it('should retrieve issue by ID and return response data', async () => {
-      const mockResponse = {
-        data: {
-          id: '10002',
-          key: 'MYPROJ-2',
-          fields: {
-            summary: 'Add login page',
-            status: { name: 'To Do' },
-            assignee: { displayName: 'Alice' },
-          },
-        },
-      };
-      mockClient.get.mockResolvedValue(mockResponse);
+    it('is exposed as a tool', () => {
+      expect(JiraConnector.actions.getIssue.isTool).toBe(true);
+    });
 
-      const result = await JiraConnector.actions.getIssue.handler(mockContext, {
-        issueId: '10002',
+    it('calls get_issue with issue_key mapped from issueId', async () => {
+      await JiraConnector.actions.getIssue.handler(mockContext, { issueId: 'PROJ-123' });
+
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'get_issue',
+        arguments: { issue_key: 'PROJ-123' },
       });
-
-      expect(mockClient.get).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/issue/10002'
-      );
-      expect(result).toEqual(mockResponse.data);
     });
   });
 
   describe('getProjects action', () => {
-    it('should fetch projects and return response data', async () => {
-      const mockResponse = {
-        data: {
-          values: [
-            { id: '10000', key: 'MYPROJ', name: 'My Project' },
-            { id: '10001', key: 'OTHER', name: 'Other Project' },
-          ],
-        },
-      };
-      mockClient.get.mockResolvedValue(mockResponse);
-
-      const result = await JiraConnector.actions.getProjects.handler(mockContext, {});
-
-      expect(mockClient.get).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/project/search',
-        { params: {} }
-      );
-      expect(result).toEqual(mockResponse.data);
+    it('is exposed as a tool', () => {
+      expect(JiraConnector.actions.getProjects.isTool).toBe(true);
     });
 
-    it('should include optional maxResults, startAt, and query as params', async () => {
-      const mockResponse = { data: { values: [] } };
-      mockClient.get.mockResolvedValue(mockResponse);
-
+    it('calls list_projects with query, max_results, and start_at', async () => {
       await JiraConnector.actions.getProjects.handler(mockContext, {
+        query: 'platform',
         maxResults: 20,
-        startAt: 10,
-        query: 'MYPROJ',
+        startAt: 0,
       });
 
-      expect(mockClient.get).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/project/search',
-        {
-          params: {
-            maxResults: 20,
-            startAt: 10,
-            query: 'MYPROJ',
-          },
-        }
-      );
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'list_projects',
+        arguments: { query: 'platform', max_results: 20, start_at: 0 },
+      });
+    });
+  });
+
+  describe('getProject action', () => {
+    it('is exposed as a tool', () => {
+      expect(JiraConnector.actions.getProject.isTool).toBe(true);
+    });
+
+    it('calls get_project with project_key mapped from projectId', async () => {
+      await JiraConnector.actions.getProject.handler(mockContext, { projectId: 'PROJ' });
+
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'get_project',
+        arguments: { project_key: 'PROJ' },
+      });
     });
   });
 
   describe('searchUsers action', () => {
-    it('should search users by query and return response data', async () => {
-      const mockResponse = {
-        data: [
-          {
-            accountId: '5b10a2844c20165700ede21g',
-            displayName: 'Mia Krystof',
-            emailAddress: 'mia@example.com',
-          },
-        ],
-      };
-      mockClient.get.mockResolvedValue(mockResponse);
-
-      const result = await JiraConnector.actions.searchUsers.handler(mockContext, {
-        query: 'mia',
-      });
-
-      expect(mockClient.get).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/user/search',
-        { params: { query: 'mia' } }
-      );
-      expect(result).toEqual(mockResponse.data);
+    it('is exposed as a tool', () => {
+      expect(JiraConnector.actions.searchUsers.isTool).toBe(true);
     });
 
-    it('should build base URL from config subdomain', async () => {
-      const mockResponse = { data: [] };
-      mockClient.get.mockResolvedValue(mockResponse);
-
-      const contextWithSubdomain = {
-        ...mockContext,
-        config: { subdomain: 'acme' },
-      } as unknown as ActionContext;
-
-      await JiraConnector.actions.searchUsers.handler(contextWithSubdomain, {
-        query: 'workplace-search',
-      });
-
-      expect(mockClient.get).toHaveBeenCalledWith(
-        'https://acme.atlassian.net/rest/api/3/user/search',
-        { params: { query: 'workplace-search' } }
-      );
-    });
-
-    it('should include optional startAt and maxResults in the request', async () => {
-      const mockResponse = { data: [] };
-      mockClient.get.mockResolvedValue(mockResponse);
-
+    it('calls search_users with mapped parameters', async () => {
       await JiraConnector.actions.searchUsers.handler(mockContext, {
         query: 'alice',
-        startAt: 10,
-        maxResults: 25,
+        accountId: 'acc123',
+        username: 'alice',
+        maxResults: 10,
+        startAt: 0,
       });
 
-      expect(mockClient.get).toHaveBeenCalledWith(
-        'https://mycompany.atlassian.net/rest/api/3/user/search',
-        {
-          params: {
-            query: 'alice',
-            startAt: 10,
-            maxResults: 25,
-          },
-        }
-      );
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'search_users',
+        arguments: {
+          query: 'alice',
+          account_id: 'acc123',
+          username: 'alice',
+          max_results: 10,
+          start_at: 0,
+        },
+      });
+    });
+  });
+
+  describe('test handler', () => {
+    it('returns ok with tool count on successful connection', async () => {
+      if (!JiraConnector.test) throw new Error('test handler not defined');
+      const result = await JiraConnector.test.handler(mockContext);
+
+      expect(mockListTools).toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: true,
+        message: 'Connected to Jira Cloud MCP server. 2 tools available.',
+      });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
@@ -9,6 +9,8 @@
 
 import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
+import { UISchemas, type ConnectorSpec } from '../../../connector_spec';
+import { withMcpClient, callToolJson } from '../../../lib/mcp';
 import type {
   GetIssueInput,
   GetProjectInput,
@@ -20,27 +22,11 @@ import {
   GetIssueInputSchema,
   GetProjectInputSchema,
   GetProjectsInputSchema,
-  SearchUsersInputSchema,
   SearchIssuesWithJqlInputSchema,
+  SearchUsersInputSchema,
 } from './types';
-import type { ActionContext, ConnectorSpec } from '../../../..';
 
-const buildBaseUrl = (ctx: ActionContext): string => {
-  if (ctx.secrets?.authType === 'oauth_authorization_code') {
-    const cloudId = String(ctx.config?.cloudId ?? '').trim();
-    if (cloudId === '') {
-      throw new Error(
-        'Jira Cloud ID is required in connector configuration when using OAuth authentication.'
-      );
-    }
-    return `https://api.atlassian.com/ex/jira/${cloudId}`;
-  }
-  const subdomain = String(ctx.config?.subdomain ?? '').trim();
-  if (subdomain === '') {
-    throw new Error('Jira Cloud subdomain is required');
-  }
-  return `https://${subdomain}.atlassian.net`;
-};
+const JIRA_CLOUD_MCP_SERVER_URL = 'https://mcp.atlassian.com/v1/sse';
 
 export const JiraConnector: ConnectorSpec = {
   metadata: {
@@ -57,6 +43,11 @@ export const JiraConnector: ConnectorSpec = {
     types: [
       {
         type: 'oauth_authorization_code',
+        defaults: {
+          authorizationUrl: 'https://auth.atlassian.com/authorize',
+          tokenUrl: 'https://auth.atlassian.com/oauth/token',
+          scope: 'read:jira-work read:jira-user offline_access',
+        },
         overrides: {
           meta: {
             authorizationUrl: { hidden: true },
@@ -64,74 +55,33 @@ export const JiraConnector: ConnectorSpec = {
             scope: { hidden: true },
           },
         },
-        defaults: {
-          authorizationUrl: 'https://auth.atlassian.com/authorize',
-          tokenUrl: 'https://auth.atlassian.com/oauth/token',
-          scope: 'read:jira-work read:jira-user offline_access',
-        },
-      },
-      {
-        type: 'basic',
-        defaults: {},
-        overrides: {
-          label: i18n.translate('core.kibanaConnectorSpecs.jira.auth.basic.label', {
-            defaultMessage: 'Shared API key',
-          }),
-          meta: {
-            password: {
-              label: i18n.translate('core.kibanaConnectorSpecs.jira.auth.password.label', {
-                defaultMessage: 'API key',
-              }),
-              helpText: i18n.translate('core.kibanaConnectorSpecs.jira.auth.password.helpText', {
-                defaultMessage: 'Your Jira API token',
-              }),
-            },
-          },
-        },
       },
     ],
   },
+
   schema: lazySchema(() =>
     z.object({
-      subdomain: z
-        .string()
-        .min(1)
-        .describe(
-          i18n.translate('core.kibanaConnectorSpecs.jira.config.subdomain.description', {
-            defaultMessage: 'Your Atlassian subdomain',
-          })
-        )
+      serverUrl: UISchemas.url()
+        .default(JIRA_CLOUD_MCP_SERVER_URL)
+        .describe('Jira Cloud MCP Server URL')
         .meta({
           widget: 'text',
-          label: i18n.translate('core.kibanaConnectorSpecs.jira.config.subdomain.label', {
-            defaultMessage: 'Subdomain',
+          placeholder: JIRA_CLOUD_MCP_SERVER_URL,
+          hidden: true,
+          label: i18n.translate('core.kibanaConnectorSpecs.jira.config.serverUrl.label', {
+            defaultMessage: 'MCP server URL',
           }),
-          placeholder: 'your-domain',
-          helpText: i18n.translate('core.kibanaConnectorSpecs.jira.config.subdomain.helpText', {
-            defaultMessage:
-              'The subdomain for your Jira Cloud site (e.g. your-domain for https://your-domain.atlassian.net)',
-          }),
-        }),
-      cloudId: z
-        .string()
-        .optional()
-        .describe(
-          i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.description', {
-            defaultMessage: 'Atlassian cloud ID (OAuth)',
-          })
-        )
-        .meta({
-          widget: 'text',
-          label: i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.label', {
-            defaultMessage: 'Cloud ID',
-          }),
-          helpText: i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.helpText', {
-            defaultMessage:
-              'Required for OAuth. To find your Cloud ID, visit https://your-subdomain.atlassian.net/_edge/tenant_info (replace your-subdomain with your Atlassian subdomain) and use the cloudId value from the response.',
+          helpText: i18n.translate('core.kibanaConnectorSpecs.jira.config.serverUrl.helpText', {
+            defaultMessage: 'The URL of the official Atlassian remote MCP server.',
           }),
         }),
     })
   ),
+
+  validateUrls: {
+    fields: ['serverUrl'],
+  },
+
   actions: {
     searchIssuesWithJql: {
       isTool: true,
@@ -139,14 +89,11 @@ export const JiraConnector: ConnectorSpec = {
         'Search or filter Jira issues using JQL (Jira Query Language). Use when you need to find issues by status, assignee, project, label, or any other criteria. Supports pagination via nextPageToken.',
       input: SearchIssuesWithJqlInputSchema,
       handler: async (ctx, input: SearchIssuesWithJqlInput) => {
-        const typedInput = input as {
-          jql: string;
-          maxResults?: number;
-          nextPageToken?: string;
-        };
-        const baseUrl = buildBaseUrl(ctx);
-        const response = await ctx.client.post(`${baseUrl}/rest/api/3/search/jql`, typedInput);
-        return response.data;
+        return callToolJson(ctx, 'search_issues_using_jql', {
+          jql: input.jql,
+          max_results: input.maxResults,
+          next_page_token: input.nextPageToken,
+        });
       },
     },
     getIssue: {
@@ -155,12 +102,7 @@ export const JiraConnector: ConnectorSpec = {
         'Fetch full details of a single Jira issue by its ID or key. Use when you already have the issue key (e.g. PROJ-123) or issue ID and need the complete record including fields, comments, and metadata.',
       input: GetIssueInputSchema,
       handler: async (ctx, input: GetIssueInput) => {
-        const typedInput = input as {
-          issueId: string;
-        };
-        const baseUrl = buildBaseUrl(ctx);
-        const response = await ctx.client.get(`${baseUrl}/rest/api/3/issue/${typedInput.issueId}`);
-        return response.data;
+        return callToolJson(ctx, 'get_issue', { issue_key: input.issueId });
       },
     },
     getProjects: {
@@ -169,16 +111,11 @@ export const JiraConnector: ConnectorSpec = {
         'List or search Jira projects. Use when you need to discover available projects or find a project by name or key. Supports pagination and optional text filtering.',
       input: GetProjectsInputSchema,
       handler: async (ctx, input: GetProjectsInput) => {
-        const typedInput = input as {
-          maxResults?: number;
-          startAt?: number;
-          query?: string;
-        };
-        const baseUrl = buildBaseUrl(ctx);
-        const response = await ctx.client.get(`${baseUrl}/rest/api/3/project/search`, {
-          params: typedInput,
+        return callToolJson(ctx, 'list_projects', {
+          query: input.query,
+          max_results: input.maxResults,
+          start_at: input.startAt,
         });
-        return response.data;
       },
     },
     getProject: {
@@ -187,14 +124,7 @@ export const JiraConnector: ConnectorSpec = {
         'Fetch full details of a single Jira project by its ID or key. Use when you already have the project key (e.g. PROJ) or numeric project ID and need the complete project record.',
       input: GetProjectInputSchema,
       handler: async (ctx, input: GetProjectInput) => {
-        const typedInput = input as {
-          projectId: string;
-        };
-        const baseUrl = buildBaseUrl(ctx);
-        const response = await ctx.client.get(
-          `${baseUrl}/rest/api/3/project/${typedInput.projectId}`
-        );
-        return response.data;
+        return callToolJson(ctx, 'get_project', { project_key: input.projectId });
       },
     },
     searchUsers: {
@@ -203,22 +133,32 @@ export const JiraConnector: ConnectorSpec = {
         'Find Jira users by name, username, or email. Use when you need a user accountId (e.g. for JQL assignee filters) or to look up user contact details. At least one search parameter should be provided.',
       input: SearchUsersInputSchema,
       handler: async (ctx, input: SearchUsersInput) => {
-        const typedInput = input as {
-          query?: string;
-          username?: string;
-          accountId?: string;
-          startAt?: number;
-          maxResults?: number;
-          property?: string;
-        };
-        const baseUrl = buildBaseUrl(ctx);
-        const response = await ctx.client.get(`${baseUrl}/rest/api/3/user/search`, {
-          params: typedInput,
+        return callToolJson(ctx, 'search_users', {
+          query: input.query,
+          account_id: input.accountId,
+          username: input.username,
+          max_results: input.maxResults,
+          start_at: input.startAt,
         });
-        return response.data;
       },
     },
   },
+  test: {
+    description: i18n.translate('core.kibanaConnectorSpecs.jira.test.description', {
+      defaultMessage:
+        'Verifies connection to the Atlassian Jira Cloud MCP server by listing available tools.',
+    }),
+    handler: async (ctx) => {
+      return withMcpClient(ctx, async (mcp) => {
+        const { tools } = await mcp.listTools();
+        return {
+          ok: true,
+          message: `Connected to Jira Cloud MCP server. ${tools.length} tools available.`,
+        };
+      });
+    },
+  },
+
   skill: [
     'Typical patterns:',
     '- Discovery: getProjects → getProject (by key) → searchIssuesWithJql (scoped to project)',

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
@@ -164,5 +164,6 @@ export const JiraConnector: ConnectorSpec = {
     '- Discovery: getProjects → getProject (by key) → searchIssuesWithJql (scoped to project)',
     '- Issue lookup: searchIssuesWithJql → getIssue (by key from results)',
     '- User-filtered search: searchUsers (to get accountId) → searchIssuesWithJql with assignee = "accountId"',
+    '- For capabilities not yet exposed as named actions: listTools to discover, callTool to invoke.',
   ].join('\n'),
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/types.ts
@@ -97,12 +97,6 @@ export const SearchUsersInputSchema = lazySchema(() =>
       .number()
       .optional()
       .describe('Maximum number of users to return (default determined by Jira API)'),
-    property: z
-      .string()
-      .optional()
-      .describe(
-        'A query string used to search user properties. Property keys and values must not exceed 100 characters.'
-      ),
   })
 );
 export type SearchUsersInput = z.infer<typeof SearchUsersInputSchema>;


### PR DESCRIPTION
## Summary

Rewrite of Jira connector using MCP.  Blocked until Atlassian supports modern MCP protocol.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




