### PR TITLE
[9.4] [Fleet] Reject package name changes on package policy update (#279730)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -4080,6 +4080,7 @@ describe('Package policy service', () => {
     describe('remove protections', () => {
       beforeEach(() => {
         mockAgentPolicyService.bumpRevision.mockReset();
+        jest.mocked(licenseService.hasAtLeast).mockReturnValue(true);
       });
 
       const generateAttributes = (overrides: Record<string, unknown> = {}) => ({
@@ -4281,19 +4282,19 @@ describe('Package policy service', () => {
           testPolicyIds,
           [],
           // Add package override for both old and new policies
-          { package: { name: 'not-endpoint', title: 'Other', version: '1.0.0' } }
+          { package: { name: 'apache', title: 'Apache', version: '1.0.0' } }
         );
 
         await packagePolicyService.update(
           savedObjectsClient,
           elasticsearchClient,
           generateSO({
-            package: { name: 'not-endpoint', title: 'Other', version: '1.0.0' },
+            package: { name: 'apache', title: 'Apache', version: '1.0.0' },
           }).id,
           generateAttributes({
             policy_ids: [],
             name: 'test-package-policy-1',
-            package: { name: 'not-endpoint', title: 'Other', version: '1.0.0' },
+            package: { name: 'apache', title: 'Apache', version: '1.0.0' },
           })
         );
 
@@ -4310,7 +4311,7 @@ describe('Package policy service', () => {
         const savedObjectsClient = createSavedObjectClientMock();
         const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
-        // Mock existing package policy
+        // Mock existing package policy with same package name as the update ('test')
         savedObjectsClient.bulkGet.mockResolvedValue({
           saved_objects: [
             {
@@ -4318,7 +4319,10 @@ describe('Package policy service', () => {
               type: 'abcd',
               references: [],
               version: 'test',
-              attributes: createPackagePolicyMock(),
+              attributes: {
+                ...createPackagePolicyMock(),
+                package: { name: 'test', title: 'Test', version: '0.0.1' },
+              },
             },
           ],
         });
@@ -4601,6 +4605,48 @@ describe('Package policy service', () => {
       expect(res.failedPolicies[0].packagePolicy).toEqual(toUpdate);
       expect(res.failedPolicies[0].error).toEqual(
         new PackagePolicyValidationError(`cat is a frozen variable and cannot be modified`)
+      );
+    });
+
+    it('should put item in failedPolicies when package name is changed', async () => {
+      const savedObjectsClient = createSavedObjectClientMock();
+      const mockPackagePolicy = createPackagePolicyMock(); // package.name: 'endpoint'
+
+      savedObjectsClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'test',
+            type: 'abcd',
+            references: [],
+            version: 'test',
+            attributes: mockPackagePolicy,
+          },
+        ],
+      });
+
+      savedObjectsClient.bulkUpdate.mockResolvedValue({ saved_objects: [] });
+
+      const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // Change package name from 'endpoint' to 'aws' — both known to mocks so the
+      // outer package-info fetch succeeds, but the per-item guard fires before the
+      // asset-lookup step and puts the item in failedPolicies.
+      const toUpdate = {
+        ...mockPackagePolicy,
+        package: { name: 'aws', title: 'AWS', version: '0.3.3' },
+      };
+
+      const res = await packagePolicyService.bulkUpdate(savedObjectsClient, elasticsearchClient, [
+        toUpdate,
+      ]);
+
+      expect(res.failedPolicies).toHaveLength(1);
+      expect(res.updatedPolicies).toHaveLength(0);
+      expect(res.failedPolicies[0].packagePolicy).toEqual(toUpdate);
+      expect(res.failedPolicies[0].error).toEqual(
+        new PackagePolicyValidationError(
+          'Cannot change the package of an existing integration policy. Create a new policy with the desired package.'
+        )
       );
     });
 
@@ -5634,16 +5680,16 @@ describe('Package policy service', () => {
         // All non-endpoint policies
         const nonEndpointPoliciesSO = [
           generateSO({
-            name: 'not-endpoint-policy',
+            name: 'apache-policy',
             policy_ids: ['test-agent-policy-1'],
-            id: 'not-endpoint-1',
-            package: { name: 'not-endpoint', title: 'Other', version: '1.0.0' },
+            id: 'apache-1',
+            package: { name: 'apache', title: 'Apache', version: '1.0.0' },
           }),
           generateSO({
-            name: 'not-endpoint-policy-2',
+            name: 'apache-policy-2',
             policy_ids: ['test-agent-policy-2'],
-            id: 'not-endpoint-2',
-            package: { name: 'not-endpoint', title: 'Other', version: '1.0.0' },
+            id: 'apache-2',
+            package: { name: 'apache', title: 'Apache', version: '1.0.0' },
           }),
         ];
 
@@ -5681,10 +5727,10 @@ describe('Package policy service', () => {
             package: { name: 'endpoint', title: 'Elastic Endpoint', version: '0.9.0' },
           }),
           generateSO({
-            name: 'not-endpoint-policy',
+            name: 'apache-policy',
             policy_ids: ['test-agent-policy-2'],
-            id: 'not-endpoint-1',
-            package: { name: 'not-endpoint', title: 'Other', version: '1.0.0' },
+            id: 'apache-1',
+            package: { name: 'apache', title: 'Apache', version: '1.0.0' },
           }),
         ];
         const mixedTestedPolicies = [
@@ -13375,6 +13421,54 @@ describe('_validateRestrictedFieldsNotModifiedOrThrow()', () => {
         oldPackagePolicy: makePolicyWithType('logs'),
         packagePolicyUpdate: makePolicyWithType('logs'),
         pkgInfo,
+      })
+    ).not.toThrow();
+  });
+
+  it('should throw if package name is changed', () => {
+    const oldPackagePolicy = createInputPkgPolicy({
+      namespace: 'default',
+      dataset: 'custom_logs.logs',
+    });
+    expect(() =>
+      _validateRestrictedFieldsNotModifiedOrThrow({
+        oldPackagePolicy,
+        packagePolicyUpdate: {
+          ...oldPackagePolicy,
+          package: { name: 'different_package', title: 'Different', version: '1.0.0' },
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot change the package of an existing integration policy. Create a new policy with the desired package."`
+    );
+  });
+
+  it('should not throw if package name is unchanged', () => {
+    const oldPackagePolicy = createInputPkgPolicy({
+      namespace: 'default',
+      dataset: 'custom_logs.logs',
+    });
+    expect(() =>
+      _validateRestrictedFieldsNotModifiedOrThrow({
+        oldPackagePolicy,
+        packagePolicyUpdate: {
+          ...oldPackagePolicy,
+          package: { name: 'custom_logs', title: 'Custom Logs', version: '2.0.0' },
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('should not throw if package is omitted from update', () => {
+    const oldPackagePolicy = createInputPkgPolicy({
+      namespace: 'default',
+      dataset: 'custom_logs.logs',
+    });
+    const { package: _pkg, ...updateWithoutPackage } = oldPackagePolicy;
+    expect(() =>
+      _validateRestrictedFieldsNotModifiedOrThrow({
+        oldPackagePolicy,
+        packagePolicyUpdate: updateWithoutPackage,
       })
     ).not.toThrow();
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1980,6 +1980,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           this.keepPolicyIdInSync(oldPackagePolicy);
         }
 
+        _validateRestrictedFieldsNotModifiedOrThrow({
+          oldPackagePolicy,
+          packagePolicyUpdate: enrichedPackagePolicy,
+        });
+
         // If the package version has increased, save the previous package policy revision.
         if (
           appContextService.getExperimentalFeatures().enablePackageRollback &&
@@ -4406,13 +4411,32 @@ export function preconfigurePackageInputs(
 
 // input only packages cannot have their namespace or dataset modified
 export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
-  pkgInfo: PackageInfo;
+  pkgInfo?: PackageInfo;
   oldPackagePolicy: PackagePolicy;
   packagePolicyUpdate: UpdatePackagePolicy;
 }) {
   const { pkgInfo, oldPackagePolicy, packagePolicyUpdate } = opts;
 
-  if (pkgInfo.type !== 'input') return;
+  if (
+    packagePolicyUpdate.package?.name &&
+    oldPackagePolicy.package?.name &&
+    packagePolicyUpdate.package.name !== oldPackagePolicy.package.name
+  ) {
+    appContextService
+      .getLogger()
+      .debug(
+        () =>
+          `Rejecting package policy update due to package name change, old val '${oldPackagePolicy.package?.name}', new val '${packagePolicyUpdate.package?.name}'`
+      );
+    throw new PackagePolicyValidationError(
+      i18n.translate('xpack.fleet.updatePackagePolicy.packageNameCannotBeModified', {
+        defaultMessage:
+          'Cannot change the package of an existing integration policy. Create a new policy with the desired package.',
+      })
+    );
+  }
+
+  if (pkgInfo?.type !== 'input') return;
 
   const { namespace, inputs } = packagePolicyUpdate;
   if (namespace && namespace !== oldPackagePolicy.namespace) {

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/update.ts
@@ -762,7 +762,7 @@ export default function (providerContext: FtrProviderContext) {
         const {
           body: { item },
         } = await supertest
-          .put(`/api/fleet/package_policies/${packagePolicyId}?format=simplified`)
+          .put(`/api/fleet/package_policies/${packagePolicyId3}?format=simplified`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: `update-simplified-package-policy-with_required_variables-${Date.now()}`,
@@ -792,7 +792,7 @@ export default function (providerContext: FtrProviderContext) {
         const {
           body: { item },
         } = await supertest
-          .put(`/api/fleet/package_policies/${packagePolicyId}?format=legacy`)
+          .put(`/api/fleet/package_policies/${packagePolicyId3}?format=legacy`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: `update-simplified-package-policy-with_required_variables-${Date.now()}`,
@@ -820,7 +820,7 @@ export default function (providerContext: FtrProviderContext) {
 
       it('should return 400 if an invalid format query param is passed', async function () {
         await supertest
-          .put(`/api/fleet/package_policies/${packagePolicyId}?format=foo`)
+          .put(`/api/fleet/package_policies/${packagePolicyId3}?format=foo`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: `update-simplified-package-policy-with_required_variables-${Date.now()}`,
@@ -900,6 +900,52 @@ export default function (providerContext: FtrProviderContext) {
 
         // Associated agent policies that existed before agentless deployment update should NOT be deleted
         await supertest.get(`/api/fleet/agent_policies/${agentPolicyId}`).expect(200);
+      });
+    });
+
+    describe('Package name immutability', () => {
+      it('should return 400 when package name is changed', async function () {
+        const response = await supertest
+          .put(`/api/fleet/package_policies/${packagePolicyId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'filetest-1',
+            description: '',
+            namespace: 'default',
+            policy_id: agentPolicyId,
+            enabled: true,
+            inputs: [],
+            package: {
+              name: 'with_required_variables',
+              title: 'With Required Variables',
+              version: '0.1.0',
+            },
+          })
+          .expect(400);
+
+        expect(response.body.message).to.eql(
+          'Cannot change the package of an existing integration policy. Create a new policy with the desired package.'
+        );
+      });
+
+      it('should return 200 when package name is unchanged', async function () {
+        await supertest
+          .put(`/api/fleet/package_policies/${packagePolicyId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'filetest-1',
+            description: 'updated description',
+            namespace: 'default',
+            policy_id: agentPolicyId,
+            enabled: true,
+            inputs: [],
+            package: {
+              name: 'filetest',
+              title: 'For File Tests',
+              version: '0.1.0',
+            },
+          })
+          .expect(200);
       });
     });
 

--- a/x-pack/solutions/security/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/solutions/security/test/fleet_api_integration/apis/package_policy/update.ts
@@ -845,7 +845,7 @@ export default function (providerContext: FtrProviderContext) {
         const {
           body: { item },
         } = await supertest
-          .put(`/api/fleet/package_policies/${packagePolicyId}?format=simplified`)
+          .put(`/api/fleet/package_policies/${packagePolicyId3}?format=simplified`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: `update-simplified-package-policy-with_required_variables-${Date.now()}`,
@@ -875,7 +875,7 @@ export default function (providerContext: FtrProviderContext) {
         const {
           body: { item },
         } = await supertest
-          .put(`/api/fleet/package_policies/${packagePolicyId}?format=legacy`)
+          .put(`/api/fleet/package_policies/${packagePolicyId3}?format=legacy`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: `update-simplified-package-policy-with_required_variables-${Date.now()}`,
@@ -903,7 +903,7 @@ export default function (providerContext: FtrProviderContext) {
 
       it('should return 400 if an invalid format query param is passed', async function () {
         await supertest
-          .put(`/api/fleet/package_policies/${packagePolicyId}?format=foo`)
+          .put(`/api/fleet/package_policies/${packagePolicyId3}?format=foo`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: `update-simplified-package-policy-with_required_variables-${Date.now()}`,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Reject package name changes on package policy update (#279730)](https://github.com/elastic/kibana/pull/279730)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-21T14:05:34Z","message":"[Fleet] Reject package name changes on package policy update (#279730)\n\nFixes https://github.com/elastic/kibana/issues/275405\n\n## Summary\n\nReject package name changes on package policy update.\n\n### Testing\n```\n  # 1. Create a policy for package A\n  POST /api/fleet/package_policies\n  { \"package\": { \"name\": \"aws\", \"version\": \"2.0.0\" }, ... }\n\n  # 2. Update it with a different package name\n  PUT /api/fleet/package_policies/{id}\n  { \"package\": { \"name\": \"gcp\", \"version\": \"2.0.0\" }, ... }\n\n{\n    \"statusCode\": 400,\n    \"error\": \"Bad Request\",\n    \"message\": \"  Cannot change the package of an existing integration policy. Create a new policy with the desired package\"\n  }\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- `PUT /api/fleet/package_policies/{id}` and bulk updates (internal\nonly) are now stricter","sha":"6e776bf5a536486e13eba0019f8c46ec353c0187","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.5.0","v9.6.0"],"title":"[Fleet] Reject package name changes on package policy update","number":279730,"url":"https://github.com/elastic/kibana/pull/279730","mergeCommit":{"message":"[Fleet] Reject package name changes on package policy update (#279730)\n\nFixes https://github.com/elastic/kibana/issues/275405\n\n## Summary\n\nReject package name changes on package policy update.\n\n### Testing\n```\n  # 1. Create a policy for package A\n  POST /api/fleet/package_policies\n  { \"package\": { \"name\": \"aws\", \"version\": \"2.0.0\" }, ... }\n\n  # 2. Update it with a different package name\n  PUT /api/fleet/package_policies/{id}\n  { \"package\": { \"name\": \"gcp\", \"version\": \"2.0.0\" }, ... }\n\n{\n    \"statusCode\": 400,\n    \"error\": \"Bad Request\",\n    \"message\": \"  Cannot change the package of an existing integration policy. Create a new policy with the desired package\"\n  }\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- `PUT /api/fleet/package_policies/{id}` and bulk updates (internal\nonly) are now stricter","sha":"6e776bf5a536486e13eba0019f8c46ec353c0187"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279862","number":279862,"state":"MERGED","mergeCommit":{"sha":"9f92c74d53a13ca2d9bc85ff58fbb3ee138748a1","message":"[9.5] [Fleet] Reject package name changes on package policy update (#279730) (#279862)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Fleet] Reject package name changes on package policy update\n(#279730)](https://github.com/elastic/kibana/pull/279730)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Cristina Amico <criamico@users.noreply.github.com>"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/279730","number":279730,"mergeCommit":{"message":"[Fleet] Reject package name changes on package policy update (#279730)\n\nFixes https://github.com/elastic/kibana/issues/275405\n\n## Summary\n\nReject package name changes on package policy update.\n\n### Testing\n```\n  # 1. Create a policy for package A\n  POST /api/fleet/package_policies\n  { \"package\": { \"name\": \"aws\", \"version\": \"2.0.0\" }, ... }\n\n  # 2. Update it with a different package name\n  PUT /api/fleet/package_policies/{id}\n  { \"package\": { \"name\": \"gcp\", \"version\": \"2.0.0\" }, ... }\n\n{\n    \"statusCode\": 400,\n    \"error\": \"Bad Request\",\n    \"message\": \"  Cannot change the package of an existing integration policy. Create a new policy with the desired package\"\n  }\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- `PUT /api/fleet/package_policies/{id}` and bulk updates (internal\nonly) are now stricter","sha":"6e776bf5a536486e13eba0019f8c46ec353c0187"}}]}] BACKPORT-->