### PR TITLE
[Security Solution][Test Plan Generator] Resolve upgrade source versions from versions.json

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/SKILL.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/SKILL.md
@@ -240,7 +240,7 @@ Follow the template in [`references/document-structure.md`](references/document-
 | Target feature type | Example |
 |---|---|
 | UI feature (flyouts, panels, forms, navigation) | [`references/example-test-plan.md`](references/example-test-plan.md) |
-| Backend / parser feature (no UI, no PR yet, unknown `TARGET_VERSION`) | [`references/example-test-plan-backend.md`](references/example-test-plan-backend.md) |
+| Backend / parser feature (no UI, no PR yet, no upgrade surface) | [`references/example-test-plan-backend.md`](references/example-test-plan-backend.md) |
 
 Pick the closer match by shape, not by domain. The two examples differ in which optional sections apply, how `N/A` is handled in the Issue Clarity Assessment, and how the Coverage Ratio is computed when no PR exists.
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/example-test-plan-backend.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/example-test-plan-backend.md
@@ -1,19 +1,19 @@
 # Example Test Plan — backend / parser feature
 
-This file is a worked example of a correctly-formed test plan for a **pure-backend feature with no UI, no PR linked yet, and no `TARGET_VERSION` available**. Use it as a reference alongside [`example-test-plan.md`](example-test-plan.md), which covers the UI-feature case.
+This file is a worked example of a correctly-formed test plan for a **pure-backend / pure-parser feature with no UI, no PR linked yet, and no upgrade surface**. Use it as a reference alongside [`example-test-plan.md`](example-test-plan.md), which covers the UI-feature case.
 
-The example is **abbreviated** (6 scenarios, 1 feature area) but **complete** — every required section is present, optional sections are omitted because the feature has no upgrade / RBAC / space / tenant / CCS surface, and all self-review checks pass.
+The example is **abbreviated** (6 scenarios, 1 feature area) but **complete** — every required section is present, upgrade is recorded under *Out of scope* (per the always-evaluated rule, with reason "no upgrade surface"), the other optional sections are omitted because the feature has no RBAC / space / tenant / CCS surface, and all self-review checks pass.
 
 ---
 
 ## What this example demonstrates (differently from the UI example)
 
 - A target that has **no linked PR and no orphan PR** — the plan is generated from issue text plus existing parser code only. The Coverage Ratio computation honours the *Boundary case: no PR linked* rule from [`issue-clarity-assessment.md`](issue-clarity-assessment.md#boundary-case-no-pr-linked) — existing-code facts are classified as `pr` for the ratio
-- A `TARGET_VERSION` that **cannot be resolved** from milestone, labels, or project fields, and a user who is unavailable to answer — applies the *User-unavailable fallback* table from `SKILL.md` Step 2 (mark `⚠️`, omit upgrade scenarios)
+- A **pure-parser feature with no upgrade surface** — applies the *User-unavailable fallback* table from `SKILL.md` Step 2 (second row: "pure parser / pure compute"): upgrade is recorded under *Out of scope* with a one-clause reason, and `TARGET_VERSION` is irrelevant to this plan (no need to resolve it)
 - Two dimensions marked **N/A** in the Issue Clarity Assessment — `UX/UI` (no UI surface) and `Data & Roles` (purely backend with the data shape fully described in the issue body, per the B3 reword)
 - A parent epic that scores **2/5** while the target scores **4/5** — the combined readability stays at 4/5 (target carries the corpus) and *Actionable feedback* bullets are included because at least one issue scored ≤ 3
 - One scenario flagged in *Known Limitations* and the Coverage Ratio breakdown as **code-derived** (an implementation detail not in any issue body)
-- Optional sections (RBAC, Multi-space, Multi-tenant, Upgrade, CCS) **explicitly omitted** with a brief justification in *Known Limitations* — never include them speculatively
+- Optional sections (RBAC, Multi-space, Multi-tenant, CCS) **explicitly omitted** with a brief justification in *Known Limitations* — never include them speculatively. Upgrade is not an optional-omit here — it is recorded under *Out of scope* per the always-evaluated rule
 - `Automation coverage` lines that name the **existing test file for the function being extended**, marked `partial` because the existing tests cover the prior behaviour but not the new variants
 
 ---
@@ -48,6 +48,7 @@ The migration intake pipeline parses vendor rule sources to identify dependencie
 - Verify non-regression of the existing `_FooBar(...)` extraction.
 
 **Out of scope:**
+- Upgrade / migration scenarios — no upgrade surface (pure parser: no persisted state, no schema, no config or navigation changes).
 - Runtime evaluation of alias variables not expressed as string literals.
 - Retrieval of watchlist content (this issue is dependency identification only).
 
@@ -57,7 +58,7 @@ The migration intake pipeline parses vendor rule sources to identify dependencie
 - **User role:** Not user-facing — the parser runs server-side during migration intake; no end-user role applies.
 - **Data setup:** Input is a single KQL query string; no fixtures or persisted state are required.
 - **Deployment type:** Applies equally to self-managed, serverless, and ECH — the parser is a pure function with no deployment-specific behaviour.
-- **Target version:** ⚠️ Not specified — no milestone, labels, or project fields on the target issue. Please confirm `TARGET_VERSION` before publishing.
+- **Target version:** N/A — pure parser has no upgrade surface (see *Out of scope*); `TARGET_VERSION` is irrelevant to this plan.
 
 ## Acceptance Criteria
 
@@ -69,10 +70,9 @@ The migration intake pipeline parses vendor rule sources to identify dependencie
 
 ## Known Limitations
 
-- ⚠️ `TARGET_VERSION` is unknown — no milestone or version label on the target issue. Upgrade scenarios are intentionally omitted per the *User-unavailable fallback* table in `SKILL.md` Step 2. Re-evaluate once the version is confirmed.
 - ⚠️ No PR is linked to the target issue at the time of writing. The plan is derived from the issue body and the existing parser code at `<path>/foobar_identifier.ts`. When the implementation PR is opened, re-run the skill in `update` mode to capture exact symbol names, error strings, and any unanticipated artifacts.
 - One scenario in this plan (*"Parser regex state does not leak across repeated invocations"*) is sourced from the existing parser implementation, not from the issue text. It is included because regex state leakage is a real-world failure mode for the existing global-regex pattern that will be extended by this work. Flagged accordingly in the Coverage Ratio breakdown below.
-- Optional sections (RBAC, Multi-space, Multi-tenant, Upgrade, CCS) do not apply: the feature is a pure server-side parser with no user-facing surface, no persisted state, no space / tenant scoping, and no Elasticsearch cluster interactions.
+- Optional sections (RBAC, Multi-space, Multi-tenant, CCS) do not apply: the feature is a pure server-side parser with no user-facing surface, no persisted state, no space / tenant scoping, and no Elasticsearch cluster interactions. Upgrade is recorded under *Out of scope* above per the always-evaluated rule — no upgrade surface.
 
 ## Test Scenarios
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/example-test-plan.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/example-test-plan.md
@@ -2,7 +2,7 @@
 
 This file is a worked example of a correctly-formed test plan for a **UI feature with a linked PR**. Use it as a reference when generating plans — it shows the correct structure, scenario format, automation coverage lines, and summary table for a realistic Security Solution feature. For a backend / parser feature without UI or a linked PR, see [`example-test-plan-backend.md`](example-test-plan-backend.md).
 
-The example is **abbreviated** (6 scenarios, 2 feature areas) but **complete** — every required section is present, optional sections are omitted because the fictional issue does not warrant them, and all self-review checks pass.
+The example is **abbreviated** (6 scenarios, 2 feature areas) but **complete** — every required section is present, optional sections are omitted where the fictional issue does not warrant them (upgrade coverage would apply — see *Known Limitations*), and all self-review checks pass.
 
 ---
 
@@ -16,7 +16,7 @@ The example is **abbreviated** (6 scenarios, 2 feature areas) but **complete** �
 - A case where no tests exist (`Manual only`)
 - A `Known Limitations` entry for an inaccessible source (no Figma)
 - A `Known Limitations` entry for a coverage gap (no API integration tests)
-- Optional sections (RBAC, upgrade, CCS, multi-space) omitted — the fictional issue does not mention them
+- Optional sections (RBAC, CCS, multi-space) omitted — the fictional issue does not mention them. Upgrade coverage would be **in scope** per the always-evaluated rule in [`optional-scenarios.md`](optional-scenarios.md#always-evaluated-coverage) (the feature ships a new `alert-notes` saved-object type), but the concrete `@upgrade` scenarios are abbreviated out of this example — see *Known Limitations*
 - An *Issue Clarity Assessment* section showing the canonical layout for a single-issue plan, with combined readability matching the per-issue score and no Actionable feedback bullets (the issue scored 4/5 and the Coverage Ratio is above 60%, so the bullets are intentionally omitted per the rules in [`output-formats.md`](output-formats.md#issue-clarity-assessment-section))
 - The footer with model identifier and date
 
@@ -81,6 +81,7 @@ Security analysts often need to record observations or hand-off context on an al
 
 - ⚠️ No Figma designs were available — scenarios are based on the issue description and PR diff only. UI layout details (e.g. character limit enforcement in the UI vs. the API) were inferred from the PR code.
 - ⚠️ No error handling scenarios are included for the `alert-notes` write path (e.g. save object store unavailable). This is intentional to keep the example concise — a real test plan for a write/modify feature must include at least one error handling scenario per the coverage guidance in `references/optional-scenarios.md`. No integration or API integration tests exist for this API; all API-level coverage is at the unit level only.
+- ⚠️ Upgrade scenarios are abbreviated out of this example for brevity. In a real plan for the Alert Notes feature, `@upgrade` scenarios from `PREVIOUS_MAJOR_LAST_MINOR` and `CURRENT_MAJOR_LAST_MINOR` to `TARGET_VERSION` are **in scope** per the always-evaluated rule (the feature introduces a new `alert-notes` saved-object type) — see the Upgrade template and version-resolution rules in [`optional-scenarios.md`](optional-scenarios.md#upgrade-scenarios).
 
 ## Test Scenarios
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/example-test-plan.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/example-test-plan.md
@@ -2,7 +2,7 @@
 
 This file is a worked example of a correctly-formed test plan for a **UI feature with a linked PR**. Use it as a reference when generating plans — it shows the correct structure, scenario format, automation coverage lines, and summary table for a realistic Security Solution feature. For a backend / parser feature without UI or a linked PR, see [`example-test-plan-backend.md`](example-test-plan-backend.md).
 
-The example is **abbreviated** (6 scenarios, 2 feature areas) but **complete** — every required section is present, optional sections are omitted where the fictional issue does not warrant them (upgrade coverage would apply — see *Known Limitations*), and all self-review checks pass.
+The example is **abbreviated** (6 scenarios, 2 feature areas) but **complete** — every required section is present, optional sections are omitted where the fictional issue does not warrant them, and all self-review checks pass. (Upgrade coverage does apply here — see *Known Limitations* — but the concrete scenarios are abbreviated for brevity.)
 
 ---
 

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/optional-scenarios.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/optional-scenarios.md
@@ -69,23 +69,26 @@ These coverage areas are **evaluated on every generation run**, not included on 
 
 ### Upgrade scenarios
 
-Use `TARGET_VERSION` (detected in Step 2) as the target version. Run upgrade scenarios from each of the following source versions:
-- The last minor of the previous major series (currently `8.19.x`)
-- The last minor of the current major cycle (currently `9.3`)
+Use `TARGET_VERSION` (detected in Step 2) as the target version.
 
-Check with the team if you are unsure which versions are current — these values change with each release cycle.
+**Resolve source versions from `<repo-root>/versions.json`** — this file is the authoritative list of currently-supported release branches and is updated as the release train advances. Resolve the two placeholders below at generation time from that file (never hardcode version numbers):
+
+- `PREVIOUS_MAJOR_LAST_MINOR` — the `version` of the entry with `branchType: "release"` whose major is exactly one less than `TARGET_VERSION`'s major (e.g. `8.19.19` when `TARGET_VERSION` is on the `9.x` line).
+- `CURRENT_MAJOR_LAST_MINOR` — the `version` of the highest-numbered entry with `branchType: "release"` whose major equals `TARGET_VERSION`'s major and whose minor is strictly less than `TARGET_VERSION`'s minor (e.g. `9.5.0` when `TARGET_VERSION` is `9.6`).
+
+If either placeholder cannot be resolved from `versions.json` (no eligible entry — e.g. `TARGET_VERSION` is the first minor of a new major cycle, so no `CURRENT_MAJOR_LAST_MINOR` exists yet), record it under *Assumptions* with a `⚠️` and ask the user to confirm before publishing — do not drop the scenario.
 
 ```gherkin
 @upgrade
-Scenario: Feature works correctly after upgrading from the last minor of the previous major to TARGET_VERSION
-  Given a Kibana instance running the last minor of the previous major series with existing data relevant to this feature
+Scenario: Feature works correctly after upgrading from PREVIOUS_MAJOR_LAST_MINOR to TARGET_VERSION
+  Given a Kibana instance running PREVIOUS_MAJOR_LAST_MINOR with existing data relevant to this feature
   When the instance is upgraded to TARGET_VERSION
   Then the feature is accessible and behaves as expected
   And existing data or configuration is preserved without errors
 
 @upgrade
-Scenario: Feature works correctly after upgrading from the last minor of the current major cycle to TARGET_VERSION
-  Given a Kibana instance running the last minor of the current major cycle with existing data relevant to this feature
+Scenario: Feature works correctly after upgrading from CURRENT_MAJOR_LAST_MINOR to TARGET_VERSION
+  Given a Kibana instance running CURRENT_MAJOR_LAST_MINOR with existing data relevant to this feature
   When the instance is upgraded to TARGET_VERSION
   Then the feature is accessible and behaves as expected
   And existing data or configuration is preserved without errors

--- a/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/optional-scenarios.md
+++ b/x-pack/solutions/security/plugins/security_solution/.agents/skills/test-plan-generator/references/optional-scenarios.md
@@ -71,12 +71,20 @@ These coverage areas are **evaluated on every generation run**, not included on 
 
 Use `TARGET_VERSION` (detected in Step 2) as the target version.
 
-**Resolve source versions from `<repo-root>/versions.json`** — this file is the authoritative list of currently-supported release branches and is updated as the release train advances. Resolve the two placeholders below at generation time from that file (never hardcode version numbers):
+**Resolve source versions from `elastic/kibana`'s `versions.json`** — the authoritative list of currently-supported release branches, updated as the release train advances. At generation time, fetch the file from:
 
-- `PREVIOUS_MAJOR_LAST_MINOR` — the `version` of the entry with `branchType: "release"` whose major is exactly one less than `TARGET_VERSION`'s major (e.g. `8.19.19` when `TARGET_VERSION` is on the `9.x` line).
+```
+https://raw.githubusercontent.com/elastic/kibana/main/versions.json
+```
+
+Fetching from `main` guarantees the values are current regardless of which branch the agent is invoked from. If the remote fetch fails (offline, network error, GitHub unavailable), fall back to reading `<repo-root>/versions.json` from the local checkout. Never hardcode version numbers.
+
+Resolve the two placeholders below from the fetched file:
+
+- `PREVIOUS_MAJOR_LAST_MINOR` — the `version` of the highest-numbered entry with `branchType: "release"` whose major is exactly one less than `TARGET_VERSION`'s major (e.g. `8.19.19` when `TARGET_VERSION` is on the `9.x` line).
 - `CURRENT_MAJOR_LAST_MINOR` — the `version` of the highest-numbered entry with `branchType: "release"` whose major equals `TARGET_VERSION`'s major and whose minor is strictly less than `TARGET_VERSION`'s minor (e.g. `9.5.0` when `TARGET_VERSION` is `9.6`).
 
-If either placeholder cannot be resolved from `versions.json` (no eligible entry — e.g. `TARGET_VERSION` is the first minor of a new major cycle, so no `CURRENT_MAJOR_LAST_MINOR` exists yet), record it under *Assumptions* with a `⚠️` and ask the user to confirm before publishing — do not drop the scenario.
+If both remote and local fetches fail, or if either placeholder has no eligible entry in the file (e.g. `TARGET_VERSION` is the first minor of a new major cycle, so no `CURRENT_MAJOR_LAST_MINOR` exists yet), record the affected placeholder under *Assumptions* with a `⚠️` and ask the user to confirm before publishing — do not drop the scenario.
 
 ```gherkin
 @upgrade


### PR DESCRIPTION
## Summary

Closes elastic/security-team#18349.

`references/optional-scenarios.md` previously hardcoded the source versions used for the mandatory upgrade scenarios (introduced by the always-evaluated coverage rule in #279789):

- `8.19.x` for the last minor of the previous major series
- `9.3` for the last minor of the current major cycle

These values are time-sensitive and go stale with each release cycle, silently undermining the "always-evaluated upgrade coverage" enforcement. Copilot flagged this on #279789 and it was scoped out of that PR.

## Core fix (issue #18349)

**`references/optional-scenarios.md`**:
- Replace the hardcoded versions with two placeholders (`PREVIOUS_MAJOR_LAST_MINOR`, `CURRENT_MAJOR_LAST_MINOR`), resolved at generation time from `<repo-root>/versions.json` — the authoritative list of currently-supported release branches, updated as the release train advances.
- Update the Upgrade Gherkin template to use the same placeholders.
- Add fallback when a placeholder cannot be resolved (e.g. first minor of a new major cycle, so no `CURRENT_MAJOR_LAST_MINOR` exists yet): record under *Assumptions* with a `⚠️` and ask the user — never drop the scenario.

## Coherence follow-up to #279789

Both example files still referenced the pre-#279789 policy where Upgrade was treated as an optional section that could be omitted when the fictional issue didn't mention it, or when `TARGET_VERSION` was unknown. Neither is true anymore under the always-evaluated coverage rule.

**`references/example-test-plan.md`** (UI example — the fictional Alert Notes feature ships a new `alert-notes` saved-object type, which triggers always-evaluated upgrade coverage):
- Remove `upgrade` from the "optional sections omitted" list in both the intro paragraph and the *What this example demonstrates* section.
- Add a Known Limitations bullet explaining that upgrade scenarios are abbreviated out of the example for brevity, linking to the Upgrade template and the new version-resolution rules.

**`references/example-test-plan-backend.md`** (pure-parser example — no upgrade surface):
- Move upgrade from *Known Limitations* / "Optional sections omitted" to `*Out of scope*` with the one-clause reason "no upgrade surface (pure parser)", matching Row 2 of the *User-unavailable fallback* table.
- Reword the `TARGET_VERSION` assumption to `N/A — pure parser has no upgrade surface`, matching the "TARGET_VERSION is irrelevant" clause of the same fallback row.

## Verification

- `python3 ~/.cursor/skills/skill-creator/scripts/quick_validate.py` on the skill passes.
- No lint errors on the three modified files.
- Simulated resolution against the current `versions.json`:
  - `TARGET_VERSION = 9.6.0` → `PREVIOUS_MAJOR_LAST_MINOR = 8.19.19`, `CURRENT_MAJOR_LAST_MINOR = 9.5.0`.
  - `TARGET_VERSION = 9.0.0` (new-major edge) → `CURRENT_MAJOR_LAST_MINOR` unresolved → `⚠️` in *Assumptions* per the rule.

## Test plan

- [ ] Skill still generates upgrade scenarios with resolved versions when invoked on an issue with `TARGET_VERSION` on the `9.x` line.
- [ ] Skill records the `⚠️` fallback in *Assumptions* when `TARGET_VERSION` is the first minor of a new major cycle.

## Release note

release_note:skip